### PR TITLE
Reinstate date format at locales.

### DIFF
--- a/decidim-admin/config/locales/ca.yml
+++ b/decidim-admin/config/locales/ca.yml
@@ -521,4 +521,4 @@ ca:
           title: Usuaris
   time:
     formats:
-      timepicker: "%d / %m / %Y %H:%M"
+      timepicker: "%d/%m/%Y %H:%M"

--- a/decidim-admin/config/locales/es.yml
+++ b/decidim-admin/config/locales/es.yml
@@ -521,4 +521,4 @@ es:
           title: Usuarios
   time:
     formats:
-      timepicker: "%d / %m / %Y %H:%M"
+      timepicker: "%d/%m/%Y %H:%M"


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fis the issue with the meetins timepickers, recovering the correct format for dates on spanish and catalan locales.yml: `timepicker: "%d/%m/%Y %H:%M"`

We need to check why this was changed to `timepicker: "%d / %m / %Y %H:%M"`

#### :ghost: GIF
![](https://media0.giphy.com/media/ehfWmij1MrqjS/giphy.gif)
