### PR TITLE
Locale sanity

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,11 +25,20 @@ task test_all: ["decidim:generate_test_app"] do
 end
 
 desc "Pushes a new build for each gem."
-task release_all: [:webpack] do
+task release_all: [:check_locale_completeness, :webpack] do
   sh "rake release"
   DECIDIM_GEMS.each do |gem_name|
     Dir.chdir("#{File.dirname(__FILE__)}/decidim-#{gem_name}") do
       sh "rake release"
+    end
+  end
+end
+
+desc "Makes sure all official locales are complete and clean."
+task :check_locale_completeness do
+  DECIDIM_GEMS.each do |gem_name|
+    Dir.chdir("#{File.dirname(__FILE__)}/decidim-#{gem_name}") do
+      system({ "ENFORCED_LOCALES" => "en,ca,es" }, "rspec spec/i18n_spec.rb")
     end
   end
 end

--- a/decidim-admin/config/i18n-tasks.yml
+++ b/decidim-admin/config/i18n-tasks.yml
@@ -70,7 +70,7 @@ search:
   # only: ["*.rb", "*.html.slim"]
 
   ## If `strict` is `false`, guess usages such as t("categories.#{category}.title"). The default is `true`.
-  # strict: true
+  strict: false
 
   ## Multiple scanners can be used. Their results are merged.
   ## The options specified above are passed down to each scanner. Per-scanner options can be specified as well.

--- a/decidim-admin/config/i18n-tasks.yml
+++ b/decidim-admin/config/i18n-tasks.yml
@@ -2,8 +2,7 @@
 
 # The "main" locale.
 base_locale: en
-## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
-locales: [en]
+
 ## Reporting locale, default: en. Available: en, ru.
 # internal_locale: en
 

--- a/decidim-admin/spec/i18n_spec.rb
+++ b/decidim-admin/spec/i18n_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "decidim/dev/test/i18n_shared_examples"
+
+RSpec.describe "I18n sanity" do
+  include_examples "I18n sanity"
+end

--- a/decidim-api/spec/i18n_spec.rb
+++ b/decidim-api/spec/i18n_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "decidim/dev/test/i18n_shared_examples"
+
+RSpec.describe "I18n sanity" do
+  include_examples "I18n sanity"
+end

--- a/decidim-budgets/config/i18n-tasks.yml
+++ b/decidim-budgets/config/i18n-tasks.yml
@@ -6,3 +6,6 @@ ignore_unused:
 - "decidim.features.budgets.actions.*"
 - "activemodel.attributes.project.*"
 - "decidim.resource_links.*"
+
+search:
+  strict: false

--- a/decidim-budgets/config/i18n-tasks.yml
+++ b/decidim-budgets/config/i18n-tasks.yml
@@ -1,5 +1,5 @@
 base_locale: en
-locales: [en]
+
 ignore_unused:
 - "decidim.features.budgets.name"
 - "decidim.features.budgets.settings.*"

--- a/decidim-budgets/spec/i18n_spec.rb
+++ b/decidim-budgets/spec/i18n_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "decidim/dev/test/i18n_shared_examples"
+
+RSpec.describe "I18n sanity" do
+  include_examples "I18n sanity"
+end

--- a/decidim-comments/config/i18n-tasks.yml
+++ b/decidim-comments/config/i18n-tasks.yml
@@ -72,7 +72,7 @@ search:
   # only: ["*.rb", "*.html.slim"]
 
   ## If `strict` is `false`, guess usages such as t("categories.#{category}.title"). The default is `true`.
-  # strict: true
+  strict: false
 
   ## Multiple scanners can be used. Their results are merged.
   ## The options specified above are passed down to each scanner. Per-scanner options can be specified as well.

--- a/decidim-comments/config/i18n-tasks.yml
+++ b/decidim-comments/config/i18n-tasks.yml
@@ -2,8 +2,7 @@
 
 # The "main" locale.
 base_locale: en
-## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
-locales: [en]
+
 ## Reporting locale, default: en. Available: en, ru.
 # internal_locale: en
 

--- a/decidim-comments/spec/i18n_spec.rb
+++ b/decidim-comments/spec/i18n_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "decidim/dev/test/i18n_shared_examples"
+
+RSpec.describe "I18n sanity" do
+  include_examples "I18n sanity"
+end

--- a/decidim-core/config/i18n-tasks.yml
+++ b/decidim-core/config/i18n-tasks.yml
@@ -70,7 +70,7 @@ search:
   # only: ["*.rb", "*.html.slim"]
 
   ## If `strict` is `false`, guess usages such as t("categories.#{category}.title"). The default is `true`.
