### PR TITLE
Add simple API to register stats

### DIFF
--- a/decidim-budgets/lib/decidim/budgets/feature.rb
+++ b/decidim-budgets/lib/decidim/budgets/feature.rb
@@ -19,6 +19,13 @@ Decidim.register_feature(:budgets) do |feature|
     resource.template = "decidim/budgets/projects/linked_projects"
   end
 
+  feature.register_stat :projects_count do |features, start_at, end_at|
+    projects = Decidim::Budgets::Project.where(feature: features)
+    projects = projects.where("created_at >= ?", start_at) if start_at.present?
+    projects = projects.where("created_at <= ?", end_at) if end_at.present?
+    projects.count
+  end
+
   feature.settings(:global) do |settings|
     settings.attribute :total_budget, type: :integer, default: 100_000_000
     settings.attribute :vote_threshold_percent, type: :integer, default: 70

--- a/decidim-core/app/controllers/decidim/pages_controller.rb
+++ b/decidim-core/app/controllers/decidim/pages_controller.rb
@@ -11,7 +11,8 @@ module Decidim
 
     authorize_resource :public_pages, class: false
     delegate :page, to: :page_finder
-    helper_method :page, :promoted_participatory_processes, :highlighted_participatory_processes, :participatory_processes, :users
+    helper_method :page, :promoted_participatory_processes, :highlighted_participatory_processes, :participatory_processes,
+                  :users, :accepted_proposals_count, :results_count, :proposals_count, :votes_count, :meetings_count
 
     def index
       @pages = current_organization.static_pages.all.to_a.sort do |a, b|
@@ -38,6 +39,32 @@ module Decidim
 
     def highlighted_participatory_processes
       @promoted_processes ||= OrganizationParticipatoryProcesses.new(current_organization) | HighlightedParticipatoryProcesses.new
+    end
+
+    private
+
+    def accepted_proposals_count
+      Decidim.stats_for(:accepted_proposals_count, published_features)
+    end
+
+    def proposals_count
+      Decidim.stats_for(:proposals_count, published_features)
+    end
+
+    def results_count
+      Decidim.stats_for(:results_count, published_features)
+    end
+
+    def votes_count
+      Decidim.stats_for(:votes_count, published_features)
+    end
+
+    def meetings_count
+      Decidim.stats_for(:meetings_count, published_features)
+    end
+
+    def published_features
+      @published_features ||= Feature.where(participatory_process: ParticipatoryProcess.published)
     end
   end
 end

--- a/decidim-core/app/controllers/decidim/pages_controller.rb
+++ b/decidim-core/app/controllers/decidim/pages_controller.rb
@@ -11,8 +11,7 @@ module Decidim
 
     authorize_resource :public_pages, class: false
     delegate :page, to: :page_finder
-    helper_method :page, :promoted_participatory_processes, :highlighted_participatory_processes, :participatory_processes,
-                  :users, :accepted_proposals_count, :results_count, :proposals_count, :votes_count, :meetings_count
+    helper_method :page, :promoted_participatory_processes, :highlighted_participatory_processes, :stats
 
     def index
       @pages = current_organization.static_pages.all.to_a.sort do |a, b|
@@ -22,15 +21,6 @@ module Decidim
 
     def page_finder
       @page_finder ||= Decidim::PageFinder.new(params[:id], current_organization)
-    end
-
-    def users
-      @users ||= Decidim::User.where(organization: current_organization)
-    end
-
-    # This should be deleted once the statistics are done properly.
-    def participatory_processes
-      @processes ||= OrganizationParticipatoryProcesses.new(current_organization) | PublicParticipatoryProcesses.new
     end
 
     def promoted_participatory_processes
@@ -43,28 +33,8 @@ module Decidim
 
     private
 
-    def accepted_proposals_count
-      Decidim.stats_for(:accepted_proposals_count, published_features)
-    end
-
-    def proposals_count
-      Decidim.stats_for(:proposals_count, published_features)
-    end
-
-    def results_count
-      Decidim.stats_for(:results_count, published_features)
-    end
-
-    def votes_count
-      Decidim.stats_for(:votes_count, published_features)
-    end
-
-    def meetings_count
-      Decidim.stats_for(:meetings_count, published_features)
-    end
-
-    def published_features
-      @published_features ||= Feature.where(participatory_process: ParticipatoryProcess.published)
+    def stats
+      @stats ||= HomeStatsPresenter.new(organization: current_organization)
     end
   end
 end

--- a/decidim-core/app/controllers/decidim/pages_controller.rb
+++ b/decidim-core/app/controllers/decidim/pages_controller.rb
@@ -24,7 +24,7 @@ module Decidim
     end
 
     def promoted_participatory_processes
-      @promoted_processes ||= participatory_processes | PromotedParticipatoryProcesses.new
+      @promoted_processes ||= OrganizationParticipatoryProcesses.new(organization) | PublicParticipatoryProcesses.new | PromotedParticipatoryProcesses.new
     end
 
     def highlighted_participatory_processes

