### PR TITLE
Fix bug when unvoting a proposal didn't update proposal votes counter cache

### DIFF
--- a/decidim-proposals/app/controllers/decidim/proposals/proposal_votes_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposal_votes_controller.rb
@@ -21,7 +21,9 @@ module Decidim
       def destroy
         authorize! :unvote, proposal
 
-        proposal.votes.where(author: current_user).delete_all
+        proposal.votes.where(author: current_user).destroy_all
+        proposal.reload
+
         @from_proposals_list = params[:from_proposals_list] == "true"
         render :update_buttons_and_counters
       end

--- a/decidim-proposals/spec/features/vote_proposal_spec.rb
+++ b/decidim-proposals/spec/features/vote_proposal_spec.rb
@@ -144,6 +144,10 @@ describe "Vote Proposal", type: :feature do
               page.find(".card__button").click
             end
 
+            within "#proposal-#{proposal.id}-votes-count" do
+              expect(page).to have_content("0 VOTES")
+            end
+
             expect(page).to have_content("REMAINING 10 VOTES")
           end
         end


### PR DESCRIPTION
#### :tophat: What? Why?

The `delete_all` method was not updating the counter cache for proposals votes.

⚠️ Warning ⚠️ 
We need to run the following script in order to fix the corrupted counters if any:
```ruby
Decidim::Proposals::Proposal.find_each { |proposal| Decidim::Proposals::Proposal.reset_counters proposal.id, :votes }
```

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
N/A

#### :ghost: GIF
None
