### PR TITLE
Add root commentable to comments

### DIFF
--- a/decidim-comments/app/commands/decidim/comments/create_comment.rb
+++ b/decidim-comments/app/commands/decidim/comments/create_comment.rb
@@ -57,8 +57,8 @@ module Decidim
       end
 
       def root_commentable(commentable)
-        return commentable unless commentable.is_a? Decidim::Comments::Comment
-        root_commentable commentable.commentable
+        return commentable.root_commentable if commentable.is_a? Decidim::Comments::Comment
+        commentable
       end
     end
   end

--- a/decidim-comments/app/commands/decidim/comments/create_comment.rb
+++ b/decidim-comments/app/commands/decidim/comments/create_comment.rb
@@ -57,7 +57,7 @@ module Decidim
       end
 
       def root_commentable(commentable)
-        return commentable unless commentable.kind_of? Decidim::Comments::Comment
+        return commentable unless commentable.is_a? Decidim::Comments::Comment
         root_commentable commentable.commentable
       end
     end

--- a/decidim-comments/app/commands/decidim/comments/create_comment.rb
+++ b/decidim-comments/app/commands/decidim/comments/create_comment.rb
@@ -34,6 +34,7 @@ module Decidim
       def create_comment
         @comment = Comment.create!(author: @author,
                                    commentable: @commentable,
+                                   root_commentable: root_commentable(@commentable),
                                    body: form.body,
                                    alignment: form.alignment,
                                    decidim_user_group_id: form.user_group_id)
@@ -53,6 +54,11 @@ module Decidim
 
       def same_author?
         @author == @commentable.author
+      end
+
+      def root_commentable(commentable)
+        return commentable unless commentable.kind_of? Decidim::Comments::Comment
+        root_commentable commentable.commentable
       end
     end
   end

--- a/decidim-comments/app/models/decidim/comments/comment.rb
+++ b/decidim-comments/app/models/decidim/comments/comment.rb
@@ -18,6 +18,7 @@ module Decidim
       MAX_DEPTH = 3
 
       belongs_to :commentable, foreign_key: "decidim_commentable_id", foreign_type: "decidim_commentable_type", polymorphic: true
+      belongs_to :root_commentable, foreign_key: "decidim_root_commentable_id", foreign_type: "decidim_root_commentable_type", polymorphic: true
       has_many :up_votes, -> { where(weight: 1) }, foreign_key: "decidim_comment_id", class_name: CommentVote, dependent: :destroy
       has_many :down_votes, -> { where(weight: -1) }, foreign_key: "decidim_comment_id", class_name: CommentVote, dependent: :destroy
 
@@ -48,12 +49,6 @@ module Decidim
       # Returns a bool value to indicate if the condition is truthy or not
       def down_voted_by?(user)
         down_votes.any? { |vote| vote.author == user }
-      end
-
-      # Public: Returns the commentable object of the parent comment
-      def root_commentable
-        return commentable if depth.zero?
-        commentable.root_commentable
       end
 
       # Public: Overrides the `reported_content` Reportable concern method.

--- a/decidim-comments/app/models/decidim/comments/comment.rb
+++ b/decidim-comments/app/models/decidim/comments/comment.rb
@@ -22,7 +22,7 @@ module Decidim
       has_many :up_votes, -> { where(weight: 1) }, foreign_key: "decidim_comment_id", class_name: CommentVote, dependent: :destroy
       has_many :down_votes, -> { where(weight: -1) }, foreign_key: "decidim_comment_id", class_name: CommentVote, dependent: :destroy
 
-      validates :author, :commentable, :body, presence: true
+      validates :author, :commentable, :root_commentable, :body, presence: true
       validates :depth, numericality: { greater_than_or_equal_to: 0 }
       validates :alignment, inclusion: { in: [0, 1, -1] }
 

--- a/decidim-comments/app/models/decidim/comments/seed.rb
+++ b/decidim-comments/app/models/decidim/comments/seed.rb
@@ -17,6 +17,7 @@ module Decidim
           random = rand(Decidim::User.count)
           Comment.create(
             commentable: resource,
+            root_commentable: resource,
             body: ::Faker::Lorem.sentence,
             author: Decidim::User.where(organization: organization).offset(random).first
           )