--- a/decidim-core/app/controllers/decidim/pages_controller.rb
+++ b/decidim-core/app/controllers/decidim/pages_controller.rb
@@ -24,7 +24,7 @@ module Decidim
     end
 
     def promoted_participatory_processes
-      @promoted_processes ||= OrganizationParticipatoryProcesses.new(organization) | PublicParticipatoryProcesses.new | PromotedParticipatoryProcesses.new
+      @promoted_processes ||= OrganizationParticipatoryProcesses.new(current_organization) | PublicParticipatoryProcesses.new | PromotedParticipatoryProcesses.new
     end
 
     def highlighted_participatory_processes

--- a/decidim-core/app/presenters/decidim/home_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/home_stats_presenter.rb
@@ -1,0 +1,39 @@
+module Decidim
+  class HomeStatsPresenter < Rectify::Presenter
+    attribute :organization, Decidim::Organization
+
+    def users_count
+      Decidim::User.where(organization: organization).count
+    end
+
+    def processes_count
+      (OrganizationParticipatoryProcesses.new(organization) | PublicParticipatoryProcesses.new).count
+    end
+
+    def accepted_proposals_count
+      Decidim.stats_for(:accepted_proposals_count, published_features)
+    end
+
+    def proposals_count
+      Decidim.stats_for(:proposals_count, published_features)
+    end
+
+    def results_count
+      Decidim.stats_for(:results_count, published_features)
+    end
+
+    def votes_count
+      Decidim.stats_for(:votes_count, published_features)
+    end
+
+    def meetings_count
+      Decidim.stats_for(:meetings_count, published_features)
+    end
+
+    private
+
+    def published_features
+      @published_features ||= Feature.where(participatory_process: ParticipatoryProcess.published)
+    end
+  end
+end

--- a/decidim-core/app/presenters/decidim/home_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/home_stats_presenter.rb
@@ -1,22 +1,33 @@
 # frozen_string_literal: true
 module Decidim
+  # A presenter to render statistics in the hoomepage.
   class HomeStatsPresenter < Rectify::Presenter
     attribute :organization, Decidim::Organization
 
+    # Public: Render a collection of primary stats.
     def highlighted
       render_stats(filtered_stats(primary: true))
     end
 
+    # Public: Render a collection of stats that are not primary.
     def not_highlighted
       render_stats(filtered_stats(primary: false))
     end
 
+    # Public: Render the number of users for the current organization.
     def users_count
-      Decidim::User.where(organization: organization).count
+      render_stats_data(
+        :users_count,
+        Decidim::User.where(organization: organization).count
+      )
     end
 
+    # Public: Render the number of published participatory processes for the current organization.
     def processes_count
-      (OrganizationParticipatoryProcesses.new(organization) | PublicParticipatoryProcesses.new).count
+      render_stats_data(
+        :processes_count,
+        (OrganizationParticipatoryProcesses.new(organization) | PublicParticipatoryProcesses.new).count
+      )
     end
 
     private
@@ -24,14 +35,18 @@ module Decidim
     def render_stats(stats = {})
       safe_join(
         stats.map do |name, _stat|
-          content_tag :div, "", class: "home-pam__data" do
-            safe_join([
-                        content_tag(:h4, I18n.t(name, scope: "pages.home.statistics"), class: "home-pam__title"),
-                        content_tag(:span, Decidim.stats_for(name, published_features), class: "home-pam__number #{name}")
-                      ])
-          end
+          render_stats_data(name, Decidim.stats_for(name, published_features))
         end
       )
+    end
+
+    def render_stats_data(name, data)
+      content_tag :div, "", class: "home-pam__data" do
+        safe_join([
+                    content_tag(:h4, I18n.t(name, scope: "pages.home.statistics"), class: "home-pam__title"),
+                    content_tag(:span, " #{data}", class: "home-pam__number #{name}")
+                  ])
+      end
     end
 
     def filtered_stats(filter = {})

--- a/decidim-core/app/presenters/decidim/home_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/home_stats_presenter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Decidim
-  # A presenter to render statistics in the hoomepage.
+  # A presenter to render statistics in the homepage.
   class HomeStatsPresenter < Rectify::Presenter
     attribute :organization, Decidim::Organization
 
@@ -54,7 +54,7 @@ module Decidim
     end
 
     def published_features
-      @published_features ||= Feature.where(participatory_process: ParticipatoryProcess.published)
+      @published_features ||= Feature.where(participatory_process: organization.participatory_processes.published)
     end
   end
 end

--- a/decidim-core/app/presenters/decidim/home_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/home_stats_presenter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Decidim
   class HomeStatsPresenter < Rectify::Presenter
     attribute :organization, Decidim::Organization
