### PR TITLE
Fix root commentable migrations

### DIFF
--- a/decidim-comments/db/migrate/20170504085413_add_root_commentable_to_comments.rb
+++ b/decidim-comments/db/migrate/20170504085413_add_root_commentable_to_comments.rb
@@ -1,24 +1,7 @@
 class AddRootCommentableToComments < ActiveRecord::Migration[5.0]
-  def root_commentable(comment)
-    return comment.commentable if comment.depth.zero?
-    root_commentable comment.commentable
-  end
-
   def change
-    # 1. Add root_commentable fields
     change_table :decidim_comments_comments do |t|
       t.references :decidim_root_commentable, polymorphic: true, index: { name: "decidim_comments_comment_root_commentable" }
     end
-
-    # 2. Store root_commentable data
-    Decidim::Comments::Comment.find_each do |comment|
-      root_commentable = comment.depth.zero? ? comment.commentable : comment.root_commentable
-      comment.root_commentable = root_commentable(comment)
-      comment.save
-    end
-
-    # 3. Set root_commentable fields null constraint
-    change_column :decidim_comments_comments, :decidim_root_commentable_id, :integer, null: false
-    change_column :decidim_comments_comments, :decidim_root_commentable_type, :string, null: false
   end
 end

--- a/decidim-comments/db/migrate/20170510091348_update_root_commentable_for_comments.rb
+++ b/decidim-comments/db/migrate/20170510091348_update_root_commentable_for_comments.rb
@@ -6,7 +6,7 @@ class UpdateRootCommentableForComments < ActiveRecord::Migration[5.0]
 
     Decidim::Comments::Comment.where("depth > 0").find_each do |comment|
       comment.root_commentable = root_commentable(comment)
-      comment.save
+      comment.save(validate: false)
     end
   end
 

--- a/decidim-comments/db/migrate/20170510091348_update_root_commentable_for_comments.rb
+++ b/decidim-comments/db/migrate/20170510091348_update_root_commentable_for_comments.rb
@@ -1,9 +1,4 @@
 class UpdateRootCommentableForComments < ActiveRecord::Migration[5.0]
-  def root_commentable(comment)
-    return comment.commentable if comment.depth.zero?
-    root_commentable comment.commentable
-  end
-
   def change
     Decidim::Comments::Comment.where(depth: 0).update_all(
       "decidim_root_commentable_id = #{decidim_commentable_id}, decidim_root_commentable_type = #{decidim_commentable_type}"
@@ -13,5 +8,12 @@ class UpdateRootCommentableForComments < ActiveRecord::Migration[5.0]
       comment.root_commentable = root_commentable(comment)
       comment.save
     end
+  end
+
+  private
+
+  def root_commentable(comment)
+    return comment.commentable if comment.depth.zero?
+    root_commentable comment.commentable
   end
 end

--- a/decidim-comments/db/migrate/20170510091348_update_root_commentable_for_comments.rb
+++ b/decidim-comments/db/migrate/20170510091348_update_root_commentable_for_comments.rb
@@ -1,5 +1,5 @@
 class UpdateRootCommentableForComments < ActiveRecord::Migration[5.0]
-  def change
+  def up
     Decidim::Comments::Comment.where(depth: 0).update_all(
       "decidim_root_commentable_id = decidim_commentable_id, decidim_root_commentable_type = decidim_commentable_type"
     )
@@ -8,6 +8,9 @@ class UpdateRootCommentableForComments < ActiveRecord::Migration[5.0]
       comment.root_commentable = root_commentable(comment)
       comment.save(validate: false)
     end
+  end
+
+  def down
   end
 
   private

--- a/decidim-comments/db/migrate/20170510091348_update_root_commentable_for_comments.rb
+++ b/decidim-comments/db/migrate/20170510091348_update_root_commentable_for_comments.rb
@@ -1,0 +1,17 @@
+class UpdateRootCommentableForComments < ActiveRecord::Migration[5.0]
+  def root_commentable(comment)
+    return comment.commentable if comment.depth.zero?
+    root_commentable comment.commentable
+  end
+
+  def change
+    Decidim::Comments::Comment.where(depth: 0).update_all(
+      "decidim_root_commentable_id = #{decidim_commentable_id}, decidim_root_commentable_type = #{decidim_commentable_type}"
+    )
+
+    Decidim::Comments::Comment.where("depth > 0").find_each do |comment|
+      comment.root_commentable = root_commentable(comment)
+      comment.save
+    end
+  end
+end

--- a/decidim-comments/db/migrate/20170510091348_update_root_commentable_for_comments.rb
+++ b/decidim-comments/db/migrate/20170510091348_update_root_commentable_for_comments.rb
@@ -1,7 +1,7 @@
 class UpdateRootCommentableForComments < ActiveRecord::Migration[5.0]
   def change
     Decidim::Comments::Comment.where(depth: 0).update_all(
-      "decidim_root_commentable_id = #{decidim_commentable_id}, decidim_root_commentable_type = #{decidim_commentable_type}"
+      "decidim_root_commentable_id = decidim_commentable_id, decidim_root_commentable_type = decidim_commentable_type"
     )
 
     Decidim::Comments::Comment.where("depth > 0").find_each do |comment|

--- a/decidim-comments/db/migrate/20170510091409_set_root_commentable_null_constraints.rb
+++ b/decidim-comments/db/migrate/20170510091409_set_root_commentable_null_constraints.rb
@@ -1,0 +1,6 @@
+class SetRootCommentableNullConstraints < ActiveRecord::Migration[5.0]
+  def change
+    change_column :decidim_comments_comments, :decidim_root_commentable_id, :integer, null: false
+    change_column :decidim_comments_comments, :decidim_root_commentable_type, :string, null: false
+  end
+end

--- a/decidim-comments/db/migrate/20170510091409_set_root_commentable_null_constraints.rb
+++ b/decidim-comments/db/migrate/20170510091409_set_root_commentable_null_constraints.rb
@@ -1,6 +1,6 @@
 class SetRootCommentableNullConstraints < ActiveRecord::Migration[5.0]
   def change
-    change_column :decidim_comments_comments, :decidim_root_commentable_id, :integer, null: false
-    change_column :decidim_comments_comments, :decidim_root_commentable_type, :string, null: false
+    change_column_null(:decidim_comments_comments, :decidim_root_commentable_id, false)
+    change_column_null(:decidim_comments_comments, :decidim_root_commentable_type, false)
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

In #1327 I introduced a bad migration `20170504085413_add_root_commentable_to_comments`.

In this PR I changed that migration for three migrations instead:

- `20170504085413_add_root_commentable_to_comments` :warning: replaces the original one
- `20170510091348_update_root_commentable_for_comments`
- `20170510091348_update_root_commentable_for_comments`

#### :pushpin: Related Issues
- Related to ##1327

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
N/A

#### :ghost: GIF
None