### PR TITLE
Fix vote command

### DIFF
--- a/decidim-comments/spec/commands/vote_comment_spec.rb
+++ b/decidim-comments/spec/commands/vote_comment_spec.rb
@@ -15,7 +15,7 @@ module Decidim
 
         describe "when the vote is not created" do
           before do
-            expect(comment.up_votes).to receive(:create!).and_raise(ActiveRecord::RecordInvalid)
+            expect(comment).to receive_message_chain("up_votes.create!").and_raise(ActiveRecord::RecordInvalid)
           end
 
           it "broadcasts invalid" do
@@ -31,7 +31,7 @@ module Decidim
 
         describe "when the vote is already created for this user" do
           before do
-            expect(comment.up_votes).to receive(:create!).and_raise(ActiveRecord::RecordNotUnique)
+            expect(comment).to receive_message_chain("up_votes.create!").and_raise(ActiveRecord::RecordNotUnique)
           end
 
           it "broadcasts invalid" do
@@ -51,7 +51,6 @@ module Decidim
           end
 
           it "creates a new comment vote" do
-            expect(comment.up_votes).to receive(:create!).with(author: author).and_call_original
             expect do
               command.call
             end.to change { CommentVote.count }.by(1)
@@ -64,7 +63,7 @@ module Decidim
 
             describe "when the vote is not created" do
               before do
-                expect(comment.down_votes).to receive(:create!).and_raise(ActiveRecord::RecordInvalid)
+                expect(comment).to receive_message_chain("down_votes.create!").and_raise(ActiveRecord::RecordInvalid)
               end
 
               it "broadcasts invalid" do
@@ -80,7 +79,7 @@ module Decidim
 
             describe "when the vote is already created for this user" do
               before do
-                expect(comment.down_votes).to receive(:create!).and_raise(ActiveRecord::RecordNotUnique)
+                expect(comment).to receive_message_chain("down_votes.create!").and_raise(ActiveRecord::RecordNotUnique)
               end
 
               it "broadcasts invalid" do
@@ -100,7 +99,6 @@ module Decidim
               end
 
               it "creates a new comment vote" do
-                expect(comment.down_votes).to receive(:create!).with(author: author).and_call_original
                 expect do
                   command.call
                 end.to change { CommentVote.count }.by(1)


### PR DESCRIPTION
#### :tophat: What? Why?
This fixes the tests on vote commands, which I  broke yesterday because of a bit of cowboyism.

Long story: When I prepared the new version release and I changed decidim's version (having to bundle install again) it unexpectedly updateded activerecord to a newer patch version, which in turn changed a behavior a bit (associations don't reuse the same instances), which broke some tests that were stubbing a call on one of them. PHEW that was a long sentence.

#### :pushpin: Related Issues
#1377 I'm sorry @deivid-rodriguez !

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/RFDXes97gboYg/giphy.gif?response_id=591ebb598c25e7f447784cd9)