@@ -22,19 +23,19 @@ module Decidim
 
     def render_stats(stats = {})
       safe_join(
-        stats.map do |name, _|
-          content_tag :div, '', class: "home-pam__data" do
+        stats.map do |name, _stat|
+          content_tag :div, "", class: "home-pam__data" do
             safe_join([
-              content_tag(:h4, I18n.t(name, scope: "pages.home.statistics"), class: "home-pam__title"),
-              content_tag(:span, Decidim.stats_for(name, published_features), class: "home-pam__number #{name}")
-            ])
+                        content_tag(:h4, I18n.t(name, scope: "pages.home.statistics"), class: "home-pam__title"),
+                        content_tag(:span, Decidim.stats_for(name, published_features), class: "home-pam__number #{name}")
+                      ])
           end
         end
       )
     end
 
     def filtered_stats(filter = {})
-      Decidim.stats.select { |name, stat| stat[:primary] == filter.fetch(:primary, false) }
+      Decidim.stats.select { |_name, stat| stat[:primary] == filter.fetch(:primary, false) }
     end
 
     def published_features

--- a/decidim-core/app/views/pages/home/_statistics.html.erb
+++ b/decidim-core/app/views/pages/home/_statistics.html.erb
@@ -7,14 +7,8 @@
       <div class="columns small-centered mediumlarge-10 large-8">
         <div class="home-pam">
           <div class="home-pam__highlight">
-            <div class="home-pam__data">
-              <h4 class="home-pam__title"><%= t(".users_count") %></h4>
-              <span class="home-pam__number users_count"><%= stats.users_count %></span>
-            </div>
-            <div class="home-pam__data">
-              <h4 class="home-pam__title"><%= t(".processes_count") %></h4>
-              <span class="home-pam__number processes_count"><%= stats.processes_count %></span>
-            </div>
+            <%= stats.users_count %>
+            <%= stats.processes_count %>
           </div>
           <div class="home-pam__highlight">
             <%= stats.highlighted %>

--- a/decidim-core/app/views/pages/home/_statistics.html.erb
+++ b/decidim-core/app/views/pages/home/_statistics.html.erb
@@ -9,35 +9,35 @@
           <div class="home-pam__highlight">
             <div class="home-pam__data">
               <h4 class="home-pam__title"><%= t(".users") %></h4>
-              <span class="home-pam__number users-count"><%= users.count %></span>
+              <span class="home-pam__number users-count"><%= stats.users_count %></span>
             </div>
             <div class="home-pam__data">
               <h4 class="home-pam__title"><%= t(".processes") %></h4>
-              <span class="home-pam__number processes-count"><%= participatory_processes.count %></span>
+              <span class="home-pam__number processes-count"><%= stats.processes_count %></span>
             </div>
           </div>
           <div class="home-pam__highlight">
             <div class="home-pam__data">
               <h4 class="home-pam__title"><%= t(".accepted_proposals") %></h4>
-              <span class="home-pam__number accepted-proposals-count"><%= accepted_proposals_count %></span>
+              <span class="home-pam__number accepted-proposals-count"><%= stats.accepted_proposals_count %></span>
             </div>
             <div class="home-pam__data">
               <h4 class="home-pam__title"><%= t(".results") %></h4>
-              <span class="home-pam__number results-count"><%= results_count %></span>
+              <span class="home-pam__number results-count"><%= stats.results_count %></span>
             </div>
           </div>
           <div class="home-pam__lowlight">
             <div class="home-pam__data">
               <h4 class="home-pam__title"><%= t(".proposals") %></h4>
-              <span class="home-pam__number proposals-count"><%= proposals_count %></span>
+              <span class="home-pam__number proposals-count"><%= stats.proposals_count %></span>
             </div>
             <div class="home-pam__data">
               <h4 class="home-pam__title"><%= t(".votes") %></h4>
-              <span class="home-pam__number votes-count"><%= votes_count %></span>
+              <span class="home-pam__number votes-count"><%= stats.votes_count %></span>
             </div>
             <div class="home-pam__data">
               <h4 class="home-pam__title"><%= t(".meetings") %></h4>
-              <span class="home-pam__number meetings-count"><%= meetings_count %></span>
+              <span class="home-pam__number meetings-count"><%= stats.meetings_count %></span>
             </div>
           </div>
         </div>

--- a/decidim-core/app/views/pages/home/_statistics.html.erb
+++ b/decidim-core/app/views/pages/home/_statistics.html.erb
@@ -8,37 +8,19 @@
         <div class="home-pam">
           <div class="home-pam__highlight">
             <div class="home-pam__data">
-              <h4 class="home-pam__title"><%= t(".users") %></h4>
-              <span class="home-pam__number users-count"><%= stats.users_count %></span>
+              <h4 class="home-pam__title"><%= t(".users_count") %></h4>
+              <span class="home-pam__number users_count"><%= stats.users_count %></span>
             </div>
             <div class="home-pam__data">
-              <h4 class="home-pam__title"><%= t(".processes") %></h4>
-              <span class="home-pam__number processes-count"><%= stats.processes_count %></span>
+              <h4 class="home-pam__title"><%= t(".processes_count") %></h4>
+              <span class="home-pam__number processes_count"><%= stats.processes_count %></span>
             </div>
           </div>
           <div class="home-pam__highlight">
