### PR TITLE
Admin can mark question as mandatory

### DIFF
--- a/decidim-core/app/helpers/decidim/decidim_form_helper.rb
+++ b/decidim-core/app/helpers/decidim/decidim_form_helper.rb
@@ -48,6 +48,7 @@ module Decidim
     # name        - The name of the input which will be suffixed with the corresponding locales.
     # value       - A hash containing the value for each locale.
     # options     - An optional hash of options.
+    #             * enable_tabs: Adds the data-tabs attribute so Foundation picks up automatically.
     #             * tabs_id: The id to identify the Foundation tabs element.
     #             * label: The label used for the field.
     #

--- a/decidim-core/app/helpers/decidim/decidim_form_helper.rb
+++ b/decidim-core/app/helpers/decidim/decidim_form_helper.rb
@@ -56,7 +56,7 @@ module Decidim
       locales = Decidim.available_locales
 
       tabs_id = options[:tabs_id] || "#{object_name}-#{name}-tabs"
-      enabled_tabs = options[:enable_tabs] == nil ? true : options[:enable_tabs]
+      enabled_tabs = options[:enable_tabs].nil? ? true : options[:enable_tabs]
       tabs_panels_data = enabled_tabs ? { tabs: true } : {}
 
       if locales.count == 1

--- a/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
+++ b/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
@@ -32,7 +32,11 @@ module Decidim
 
         def update_survey_questions
           @form.questions.each do |form_question|
-            question_attributes = { body: form_question.body, position: form_question.position }
+            question_attributes = {
+              body: form_question.body,
+              position: form_question.position,
+              mandatory: form_question.mandatory
+            }
             if form_question.id.present?
               question = @survey.questions.where(id: form_question.id).first
               if form_question.deleted?

--- a/decidim-surveys/app/commands/decidim/surveys/answer_survey.rb
+++ b/decidim-surveys/app/commands/decidim/surveys/answer_survey.rb
@@ -31,7 +31,7 @@ module Decidim
             SurveyAnswer.create!(
               user: @current_user,
               survey: @survey,
-              decidim_survey_question_id: form_answer.survey_question_id,
+              question: form_answer.question,
               body: form_answer.body
             )
           end

--- a/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_form.rb
@@ -8,6 +8,7 @@ module Decidim
 
         attribute :id, String
         attribute :position, Integer
+        attribute :mandatory, Boolean, default: false
         attribute :deleted, Boolean, default: false
 
         translatable_attribute :body, String

--- a/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
@@ -11,6 +11,13 @@ module Decidim
       def question
         @question ||= SurveyQuestion.find(question_id)
       end
+
+      # Private: Map the correct fields.
+      #
+      # Returns nothing.
+      def map_model(model)
+        self.question_id = model.id
+      end
     end
   end
 end

--- a/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
@@ -9,14 +9,20 @@ module Decidim
       validates :body, presence: true, if: -> { question.mandatory? }
 
       def question
-        @question ||= SurveyQuestion.find(question_id)
+        @question ||= survey.questions.find(question_id)
       end
 
-      # Private: Map the correct fields.
+      # Public: Map the correct fields.
       #
       # Returns nothing.
       def map_model(model)
         self.question_id = model.id
+      end
+
+      private
+
+      def survey
+        @survey ||= Survey.where(feature: current_feature).first
       end
     end
   end

--- a/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
@@ -3,9 +3,14 @@ module Decidim
   module Surveys
     # This class holds a Form to update survey unswers from Decidim's public page
     class SurveyAnswerForm < Decidim::Form
-      attribute :question
-      attribute :survey_question_id, String
+      attribute :question_id, String
       attribute :body, String
+
+      validates :body, presence: true, if: -> { question.mandatory? }
+
+      def question
+        @question ||= SurveyQuestion.find(question_id)
+      end
     end
   end
 end

--- a/decidim-surveys/app/forms/decidim/surveys/survey_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_form.rb
@@ -10,7 +10,7 @@ module Decidim
       # Returns nothing.
       def map_model(model)
         self.answers = model.questions.map do |question|
-          SurveyAnswerForm.from_params(question: question)
+          SurveyAnswerForm.from_params(question_id: question.id)
         end
       end
     end

--- a/decidim-surveys/app/models/decidim/surveys/survey_answer.rb
+++ b/decidim-surveys/app/models/decidim/surveys/survey_answer.rb
@@ -7,6 +7,7 @@ module Decidim
       belongs_to :survey, class_name: Survey, foreign_key: "decidim_survey_id"
       belongs_to :question, class_name: SurveyQuestion, foreign_key: "decidim_survey_question_id"
 