-  # strict: true
+  strict: false
 
   ## Multiple scanners can be used. Their results are merged.
   ## The options specified above are passed down to each scanner. Per-scanner options can be specified as well.

--- a/decidim-core/config/i18n-tasks.yml
+++ b/decidim-core/config/i18n-tasks.yml
@@ -2,8 +2,7 @@
 
 # The "main" locale.
 base_locale: en
-## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
-locales: [en]
+
 ## Reporting locale, default: en. Available: en, ru.
 # internal_locale: en
 

--- a/decidim-core/spec/i18n_spec.rb
+++ b/decidim-core/spec/i18n_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "decidim/dev/test/i18n_shared_examples"
+
+RSpec.describe "I18n sanity" do
+  include_examples "I18n sanity"
+end

--- a/decidim-dev/config/i18n-tasks.yml
+++ b/decidim-dev/config/i18n-tasks.yml
@@ -2,3 +2,5 @@ base_locale: en
 ignore_unused:
 - "decidim.resource_links.test_link.*"
 - "decidim.dummy.admin.exports.dummies"
+search:
+  strict: false

--- a/decidim-dev/config/i18n-tasks.yml
+++ b/decidim-dev/config/i18n-tasks.yml
@@ -1,5 +1,4 @@
 base_locale: en
-locales: [en]
 ignore_unused:
 - "decidim.resource_links.test_link.*"
 - "decidim.dummy.admin.exports.dummies"

--- a/decidim-dev/lib/decidim/dev/common_rake.rb
+++ b/decidim-dev/lib/decidim/dev/common_rake.rb
@@ -3,9 +3,5 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
-RSpec::Core::RakeTask.new(:spec) do |t|
-  # The i18n_spec part needs to go first or it won't be include. It seems like a
-  # bug in RSpec to me... https://github.com/rspec/rspec-core/issues/2418
-  t.rspec_opts = "--pattern #{__dir__}/test/i18n_spec.rb,**/*_spec.rb"
-end
+RSpec::Core::RakeTask.new(:spec)
 task default: [:spec]

--- a/decidim-dev/lib/decidim/dev/test/i18n_shared_examples.rb
+++ b/decidim-dev/lib/decidim/dev/test/i18n_shared_examples.rb
@@ -3,7 +3,11 @@
 require "i18n/tasks"
 
 RSpec.shared_examples_for "I18n sanity" do
-  let(:i18n) { I18n::Tasks::BaseTask.new(locales: [I18n.default_locale]) }
+  let(:locales) do
+    ENV["ENFORCED_LOCALES"].present? ? ENV["ENFORCED_LOCALES"].split(",") : [:en]
+  end
+
+  let(:i18n) { I18n::Tasks::BaseTask.new(locales: locales) }
   let(:missing_keys) { i18n.missing_keys }
   let(:unused_keys) { i18n.unused_keys }
 

--- a/decidim-dev/lib/decidim/dev/test/i18n_shared_examples.rb
+++ b/decidim-dev/lib/decidim/dev/test/i18n_shared_examples.rb
@@ -8,13 +8,11 @@ RSpec.shared_examples_for "I18n sanity" do
   let(:unused_keys) { i18n.unused_keys }
 
   it "does not have missing keys" do
-    expect(missing_keys).to be_empty,
-                            "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing` to show them"
+    expect(missing_keys).to be_empty, "#{missing_keys.inspect} are missing"
   end
 
   it "does not have unused keys" do
-    expect(unused_keys).to be_empty,
-                           "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused` to show them"
+    expect(unused_keys).to be_empty, "#{unused_keys.inspect} are unused"
   end
 
   it "is normalized" do

--- a/decidim-dev/lib/decidim/dev/test/i18n_shared_examples.rb
+++ b/decidim-dev/lib/decidim/dev/test/i18n_shared_examples.rb
@@ -2,7 +2,7 @@
 
 require "i18n/tasks"
 
-RSpec.describe "I18n" do
+RSpec.shared_examples_for "I18n sanity" do
   let(:i18n) { I18n::Tasks::BaseTask.new(locales: [I18n.default_locale]) }
   let(:missing_keys) { i18n.missing_keys }
   let(:unused_keys) { i18n.unused_keys }

--- a/decidim-dev/lib/generators/decidim/dummy_generator.rb
+++ b/decidim-dev/lib/generators/decidim/dummy_generator.rb
@@ -47,12 +47,6 @@ module Decidim
         ]
       end
 
-      def set_locales
-        inject_into_file "#{dummy_app_path}/config/application.rb", after: "class Application < Rails::Application" do
-          "\n    config.i18n.available_locales = %w(en ca es)\n    config.i18n.default_locale = :en"
-        end
-      end
-
       def decidim_dev
         template "decidim_dev.rb", "#{dummy_app_path}/config/initializers/decidim_dev.rb"
 

