### PR TITLE
Render no participatory processes page

### DIFF
--- a/decidim-core/app/views/decidim/participatory_processes/index.html.erb
+++ b/decidim-core/app/views/decidim/participatory_processes/index.html.erb
@@ -11,7 +11,7 @@
   <section id="processes-grid" class="section row collapse">
     <%= render partial: "order_by_processes" %>
     <div class="row small-up-1 medium-up-2 large-up-3 card-grid">
-      <%= render collection || render(partial: "no_processes_yet") %>
+      <%= render(collection) || render(partial: "no_processes_yet") %>
     </div>
   </section>
 </main>

--- a/decidim-core/spec/features/participatory_processes_spec.rb
+++ b/decidim-core/spec/features/participatory_processes_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe "Participatory Processes", type: :feature do
   let(:organization) { create(:organization) }
-  let!(:participatory_process) do
+  let(:base_process) do
     create(
       :participatory_process,
       organization: organization,
@@ -17,7 +17,18 @@ describe "Participatory Processes", type: :feature do
     switch_to_host(organization.host)
   end
 
+  context "when there are no processes" do
+    before do
+      visit decidim.participatory_processes_path
+    end
+
+    it "shows a messages about the lack of processes" do
+      expect(page).to have_content("No participatory processes yet!")
+    end
+  end
+
   context "when there are some processes" do
+    let!(:participatory_process) { base_process }
     let!(:promoted_process) { create(:participatory_process, :promoted, organization: organization) }
     let!(:unpublished_process) { create(:participatory_process, :unpublished, organization: organization) }
 
@@ -74,6 +85,7 @@ describe "Participatory Processes", type: :feature do
   end
 
   describe "when going to the participatory process page" do
+    let!(:participatory_process) { base_process }
     let!(:published_feature) { create(:feature, :published, participatory_process: participatory_process) }
     let!(:unpublished_feature) { create(:feature, :unpublished, participatory_process: participatory_process) }
 

--- a/decidim-core/spec/features/participatory_processes_spec.rb
+++ b/decidim-core/spec/features/participatory_processes_spec.rb
@@ -73,7 +73,7 @@ describe "Participatory Processes", type: :feature do
     end
   end
 
-  describe "show" do
+  describe "when going to the participatory process page" do
     let!(:published_feature) { create(:feature, :published, participatory_process: participatory_process) }
     let!(:unpublished_feature) { create(:feature, :unpublished, participatory_process: participatory_process) }
 


### PR DESCRIPTION
#### :tophat: What? Why?
Fixing a incredibly minor bug that would only appear when there are not any participatory processes. But hey, it's a bug!

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
#### Before
![before](https://cloud.githubusercontent.com/assets/2887858/26271115/0af0e008-3cd8-11e7-9190-36cfaab1ae1c.png)

#### After
![after](https://cloud.githubusercontent.com/assets/2887858/26271068/96299828-3cd7-11e7-88c7-d7bd0604b5cb.png)

#### :ghost: GIF
![limando_unas](https://cloud.githubusercontent.com/assets/2887858/26271096/d069fc30-3cd7-11e7-8414-f7fbe4def6fc.gif)


