### PR TITLE
Fix missing translations and some minor bugs at the admin panel.

### DIFF
--- a/decidim-admin/app/views/decidim/admin/participatory_process_groups/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_process_groups/index.html.erb
@@ -18,7 +18,7 @@
           <% collection.each do |group| %>
             <tr>
               <td>
-                <%= link_to translated_attribute(group.name), group %><br />
+                <%= link_to translated_attribute(group.name), ['edit', group] %><br />
               </td>
               <td class="table-list__actions">
                 <% if can? :update, group %>

--- a/decidim-admin/app/views/decidim/admin/static_pages/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_pages/index.html.erb
@@ -1,6 +1,6 @@
 <div class="card">
   <div class="card-divider">
-    <h2 class="card-title"><%= t "decidim.admin.titles.static_pages" %> <%= link_to t("static_pages.new.title", scope: "decidim.admin"), ['new', 'static_page'], class: 'button tiny button--title new' %></h2>
+    <h2 class="card-title"><%= t "decidim.admin.titles.static_pages" %> <%= link_to t("static_pages.new.create", scope: "decidim.admin"), ['new', 'static_page'], class: 'button tiny button--title new' %></h2>
   </div>
   <div class="card-section">
     <div class="table-scroll">
@@ -16,7 +16,7 @@
           <% @pages.each do |page| %>
             <tr>
               <td>
-                <%= link_to translated_attribute(page.title), page %><br />
+                <%= link_to translated_attribute(page.title), ['edit', page] %><br />
               </td>
               <td>
                 <%= l page.created_at, format: :short %>

--- a/decidim-admin/app/views/layouts/decidim/admin/pages.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/pages.html.erb
@@ -4,7 +4,7 @@
       <%= t "decidim.admin.titles.static_pages" %>
     </div>
     <div class="secondary-nav__actions">
-      <%= link_to t("static_pages.new.title", scope: "decidim.admin"), ['new', 'static_page'], class: 'button expanded small new' %>
+      <%= link_to t("static_pages.new.create", scope: "decidim.admin"), ['new', 'static_page'], class: 'button expanded small new' %>
     </div>
   </div>
 <% end %>

--- a/decidim-admin/config/locales/ca.yml
+++ b/decidim-admin/config/locales/ca.yml
@@ -101,7 +101,6 @@ ca:
         content: Contingut
         slug: Nom curt d'URL
         title: Títol
-
   decidim:
     admin:
       actions:

--- a/decidim-admin/config/locales/ca.yml
+++ b/decidim-admin/config/locales/ca.yml
@@ -101,6 +101,7 @@ ca:
         content: Contingut
         slug: Nom curt d'URL
         title: Títol
+
   decidim:
     admin:
       actions:
@@ -111,7 +112,7 @@ ca:
         destroy: Eliminar
         edit: Editar
         manage: Gestionar
-        new: Nou %{name}
+        new: Nou
         permissions: Permisos
         preview: Previsualitzar
         publish: Publicar
@@ -449,7 +450,7 @@ ca:
           title: Editar pàgina
           update: Actualitzar pàgina
         new:
-          create: Crear pàgina
+          create: Crear
           title: Nova pàgina
         update:
           error: S'ha produït un error en l'actualització d'aquests pàgina.

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -102,6 +102,9 @@ en:
         content: Content
         slug: URL slug
         title: Title
+      decidim/participatory_process_step:
+        start_date: Start date
+        end_date: End date
   decidim:
     admin:
       actions:
@@ -112,7 +115,7 @@ en:
         destroy: Destroy
         edit: Edit
         manage: Manage
-        new: New %{name}
+        new: Create
         permissions: Permissions
         preview: Preview
         publish: Publish
@@ -127,7 +130,7 @@ en:
           success: Attachment destroyed successfully.
         edit:
           title: Edit attachment
-          update: Update attachment
+          update: Update
         form:
           current_file: Current file
           url: Url