--- a/decidim-dev/lib/tasks/locale_checker.rake
+++ b/decidim-dev/lib/tasks/locale_checker.rake
@@ -9,7 +9,7 @@ namespace :decidim do
     }
 
     Bundler.definition.specs.each do |spec|
-      next unless spec.name =~ /decidim-/
+      next unless spec.name.match?(/decidim-/)
 
       Dir.chdir(spec.full_gem_path) do
         Bundler.with_clean_env do

--- a/decidim-dev/lib/tasks/locale_checker.rake
+++ b/decidim-dev/lib/tasks/locale_checker.rake
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+namespace :decidim do
+  desc "Allows a decidim installation to check whether its locales are complete"
+  task :check_locales do
+    env = {
+      "BUNDLE_GEMFILE" => File.expand_path("Gemfile"),
+      "ENFORCED_LOCALES" => Decidim.available_locales.join(",")
+    }
+
+    Bundler.definition.specs.each do |spec|
+      next unless spec.name =~ /decidim-/
+
+      Dir.chdir(spec.full_gem_path) do
+        Bundler.with_clean_env do
+          system(env, "bundle exec rspec spec/i18n_spec.rb")
+        end
+      end
+    end
+  end
+end

--- a/decidim-dev/spec/i18n_spec.rb
+++ b/decidim-dev/spec/i18n_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "decidim/dev/test/i18n_shared_examples"
+
+RSpec.describe "I18n sanity" do
+  include_examples "I18n sanity"
+end

--- a/decidim-meetings/config/i18n-tasks.yml
+++ b/decidim-meetings/config/i18n-tasks.yml
@@ -1,5 +1,4 @@
 base_locale: en
-locales: [en]
 ignore_unused:
 - "decidim.features.meetings.name"
 - "activemodel.attributes.*"

--- a/decidim-meetings/config/i18n-tasks.yml
+++ b/decidim-meetings/config/i18n-tasks.yml
@@ -3,3 +3,5 @@ ignore_unused:
 - "decidim.features.meetings.name"
 - "activemodel.attributes.*"
 - "decidim.resource_links.*"
+search:
+  strict: false

--- a/decidim-meetings/spec/i18n_spec.rb
+++ b/decidim-meetings/spec/i18n_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "decidim/dev/test/i18n_shared_examples"
+
+RSpec.describe "I18n sanity" do
+  include_examples "I18n sanity"
+end

--- a/decidim-pages/config/i18n-tasks.yml
+++ b/decidim-pages/config/i18n-tasks.yml
@@ -2,3 +2,5 @@ base_locale: en
 ignore_unused:
 - "decidim.features.pages.name"
 - "decidim.features.pages.settings.*"
+search:
+  strict: false

--- a/decidim-pages/config/i18n-tasks.yml
+++ b/decidim-pages/config/i18n-tasks.yml
@@ -1,5 +1,4 @@
 base_locale: en
-locales: [en]
 ignore_unused:
 - "decidim.features.pages.name"
 - "decidim.features.pages.settings.*"

--- a/decidim-pages/spec/i18n_spec.rb
+++ b/decidim-pages/spec/i18n_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "decidim/dev/test/i18n_shared_examples"
+
+RSpec.describe "I18n sanity" do
+  include_examples "I18n sanity"
+end

--- a/decidim-proposals/config/i18n-tasks.yml
+++ b/decidim-proposals/config/i18n-tasks.yml
@@ -10,3 +10,5 @@ ignore_unused:
 - "decidim.proposals.admin.exports.proposals"
 ignore_missing:
   - decidim.participatory_processes.scopes.global
+search:
+  strict: false

--- a/decidim-proposals/config/i18n-tasks.yml
+++ b/decidim-proposals/config/i18n-tasks.yml
@@ -1,5 +1,4 @@
 base_locale: en
-locales: [en]
 ignore_unused:
 - "decidim.features.proposals.name"
 - "decidim.features.proposals.settings.*"

--- a/decidim-proposals/spec/i18n_spec.rb
+++ b/decidim-proposals/spec/i18n_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "decidim/dev/test/i18n_shared_examples"
+
+RSpec.describe "I18n sanity" do
+  include_examples "I18n sanity"
+end

--- a/decidim-results/config/i18n-tasks.yml
+++ b/decidim-results/config/i18n-tasks.yml
@@ -1,5 +1,4 @@
 base_locale: en
-locales: [en]
 ignore_unused:
 - "decidim.features.results.name"
 - "decidim.features.results.settings.*"

--- a/decidim-results/config/i18n-tasks.yml
+++ b/decidim-results/config/i18n-tasks.yml
@@ -5,3 +5,5 @@ ignore_unused:
 - "decidim.resource_links.*"
 - activerecord.attributes.*
 - activemodel.attributes.*
