### PR TITLE
Fix default button when no voting enabled

### DIFF
--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
@@ -51,10 +51,7 @@ module Decidim
         def reorder(proposals)
           case order
           when "random"
-            Proposal.transaction do
-              Proposal.connection.execute("SELECT setseed(#{Proposal.connection.quote(random_seed)})")
-              proposals.order("RANDOM()").load
-            end
+            proposals.order_randomly(random_seed)
           when "most_voted"
             proposals.order(proposal_votes_count: :desc)
           when "recent"

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -24,6 +24,13 @@ module Decidim
       scope :accepted,   -> { where(state: "accepted") }
       scope :rejected,   -> { where(state: "rejected") }
 
+      def self.order_randomly(seed)
+        transaction do
+          connection.execute("SELECT setseed(#{connection.quote(seed)})")
+          order("RANDOM()").load
+        end
+      end
+
       def author_name
         user_group&.name || author&.name || I18n.t("decidim.proposals.models.proposal.fields.official_proposal")
       end

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_proposal.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_proposal.html.erb
@@ -26,6 +26,9 @@
         <% if current_settings.votes_enabled? %>
           <%= render partial: "votes_count", locals: { proposal: proposal, from_proposals_list: true } %>
           <%= render partial: "vote_button", locals: { proposal: proposal, from_proposals_list: true } %>
+        <% else %>
+          <div class="card__support__data"></div>
+          <%= link_to t(".view_proposal"), proposal, class: "card__button button small secondary" %>
         <% end %>
       </div>
     </div>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_vote_button.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_vote_button.html.erb
@@ -1,7 +1,7 @@
 <div id="proposal-<%= proposal.id %>-vote-button">
   <% if !current_user %>
     <% if current_settings.votes_blocked? %>
-      <button class="card__button button <%= vote_button_classes(from_proposals_list) %> disabled" data-toggle="loginModal">
+      <button class="card__button button <%= vote_button_classes(from_proposals_list) %> disabled" disabled data-toggle="loginModal">
         <%= t('.votes_blocked') %>
       </button>
     <% else %>
@@ -16,7 +16,7 @@
       <% if vote_limit_enabled? && remaining_votes_count_for(current_user) == 0 %>
         <%= action_authorized_button_to :vote, t('.no_votes_remaining'), proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list), remote: true, data: { disable: true }, class: "card__button button #{vote_button_classes(from_proposals_list)}", disabled: true %>
       <% elsif current_settings.votes_blocked? %>
-        <button class="card__button button <%= vote_button_classes(from_proposals_list) %> disabled">
+        <button class="card__button button <%= vote_button_classes(from_proposals_list) %> disabled" disabled>
           <%= t('.votes_blocked') %>
         </button>
       <% else %>

--- a/decidim-proposals/config/locales/ca.yml
+++ b/decidim-proposals/config/locales/ca.yml
@@ -120,6 +120,8 @@ ca:
           most_voted: Més votat
           random: Aleatori
           recent: Recent
+        proposal:
+          view_proposal: Veure proposta
         show:
           proposal_accepted_reason: 'Aquesta proposta ha estat acceptada perquè:'
           proposal_rejected_reason: 'Aquesta proposta ha estat rebutjada perquè:'

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -123,6 +123,8 @@ en:
           most_voted: Most voted
           random: Random
           recent: Recent
+        proposal:
+          view_proposal: View proposal
         show:
           proposal_accepted_reason: 'This proposal has been accepted because:'
           proposal_rejected_reason: 'This proposal has been rejected because:'

--- a/decidim-proposals/config/locales/es.yml
+++ b/decidim-proposals/config/locales/es.yml
@@ -120,6 +120,8 @@ es:
           most_voted: Más votado
           random: Aleatorio
           recent: Reciente
+        proposal:
+          view_proposal: Ver propuesta
         show:
           proposal_accepted_reason: 'Esta propuesta ha sido aceptada porque:'
           proposal_rejected_reason: 'Esta propuesta ha sido rechazada porque:'

--- a/decidim-proposals/config/locales/eu.yml
+++ b/decidim-proposals/config/locales/eu.yml
@@ -121,6 +121,8 @@ eu:
           most_voted: Bozkatuenak
           random: Ausazkoa eran
           recent: Berrienak
+        proposal:
+          view_proposal: Ikusi proposamena
         show:
           proposal_accepted_reason: 'Proposamen hau onartu da arrazoi hauengatik:'
           proposal_rejected_reason: 'Proposamen hau baztertu da arrazoi hauengatik:'