@@ -146,7 +149,7 @@ en:
           success: Category deleted successfully.
         edit:
           title: Edit category
-          update: Update category
+          update: Update
         new:
           create: Create category
           title: New category
@@ -326,7 +329,7 @@ en:
       organization:
         edit:
           title: Edit organization
-          update: Update organization
+          update: Update
         form:
           current_image: Current image
           facebook: Facebook
@@ -374,9 +377,9 @@ en:
           success: Participatory process step destroyed successfully.
         edit:
           title: Edit participatory process step
-          update: Update participatory process step
+          update: Update
         new:
-          create: Create participatory process step
+          create: Create
           title: New participatory process step
         ordering:
           error: There was an error when reordering this participatory process steps.
@@ -405,7 +408,7 @@ en:
         destroy:
           success: Participatory process destroyed successfully.
         edit:
-          update: Update participatory process
+          update: Update
         form:
           current_image: Current image
           title: General Information
@@ -414,8 +417,8 @@ en:
           not_published: Not published
           published: Published
         new:
-          create: Create particiatory process
-          title: New particiatory process
+          create: Create
+          title: New participatory process
         update:
           error: There was an error when updating this participatory process.
           success: Participatory process updated successfully.
@@ -431,7 +434,7 @@ en:
           success: Scope successfully destroyed
         edit:
           title: Edit scope
-          update: Update scope
+          update: Update
         new:
           create: Create scope
           title: New scope
@@ -448,9 +451,9 @@ en:
           success: Page successfully destroyed
         edit:
           title: Edit page
-          update: Update page
+          update: Update
         new:
-          create: Create page
+          create: Create
           title: New page
         update:
           error: There was an error when updating this page.

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -98,13 +98,13 @@ en:
         subtitle: Subtitle
         target: Target
         title: Title
+      decidim/participatory_process_step:
+        end_date: End date
+        start_date: Start date
       decidim/static_page:
         content: Content
         slug: URL slug
         title: Title
-      decidim/participatory_process_step:
-        start_date: Start date
-        end_date: End date
   decidim:
     admin:
       actions:
@@ -115,7 +115,7 @@ en:
         destroy: Destroy
         edit: Edit
         manage: Manage
-        new: Create
+        new: New
         permissions: Permissions
         preview: Preview
         publish: Publish
@@ -453,7 +453,7 @@ en:
           title: Edit page
           update: Update
         new:
-          create: Create
+          create: New
           title: New page
         update:
           error: There was an error when updating this page.

--- a/decidim-admin/config/locales/es.yml
+++ b/decidim-admin/config/locales/es.yml
@@ -111,7 +111,7 @@ es:
         destroy: Eliminar
         edit: Editar
         manage: Gestionar
-        new: Nuevo %{name}
+        new: Nuevo
         permissions: Permisos
         preview: Previsualizar
         publish: Publicar

--- a/decidim-admin/config/locales/eu.yml
+++ b/decidim-admin/config/locales/eu.yml
@@ -10,6 +10,7 @@ eu:
       category:
         description: Deskribapena
         name: Izena
+        parent_id: Nagusia
       feature:
         name: Izena
         weight: Pisua

--- a/decidim-admin/config/locales/fi.yml
+++ b/decidim-admin/config/locales/fi.yml
@@ -8,6 +8,7 @@ fi:
       category:
         description: Kuvaus
         name: Nimi
+        parent_id: Isäntä
       feature:
         name: Nimi
         weight: Painoarvo

--- a/decidim-admin/spec/features/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_organization_spec.rb
@@ -35,7 +35,7 @@ describe "Admin manages ogranization", type: :feature do
         fill_in "organization_#{network.downcase}_handler", with: "decidim"
       end
 
-      click_button "Update organization"
+      click_button "Update"
       select "Castellano", from: "Default locale"
       fill_in "Reference prefix", with: "ABC"
       fill_in "Official organization url", with: "http://www.example.com"

