### PR TITLE
Add allow_answers step setting

### DIFF
--- a/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
+++ b/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
@@ -55,11 +55,9 @@ module Decidim
         end
 
         def update_survey
-          @survey.update_attributes!({
-            title: @form.title,
-            description: @form.description,
-            tos: @form.tos
-          })
+          @survey.update_attributes!(title: @form.title,
+                                     description: @form.description,
+                                     tos: @form.tos)
         end
 
         def questions_are_editable?

--- a/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
+++ b/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
@@ -55,21 +55,15 @@ module Decidim
         end
 
         def update_survey
-          attributes = {
+          @survey.update_attributes!({
             title: @form.title,
             description: @form.description,
             tos: @form.tos
-          }
-
-          if @form.published_at.present?
-            attributes[:published_at] = @form.published_at
-          end
-
-          @survey.update_attributes!(attributes)
+          })
         end
 
         def questions_are_editable?
-          !@survey.published?
+          !@survey.answered?
         end
       end
     end

--- a/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
+++ b/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
@@ -22,7 +22,7 @@ module Decidim
           return broadcast(:invalid) if @form.invalid?
 
           Survey.transaction do
-            update_survey_questions if questions_are_editable?
+            update_survey_questions if @survey.questions_editable?
             update_survey
           end
 
@@ -58,10 +58,6 @@ module Decidim
           @survey.update_attributes!(title: @form.title,
                                      description: @form.description,
                                      tos: @form.tos)
-        end
-
-        def questions_are_editable?
-          !@survey.answered?
         end
       end
     end

--- a/decidim-surveys/app/helpers/decidim/surveys/admin/application_helper.rb
+++ b/decidim-surveys/app/helpers/decidim/surveys/admin/application_helper.rb
@@ -17,7 +17,7 @@ module Decidim
         end
 
         def label_for_question(survey, _question)
-          survey.answered? ? t(".question") : "#{icon("move")} #{t(".question")}".html_safe
+          survey.questions_editable? ? "#{icon("move")} #{t(".question")}".html_safe : t(".question")
         end
 
         def mandatory_id_for_question(question)
@@ -31,7 +31,7 @@ module Decidim
         end
 
         def disabled_for_question(survey, question)
-          !question.persisted? || survey.answered?
+          !question.persisted? || !survey.questions_editable?
         end
       end
     end

--- a/decidim-surveys/app/helpers/decidim/surveys/admin/application_helper.rb
+++ b/decidim-surveys/app/helpers/decidim/surveys/admin/application_helper.rb
@@ -17,7 +17,7 @@ module Decidim
         end
 
         def label_for_question(survey, _question)
-          survey.published? ? t(".question") : "#{icon("move")} #{t(".question")}".html_safe
+          survey.answered? ? t(".question") : "#{icon("move")} #{t(".question")}".html_safe
         end
 
         def mandatory_id_for_question(question)
@@ -31,7 +31,7 @@ module Decidim
         end
 
         def disabled_for_question(survey, question)
-          !question.persisted? || survey.published?
+          !question.persisted? || survey.answered?
         end
       end
     end

--- a/decidim-surveys/app/models/decidim/surveys/survey.rb
+++ b/decidim-surveys/app/models/decidim/surveys/survey.rb
@@ -11,12 +11,12 @@ module Decidim
       has_many :questions, -> { order(:position) }, class_name: SurveyQuestion, foreign_key: "decidim_survey_id"
       has_many :answers, class_name: SurveyAnswer, foreign_key: "decidim_survey_id"
 
-      # Public: returns wether the survey is answered or not.
-      def answered?
-        answers.any?
+      # Public: returns whether the survey questions can be modified or not.
+      def questions_editable?
+        answers.empty?
       end
 
-      # Public: returns wether the survey is answered by the user or not.
+      # Public: returns whether the survey is answered by the user or not.
       def answered_by?(user)
         answers.where(user: user).count == questions.length
       end

