### PR TITLE
Regenerate dummy app when rake task is called

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -77,17 +77,15 @@ dummy_app_path = File.expand_path(File.join(dummy_path, "spec", "decidim_dummy_a
 
 desc "Generates a dummy app for testing"
 task :generate_test_app do
-  unless Dir.exists? dummy_app_path
-    Decidim::Generators::DummyGenerator.start(
-      [
-        "--dummy_app_path=#{dummy_app_path}",
-        "--migrate=true",
-        "--quiet"
-      ]
-    )
+  Decidim::Generators::DummyGenerator.start(
+    [
+      "--dummy_app_path=#{dummy_app_path}",
+      "--migrate=true",
+      "--quiet"
+    ]
+  )
 
-    require File.join(dummy_app_path, "config", "application")
-    Rails.application.load_tasks
-    Rake.application["assets:precompile"].invoke
-  end
+  require File.join(dummy_app_path, "config", "application")
+  Rails.application.load_tasks
+  Rake.application["assets:precompile"].invoke
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Since #1284, when we try to generate the dummy app and it already exists, the app is not generated, which forces us to manually remove it. This change was done while trying to cache the dummy app, but since we are not caching it right now it does not make sense to keep it.

This PR brings the old behaviour back.

#### :pushpin: Related Issues
- Related to #1284

#### :clipboard: Subtasks
None