### PR TITLE
Fix tests in local environment

### DIFF
--- a/decidim-comments/.gitignore
+++ b/decidim-comments/.gitignore
@@ -1,2 +1,1 @@
-yarn.lock
 app/assets/javascripts/decidim/comments/bundle.js.map

--- a/decidim-dev/app/assets/images/decidim/dummy.svg
+++ b/decidim-dev/app/assets/images/decidim/dummy.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36.02 36.02">
+  <circle cx="18.01" cy="18.01" r="15.75" stroke="#2ecc71" stroke-width="4" fill="none"></circle>
+  <circle cx="18.01" cy="18.01" r="11.25" stroke="#08BCD0" stroke-width="4" fill="none" />
+</svg>

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -31,7 +31,8 @@ capybara_options = {
     )
   ],
   js_errors: true,
-  url_whitelist: ["http://*.lvh.me", "localhost", "127.0.0.1"]
+  url_whitelist: ["http://*.lvh.me", "localhost", "127.0.0.1"],
+  timeout: 1.minute
 }
 
 Capybara.register_driver :poltergeist do |app|

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
@@ -68,6 +68,7 @@ end
 Decidim.register_feature(:dummy) do |feature|
   feature.engine = Decidim::DummyEngine
   feature.admin_engine = Decidim::DummyAdminEngine
+  feature.icon = "decidim/dummy.svg"
 
   feature.actions = %w(foo bar)
 

--- a/decidim-dev/lib/tasks/test_app.rake
+++ b/decidim-dev/lib/tasks/test_app.rake
@@ -14,11 +14,5 @@ namespace :decidim do
         "--quiet"
       ]
     )
-
-    if ENV["CI"]
-      Dir.chdir(dummy_app_path) do
-        Bundler.with_clean_env { sh "bundle exec rake assets:precompile" }
-      end
-    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

After #1392 I started getting a bunch of failures like the following when running the tests:

```
     Failure/Error: <%= stylesheet_link_tag "decidim/email" %>
     
     ActionView::Template::Error:
       unknown filter type: nil
     # /home/deivid/.gem/ruby/2.4.1/gems/sprockets-3.7.1/lib/sprockets/legacy.rb:296:in `compile_match_filter'
     # /home/deivid/.gem/ruby/2.4.1/gems/sprockets-3.7.1/lib/sprockets/manifest.rb:129:in `block in find'
     # /home/deivid/.gem/ruby/2.4.1/gems/sprockets-3.7.1/lib/sprockets/manifest.rb:129:in `map'
     # /home/deivid/.gem/ruby/2.4.1/gems/sprockets-3.7.1/lib/sprockets/manifest.rb:129:in `find'

(... a huge stacktrace redacted ...)

     # /home/deivid/Code/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/database_cleaner.rb:10:in `block (2 levels) in <top (required)>'
     # /home/deivid/Code/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/i18n.rb:13:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # TypeError:
     #   unknown filter type: nil
     #   /home/deivid/.gem/ruby/2.4.1/gems/sprockets-3.7.1/lib/sprockets/legacy.rb:296:in `compile_match_filter'
```

I investigated and the reason is that since assets are now pre-compiled on first access, but that time the [dummy feature](https://github.com/decidim/decidim/blob/a4d0b55966458f3ba97683689695acc391ad61ec/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb#L68-L99) has already been registered. And since it doesn't provide an icon, a `nil` asset is added for precompilation [here](https://github.com/decidim/decidim/blob/a4d0b55966458f3ba97683689695acc391ad61ec/decidim-core/lib/decidim/core/engine.rb#L61-L63), and things blow up.

I fixed this by adding an icon to the dummy feature in f17035c4f06196ab355e9968181e78afc9f7a0a8.

After fixing it, I started getting the following failure on the first test being run:

```
F.

Failures:

  1) User groups when the user group is not verified the user can check its status on his account page
     Failure/Error: visit decidim.own_user_groups_path
     
     Capybara::Poltergeist::StatusFailError:
       Request to 'http://1.lvh.me:46345/own_user_groups' failed to reach server, check DNS and/or server status
     # /home/deivid/.gem/ruby/2.4.1/gems/poltergeist-1.14.0/lib/capybara/poltergeist/browser.rb:376:in `command'
     # /home/deivid/.gem/ruby/2.4.1/gems/poltergeist-1.14.0/lib/capybara/poltergeist/browser.rb:35:in `visit'
     # /home/deivid/.gem/ruby/2.4.1/gems/poltergeist-1.14.0/lib/capybara/poltergeist/driver.rb:97:in `visit'
     # ./spec/features/user_groups_spec.rb:18:in `block (3 levels) in <top (required)>'
     # /home/deivid/Code/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/database_cleaner.rb:11:in `block (3 levels) in <top (required)>'
     # /home/deivid/.gem/ruby/2.4.1/gems/database_cleaner-1.5.3/lib/database_cleaner/generic/base.rb:16:in `cleaning'
     # /home/deivid/.gem/ruby/2.4.1/gems/database_cleaner-1.5.3/lib/database_cleaner/base.rb:98:in `cleaning'
     # /home/deivid/.gem/ruby/2.4.1/gems/database_cleaner-1.5.3/lib/database_cleaner/configuration.rb:86:in `block (2 levels) in cleaning'
     # /home/deivid/.gem/ruby/2.4.1/gems/database_cleaner-1.5.3/lib/database_cleaner/configuration.rb:87:in `cleaning'
     # /home/deivid/Code/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/database_cleaner.rb:10:in `block (2 levels) in <top (required)>'
     # /home/deivid/Code/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/i18n.rb:13:in `block (2 levels) in <top (required)>'

Finished in 51.18 seconds (files took 3.28 seconds to load)
2 examples, 1 failure

Failed examples:

rspec ./spec/features/user_groups_spec.rb:17 # User groups when the user group is not verified the user can check its status on his account page
```

This is because asset precompilation takes a while and poltergeist times out. I fixed that by specifying a high timeout to give asset precompilation time enough to happen successfully (e4b8763).

I also removed asset precompilation in CI before tests since I didn't see any reason to have tests behave differently depending on the environment (2dae166).

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![ping](https://cloud.githubusercontent.com/assets/2887858/26606273/b2fa36f4-4567-11e7-9761-74307906e44e.gif)