--- a/decidim-admin/spec/features/admin_manages_participatory_processes_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_participatory_processes_spec.rb
@@ -82,7 +82,7 @@ describe "Admin manage participatory processes", type: :feature do
     it "update a participatory process without images does not delete them" do
       click_link translated(participatory_process3.title)
       click_processes_menu_link "Info"
-      click_button "Update participatory process"
+      click_button "Update"
 
       within ".callout-wrapper" do
         expect(page).to have_content("successfully")

--- a/decidim-admin/spec/features/static_pages_spec.rb
+++ b/decidim-admin/spec/features/static_pages_spec.rb
@@ -102,11 +102,6 @@ describe "Content pages", type: :feature do
 
         within "table" do
           expect(page).to have_content("Not welcomed anymore")
-          click_link("Not welcomed anymore")
-        end
-
-        within "dl" do
-          expect(page).to have_content("This is the new content")
         end
       end
 

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -16,7 +16,7 @@ en:
         confirm_destroy: Are you sure you want to delete this project?
         destroy: Delete
         edit: Edit
-        new: New %{name}
+        new: New
         preview: Preview
         title: Actions
       admin:
@@ -31,13 +31,13 @@ en:
             success: Project successfully destroyed
           edit:
             title: Edit project
-            update: Update project
+            update: Update
           index:
             finished_orders: Finished orders
             pending_orders: Pending orders
             title: Projects
           new:
-            create: Create project
+            create: Create
             title: New result
           update:
             invalid: There's been a problem updating this project

--- a/decidim-budgets/spec/shared/manage_projects_examples.rb
+++ b/decidim-budgets/spec/shared/manage_projects_examples.rb
@@ -63,7 +63,7 @@ RSpec.shared_examples "manage projects" do
   end
 
   it "creates a new project" do
