### PR TITLE
Don't autorun i18n specs when requiring test helper

### DIFF
--- a/decidim-dev/lib/decidim/dev/common_rake.rb
+++ b/decidim-dev/lib/decidim/dev/common_rake.rb
@@ -2,5 +2,7 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
-RSpec::Core::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.rspec_opts = "--pattern **/*_spec.rb,#{__dir__}/test/i18n_spec.rb"
+end
 task default: [:spec]

--- a/decidim-dev/lib/decidim/dev/test/base_spec_helper.rb
+++ b/decidim-dev/lib/decidim/dev/test/base_spec_helper.rb
@@ -45,4 +45,3 @@ Dir["#{engine_spec_dir}/support/**/*.rb"].each { |f| require f }
 Dir["#{engine_spec_dir}/shared/**/*.rb"].each { |f| require f }
 
 require_relative "spec_helper"
-require_relative "i18n_spec"


### PR DESCRIPTION
#### :tophat: What? Why?

I'm getting some local test failures. To investigate, it's useful to run the failing specs in isolation. At the moment, the i18n quality specs (common for all gems) get always run whenever you require the test helper. This change fixes that.

This is a bit faster (no a very big difference but would keep growing as the repo grows), but also less confusing (my first though was "why 4 specs get run if I'm only running one??").

#### :pushpin: Related Issues
_None_

#### :clipboard: Subtasks
_None_

### :camera: Screenshots (optional)

#### Before
![before](https://cloud.githubusercontent.com/assets/2887858/25488582/c60855da-2b3d-11e7-83e0-f83ecdcab701.png)

#### After
![after](https://cloud.githubusercontent.com/assets/2887858/25488438/609e8be2-2b3d-11e7-86a0-cbd0a1f5f891.png)

#### :ghost: GIF
![begnini](https://cloud.githubusercontent.com/assets/2887858/25488366/359da3d8-2b3d-11e7-892d-3f2329e26e03.gif)
