### PR TITLE
Remove skip_before_filter deprecation warnings

### DIFF
--- a/decidim-api/app/controllers/decidim/api/application_controller.rb
+++ b/decidim-api/app/controllers/decidim/api/application_controller.rb
@@ -3,7 +3,7 @@ module Decidim
   module Api
     # Base controller for `decidim-api`. All other controllers inherit from this.
     class ApplicationController < ::DecidimController
-      skip_before_filter :verify_authenticity_token
+      skip_before_action :verify_authenticity_token
       include NeedsOrganization
     end
   end

--- a/decidim-core/app/controllers/decidim/widgets_controller.rb
+++ b/decidim-core/app/controllers/decidim/widgets_controller.rb
@@ -3,7 +3,7 @@
 module Decidim
   class WidgetsController < Decidim::ApplicationController
     skip_authorization_check only: :show
-    skip_before_filter :verify_authenticity_token
+    skip_before_action :verify_authenticity_token
     after_action :allow_iframe, only: :show
 
     layout "decidim/widget"


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes some deprecation warnings form Rails 5.1. 

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None