### PR TITLE
Searching, filtering and validating organizations

### DIFF
--- a/decidim-admin/app/assets/stylesheets/decidim/admin/_variables.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/_variables.scss
@@ -2,10 +2,6 @@
 
 $brand: #9675ce !default;
 
-$success: #57d685 !default;
-$warning: #ffae00 !default;
-$alert: #ec5840 !default;
-
 $twitter: #55acee !default;
 $facebook: #3b5998 !default;
 $google: #dd4b39 !default;

--- a/decidim-admin/app/assets/stylesheets/decidim/admin/_variables.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/_variables.scss
@@ -2,6 +2,10 @@
 
 $brand: #9675ce !default;
 
+$success: #57d685 !default;
+$warning: #ffae00 !default;
+$alert: #ec5840 !default;
+
 $twitter: #55acee !default;
 $facebook: #3b5998 !default;
 $google: #dd4b39 !default;

--- a/decidim-admin/app/assets/stylesheets/decidim/admin/extra/_action-icon.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/extra/_action-icon.scss
@@ -2,6 +2,7 @@
   .action-icon {
     &.action-icon--disabled {
       color: rgba($muted, .3);
+      vertical-align: bottom
     }
   }
 }

--- a/decidim-admin/app/assets/stylesheets/decidim/admin/extra/_dropdown_inverted.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/extra/_dropdown_inverted.scss
@@ -1,4 +1,4 @@
-.user-groups__dropmenu{
+.dropdown-inverted{
   display: inline-block;
   vertical-align: middle;
   padding: 2px 10px 2px 2px;
@@ -33,18 +33,6 @@
   }
 }
 
-.dropdown_text{
+.dropdown-menu-inverted_label{
   vertical-align: middle;
-}
-
-#user-groups{
-  .action-icon--disabled {
-    pointer-events: none;
-  }
-  .action-icon--remove{
-    color: $muted;
-    &:hover{
-      color: $primary-color;
-    }
-  }
 }

--- a/decidim-admin/app/assets/stylesheets/decidim/admin/extra/_user-groups_filter.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/extra/_user-groups_filter.scss
@@ -1,0 +1,50 @@
+.user-groups__dropmenu{
+  display: inline-block;
+  vertical-align: middle;
+  padding: 2px 10px 2px 2px;
+  text-align: right;
+  .dropdown > li > a{
+    padding-left: 0;
+  }
+  .dropdown{
+    display: inline-block;
+    vertical-align: middle;
+  }
+  .is-dropdown-submenu{
+    z-index: 2;
+    text-align: left;
+    background-color: $white !important;
+    border: 1px solid $light-gray !important;
+    box-shadow: 0 3px 5px rgba(0, 0, 0, .3);
+    min-width: 100px;
+    li{
+        padding: 8px 8px 0
+    }
+    li:hover{
+      background-color: darken($white, 5%) !important;
+    }
+    a{
+      color: $body-font-color;
+      padding: .5rem;
+    }
+    a:hover{
+      color: lighten($body-font-color, 20);
+    }
+  }
+}
+
+.dropdown_text{
+  vertical-align: middle;
+}
+
+#user-groups{
+  .action-icon--disabled {
+    pointer-events: none;
+  }
+  .action-icon--remove{
+    color: $muted;
+    &:hover{
+      color: $primary-color;
+    }
+  }
+}

--- a/decidim-admin/app/commands/decidim/admin/copy_participatory_process.rb
+++ b/decidim-admin/app/commands/decidim/admin/copy_participatory_process.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Decidim
   module Admin
     # A command with all the business logic when copying a new participatory

--- a/decidim-admin/app/commands/decidim/admin/reject_user_group.rb
+++ b/decidim-admin/app/commands/decidim/admin/reject_user_group.rb
@@ -20,7 +20,7 @@ module Decidim
       def call
         return broadcast(:invalid) unless @user_group.valid?
         reject_user_group
-        return broadcast(:ok)
+        broadcast(:ok)
       end
 
       private

--- a/decidim-admin/app/commands/decidim/admin/reject_user_group.rb
+++ b/decidim-admin/app/commands/decidim/admin/reject_user_group.rb
@@ -14,6 +14,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
+      # - :invalid if the form wasn't valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/reject_user_group.rb
+++ b/decidim-admin/app/commands/decidim/admin/reject_user_group.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module Admin
-    # A command with all the business logic when updating a user_group.
+    # A command with all the business logic when rejecting a user_group.
     class RejectUserGroup < Rectify::Command
       # Public: Initializes the command.
       #
@@ -18,7 +18,7 @@ module Decidim
       #
       # Returns nothing.
       def call
-        verify_user_group
+        reject_user_group
         broadcast(:ok)
       rescue ActiveRecord::RecordInvalid
         broadcast(:invalid)
@@ -26,7 +26,7 @@ module Decidim
 
       private
 
-      def verify_user_group
+      def reject_user_group
         @user_group.update_attributes!(rejected_at: Time.current, verified_at: nil)
       end
     end

--- a/decidim-admin/app/commands/decidim/admin/reject_user_group.rb
+++ b/decidim-admin/app/commands/decidim/admin/reject_user_group.rb
@@ -18,16 +18,15 @@ module Decidim
       #
       # Returns nothing.
       def call
+        return broadcast(:invalid) unless @user_group.valid?
         reject_user_group
-        broadcast(:ok)
-      rescue ActiveRecord::RecordInvalid
-        broadcast(:invalid)
+        return broadcast(:ok)
       end
 
       private
 
       def reject_user_group
-        @user_group.update_attributes!(rejected_at: Time.current, verified_at: nil)
+        @user_group.update_attributes(rejected_at: Time.current, verified_at: nil)
       end
     end
   end

--- a/decidim-admin/app/commands/decidim/admin/reject_user_group.rb
+++ b/decidim-admin/app/commands/decidim/admin/reject_user_group.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # A command with all the business logic when updating a user_group.
+    class RejectUserGroup < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # user_group - The user_group to reject
+      def initialize(user_group)
+        @user_group = user_group
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid.
+      #
+      # Returns nothing.
+      def call
+        verify_user_group
+        broadcast(:ok)
+      rescue ActiveRecord::RecordInvalid
+        broadcast(:invalid)
+      end
+
+      private
+
+      def verify_user_group
+        @user_group.update_attributes!(rejected_at: Time.current, verified_at: nil)
+      end
+    end
+  end
+end

--- a/decidim-admin/app/commands/decidim/admin/update_user_groups.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_user_groups.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # A command with all the business logic when updating a usergroup.
+    class UpdateUserGroups < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # scope - The Scope to update
+      # form - A form object with the params.
+      def initialize(user_group)
+        @user_group = user_group
+        @form = form
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid.
+      # - :invalid if the form wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        return broadcast(:invalid) if form.invalid?
+
+        update_scope
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :form
+
+      def update_scope
+        @scope.update_attributes!(attributes)
+      end
+
+      def attributes
+        {
+          name: form.name
+        }
+      end
+    end
+  end
+end

--- a/decidim-admin/app/commands/decidim/admin/verify_user_group.rb
+++ b/decidim-admin/app/commands/decidim/admin/verify_user_group.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module Admin
-    # A command with all the business logic when updating a user_group.
+    # A command with all the business logic when verifying a user_group.
     class VerifyUserGroup < Rectify::Command
       # Public: Initializes the command.
       #

