### PR TITLE
Only precompile test app assets on CI

### DIFF
--- a/decidim-dev/lib/tasks/test_app.rake
+++ b/decidim-dev/lib/tasks/test_app.rake
@@ -15,8 +15,10 @@ namespace :decidim do
       ]
     )
 
-    Dir.chdir(dummy_app_path) do
-      Bundler.with_clean_env { sh "bundle exec rake assets:precompile" }
+    if ENV["CI"]
+      Dir.chdir(dummy_app_path) do
+        Bundler.with_clean_env { sh "bundle exec rake assets:precompile" }
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Using the test app locally forces us to recompile assets every time something is changed. This deals with it by only precompiling assets using a specific task meant for CI environments.

#### :pushpin: Related Issues
- Fixes #1240

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/26uf9mAqt70pjwtVK/giphy.gif?response_id=5923e27620ee66f0130c7a07)
