### PR TITLE
Evaluate `maximum_attachment_size` at require time

### DIFF
--- a/decidim-admin/app/forms/decidim/admin/organization_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_form.rb
@@ -33,10 +33,10 @@ module Decidim
       validates :default_locale, inclusion: { in: :available_locales }
 
       validates :official_img_header,
-                file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } },
+                file_size: { less_than_or_equal_to: Decidim.maximum_attachment_size },
                 file_content_type: { allow: ["image/jpeg", "image/png"] }
       validates :official_img_footer,
-                file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } },
+                file_size: { less_than_or_equal_to: Decidim.maximum_attachment_size },
                 file_content_type: { allow: ["image/jpeg", "image/png"] }
 
       private

--- a/decidim-admin/app/forms/decidim/admin/participatory_process_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_process_form.rb
@@ -35,8 +35,8 @@ module Decidim
 
       validate :slug, :slug_uniqueness
 
-      validates :hero_image, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } }, file_content_type: { allow: ["image/jpeg", "image/png"] }
-      validates :banner_image, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } }, file_content_type: { allow: ["image/jpeg", "image/png"] }
+      validates :hero_image, file_size: { less_than_or_equal_to: Decidim.maximum_attachment_size }, file_content_type: { allow: ["image/jpeg", "image/png"] }
+      validates :banner_image, file_size: { less_than_or_equal_to: Decidim.maximum_attachment_size }, file_content_type: { allow: ["image/jpeg", "image/png"] }
 
       def scope
         @scope ||= current_organization.scopes.where(id: scope_id).first

--- a/decidim-admin/app/forms/decidim/admin/participatory_process_group_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_process_group_form.rb
@@ -17,7 +17,7 @@ module Decidim
 
       validates :name, :description, translatable_presence: true
 
-      validates :hero_image, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } }, file_content_type: { allow: ["image/jpeg", "image/png"] }
+      validates :hero_image, file_size: { less_than_or_equal_to: Decidim.maximum_attachment_size }, file_content_type: { allow: ["image/jpeg", "image/png"] }
     end
   end
 end

--- a/decidim-admin/spec/forms/participatory_process_form_spec.rb
+++ b/decidim-admin/spec/forms/participatory_process_form_spec.rb
@@ -69,8 +69,8 @@ module Decidim
 
       context "when hero_image is too big" do
         before do
-          allow(Decidim).to receive(:maximum_attachment_size).and_return(5.megabytes)
-          expect(subject.hero_image).to receive(:size).twice.and_return(6.megabytes)
+          an_amount_too_large = (Decidim.maximum_attachment_size + 1).megabytes
+          expect(subject.hero_image).to receive(:size).twice.and_return(an_amount_too_large)
         end
 
         it { is_expected.not_to be_valid }
@@ -78,8 +78,8 @@ module Decidim
 
       context "when banner_image is too big" do
         before do
-          allow(Decidim).to receive(:maximum_attachment_size).and_return(5.megabytes)
-          expect(subject.banner_image).to receive(:size).twice.and_return(6.megabytes)
+          an_amount_too_large = (Decidim.maximum_attachment_size + 1).megabytes
+          expect(subject.banner_image).to receive(:size).twice.and_return(an_amount_too_large)
         end
 
         it { is_expected.not_to be_valid }

--- a/decidim-admin/spec/forms/participatory_process_group_form_spec.rb
+++ b/decidim-admin/spec/forms/participatory_process_group_form_spec.rb
@@ -48,8 +48,8 @@ module Decidim
 
       context "when hero_image is too big" do
         before do
-          allow(Decidim).to receive(:maximum_attachment_size).and_return(5.megabytes)
-          expect(subject.hero_image).to receive(:size).and_return(6.megabytes)
+          an_amount_too_large = (Decidim.maximum_attachment_size + 1).megabytes
+          expect(subject.hero_image).to receive(:size).and_return(an_amount_too_large)
         end
 
         it { is_expected.not_to be_valid }

--- a/decidim-core/app/models/decidim/attachment.rb
+++ b/decidim-core/app/models/decidim/attachment.rb
@@ -6,7 +6,7 @@ module Decidim
     belongs_to :attached_to, polymorphic: true
 
     validates :file, :attached_to, :content_type, presence: true
-    validates :file, file_size: { less_than_or_equal_to: ->(_attachment) { Decidim.maximum_attachment_size } }
+    validates :file, file_size: { less_than_or_equal_to: Decidim.maximum_attachment_size }
     mount_uploader :file, Decidim::AttachmentUploader
 
     # Whether this attachment is a photo or not.

--- a/decidim-core/spec/models/decidim/attachment_spec.rb
+++ b/decidim-core/spec/models/decidim/attachment_spec.rb
@@ -14,8 +14,8 @@ module Decidim
     describe "validations" do
       context "when the file is too big" do
         before do
-          allow(Decidim).to receive(:maximum_attachment_size).and_return(5.megabytes)
-          expect(subject.file).to receive(:size).and_return(6.megabytes)
+          an_amount_too_large = (Decidim.maximum_attachment_size + 1).megabytes
+          expect(subject.file).to receive(:size).and_return(an_amount_too_large)
         end
 
         it { is_expected.not_to be_valid }


### PR DESCRIPTION
#### :tophat: What? Why?

While investigating how code coverage works, I noticed some "unnecessarily" uncovered lambdas. I don't think we need this dynamic-ness. You normally use this when the validation is dependent on validation time or when it depends on the record being validated. Since it's not the case here, I think we can skip the complexity.

#### :ghost: GIF
![ronaldo](https://cloud.githubusercontent.com/assets/2887858/25586900/e7b36700-2e77-11e7-9863-73fbdceacdca.gif)
