### PR TITLE
Fix invalid erb tags

### DIFF
--- a/decidim-core/app/views/decidim/participatory_processes/show.html.erb
+++ b/decidim-core/app/views/decidim/participatory_processes/show.html.erb
@@ -20,49 +20,49 @@
       <div class="card extra definition-data">
         <% if translated_attribute(current_participatory_process.meta_scope).present? %>
           <div class="definition-data__item scope">
-            <span class="definition-data__title"><%= t(".scope") =%></span>
+            <span class="definition-data__title"><%= t(".scope") %></span>
               <%== translated_attribute(current_participatory_process.meta_scope) %>
           </div>
         <% end %>
 
         <% if current_participatory_process.end_date.present? %>
           <div class="definition-data__item end-date">
-            <span class="definition-data__title"><%= t(".end_date")=%></span>
+            <span class="definition-data__title"><%= t(".end_date") %></span>
               <%== l(current_participatory_process.end_date, format: :long) %>
           </div>
         <% end %>
 
         <% if translated_attribute(current_participatory_process.developer_group).present? %>
           <div class="definition-data__item developer-group">
-            <span class="definition-data__title"><%= t(".developer_group") =%></span>
+            <span class="definition-data__title"><%= t(".developer_group") %></span>
               <%== translated_attribute(current_participatory_process.developer_group) %>
           </div>
         <% end %>
 
         <% if translated_attribute(current_participatory_process.local_area).present? %>
           <div class="definition-data__item local_area">
-            <span class="definition-data__title"><%= t(".local_area") =%></span>
+            <span class="definition-data__title"><%= t(".local_area") %></span>
               <%== translated_attribute(current_participatory_process.local_area) %>
           </div>
         <% end %>
 
          <% if translated_attribute(current_participatory_process.target).present? %>
           <div class="definition-data__item target">
-            <span class="definition-data__title"><%= t(".target") =%></span>
+            <span class="definition-data__title"><%= t(".target") %></span>
               <%== translated_attribute(current_participatory_process.target) %>
           </div>
         <% end %>
 
          <% if translated_attribute(current_participatory_process.participatory_scope).present? %>
           <div class="definition-data__item participatory_scope">
-            <span class="definition-data__title"><%= t(".participatory_scope") =%></span>
+            <span class="definition-data__title"><%= t(".participatory_scope") %></span>
               <%== translated_attribute(current_participatory_process.participatory_scope) %>
           </div>
         <% end %>
 
         <% if translated_attribute(current_participatory_process.participatory_structure).present? %>
           <div class="definition-data__item participatory_structure">
-            <span class="definition-data__title"><%= t(".participatory_structure") =%></span>
+            <span class="definition-data__title"><%= t(".participatory_structure") %></span>
               <%== translated_attribute(current_participatory_process.participatory_structure) %>
           </div>
         <% end %>


### PR DESCRIPTION
I had these changes on a branch but forgot to open PR.

#### :tophat: What? Why?
I've never seen these closing tags. And syntastic complains about the
syntax (`unexpected '=', expecting keyword_end`), so I think these are
just typos that somehow don't break things.

#### :pushpin: Related Issues
_None_

#### :clipboard: Subtasks
_None_

### :camera: Screenshots (optional)
_None_

#### :ghost: GIF
![viola-davis-nina-simone-as-tzkgj3utup64e](https://cloud.githubusercontent.com/assets/2887858/25900232/252bb81a-3569-11e7-9c30-ddb9d8214b61.gif)

