### PR TITLE
Fix missing locales on budgets admin.

### DIFF
--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -120,6 +120,7 @@ en:
           step:
             comments_blocked: Comments blocked
             votes_enabled: Votes enabled
+            show_votes: Show votes
     orders:
       checkout:
         error: An error ocurred while processing your vote

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -119,8 +119,8 @@ en:
             vote_threshold_percent: Vote threshold percent
           step:
             comments_blocked: Comments blocked
-            votes_enabled: Votes enabled
             show_votes: Show votes
+            votes_enabled: Votes enabled
     orders:
       checkout:
         error: An error ocurred while processing your vote


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds the missing locale that was causing an i18n error when the admin user tried to add a budgets feature.


#### :pushpin: Related Issues
- Fixes #1303

### :camera: Screenshots (optional)
![screen shot 2017-05-10 at 15 33 49](https://cloud.githubusercontent.com/assets/953911/25901163/25e05bd0-3596-11e7-8df0-7c43817bdcb9.png)

#### :ghost: GIF
![](https://media2.giphy.com/media/aDOZ50cD505uU/giphy.gif)