--- a/decidim-proposals/config/locales/fi.yml
+++ b/decidim-proposals/config/locales/fi.yml
@@ -108,6 +108,8 @@ fi:
           most_voted: Eniten ääniä saaneet
           random: Satunnainen
           recent: Viimeisimmät
+        proposal:
+          view_proposal: Näytä ehdotus
         show:
           proposal_accepted_reason: 'Tämä ehdotus on hyväksytty, koska:'
           proposal_rejected_reason: 'Tämä ehdotus on hylätty, koska:'

--- a/decidim-proposals/config/locales/fr.yml
+++ b/decidim-proposals/config/locales/fr.yml
@@ -118,6 +118,8 @@ fr:
           most_voted: Les plus votées
           random: Aléatoire
           recent: Les plus récents
+        proposal:
+          view_proposal: Voir la proposition
         show:
           proposal_accepted_reason: 'Cette proposition a été acceptée parce que :'
           proposal_rejected_reason: 'Cette proposition a été refusée parce que:'

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -21,6 +21,14 @@ FactoryGirl.define do
       end
     end
 
+    trait :with_votes_disabled do
+      step_settings do
+        {
+          participatory_process.active_step.id => { votes_enabled: false }
+        }
+      end
+    end
+
     trait :with_vote_limit do
       transient do
         vote_limit 10

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -407,6 +407,7 @@ describe "Proposals", type: :feature do
 
         visit_feature
 
+        expect(page).to have_selector("a", text: "Most voted")
         expect(page).to have_selector("#proposals .card-grid .column:first-child", text: most_voted_proposal.title)
         expect(page).to have_selector("#proposals .card-grid .column:last-child", text: less_voted_proposal.title)
       end

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -4,14 +4,8 @@ require "spec_helper"
 
 describe "Proposals", type: :feature do
   include_context "feature"
-  let!(:feature) do
-    create(:proposal_feature,
-           manifest: manifest,
-           participatory_process: participatory_process)
-  end
   let(:manifest_name) { "proposals" }
 
-  let!(:proposals) { create_list(:proposal, 3, feature: feature) }
   let!(:category) { create :category, participatory_process: participatory_process }
   let!(:scope) { create :scope, organization: organization }
   let!(:user) { create :user, :confirmed, organization: organization }
@@ -213,6 +207,14 @@ describe "Proposals", type: :feature do
   end
 
   context "viewing a single proposal" do
+    let!(:feature) do
+      create(:proposal_feature,
+             manifest: manifest,
+             participatory_process: participatory_process)
+    end
+
+    let!(:proposals) { create_list(:proposal, 3, feature: feature) }
+
     it "allows viewing a single proposal" do
       proposal = proposals.first
 
@@ -355,6 +357,11 @@ describe "Proposals", type: :feature do
   end
 
   context "when a proposal has been linked in a project" do
+    let(:feature) do
+      create(:proposal_feature,
+             manifest: manifest,
+             participatory_process: participatory_process)
+    end
     let(:proposal) { create(:proposal, feature: feature) }
     let(:budget_feature) do
       create(:feature, manifest_name: :budgets, participatory_process: proposal.feature.participatory_process)
@@ -375,6 +382,12 @@ describe "Proposals", type: :feature do
 
   context "listing proposals in a participatory process" do
     it "lists all the proposals" do
+      create(:proposal_feature,
+             manifest: manifest,
+             participatory_process: participatory_process)
+
+      create_list(:proposal, 3, feature: feature)
+
       visit_feature
       expect(page).to have_css(".card--proposal", count: 3)
     end
@@ -413,7 +426,7 @@ describe "Proposals", type: :feature do
 
         expect(page).to have_selector(".pagination .current", text: "2")
 
-        expect(page).to have_css(".card--proposal", count: 8)
+        expect(page).to have_css(".card--proposal", count: 5)
       end
     end
 
@@ -433,28 +446,31 @@ describe "Proposals", type: :feature do
 
         context "by origin 'official'" do
           it "lists the filtered proposals" do
-            create(:proposal, :official, feature: feature, scope: scope)
+            create_list(:proposal, 2, :official, feature: feature, scope: scope)
+            create(:proposal, feature: feature, scope: scope)
             visit_feature
 
             within ".filters" do
               choose "Official"
             end
 
-            expect(page).to have_css(".card--proposal", count: 1)
-            expect(page).to have_content("1 PROPOSAL")
+            expect(page).to have_css(".card--proposal", count: 2)
+            expect(page).to have_content("2 PROPOSALS")
           end
         end
 
         context "by origin 'citizenship'" do
           it "lists the filtered proposals" do