-            <div class="home-pam__data">
-              <h4 class="home-pam__title"><%= t(".accepted_proposals") %></h4>
-              <span class="home-pam__number accepted-proposals-count"><%= stats.accepted_proposals_count %></span>
-            </div>
-            <div class="home-pam__data">
-              <h4 class="home-pam__title"><%= t(".results") %></h4>
-              <span class="home-pam__number results-count"><%= stats.results_count %></span>
-            </div>
+            <%= stats.highlighted %>
           </div>
           <div class="home-pam__lowlight">
-            <div class="home-pam__data">
-              <h4 class="home-pam__title"><%= t(".proposals") %></h4>
-              <span class="home-pam__number proposals-count"><%= stats.proposals_count %></span>
-            </div>
-            <div class="home-pam__data">
-              <h4 class="home-pam__title"><%= t(".votes") %></h4>
-              <span class="home-pam__number votes-count"><%= stats.votes_count %></span>
-            </div>
-            <div class="home-pam__data">
-              <h4 class="home-pam__title"><%= t(".meetings") %></h4>
-              <span class="home-pam__number meetings-count"><%= stats.meetings_count %></span>
-            </div>
+            <%= stats.not_highlighted %>
           </div>
         </div>
       </div>

--- a/decidim-core/app/views/pages/home/_statistics.html.erb
+++ b/decidim-core/app/views/pages/home/_statistics.html.erb
@@ -16,6 +16,30 @@
               <span class="home-pam__number processes-count"><%= participatory_processes.count %></span>
             </div>
           </div>
+          <div class="home-pam__highlight">
+            <div class="home-pam__data">
+              <h4 class="home-pam__title"><%= t(".accepted_proposals") %></h4>
+              <span class="home-pam__number accepted-proposals-count"><%= accepted_proposals_count %></span>
+            </div>
+            <div class="home-pam__data">
+              <h4 class="home-pam__title"><%= t(".results") %></h4>
+              <span class="home-pam__number results-count"><%= results_count %></span>
+            </div>
+          </div>
+          <div class="home-pam__lowlight">
+            <div class="home-pam__data">
+              <h4 class="home-pam__title"><%= t(".proposals") %></h4>
+              <span class="home-pam__number proposals-count"><%= proposals_count %></span>
+            </div>
+            <div class="home-pam__data">
+              <h4 class="home-pam__title"><%= t(".votes") %></h4>
+              <span class="home-pam__number votes-count"><%= votes_count %></span>
+            </div>
+            <div class="home-pam__data">
+              <h4 class="home-pam__title"><%= t(".meetings") %></h4>
+              <span class="home-pam__number meetings-count"><%= meetings_count %></span>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/decidim-core/config/i18n-tasks.yml
+++ b/decidim-core/config/i18n-tasks.yml
@@ -104,6 +104,7 @@ ignore_unused:
   - invisible_captcha.*
   - decidim.participatory_processes.scopes.global
   - decidim.participatory_processes.participatory_process_groups.none
+  - pages.home.statistics.*
 # - 'activerecord.attributes.*'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -351,9 +351,14 @@ en:
         active_step: Active step
         see_all_processes: See all processes
       statistics:
+        accepted_proposals: Accepted proposals
         headline: Current state of %{organization}
+        meetings: Meetings
         processes: Processes
+        proposals: Total proposals
+        results: Results
         users: Users
+        votes: Votes
       sub_hero:
         register: Register
   social_share_button:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -351,14 +351,14 @@ en:
         active_step: Active step
         see_all_processes: See all processes
       statistics:
-        accepted_proposals: Accepted proposals
+        accepted_proposals_count: Accepted proposals
         headline: Current state of %{organization}
-        meetings: Meetings
-        processes: Processes
-        proposals: Total proposals
-        results: Results
-        users: Users
-        votes: Votes
+        meetings_count: Meetings
+        processes_count: Processes
+        proposals_count: Total proposals
+        results_count: Results
+        users_count: Users
+        votes_count: Votes
       sub_hero:
         register: Register
   social_share_button:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -351,11 +351,11 @@ en:
         active_step: Active step
         see_all_processes: See all processes
       statistics:
-        accepted_proposals_count: Accepted proposals
         headline: Current state of %{organization}
         meetings_count: Meetings
         processes_count: Processes
-        proposals_count: Total proposals
+        projects_count: Projects
+        proposals_count: Proposals
         results_count: Results
         users_count: Users
         votes_count: Votes

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -155,4 +155,17 @@ module Decidim
   def self.resource_manifests
     @resource_manifests ||= feature_manifests.flat_map(&:resource_manifests)
   end
+
+  def self.stats
+    @stats ||= {}
+  end
+
+  def self.register_stat(name, block)
+    stats[name] = block
+  end
+
+  def self.stats_for(name, features)
+    return stats[name].call(features) if stats[name].present?
+    raise StandardError.new("Stats '#{name}' is not registered.")
+  end
 end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -166,6 +166,6 @@ module Decidim
 
   def self.stats_for(name, features)
     return stats[name][:block].call(features) if stats[name].present?
