### PR TITLE
Changes "open source software" to "free software"

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -278,7 +278,7 @@ en:
         link_label: here
         ok: I agree
       footer:
-        made_with_open_source: Website made with <a target="_blank" href="https://github.com/decidim/decidim">open-source software</a>.
+        made_with_open_source: Website made with <a target="_blank" href="https://github.com/decidim/decidim">free software</a>.
       header:
         close_menu: Close menu
         navigation: Navigation


### PR DESCRIPTION
#### :tophat: What? Why?

According to the FSF, it's better to talk about Free Software. 

Why Open Source misses the point of Free Software - https://www.gnu.org/philosophy/open-source-misses-the-point.html

#### :ghost: GIF
![RMS](https://media.giphy.com/media/XXVYCLbrhlr5m/giphy.gif)
