### PR TITLE
Set dummy app constant name manually

### DIFF
--- a/decidim-dev/lib/generators/decidim/dummy_generator.rb
+++ b/decidim-dev/lib/generators/decidim/dummy_generator.rb
@@ -34,6 +34,7 @@ module Decidim
       def create_dummy_app
         Decidim::Generators::AppGenerator.start [
           dummy_app_path,
+          "--app_const_base=DummyApplication",
           "--skip_gemfile",
           "--skip-bundle",
           "--skip-git",

--- a/lib/generators/decidim/app_generator.rb
+++ b/lib/generators/decidim/app_generator.rb
@@ -46,6 +46,9 @@ module Decidim
       class_option :migrate, type: :boolean, default: false,
                              desc: "Run migrations after installing decidim"
 
+      class_option :app_const_base, type: :string,
+                                    desc: "The application constant name"
+
       def database_yml
         template "database.yml.erb", "config/database.yml", force: true
       end
@@ -78,6 +81,10 @@ module Decidim
           "--migrate=#{options[:migrate]}",
           "--app_name=#{app_name}"
         ]
+      end
+
+      def app_const_base
+        options["app_const_base"] || super
       end
 
       def add_ignore_uploads


### PR DESCRIPTION
#### :tophat: What? Why?

We are having problems to generate a test app in decidim installations because the generator is using the current folder as a application constant name. i.e. **decidim-barcelona** generates a **DecidimBarcelona** constant.

The generator complains when the constant already exists so I'm overriding it to use **DummyApplication** instead.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None

#### :ghost: GIF
None
