### PR TITLE
Vote button disabled when voting is blocked

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/proposals/_vote_button.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_vote_button.html.erb
@@ -1,8 +1,14 @@
 <div id="proposal-<%= proposal.id %>-vote-button">
   <% if !current_user %>
-    <button class="card__button button <%= vote_button_classes(from_proposals_list) %>" data-toggle="loginModal">
-      <%= t('.vote') %>
-    </button>
+    <% if current_settings.votes_blocked? %>
+      <button class="card__button button <%= vote_button_classes(from_proposals_list) %> disabled" data-toggle="loginModal">
+        <%= t('.votes_blocked') %>
+      </button>
+    <% else %>
+      <button class="card__button button <%= vote_button_classes(from_proposals_list) %>" data-toggle="loginModal">
+        <%= t('.vote') %>
+       </button>
+    <% end %>
   <% else %>
     <% if @voted_proposals ? @voted_proposals.include?(proposal.id) : proposal.voted_by?(current_user) %>
       <% if vote_limit_enabled? %>

--- a/decidim-proposals/spec/features/vote_proposal_spec.rb
+++ b/decidim-proposals/spec/features/vote_proposal_spec.rb
@@ -41,6 +41,20 @@ describe "Vote Proposal", type: :feature do
         expect(page).to have_css('#loginModal', visible: true)
       end
     end
+  
+    context "when votes are blocked" do
+      let!(:feature) do
+        create(:proposal_feature,
+          :with_votes_blocked,
+          manifest: manifest,
+          participatory_process: participatory_process)
+      end
+
+      it "shows the vote count but not the vote button" do
+        expect(page).to have_css('.card__support__data', text: "1 VOTE")
+        expect(page).to have_content("Voting disabled")
+      end
+    end
 
     context "when the user is logged in" do
       before do

--- a/decidim-proposals/spec/features/vote_proposal_spec.rb
+++ b/decidim-proposals/spec/features/vote_proposal_spec.rb
@@ -22,6 +22,20 @@ describe "Vote Proposal", type: :feature do
     end
   end
 
+  context "when votes are blocked" do
+    let!(:feature) do
+      create(:proposal_feature,
+        :with_votes_blocked,
+        manifest: manifest,
+        participatory_process: participatory_process)
+    end
+
+    it "shows the vote count but not the vote button" do
+      expect(page).to have_css('.card__support__data', text: "1 VOTE")
+      expect(page).to have_content("Voting disabled")
+    end
+  end
+
   context "when votes are enabled" do
     let!(:feature) do
       create(:proposal_feature,
@@ -39,20 +53,6 @@ describe "Vote Proposal", type: :feature do
         end
 
         expect(page).to have_css('#loginModal', visible: true)
-      end
-    end
-  
-    context "when votes are blocked" do
-      let!(:feature) do
-        create(:proposal_feature,
-          :with_votes_blocked,
-          manifest: manifest,
-          participatory_process: participatory_process)
-      end
-
-      it "shows the vote count but not the vote button" do
-        expect(page).to have_css('.card__support__data', text: "1 VOTE")
-        expect(page).to have_content("Voting disabled")
       end
     end
 

--- a/decidim-proposals/spec/features/vote_proposal_spec.rb
+++ b/decidim-proposals/spec/features/vote_proposal_spec.rb
@@ -30,8 +30,9 @@ describe "Vote Proposal", type: :feature do
         participatory_process: participatory_process)
     end
 
-    it "shows the vote count but not the vote button" do
-      expect(page).to have_css('.card__support__data', text: "1 VOTE")
+    it "shows the vote count and the vote button is disabled" do
+      visit_feature
+      expect(page).to have_css('.card__support__data', text: "0 VOTES")
       expect(page).to have_content("Voting disabled")
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds a conditional to the vote button renderer to check if votes are blocked, and then display them correctly.

#### :pushpin: Related Issues
- Fixes #809 

### :camera: Screenshots (optional)
![screen shot 2017-04-24 at 12 01 48](https://cloud.githubusercontent.com/assets/953911/25332247/07d7dd5a-28e6-11e7-85ed-965632485ab4.png)
![screen shot 2017-04-24 at 12 02 07](https://cloud.githubusercontent.com/assets/953911/25332248/07d8df70-28e6-11e7-8627-f67a7d2dd686.png)

#### :ghost: GIF
![](https://media4.giphy.com/media/1Erx4cu7f9IBi/giphy.gif)
