### PR TITLE
Fix pagination components not shown in mobile

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_modules.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_modules.scss
@@ -34,6 +34,7 @@
 @import "tags";
 @import "list-docs";
 @import "datepicker";
+@import "pagination";
 
 //Process elements
 @import "process-header";

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_pagination.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_pagination.scss
@@ -1,0 +1,5 @@
+.pagination {
+  .pagination-previous, .pagination-next {
+    display: inline-block;
+  }
+}


### PR DESCRIPTION
#### :tophat: What? Why?

Next and Previous links of the pagination component were hidden in small resolutions.
This happened because the way Foundation manages pagination by default:

http://foundation.zurb.com/sites/docs/pagination.html

### :camera: Screenshots (optional)

**Before:**

See the next button hidden in mobile resolutions:

<img width="262" alt="screen shot 2017-05-23 at 15 24 53" src="https://cloud.githubusercontent.com/assets/1968046/26356520/9afb28f6-3fcc-11e7-8452-c8e158a6a686.png">

**After:**

<img width="267" alt="screen shot 2017-05-23 at 15 25 52" src="https://cloud.githubusercontent.com/assets/1968046/26356535/a6e4f87c-3fcc-11e7-86b4-c1a55c85117a.png">

