### PR TITLE
Use delimiters in stats for better readability

### DIFF
--- a/decidim-core/app/presenters/decidim/home_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/home_stats_presenter.rb
@@ -62,7 +62,7 @@ module Decidim
       content_tag :div, "", class: "home-pam__data" do
         safe_join([
                     content_tag(:h4, I18n.t(name, scope: "pages.home.statistics"), class: "home-pam__title"),
-                    content_tag(:span, " #{data}", class: "home-pam__number #{name}")
+                    content_tag(:span, " #{number_with_delimiter(data)}", class: "home-pam__number #{name}")
                   ])
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
This uses delimiters in stats to increase readability.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
![image](https://cloud.githubusercontent.com/assets/111746/26298563/18d73918-3ed8-11e7-9cbb-d31490e4e067.png)

#### :ghost: GIF
![](https://media.giphy.com/media/VgY4dDdN1W3NS/giphy.gif?response_id=59229f1129d3b60923c01280)
