### PR TITLE
Fix cross origin iframes

### DIFF
--- a/decidim-core/app/assets/config/decidim_core_manifest.js
+++ b/decidim-core/app/assets/config/decidim_core_manifest.js
@@ -7,3 +7,4 @@
 //= link decidim/map.css
 //= link_directory ../../../vendor/assets/javascripts/datepicker-locales
 //= link decidim/widget.css
+//= link decidim/widget.js

--- a/decidim-core/app/assets/javascripts/decidim/widget.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/widget.js.es6
@@ -1,9 +1,14 @@
-window.addEventListener("message", function (event) {
+window.addEventListener("message", (event) => {
   if (event.data.type === "GET_HEIGHT") {
-    let body = document.body;
-    let html = document.documentElement;
-    let height = Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight);
+    const body = document.body;
+    const html = document.documentElement;
+    const height = Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight);
 
     parent.postMessage({ type: "SET_HEIGHT", height: height }, "*");
   }
+});
+
+$(() => {
+  // Set target blank for all widget links.
+  $('a').attr('target', '_blank');
 });

--- a/decidim-core/app/assets/javascripts/decidim/widget.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/widget.js.es6
@@ -1,0 +1,9 @@
+window.addEventListener("message", function (event) {
+  if (event.data.type === "GET_HEIGHT") {
+    let body = document.body;
+    let html = document.documentElement;
+    let height = Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight);
+
+    parent.postMessage({ type: "SET_HEIGHT", height: height }, "*");
+  }
+});

--- a/decidim-core/app/controllers/decidim/widgets_controller.rb
+++ b/decidim-core/app/controllers/decidim/widgets_controller.rb
@@ -4,6 +4,7 @@ module Decidim
   class WidgetsController < Decidim::ApplicationController
     skip_authorization_check only: :show
     skip_before_filter :verify_authenticity_token
+    after_action :allow_iframe, only: :show
 
     layout 'decidim/widget'
 
@@ -20,6 +21,10 @@ module Decidim
 
     def iframe_url
       raise NotImplementedError
+    end
+
+    def allow_iframe
+      response.headers.delete "X-Frame-Options"
     end
   end
 end

--- a/decidim-core/app/views/decidim/widgets/show.js.erb
+++ b/decidim-core/app/views/decidim/widgets/show.js.erb
@@ -1,28 +1,22 @@
 /* eslint-disable no-var, prefer-template */
-document.write('<iframe src="<%= iframe_url %>" frameborder="0" scrolling="no" onload="setIframeHeight(this)"></iframe>');
+var iframe = document.createElement('iframe');
 
-(function (exports) {
-  var getDocHeight = function(doc) {
-    var body = doc.body;
-    var html = doc.documentElement;
-    var height = Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight);
+iframe.src = "<%= iframe_url %>";
+iframe.frameBorder = "0"
+iframe.scrolling = "no";
+iframe.style.visibility = 'hidden';
+iframe.style.height = "10px";
+iframe.onload = function () {
+  iframe.contentWindow.postMessage({ type: "GET_HEIGHT" }, "*");
+}
 
-    return height;
+document.body.appendChild(iframe);
+
+window.addEventListener("message", function (event) {
+  var height = event.data.height;
+
+  if (event.data.type === "SET_HEIGHT") {
+    iframe.style.height = height + "px";
+    iframe.style.visibility = 'visible';
   }
-
-  exports.setIframeHeight = function(ifrm) {
-    var doc = null;
-
-    if (ifrm.contentDocument) {
-      doc = ifrm.contentDocument;
-    } else {
-      doc = ifrm.contentWindow.document;
-    }
-
-    ifrm.style.visibility = 'hidden';
-    ifrm.style.height = "10px";
-
-    ifrm.style.height = getDocHeight(doc) + 4 + "px";
-    ifrm.style.visibility = 'visible';
-  }
-}(window));
+});

--- a/decidim-core/app/views/layouts/decidim/widget.html.erb
+++ b/decidim-core/app/views/layouts/decidim/widget.html.erb
@@ -12,5 +12,6 @@
     <div class="organization">
       <%= render partial: "layouts/decidim/logo", locals: { organization: current_organization } %>
     </div>
+    <%= javascript_include_tag 'decidim/widget' %>
   </body>
 </html>


### PR DESCRIPTION
#### :tophat: What? Why?

Decidim widgets couldn't be embedded on other sites because cross origin restrictions. I fixed the problem using the great `postMessage` api.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None

#### :ghost: GIF
None