### PR TITLE
Fix date time picker

### DIFF
--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -136,14 +136,15 @@ module Decidim
     # Public: Override so the date fields are rendered using foundation
     # datepicker library
     def date_field(attribute, options = {})
+      value = object.send(attribute)
       template = ""
       template += label(attribute, label_for(attribute))
       template += @template.text_field(@object_name, attribute, options.merge({
         name: nil,
         id: "date_field_#{@object_name}_#{attribute}",
-        data: { datepicker: '', startdate: object.send(attribute) }
+        data: { datepicker: '', startdate: value }
       }))
-      template += @template.hidden_field(@object_name, attribute)
+      template += @template.hidden_field(@object_name, attribute, value: value)
       template += error_and_help_text(attribute, options)
       template.html_safe
     end
@@ -161,7 +162,7 @@ module Decidim
         id: "datetime_field_#{@object_name}_#{attribute}",
         data: { datepicker: '', timepicker: '' }
       }))
-      template += @template.hidden_field(@object_name, attribute)
+      template += @template.hidden_field(@object_name, attribute, value: value)
       template += error_and_help_text(attribute, options)
       template.html_safe
     end

--- a/decidim-core/vendor/assets/javascripts/form_datepicker.js.es6
+++ b/decidim-core/vendor/assets/javascripts/form_datepicker.js.es6
@@ -20,7 +20,7 @@
         leftArrow: '<<',
         rightArrow: '>>'
       }).on('changeDate', (ev) => {
-        $(ev.target).siblings('input').val(exports.moment.utc(ev.date));
+        $(ev.target).siblings('input').val(exports.moment(ev.date));
       });
     });
   };


### PR DESCRIPTION
#### :tophat: What? Why?

This is fixing two issues related to the date picker:

- The JS code was assuming the date was in UTC, this is wrong since the users set the date times in their timezone.

- The form builder wasn't setting the current value at the hidden field, so when resubmitting the form the value was lost.