-    click_link "New Project"
+   click_link "New"
 
     within ".new_project" do
       fill_in_i18n(

--- a/decidim-budgets/spec/shared/manage_projects_examples.rb
+++ b/decidim-budgets/spec/shared/manage_projects_examples.rb
@@ -63,7 +63,7 @@ RSpec.shared_examples "manage projects" do
   end
 
   it "creates a new project" do
-   click_link "New"
+    find(".card-title a.button").click
 
     within ".new_project" do
       fill_in_i18n(

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -154,7 +154,7 @@ module Decidim
       value = object.send(attribute)
       formatted_value = I18n.localize(value, format: :timepicker) if value
       template = ""
-      template += @template.label(@object_name, attribute)
+      template += label(attribute, label_for(attribute))
       template += @template.text_field(@object_name, attribute, options.merge({
         value: formatted_value,
         name: nil,

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -137,7 +137,7 @@ module Decidim
     # datepicker library
     def date_field(attribute, options = {})
       template = ""
-      template += @template.label(@object_name, attribute)
+      template += label(attribute, label_for(attribute))
       template += @template.text_field(@object_name, attribute, options.merge({
         name: nil,
         id: "date_field_#{@object_name}_#{attribute}",

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -51,8 +51,8 @@ en:
           index:
             title: Meetings
           new:
-            create: Create meeting
-            title: Create
+            create: Create 
+            title: Create meeting
           update:
             invalid: There's been a problem updating this meeting
             success: Meeting successfully updated

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -29,7 +29,7 @@ en:
         confirm_destroy: Are you sure you want to delete this meeting?
         destroy: Delete
         edit: Edit
-        new: New %{name}
+        new: New
         preview: Preview
         title: Actions
       admin:
@@ -47,12 +47,12 @@ en:
           destroy:
             success: Meeting successfully deleted
           edit:
-            update: Update meeting
+            update: Update
           index:
             title: Meetings
           new:
             create: Create meeting
-            title: New meeting
+            title: Create
           update:
             invalid: There's been a problem updating this meeting
             success: Meeting successfully updated

--- a/decidim-meetings/spec/shared/manage_meetings_examples.rb
+++ b/decidim-meetings/spec/shared/manage_meetings_examples.rb
@@ -52,7 +52,7 @@ RSpec.shared_examples "manage meetings" do
   end
 
   it "creates a new meeting" do
-    click_link "New"
+    find(".card-title a.button").click
 
     fill_in_i18n(
       :meeting_title,
@@ -166,7 +166,7 @@ RSpec.shared_examples "manage meetings" do
     end
 
     it "creates a new meeting" do
-      click_link "New"
+      find(".card-title a.button").click
 
       fill_in_i18n(
         :meeting_title,

--- a/decidim-meetings/spec/shared/manage_meetings_examples.rb
+++ b/decidim-meetings/spec/shared/manage_meetings_examples.rb
@@ -52,7 +52,7 @@ RSpec.shared_examples "manage meetings" do
   end
 
   it "creates a new meeting" do
-    click_link "New Meeting"
+    click_link "New"
 
     fill_in_i18n(
       :meeting_title,
@@ -166,7 +166,7 @@ RSpec.shared_examples "manage meetings" do
     end
 
     it "creates a new meeting" do
-      click_link "New Meeting"
+      click_link "New"
 
       fill_in_i18n(
         :meeting_title,

--- a/decidim-pages/config/locales/en.yml
+++ b/decidim-pages/config/locales/en.yml
@@ -16,7 +16,7 @@ en:
             body: Body
         pages:
           edit:
-            save: Save page
+            save: Update
             title: Edit page
           update:
             invalid: There's been errors when saving the page.

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -14,7 +14,7 @@ en:
     features:
       proposals:
         actions:
-          create: Create proposals
+          create: Create
           vote: Vote
         name: Proposals
         settings:
@@ -33,7 +33,7 @@ en:
     proposals:
       actions:
         answer: Answer
-        new: Create
+        new: New
         title: Actions
       admin:
         actions:
@@ -44,7 +44,7 @@ en:
         proposal_answers:
           edit:
             accepted: Accepted
-            answer_proposal: Answer proposal
+            answer_proposal: Answer
             rejected: Rejected
             title: Answer for proposal %{title}
         proposals:
@@ -59,8 +59,8 @@ en:
           index:
             title: Proposals
           new:
-            create: Create proposal
-            title: Create
+            create: Create
+            title: Create proposal
       answers:
         accepted: Accepted
         not_answered: Not answered

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -33,7 +33,7 @@ en:
     proposals:
       actions:
         answer: Answer
-        new: New Proposal
+        new: Create
         title: Actions
       admin:
         actions:
@@ -60,7 +60,7 @@ en:
             title: Proposals
           new:
             create: Create proposal
-            title: New proposal
+            title: Create
       answers:
         accepted: Accepted
         not_answered: Not answered

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -47,7 +47,7 @@ describe "Proposals", type: :feature do
           it "can be related to a scope" do
             visit_feature
 
-            click_link "New proposal"
+           click_link "New"
 
             within "form.new_proposal" do
               expect(page).to have_content(/Scope/i)
@@ -63,7 +63,7 @@ describe "Proposals", type: :feature do
           it "cannot be related to a scope" do
             visit_feature
 
-            click_link "New proposal"
+           click_link "New"
 
             within "form.new_proposal" do
               expect(page).not_to have_content("Scope")
@@ -74,7 +74,7 @@ describe "Proposals", type: :feature do
         it "creates a new proposal" do
           visit_feature
 
-          click_link "New proposal"
+         click_link "New"
 
           within ".new_proposal" do
             fill_in :proposal_title, with: "Oriol for president"
@@ -105,7 +105,7 @@ describe "Proposals", type: :feature do
           it "creates a new proposal" do
             visit_feature
 
-            click_link "New proposal"
+           click_link "New"
 
             within ".new_proposal" do
               fill_in :proposal_title, with: "Oriol for president"
@@ -137,7 +137,7 @@ describe "Proposals", type: :feature do
           it "creates a new proposal as a user group" do
             visit_feature
 
-            click_link "New proposal"
+           click_link "New"
 
             within ".new_proposal" do
               fill_in :proposal_title, with: "Oriol for president"
@@ -160,7 +160,7 @@ describe "Proposals", type: :feature do
           context "when geocoding is enabled" do
             let!(:feature) do
               create(:proposal_feature,
-                    :with_creation_enabled,          
+                    :with_creation_enabled,
                     :with_geocoding_enabled,
                     manifest: manifest,
                     participatory_process: participatory_process)
@@ -169,7 +169,7 @@ describe "Proposals", type: :feature do
             it "creates a new proposal as a user group" do
               visit_feature
 
-              click_link "New proposal"
+             click_link "New"
 
               within ".new_proposal" do
                 fill_in :proposal_title, with: "Oriol for president"
@@ -200,7 +200,7 @@ describe "Proposals", type: :feature do
 
           it "should show a modal dialog" do
             visit_feature
-            click_link "New proposal"
+           click_link "New"
             expect(page).to have_content("Authorization required")
           end
         end

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -46,8 +46,7 @@ describe "Proposals", type: :feature do
 
           it "can be related to a scope" do
             visit_feature
-
-           find(".card-title a.button").click
+            click_link "New proposal"
 
             within "form.new_proposal" do
               expect(page).to have_content(/Scope/i)
@@ -62,8 +61,7 @@ describe "Proposals", type: :feature do
 
           it "cannot be related to a scope" do
             visit_feature
-
-           find(".card-title a.button").click
+            click_link "New proposal"
 
             within "form.new_proposal" do
               expect(page).not_to have_content("Scope")
@@ -74,7 +72,7 @@ describe "Proposals", type: :feature do
         it "creates a new proposal" do
           visit_feature
 
-         find(".card-title a.button").click
+          click_link "New proposal"
 
           within ".new_proposal" do
             fill_in :proposal_title, with: "Oriol for president"
@@ -104,8 +102,7 @@ describe "Proposals", type: :feature do
 
           it "creates a new proposal" do
             visit_feature
-
-           find(".card-title a.button").click
+            click_link "New proposal"
 
             within ".new_proposal" do
               fill_in :proposal_title, with: "Oriol for president"
@@ -136,8 +133,7 @@ describe "Proposals", type: :feature do
 
           it "creates a new proposal as a user group" do
             visit_feature
-
-           find(".card-title a.button").click
+            click_link "New proposal"
 
             within ".new_proposal" do
               fill_in :proposal_title, with: "Oriol for president"
@@ -168,8 +164,7 @@ describe "Proposals", type: :feature do
 
             it "creates a new proposal as a user group" do
               visit_feature
-
-             find(".card-title a.button").click
+              click_link "New proposal"
 
               within ".new_proposal" do
                 fill_in :proposal_title, with: "Oriol for president"
@@ -200,7 +195,7 @@ describe "Proposals", type: :feature do
 
           it "should show a modal dialog" do
             visit_feature
-           find(".card-title a.button").click
+            click_link "New proposal"
             expect(page).to have_content("Authorization required")
           end
         end

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -47,7 +47,7 @@ describe "Proposals", type: :feature do
           it "can be related to a scope" do
             visit_feature
 
-           click_link "New"
+           find(".card-title a.button").click
 
             within "form.new_proposal" do
               expect(page).to have_content(/Scope/i)
@@ -63,7 +63,7 @@ describe "Proposals", type: :feature do
           it "cannot be related to a scope" do
             visit_feature
 
-           click_link "New"
+           find(".card-title a.button").click
 
             within "form.new_proposal" do
               expect(page).not_to have_content("Scope")
@@ -74,7 +74,7 @@ describe "Proposals", type: :feature do
         it "creates a new proposal" do
           visit_feature
 
-         click_link "New"
+         find(".card-title a.button").click
 
           within ".new_proposal" do
             fill_in :proposal_title, with: "Oriol for president"
@@ -105,7 +105,7 @@ describe "Proposals", type: :feature do
           it "creates a new proposal" do
             visit_feature
 
-           click_link "New"
+           find(".card-title a.button").click
 
             within ".new_proposal" do
               fill_in :proposal_title, with: "Oriol for president"
@@ -137,7 +137,7 @@ describe "Proposals", type: :feature do
           it "creates a new proposal as a user group" do
             visit_feature
 
-           click_link "New"
+           find(".card-title a.button").click
 
             within ".new_proposal" do
               fill_in :proposal_title, with: "Oriol for president"
@@ -169,7 +169,7 @@ describe "Proposals", type: :feature do
             it "creates a new proposal as a user group" do
               visit_feature
 
-             click_link "New"
+             find(".card-title a.button").click
 
               within ".new_proposal" do
                 fill_in :proposal_title, with: "Oriol for president"
@@ -200,7 +200,7 @@ describe "Proposals", type: :feature do
 
           it "should show a modal dialog" do
             visit_feature
-           click_link "New"
+           find(".card-title a.button").click
             expect(page).to have_content("Authorization required")
           end
         end

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -48,7 +48,7 @@ RSpec.shared_examples "manage proposals" do
           end
 
           it "can be related to a scope" do
-            click_link "New Proposal"
+            click_link "New"
 
             within "form" do
               expect(page).to have_content(/Scope/i)
@@ -56,7 +56,7 @@ RSpec.shared_examples "manage proposals" do
           end
 
           it "creates a new proposal" do
-            click_link "New Proposal"
+            click_link "New"
 
             within ".new_proposal" do
               fill_in :proposal_title, with: "Make decidim great again"
@@ -88,7 +88,7 @@ RSpec.shared_examples "manage proposals" do
           end
 
           it "cannot be related to a scope" do
-            click_link "New Proposal"
+            click_link "New"
 
             within "form" do
               expect(page).not_to have_content(/Scope/i)
@@ -96,7 +96,7 @@ RSpec.shared_examples "manage proposals" do
           end
 
           it "creates a new proposal related to the process scope" do
-            click_link "New Proposal"
+            click_link "New"
 
             within ".new_proposal" do
               fill_in :proposal_title, with: "Make decidim great again"
@@ -128,7 +128,7 @@ RSpec.shared_examples "manage proposals" do
             end
 
             it "creates a new proposal related to the process scope" do
-              click_link "New Proposal"
+              click_link "New"
 
               within ".new_proposal" do
                 fill_in :proposal_title, with: "Make decidim great again"
@@ -198,7 +198,7 @@ RSpec.shared_examples "manage proposals" do
             ca: "La proposta no te sentit"
           )
           choose "Rejected"
-          click_button "Answer proposal"
+          click_button "Answer"
         end
 
         within ".callout-wrapper" do
@@ -219,7 +219,7 @@ RSpec.shared_examples "manage proposals" do
 
         within ".edit_proposal_answer" do
           choose "Accepted"
-          click_button "Answer proposal"
+          click_button "Answer"
         end
 
         within ".callout-wrapper" do
@@ -253,7 +253,7 @@ RSpec.shared_examples "manage proposals" do
 
         within ".edit_proposal_answer" do
           choose "Accepted"
-          click_button "Answer proposal"
+          click_button "Answer"
         end
 
         within ".callout-wrapper" do

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -48,7 +48,7 @@ RSpec.shared_examples "manage proposals" do
           end
 
           it "can be related to a scope" do
-            click_link "New"
+            find(".card-title a.button").click
 
             within "form" do
               expect(page).to have_content(/Scope/i)
@@ -56,7 +56,7 @@ RSpec.shared_examples "manage proposals" do
           end
 
           it "creates a new proposal" do
-            click_link "New"
+            find(".card-title a.button").click
 
             within ".new_proposal" do
               fill_in :proposal_title, with: "Make decidim great again"
@@ -88,7 +88,7 @@ RSpec.shared_examples "manage proposals" do
           end
 
           it "cannot be related to a scope" do
-            click_link "New"
+            find(".card-title a.button").click
 
             within "form" do
               expect(page).not_to have_content(/Scope/i)
@@ -96,7 +96,7 @@ RSpec.shared_examples "manage proposals" do
           end
 
           it "creates a new proposal related to the process scope" do
-            click_link "New"
+            find(".card-title a.button").click
 
             within ".new_proposal" do
               fill_in :proposal_title, with: "Make decidim great again"
@@ -128,7 +128,7 @@ RSpec.shared_examples "manage proposals" do
             end
 
             it "creates a new proposal related to the process scope" do
-              click_link "New"
+              find(".card-title a.button").click
 
               within ".new_proposal" do
                 fill_in :proposal_title, with: "Make decidim great again"

--- a/decidim-results/config/locales/en.yml
+++ b/decidim-results/config/locales/en.yml
@@ -27,7 +27,7 @@ en:
         confirm_destroy: Are you sure you want to delete this result?
         destroy: Delete
         edit: Edit
-        new: New %{name}
+        new: New
         preview: Preview
         title: Actions
       admin:
@@ -42,11 +42,11 @@ en:
             success: Result successfully deleted
           edit:
             title: Edit result
-            update: Update result
+            update: Update
           index:
             title: Results
           new:
-            create: Create result
+            create: Create
             title: New result
           update:
             invalid: There's been a problem updating this result

--- a/decidim-results/spec/shared/manage_results_examples.rb
+++ b/decidim-results/spec/shared/manage_results_examples.rb
@@ -41,7 +41,7 @@ RSpec.shared_examples "manage results" do
   end
 
   it "creates a new result" do
-   click_link "New"
+    find(".card-title a.button").click
 
     within ".new_result" do
       fill_in_i18n(

--- a/decidim-results/spec/shared/manage_results_examples.rb
+++ b/decidim-results/spec/shared/manage_results_examples.rb
@@ -41,7 +41,7 @@ RSpec.shared_examples "manage results" do
   end
 
   it "creates a new result" do
-    click_link "New Result"
+   click_link "New"
 
     within ".new_result" do
       fill_in_i18n(

--- a/decidim-system/config/locales/en.yml
+++ b/decidim-system/config/locales/en.yml
@@ -6,7 +6,7 @@ en:
         confirm_destroy: Are you sure you want to delete this?
         destroy: Destroy
         edit: Edit
-        new: New %{name}
+        new: New
         save: Save
         title: Actions
       admins:
@@ -17,11 +17,11 @@ en:
           success: Admin successfully destroyed
         edit:
           title: Edit admin
-          update: Update admin
+          update: Update
         index:
           title: Admins
         new:
-          create: Create admin
+          create: Create
           title: New admin
         update:
           error: There was an error when updating this admin.


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds several translations missing at some forms in the admin panel, also rephrases some buttons to be shorter and more especific and fix some minor bugs.

I changed also most of the tests that were validating the create action on the admin panel, to find the css button instead of the string "New", so now it's not depending on an exact string anymore.

#### :pushpin: Related Issues
- Fixes #1282 
- Fixes #1267

### :camera: Screenshots (optional)
Shorter buttons example:
![screen shot 2017-04-25 at 11 42 19](https://cloud.githubusercontent.com/assets/953911/25427088/b58a4d84-2a71-11e7-9720-4a4361291584.png)
![screen shot 2017-04-25 at 11 42 37](https://cloud.githubusercontent.com/assets/953911/25427089/b58adc86-2a71-11e7-91ec-c2895e367678.png)

#### :ghost: GIF
![](https://media4.giphy.com/media/AD52cvcgIblfy/giphy.gif)
