### PR TITLE
Fix bug when not noticing the user to reconfirm the email

### DIFF
--- a/decidim-core/app/controllers/decidim/account_controller.rb
+++ b/decidim-core/app/controllers/decidim/account_controller.rb
@@ -18,7 +18,7 @@ module Decidim
       @account = form(AccountForm).from_params(params)
 
       UpdateAccount.call(current_user, @account) do
-        on(:ok) do |_account, unconfirmed_email|
+        on(:ok) do |unconfirmed_email|
           flash.now[:notice] = if unconfirmed_email
                                  t("account.update.success_with_email_confirmation", scope: "decidim")
                                else

--- a/decidim-core/app/controllers/decidim/account_controller.rb
+++ b/decidim-core/app/controllers/decidim/account_controller.rb
@@ -18,8 +18,8 @@ module Decidim
       @account = form(AccountForm).from_params(params)
 
       UpdateAccount.call(current_user, @account) do
-        on(:ok) do |unconfirmed_email|
-          flash.now[:notice] = if unconfirmed_email
+        on(:ok) do |email_is_unconfirmed|
+          flash.now[:notice] = if email_is_unconfirmed
                                  t("account.update.success_with_email_confirmation", scope: "decidim")
                                else
                                  t("account.update.success", scope: "decidim")

--- a/decidim-core/spec/commands/decidim/update_account_spec.rb
+++ b/decidim-core/spec/commands/decidim/update_account_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 module Decidim
   describe UpdateAccount, perform_enqueued: true do
     let(:command) { described_class.new(user, form) }
-    let(:user) { create(:user) }
+    let(:user) { create(:user, :confirmed) }
     let(:valid) { true }
     let(:data) do
       {

--- a/decidim-core/spec/features/account_spec.rb
+++ b/decidim-core/spec/features/account_spec.rb
@@ -83,6 +83,20 @@ describe "Account", type: :feature, perform_enqueued: true do
           expect(user.reload.valid_password?("sekritpass123")).to eq(false)
         end
       end
+
+      context "when updating the email" do
+        it "needs to confirm it" do
+          within "form.edit_user" do
+            fill_in :user_email, with: "foo@bar.com"
+
+            find("*[type=submit]").click
+          end
+
+          within_flash_messages do
+            expect(page).to have_content("email to confirm")
+          end
+        end
+      end
     end
 
     context "when on the notifications settings page" do


### PR DESCRIPTION
#### :tophat: What? Why?

When a user changed the email he received an email to confirm it but the callout noticing the user was wrong. In other words, the reconfirming was working well but the user wasn't aware of it.

#### :pushpin: Related Issues
- Fixes #1400 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![image](https://cloud.githubusercontent.com/assets/106021/26779075/464bf2f0-49e4-11e7-8b99-6af344a7c4a4.png)

#### :ghost: GIF
![](https://media0.giphy.com/media/EQbGeIhwMnOnu/giphy.gif)