+      validates :body, presence: true, if: -> { question.mandatory? }
       validate :user_survey_same_organization
       validate :question_belongs_to_survey
 

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
@@ -19,7 +19,13 @@
 
         <template id="survey-question-tmpl">
           <div class="survey-question">
-            <%= translated_field_tag :text_field_tag, "survey[questions][]", "body", {}, label: "#{icon("move")} #{t('.question')}".html_safe, disabled: true %>
+            <div class="row column">
+              <%= translated_field_tag :text_field_tag, "survey[questions][]", "body", {}, label: "#{icon("move")} #{t('.question')}".html_safe, disabled: true %>
+            </div>
+            <div class="row column">
+              <%= check_box_tag "survey[questions][][mandatory]" %>
+              <%= label_tag "survey_questions__mandatory", t('activemodel.attributes.survey_question.mandatory') %>              
+            </div>
             <%= hidden_field_tag "survey[questions][][position]", "", disabled: true %>
             <button class="button small alert hollow remove-question"><%= t('.remove_question') %></button>
           </div>
@@ -31,7 +37,15 @@
           <div class="survey-question">
             <%- label = @survey.published? ? t('.question') : "#{icon("move")} #{t('.question')} ##{(question.position || idx) + 1}".html_safe
 %>
-            <%= translated_field_tag :text_field_tag, "survey[questions][]", "body", question.body, label: label, tabs_prefix: "survey-question-#{question.id}", disabled: @survey.published? %>
+            <div class="row column">
+              <%= translated_field_tag :text_field_tag, "survey[questions][]", "body", question.body, label: label, tabs_prefix: "survey-question-#{question.id}", disabled: @survey.published? %>
+            </div>
+
+            <div class="row column">
+              <%= check_box_tag "survey[questions][][mandatory]", "1", question.mandatory, id: "survey_questions_#{question.id}_mandatory" %>
+              <%= label_tag "survey_questions_#{question.id}_mandatory", t('activemodel.attributes.survey_question.mandatory') %>
+            </div>
+
             <%= hidden_field_tag "survey[questions][][id]", question.id %>
             <%= hidden_field_tag "survey[questions][][position]", question.position || idx %>
             <% unless @survey.published? %>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
@@ -24,7 +24,7 @@
             </div>
             <div class="row column">
               <%= check_box_tag "survey[questions][][mandatory]" %>
-              <%= label_tag "survey_questions__mandatory", t('activemodel.attributes.survey_question.mandatory') %>              
+              <%= label_tag "survey_questions__mandatory", t('activemodel.attributes.survey_question.mandatory') %>
             </div>
             <%= hidden_field_tag "survey[questions][][position]", "", disabled: true %>
             <button class="button small alert hollow remove-question"><%= t('.remove_question') %></button>
@@ -42,7 +42,7 @@
             </div>
 
             <div class="row column">
-              <%= check_box_tag "survey[questions][][mandatory]", "1", question.mandatory, id: "survey_questions_#{question.id}_mandatory" %>
+              <%= check_box_tag "survey[questions][][mandatory]", "1", question.mandatory, id: "survey_questions_#{question.id}_mandatory", disabled: @survey.published? %>
               <%= label_tag "survey_questions_#{question.id}_mandatory", t('activemodel.attributes.survey_question.mandatory') %>
             </div>
 

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
@@ -20,13 +20,13 @@
         <template id="survey-question-tmpl">
           <div class="survey-question">
             <div class="row column">
-              <%= translated_field_tag :text_field_tag, "survey[questions][]", "body", {}, label: "#{icon("move")} #{t('.question')}".html_safe, disabled: true %>
+              <%= translated_field_tag :text_field_tag, "survey[questions][]", "body", {}, tabs_id: "${tabsId}", label: "#{icon("move")} #{t('.question')} #${questionLabelPosition}".html_safe, disabled: true, enable_tabs: false %>
             </div>
             <div class="row column">
-              <%= check_box_tag "survey[questions][][mandatory]" %>
-              <%= label_tag "survey_questions__mandatory", t('activemodel.attributes.survey_question.mandatory') %>
+              <%= check_box_tag "survey[questions][][mandatory]", "1", false, id: "${tabsId}_mandatory" %>
+              <%= label_tag "", t('activemodel.attributes.survey_question.mandatory'), for: "${tabsId}_mandatory" %>
             </div>