--- a/decidim-admin/app/commands/decidim/admin/verify_user_group.rb
+++ b/decidim-admin/app/commands/decidim/admin/verify_user_group.rb
@@ -17,16 +17,15 @@ module Decidim
       #
       # Returns nothing.
       def call
+        return broadcast(:invalid) unless @user_group.valid?
         verify_user_group
-        broadcast(:ok)
-      rescue ActiveRecord::RecordInvalid
-        broadcast(:invalid)
+        return broadcast(:ok)
       end
 
       private
 
       def verify_user_group
-        @user_group.update_attributes!(verified_at: Time.current, rejected_at: nil)
+        @user_group.update_attributes(verified_at: Time.current, rejected_at: nil)
       end
     end
   end

--- a/decidim-admin/app/commands/decidim/admin/verify_user_group.rb
+++ b/decidim-admin/app/commands/decidim/admin/verify_user_group.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # A command with all the business logic when updating a user_group.
+    class VerifyUserGroup < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # user_group - The user_group to verify
+      def initialize(user_group)
+        @user_group = user_group
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid.
+      #
+      # Returns nothing.
+      def call
+        verify_user_group
+        broadcast(:ok)
+      rescue ActiveRecord::RecordInvalid
+        broadcast(:invalid)
+      end
+
+      private
+
+      def verify_user_group
+        @user_group.update_attributes!(verified_at: Time.current, rejected_at: nil)
+      end
+    end
+  end
+end

--- a/decidim-admin/app/commands/decidim/admin/verify_user_group.rb
+++ b/decidim-admin/app/commands/decidim/admin/verify_user_group.rb
@@ -19,7 +19,7 @@ module Decidim
       def call
         return broadcast(:invalid) unless @user_group.valid?
         verify_user_group
-        return broadcast(:ok)
+        broadcast(:ok)
       end
 
       private

--- a/decidim-admin/app/controllers/decidim/admin/participatory_process_copies_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/participatory_process_copies_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_dependency "decidim/admin/application_controller"
 
 module Decidim

--- a/decidim-admin/app/controllers/decidim/admin/user_groups_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/user_groups_controller.rb
@@ -36,12 +36,12 @@ module Decidim
 
         VerifyUserGroup.call(@user_group) do
           on(:ok) do
-            flash[:notice] = I18n.t("user_groups.verify.success", scope: "decidim.admin")
+            flash[:notice] = I18n.t("user_group.verify.success", scope: "decidim.admin")
             redirect_back(fallback_location: decidim_admin.user_groups_path)
           end
 
           on(:invalid) do 
-            flash[:alert] = I18n.t("user_groups.verify.invalid", scope: "decidim.admin")
+            flash[:alert] = I18n.t("user_group.verify.invalid", scope: "decidim.admin")
             redirect_back(fallback_location: decidim_admin.user_groups_path)
           end
         end
@@ -53,12 +53,12 @@ module Decidim
 
         RejectUserGroup.call(@user_group) do
           on(:ok) do
-            flash[:notice] = I18n.t("user_groups.reject.success", scope: "decidim.admin")
+            flash[:notice] = I18n.t("user_group.reject.success", scope: "decidim.admin")
             redirect_back(fallback_location: decidim_admin.user_groups_path)
           end
 
           on(:invalid) do 
-            flash[:alert] = I18n.t("user_groups.reject.invalid", scope: "decidim.admin")
+            flash[:alert] = I18n.t("user_group.reject.invalid", scope: "decidim.admin")
             redirect_back(fallback_location: decidim_admin.user_groups_path)
           end
         end

--- a/decidim-admin/app/controllers/decidim/admin/user_groups_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/user_groups_controller.rb
@@ -16,14 +16,14 @@ module Decidim
         @user_groups = @user_groups.where("LOWER(name) LIKE LOWER('%#{@query}%')") if @query.present?
 
         @user_groups = case @state
-                        when "verified"
-                          @user_groups.where.not(verified_at: nil)
-                        when "rejected"
-                          @user_groups.where.not(rejected_at: nil)
-                        when "pending"
-                          @user_groups.where(verified_at: nil, rejected_at: nil)
-                        else
-                          @user_groups
+                       when "verified"
+                         @user_groups.where.not(verified_at: nil)
+                       when "rejected"
+                         @user_groups.where.not(rejected_at: nil)
+                       when "pending"
+                         @user_groups.where(verified_at: nil, rejected_at: nil)
+                       else
+                         @user_groups
                         end
 
         @user_groups = @user_groups.page(params[:page])
@@ -40,7 +40,7 @@ module Decidim
             redirect_back(fallback_location: decidim_admin.user_groups_path)
           end
 
-          on(:invalid) do 
+          on(:invalid) do
             flash[:alert] = I18n.t("user_group.verify.invalid", scope: "decidim.admin")
             redirect_back(fallback_location: decidim_admin.user_groups_path)
           end
@@ -57,7 +57,7 @@ module Decidim
             redirect_back(fallback_location: decidim_admin.user_groups_path)
           end
 
-          on(:invalid) do 
+          on(:invalid) do
             flash[:alert] = I18n.t("user_group.reject.invalid", scope: "decidim.admin")
             redirect_back(fallback_location: decidim_admin.user_groups_path)
           end

--- a/decidim-admin/app/controllers/decidim/admin/user_groups_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/user_groups_controller.rb
@@ -13,7 +13,7 @@ module Decidim
         @state = params[:state]
 
         @user_groups = Decidim::Admin::UserGroupsEvaluation.for(collection, @query, @state)
-                      .page(params[:page]).per(15)
+                                                           .page(params[:page]).per(15)
       end
 
       def verify

--- a/decidim-admin/app/controllers/decidim/admin/user_groups_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/user_groups_controller.rb
@@ -9,17 +9,59 @@ module Decidim
 
       def index
         authorize! :index, UserGroup
-        @user_groups = collection.page(params[:page]).per(15)
+        @query = params[:q]
+        @state = params[:state]
+        @user_groups = collection
+
+        @user_groups = @user_groups.where("LOWER(name) LIKE LOWER('%#{@query}%')") if @query.present?
+
+        @user_groups = case @state
+                        when "verified"
+                          @user_groups.where.not(verified_at: nil)
+                        when "rejected"
+                          @user_groups.where.not(rejected_at: nil)
+                        when "pending"
+                          @user_groups.where(verified_at: nil, rejected_at: nil)
+                        else
+                          @user_groups
+                        end
+
+        @user_groups = @user_groups.page(params[:page])
+                                   .per(15)
       end
 
       def verify
         @user_group = collection.find(params[:id])
         authorize! :verify, @user_group
 
-        @user_group.verify!
+        VerifyUserGroup.call(@user_group) do
+          on(:ok) do
+            flash[:notice] = I18n.t("user_groups.verify.success", scope: "decidim.admin")
+            redirect_back(fallback_location: decidim_admin.user_groups_path)
+          end
 
