### PR TITLE
Use path on layout helper

### DIFF
--- a/decidim-core/app/helpers/decidim/layout_helper.rb
+++ b/decidim-core/app/helpers/decidim/layout_helper.rb
@@ -44,7 +44,7 @@ module Decidim
       html_properties["class"] = (["icon--#{name}"] + _icon_classes(options)).join(" ")
 
       content_tag :svg, html_properties do
-        content_tag :use, nil, "xlink:href" => "#{asset_url("decidim/icons.svg")}#icon-#{name}"
+        content_tag :use, nil, "xlink:href" => "#{asset_path("decidim/icons.svg")}#icon-#{name}"
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

The layout helper was using `asset_url` instead of `asset_path`. This was inconsistent with the rest of the helpers.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media4.giphy.com/media/xN44uQQ3xHv0I/giphy.gif)