-            <%= hidden_field_tag "survey[questions][][position]", "", disabled: true %>
+            <%= hidden_field_tag "survey[questions][][position]", "${position}", disabled: true %>
             <button class="button small alert hollow remove-question"><%= t('.remove_question') %></button>
           </div>
         </template>
@@ -38,7 +38,7 @@
             <%- label = @survey.published? ? t('.question') : "#{icon("move")} #{t('.question')} ##{(question.position || idx) + 1}".html_safe
 %>
             <div class="row column">
-              <%= translated_field_tag :text_field_tag, "survey[questions][]", "body", question.body, label: label, tabs_prefix: "survey-question-#{question.id}", disabled: @survey.published? %>
+              <%= translated_field_tag :text_field_tag, "survey[questions][]", "body", question.body, tabs_id: "survey-question-#{question.id}", label: label, disabled: @survey.published? %>
             </div>
 
             <div class="row column">

--- a/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
@@ -37,9 +37,12 @@
                 <% @form.answers.each_with_index do |answer, idx| %>
                   <div class="field">
                     <% field_id = "survey_#{survey.id}_question_#{answer.question.id}_answer_body" %>
-                    <%= label_tag field_id , "#{idx + 1}. #{translated_attribute(answer.question.body)}" %>
-                    <%= text_field_tag "survey[answers][][body]", "", id: field_id %>
-                    <%= hidden_field_tag "survey[answers][][survey_question_id]", answer.question.id %>
+                    <%= label_tag field_id , "#{idx + 1}. #{translated_attribute(answer.question.body)} #{'*' if answer.question.mandatory?}" %>
+                    <%= text_field_tag "survey[answers][][body]", answer.body, id: field_id, class: "#{'is-invalid-input' unless answer.errors.empty?}" %>
+                    <%= hidden_field_tag "survey[answers][][question_id]", answer.question.id %>
+                    <% answer.errors.full_messages.each do |msg| %>
+                      <%= content_tag :small, msg, class: "form-error is-visible" %>
+                    <% end %>
                   </div>
                 <% end %>
 

--- a/decidim-surveys/config/i18n-tasks.yml
+++ b/decidim-surveys/config/i18n-tasks.yml
@@ -3,5 +3,6 @@ locales: [en]
 ignore_unused:
 - "decidim.features.surveys.name"
 - "decidim.features.surveys.actions.*"
+- "activemodel.attributes.survey_answer.*"
 ignore_missing:
   - decidim.participatory_processes.scopes.global

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -2,10 +2,10 @@
 en:
   activemodel:
     attributes:
-      survey_question:
-        mandatory: "Mandatory"
       survey_answer:
-        body: "Answer"
+        body: Answer
+      survey_question:
+        mandatory: Mandatory
   decidim:
     features:
       surveys:

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -1,5 +1,9 @@
 ---
 en:
+  activemodel:
+    attributes:
+      survey_question:
+        mandatory: "Mandatory"
   decidim:
     features:
       surveys:

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -4,6 +4,8 @@ en:
     attributes:
       survey_question:
         mandatory: "Mandatory"
+      survey_answer:
+        body: "Answer"
   decidim:
     features:
       surveys:

--- a/decidim-surveys/db/migrate/20170522075938_add_mandatory_to_surveys_questions.rb
+++ b/decidim-surveys/db/migrate/20170522075938_add_mandatory_to_surveys_questions.rb
@@ -1,0 +1,5 @@
+class AddMandatoryToSurveysQuestions < ActiveRecord::Migration[5.0]
+  def change
+    add_column :decidim_surveys_survey_questions, :mandatory, :boolean
+  end
+end

--- a/decidim-surveys/lib/decidim/surveys/test/factories.rb
+++ b/decidim-surveys/lib/decidim/surveys/test/factories.rb
@@ -21,6 +21,7 @@ FactoryGirl.define do
 
   factory :survey_question, class: Decidim::Surveys::SurveyQuestion do
     body { Decidim::Faker::Localized.sentence }
+    mandatory false
     survey
   end
 

--- a/decidim-surveys/spec/commands/decidim/surveys/admin/update_survey_spec.rb
+++ b/decidim-surveys/spec/commands/decidim/surveys/admin/update_survey_spec.rb
@@ -32,7 +32,8 @@ module Decidim
                   "ca" => "Segona pregunta",
                   "es" => "Segunda pregunta"
                 },
-                "position" => "1"
+                "position" => "1",
+                "mandatory" => "1"
               }
             ],
             "published_at" => published_at
@@ -77,6 +78,8 @@ module Decidim
             survey.questions.each_with_index do |question, idx|
               expect(question.body["en"]).to eq(form_params["questions"][idx]["body"]["en"])
             end
