### PR TITLE
Add missing helper to devise controllers

### DIFF
--- a/decidim-core/app/controllers/concerns/decidim/devise_controllers.rb
+++ b/decidim-core/app/controllers/concerns/decidim/devise_controllers.rb
@@ -20,6 +20,7 @@ module Decidim
       helper Decidim::LanguageChooserHelper
       helper Decidim::CookiesHelper
       helper Decidim::ReplaceButtonsHelper
+      helper Decidim::LayoutHelper
 
       layout "layouts/decidim/application"
     end


### PR DESCRIPTION
#### :tophat: What? Why?
This adds a missing helper to devise's controllers. It only happens on development when we load controllers before the app loads (in order to patch them, for example).

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/CEJ1N2BsiWDm0/giphy.gif)