-        flash[:notice] = I18n.t("user_groups.verify.success", scope: "decidim.admin")
-        redirect_to decidim_admin.user_groups_path
+          on(:invalid) do 
+            flash[:alert] = I18n.t("user_groups.verify.invalid", scope: "decidim.admin")
+            redirect_back(fallback_location: decidim_admin.user_groups_path)
+          end
+        end
+      end
+
+      def reject
+        @user_group = collection.find(params[:id])
+        authorize! :reject, @user_group
+
+        RejectUserGroup.call(@user_group) do
+          on(:ok) do
+            flash[:notice] = I18n.t("user_groups.reject.success", scope: "decidim.admin")
+            redirect_back(fallback_location: decidim_admin.user_groups_path)
+          end
+
+          on(:invalid) do 
+            flash[:alert] = I18n.t("user_groups.reject.invalid", scope: "decidim.admin")
+            redirect_back(fallback_location: decidim_admin.user_groups_path)
+          end
+        end
       end
 
       private

--- a/decidim-admin/app/controllers/decidim/admin/user_groups_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/user_groups_controller.rb
@@ -11,23 +11,9 @@ module Decidim
         authorize! :index, UserGroup
         @query = params[:q]
         @state = params[:state]
-        @user_groups = collection
 
-        @user_groups = @user_groups.where("LOWER(name) LIKE LOWER('%#{@query}%')") if @query.present?
-
-        @user_groups = case @state
-                       when "verified"
-                         @user_groups.where.not(verified_at: nil)
-                       when "rejected"
-                         @user_groups.where.not(rejected_at: nil)
-                       when "pending"
-                         @user_groups.where(verified_at: nil, rejected_at: nil)
-                       else
-                         @user_groups
-                        end
-
-        @user_groups = @user_groups.page(params[:page])
-                                   .per(15)
+        @user_groups = Decidim::Admin::UserGroupsEvaluation.for(collection, @query, @state)
+                      .page(params[:page]).per(15)
       end
 
       def verify

--- a/decidim-admin/app/forms/decidim/admin/participatory_process_copy_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_process_copy_form.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Decidim
   module Admin
     # A form object used to copy a participatory processes from the admin

--- a/decidim-admin/app/models/decidim/admin/abilities/admin_user.rb
+++ b/decidim-admin/app/models/decidim/admin/abilities/admin_user.rb
@@ -39,7 +39,7 @@ module Decidim
             user != user_to_destroy
           end
 
-          can [:index, :verify], UserGroup
+          can [:index, :verify, :reject], UserGroup
         end
       end
     end

--- a/decidim-admin/app/queries/decidim/admin/user_groups_evaluation.rb
+++ b/decidim-admin/app/queries/decidim/admin/user_groups_evaluation.rb
@@ -49,7 +49,7 @@ module Decidim
           user_groups.where(verified_at: nil, rejected_at: nil)
         else
           user_groups
-          end
+        end
       end
     end
   end

--- a/decidim-admin/app/queries/decidim/admin/user_groups_evaluation.rb
+++ b/decidim-admin/app/queries/decidim/admin/user_groups_evaluation.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # A class used to find the ParticipatoryProcesses that the given user can
+    # manage.
+    class UserGroupsEvaluation < Rectify::Query
+      # Syntactic sugar to initialize the class and return the queried objects.
+      #
+      # user - a User Group that needs to be listed.
+      def self.for(user_groups, q = nil, state = nil)
+        new(user_groups, q, state).query
+      end
+
+      # Initializes the class.
+      #
+      # user_group - a User groups that need to be lsited
+      def initialize(user_groups, q = nil, state = nil)
+        @user_groups = user_groups
+        @q = q
+        @state = state
+      end
+
+      # List the User groups by the diferents filters.
+      def query
+        @user_groups = filter_by_search(@user_groups)
+        @user_groups = filter_by_state(@user_groups)
+        @user_groups
+      end
+
+      private
+
+      attr_reader :user_group
+
+      def filter_by_search(user_groups)
+        if @q.present?
+          user_groups = user_groups.where("LOWER(name) LIKE LOWER('%#{@q}%')")
+        end
+        user_groups
+      end
+
+      def filter_by_state(user_groups)
+        case @state
+          when "verified"
+            user_groups.where.not(verified_at: nil)
+          when "rejected"
+            user_groups.where.not(rejected_at: nil)
+          when "pending"
+            user_groups.where(verified_at: nil, rejected_at: nil)
+          else
+            user_groups
+          end
+      end
+    end
+  end
+end

--- a/decidim-admin/app/queries/decidim/admin/user_groups_evaluation.rb
+++ b/decidim-admin/app/queries/decidim/admin/user_groups_evaluation.rb
@@ -41,14 +41,14 @@ module Decidim
 
       def filter_by_state(user_groups)
         case @state
-          when "verified"
-            user_groups.where.not(verified_at: nil)
-          when "rejected"
-            user_groups.where.not(rejected_at: nil)
-          when "pending"
-            user_groups.where(verified_at: nil, rejected_at: nil)
-          else
-            user_groups
+        when "verified"
+          user_groups.where.not(verified_at: nil)
+        when "rejected"
+          user_groups.where.not(rejected_at: nil)
+        when "pending"
+          user_groups.where(verified_at: nil, rejected_at: nil)
+        else
+          user_groups
           end
       end
     end

--- a/decidim-admin/app/queries/decidim/admin/user_groups_evaluation.rb
+++ b/decidim-admin/app/queries/decidim/admin/user_groups_evaluation.rb
@@ -33,10 +33,8 @@ module Decidim
       attr_reader :user_group
 
       def filter_by_search(user_groups)
-        if @q.present?
-          user_groups = user_groups.where("LOWER(name) LIKE LOWER('%#{@q}%')")
-        end
-        user_groups
+        return user_groups if @q.blank?
+        user_groups.where("LOWER(name) LIKE LOWER('%#{@q}%')")
       end
 
       def filter_by_state(user_groups)

--- a/decidim-admin/app/views/decidim/admin/scopes/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/scopes/new.html.erb
@@ -1,4 +1,3 @@
-
 <%= decidim_form_for(@form) do |f| %>
   <div class="card">
     <div class="card-divider">

--- a/decidim-admin/app/views/decidim/admin/user_groups/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/user_groups/index.html.erb
@@ -1,7 +1,7 @@
 <div class="filters row">
   <div class="column medium-3">
-    <span class="dropdown_text"><%= t(".filter_by") %> :</span>
-    <ul class="dropdown menu user-groups__dropmenu" data-dropdown-menu data-close-on-click-inside="false">
+    <span class="dropdown-menu-inverted_label"><%= t(".filter_by") %> :</span>
+    <ul class="dropdown menu dropdown-inverted" data-dropdown-menu data-close-on-click-inside="false">
         <li class="is-dropdown-submenu-parent">
           <a href="#">
           <% if @state.present? %>
@@ -76,17 +76,17 @@
               <td class="table-list__actions">
                 <% if can?(:verify, user_group) %>
                   <% if !user_group.verified? %>
-                    <%= icon_link_to "circle-check", decidim_admin.verify_user_group_path(user_group), t("actions.verify", scope: "decidim.admin"), method: :put, class: "action-icon--activate" %>
+                    <%= icon_link_to "circle-check", decidim_admin.verify_user_group_path(user_group), t("actions.verify", scope: "decidim.admin"), method: :put, class: "action-icon--verify" %>
                   <% else %>
