### PR TITLE
Attachment size

### DIFF
--- a/decidim-admin/app/forms/decidim/admin/organization_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_form.rb
@@ -33,10 +33,10 @@ module Decidim
       validates :default_locale, inclusion: { in: :available_locales }
 
       validates :official_img_header,
-                file_size: { less_than_or_equal_to: Decidim.maximum_attachment_size },
+                file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } },
                 file_content_type: { allow: ["image/jpeg", "image/png"] }
       validates :official_img_footer,
-                file_size: { less_than_or_equal_to: Decidim.maximum_attachment_size },
+                file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } },
                 file_content_type: { allow: ["image/jpeg", "image/png"] }
 
       private

--- a/decidim-admin/app/forms/decidim/admin/participatory_process_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_process_form.rb
@@ -35,8 +35,8 @@ module Decidim
 
       validate :slug, :slug_uniqueness
 
-      validates :hero_image, file_size: { less_than_or_equal_to: Decidim.maximum_attachment_size }, file_content_type: { allow: ["image/jpeg", "image/png"] }
-      validates :banner_image, file_size: { less_than_or_equal_to: Decidim.maximum_attachment_size }, file_content_type: { allow: ["image/jpeg", "image/png"] }
+      validates :hero_image, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } }, file_content_type: { allow: ["image/jpeg", "image/png"] }
+      validates :banner_image, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } }, file_content_type: { allow: ["image/jpeg", "image/png"] }
 
       def map_model(model)
         self.scope_id = model.decidim_scope_id

--- a/decidim-admin/app/forms/decidim/admin/participatory_process_group_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_process_group_form.rb
@@ -17,7 +17,7 @@ module Decidim
 
       validates :name, :description, translatable_presence: true
 
-      validates :hero_image, file_size: { less_than_or_equal_to: Decidim.maximum_attachment_size }, file_content_type: { allow: ["image/jpeg", "image/png"] }
+      validates :hero_image, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } }, file_content_type: { allow: ["image/jpeg", "image/png"] }
     end
   end
 end

--- a/decidim-admin/spec/forms/participatory_process_form_spec.rb
+++ b/decidim-admin/spec/forms/participatory_process_form_spec.rb
@@ -69,8 +69,8 @@ module Decidim
 
       context "when hero_image is too big" do
         before do
-          an_amount_too_large = (Decidim.maximum_attachment_size + 1).megabytes
-          expect(subject.hero_image).to receive(:size).twice.and_return(an_amount_too_large)
+          allow(Decidim).to receive(:maximum_attachment_size).and_return(5.megabytes)
+          expect(subject.hero_image).to receive(:size).twice.and_return(6.megabytes)
         end
 
         it { is_expected.not_to be_valid }
@@ -78,8 +78,8 @@ module Decidim
 
       context "when banner_image is too big" do
         before do
-          an_amount_too_large = (Decidim.maximum_attachment_size + 1).megabytes
-          expect(subject.banner_image).to receive(:size).twice.and_return(an_amount_too_large)
+          allow(Decidim).to receive(:maximum_attachment_size).and_return(5.megabytes)
+          expect(subject.banner_image).to receive(:size).twice.and_return(6.megabytes)
         end
 
         it { is_expected.not_to be_valid }

--- a/decidim-admin/spec/forms/participatory_process_form_spec.rb
+++ b/decidim-admin/spec/forms/participatory_process_form_spec.rb
@@ -35,7 +35,7 @@ module Decidim
         }
       end
       let(:slug) { "slug" }
-      let(:attachement) { test_file("city.jpeg", "image/jpeg") }
+      let(:attachment) { test_file("city.jpeg", "image/jpeg") }
       let(:attributes) do
         {
           "participatory_process" => {
@@ -51,8 +51,8 @@ module Decidim
             "short_description_en" => short_description[:en],
             "short_description_es" => short_description[:es],
             "short_description_ca" => short_description[:ca],
-            "hero_image" => attachement,
-            "banner_image" => attachement,
+            "hero_image" => attachment,
+            "banner_image" => attachment,
             "slug" => slug
           }
         }
@@ -86,7 +86,7 @@ module Decidim
       end
 
       context "when images are not the expected type" do
-        let(:attachement) { test_file("Exampledocument.pdf", "application/pdf") }
+        let(:attachment) { test_file("Exampledocument.pdf", "application/pdf") }
 
         it { is_expected.not_to be_valid }
       end

--- a/decidim-admin/spec/forms/participatory_process_group_form_spec.rb
+++ b/decidim-admin/spec/forms/participatory_process_group_form_spec.rb
@@ -48,8 +48,8 @@ module Decidim
 
       context "when hero_image is too big" do
         before do
-          an_amount_too_large = (Decidim.maximum_attachment_size + 1).megabytes
-          expect(subject.hero_image).to receive(:size).and_return(an_amount_too_large)
+          allow(Decidim).to receive(:maximum_attachment_size).and_return(5.megabytes)
+          expect(subject.hero_image).to receive(:size).and_return(6.megabytes)
         end
 
         it { is_expected.not_to be_valid }

--- a/decidim-core/app/models/decidim/attachment.rb
+++ b/decidim-core/app/models/decidim/attachment.rb
@@ -6,7 +6,7 @@ module Decidim
     belongs_to :attached_to, polymorphic: true
 
     validates :file, :attached_to, :content_type, presence: true
-    validates :file, file_size: { less_than_or_equal_to: Decidim.maximum_attachment_size }
+    validates :file, file_size: { less_than_or_equal_to: ->(_attachment) { Decidim.maximum_attachment_size } }
     mount_uploader :file, Decidim::AttachmentUploader
 
     # Whether this attachment is a photo or not.

--- a/decidim-core/app/uploaders/decidim/image_uploader.rb
+++ b/decidim-core/app/uploaders/decidim/image_uploader.rb
@@ -27,7 +27,7 @@ module Decidim
 
     def validate_size
       manipulate! do |image|
-        validation_error!(I18n.t("carrierwave.errors.image_too_big")) if image.size > 10.megabytes
+        validation_error!(I18n.t("carrierwave.errors.image_too_big")) if image.size > Decidim.maximum_attachment_size
         image
       end
     end

--- a/decidim-core/spec/models/decidim/attachment_spec.rb
+++ b/decidim-core/spec/models/decidim/attachment_spec.rb
@@ -14,8 +14,8 @@ module Decidim
     describe "validations" do
       context "when the file is too big" do
         before do
-          an_amount_too_large = (Decidim.maximum_attachment_size + 1).megabytes
-          expect(subject.file).to receive(:size).and_return(an_amount_too_large)
+          allow(Decidim).to receive(:maximum_attachment_size).and_return(5.megabytes)
+          expect(subject.file).to receive(:size).and_return(6.megabytes)
         end
 
         it { is_expected.not_to be_valid }


### PR DESCRIPTION
#### :tophat: What? Why?

I messed up. When the application boots, models are required before initializers, so validations would get the default value before the customized value was even applied. So we do need to lazy evaluate the setting. This reverts #1315.

#### :pushpin: Related Issues
- Fixes #1351.
- Related to #1315.

#### :clipboard: Subtasks
_None_

### :camera: Screenshots (optional)
_None_

#### :ghost: GIF
![filmeditor-home-alone-christmas-movies-3oha2zd9ekek2ayfdk](https://cloud.githubusercontent.com/assets/2887858/26030271/823ac92a-3824-11e7-8c45-762a4e0635dd.gif)

