### PR TITLE
Codecov improvements

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,85 +1,19 @@
-codecov:
-  branch: master
-  bot: null
-  notify:
-    after_n_builds: 
+---
 
 coverage:
   precision: 2
   round: down
-  range: "70...100"
-
-  notify:
-    slack:
-      default:
-        url: null
-        threshold: null
-        branches: null
-        attachments: "sunburst, diff"
-
-    hipchat:
-      default:
-        url: null
-        notify: no
-        threshold: null
-        branches: null
-        card: yes
-        only_pulls: null
-        message: null
-
-    gitter:
-      default:
-        url: null
-        threshold: null
-        branches: null
-        message: null
-
-    webhook:
-      default:
-        url: null
-        threshold: null
-        branches: null
-        only_pulls: null
-
-    irc:
-      default:
-        server: null
-        channel: null
-        branches: null
-        threshold: null
-        message: null
+  range: 70...100
 
   status:
-    project:
-      default:
-        base: pr
-        target: auto
-        threshold: 0.5%
-        branches: null
+    project: true
 
     patch:
       default:
-        only_pulls: true
-        base: pr
-        target: auto
         target: 50%
-        branches: null
 
-    changes:
-      default:
-        branches: null
-
-  ignore:
-  - "decidim-*/spec/*"
-  - "spec/*"
-  - "decidim-*/lib/**/*/test/*"
-  - "lib/**/*/test/*"
-  - "bundle.js"
-  - "vendor/*"
-  - "node_modules/*"
-  - ".bundle/*"
+    changes: false
 
 comment:
-  layout: "header, diff, changes, sunburst, uncovered, tree"
-  branches: null
+  layout: "header, diff"
   behavior: default

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -140,9 +140,13 @@ module Decidim
       value = object.send(attribute)
       template = ""
       template += label(attribute, label_for(attribute))
-      template += @template.text_field(@object_name, attribute, options.merge(name: nil,
-                                                                              id: "date_field_#{@object_name}_#{attribute}",
-                                                                              data: { datepicker: "", startdate: value }))
+      template += @template.text_field(
+        @object_name,
+        attribute,
+        options.merge(name: nil,
+                      id: "date_field_#{@object_name}_#{attribute}",
+                      data: { datepicker: "", startdate: value })
+      )
       template += @template.hidden_field(@object_name, attribute, value: value)
       template += error_and_help_text(attribute, options)
       template.html_safe
@@ -155,10 +159,14 @@ module Decidim
       formatted_value = I18n.localize(value, format: :timepicker) if value
       template = ""
       template += label(attribute, label_for(attribute))
-      template += @template.text_field(@object_name, attribute, options.merge(value: formatted_value,
-                                                                              name: nil,
-                                                                              id: "datetime_field_#{@object_name}_#{attribute}",
-                                                                              data: { datepicker: "", timepicker: "" }))
+      template += @template.text_field(
+        @object_name,
+        attribute,
+        options.merge(value: formatted_value,
+                      name: nil,
+                      id: "datetime_field_#{@object_name}_#{attribute}",
+                      data: { datepicker: "", timepicker: "" })
+      )
       template += @template.hidden_field(@object_name, attribute, value: value)
       template += error_and_help_text(attribute, options)
       template.html_safe


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes our codecov configuration.

__Previous configuration__

Previous configuration was invalid, so the default codecov config plus whatever "team settings" we have setup is what has been used so far. You can check this with the following command, that fails with the previous file.

```
curl --data-binary @codecov.yml https://codecov.io/validate
```

__New setup__

What I did was to copy over [codecov's default configuration](https://github.com/codecov/support/blob/master/codecov.yml) because:

* We seem happy with it (nobody has complained).
* We like explicit configuration (the file was there).

The only deviation from this is the required "diff coverage" for the check to pass. The default is the global coverage percentage of the project, which at the moment is ~95%. I changed it to 50% because:

* I find ~95% too much for a required check. If any PR changes an uncovered line (a style change or simple refactoring, for example), the check will most likely fail unless the size of the diff is very big.
* The original file had this already set to 50%. It was just not applied because the file was invalid.

__How to check this__

To prove the changes, I added style changes on 2 lines (1 covered, 1 uncovered) in https://github.com/deivid-rodriguez/decidim/commit/4a5f0638416cf339445bddf931d21d21383c5bab, so that the "diff coverage" is 50%. The new configuration should be green against these changes.

However, it is not, the PR don't seem to pick up any changes in the `codecov.yml` file. I think this can be because of two reasons:

* You have `strict_yaml_branch: master` configured in your team settings (https://docs.codecov.io/docs/codecov-yaml#section-restricting-changes).

* Codecov just ignores changes in `codecov.yml` when they don't originate in the main repository but come from a fork.

So to prove the changes, I added them in my own fork. You can see [this sample PR](https://github.com/deivid-rodriguez/decidim#2) in my fork where the codecov status is green even with the 50% covered patch.

#### :pushpin: Related Issues
- Related to deivid-rodriguez/decidim#2.

#### :ghost: GIF
![cat2](https://cloud.githubusercontent.com/assets/2887858/25586397/8885b2f8-2e75-11e7-93f0-a5702c08a4ff.gif)