--- a/decidim-surveys/app/models/decidim/surveys/survey.rb
+++ b/decidim-surveys/app/models/decidim/surveys/survey.rb
@@ -9,23 +9,16 @@ module Decidim
       feature_manifest_name "surveys"
 
       has_many :questions, -> { order(:position) }, class_name: SurveyQuestion, foreign_key: "decidim_survey_id"
+      has_many :answers, class_name: SurveyAnswer, foreign_key: "decidim_survey_id"
 
-      validate :questions_before_publishing?
-
-      # Public: returns wether the survey is published or not.
-      def published?
-        published_at.present?
+      # Public: returns wether the survey is answered or not.
+      def answered?
+        answers.any?
       end
 
       # Public: returns wether the survey is answered by the user or not.
       def answered_by?(user)
-        SurveyAnswer.where(user: user, survey: self, question: questions).count == questions.length
-      end
-
-      private
-
-      def questions_before_publishing?
-        errors.add(:published_at, :invalid) if published? && questions.empty?
+        answers.where(user: user).count == questions.length
       end
     end
   end

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
@@ -2,7 +2,7 @@
   <div class="card-divider">
     <h2 class="card-title">
     <span><%= t(".answer_option") %></span>
-    <% unless survey.answered? %>
+    <% if survey.questions_editable? %>
       <button class="button small alert hollow remove-answer-option button--title"><%= t('.remove_answer_option') %></button>
     <% end %>
     </h2>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
@@ -2,7 +2,7 @@
   <div class="card-divider">
     <h2 class="card-title">
     <span><%= t(".answer_option") %></span>
-    <% unless survey.published? %>
+    <% unless survey.answered? %>
       <button class="button small alert hollow remove-answer-option button--title"><%= t('.remove_answer_option') %></button>
     <% end %>
     </h2>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
@@ -21,11 +21,7 @@
 </div>
 
 <div class="survey-questions">
-  <% if survey.answered? %>
-    <div class="callout warning">
-      <%= t('.already_answered_warning') %>
-    </div>
-  <% else %>
+  <% if survey.questions_editable? %>
     <button class="button add-question"><%= t('.add_question') %></button>
 
     <template id="survey-question-tmpl">
@@ -35,9 +31,13 @@
     <template id="survey-question-answer-option-tmpl">
       <%= render "answer_option", answer_option: blank_answer_option, question: nil, idx: nil %>
     </template>
+  <% else %>
+    <div class="callout warning">
+      <%= t('.already_answered_warning') %>
+    </div>
   <% end %>
 
-  <div class="survey-questions-list <%= 'answered' if survey.answered? %>">
+  <div class="survey-questions-list">
     <% @form.questions.each_with_index do |question, idx| %>
       <%= render "question", question: question %>
     <% end %>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
@@ -21,7 +21,11 @@
 </div>
 
 <div class="survey-questions">
-  <% unless survey.published? %>
+  <% if survey.answered? %>
+    <div class="callout warning">
+      <%= t('.already_answered_warning') %>
+    </div>
+  <% else %>
     <button class="button add-question"><%= t('.add_question') %></button>
 
     <template id="survey-question-tmpl">
@@ -33,7 +37,7 @@
     </template>
   <% end %>
 
-  <div class="survey-questions-list <%= 'published' if survey.published? %>">
+  <div class="survey-questions-list <%= 'answered' if survey.answered? %>">
     <% @form.questions.each_with_index do |question, idx| %>
       <%= render "question", question: question %>
     <% end %>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
@@ -2,7 +2,7 @@
   <div class="card-divider question-divider">
     <h2 class="card-title">
     <span><%= label_for_question(survey, question) %></span>
-    <% unless survey.published? %>
+    <% unless survey.answered? %>
       <button class="button small alert hollow remove-question button--title"><%= t('.remove_question') %></button>
     <% end %>
     </h2>
