### PR TITLE
Add generate_test_app to decidim namespace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
             yarn
       - run:
           name: Generate test app
-          command: bundle exec rake generate_test_app
+          command: bundle exec rake decidim:generate_test_app
       - run:
           name: Run tests
           command: |

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,8 @@ require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require_relative "lib/generators/decidim/app_generator"
 require_relative "lib/generators/decidim/docker_generator"
-require_relative "./decidim-dev/lib/generators/decidim/dummy_generator"
+
+load "decidim-core/lib/tasks/decidim_tasks.rake"
 
 DECIDIM_GEMS = %w(core system admin api pages meetings proposals comments results budgets dev).freeze
 
@@ -12,7 +13,7 @@ RSpec::Core::RakeTask.new(:spec)
 task default: :spec
 
 desc "Runs all tests in all Decidim engines"
-task test_all: [:generate_test_app] do
+task test_all: ['decidim:generate_test_app'] do
   DECIDIM_GEMS.each do |gem_name|
     Dir.chdir("#{File.dirname(__FILE__)}/decidim-#{gem_name}") do
       sh "rake"
@@ -70,22 +71,4 @@ end
 desc "Install yarn dependencies"
 task "yarn:install" do
   sh "yarn"
-end
-
-dummy_path = Dir.pwd
-dummy_app_path = File.expand_path(File.join(dummy_path, "spec", "decidim_dummy_app"))
-
-desc "Generates a dummy app for testing"
-task :generate_test_app do
-  Decidim::Generators::DummyGenerator.start(
-    [
-      "--dummy_app_path=#{dummy_app_path}",
-      "--migrate=true",
-      "--quiet"
-    ]
-  )
-
-  require File.join(dummy_app_path, "config", "application")
-  Rails.application.load_tasks
-  Rake.application["assets:precompile"].invoke
 end

--- a/decidim-core/lib/tasks/decidim_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_tasks.rake
@@ -3,8 +3,24 @@
 # task :decidim do
 #   # Task goes here
 # end
-
+require_relative "../../../decidim-dev/lib/generators/decidim/dummy_generator"
+require 'byebug'
 namespace :decidim do
   desc "Install migrations from Decidim to the app."
   task upgrade: ["railties:install:migrations"]
+
+  desc "Generates a dummy app for testing"
+  task :generate_test_app do
+    dummy_app_path = File.expand_path(File.join(Dir.pwd, "spec", "decidim_dummy_app"))
+
+    Decidim::Generators::DummyGenerator.start(
+      [
+        "--dummy_app_path=#{dummy_app_path}",
+        "--migrate=true",
+        "--quiet"
+      ]
+    )
+
+    sh "cd #{dummy_app_path} && bundle exec rake assets:precompile"
+  end
 end

--- a/decidim-core/lib/tasks/decidim_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_tasks.rake
@@ -4,7 +4,7 @@
 #   # Task goes here
 # end
 require_relative "../../../decidim-dev/lib/generators/decidim/dummy_generator"
-require 'byebug'
+
 namespace :decidim do
   desc "Install migrations from Decidim to the app."
   task upgrade: ["railties:install:migrations"]

--- a/decidim-dev/lib/decidim/dev/test/base_spec_helper.rb
+++ b/decidim-dev/lib/decidim/dev/test/base_spec_helper.rb
@@ -35,7 +35,7 @@ require "#{File.dirname(__FILE__)}/rspec_support/feature.rb"
 begin
   require "#{dummy_app_path}/config/environment"
 rescue LoadError
-  puts "Could not load dummy application. Please ensure you have run `bundle exec rake generate_test_app`"
+  puts "Could not load dummy application. Please ensure you have run `bundle exec rake decidim:generate_test_app`"
   puts "Tried to load it from #{dummy_app_path}"
   exit(-1)
 end

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -5,7 +5,7 @@
 You need to create a dummy application to run your tests. Run the following command in the decidim root's folder:
 
 ```bash
-bundle exec rake generate_test_app
+bundle exec rake decidim:generate_test_app
 ```
 
 ## Running the test suite

--- a/run_ci.sh
+++ b/run_ci.sh
@@ -6,6 +6,6 @@ if [ "$GEM" == "." ]; then
   bundle exec rspec spec
 else
   yarn test -- $GEM
-  bundle exec rake generate_test_app
+  bundle exec rake decidim:generate_test_app
   cd $GEM && bundle exec rake
 fi


### PR DESCRIPTION
#### :tophat: What? Why?

We need to run the task `generate_test_app` from a decidim installation so the rake task must be present in gem tasks.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None

#### :ghost: GIF
None
