### PR TITLE
Update create participatory process command.

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/create_participatory_process.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_participatory_process.rb
@@ -35,30 +35,30 @@ module Decidim
       attr_reader :form
 
       def create_participatory_process
-        transaction do
-          process = ParticipatoryProcess.new(
-            organization: form.current_organization,
-            title: form.title,
-            subtitle: form.subtitle,
-            slug: form.slug,
-            hashtag: form.hashtag,
-            description: form.description,
-            short_description: form.short_description,
-            hero_image: form.hero_image,
-            banner_image: form.banner_image,
-            promoted: form.promoted,
-            scope: form.scope,
-            developer_group: form.developer_group,
-            local_area: form.local_area,
-            target: form.target,
-            participatory_scope: form.participatory_scope,
-            participatory_structure: form.participatory_structure,
-            meta_scope: form.meta_scope,
-            end_date: form.end_date,
-            participatory_process_group: form.participatory_process_group
-          )
+        process = ParticipatoryProcess.new(
+          organization: form.current_organization,
+          title: form.title,
+          subtitle: form.subtitle,
+          slug: form.slug,
+          hashtag: form.hashtag,
+          description: form.description,
+          short_description: form.short_description,
+          hero_image: form.hero_image,
+          banner_image: form.banner_image,
+          promoted: form.promoted,
+          scope: form.scope,
+          developer_group: form.developer_group,
+          local_area: form.local_area,
+          target: form.target,
+          participatory_scope: form.participatory_scope,
+          participatory_structure: form.participatory_structure,
+          meta_scope: form.meta_scope,
+          end_date: form.end_date,
+          participatory_process_group: form.participatory_process_group
+        )
 
-          return process unless process.valid?
+        return process unless process.valid?
+        transaction do
           process.save!
 
           process.steps.create!(

--- a/decidim-admin/app/commands/decidim/admin/create_participatory_process.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_participatory_process.rb
@@ -37,6 +37,7 @@ module Decidim
       def create_participatory_process
         transaction do
           process = ParticipatoryProcess.new(
+            organization: form.current_organization,
             title: form.title,
             subtitle: form.subtitle,
             slug: form.slug,
@@ -46,9 +47,14 @@ module Decidim
             hero_image: form.hero_image,
             banner_image: form.banner_image,
             promoted: form.promoted,
-            meta_scope: form.meta_scope,
             scope: form.scope,
-            organization: form.current_organization,
+            developer_group: form.developer_group,
+            local_area: form.local_area,
+            target: form.target,
+            participatory_scope: form.participatory_scope,
+            participatory_structure: form.participatory_structure,
+            meta_scope: form.meta_scope,
+            end_date: form.end_date,
             participatory_process_group: form.participatory_process_group
           )
 

--- a/decidim-admin/app/controllers/decidim/admin/participatory_processes_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/participatory_processes_controller.rb
@@ -26,7 +26,7 @@ module Decidim
         CreateParticipatoryProcess.call(@form) do
           on(:ok) do |participatory_process|
             flash[:notice] = I18n.t("participatory_processes.create.success", scope: "decidim.admin")
-            redirect_to participatory_process_path(participatory_process)
+            redirect_to edit_participatory_process_path(participatory_process)
           end
 
           on(:invalid) do

--- a/decidim-admin/app/forms/decidim/admin/participatory_process_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_process_form.rb
@@ -38,6 +38,11 @@ module Decidim
       validates :hero_image, file_size: { less_than_or_equal_to: Decidim.maximum_attachment_size }, file_content_type: { allow: ["image/jpeg", "image/png"] }
       validates :banner_image, file_size: { less_than_or_equal_to: Decidim.maximum_attachment_size }, file_content_type: { allow: ["image/jpeg", "image/png"] }
 
+      def map_model(model)
+        self.scope_id = model.decidim_scope_id
+        self.participatory_process_group_id = model.decidim_participatory_process_group_id
+      end
+
       def scope
         @scope ||= current_organization.scopes.where(id: scope_id).first
       end

--- a/decidim-admin/spec/commands/create_participatory_process_spec.rb
+++ b/decidim-admin/spec/commands/create_participatory_process_spec.rb
@@ -6,7 +6,7 @@ describe Decidim::Admin::CreateParticipatoryProcess do
   let(:scope) { create :scope, organization: organization }
   let(:errors) { double.as_null_object }
   let(:form) do
-    double(
+    instance_double( Decidim::Admin::ParticipatoryProcessForm,
       :invalid? => invalid,
       title: {en: "title"},
       subtitle: {en: "subtitle"},
@@ -16,6 +16,12 @@ describe Decidim::Admin::CreateParticipatoryProcess do
       hero_image: nil,
       banner_image: nil,
       promoted: nil,
+      developer_group: "developer group",
+      local_area: "local",
+      target: "target",
+      participatory_scope: "participatory scope",
+      participatory_structure: "participatory structure",
+      end_date: nil,
       description: {en: "description"},
       short_description: {en: "short_description"},
       current_organization: organization,

--- a/decidim-admin/spec/features/admin_manages_participatory_processes_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_participatory_processes_spec.rb
@@ -65,8 +65,8 @@ describe "Admin manage participatory processes", type: :feature do
     end
 
     within ".container" do
-      expect(page).to have_content("My participatory process")
-      expect(page).to have_content(@group_name)
+      expect(page).to have_selector("input[value='My participatory process']")
+      expect(page).to have_selector("option[selected]", text: @group_name)
       expect(page).to have_css("img[src*='#{image1_filename}']")
       expect(page).to have_css("img[src*='#{image2_filename}']")
     end


### PR DESCRIPTION
#### :tophat: What? Why?
When an user creates a new PP as an admin,  some of the optional fields weren't saved properly with the `create_participatory_process` command.

This PR updates this attribute list to solve the issue, fixes the redirect_to and add `map_model` method to the respective form to fix some rendering issues.

#### :pushpin: Related Issues
- Fixes #1329 

### :camera: Screenshots (optional)
![screen shot 2017-05-10 at 09 24 37](https://cloud.githubusercontent.com/assets/953911/25887455/8ce21352-3562-11e7-918b-28b01890815f.png)

#### :ghost: GIF
![](https://media3.giphy.com/media/VcGAyTT62OIdq/giphy.gif)
