### PR TITLE
Fix bundler error when generating dev app

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -49,9 +49,11 @@ task :development_app do
   )
 
   Dir.chdir("#{File.dirname(__FILE__)}/development_app") do
-    sh "bundle exec spring stop"
-    sh "bundle exec rake db:drop db:create db:migrate db:seed"
-    sh "bundle exec rails generate decidim:demo"
+    Bundler.with_clean_env do
+      sh "bundle exec spring stop"
+      sh "bundle exec rake db:drop db:create db:migrate db:seed"
+      sh "bundle exec rails generate decidim:demo"
+    end
   end
 end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Fixes a `bundler` error when settting up and development environment and running `bundle exec rake development_app`.

Since we are running "bundler inside bundler" but we want to use a different `Gemfile` from the original invocation, we need to reset the `bundler` environment so the new `Gemfile` is properly guessed to be the current's folder `Gemfile`. As an alternative, we could pass the `BUNDLE_GEMFILE` environment variable to the commands, so we wouldn't even need to switch folders (I think, haven't tried it).

Note that this only reproduces in very recent bundlers (1.15.0.pre1 at least). My guess is that some change in `bundler` uncovered this problem in our code, but if you're not convinced I could try to dig in further and confirm that this is not a bug in `bundler` itself.

### :camera: Screenshots (optional)

![error](https://cloud.githubusercontent.com/assets/2887858/25349465/50211a4c-28f8-11e7-8b90-8261032b008f.png)

#### :ghost: GIF

![pr merged](https://cloud.githubusercontent.com/assets/2887858/25349489/6a1c1d98-28f8-11e7-8c0d-575c8b24c1da.gif)

