### PR TITLE
Decouple decidim generator task from core

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ require_relative "lib/generators/decidim/app_generator"
 require_relative "lib/generators/decidim/docker_generator"
 
 load "decidim-core/lib/tasks/decidim_tasks.rake"
+load "decidim-dev/lib/tasks/test_app.rake"
 
 DECIDIM_GEMS = %w(core system admin api pages meetings proposals comments results budgets dev).freeze
 

--- a/decidim-core/lib/tasks/decidim_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_tasks.rake
@@ -1,26 +1,5 @@
 # frozen_string_literal: true
-# desc "Explaining what the task does"
-# task :decidim do
-#   # Task goes here
-# end
-require_relative "../../../decidim-dev/lib/generators/decidim/dummy_generator"
-
 namespace :decidim do
   desc "Install migrations from Decidim to the app."
   task upgrade: ["railties:install:migrations"]
-
-  desc "Generates a dummy app for testing"
-  task :generate_test_app do
-    dummy_app_path = File.expand_path(File.join(Dir.pwd, "spec", "decidim_dummy_app"))
-
-    Decidim::Generators::DummyGenerator.start(
-      [
-        "--dummy_app_path=#{dummy_app_path}",
-        "--migrate=true",
-        "--quiet"
-      ]
-    )
-
-    sh "cd #{dummy_app_path} && bundle exec rake assets:precompile"
-  end
 end

--- a/decidim-dev/lib/decidim/dev.rb
+++ b/decidim-dev/lib/decidim/dev.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "letter_opener_web"
+require "decidim/dev/railtie"
+require "generators/decidim/dummy_generator"
 
 module Decidim
   # Decidim::Dev holds all the convenience logic and libraries to be able to

--- a/decidim-dev/lib/decidim/dev.rb
+++ b/decidim-dev/lib/decidim/dev.rb
@@ -2,7 +2,6 @@
 
 require "letter_opener_web"
 require "decidim/dev/railtie"
-require "generators/decidim/dummy_generator"
 
 module Decidim
   # Decidim::Dev holds all the convenience logic and libraries to be able to

--- a/decidim-dev/lib/decidim/dev/railtie.rb
+++ b/decidim-dev/lib/decidim/dev/railtie.rb
@@ -1,0 +1,13 @@
+module Decidim
+  module Dev
+    class Railtie < Rails::Railtie
+      railtie_name :decidim_dev
+
+      rake_tasks do
+        Dir[File.join(File.dirname(__FILE__), "../../tasks/*.rake")].each do |file|
+          load file
+        end
+      end
+    end
+  end
+end

--- a/decidim-dev/lib/tasks/dummy.rake
+++ b/decidim-dev/lib/tasks/dummy.rake
@@ -1,0 +1,16 @@
+namespace :decidim do
+  desc "Generates a dummy app for testing"
+  task :generate_test_app do
+    dummy_app_path = File.expand_path(File.join(Dir.pwd, "spec", "decidim_dummy_app"))
+
+    Decidim::Generators::DummyGenerator.start(
+      [
+        "--dummy_app_path=#{dummy_app_path}",
+        "--migrate=true",
+        "--quiet"
+      ]
+    )
+
+    sh "cd #{dummy_app_path} && bundle exec rake assets:precompile"
+  end
+end

--- a/decidim-dev/lib/tasks/test_app.rake
+++ b/decidim-dev/lib/tasks/test_app.rake
@@ -1,3 +1,5 @@
+require "generators/decidim/dummy_generator"
+
 namespace :decidim do
   desc "Generates a dummy app for testing"
   task :generate_test_app do


### PR DESCRIPTION
#### :tophat: What? Why?
This decouples decidim's dummy generator task from the core so apps without `decidim-dev` work.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/3ohzdVNNaM06SLVCak/giphy.gif)