-    raise StandardError.new("Stats '#{name}' is not registered.")
+    raise StandardError, "Stats '#{name}' is not registered."
   end
 end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -178,10 +178,12 @@ module Decidim
   #
   # name - The name of the stat
   # features - An array of Decidim::Feature
+  # start_at - A date to filter resources created after it
+  # end_at - A date to filter resources created before it.
   #
   # Returns the result of executing the stats block using the passing features or an error.
-  def self.stats_for(name, features)
-    return stats[name][:block].call(features) if stats[name].present?
+  def self.stats_for(name, features, start_at = nil, end_at = nil)
+    return stats[name][:block].call(features, start_at, end_at) if stats[name].present?
     raise StandardError, "Stats '#{name}' is not registered."
   end
 end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -156,14 +156,30 @@ module Decidim
     @resource_manifests ||= feature_manifests.flat_map(&:resource_manifests)
   end
 
+  # Public: Stores all the registered stats
+  #
+  # Returns a Hash where each key is the name of the registered stat and
+  # the value is another Hash containing some stats properties.
   def self.stats
     @stats ||= {}
   end
 
+  # Public: Register a stat
+  #
+  # name - The name of the stat
+  # options - A hash of options
+  #         * primary: Wether the stat is primary or not.
+  # block - A block that receive the features to filter out the stat.
   def self.register_stat(name, options = {}, block)
     stats[name] = { primary: options.fetch(:primary, false), block: block }
   end
 
+  # Public: Returns a number returned by executing the corresponding block.
+  #
+  # name - The name of the stat
+  # features - An array of Decidim::Feature
+  #
+  # Returns the result of executing the stats block using the passing features or an error.
   def self.stats_for(name, features)
     return stats[name][:block].call(features) if stats[name].present?
     raise StandardError, "Stats '#{name}' is not registered."

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -160,12 +160,12 @@ module Decidim
     @stats ||= {}
   end
 
-  def self.register_stat(name, block)
-    stats[name] = block
+  def self.register_stat(name, options = {}, block)
+    stats[name] = { primary: options.fetch(:primary, false), block: block }
   end
 
   def self.stats_for(name, features)
-    return stats[name].call(features) if stats[name].present?
+    return stats[name][:block].call(features) if stats[name].present?
     raise StandardError.new("Stats '#{name}' is not registered.")
   end
 end

--- a/decidim-core/lib/decidim/feature_manifest.rb
+++ b/decidim-core/lib/decidim/feature_manifest.rb
@@ -144,8 +144,8 @@ module Decidim
     # block - A block that receive the features to filter out the stat.
     #
     # Returns nothing.
-    def register_stat(name, &block)
-      Decidim.register_stat(name, block)
+    def register_stat(name, options = {}, &block)
+      Decidim.register_stat(name, options, block)
     end
   end
 end

--- a/decidim-core/lib/decidim/feature_manifest.rb
+++ b/decidim-core/lib/decidim/feature_manifest.rb
@@ -141,6 +141,8 @@ module Decidim
     # These stats can be used anywhere in the application using Decidim.stats_for method.
     #
     # name - The name of the stat
+    # options - A hash of options
+    #         * primary: Wether the stat is primary or not.
     # block - A block that receive the features to filter out the stat.
     #
     # Returns nothing.

--- a/decidim-core/lib/decidim/feature_manifest.rb
+++ b/decidim-core/lib/decidim/feature_manifest.rb
@@ -135,5 +135,17 @@ module Decidim
     def resource_manifests
       @resource_manifests ||= []
     end
+
+    # Public: Registers a stat inside a feature manifest.
+    #
+    # These stats can be used anywhere in the application using Decidim.stats_for method.
+    #
+    # name - The name of the stat
+    # block - A block that receive the features to filter out the stat.
+    #
+    # Returns nothing.
+    def register_stat(name, &block)
+      Decidim.register_stat(name, block)
+    end
   end
 end

--- a/decidim-core/spec/features/homepage_spec.rb
+++ b/decidim-core/spec/features/homepage_spec.rb
@@ -127,11 +127,11 @@ describe "Homepage", type: :feature do
         end
 
         it "should have the correct values for the statistics" do
-          within ".users-count" do
+          within ".users_count" do
             expect(page).to have_content("4")
           end
 
-          within ".processes-count" do
+          within ".processes_count" do
             expect(page).to have_content("2")
           end
         end

--- a/decidim-core/spec/lib/feature_manifest_spec.rb
+++ b/decidim-core/spec/lib/feature_manifest_spec.rb
@@ -54,5 +54,19 @@ module Decidim
         end
       end
     end
+
+    describe "register_stat" do
+      before do
+        allow(Decidim).to receive(:register_stat)
+      end
+
+      it "calls Decidim.register_stat with the same arguments" do
+        options = { primary: true }
+        subject.register_stat :foo, options do
+          10
+        end
+        expect(Decidim).to have_received(:register_stat).with(:foo, options, instance_of(Proc))
+      end
+    end
   end
 end