-                    <%= icon_link_to "circle-check", decidim_admin.verify_user_group_path(user_group), t("actions.verify", scope: "decidim.admin"), method: :put, class: "action-icon--disabled" %>
+                    <%= icon "circle-check", class: "action-icon action-icon--disabled" %>
                   <% end %>
                 <% end %>
 
                 <% if can?(:reject, user_group) %>
                   <% if !user_group.rejected? %>
-                    <%= icon_link_to "circle-x", decidim_admin.reject_user_group_path(user_group), t("actions.reject", scope: "decidim.admin"), method: :put, class: "action-icon--remove" %>
+                    <%= icon_link_to "circle-x", decidim_admin.reject_user_group_path(user_group), t("actions.reject", scope: "decidim.admin"), method: :put, class: "action-icon--reject" %>
                   <% else %>
-                    <%= icon_link_to "circle-x", decidim_admin.reject_user_group_path(user_group), t("actions.reject", scope: "decidim.admin"), method: :put, class: "action-icon--disabled" %>
+                    <%= icon "circle-x", class: "action-icon action-icon--disabled" %>
                   <% end %>
                 <% end %>
               </td>

--- a/decidim-admin/app/views/decidim/admin/user_groups/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/user_groups/index.html.erb
@@ -1,4 +1,42 @@
-<div class="card">
+<div class="filters row">
+  <div class="column medium-3">
+    <span class="dropdown_text"><%= t(".filter_by") %> :</span>
+    <ul class="dropdown menu user-groups__dropmenu" data-dropdown-menu data-close-on-click-inside="false">
+        <li class="is-dropdown-submenu-parent">
+          <a href="#">
+          <% if @state.present? %>
+            <%= t(".filter.#{@state}") %>
+          <% else %>
+            <%= t(".filter.all") %>
+          <% end %>
+          </a>
+          <ul class="menu is-dropdown-submenu">
+            <li><%= link_to t(".filter.pending"), url_for(state: "pending", q: @query) %></li>
+            <li><%= link_to t(".filter.rejected"), url_for(state: "rejected", q: @query) %></li>
+            <li><%= link_to t(".filter.verified"), url_for(state: "verified", q: @query) %></li>
+            <li><%= link_to t(".filter.all"), url_for(q: @query) %></li>
+          </ul>
+        </li>
+      </ul>
+  </div>
+  <div class="column medium-4">
+    <%= form_tag "", method: :get do %>
+      <div class="filters__search">
+        <div class="input-group">
+          <%= search_field_tag :q, @query,label: false, class: "input-group-field", placeholder: t('.search') %>
+          <%= hidden_field_tag :state, @state %>
+          <div class="input-group-button">
+            <button type="submit" class="button button--muted">
+              <%= icon "magnifying-glass", aria_label: t('.search') %>
+            </button>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<div class="card" id='user-groups'>
   <div class="card-divider">
     <h2 class="card-title"><%= t "decidim.admin.titles.user_groups" %></h2>
   </div>
@@ -12,7 +50,8 @@
             <th><%= t("models.user_group.fields.phone", scope: "decidim.admin") %></th>
             <th><%= t("models.user_group.fields.users_count", scope: "decidim.admin") %></th>
             <th><%= t("models.user_group.fields.created_at", scope: "decidim.admin") %></th>
-            <th></th>
+            <th><%= t("models.user_group.fields.state", scope: "decidim.admin") %></th>
+            <th><%= t("models.user_group.fields.actions", scope: "decidim.admin") %></th>
           </tr>
         </thead>
         <tbody>
@@ -23,9 +62,32 @@
               <td><%= user_group.phone %></td>
               <td><%= user_group.users.size %></td>
               <td><%= l user_group.created_at, format: :short %></td>
-              <td class="text-right">
-                <% if can?(:verify, user_group) && !user_group.verified? %>
-                  <%= link_to t("actions.verify", scope: "decidim.admin"), decidim_admin.verify_user_group_path(user_group), method: :put, class: "button tiny" %>
+              <td>
+              <% if user_group.verified? %>
+                <%= t(".state.verified") %>
+              <% end %>
+              <% if user_group.rejected? %>
+                <%= t(".state.rejected") %>
+              <% end %>
+              <% if !user_group.verified? && !user_group.rejected?%>
+                <%= t(".state.pending") %>
+              <% end %>
+              </td>
+              <td class="table-list__actions">
+                <% if can?(:verify, user_group) %>
+                  <% if !user_group.verified? %>
+                    <%= icon_link_to "circle-check", decidim_admin.verify_user_group_path(user_group), t("actions.verify", scope: "decidim.admin"), method: :put, class: "action-icon--activate" %>
+                  <% else %>
+                    <%= icon_link_to "circle-check", decidim_admin.verify_user_group_path(user_group), t("actions.verify", scope: "decidim.admin"), method: :put, class: "action-icon--disabled" %>
+                  <% end %>
+                <% end %>
+
+                <% if can?(:reject, user_group) %>
+                  <% if !user_group.rejected? %>
+                    <%= icon_link_to "circle-x", decidim_admin.reject_user_group_path(user_group), t("actions.reject", scope: "decidim.admin"), method: :put, class: "action-icon--remove" %>
+                  <% else %>
+                    <%= icon_link_to "circle-x", decidim_admin.reject_user_group_path(user_group), t("actions.reject", scope: "decidim.admin"), method: :put, class: "action-icon--disabled" %>
+                  <% end %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-admin/app/views/decidim/admin/user_groups/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/user_groups/index.html.erb
@@ -69,7 +69,7 @@
               <% if user_group.rejected? %>
                 <%= t(".state.rejected") %>
               <% end %>
-              <% if !user_group.verified? && !user_group.rejected?%>
+              <% if user_group.pending?%>
                 <%= t(".state.pending") %>
               <% end %>
               </td>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -124,6 +124,7 @@ en:
         permissions: Permissions
         preview: Preview
         publish: Publish
+        reject: Reject
         resend_invitation: Resend invitation
         unpublish: Unpublish
         verify: Verify
@@ -297,10 +298,12 @@ en:
           name: User
         user_group:
           fields:
+            actions: Actions
             created_at: Created at
             document_number: Document number
             name: Name
             phone: Phone
+            state: State
             users_count: Users count
       moderations:
         index:
@@ -484,6 +487,20 @@ en:
         user_groups: User groups
         users: Users
       user_groups:
+        index:
+          filter:
+            all: All
+            pending: Pending
+            rejected: Rejected
+            verified: Verified
+          filter_by: Filter by
+          search: Search
+          state:
+            pending: Pending
+            rejected: Rejected
+            verified: Verified
+        reject:
+          success: Success
         verify:
           success: The user group was verified successfully.
       users:

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -489,10 +489,10 @@ en:
       user_group:
         reject:
           invalid: There was an error when rejecting this user group.
-          success: User group updated successfully
+          success: User group rejected successfully
         verify:
           invalid: There was an error when verifying this user group.
-          success: User group updated successfully
+          success: User group verified successfully
       user_groups:
         index:
           filter:

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -486,6 +486,13 @@ en:
         static_pages: Pages
         user_groups: User groups
         users: Users
+      user_group:
+        reject:
+          invalid: There was an error when rejecting this user group.
+          success: User group updated successfully
+        verify:
+          invalid: There was an error when verifying this user group.
+          success: User group updated successfully
       user_groups:
         index:
           filter:
@@ -499,10 +506,6 @@ en:
             pending: Pending
             rejected: Rejected
             verified: Verified
-        reject:
-          success: Success
-        verify:
-          success: The user group was verified successfully.
       users:
         create:
           error: There was an error when inviting this user.

--- a/decidim-admin/config/routes.rb
+++ b/decidim-admin/config/routes.rb
@@ -66,6 +66,7 @@ Decidim::Admin::Engine.routes.draw do
     resources :user_groups, only: [:index] do
       member do
         put :verify
+        put :reject
       end
     end
 

--- a/decidim-admin/db/migrate/20170529143809_add_rejected_at_to_user_groups.rb
+++ b/decidim-admin/db/migrate/20170529143809_add_rejected_at_to_user_groups.rb
@@ -1,0 +1,5 @@
+class AddRejectedAtToUserGroups < ActiveRecord::Migration[5.0]
+  def change
+    add_column :decidim_user_groups, :rejected_at, :datetime
+  end
+end

--- a/decidim-admin/db/migrate/20170529143809_add_rejected_at_to_user_groups.rb
+++ b/decidim-admin/db/migrate/20170529143809_add_rejected_at_to_user_groups.rb
@@ -1,5 +1,0 @@
-class AddRejectedAtToUserGroups < ActiveRecord::Migration[5.0]
-  def change
-    add_column :decidim_user_groups, :rejected_at, :datetime
-  end
-end

--- a/decidim-admin/spec/commands/copy_participatory_process_spec.rb
+++ b/decidim-admin/spec/commands/copy_participatory_process_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "spec_helper"
 
 describe Decidim::Admin::CopyParticipatoryProcess do

--- a/decidim-admin/spec/commands/reject_user_group_spec.rb
+++ b/decidim-admin/spec/commands/reject_user_group_spec.rb
@@ -26,18 +26,16 @@ describe Decidim::Admin::RejectUserGroup do
     end
 
     context "when the command is valid" do
-
       it "the user group is rejected" do
         expect { subject.call }.to broadcast(:ok)
 
         expect(user_group.verified_at).to be_nil
         expect(user_group.rejected_at).not_to be_nil
       end
-
     end
   end
 
-   describe "User group is already rejected" do
+  describe "User group is already rejected" do
     let!(:user_group) { create(:user_group, verified_at: Time.current, users: [create(:user, organization: organization)]) }
 
     subject { described_class.new(user_group) }
@@ -58,14 +56,12 @@ describe Decidim::Admin::RejectUserGroup do
     end
 
     context "when the command is valid" do
-
       it "the user group is rejected" do
         expect { subject.call }.to broadcast(:ok)
 
         expect(user_group.verified_at).to be_nil
         expect(user_group.rejected_at).not_to be_nil
       end
-
     end
   end
 end

--- a/decidim-admin/spec/commands/reject_user_group_spec.rb
+++ b/decidim-admin/spec/commands/reject_user_group_spec.rb
@@ -12,7 +12,7 @@ describe Decidim::Admin::RejectUserGroup do
 
     context "when the command is not valid" do
       before do
-        allow(user_group).to receive(:update_attributes!).and_raise(ActiveRecord::RecordInvalid)
+        allow(user_group).to receive(:update_attributes).and_raise(ActiveRecord::RecordInvalid)
       end
 
       let(:invalid) { true }
@@ -42,7 +42,7 @@ describe Decidim::Admin::RejectUserGroup do
 
     context "when the command is not valid" do
       before do
-        allow(user_group).to receive(:update_attributes!).and_raise(ActiveRecord::RecordInvalid)
+        allow(user_group).to receive(:update_attributes).and_raise(ActiveRecord::RecordInvalid)
       end
 
       let(:invalid) { true }

--- a/decidim-admin/spec/commands/reject_user_group_spec.rb
+++ b/decidim-admin/spec/commands/reject_user_group_spec.rb
@@ -11,13 +11,10 @@ describe Decidim::Admin::RejectUserGroup do
     subject { described_class.new(user_group) }
 
     context "when the command is not valid" do
-      before do
-        allow(user_group).to receive(:update_attributes).and_raise(ActiveRecord::RecordInvalid)
-      end
-
       let(:invalid) { true }
 
       it "broadcast invalid in return" do
+        expect(user_group).to receive(:valid?).and_return(false)
         expect { subject.call }.to broadcast(:invalid)
 
         expect(user_group.rejected_at).to be_nil
@@ -41,13 +38,10 @@ describe Decidim::Admin::RejectUserGroup do
     subject { described_class.new(user_group) }
 
     context "when the command is not valid" do
-      before do
-        allow(user_group).to receive(:update_attributes).and_raise(ActiveRecord::RecordInvalid)
-      end
-
       let(:invalid) { true }
 
       it "broadcast invalid in return and do not clean verified_at" do
+        expect(user_group).to receive(:valid?).and_return(false)
         expect { subject.call }.to broadcast(:invalid)
 
         expect(user_group.verified_at).not_to be_nil

--- a/decidim-admin/spec/commands/reject_user_group_spec.rb
+++ b/decidim-admin/spec/commands/reject_user_group_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Admin::RejectUserGroup do
+  let(:organization) { create :organization }
+
+  describe "User group validation is pending" do
+    let!(:user_group) { create(:user_group, users: [create(:user, organization: organization)]) }
+
+    subject { described_class.new(user_group) }
+
+    context "when the command is not valid" do
+      before do
+        allow(user_group).to receive(:update_attributes!).and_raise(ActiveRecord::RecordInvalid)
+      end
+
+      let(:invalid) { true }
+
+      it "broadcast invalid in return" do
+        expect { subject.call }.to broadcast(:invalid)
+
+        expect(user_group.rejected_at).to be_nil
+        expect(user_group.verified_at).to be_nil
+      end
+    end
+
+    context "when the command is valid" do
+
+      it "the user group is rejected" do
+        expect { subject.call }.to broadcast(:ok)
+
+        expect(user_group.verified_at).to be_nil
+        expect(user_group.rejected_at).not_to be_nil
+      end
+
+    end
+  end
+
+   describe "User group is already rejected" do
+    let!(:user_group) { create(:user_group, verified_at: Time.current, users: [create(:user, organization: organization)]) }
+
+    subject { described_class.new(user_group) }
+
+    context "when the command is not valid" do
+      before do
+        allow(user_group).to receive(:update_attributes!).and_raise(ActiveRecord::RecordInvalid)
+      end
+
+      let(:invalid) { true }
+
+      it "broadcast invalid in return and do not clean verified_at" do
+        expect { subject.call }.to broadcast(:invalid)
+
+        expect(user_group.verified_at).not_to be_nil
+        expect(user_group.rejected_at).to be_nil
+      end
+    end
+
+    context "when the command is valid" do
+
+      it "the user group is rejected" do
+        expect { subject.call }.to broadcast(:ok)
+
+        expect(user_group.verified_at).to be_nil
+        expect(user_group.rejected_at).not_to be_nil
+      end
+
+    end
+  end
+end

--- a/decidim-admin/spec/commands/verify_user_group_spec.rb
+++ b/decidim-admin/spec/commands/verify_user_group_spec.rb
@@ -11,13 +11,10 @@ describe Decidim::Admin::VerifyUserGroup do
     subject { described_class.new(user_group) }
 
     context "when the command is not valid" do