+
+            expect(survey.questions[1]).to be_mandatory
           end
         end
 

--- a/decidim-surveys/spec/commands/decidim/surveys/answer_survey_spec.rb
+++ b/decidim-surveys/spec/commands/decidim/surveys/answer_survey_spec.rb
@@ -29,7 +29,8 @@ module Decidim
         SurveyForm.from_params(
           form_params
         ).with_context(
-          current_organization: current_organization
+          current_organization: current_organization,
+          current_feature: feature
         )
       end
       let(:command) { described_class.new(form, current_user, survey) }

--- a/decidim-surveys/spec/commands/decidim/surveys/answer_survey_spec.rb
+++ b/decidim-surveys/spec/commands/decidim/surveys/answer_survey_spec.rb
@@ -16,11 +16,11 @@ module Decidim
           "answers" => [
             {
               "body" => "This is my first answer",
-              "survey_question_id" => survey_question_1.id
+              "question_id" => survey_question_1.id
             },
             {
               "body" => "This is my first answer",
-              "survey_question_id" => survey_question_2.id
+              "question_id" => survey_question_2.id
             }
           ]
         }

--- a/decidim-surveys/spec/features/admin_spec.rb
+++ b/decidim-surveys/spec/features/admin_spec.rb
@@ -56,13 +56,13 @@ describe "Edit a survey", type: :feature do
         questions_body[idx].each do |locale, value|
           within survey_question do
             click_link I18n.with_locale(locale) { I18n.t("name", scope: "locale") }
-            fill_in "survey_questions__body_#{locale}", with: value
+            find("input[name='survey[questions][][body_#{locale}]']").send_keys value
           end
         end
       end
 
       within ".survey-question:last-child" do
-        check "survey_questions__mandatory"
+        check "Mandatory"
       end
 
       click_button "Save"
@@ -95,7 +95,7 @@ describe "Edit a survey", type: :feature do
         expect(page).to have_selector(".survey-question", count: 1)
 
         within ".survey-question" do
-          fill_in "survey_questions__body_en", with: "Modified question"
+          fill_in "survey-question-#{survey_question.id}_body_en", with: "Modified question"
         end
 
         click_button "Save and publish"

--- a/decidim-surveys/spec/features/admin_spec.rb
+++ b/decidim-surveys/spec/features/admin_spec.rb
@@ -61,6 +61,10 @@ describe "Edit a survey", type: :feature do
         end
       end
 
+      within ".survey-question:last-child" do
+        check "survey_questions__mandatory"
+      end
+
       click_button "Save"
     end
 

--- a/decidim-surveys/spec/features/survey_spec.rb
+++ b/decidim-surveys/spec/features/survey_spec.rb
@@ -94,6 +94,21 @@ describe "Answer a survey", type: :feature do
         expect(form_fields[0]).to have_i18n_content(survey_question_2.body)
         expect(form_fields[1]).to have_i18n_content(survey_question_1.body)
       end
+
+      context "when a question is mandatory" do
+        let!(:survey_question_2) { create(:survey_question, survey: survey, position: 0, mandatory: true) }
+
+        it "users cannot leave that question blank" do
+          visit_feature
+
+          click_button "Submit"
+
+          within ".alert.flash" do
+            expect(page).to have_content("error")
+          end
+          expect(page).to have_content("can't be blank")          
+        end
+      end
     end
   end
 end

--- a/decidim-surveys/spec/features/survey_spec.rb
+++ b/decidim-surveys/spec/features/survey_spec.rb
@@ -106,7 +106,7 @@ describe "Answer a survey", type: :feature do
           within ".alert.flash" do
             expect(page).to have_content("error")
           end
-          expect(page).to have_content("can't be blank")          
+          expect(page).to have_content("can't be blank")
         end
       end
     end

--- a/decidim-surveys/spec/forms/decidim/surveys/admin/survey_form_spec.rb
+++ b/decidim-surveys/spec/forms/decidim/surveys/admin/survey_form_spec.rb
@@ -32,7 +32,8 @@ module Decidim
                 "ca" => "Segona pregunta",
                 "es" => "Segunda pregunta"
               },
-              position: 1
+              position: 1,
+              mandatory: true
             }
           ]
         end

--- a/decidim-surveys/spec/forms/decidim/surveys/survey_answer_form_spec.rb
+++ b/decidim-surveys/spec/forms/decidim/surveys/survey_answer_form_spec.rb
@@ -11,7 +11,9 @@ module Decidim
       let!(:survey_answer) { create(:survey_answer, user: user, survey: survey, question: survey_question) }
 
       subject do
