### PR TITLE
Let admins hide votes when voting is enabled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,31 +36,31 @@ jobs:
               0)
                 cd /code && yarn lint && bundle exec rspec spec
                 cd /code && yarn test -- decidim-api
-                cd /code/decidim-api && bundle exec rspec spec
+                cd /code/decidim-api && bundle exec rake
                 cd /code && yarn test -- decidim-core
-                cd /code/decidim-core && bundle exec rspec spec
+                cd /code/decidim-core && bundle exec rake
                 ;;
               1)
                 cd /code && yarn test -- decidim-admin
-                cd /code/decidim-admin && bundle exec rspec spec
+                cd /code/decidim-admin && bundle exec rake
                 cd /code && yarn test -- decidim-meetings
-                cd /code/decidim-meetings && bundle exec rspec spec
+                cd /code/decidim-meetings && bundle exec rake
                 ;;
               2)
                 cd /code && yarn test -- decidim-proposals
-                cd /code/decidim-proposals && bundle exec rspec spec
+                cd /code/decidim-proposals && bundle exec rake
                 cd /code && yarn test -- decidim-comments
-                cd /code/decidim-comments && bundle exec rspec spec
+                cd /code/decidim-comments && bundle exec rake
                 ;;
               3)
                 cd /code && yarn test -- decidim-pages
-                cd /code/decidim-pages && bundle exec rspec spec
+                cd /code/decidim-pages && bundle exec rake
                 cd /code && yarn test -- decidim-system
-                cd /code/decidim-system && bundle exec rspec spec
+                cd /code/decidim-system && bundle exec rake
                 cd /code && yarn test -- decidim-results
-                cd /code/decidim-results && bundle exec rspec spec
+                cd /code/decidim-results && bundle exec rake
                 cd /code && yarn test -- decidim-budgets
-                cd /code/decidim-budgets && bundle exec rspec spec
+                cd /code/decidim-budgets && bundle exec rake
                 ;;
             esac
       - store_artifacts:

--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -65,7 +65,9 @@ module Decidim
       private
 
       def order
-        @order = params[:order] || "random"
+        return @order if @order
+        @order = "random" if current_settings.votes_enabled? && current_settings.votes_hidden? && params[:order] == "most_voted"
+        @order ||= params[:order] || "random"
       end
 
       # Returns: A random float number between -1 and 1 to be used as a random seed at the database.

--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -20,9 +20,6 @@ module Decidim
                      .includes(:category)
                      .includes(:scope)
 
