### PR TITLE
Remove permissions links if feature doesn't have actions

### DIFF
--- a/decidim-admin/app/assets/stylesheets/decidim/admin/extra/_action-icon.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/extra/_action-icon.scss
@@ -1,0 +1,7 @@
+.table-list__actions {
+  .action-icon {
+    &.action-icon--disabled {
+      color: rgba($muted, .3);
+    }
+  }
+}

--- a/decidim-admin/app/views/decidim/admin/features/_feature.html.erb
+++ b/decidim-admin/app/views/decidim/admin/features/_feature.html.erb
@@ -25,7 +25,11 @@
     <% end %>
 
     <% if can? :update, feature %>
-      <%= icon_link_to "key", edit_participatory_process_feature_permissions_path(feature_id: feature), t("actions.permissions", scope: "decidim.admin"), class: "action-icon--permissions" %>
+      <% if feature.manifest.actions.empty? %>
+        <%= icon "key", class: "action-icon action-icon--disabled" %>
+      <% else %>
+        <%= icon_link_to "key", edit_participatory_process_feature_permissions_path(feature_id: feature), t("actions.permissions", scope: "decidim.admin"), class: "action-icon--permissions" %>
+      <% end %>
     <% end %>
 
     <%= icon_link_to "circle-x", url_for(action: :destroy, id: feature, controller: "features"), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete %>


### PR DESCRIPTION
#### :tophat: What? Why?

If a feature doesn't have actions to configure its permissions the link should not be active. I replaced the link with an icon with a class `.action-icon--disabled`.

I added the css to the extra folder since it's not included in the original https://github.com/decidim/design-admin

#### :pushpin: Related Issues
- Fixes #1304 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![image](https://cloud.githubusercontent.com/assets/106021/25707690/9d8fcadc-30e4-11e7-8d2b-6a6f0c47a38c.png)

#### :ghost: GIF
![](https://media1.giphy.com/media/3boPPdHk2ueo8/giphy.gif)
