### PR TITLE
Check if users are `confirmed` to count on homepage stats.

### DIFF
--- a/decidim-core/app/queries/decidim/public_participatory_processes.rb
+++ b/decidim-core/app/queries/decidim/public_participatory_processes.rb
@@ -8,3 +8,4 @@ module Decidim
     end
   end
 end
+

--- a/decidim-core/app/queries/decidim/public_participatory_processes.rb
+++ b/decidim-core/app/queries/decidim/public_participatory_processes.rb
@@ -8,4 +8,3 @@ module Decidim
     end
   end
 end
-

--- a/decidim-core/app/queries/decidim/stats_users_count.rb
+++ b/decidim-core/app/queries/decidim/stats_users_count.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+module Decidim
+  # This query counts registered users from a collection of organizations
+  # in an optional interval of time.
+  class StatsUsersCount < Rectify::Query
+    def self.for(organization, start_at = nil, end_at = nil)
+      new(organization, start_at, end_at).query
+    end
+
+    def initialize(organization, start_at = nil, end_at = nil)
+      @organization = organization
+      @start_at = start_at
+      @end_at = end_at
+    end
+
+    def query
+      users = Decidim::User.where(organization: @organization)
+      users = users.where("created_at >= ?", @start_at) if @start_at.present?
+      users = users.where("created_at <= ?", @end_at) if @end_at.present?
+      users = users.where.not(confirmed_at: nil)
+      users.count
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -125,6 +125,7 @@ module Decidim
           users = Decidim::User.where(organization: organization)
           users = users.where("created_at >= ?", start_at) if start_at.present?
           users = users.where("created_at <= ?", end_at) if end_at.present?
+          users = users.where.not(confirmed_at: nil)
           users.count
         end
 

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -122,11 +122,7 @@ module Decidim
 
       initializer "decidim.stats" do
         Decidim.stats.register :users_count, priority: StatsRegistry::HIGH_PRIORITY do |organization, start_at, end_at|
-          users = Decidim::User.where(organization: organization)
-          users = users.where("created_at >= ?", start_at) if start_at.present?
-          users = users.where("created_at <= ?", end_at) if end_at.present?
-          users = users.where.not(confirmed_at: nil)
-          users.count
+          StatsUsersCount.for(organization, start_at, end_at)
         end
 
         Decidim.stats.register :processes_count, priority: StatsRegistry::HIGH_PRIORITY do |organization, start_at, end_at|

--- a/decidim-core/spec/presenters/decidim/home_stats_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/home_stats_presenter_spec.rb
@@ -6,7 +6,7 @@ module Decidim
     subject { described_class.new(organization: organization) }
 
     let!(:organization) { create(:organization) }
-    let!(:user) { create(:user, organization: organization) }
+    let!(:user) { create(:user, :confirmed, organization: organization) }
     let!(:process) { create(:participatory_process, organization: organization) }
 
     before :all do

--- a/decidim-core/spec/queries/stats_users_count_spec.rb
+++ b/decidim-core/spec/queries/stats_users_count_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  describe StatsUsersCount do
+    let(:organization) { create(:organization) }
+    let(:start_at) { nil }
+    let(:end_at) { nil }
+    subject { described_class.new(organization, start_at, end_at) }
+
+    context "without start and end date" do
+      it "returns the number of confirmed users" do
+        create(:user, :confirmed)
+        create(:user, :confirmed, organization: organization)
+        create(:user, organization: organization)
+
+        expect(subject.query).to eq(1)
+      end
+    end
+
+    context "with start date" do
+      let(:start_at) { 1.week.ago }
+
+      it "returns the number of confirmed user created equal or after this date" do
+        create(:user, :confirmed, organization: organization, created_at: 2.weeks.ago)
+        create(:user, :confirmed, organization: organization)
+
+        expect(subject.query).to eq(1)
+      end
+    end
+
+    context "with end date" do
+      let(:end_at) { 1.week.from_now }
+
+      it "returns the number of confirmed user created equal or after this date" do
+        create(:user, :confirmed, organization: organization, created_at: 2.weeks.from_now)
+        create(:user, :confirmed, organization: organization)
+
+        expect(subject.query).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR updates the users stats query to not count users until the registration is fully completed.

#### :pushpin: Related Issues
- Fixes #1357 

#### :ghost: GIF
![](https://media1.giphy.com/media/3oKIPzVXlzxhAWamNW/giphy.gif)