--- a/decidim-comments/db/migrate/20170504085413_add_root_commentable_to_comments.rb
+++ b/decidim-comments/db/migrate/20170504085413_add_root_commentable_to_comments.rb
@@ -1,0 +1,31 @@
+module Decidim
+  module Comments
+    class Comment < ApplicationRecord
+      # Public: Returns the commentable object of the parent comment
+      def root_commentable
+        return commentable if depth.zero?
+        commentable.root_commentable
+      end
+    end
+  end
+end
+
+class AddRootCommentableToComments < ActiveRecord::Migration[5.0]
+  def change
+    # 1. Add root_commentable fields
+    change_table :decidim_comments_comments do |t|
+      t.references :decidim_root_commentable, polymorphic: true, index: { name: "decidim_comments_comment_root_commentable" }
+    end
+
+    # 2. Store root_commentable data
+    Decidim::Comments::Comment.find_each do |comment|
+      root_commentable = comment.depth.zero? ? comment.commentable : comment.root_commentable
+      comment.root_commentable = root_commentable
+      comment.save
+    end
+
+    # 3. Set root_commentable fields null constraint
+    change_column :decidim_comments_comments, :decidim_root_commentable_id, :integer, null: false
+    change_column :decidim_comments_comments, :decidim_root_commentable_type, :string, null: false
+  end
+end

--- a/decidim-comments/db/seeds.rb
+++ b/decidim-comments/db/seeds.rb
@@ -6,6 +6,7 @@
 #   Decidim::Comments::Comment.create!(
 #     author: author,
 #     commentable: commentable,
+#     root_commentable: commentable,
 #     body: Faker::Lorem.paragraph
 #   )
 # end

--- a/decidim-comments/lib/decidim/comments/test/factories.rb
+++ b/decidim-comments/lib/decidim/comments/test/factories.rb
@@ -6,6 +6,7 @@ FactoryGirl.define do
   factory :comment, class: "Decidim::Comments::Comment" do
     author { build(:user, organization: commentable.organization) }
     commentable { build(:dummy_resource) }
+    root_commentable { commentable }
     body { Faker::Lorem.paragraph }
   end
 

--- a/decidim-comments/spec/commands/create_comment_spec.rb
+++ b/decidim-comments/spec/commands/create_comment_spec.rb
@@ -55,6 +55,7 @@ module Decidim
             expect(Comment).to receive(:create!).with({
               author: author,
               commentable: commentable,
+              root_commentable: commentable,
               body: body,
               alignment: alignment,
               decidim_user_group_id: user_group_id
@@ -108,6 +109,11 @@ module Decidim
 
           context "and the comment is a reply" do
             let (:commentable) { create(:comment, commentable: dummy_resource) }
+
+            it "stores the root commentable" do
+              command.call
+              expect(Comment.last.root_commentable).to eq(dummy_resource)
+            end
 
             it "sends an email to the author of the parent comment" do
               expect(CommentNotificationMailer)

--- a/decidim-comments/spec/models/comment_spec.rb
+++ b/decidim-comments/spec/models/comment_spec.rb
@@ -6,7 +6,7 @@ module Decidim
     describe Comment do
       let!(:commentable) { create(:dummy_resource) }
       let!(:comment) { create(:comment, commentable: commentable) }
-      let!(:replies) { 3.times.map { create(:comment, commentable: comment) } }
+      let!(:replies) { 3.times.map { create(:comment, commentable: comment, root_commentable: commentable) } }
       let!(:up_vote) { create(:comment_vote, :up_vote, comment: comment) }
       let!(:down_vote) { create(:comment_vote, :down_vote, comment: comment) }
 
@@ -21,6 +21,10 @@ module Decidim
 
       it "has an associated commentable" do
         expect(subject.commentable).to eq(commentable)
+      end
+
+      it "has an associated commentable" do
+        expect(subject.root_commentable).to eq(commentable)
       end
 
       it "has a up_votes association returning comment votes with weight 1" do
@@ -81,14 +85,6 @@ module Decidim
 
         it "should return false if the given user has not downvoted the comment" do
           expect(subject.down_voted_by?(user)).to be_falsy
-        end
-      end
-
-      describe "#root_commentable" do
-        let(:reply) { create(:comment, commentable: subject) }
-
-        it "returns the commentable object from the parent comment" do
-          expect(reply.root_commentable).to eq(subject.commentable)
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

Adds a `root_commentable` association to `Comment`. This can be useful to count comments and replies for a particular resource.

⚠️  **Warning** ⚠️  This PR includes a time consuming migration. Proceed carefully.

#### :pushpin: Related Issues
- Related to #1326 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
N/A

#### :ghost: GIF
![](https://media0.giphy.com/media/RD5uDx4RcRVSg/giphy.gif)
