### PR TITLE
Unescape the proposal rejected reason

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -61,7 +61,7 @@
         <div class="section">
           <div class="callout warning">
             <h5><%= t(".proposal_rejected_reason") %></h5>
-            <p><%= translated_attribute @proposal.answer %></p>
+            <p><%== translated_attribute @proposal.answer %></p>
           </div>
         </div>
       <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

An answer to a proposal accepts HTML tags. However, when the proposal is rejected, the
contents of the answer are escaped, displaying HTML tags in the view. This fix unescapes
the proposal answer when the proposal has been rejected.

### :camera: Screenshots (optional)

Before: 
![Before](https://cloud.githubusercontent.com/assets/1968046/26346174/af366334-3fa5-11e7-9486-440aa4409b3c.png)

After:
<img width="1226" alt="screen shot 2017-05-23 at 10 41 01" src="https://cloud.githubusercontent.com/assets/1968046/26346247/e13ccbf2-3fa5-11e7-860b-3359e2471d66.png">