--- a/decidim-core/spec/lib/stats_spec.rb
+++ b/decidim-core/spec/lib/stats_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe Decidim do
+  before :each do
+    Decidim.instance_variable_set(:@stats, {})
+  end
+
+  describe "register_stat" do
+    it "registers a stat by its name and sets primary to false by default" do
+      Decidim.register_stat :foo, Proc.new { 10 }
+      expect(Decidim.stats[:foo][:primary]).to be_falsy
+    end
+
+    it "registers a primary stat if the primary option is enabled" do
+      Decidim.register_stat :bar, { primary: true }, Proc.new { 10 }
+      expect(Decidim.stats[:bar][:primary]).to be_truthy
+    end
+  end
+
+  describe "stats_for" do
+    before do
+      Decidim.register_stat :foo, Proc.new { 10 }
+    end
+
+    it "returns the value registered" do
+      expect(Decidim.stats_for :foo, []).to eq(10)
+    end
+
+    it "passes arguments to the block executed" do
+      block = Proc.new { 10 }
+      features = [:foo, :bar]
+      start_at = Time.current
+      end_at = Time.current + 1.day
+      expect(block).to receive(:call).with(features, start_at, end_at)
+      Decidim.register_stat :bar, block
+      Decidim.stats_for :bar, features, start_at, end_at
+    end
+
+    it "raises an error if the stat is not registered" do
+      expect {
+        Decidim.stats_for :bar, []
+      }.to raise_error StandardError
+    end
+  end
+end

--- a/decidim-core/spec/presenters/decidim/home_stats_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/home_stats_presenter_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  describe HomeStatsPresenter do
+    subject { described_class.new(organization: organization) }
+
+    let!(:organization) { create(:organization) }
+
+    before do
+      allow(Decidim).to receive(:stats).and_return({
+        foo: { primary: true, block: Proc.new { 10 } },
+        bar: { primary: true, block: Proc.new { 20 } },
+        foz: { primary: false, block: Proc.new { 30 } },
+        baz: { primary: false, block: Proc.new { 40 } }
+      })
+      I18n.backend.store_translations(:en, {
+        pages: {
+          home: {
+            statistics: {
+              foo: "Foo",
+              bar: "Bar",
+              foz: "Foz",
+              baz: "Baz"
+            }
+          }
+        }
+      })
+    end
+
+    describe "#highlighted" do
+      it "renders a collection of primary stats" do
+        expect(subject.highlighted).to eq("<div class=\"home-pam__data\"><h4 class=\"home-pam__title\">Foo</h4><span class=\"home-pam__number foo\"> 10</span></div><div class=\"home-pam__data\"><h4 class=\"home-pam__title\">Bar</h4><span class=\"home-pam__number bar\"> 20</span></div>")
+      end
+    end
+
+    describe "#not_highlighted" do
+      it "renders a collection of not primary stats" do
+        expect(subject.not_highlighted).to eq("<div class=\"home-pam__data\"><h4 class=\"home-pam__title\">Foz</h4><span class=\"home-pam__number foz\"> 30</span></div><div class=\"home-pam__data\"><h4 class=\"home-pam__title\">Baz</h4><span class=\"home-pam__number baz\"> 40</span></div>")
+      end
+    end
+
+    describe "#users_count" do
+      before do
+        create_list(:user, 3, organization: organization)
+      end
+
+      it "renders the number of users for this organization" do
+        expect(subject.users_count).to eq("<div class=\"home-pam__data\"><h4 class=\"home-pam__title\">Users</h4><span class=\"home-pam__number users_count\"> 3</span></div>")
+      end
+    end
+
+    describe "#processes_count" do
+      before do
+        create_list(:participatory_process, 3, organization: organization)
+        ParticipatoryProcess.last.update_attributes(published_at: false)
+      end
+
+      it "renders the number of published processes for this organization" do
+        expect(subject.processes_count).to eq("<div class=\"home-pam__data\"><h4 class=\"home-pam__title\">Processes</h4><span class=\"home-pam__number processes_count\"> 2</span></div>")
+      end
+    end
+  end
+end

--- a/decidim-meetings/lib/decidim/meetings/feature.rb
+++ b/decidim-meetings/lib/decidim/meetings/feature.rb
@@ -16,8 +16,11 @@ Decidim.register_feature(:meetings) do |feature|
     resource.template = "decidim/meetings/meetings/linked_meetings"
   end
 
-  feature.register_stat :meetings_count do |features|
-    Decidim::Meetings::Meeting.where(feature: features).count
+  feature.register_stat :meetings_count do |features, start_at, end_at|
+    meetings = Decidim::Meetings::Meeting.where(feature: features)
+    meetings = meetings.where("created_at >= ?", start_at) if start_at.present?
+    meetings = meetings.where("created_at <= ?", end_at) if end_at.present?
+    meetings.count
   end
 
   feature.seeds do

--- a/decidim-meetings/lib/decidim/meetings/feature.rb
+++ b/decidim-meetings/lib/decidim/meetings/feature.rb
@@ -16,6 +16,10 @@ Decidim.register_feature(:meetings) do |feature|
     resource.template = "decidim/meetings/meetings/linked_meetings"
   end
 
