### PR TITLE
Make date(time) pickers work in any timezone

### DIFF
--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -138,6 +138,7 @@ module Decidim
     # datepicker library
     def date_field(attribute, options = {})
       value = object.send(attribute)
+      iso_value = value.strftime("%Y-%m-%dT%H:%M:%S") if value
       template = ""
       template += label(attribute, label_for(attribute))
       template += @template.text_field(
@@ -147,7 +148,7 @@ module Decidim
                       id: "date_field_#{@object_name}_#{attribute}",
                       data: { datepicker: "", startdate: value })
       )
-      template += @template.hidden_field(@object_name, attribute, value: value)
+      template += @template.hidden_field(@object_name, attribute, value: iso_value)
       template += error_and_help_text(attribute, options)
       template.html_safe
     end
@@ -156,7 +157,10 @@ module Decidim
     # datepicker library
     def datetime_field(attribute, options = {})
       value = object.send(attribute)
-      formatted_value = I18n.localize(value, format: :timepicker) if value
+      if value
+        iso_value = value.strftime("%Y-%m-%dT%H:%M:%S")
+        formatted_value = I18n.localize(value, format: :timepicker)
+      end
       template = ""
       template += label(attribute, label_for(attribute))
       template += @template.text_field(
@@ -167,7 +171,7 @@ module Decidim
                       id: "datetime_field_#{@object_name}_#{attribute}",
                       data: { datepicker: "", timepicker: "" })
       )
-      template += @template.hidden_field(@object_name, attribute, value: value)
+      template += @template.hidden_field(@object_name, attribute, value: iso_value)
       template += error_and_help_text(attribute, options)
       template.html_safe
     end

--- a/decidim-core/vendor/assets/javascripts/form_datepicker.js.es6
+++ b/decidim-core/vendor/assets/javascripts/form_datepicker.js.es6
@@ -20,7 +20,9 @@
         leftArrow: '<<',
         rightArrow: '>>'
       }).on('changeDate', (ev) => {
-        $(ev.target).siblings('input').val(exports.moment(ev.date));
+        let newDate = exports.moment.utc(ev.date).format('YYYY-MM-DDTHH:mm:ss');
+
+        $(ev.target).siblings('input').val(newDate);
       });
     });
   };


### PR DESCRIPTION
#### :tophat: What? Why?

Fixes datetime pickers when the user is in a different timezone from the app. And it also gets me closer to green tests locally :). Follows up on the discussion in https://github.com/decidim/decidim/pull/1307.

Instead of messing with timezones, I implemented what I think it's a simpler solution. Just send the dates without timezones, so they are correctly interpreted by the server as "local".

#### :pushpin: Related Issues
- Related to #1307.

#### :ghost: GIF
![trenza](https://cloud.githubusercontent.com/assets/2887858/25661693/fe742166-2fe7-11e7-864c-750ba1961d4c.gif)