@@ -43,11 +43,11 @@
     <%= hidden_field_tag "survey[questions][][deleted]", false, disabled: disabled_for_question(survey, question) %>
 
     <div class="survey-question-answer-options">
-      <% unless survey.published? %>
+      <% unless survey.answered? %>
         <button class="button add-answer-option"><%= t('.add_answer_option') %></button>
       <% end %>
 
-      <div class="survey-question-answer-options-list <%= 'published' if survey.published? %>">
+      <div class="survey-question-answer-options-list <%= 'answered' if survey.answered? %>">
         <% question.answer_options.each_with_index do |answer_option, idx| %>
           <%= render "answer_option", question: question, answer_option: answer_option, idx: idx %>
         <% end %>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
@@ -2,7 +2,7 @@
   <div class="card-divider question-divider">
     <h2 class="card-title">
     <span><%= label_for_question(survey, question) %></span>
-    <% unless survey.answered? %>
+    <% if survey.questions_editable? %>
       <button class="button small alert hollow remove-question button--title"><%= t('.remove_question') %></button>
     <% end %>
     </h2>
@@ -43,11 +43,11 @@
     <%= hidden_field_tag "survey[questions][][deleted]", false, disabled: disabled_for_question(survey, question) %>
 
     <div class="survey-question-answer-options">
-      <% unless survey.answered? %>
+      <% if survey.questions_editable? %>
         <button class="button add-answer-option"><%= t('.add_answer_option') %></button>
       <% end %>
 
-      <div class="survey-question-answer-options-list <%= 'answered' if survey.answered? %>">
+      <div class="survey-question-answer-options-list">
         <% question.answer_options.each_with_index do |answer_option, idx| %>
           <%= render "answer_option", question: question, answer_option: answer_option, idx: idx %>
         <% end %>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/edit.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/edit.html.erb
@@ -2,11 +2,6 @@
   <%= render partial: 'form', object: form, locals: { title: t('.title') }  %>
 
   <div class="button--double form-general-submit">
-    <% if @survey.published? %>
-      <%= form.submit t(".save"), class: "button" %>
-    <% else %>
-      <%= form.submit t(".save"), class: "button hollow" %>
-      <%= form.submit t(".save_and_publish"), name: "save_and_publish", data: { confirm: t('.are_you_sure') } %>
-    <% end %>
+    <%= form.submit t(".save"), class: "button" %>
   </div>
 <% end %>

--- a/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
@@ -16,7 +16,7 @@
   <div class="columns large-6 medium-centered">
     <div class="card">
       <div class="card__content">
-        <% unless survey.published? %>
+        <% unless survey.answered? %>
           <div class="section">
             <div class="callout warning">
               <h5><%= t('.survey_not_published.title') %></h5>

--- a/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
@@ -16,14 +16,7 @@
   <div class="columns large-6 medium-centered">
     <div class="card">
       <div class="card__content">
-        <% unless survey.answered? %>
-          <div class="section">
-            <div class="callout warning">
-              <h5><%= t('.survey_not_published.title') %></h5>
-              <p><%= t('.survey_not_published.body') %></p>
-            </div>
-          </div>
-        <% else %>
+        <% if current_settings.allow_answers? %>
           <% if current_user %>
             <% if survey.answered_by?(current_user) %>
               <div class="section">
@@ -82,21 +75,28 @@
                     </div>
                   <% end %>
 
-                <div class="button--double form-general-submit">
-                  <%= form.submit t(".submit"), class: "button", data: { confirm: t('.are_you_sure') } %>
-                </div>
-              <% end %>
+                  <div class="button--double form-general-submit">
+                    <%= form.submit t(".submit"), class: "button", data: { confirm: t('.are_you_sure') } %>
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
+          <% else %>
+            <div class="answer-survey">
+              <h5 class="section-heading"><%= t('.answer_survey.title') %></h5>
+              <p>
+                <%= t('.answer_survey.anonymous_user_message', sign_in_link: decidim.new_user_session_path, sign_up_link: decidim.new_user_registration_path).html_safe %>
+              </p>
             </div>
           <% end %>
         <% else %>