+  feature.register_stat :meetings_count do |features|
+    Decidim::Meetings::Meeting.where(feature: features).count
+  end
+
   feature.seeds do
     Decidim::ParticipatoryProcess.all.each do |process|
       next unless process.steps.any?

--- a/decidim-proposals/app/queries/decidim/proposals/filtered_proposals.rb
+++ b/decidim-proposals/app/queries/decidim/proposals/filtered_proposals.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+module Decidim
+  module Proposals
+    # A class used to find comments for a commentable resource
+    class FilteredProposals < Rectify::Query
+      # Syntactic sugar to initialize the class and return the queried objects.
+      #
+      # features - An array of Decidim::Feature
+      # start_at - A date to filter resources created after it
+      # end_at - A date to filter resources created before it.
+      def self.for(features, start_at, end_at)
+        new(features, start_at, end_at).query
+      end
+
+      # Initializes the class.
+      #
+      # features - An array of Decidim::Feature
+      # start_at - A date to filter resources created after it
+      # end_at - A date to filter resources created before it.
+      def initialize(features, start_at, end_at)
+        @features = features
+        @start_at = start_at
+        @end_at = end_at
+      end
+
+      # Finds the Proposals scoped to an array of features and filtered
+      # by a range of dates.
+      def query
+        proposals = Decidim::Proposals::Proposal.where(feature: @features)
+        proposals = proposals.where("created_at >= ?", @start_at) if @start_at.present?
+        proposals = proposals.where("end_at <= ?", @end_at) if @end_at.present?
+        proposals
+      end
+    end
+  end
+end

--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -37,11 +37,7 @@ Decidim.register_feature(:proposals) do |feature|
     resource.template = "decidim/proposals/proposals/linked_proposals"
   end
 
-  feature.register_stat :accepted_proposals_count, primary: true do |features, start_at, end_at|
-    Decidim::Proposals::FilteredProposals.for(features, start_at, end_at).accepted.count
-  end
-
-  feature.register_stat :proposals_count do |features, start_at, end_at|
+  feature.register_stat :proposals_count, primary: true do |features, start_at, end_at|
     Decidim::Proposals::FilteredProposals.for(features, start_at, end_at).count
   end
 

--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -37,6 +37,19 @@ Decidim.register_feature(:proposals) do |feature|
     resource.template = "decidim/proposals/proposals/linked_proposals"
   end
 
+  feature.register_stat :proposals_count do |features|
+    Decidim::Proposals::Proposal.where(feature: features).count
+  end
+
+  feature.register_stat :accepted_proposals_count do |features|
+    Decidim::Proposals::Proposal.where(feature: features).accepted.count
+  end
+
+  feature.register_stat :votes_count do |features|
+    proposals = Decidim::Proposals::Proposal.where(feature: features)
+    Decidim::Proposals::ProposalVote.where(proposal: proposals).count
+  end
+
   feature.seeds do
     Decidim::ParticipatoryProcess.all.each do |process|
       next unless process.steps.any?

--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -37,16 +37,16 @@ Decidim.register_feature(:proposals) do |feature|
     resource.template = "decidim/proposals/proposals/linked_proposals"
   end
 
-  feature.register_stat :accepted_proposals_count, primary: true do |features|
-    Decidim::Proposals::Proposal.where(feature: features).accepted.count
+  feature.register_stat :accepted_proposals_count, primary: true do |features, start_at, end_at|
+    Decidim::Proposals::FilteredProposals.for(features, start_at, end_at).accepted.count
   end
 
-  feature.register_stat :proposals_count do |features|
-    Decidim::Proposals::Proposal.where(feature: features).count
+  feature.register_stat :proposals_count do |features, start_at, end_at|
+    Decidim::Proposals::FilteredProposals.for(features, start_at, end_at).count
   end
 
-  feature.register_stat :votes_count do |features|
-    proposals = Decidim::Proposals::Proposal.where(feature: features)
+  feature.register_stat :votes_count do |features, start_at, end_at|
+    proposals = Decidim::Proposals::FilteredProposals.for(features, start_at, end_at)
     Decidim::Proposals::ProposalVote.where(proposal: proposals).count
   end
 

--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -37,12 +37,12 @@ Decidim.register_feature(:proposals) do |feature|
     resource.template = "decidim/proposals/proposals/linked_proposals"
   end
 
-  feature.register_stat :proposals_count do |features|
-    Decidim::Proposals::Proposal.where(feature: features).count
+  feature.register_stat :accepted_proposals_count, primary: true do |features|
+    Decidim::Proposals::Proposal.where(feature: features).accepted.count
   end
 
-  feature.register_stat :accepted_proposals_count do |features|
-    Decidim::Proposals::Proposal.where(feature: features).accepted.count
+  feature.register_stat :proposals_count do |features|
+    Decidim::Proposals::Proposal.where(feature: features).count
   end
 
   feature.register_stat :votes_count do |features|