-      before do
-        allow(user_group).to receive(:update_attributes!).and_raise(ActiveRecord::RecordInvalid)
-      end
-
       let(:invalid) { true }
 
       it "broadcast invalid in return" do
+        expect(user_group).to receive(:valid?).and_return(false)
         expect { subject.call }.to broadcast(:invalid)
 
         expect(user_group.rejected_at).to be_nil
@@ -40,14 +37,11 @@ describe Decidim::Admin::VerifyUserGroup do
 
     subject { described_class.new(user_group) }
 
-    context "when the command is not valid" do
-      before do
-        allow(user_group).to receive(:update_attributes!).and_raise(ActiveRecord::RecordInvalid)
-      end
-
+    context "when the command is not valid" do 
       let(:invalid) { true }
 
       it "broadcast invalid in return and do not clean rejected_at" do
+        expect(user_group).to receive(:valid?).and_return(false)
         expect { subject.call }.to broadcast(:invalid)
 
         expect(user_group.rejected_at).not_to be_nil

--- a/decidim-admin/spec/commands/verify_user_group_spec.rb
+++ b/decidim-admin/spec/commands/verify_user_group_spec.rb
@@ -37,7 +37,7 @@ describe Decidim::Admin::VerifyUserGroup do
 
     subject { described_class.new(user_group) }
 
-    context "when the command is not valid" do 
+    context "when the command is not valid" do
       let(:invalid) { true }
 
       it "broadcast invalid in return and do not clean rejected_at" do

--- a/decidim-admin/spec/commands/verify_user_group_spec.rb
+++ b/decidim-admin/spec/commands/verify_user_group_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Admin::VerifyUserGroup do
+  let(:organization) { create :organization }
+
+  describe "User group validation is pending" do
+    let!(:user_group) { create(:user_group, users: [create(:user, organization: organization)]) }
+
+    subject { described_class.new(user_group) }
+
+    context "when the command is not valid" do
+      before do
+        allow(user_group).to receive(:update_attributes!).and_raise(ActiveRecord::RecordInvalid)
+      end
+
+      let(:invalid) { true }
+
+      it "broadcast invalid in return" do
+        expect { subject.call }.to broadcast(:invalid)
+
+        expect(user_group.rejected_at).to be_nil
+        expect(user_group.verified_at).to be_nil
+      end
+    end
+
+    context "when the command is valid" do
+
+      it "the user group is rejected" do
+        expect { subject.call }.to broadcast(:ok)
+
+        expect(user_group.rejected_at).to be_nil
+        expect(user_group.verified_at).not_to be_nil
+      end
+
+    end
+  end
+
+   describe "User group is already rejected" do
+    let!(:user_group) { create(:user_group, rejected_at: Time.current, users: [create(:user, organization: organization)]) }
+
+    subject { described_class.new(user_group) }
+
+    context "when the command is not valid" do
+      before do
+        allow(user_group).to receive(:update_attributes!).and_raise(ActiveRecord::RecordInvalid)
+      end
+
+      let(:invalid) { true }
+
+      it "broadcast invalid in return and do not clean rejected_at" do
+        expect { subject.call }.to broadcast(:invalid)
+
+        expect(user_group.rejected_at).not_to be_nil
+        expect(user_group.verified_at).to be_nil
+      end
+    end
+
+    context "when the command is valid" do
+
+      it "the user group is verified" do
+        expect { subject.call }.to broadcast(:ok)
+
+        expect(user_group.rejected_at).to be_nil
+        expect(user_group.verified_at).not_to be_nil
+      end
+
+    end
+  end
+end

--- a/decidim-admin/spec/commands/verify_user_group_spec.rb
+++ b/decidim-admin/spec/commands/verify_user_group_spec.rb
@@ -26,18 +26,16 @@ describe Decidim::Admin::VerifyUserGroup do
     end
 
     context "when the command is valid" do
-
       it "the user group is rejected" do
         expect { subject.call }.to broadcast(:ok)
 
         expect(user_group.rejected_at).to be_nil
         expect(user_group.verified_at).not_to be_nil
       end
-
     end
   end
 
-   describe "User group is already rejected" do
+  describe "User group is already rejected" do
     let!(:user_group) { create(:user_group, rejected_at: Time.current, users: [create(:user, organization: organization)]) }
 
     subject { described_class.new(user_group) }
@@ -58,14 +56,12 @@ describe Decidim::Admin::VerifyUserGroup do
     end
 
     context "when the command is valid" do
-
       it "the user group is verified" do
         expect { subject.call }.to broadcast(:ok)
 
         expect(user_group.rejected_at).to be_nil
         expect(user_group.verified_at).not_to be_nil
       end
-
     end
   end
 end

--- a/decidim-admin/spec/features/admin_copy_participatory_process_spec.rb
+++ b/decidim-admin/spec/features/admin_copy_participatory_process_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "spec_helper"
 
 describe "Admin copy participatory process", type: :feature do

--- a/decidim-admin/spec/features/admin_manages_user_groups_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_user_groups_spec.rb
@@ -17,7 +17,7 @@ describe "Admin manage user groups", type: :feature do
 
   it "verifies a user group" do
     within "tr[data-user-group-id=\"#{user_group.id}\"]" do
-       page.find(".action-icon--activate", match: :first).click
+      page.find(".action-icon--activate", match: :first).click
     end
 
     expect(page).to have_content("verified successfully")
@@ -29,7 +29,7 @@ describe "Admin manage user groups", type: :feature do
 
   it "reject a user group" do
     within "tr[data-user-group-id=\"#{user_group.id}\"]" do
-       page.find(".action-icon--remove", match: :first).click
+      page.find(".action-icon--remove", match: :first).click
     end
 
     expect(page).to have_content("rejected successfully")

--- a/decidim-admin/spec/features/admin_manages_user_groups_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_user_groups_spec.rb
@@ -17,7 +17,7 @@ describe "Admin manage user groups", type: :feature do
 
   it "verifies a user group" do
     within "tr[data-user-group-id=\"#{user_group.id}\"]" do
-      page.find(".action-icon--activate", match: :first).click
+      page.find(".action-icon--verify", match: :first).click
     end
 
     expect(page).to have_content("verified successfully")
@@ -29,7 +29,7 @@ describe "Admin manage user groups", type: :feature do
 
   it "reject a user group" do
     within "tr[data-user-group-id=\"#{user_group.id}\"]" do
-      page.find(".action-icon--remove", match: :first).click
+      page.find(".action-icon--reject", match: :first).click
     end
 
     expect(page).to have_content("rejected successfully")

--- a/decidim-admin/spec/features/admin_manages_user_groups_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_user_groups_spec.rb
@@ -17,13 +17,25 @@ describe "Admin manage user groups", type: :feature do
 
   it "verifies a user group" do
     within "tr[data-user-group-id=\"#{user_group.id}\"]" do
-      click_link "Verify", match: :first
+       page.find(".action-icon--activate", match: :first).click
     end
 
     expect(page).to have_content("verified successfully")
 
     within "tr[data-user-group-id=\"#{user_group.id}\"]" do
