### PR TITLE
Add order to results

### DIFF
--- a/decidim-results/app/controllers/decidim/results/results_controller.rb
+++ b/decidim-results/app/controllers/decidim/results/results_controller.rb
@@ -12,7 +12,7 @@ module Decidim
       private
 
       def results
-        @results ||= search.results.page(params[:page]).per(12)
+        @results ||= search.results.order("title -> '#{I18n.locale}' ASC").page(params[:page]).per(12)
       end
 
       def result

--- a/decidim-results/spec/controllers/results_controller_spec.rb
+++ b/decidim-results/spec/controllers/results_controller_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  module Results
+    describe ResultsController, type: :controller do
+      before do
+        @request.env["decidim.current_organization"] = feature.organization
+        @request.env["decidim.current_participatory_process"] = feature.participatory_process
+        @request.env["decidim.current_feature"] = feature
+      end
+
+      describe "results" do
+        let(:titles) { %w(Biure Atque Delectus Quia Fuga) }
+        let(:feature) { create(:result_feature)}
+        let(:results_count) { titles.size }
+
+        it "returns a collection of results ordered by title" do
+          Array.new(results_count) do |n|
+            title = {}
+            title[I18n.locale.to_s] = titles[n]
+            create(:result, title: title, feature: feature)
+          end
+
+          results = controller.send(:results)
+          expect(results.pluck(:title).map { |title| title[I18n.locale.to_s] }).to eq(titles.sort)
+        end
+      end
+    end
+  end
+end

--- a/decidim-results/spec/controllers/results_controller_spec.rb
+++ b/decidim-results/spec/controllers/results_controller_spec.rb
@@ -12,7 +12,7 @@ module Decidim
 
       describe "results" do
         let(:titles) { %w(Biure Atque Delectus Quia Fuga) }
-        let(:feature) { create(:result_feature)}
+        let(:feature) { create(:result_feature) }
         let(:results_count) { titles.size }
 
         it "returns a collection of results ordered by title" do

--- a/decidim-results/spec/features/explore_results_spec.rb
+++ b/decidim-results/spec/features/explore_results_spec.rb
@@ -15,17 +15,14 @@ describe "Explore results", type: :feature do
   end
 
   context "index" do
-    it "shows all result ordered alphabetically", driver: :debug do
+    it "shows all results ordered alphabetically" do
       visit_feature
 
-      expect(page).to have_selector("article.card", count: results_count)
-      card_titles = page.all(".card__title")
+      expect(page).to have_selector(".card--result", count: results_count)
 
-      expect(card_titles[0].text).to eq(titles[1])
-      expect(card_titles[1].text).to eq(titles[0])
-      expect(card_titles[2].text).to eq(titles[2])
-      expect(card_titles[3].text).to eq(titles[4])
-      expect(card_titles[4].text).to eq(titles[3])
+      results.each do |result|
+        expect(page).to have_content(translated(result.title))
+      end
     end
 
     context "when filtering" do

--- a/decidim-results/spec/features/explore_results_spec.rb
+++ b/decidim-results/spec/features/explore_results_spec.rb
@@ -3,30 +3,74 @@ require "spec_helper"
 
 describe "Explore results", type: :feature do
   include_context "feature"
-  let(:manifest_name) { "results" }
 
+  let(:titles) { ["Biure", "Atque", "Delectus", "Quia", "Fuga"] }
+  let(:manifest_name) { "results" }
   let(:results_count) { 5 }
   let!(:scope) { create :scope, organization: organization }
   let!(:results) do
-    create_list(
-      :result,
-      results_count,
-      feature: feature
-    )
-  end
-
-  before do
-    visit path
+    results_count.times.map do |n|
+      create(:result, title: { en: titles[n] }, feature: feature)
+    end
   end
 
   context "index" do
-    let(:path) { decidim_results.results_path(participatory_process_id: participatory_process.id, feature_id: feature.id) }
-
-    it "shows all results for the given process" do
+    it "shows all result ordered alphabetically", driver: :debug do
+      visit_feature
+      sleep 1
       expect(page).to have_selector("article.card", count: results_count)
+      card_titles = page.all(".card__title")
 
-      results.each do |result|
-        expect(page).to have_content(translated(result.title))
+      expect(card_titles[0].text).to eq(titles[1])
+      expect(card_titles[1].text).to eq(titles[0])
+      expect(card_titles[2].text).to eq(titles[2])
+      expect(card_titles[3].text).to eq(titles[4])
+      expect(card_titles[4].text).to eq(titles[3])
+    end
+
+    context "when filtering" do
+      before do
+        create(:result, feature: feature, scope: scope)
+      end
+
+      context "when the process has a linked scope" do
+        before do
+          participatory_process.update_attributes(scope: scope)
+        end
+
+        it "enables filtering by scope" do
+          visit_feature
+
+          within ".filters" do
+            expect(page).not_to have_content(/Scopes/i)
+          end
+        end
+      end
+
+      context "when the process has no linked scope" do
+        before do
+          participatory_process.update_attributes(scope: nil)
+        end
+
+        it "enables filtering by scope" do
+          visit_feature
+
+          within ".filters" do
+            expect(page).to have_content(/Scopes/i)
+          end
+        end
+      end
+
+      context "when filtering by scope" do
+        it "lists the filtered results" do
+          visit_feature
+
+          within ".filters" do
+            check scope.name
+          end
+
+          expect(page).to have_css(".card--result", count: 1)
+        end
       end
     end
   end
@@ -37,6 +81,8 @@ describe "Explore results", type: :feature do
     let(:result) { results.first }
 
     it "shows all result info" do
