### PR TITLE
Remove SIMPLECOV env variable from TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
     - BUNDLE_PATH="$HOME/.bundle"
     - PHANTOMJS_VERSION=2.1.1
     - PHANTOMJS_BIN="$HOME/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64/bin/phantomjs"
-    - SIMPLECOV=true
   matrix:
     - GEM=. DB=postgres
     - GEM=decidim-admin DB=postgres


### PR DESCRIPTION
#### :tophat: What? Why?
coming from https://github.com/decidim/decidim/pull/1321#issuecomment-298628697, it disables code coverage on TravisCI since we're relying more on CircleCI as our main test suite runner.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None