-        @proposals = @proposals.page(params[:page]).per(12)
-        @proposals = reorder(@proposals)
-
         @voted_proposals = if current_user
                              ProposalVote.where(
                                author: current_user,
@@ -31,6 +28,10 @@ module Decidim
                            else
                              []
                            end
+
+        @proposals = @proposals.page(params[:page]).per(12)
+        @proposals = reorder(@proposals)
+
       end
 
       def show
@@ -64,6 +65,11 @@ module Decidim
 
       private
 
+      # Gets how the proposals should be ordered based on the choice made by the user.
+      #
+      # Note that when votes are active and hidden at the same time, the "most_voted"
+      # option is not available, so it's replaced to "random" to avoid people
+      # changing the URL manually.
       def order
         return @order if @order
         @order = "random" if current_settings.votes_enabled? && current_settings.votes_hidden? && params[:order] == "most_voted"

--- a/decidim-proposals/app/helpers/decidim/proposals/proposal_order_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/proposal_order_helper.rb
@@ -7,7 +7,7 @@ module Decidim
       def order_fields
         @order_fields ||= begin
           order_fields = [:random, :recent]
-          order_fields << :most_voted if current_settings.votes_enabled?
+          order_fields << :most_voted if current_settings.votes_enabled? && !current_settings.votes_hidden?
           order_fields
         end
       end

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_votes_count.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_votes_count.html.erb
@@ -1,9 +1,10 @@
 <div id="proposal-<%= proposal.id %>-votes-count" class="card__support__data">
-  <span class="<%= votes_count_classes(from_proposals_list)[:number] %>">
-    <%= proposal.proposal_votes_count %>
-  </span>
-  <span class="<%= votes_count_classes(from_proposals_list)[:label]  %>">
-    <%= t('.count', count: proposal.proposal_votes_count) %>
-  </span>
-
+  <% if !current_settings.votes_hidden? %>
+    <span class="<%= votes_count_classes(from_proposals_list)[:number] %>">
+      <%= proposal.proposal_votes_count %>
+    </span>
+    <span class="<%= votes_count_classes(from_proposals_list)[:label]  %>">
+      <%= t('.count', count: proposal.proposal_votes_count) %>
+    </span>
+  <% end %>
 </div>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -31,12 +31,8 @@
     <% if current_settings.votes_enabled? %>
       <div class="card extra">
         <div class="card__content">
-            <div id="proposal-<%= @proposal.id %>-votes-count">
-              <%= render partial: "votes_count", locals: { proposal: @proposal, from_proposals_list: false } %>
-            </div>
-            <div id="proposal-<%= @proposal.id %>-vote-button">
-              <%= render partial: "vote_button", locals: { proposal: @proposal, from_proposals_list: false } %>
-            </div>
+          <%= render partial: "votes_count", locals: { proposal: @proposal, from_proposals_list: false } %>
+          <%= render partial: "vote_button", locals: { proposal: @proposal, from_proposals_list: false } %>
         </div>
       </div>
     <% end %>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -30,6 +30,7 @@ en:
             proposal_answering_enabled: Proposal answering enabled
             votes_blocked: Votes blocked
             votes_enabled: Votes enabled
+            votes_hidden: Votes hidden (if votes are enabled, checking this will hide the number of votes)
     proposals:
       actions:
         answer: Answer

--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -26,6 +26,7 @@ Decidim.register_feature(:proposals) do |feature|
   feature.settings(:step) do |settings|
     settings.attribute :votes_enabled, type: :boolean
     settings.attribute :votes_blocked, type: :boolean
+    settings.attribute :votes_hidden, type: :boolean, default: false
     settings.attribute :comments_blocked, type: :boolean, default: false
     settings.attribute :creation_enabled, type: :boolean
     settings.attribute :proposal_answering_enabled, type: :boolean, default: true

--- a/decidim-proposals/spec/helpers/proposal_order_helper_spec.rb
+++ b/decidim-proposals/spec/helpers/proposal_order_helper_spec.rb
@@ -10,10 +10,20 @@ module Decidim
 
       describe "#order_fields" do
         context "with votes enabled" do
-          let(:current_settings) { double(:current_settings, { votes_enabled?: true }) }
+          context "with votes hidden" do
+            let(:current_settings) { double(:current_settings, { votes_enabled?: true, votes_hidden?: true }) }
 
-          it "shows most_voted option to sort" do
-            expect(helper.order_fields).to include(:most_voted)
+            it "does not show most_voted option to sort" do
+              expect(helper.order_fields).not_to include(:most_voted)
+            end
+          end
+
+          context "with votes not hidden" do
+            let(:current_settings) { double(:current_settings, { votes_enabled?: true, votes_hidden?: false }) }
+
+            it "shows most_voted option to sort" do
+              expect(helper.order_fields).to include(:most_voted)
+            end
           end
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Lets admins hide proposal votes when voting is enabled by checking a flag in the feature.

#### :pushpin: Related Issues
- Fixes #1222 

#### :clipboard: Subtasks
- [x] Add config toggle in the feature settings
- [x] Hide votes from index and show pages when check is active
- [x] Check that proposals cannot be ordered by "Most voted" when votes are active && hidden at the same time. Instead, they are sorted randomly.

### :camera: Screenshots (optional)
Index when votes are hidden, showing an un-voted proposal. Votes are not shown. Also, notice the order dropdown, which hides the "Most voted" option:
![Description](https://i.imgur.com/g39tLWJ.png)

Proposal page with votes hidden. Note that votes are not shown:
![](https://i.imgur.com/2Qsnb2w.png)
