### PR TITLE
Fix devise namespace collision

### DIFF
--- a/decidim-core/app/mailers/decidim/decidim_devise_mailer.rb
+++ b/decidim-core/app/mailers/decidim/decidim_devise_mailer.rb
@@ -3,7 +3,7 @@
 module Decidim
   # A custom mailer for Devise so we can tweak the invitation instructions for
   # each role and use a localised version.
-  class DecidimDeviseMailer < Devise::Mailer
+  class DecidimDeviseMailer < ::Devise::Mailer
     include LocalisedMailer
 
     layout "decidim/mailer"


### PR DESCRIPTION
#### :tophat: What? Why?
This fixes a namespace collision bug that happened while eager-loading some controllers.

#### :pushpin: Related Issues
* https://github.com/AjuntamentdeBarcelona/decidim-barcelona/pull/124#discussion_r118498762

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/9i47EMiOk8Bd6/giphy.gif)