-          <div class="answer-survey">
-            <h5 class="section-heading"><%= t('.answer_survey.title') %></h5>
-            <p>
-              <%= t('.answer_survey.anonymous_user_message', sign_in_link: decidim.new_user_session_path, sign_up_link: decidim.new_user_registration_path).html_safe %>
-            </p>
+          <div class="section">
+            <div class="callout warning">
+              <h5><%= t('.survey_closed.title') %></h5>
+              <p><%= t('.survey_closed.body') %></p>
+            </div>
           </div>
         <% end %>
-      <% end %>
     </div>
   </div>
 </div>

--- a/decidim-surveys/config/i18n-tasks.yml
+++ b/decidim-surveys/config/i18n-tasks.yml
@@ -3,6 +3,7 @@ locales: [en]
 ignore_unused:
 - "decidim.features.surveys.name"
 - "decidim.features.surveys.actions.*"
+- "decidim.features.surveys.settings.*"
 - "decidim.surveys.admin.surveys.question.question"
 - "decidim.surveys.admin.exports.*"
 - "activemodel.attributes.survey_answer.*"

--- a/decidim-surveys/config/i18n-tasks.yml
+++ b/decidim-surveys/config/i18n-tasks.yml
@@ -4,6 +4,7 @@ ignore_unused:
 - "decidim.features.surveys.name"
 - "decidim.features.surveys.actions.*"
 - "decidim.surveys.admin.surveys.question.question"
+- "decidim.surveys.admin.exports.*"
 - "activemodel.attributes.survey_answer.*"
 ignore_missing:
   - decidim.participatory_processes.scopes.global

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -13,6 +13,9 @@ en:
         actions:
           answer: Answer
         name: Survey
+        settings:
+          step:
+            allow_answers: Allow answers
     surveys:
       admin:
         application_helper:
@@ -34,7 +37,8 @@ en:
             title: Title
           form:
             add_question: Add question
-            already_answered_warning: The survey is already answered by some users so you cannot modify its questions.
+            already_answered_warning: The survey is already answered by some users
+              so you cannot modify its questions.
           question:
             add_answer_option: Add answer option
             question: Question
@@ -63,7 +67,7 @@ en:
           survey_answered:
             body: You have already answered this survey.
             title: Survey answered
-          survey_not_published:
-            body: The survey is not published yet and cannot be answered.
-            title: Survey not published
+          survey_closed:
+            body: The survey is closed and cannot be answered.
+            title: Survey closed
           tos_agreement: By participating in this survey you accept its Terms of Service

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -14,14 +14,12 @@ en:
           answer: Answer
         name: Survey
     surveys:
-      actions:
-        export: Export
       admin:
-        exports:
-          survey_user_answers: Survey user answers
         application_helper:
           label_for_question:
             question: Question
+        exports:
+          survey_user_answers: Survey user answers
         models:
           components:
             description: Description
@@ -32,13 +30,11 @@ en:
             remove_answer_option: Remove answer option
             statement: Statement
           edit:
-            are_you_sure: This action will publish the survey and you will not be
-              able to keep editing the survey questions. Are you sure?
             save: Save
-            save_and_publish: Save and publish
             title: Title
           form:
             add_question: Add question
+            already_answered_warning: The survey is already answered by some users so you cannot modify its questions.
           question:
             add_answer_option: Add answer option
             question: Question

--- a/decidim-surveys/lib/decidim/surveys/feature.rb
+++ b/decidim-surveys/lib/decidim/surveys/feature.rb
@@ -29,9 +29,9 @@ Decidim.register_feature(:surveys) do |feature|
   #   # settings.attribute :vote_limit, type: :integer, default: 0
   # end
 
