### PR TITLE
Enable rubocop encoding checks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -454,6 +454,7 @@ Style/EmptyLinesAroundModuleBody:
 # AutoCorrectEncodingComment must match the regex
 # /#.*coding\s?[:=]\s?(?:UTF|utf)-8/
 Style/Encoding:
+  Enabled: true
   EnforcedStyle: never
   SupportedStyles:
     - when_needed

--- a/decidim-admin/app/commands/decidim/admin/copy_participatory_process.rb
+++ b/decidim-admin/app/commands/decidim/admin/copy_participatory_process.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Decidim
   module Admin
     # A command with all the business logic when copying a new participatory

--- a/decidim-admin/app/controllers/decidim/admin/participatory_process_copies_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/participatory_process_copies_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_dependency "decidim/admin/application_controller"
 
 module Decidim

--- a/decidim-admin/app/forms/decidim/admin/participatory_process_copy_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_process_copy_form.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Decidim
   module Admin
     # A form object used to copy a participatory processes from the admin

--- a/decidim-admin/spec/commands/copy_participatory_process_spec.rb
+++ b/decidim-admin/spec/commands/copy_participatory_process_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "spec_helper"
 
 describe Decidim::Admin::CopyParticipatoryProcess do

--- a/decidim-admin/spec/features/admin_copy_participatory_process_spec.rb
+++ b/decidim-admin/spec/features/admin_copy_participatory_process_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "spec_helper"
 
 describe "Admin copy participatory process", type: :feature do

--- a/decidim-admin/spec/features/admin_manages_features_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_features_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/decidim-admin/spec/features/admin_manages_newsletters_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_newsletters_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/decidim-admin/spec/features/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_organization_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/decidim-admin/spec/forms/category_form_spec.rb
+++ b/decidim-admin/spec/forms/category_form_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/decidim-admin/spec/forms/newsletter_form_spec.rb
+++ b/decidim-admin/spec/forms/newsletter_form_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/decidim-admin/spec/forms/participatory_process_form_spec.rb
+++ b/decidim-admin/spec/forms/participatory_process_form_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/decidim-admin/spec/forms/participatory_process_group_form_spec.rb
+++ b/decidim-admin/spec/forms/participatory_process_group_form_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/decidim-admin/spec/forms/participatory_process_step_form_spec.rb
+++ b/decidim-admin/spec/forms/participatory_process_step_form_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/decidim-admin/spec/forms/static_page_form_spec.rb
+++ b/decidim-admin/spec/forms/static_page_form_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/decidim-admin/spec/shared/manage_process_steps_examples.rb
+++ b/decidim-admin/spec/shared/manage_process_steps_examples.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 RSpec.shared_examples "manage process steps examples" do

--- a/decidim-admin/spec/shared/manage_processes_examples.rb
+++ b/decidim-admin/spec/shared/manage_processes_examples.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 RSpec.shared_examples "manage processes examples" do

--- a/decidim-budgets/spec/features/orders_spec.rb
+++ b/decidim-budgets/spec/features/orders_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/decidim-comments/spec/lib/comment_serializer_spec.rb
+++ b/decidim-comments/spec/lib/comment_serializer_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "spec_helper"
 
 module Decidim

--- a/decidim-comments/spec/lib/export_spec.rb
+++ b/decidim-comments/spec/lib/export_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "spec_helper"
 
 module Decidim

--- a/decidim-core/app/helpers/decidim/action_authorization_helper.rb
+++ b/decidim-core/app/helpers/decidim/action_authorization_helper.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Decidim

--- a/decidim-core/app/helpers/decidim/application_helper.rb
+++ b/decidim-core/app/helpers/decidim/application_helper.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Decidim

--- a/decidim-core/app/helpers/decidim/cookies_helper.rb
+++ b/decidim-core/app/helpers/decidim/cookies_helper.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Decidim

--- a/decidim-core/app/validators/etiquette_validator.rb
+++ b/decidim-core/app/validators/etiquette_validator.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 # This validator takes care of ensuring the validated content is

--- a/decidim-core/app/validators/geocoding_validator.rb
+++ b/decidim-core/app/validators/geocoding_validator.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 # This validator takes care of ensuring the validated content is

--- a/decidim-core/lib/decidim/devise_failure_app.rb
+++ b/decidim-core/lib/decidim/devise_failure_app.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Decidim

--- a/decidim-core/spec/features/components_spec.rb
+++ b/decidim-core/spec/features/components_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/decidim-core/spec/features/locales_spec.rb
+++ b/decidim-core/spec/features/locales_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/decidim-core/spec/features/participatory_process_groups_spec.rb
+++ b/decidim-core/spec/features/participatory_process_groups_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/decidim-core/spec/features/participatory_process_steps_spec.rb
+++ b/decidim-core/spec/features/participatory_process_steps_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/decidim-core/spec/features/participatory_processes_spec.rb
+++ b/decidim-core/spec/features/participatory_processes_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/decidim-core/spec/helpers/decidim/filters_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/filters_helper_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/decidim-core/spec/helpers/decidim/omniauth_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/omniauth_helper_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/decidim-core/spec/helpers/decidim/replace_buttons_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/replace_buttons_helper_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/decidim-core/spec/helpers/decidim/translations_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/translations_helper_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/decidim-core/spec/lib/stats_registry_spec.rb
+++ b/decidim-core/spec/lib/stats_registry_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/decidim-core/spec/lib/translatable_attributes_spec.rb
+++ b/decidim-core/spec/lib/translatable_attributes_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/decidim-core/spec/validators/etiquette_validator_spec.rb
+++ b/decidim-core/spec/validators/etiquette_validator_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/decidim-core/spec/validators/geocoding_validator_spec.rb
+++ b/decidim-core/spec/validators/geocoding_validator_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/decidim-pages/app/commands/decidim/pages/copy_page.rb
+++ b/decidim-pages/app/commands/decidim/pages/copy_page.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Decidim
   module Pages
     # Command that gets called whenever a feature's page has to be duplicated.

--- a/decidim-pages/spec/commands/copy_page_spec.rb
+++ b/decidim-pages/spec/commands/copy_page_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "spec_helper"
 
 module Decidim

--- a/decidim-pages/spec/features/admin_spec.rb
+++ b/decidim-pages/spec/features/admin_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/decidim-pages/spec/features/page_show_spec.rb
+++ b/decidim-pages/spec/features/page_show_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/decidim-pages/spec/forms/page_form_spec.rb
+++ b/decidim-pages/spec/forms/page_form_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"


### PR DESCRIPTION
#### :tophat: What? Why?

This cop was not being applied because it's disabled in default's RuboCop config. Well, [not anymore](https://github.com/bbatsov/rubocop/pull/4445). :)

We can benefit from it, we don't need those encoding magic comments nowadays!

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![boulder_acrobatics](https://cloud.githubusercontent.com/assets/2887858/26590556/486db602-4531-11e7-88d0-448bac16c5d9.gif)
