### PR TITLE
Add French and Dutch translations as available languages

### DIFF
--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -82,7 +82,7 @@ module Decidim
 
   # Exposes a configuration option: The application name String.
   config_accessor :available_locales do
-    %w(en ca es eu fi)
+    %w(en ca es eu fi fr nl)
   end
 
   # Exposes a configuration option: an object to configure geocoder


### PR DESCRIPTION
#### :tophat: What? Why?
French and Dutch translations were missing from our staging app. This is due to them not being available as languages for some reason.

#### :pushpin: Related Issues
- Related to #1264

#### :clipboard: Subtasks
None