-  # feature.settings(:step) do |settings|
-  #   # Add your settings per step
-  # end
+  feature.settings(:step) do |settings|
+    settings.attribute :allow_answers, type: :boolean, default: false
+  end
 
   # feature.register_resource do |resource|
   #   # Register a optional resource that can be references from other resources.

--- a/decidim-surveys/spec/commands/decidim/surveys/admin/update_survey_spec.rb
+++ b/decidim-surveys/spec/commands/decidim/surveys/admin/update_survey_spec.rb
@@ -141,17 +141,6 @@ module Decidim
             end
           end
         end
-
-        describe "when the form params include the published_at field" do
-          let(:published_at) { Time.current }
-
-          it "publishes the survey" do
-            command.call
-            survey.reload
-
-            expect(survey).to be_published
-          end
-        end
       end
     end
   end

--- a/decidim-surveys/spec/features/survey_spec.rb
+++ b/decidim-surveys/spec/features/survey_spec.rb
@@ -24,7 +24,7 @@ describe "Answer a survey", type: :feature do
   let!(:survey_question_1) { create(:survey_question, survey: survey, position: 1) }
   let!(:survey_question_2) { create(:survey_question, survey: survey, position: 0) }
 
-  context "when the survey is not published" do
+  context "when the survey doesn't allow answers" do
     it "the survey cannot be answered" do
       visit_feature
 
@@ -34,13 +34,19 @@ describe "Answer a survey", type: :feature do
       expect(page).not_to have_i18n_content(survey_question_1.body)
       expect(page).not_to have_i18n_content(survey_question_2.body)
 
-      expect(page).to have_content("The survey is not published yet and cannot be answered.")
+      expect(page).to have_content("The survey is closed and cannot be answered.")
     end
   end
 
-  context "when the survey is published" do
+  context "when the survey allow answers" do
     before do
-      survey.update_attributes(published_at: Time.current)
+      feature.update_attributes(
+        step_settings: {
+          feature.participatory_process.active_step.id => {
+            allow_answers: true
+          }
+        }
+      )
     end
 
     context "when the user is not logged in" do

--- a/decidim-surveys/spec/models/decidim/surveys/survey_spec.rb
+++ b/decidim-surveys/spec/models/decidim/surveys/survey_spec.rb
@@ -40,10 +40,10 @@ module Decidim
         expect(survey.feature).to be_a(Decidim::Feature)
       end
 
-      context "#answered?" do
-        it "returns true when survey has already answers" do
+      context "#questions_editable?" do
+        it "returns false when survey has already answers" do
           create(:survey_answer, survey: survey)
-          expect(subject.reload).to be_answered
+          expect(subject.reload).not_to be_questions_editable
         end
       end
 

--- a/decidim-surveys/spec/models/decidim/surveys/survey_spec.rb
+++ b/decidim-surveys/spec/models/decidim/surveys/survey_spec.rb
@@ -18,6 +18,12 @@ module Decidim
         expect(subject.questions.count).to eq(2)
       end
 
+      it "has an association of answers" do
+        create(:survey_answer, survey: subject, user: create(:user, organization: survey.feature.organization))
+        create(:survey_answer, survey: subject, user: create(:user, organization: survey.feature.organization))
+        expect(subject.reload.answers.count).to eq(2)
+      end
+
       context "without a feature" do
         let(:survey) { build :survey, feature: nil }
 
@@ -30,30 +36,14 @@ module Decidim
         it { is_expected.not_to be_valid }
       end
 
-      context "without questions" do
-        it "cannot be published" do
-          survey.published_at = Time.current
-          expect(survey).not_to be_valid
-        end
-      end
-
-      context "with questions" do
-        it "can be published" do
-          create(:survey_question, survey: survey)
-          survey.reload
-          survey.published_at = Time.current
-          expect(survey).to be_valid
-        end
-      end
-
       it "has an associated feature" do
         expect(survey.feature).to be_a(Decidim::Feature)
       end
 
