### PR TITLE
Don't autorun i18n specs when requiring test helper

### DIFF
--- a/decidim-dev/lib/decidim/dev/common_rake.rb
+++ b/decidim-dev/lib/decidim/dev/common_rake.rb
@@ -2,5 +2,7 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
-RSpec::Core::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.rspec_opts = "--pattern **/*_spec.rb,#{__dir__}/test/i18n_spec.rb"
+end
 task default: [:spec]

--- a/decidim-dev/lib/decidim/dev/common_rake.rb
+++ b/decidim-dev/lib/decidim/dev/common_rake.rb
@@ -3,6 +3,8 @@ require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec) do |t|
-  t.rspec_opts = "--pattern **/*_spec.rb,#{__dir__}/test/i18n_spec.rb"
+  # The i18n_spec part needs to go first or it won't be include. It seems like a
+  # bug in RSpec to me... https://github.com/rspec/rspec-core/issues/2418
+  t.rspec_opts = "--pattern #{__dir__}/test/i18n_spec.rb,**/*_spec.rb"
 end
 task default: [:spec]

--- a/decidim-dev/lib/decidim/dev/test/base_spec_helper.rb
+++ b/decidim-dev/lib/decidim/dev/test/base_spec_helper.rb
@@ -45,4 +45,3 @@ Dir["#{engine_spec_dir}/support/**/*.rb"].each { |f| require f }
 Dir["#{engine_spec_dir}/shared/**/*.rb"].each { |f| require f }
 
 require_relative "spec_helper"
-require_relative "i18n_spec"


### PR DESCRIPTION
#### :tophat: What? Why?

This is just #1305 with a different name so that circle CI can handle it. 

#### :pushpin: Related Issues
- Related to #1305.

#### :clipboard: Subtasks
_None_

#### :ghost: GIF
![comaneci](https://cloud.githubusercontent.com/assets/2887858/25617604/7dd5418a-2f19-11e7-88bd-db547f56b515.gif)