--- a/decidim-results/lib/decidim/results/feature.rb
+++ b/decidim-results/lib/decidim/results/feature.rb
@@ -16,8 +16,11 @@ Decidim.register_feature(:results) do |feature|
     resource.template = "decidim/results/results/linked_results"
   end
 
-  feature.register_stat :results_count, primary: true do |features|
-    Decidim::Results::Result.where(feature: features).count
+  feature.register_stat :results_count, primary: true do |features, start_at, end_at|
+    results = Decidim::Results::Result.where(feature: features)
+    results = results.where("created_at >= ?", start_at) if start_at.present?
+    results = results.where("created_at <= ?", end_at) if end_at.present?
+    results.count
   end
 
   feature.settings(:global) do |settings|

--- a/decidim-results/lib/decidim/results/feature.rb
+++ b/decidim-results/lib/decidim/results/feature.rb
@@ -16,6 +16,10 @@ Decidim.register_feature(:results) do |feature|
     resource.template = "decidim/results/results/linked_results"
   end
 
+  feature.register_stat :results_count do |features|
+    Decidim::Results::Result.where(feature: features).count
+  end
+
   feature.settings(:global) do |settings|
     settings.attribute :comments_enabled, type: :boolean, default: true
   end

--- a/decidim-results/lib/decidim/results/feature.rb
+++ b/decidim-results/lib/decidim/results/feature.rb
@@ -16,7 +16,7 @@ Decidim.register_feature(:results) do |feature|
     resource.template = "decidim/results/results/linked_results"
   end
 
-  feature.register_stat :results_count do |features|
+  feature.register_stat :results_count, primary: true do |features|
     Decidim::Results::Result.where(feature: features).count
   end
 

--- a/docs/how_to_create_a_plugin.md
+++ b/docs/how_to_create_a_plugin.md
@@ -166,16 +166,61 @@ module Decidim
 end
 ```
 
-9. Replace `Rakefile` with:
+9. Add `lib/decidim/<engine_name>/feature.rb` with this:
+
+```ruby
+# frozen_string_literal: true
+
+require_dependency "decidim/features/namer"
+
+Decidim.register_feature(:<engine_name>) do |feature|
+  feature.engine = Decidim::<EngineName>::Engine
+  feature.admin_engine = Decidim::<EngineName>::AdminEngine
+  feature.icon = "decidim/<engine_name>/icon.svg"
+
+  feature.on(:before_destroy) do |instance|
+    # Code executed before removing the feature
+  end
+
+  # These actions permissions can be configured in the admin panel
+  feature.actions = %w()
+
+  feature.settings(:global) do |settings|
+    # Add your global settings
+    # Available types: :integer, :boolean
+    # settings.attribute :vote_limit, type: :integer, default: 0
+  end
+
+  feature.settings(:step) do |settings|
+    # Add your settings per step
+  end
+
+  feature.register_resource do |resource|
+    # Register a optional resource that can be references from other resources.
+    # resource.model_class_name = "Decidim::<EngineName>::<ResourceName>"
+    # resource.template = "decidim/<engine_name>/<resource_view_folder>/linked_<resource_name_plural>"
+  end
+
+  feature.register_stat :some_stat do |features, start_at, end_at|
+    # Register some stat number to the application
+  end
+
+  feature.seeds do
+    # Add some seeds for this feature
+  end
+end
+```
+
+10. Replace `Rakefile` with:
 
 ```ruby
 # frozen_string_literal: true
 require "decidim/common_rake"
 ```
 
-10. Remove `license` and change `README`
+11. Remove `license` and change `README`
 
-11. Add `spec/spec_helper.rb` with:
+12. Add `spec/spec_helper.rb` with:
 
 ```ruby
 ENV["ENGINE_NAME"] = File.dirname(File.dirname(__FILE__)).split("/").last


### PR DESCRIPTION
#### :tophat: What? Why?

Add a simple API to register stats for each feature. The API works as follows:

1. Register a stat from a feature manifest like this:

```ruby
feature.register_stat :results_count, primary: true do |features, start_at, end_at|
  # Some logic to fetch the number
end
```

2. Retrieve the value anywhere like this:

```ruby
# Fetch the number of results
Decidim.stats_for :results_count, features
# Decidim.stats_for :results_count, features, 1.week.ago, Time.current
```
I used the API myself to register a few stats and print them in the homepage. I created `HomeStatsPresenter` to render all registered stats but it can be overrided in any Decidim installation.

#### :pushpin: Related Issues
- Related to #422 

#### :clipboard: Subtasks
- [x] Basic implementation
- [x] Refactor pages controller (use Presenters maybe)
- [x] Testing and documentation
- [x] Add date range optional argument

### :camera: Screenshots (optional)
![image](https://cloud.githubusercontent.com/assets/106021/25655791/80b26792-2ff6-11e7-9b45-e6f41b9fb438.png)

#### :ghost: GIF
![](https://media3.giphy.com/media/SGdTdzWTCLya4/giphy.gif)