-      context "#published?" do
-        it "returns true when published_at is not nil" do
-          survey.published_at = Time.current
-          expect(survey).to be_published
+      context "#answered?" do
+        it "returns true when survey has already answers" do
+          create(:survey_answer, survey: survey)
+          expect(subject.reload).to be_answered
         end
       end
 

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -2,6 +2,14 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "edit surveys" do
+  let(:body) do
+    {
+      en: "This is the first question",
+      ca: "Aquesta es la primera pregunta",
+      es: "Esta es la primera pregunta"
+    }
+  end
+
   it "updates the survey" do
     visit_feature_admin
 
@@ -25,159 +33,35 @@ RSpec.shared_examples "edit surveys" do
     expect(page).to have_content("New description")
   end
 
-  it "adds a few questions to the survey" do
-    visit_feature_admin
-
-    questions_body = [
-      {
-        en: "This is the first question",
-        ca: "Aquesta es la primera pregunta",
-        es: "Esta es la primera pregunta"
-      },
-      {
-        en: "This is the second question",
-        ca: "Aquesta es la segona pregunta",
-        es: "Esta es la segunda pregunta"
-      }
-    ]
-
-    within "form.edit_survey" do
-      2.times { click_button "Add question" }
-
-      expect(page).to have_selector(".survey-question", count: 2)
-
-      page.all(".survey-question").each_with_index do |survey_question, idx|
-        questions_body[idx].each do |locale, value|
-          within survey_question do
-            click_link I18n.with_locale(locale) { I18n.t("name", scope: "locale") }
-            find("input[name='survey[questions][][body_#{locale}]']").send_keys value
-          end
-        end
-      end
-
-      click_button "Save"
-    end
-
-    within ".callout-wrapper" do
-      expect(page).to have_content("successfully")
-    end
-
-    visit_feature_admin
-
-    expect(page).to have_selector("input[value='This is the first question']")
-    expect(page).to have_selector("input[value='This is the second question']")
-  end
-
-  it "adds a question with answer options" do
-    visit_feature_admin
-
-    question_body = {
-      en: "This is the first question",
-      ca: "Aquesta es la primera pregunta",
-      es: "Esta es la primera pregunta"
-    }
-
-    answer_options_body = [
-      {
-        en: "This is the first option",
-        ca: "Aquesta es la primera opció",
-        es: "Esta es la primera opción"
-      },
-      {
-        en: "This is the second option",
-        ca: "Aquesta es la segona opció",
-        es: "Esta es la segunda opción"
-      }
-    ]
-
-    within "form.edit_survey" do
-      click_button "Add question"
-
-      expect(page).to have_selector(".survey-question", count: 1)
-
-      question_body.each do |locale, value|
-        within ".survey-question" do
-          click_link I18n.with_locale(locale) { I18n.t("name", scope: "locale") }
-          find("input[name='survey[questions][][body_#{locale}]']").send_keys value
-        end
-      end
-
-      expect(page).not_to have_content "Add answer option"
-
-      select "Single option", from: "Type"
-
-      expect(page).to have_content "Add answer option"
-
-      2.times { click_button "Add answer option" }
-
-      page.all(".survey-question-answer-option").each_with_index do |survey_question_answer_option, idx|
-        answer_options_body[idx].each do |locale, value|
-          within survey_question_answer_option do
-            click_link I18n.with_locale(locale) { I18n.t("name", scope: "locale") }
-            find("input[name='survey[questions][][answer_options][][body_#{locale}]']").send_keys value
-          end
-        end
-      end
-
-      click_button "Save"
-    end
-
-    within ".callout-wrapper" do
-      expect(page).to have_content("successfully")
-    end
-
-    visit_feature_admin
-
-    expect(page).to have_selector("input[value='This is the first question']")
-    expect(page).to have_selector("input[value='This is the first option']")
-    expect(page).to have_selector("input[value='This is the second option']")
-  end
-
-  describe "when a survey has an existing question" do
-    let(:body) do
-      {
-        en: "This is the first question",
-        ca: "Aquesta es la primera pregunta",
-        es: "Esta es la primera pregunta"
-      }
-    end
-    let!(:survey_question) { create(:survey_question, survey: survey, body: body) }
-
-    it "modifies the question" do
+  context "when the survey is not already answered" do
+    it "adds a few questions to the survey" do
       visit_feature_admin