+      visit path
+
       expect(page).to have_i18n_content(result.title)
       expect(page).to have_i18n_content(result.description)
       expect(page).to have_content(result.reference)
@@ -53,6 +99,8 @@ describe "Explore results", type: :feature do
 
     context "without category or scope" do
       it "does not show any tag" do
+        visit path
+
         expect(page).not_to have_selector("ul.tags.tags--result")
       end
     end
@@ -66,6 +114,8 @@ describe "Explore results", type: :feature do
       end
 
       it "shows tags for category" do
+        visit path
+
         expect(page).to have_selector("ul.tags.tags--result")
         within "ul.tags.tags--result" do
           expect(page).to have_content(translated(result.category.name))
@@ -73,6 +123,8 @@ describe "Explore results", type: :feature do
       end
 
       it "links to the filter for this category" do
+        visit path
+
         within "ul.tags.tags--result" do
           click_link translated(result.category.name)
         end
@@ -89,6 +141,8 @@ describe "Explore results", type: :feature do
       end
 
       it "shows tags for scope" do
+        visit path
+
         expect(page).to have_selector("ul.tags.tags--result")
         within "ul.tags.tags--result" do
           expect(page).to have_content(result.scope.name)
@@ -96,6 +150,8 @@ describe "Explore results", type: :feature do
       end
 
       it "links to the filter for this scope" do
+        visit path
+
         within "ul.tags.tags--result" do
           click_link result.scope.name
         end
@@ -108,11 +164,9 @@ describe "Explore results", type: :feature do
       let(:author) { create(:user, :confirmed, organization: feature.organization) }
       let!(:comments) { create_list(:comment, 3, commentable: result) }
 
-      before do
-        visit current_path
-      end
-
       it "shows the comments" do
+        visit path
+
         comments.each do |comment|
           expect(page).to have_content(comment.body)
         end
@@ -127,10 +181,11 @@ describe "Explore results", type: :feature do
 
       before do
         result.link_resources(proposals, "included_proposals")
-        visit current_path
       end
 
       it "shows related proposals" do
+        visit path
+
         proposals.each do |proposal|
           expect(page).to have_content(proposal.title)
           expect(page).to have_content(proposal.author_name)
@@ -147,66 +202,14 @@ describe "Explore results", type: :feature do
 
       before do
         result.link_resources(meetings, "meetings_through_proposals")
-        visit current_path
       end
 
       it "shows related meetings" do
+        visit path
+
         meetings.each do |meeting|
           expect(page).to have_i18n_content(meeting.title)
           expect(page).to have_i18n_content(meeting.description)
-        end
-      end
-    end
-
-    context "when filtering" do
-      before do
-        create(:result, feature: feature, scope: scope)
-        visit_feature
-      end
-
-      context "when the process has a linked scope" do
-        before do
-          participatory_process.update_attributes(scope: scope)
-          visit current_path
-        end
-
-        it "enables filtering by scope" do
-          within ".filters" do
-            expect(page).not_to have_content(/Scopes/i)
-          end
-        end
-      end
-
-      context "when the process has no linked scope" do
-        before do
-          participatory_process.update_attributes(scope: nil)
-          visit current_path
-        end
-
-        it "enables filtering by scope" do
-          within ".filters" do
-            expect(page).to have_content(/Scopes/i)
-          end
-        end
-      end
-
-      context "by origin 'official'" do
-        it "lists the filtered results" do
-          within ".filters" do
-            check scope.name
-          end
-
-          expect(page).to have_css(".card--result", count: 1)
-        end
-      end
-
-      context "by origin 'citizenship'" do
-        it "lists the filtered results" do
-          within ".filters" do
-            check scope.name
-          end
-
-          expect(page).to have_css(".card--result", count: results.size)
         end
       end
     end

--- a/decidim-results/spec/features/explore_results_spec.rb
+++ b/decidim-results/spec/features/explore_results_spec.rb
@@ -4,12 +4,12 @@ require "spec_helper"
 describe "Explore results", type: :feature do
   include_context "feature"
 
-  let(:titles) { ["Biure", "Atque", "Delectus", "Quia", "Fuga"] }
+  let(:titles) { %w(Biure Atque Delectus Quia Fuga) }
   let(:manifest_name) { "results" }
   let(:results_count) { 5 }
   let!(:scope) { create :scope, organization: organization }
   let!(:results) do
-    results_count.times.map do |n|
+    Array.new(results_count) do |n|
       create(:result, title: { en: titles[n] }, feature: feature)
     end
   end

--- a/decidim-results/spec/features/explore_results_spec.rb
+++ b/decidim-results/spec/features/explore_results_spec.rb
@@ -17,7 +17,7 @@ describe "Explore results", type: :feature do
   context "index" do
     it "shows all result ordered alphabetically", driver: :debug do
       visit_feature
-      sleep 1
+
       expect(page).to have_selector("article.card", count: results_count)
       card_titles = page.all(".card__title")
 


### PR DESCRIPTION
#### :tophat: What? Why?
This PR updates the results controller to ordering results alphabetically instead of relying on their ordering on the DB.

#### :pushpin: Related Issues
- Fixes #1363 

### :camera: Screenshots (optional)

<img width="1200" alt="screen shot 2017-05-17 at 10 23 44" src="https://cloud.githubusercontent.com/assets/953911/26144942/f893e2f0-3aea-11e7-8dc1-5756502c36c5.png">

#### :ghost: GIF
![](https://media4.giphy.com/media/3oEjHFOscgNwdSRRDy/giphy.gif)