+search:
+  strict: false

--- a/decidim-results/spec/i18n_spec.rb
+++ b/decidim-results/spec/i18n_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "decidim/dev/test/i18n_shared_examples"
+
+RSpec.describe "I18n sanity" do
+  include_examples "I18n sanity"
+end

--- a/decidim-system/config/i18n-tasks.yml
+++ b/decidim-system/config/i18n-tasks.yml
@@ -70,7 +70,7 @@ search:
   # only: ["*.rb", "*.html.slim"]
 
   ## If `strict` is `false`, guess usages such as t("categories.#{category}.title"). The default is `true`.
-  # strict: true
+  strict: false
 
   ## Multiple scanners can be used. Their results are merged.
   ## The options specified above are passed down to each scanner. Per-scanner options can be specified as well.

--- a/decidim-system/config/i18n-tasks.yml
+++ b/decidim-system/config/i18n-tasks.yml
@@ -2,8 +2,7 @@
 
 # The "main" locale.
 base_locale: en
-## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
-locales: [en]
+
 ## Reporting locale, default: en. Available: en, ru.
 # internal_locale: en
 

--- a/decidim-system/spec/i18n_spec.rb
+++ b/decidim-system/spec/i18n_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "decidim/dev/test/i18n_shared_examples"
+
+RSpec.describe "I18n sanity" do
+  include_examples "I18n sanity"
+end

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -133,3 +133,13 @@ And make sure you get all the latest migrations:
 $ bin/rails decidim:upgrade
 $ bin/rails db:migrate
 ```
+
+You can also make sure new translations are complete for all languages in your
+application with:
+
+```
+$ bin/rails decidim:check_locales
+```
+
+Be aware that this task might not be able to detect everything, so make sure you
+also manually check your application before uprading.

--- a/lib/generators/decidim/app_generator.rb
+++ b/lib/generators/decidim/app_generator.rb
@@ -94,6 +94,12 @@ module Decidim
         end
       end
 
+      def set_locales
+        inject_into_file "config/application.rb", after: "class Application < Rails::Application" do
+          "\n    config.i18n.available_locales = %w(en ca es)\n    config.i18n.default_locale = :en"
+        end
+      end
+
       def remove_default_error_pages
         remove_file "public/404.html"
         remove_file "public/500.html"


### PR DESCRIPTION
#### :tophat: What? Why?

Just a quick proof of concept of how ensuring complete `:es`, `:ca` and `:en` would look. This would partially fix translation issues for the current installations, so we can deal with the versioning stuff discussed at a later stage.

##### Enabling the check for `:es` and `:ca` locales.

This change (ad8cbda) detected some missing translations in `decidim-core`. At a first glance, they look true positives to me, but I'm not sure:

```
Missing translations (16) | i18n-tasks v0.9.13
+--------+---------------------------------------+----------------------------------+
| Locale | Key                                   | Value in other locales or source |
+--------+---------------------------------------+----------------------------------+
|   ca   | pages.home.statistics.meetings_count  | en Meetings                      |
|   ca   | pages.home.statistics.processes_count | en Processes                     |
|   ca   | pages.home.statistics.projects_count  | en Projects                      |
|   ca   | pages.home.statistics.proposals_count | en Proposals                     |
|   ca   | pages.home.statistics.results_count   | en Results                       |
|   ca   | pages.home.statistics.users_count     | en Users                         |
|   ca   | pages.home.statistics.votes_count     | en Votes                         |
|   en   | pages.home.statistics.processes       | nl Processen                     |
|   en   | pages.home.statistics.users           | nl Gebruikers                    |
|   es   | pages.home.statistics.meetings_count  | en Meetings                      |
|   es   | pages.home.statistics.processes_count | en Processes                     |
|   es   | pages.home.statistics.projects_count  | en Projects                      |
|   es   | pages.home.statistics.proposals_count | en Proposals                     |
|   es   | pages.home.statistics.results_count   | en Results                       |
|   es   | pages.home.statistics.users_count     | en Users                         |
|   es   | pages.home.statistics.votes_count     | en Votes                         |
+--------+---------------------------------------+----------------------------------+
```

##### Enabling dynamic guessing.

This change (e454c48) led to nothing new, so I'm not sure whether it's a good change or not.

#### :pushpin: Related Issues
- Related to #1309.

#### :clipboard: Subtasks
_None_

### :camera: Screenshots (optional)
_None_

#### :ghost: GIF
![forrest](https://cloud.githubusercontent.com/assets/2887858/25727778/8b8b96be-3101-11e7-91ed-1065783625ec.gif)