+
+      questions_body = [
+        {
+          en: "This is the first question",
+          ca: "Aquesta es la primera pregunta",
+          es: "Esta es la primera pregunta"
+        },
+        {
+          en: "This is the second question",
+          ca: "Aquesta es la segona pregunta",
+          es: "Esta es la segunda pregunta"
+        }
+      ]
 
       within "form.edit_survey" do
-        expect(page).to have_selector(".survey-question", count: 1)
+        2.times { click_button "Add question" }
 
-        within ".survey-question" do
-          fill_in "survey-question-#{survey_question.id}_body_en", with: "Modified question"
-          check "Mandatory"
-          select "Long answer", from: "Type"
-        end
+        expect(page).to have_selector(".survey-question", count: 2)
 
-        click_button "Save and publish"
-      end
-
-      within ".callout-wrapper" do
-        expect(page).to have_content("successfully")
-      end
-
-      visit_feature_admin
-
-      expect(page).to have_selector("input[value='Modified question']")
-      expect(page).not_to have_selector("input[value='This is the first question']")
-      expect(page).to have_selector("input#survey_questions_#{survey_question.id}_mandatory[checked]")
-      expect(page).to have_selector("select#survey_questions_#{survey_question.id}_question_type option[value='long_answer'][selected]")
-    end
-
-    it "removes the question" do
-      visit_feature_admin
-
-      within "form.edit_survey" do
-        expect(page).to have_selector(".survey-question", count: 1)
-
-        within ".survey-question" do
-          click_button "Remove question"
+        page.all(".survey-question").each_with_index do |survey_question, idx|
+          questions_body[idx].each do |locale, value|
+            within survey_question do
+              click_link I18n.with_locale(locale) { I18n.t("name", scope: "locale") }
+              find("input[name='survey[questions][][body_#{locale}]']").send_keys value
+            end
+          end
         end
 
         click_button "Save"
@@ -189,16 +73,62 @@ RSpec.shared_examples "edit surveys" do
 
       visit_feature_admin
 
-      within "form.edit_survey" do
-        expect(page).to have_selector(".survey-question", count: 0)
-      end
+      expect(page).to have_selector("input[value='This is the first question']")
+      expect(page).to have_selector("input[value='This is the second question']")
     end
 
-    it "publishes a survey" do
+    it "adds a question with answer options" do
       visit_feature_admin
 
+      question_body = {
+        en: "This is the first question",
+        ca: "Aquesta es la primera pregunta",
+        es: "Esta es la primera pregunta"
+      }
+
+      answer_options_body = [
+        {
+          en: "This is the first option",
+          ca: "Aquesta es la primera opció",
+          es: "Esta es la primera opción"
+        },
+        {
+          en: "This is the second option",
+          ca: "Aquesta es la segona opció",
+          es: "Esta es la segunda opción"
+        }
+      ]
+
       within "form.edit_survey" do