-      expect(page).to have_no_selector(".actions button", match: :first)
+      expect(page).to have_content("Verified")
+    end
+  end
+
+  it "reject a user group" do
+    within "tr[data-user-group-id=\"#{user_group.id}\"]" do
+       page.find(".action-icon--remove", match: :first).click
+    end
+
+    expect(page).to have_content("rejected successfully")
+
+    within "tr[data-user-group-id=\"#{user_group.id}\"]" do
+      expect(page).to have_content("Rejected")
     end
   end
 end

--- a/decidim-admin/spec/queries/user_group_evaluation_spec.rb
+++ b/decidim-admin/spec/queries/user_group_evaluation_spec.rb
@@ -8,30 +8,32 @@ describe Decidim::Admin::UserGroupsEvaluation do
   let(:filter) { nil }
   subject { described_class.new(Decidim::UserGroup.all, query, filter) }
 
-  describe 'when the list is not filtered' do
+  describe "when the list is not filtered" do
     let!(:user_groups) { create_list(:user_group, 10, users: [create(:user, organization: organization)]) }
 
     it "returns all the user groups" do
-      expect(subject.query).to eq (user_groups)
+      expect(subject.query).to eq user_groups
     end
   end
 
-  describe 'when the list is filtered' do
-    context 'recieves a search param' do
-      let(:user_groups) { ["Walter", "Fargo", "Phargo"]
-        .map { |name| create(:user_group, name: name,
-              users: [create(:user, organization: organization)])
-            }
-        }
+  describe "when the list is filtered" do
+    context "recieves a search param" do
+      let(:user_groups) do
+        %w(Walter Fargo Phargo)
+          .map do |name|
+          create(:user_group, name: name,
+                              users: [create(:user, organization: organization)])
+        end
+      end
 
       let(:query) { "Argo" }
 
-      it 'returns all the user groups' do
+      it "returns all the user groups" do
         expect(subject.query).to match_array([user_groups[1], user_groups[2]])
       end
     end
 
-    describe 'recieves a filter param' do
+    describe "recieves a filter param" do
       let!(:rejected_user_groups) { create_list(:user_group, 2, :rejected, users: [create(:user, organization: organization)]) }
       let!(:verified_user_groups) { create_list(:user_group, 5, :verified, users: [create(:user, organization: organization)]) }
       let!(:pedning_user_groups) { create_list(:user_group, 4, users: [create(:user, organization: organization)]) }
@@ -59,22 +61,28 @@ describe Decidim::Admin::UserGroupsEvaluation do
       end
     end
 
-    context 'recieves a search and a filter aram' do
-      let(:rejected_user_groups) { ["Lorem", "Ipsum", "Dolor", "Amet"]
-        .map { |name| create(:user_group, :rejected, name: name,
-             users: [create(:user, organization: organization)])
-           }
-        }
-      let(:verified_user_groups) { ["Elit", "Vivamus", "Doctum"]
-        .map { |name| create(:user_group, :verified, name: name,
-             users: [create(:user, organization: organization)])
-            }
-        }
-      let(:pending_user_groups) { ["Walter", "Fargo", "Phargo"]
-        .map { |name| create(:user_group, name: name,
-             users: [create(:user, organization: organization)])
-            }
-        }
+    context "recieves a search and a filter aram" do
+      let(:rejected_user_groups) do
+        %w(Lorem Ipsum Dolor Amet)
+          .map do |name|
+          create(:user_group, :rejected, name: name,
+                                         users: [create(:user, organization: organization)])
+        end
+      end
+      let(:verified_user_groups) do
+        %w(Elit Vivamus Doctum)
+          .map do |name|
+          create(:user_group, :verified, name: name,
+                                         users: [create(:user, organization: organization)])
+        end
+      end
+      let(:pending_user_groups) do
+        %w(Walter Fargo Phargo)
+          .map do |name|
+          create(:user_group, name: name,
+                              users: [create(:user, organization: organization)])
+        end
+      end
       let(:query) { "lo" }
       let(:filter) { "rejected" }
 

--- a/decidim-core/app/models/decidim/user_group.rb
+++ b/decidim-core/app/models/decidim/user_group.rb
@@ -10,6 +10,8 @@ module Decidim
     validates :document_number, presence: true
     validates :phone, presence: true
     validates :avatar, file_size: { less_than_or_equal_to: 5.megabytes }
+    validate :correct_state
+
     mount_uploader :avatar, Decidim::AvatarUploader
 
     scope :verified, -> { where.not(verified_at: nil) }
@@ -23,6 +25,18 @@ module Decidim
     # Public: Checks if the user group is rejected.
     def rejected?
       rejected_at.present?
+    end
+
+     # Public: Checks if the user group is pending.
+    def pending?
+      verified_at.blank? && rejected_at.blank?
+    end
+
+    private
+
+    # Private: Checks if the state user group is correct.
+    def correct_state
+      errors.add(:base, :invalid) if verified? && rejected?
     end
   end
 end

--- a/decidim-core/app/models/decidim/user_group.rb
+++ b/decidim-core/app/models/decidim/user_group.rb
@@ -10,6 +10,7 @@ module Decidim
     validates :document_number, presence: true
     validates :phone, presence: true
     validates :avatar, file_size: { less_than_or_equal_to: 5.megabytes }
+
     validate :correct_state
 
     mount_uploader :avatar, Decidim::AvatarUploader
@@ -27,7 +28,7 @@ module Decidim
       rejected_at.present?
     end
 
-     # Public: Checks if the user group is pending.
+    # Public: Checks if the user group is pending.
     def pending?
       verified_at.blank? && rejected_at.blank?
     end

--- a/decidim-core/app/models/decidim/user_group.rb
+++ b/decidim-core/app/models/decidim/user_group.rb
@@ -15,19 +15,9 @@ module Decidim
     scope :verified, -> { where.not(verified_at: nil) }
     scope :rejected, -> { where.not(rejected_at: nil) }
 
-    # Public: Mark the user group as verified
-    def verify!
-      update_attributes(verified_at: Time.current, rejected_at: nil)
-    end
-
     # Public: Checks if the user group is verified.
     def verified?
       verified_at.present?
-    end
-
-    # Public: Mark the user group as rejected
-    def reject!
-      update_attributes(rejected_at: Time.current, verified_at: nil)
     end
 
     # Public: Checks if the user group is rejected.

--- a/decidim-core/app/models/decidim/user_group.rb
+++ b/decidim-core/app/models/decidim/user_group.rb
@@ -13,15 +13,26 @@ module Decidim
     mount_uploader :avatar, Decidim::AvatarUploader
 
     scope :verified, -> { where.not(verified_at: nil) }
+    scope :rejected, -> { where.not(rejected_at: nil) }
 
     # Public: Mark the user group as verified
     def verify!
-      update_attribute(:verified_at, Time.current)
+      update_attributes(verified_at: Time.current, rejected_at: nil)
     end
 
     # Public: Checks if the user group is verified.
     def verified?
       verified_at.present?
+    end
+
+    # Public: Mark the user group as rejected
+    def reject!
+      update_attributes(rejected_at: Time.current, verified_at: nil)
+    end
+
+    # Public: Checks if the user group is rejected.
+    def rejected?
+      rejected_at.present?
     end
   end
 end

--- a/decidim-core/app/views/decidim/own_user_groups/index.html.erb
+++ b/decidim-core/app/views/decidim/own_user_groups/index.html.erb
@@ -8,14 +8,16 @@
               <h5 class="card--list__heading">
                 <%= user_group.name %>
               </h5>
