### PR TITLE
Fixed locale used when notifying about a comment reply

### DIFF
--- a/decidim-comments/app/commands/decidim/comments/create_comment.rb
+++ b/decidim-comments/app/commands/decidim/comments/create_comment.rb
@@ -43,9 +43,9 @@ module Decidim
 
       def send_notification_to_author
         if @comment.depth.positive? && @commentable.author.replies_notifications?
-          CommentNotificationMailer.reply_created(@author, @comment, @commentable, @comment.root_commentable).deliver_later
+          CommentNotificationMailer.reply_created(@comment, @commentable, @comment.root_commentable).deliver_later
         elsif @comment.depth.zero? && @commentable.author.comments_notifications?
-          CommentNotificationMailer.comment_created(@author, @comment, @commentable).deliver_later
+          CommentNotificationMailer.comment_created(@comment, @commentable).deliver_later
         end
       end
 

--- a/decidim-comments/app/mailers/decidim/comments/comment_notification_mailer.rb
+++ b/decidim-comments/app/mailers/decidim/comments/comment_notification_mailer.rb
@@ -9,8 +9,8 @@ module Decidim
 
       helper_method :commentable_title
 
-      def comment_created(user, comment, commentable)
-        with_user(user) do
+      def comment_created(comment, commentable)
+        with_user(commentable.author) do
           @comment = comment
           @commentable = commentable
           @organization = commentable.organization
@@ -19,8 +19,8 @@ module Decidim
         end
       end
 
-      def reply_created(user, reply, comment, commentable)
-        with_user(user) do
+      def reply_created(reply, comment, commentable)
+        with_user(comment.author) do
           @reply = reply
           @comment = comment
           @commentable = commentable

--- a/decidim-comments/spec/commands/create_comment_spec.rb
+++ b/decidim-comments/spec/commands/create_comment_spec.rb
@@ -82,7 +82,7 @@ module Decidim
             it "sends an email to the author of the commentable" do
               expect(CommentNotificationMailer)
                 .to receive(:comment_created)
-                .with(author, an_instance_of(Comment), commentable)
+                .with(an_instance_of(Comment), commentable)
                 .and_call_original
 
               command.call
@@ -120,7 +120,7 @@ module Decidim
             it "sends an email to the author of the parent comment" do
               expect(CommentNotificationMailer)
                 .to receive(:reply_created)
-                .with(author, an_instance_of(Comment), commentable, commentable.root_commentable)
+                .with(an_instance_of(Comment), commentable, commentable.root_commentable)
                 .and_call_original
 
               command.call

--- a/decidim-comments/spec/mailers/comment_notification_mailer_spec.rb
+++ b/decidim-comments/spec/mailers/comment_notification_mailer_spec.rb
@@ -6,9 +6,14 @@ require "spec_helper"
 module Decidim
   module Comments
     describe CommentNotificationMailer, type: :mailer do
-      let(:commentable) { create(:dummy_resource) }
-      let(:comment) { create(:comment, commentable: commentable) }
-      let(:reply) { create(:comment, commentable: comment) }
+      let(:organization) { create(:organization) }
+      let(:participatory_process) { create(:participatory_process, organization: organization)}
+      let(:feature) { create(:feature, participatory_process: participatory_process)}
+      let(:commentable_author) { create(:user, organization: organization) }
+      let(:commentable) { create(:dummy_resource, author: commentable_author, feature: feature) }
+      let(:author) { create(:user, organization: organization) }
+      let(:comment) { create(:comment, author: author, commentable: commentable) }
+      let(:reply) { create(:comment, author: author, commentable: comment) }
 
       describe "comment_created" do
         let(:mail) { described_class.comment_created(comment, commentable) }
@@ -19,7 +24,7 @@ module Decidim
         let(:body) { "Hi ha un nou comentari d" }
         let(:default_body) { "There is a new comment" }
 
-        include_examples "localised email"
+        include_examples "author localised email"
       end
 
       describe "reply_created" do
@@ -31,7 +36,7 @@ module Decidim
         let(:body) { "Hi ha una nova resposta de" }
         let(:default_body) { "There is a new reply of your comment" }
 
-        include_examples "localised email"
+        include_examples "author localised email"
       end
     end
   end

--- a/decidim-comments/spec/mailers/comment_notification_mailer_spec.rb
+++ b/decidim-comments/spec/mailers/comment_notification_mailer_spec.rb
@@ -11,7 +11,7 @@ module Decidim
       let(:reply) { create(:comment, commentable: comment) }
 
       describe "comment_created" do
-        let(:mail) { described_class.comment_created(user, comment, commentable) }
+        let(:mail) { described_class.comment_created(comment, commentable) }
 
         let(:subject) { "Tens un nou comentari" }
         let(:default_subject) { "You have a new comment" }
@@ -23,7 +23,7 @@ module Decidim
       end
 
       describe "reply_created" do
-        let(:mail) { described_class.reply_created(user, reply, comment, commentable) }
+        let(:mail) { described_class.reply_created(reply, comment, commentable) }
 
         let(:subject) { "Tens una nova resposta del teu comentari" }
         let(:default_subject) { "You have a new reply of your comment" }

--- a/decidim-comments/spec/shared/author_localised_email.rb
+++ b/decidim-comments/spec/shared/author_localised_email.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+shared_examples "author localised email" do
+  let(:author) { create(:user, locale: locale, organization: organization) }
+  let(:commentable_author) { create(:user, locale: locale, organization: organization) }
+
+  context "when the user has a custom locale" do
+    let(:locale) { "ca" }
+
+    it "uses the user's locale" do
+      expect(mail.subject).to eq(subject)
+      expect(mail.body.encoded).to match(body)
+    end
+  end
+
+  context "otherwise" do
+    let(:locale) { nil }
+
+    it "uses the default locale" do
+      expect(mail.subject).to eq(default_subject)
+      expect(mail.body.encoded).to match(default_body)
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes the locales the comment_mailer was using to send the emails to the authors, instead of using the page current locale it will use the author locale.

#### :pushpin: Related Issues
- Fixes #1438

#### :ghost: GIF
![](https://media3.giphy.com/media/h12M3gRZUjRM4/giphy.gif)
