### PR TITLE
Typo

### DIFF
--- a/decidim-admin/spec/shared/manage_processes_examples.rb
+++ b/decidim-admin/spec/shared/manage_processes_examples.rb
@@ -29,7 +29,7 @@ RSpec.shared_examples "manage processes examples" do
     end
   end
 
-  it "updates an participatory_process" do
+  it "updates a participatory_process" do
     click_link translated(participatory_process.title)
 
     fill_in_i18n(


### PR DESCRIPTION
#### :tophat: What? Why?

What? Just a little grammar fix. Why? Because I can't help fixing it once I see it... :relaxed: 

#### :ghost: GIF

![turtle](https://cloud.githubusercontent.com/assets/2887858/25442895/9fa7e8b8-2a7c-11e7-9d58-5f11ec49993c.gif)