-              
               <span class="text-small"><%= l(user_group.created_at, format: :long) %></span>
-              
               <% if user_group.verified? %>
-                <span class="success label"><%= t('.verified') %></span>                
-              <% else %>
+                <span class="success label"><%= t('.verified') %></span>
+              <% end %>
+              <% if user_group.rejected? %>
+                <span class="alert label"><%= t('.rejected') %></span>
+              <% end %>
+              <% if !user_group.verified? && !user_group.rejected? %>
                 <span class="warning label"><%= t('.not_verified') %></span>
-              <% end %>             
+              <% end %>
             </div>
           </div>
         </div>

--- a/decidim-core/app/views/decidim/own_user_groups/index.html.erb
+++ b/decidim-core/app/views/decidim/own_user_groups/index.html.erb
@@ -16,7 +16,7 @@
                 <span class="alert label"><%= t('.rejected') %></span>
               <% end %>
               <% if !user_group.verified? && !user_group.rejected? %>
-                <span class="warning label"><%= t('.not_verified') %></span>
+                <span class="warning label"><%= t('.pending') %></span>
               <% end %>
             </div>
           </div>

--- a/decidim-core/app/views/decidim/own_user_groups/index.html.erb
+++ b/decidim-core/app/views/decidim/own_user_groups/index.html.erb
@@ -15,7 +15,7 @@
               <% if user_group.rejected? %>
                 <span class="alert label"><%= t('.rejected') %></span>
               <% end %>
-              <% if !user_group.verified? && !user_group.rejected? %>
+              <% if user_group.pending? %>
                 <span class="warning label"><%= t('.pending') %></span>
               <% end %>
             </div>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -153,6 +153,7 @@ en:
     own_user_groups:
       index:
         not_verified: Not verified
+        rejected: Rejected
         verified: Verified
     pages:
       index:
@@ -324,7 +325,7 @@ en:
         title: User settings
         user_groups: Organizations
       widget:
-        see_more: "See more"
+        see_more: See more
   locale:
     name: English
   pages:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -152,7 +152,7 @@ en:
         success: Your notifications settings were updated successfully.
     own_user_groups:
       index:
-        not_verified: Not verified
+        pending: Pending
         rejected: Rejected
         verified: Verified
     pages:

--- a/decidim-core/db/migrate/20170529150743_add_rejected_at_to_user_groups.rb
+++ b/decidim-core/db/migrate/20170529150743_add_rejected_at_to_user_groups.rb
@@ -1,0 +1,5 @@
+class AddRejectedAtToUserGroups < ActiveRecord::Migration[5.0]
+  def change
+    add_column :decidim_user_groups, :rejected_at, :datetime
+  end
+end

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -172,6 +172,10 @@ FactoryGirl.define do
       verified_at { Time.current }
     end
 
+    trait :rejected do
+      rejected_at { Time.current }
+    end
+
     after(:create) do |user_group, evaluator|
       users = evaluator.users
       next if users.empty?

--- a/decidim-core/spec/features/user_groups_spec.rb
+++ b/decidim-core/spec/features/user_groups_spec.rb
@@ -13,21 +13,19 @@ describe "User groups", type: :feature, perform_enqueued: true do
     login_as user, scope: :user
   end
 
-  context "when the user group is not verified" do
+  context "when the user group is pending" do
     it "the user can check its status on his account page" do
       visit decidim.own_user_groups_path
 
       click_link "Organizations"
 
       expect(page).to have_content(user_group.name)
-      expect(page).to have_content("Not verified")
+      expect(page).to have_content("Pending")
     end
   end
 
-  context "when the user group is not verified" do
-    before do
-      user_group.verify!
-    end
+  context "when the user group is rejected" do
+    let(:user_group) { create(:user_group, :rejected) }
 
     it "the user can check its status on his account page" do
       visit decidim.own_user_groups_path
@@ -35,7 +33,19 @@ describe "User groups", type: :feature, perform_enqueued: true do
       click_link "Organizations"
 
       expect(page).to have_content(user_group.name)
-      expect(page).not_to have_content("Not verified")
+      expect(page).to have_content("Rejected")
+    end
+  end
+
+  context "when the user group is verified" do
+    let(:user_group) { create(:user_group, :verified) }
+
+    it "the user can check its status on his account page" do
+      visit decidim.own_user_groups_path
+
+      click_link "Organizations"
+
+      expect(page).to have_content(user_group.name)
       expect(page).to have_content("Verified")
     end
   end

--- a/decidim-core/spec/models/decidim/user_group_spec.rb
+++ b/decidim-core/spec/models/decidim/user_group_spec.rb
@@ -18,12 +18,6 @@ module Decidim
       expect(subject.users.count).to eq(2)
     end
 
-    describe "#verify!" do
-      it "mark the user group as verified" do
-        subject.verify!
-        expect(subject).to be_verified
-      end
-    end
 
     describe "scopes" do
       describe "#verified" do
@@ -32,6 +26,14 @@ module Decidim
           expect(UserGroup.verified.count).to eq(1)
         end
       end
+
+      describe "#rejected" do
+        it "returns rejected organizations" do
+          create(:user_group, :rejected)
+          expect(UserGroup.rejected.count).to eq(1)
+        end
+      end
+
     end
 
     describe "validations" do

--- a/decidim-core/spec/models/decidim/user_group_spec.rb
+++ b/decidim-core/spec/models/decidim/user_group_spec.rb
@@ -18,7 +18,6 @@ module Decidim
       expect(subject.users.count).to eq(2)
     end
 
-
     describe "scopes" do
       describe "#verified" do
         it "returns verified organizations" do
@@ -33,7 +32,6 @@ module Decidim
           expect(UserGroup.rejected.count).to eq(1)
         end
       end
-
     end
 
     describe "validations" do

--- a/decidim-pages/app/commands/decidim/pages/copy_page.rb
+++ b/decidim-pages/app/commands/decidim/pages/copy_page.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Decidim
   module Pages
     # Command that gets called whenever a feature's page has to be duplicated.

--- a/decidim-pages/spec/commands/copy_page_spec.rb
+++ b/decidim-pages/spec/commands/copy_page_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "spec_helper"
 
 module Decidim


### PR DESCRIPTION
#### :tophat: What? Why?
In order to facilitate the organization's verification process, this PR adds a searching engine and filtering engine. Also to be able to categorize user groups this PR adds the rejected state to the user groups.

#### :pushpin: Related Issues
- Fixes #1408

#### :clipboard: Subtasks
- [x] Add rejected_at tom user_groups
- [x] Update view to match the new options
- [x] Add state filter
- [x] Add search field
- [x] Specs for all

### :camera: Screenshots (optional)
![screen shot 2017-05-30 at 12 08 26](https://cloud.githubusercontent.com/assets/953911/26624453/3784d652-45f1-11e7-9a5f-f02e05d7ed10.png)
![screen shot 2017-05-30 at 16 13 03](https://cloud.githubusercontent.com/assets/953911/26624454/378e1fd2-45f1-11e7-8a42-c70f3175f1d4.png)

#### :ghost: GIF
![](https://media2.giphy.com/media/Z5awr84TAk6d2/giphy.gif)