-        described_class.from_model(survey_answer)
+        described_class.from_model(survey_answer).with_context({
+          current_feature: survey.feature
+        })
       end
 
       context "when everything is OK" do

--- a/decidim-surveys/spec/forms/decidim/surveys/survey_answer_form_spec.rb
+++ b/decidim-surveys/spec/forms/decidim/surveys/survey_answer_form_spec.rb
@@ -1,0 +1,31 @@
+# coding: utf-8
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  module Surveys
+    describe SurveyAnswerForm do
+      let!(:survey) { create(:survey) }
+      let!(:user) { create(:user, organization: survey.feature.participatory_process.organization) }
+      let!(:survey_question) { create(:survey_question, survey: survey) }
+      let!(:survey_answer) { create(:survey_answer, user: user, survey: survey, question: survey_question) }
+
+      subject do
+        described_class.from_model(survey_answer)
+      end
+
+      context "when everything is OK" do
+        it { is_expected.to be_valid }
+      end
+
+      context "when the question is mandatory" do
+        let!(:survey_question) { create(:survey_question, survey: survey, mandatory: true) }
+
+        it "is not valid if body is not present" do
+          subject.body = ""
+          expect(subject).not_to be_valid
+        end
+      end
+    end
+  end
+end

--- a/decidim-surveys/spec/forms/decidim/surveys/survey_answer_form_spec.rb
+++ b/decidim-surveys/spec/forms/decidim/surveys/survey_answer_form_spec.rb
@@ -11,9 +11,7 @@ module Decidim
       let!(:survey_answer) { create(:survey_answer, user: user, survey: survey, question: survey_question) }
 
       subject do
-        described_class.from_model(survey_answer).with_context({
-          current_feature: survey.feature
-        })
+        described_class.from_model(survey_answer).with_context(current_feature: survey.feature)
       end
 
       context "when everything is OK" do

--- a/decidim-surveys/spec/forms/decidim/surveys/survey_form_spec.rb
+++ b/decidim-surveys/spec/forms/decidim/surveys/survey_form_spec.rb
@@ -9,7 +9,9 @@ module Decidim
       let!(:survey_question) { create(:survey_question, survey: survey) }
 
       subject do
-        described_class.from_model(survey)
+        described_class.from_model(survey).with_context({
+          current_feature: survey.feature
+        })
       end
 
       it "builds empty answers for each question" do

--- a/decidim-surveys/spec/forms/decidim/surveys/survey_form_spec.rb
+++ b/decidim-surveys/spec/forms/decidim/surveys/survey_form_spec.rb
@@ -9,9 +9,7 @@ module Decidim
       let!(:survey_question) { create(:survey_question, survey: survey) }
 
       subject do
-        described_class.from_model(survey).with_context({
-          current_feature: survey.feature
-        })
+        described_class.from_model(survey).with_context(current_feature: survey.feature)
       end
 
       it "builds empty answers for each question" do

--- a/decidim-surveys/spec/models/decidim/surveys/survey_answer_spec.rb
+++ b/decidim-surveys/spec/models/decidim/surveys/survey_answer_spec.rb
@@ -40,6 +40,15 @@ module Decidim
           expect(subject).not_to be_valid
         end
       end
+
+      context "when question is mandatory" do
+        let(:survey_question) { create(:survey_question, survey: survey, mandatory: true) }
+
+        it "is not valid with an empty body" do
+          subject.body = ""
+          expect(subject).not_to be_valid
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

As an admin I should be able to mark some questions as mandatory so users cannot leave them blank.

I also included some bugfixes and minor refactrors.

#### :pushpin: Related Issues
- Related to #1342 

#### :clipboard: Subtasks
- [x] Admin can mark questions as mandatory from the edit form
- [x] Users cannot leave mandatory questions blank
- [x] Refactor javascript template
- [x] [bug] adding multiple questions and mandatory labels
- [x] [bug] can't drag and drop new questions

### :camera: Screenshots (optional)
![image](https://cloud.githubusercontent.com/assets/106021/26305079/1ffef292-3eee-11e7-98e4-0ff4e4594edf.png)
![image](https://cloud.githubusercontent.com/assets/106021/26305056/09b341dc-3eee-11e7-87da-c8a3b8742c1c.png)

#### :ghost: GIF
![](https://media3.giphy.com/media/f4HpCDvF84oh2/giphy.gif?response_id=5923013337df0d84a7751d58)