-        click_button "Save and publish"
+        click_button "Add question"
+
+        expect(page).to have_selector(".survey-question", count: 1)
+
+        question_body.each do |locale, value|
+          within ".survey-question" do
+            click_link I18n.with_locale(locale) { I18n.t("name", scope: "locale") }
+            find("input[name='survey[questions][][body_#{locale}]']").send_keys value
+          end
+        end
+
+        expect(page).not_to have_content "Add answer option"
+
+        select "Single option", from: "Type"
+
+        expect(page).to have_content "Add answer option"
+
+        2.times { click_button "Add answer option" }
+
+        page.all(".survey-question-answer-option").each_with_index do |survey_question_answer_option, idx|
+          answer_options_body[idx].each do |locale, value|
+            within survey_question_answer_option do
+              click_link I18n.with_locale(locale) { I18n.t("name", scope: "locale") }
+              find("input[name='survey[questions][][answer_options][][body_#{locale}]']").send_keys value
+            end
+          end
+        end
+
+        click_button "Save"
       end
 
       within ".callout-wrapper" do
@@ -207,13 +137,77 @@ RSpec.shared_examples "edit surveys" do
 
       visit_feature_admin
 
+      expect(page).to have_selector("input[value='This is the first question']")
+      expect(page).to have_selector("input[value='This is the first option']")
+      expect(page).to have_selector("input[value='This is the second option']")
+    end
+
+    describe "when a survey has an existing question" do
+      let!(:survey_question) { create(:survey_question, survey: survey, body: body) }
+
+      it "modifies the question" do
+        visit_feature_admin
+
+        within "form.edit_survey" do
+          expect(page).to have_selector(".survey-question", count: 1)
+
+          within ".survey-question" do
+            fill_in "survey-question-#{survey_question.id}_body_en", with: "Modified question"
+            check "Mandatory"
+            select "Long answer", from: "Type"
+          end
+
+          click_button "Save"
+        end
+
+        within ".callout-wrapper" do
+          expect(page).to have_content("successfully")
+        end
+
+        visit_feature_admin
+
+        expect(page).to have_selector("input[value='Modified question']")
+        expect(page).not_to have_selector("input[value='This is the first question']")
+        expect(page).to have_selector("input#survey_questions_#{survey_question.id}_mandatory[checked]")
+        expect(page).to have_selector("select#survey_questions_#{survey_question.id}_question_type option[value='long_answer'][selected]")
+      end
+
+      it "removes the question" do
+        visit_feature_admin
+
+        within "form.edit_survey" do
+          expect(page).to have_selector(".survey-question", count: 1)
+
+          within ".survey-question" do
+            click_button "Remove question"
+          end
+
+          click_button "Save"
+        end
+
+        within ".callout-wrapper" do
+          expect(page).to have_content("successfully")
+        end
+
+        visit_feature_admin
+
+        within "form.edit_survey" do
+          expect(page).to have_selector(".survey-question", count: 0)
+        end
+      end
+    end
+  end
+
+  context "when the survey is already answered" do
+    let!(:survey_question) { create(:survey_question, survey: survey, body: body) }
+    let!(:survey_answer) { create(:survey_answer, survey: survey, question: survey_question) }
+
+    it "cannot modify survey questions" do
+      visit_feature_admin
+
       expect(page).not_to have_content("Add question")
       expect(page).not_to have_content("Remove question")
       expect(page).to have_selector("input[value='This is the first question'][disabled]")
-
-      visit_feature
-
-      expect(page).to have_content("This is the first question")
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

As a admin I should be able to allow or disallow answers to the survey in a step.

#### :pushpin: Related Issues
- Related to #1342 

#### :clipboard: Subtasks
- [x] Admin cannot modify questions if already answered
- [x] Add allow answers step setting
- [x] Fix surveys public page

### :camera: Screenshots (optional)
![image](https://cloud.githubusercontent.com/assets/106021/26675635/fff4ae2c-46c4-11e7-9552-f5205e4a5189.png)
![image](https://cloud.githubusercontent.com/assets/106021/26675940/081a68ca-46c6-11e7-89db-10f5172c40df.png)
![image](https://cloud.githubusercontent.com/assets/106021/26676486/47d51116-46c8-11e7-977c-960fd27d2c47.png)

#### :ghost: GIF
![](https://media3.giphy.com/media/vVCSJxqWdFfiw/giphy.gif)