+            create_list(:proposal, 2, feature: feature, scope: scope)
+            create(:proposal, :official, feature: feature, scope: scope)
             visit_feature
 
             within ".filters" do
               choose "Citizenship"
             end
 
-            expect(page).to have_css(".card--proposal", count: proposals.size)
-            expect(page).to have_content("#{proposals.size} PROPOSALS")
+            expect(page).to have_css(".card--proposal", count: 2)
+            expect(page).to have_content("2 PROPOSALS")
           end
         end
       end

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -416,8 +416,9 @@ describe "Proposals", type: :feature do
         expect(page).to have_selector("#proposals .card-grid .column:last-child", text: less_voted_proposal.title)
       end
 
-      it "shows a disabled vote button for each proposal" do
+      it "shows a disabled vote button for each proposal, but no links to full proposals" do
         expect(page).to have_button("Voting disabled", disabled: true, count: 2)
+        expect(page).to have_no_link("View proposal")
       end
     end
 
@@ -441,6 +442,14 @@ describe "Proposals", type: :feature do
         expect(page).to have_selector("a", text: "Random")
         expect(page).to have_selector("#proposals .card-grid .column:first-child", text: lucky_proposal.title)
         expect(page).to have_selector("#proposals .card-grid .column:last-child", text: unlucky_proposal.title)
+      end
+
+      it "shows only links to full proposals" do
+        visit_feature
+
+        expect(page).to have_no_button("Voting disabled", disabled: true)
+        expect(page).to have_no_button("Vote")
+        expect(page).to have_link("View proposal", count: 2)
       end
     end
 

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -413,6 +413,29 @@ describe "Proposals", type: :feature do
       end
     end
 
+    context "when voting is disabled" do
+      let!(:feature) do
+        create(:proposal_feature,
+               :with_votes_disabled,
+               manifest: manifest,
+               participatory_process: participatory_process)
+      end
+
+      let!(:lucky_proposal) { create(:proposal, title: "A", feature: feature) }
+      let!(:unlucky_proposal) { create(:proposal, title: "B", feature: feature) }
+
+      it "lists the proposals ordered randomly by default" do
+        allow_any_instance_of(Decidim::Proposals::Proposal::ActiveRecord_Relation).to \
+          receive(:order_randomly) { |scope, _seed| scope.order(title: :asc) }
+
+        visit_feature
+
+        expect(page).to have_selector("a", text: "Random")
+        expect(page).to have_selector("#proposals .card-grid .column:first-child", text: lucky_proposal.title)
+        expect(page).to have_selector("#proposals .card-grid .column:last-child", text: unlucky_proposal.title)
+      end
+    end
+
     context "when there are a lot of proposals" do
       before do
         create_list(:proposal, 17, feature: feature)

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -400,16 +400,24 @@ describe "Proposals", type: :feature do
                participatory_process: participatory_process)
       end
 
+      let!(:most_voted_proposal) do
+        proposal = create(:proposal, feature: feature)
+        create_list(:proposal_vote, 3, proposal: proposal)
+        proposal
+      end
+
+      let!(:less_voted_proposal) { create(:proposal, feature: feature) }
+
+      before { visit_feature }
+
       it "lists the proposals ordered by votes by default" do
-        most_voted_proposal = create(:proposal, feature: feature)
-        create_list(:proposal_vote, 3, proposal: most_voted_proposal)
-        less_voted_proposal = create(:proposal, feature: feature)
-
-        visit_feature
-
         expect(page).to have_selector("a", text: "Most voted")
         expect(page).to have_selector("#proposals .card-grid .column:first-child", text: most_voted_proposal.title)
         expect(page).to have_selector("#proposals .card-grid .column:last-child", text: less_voted_proposal.title)
+      end
+
+      it "shows a disabled vote button for each proposal" do
+        expect(page).to have_button("Voting disabled", disabled: true, count: 2)
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

In previous PR (#1427), I accidentally removed some _used_ logic, proving that my prepositional logic skills are a bit rusty :sweat_smile:. In particular, I removed the "View proposal" link that appears instead of the "Vote" button when voting is not enabled.

This PR restores that, backs it up with tests, and improves and adds some other tests and code around proposal listing.

#### :pushpin: Related Issues
- Related to #1427.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![mrbean](https://cloud.githubusercontent.com/assets/2887858/26661903/e0f2e4bc-4656-11e7-84f1-141b51c7eaf2.gif)
