### PR TITLE
A translation was missing in account page

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
         user_group_document_number: Organization document number
         user_group_name: Organization name
         user_group_phone: Organization phone
+        remove_avatar: Remove avatar
   activerecord:
     attributes:
       decidim/user:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -9,10 +9,10 @@ en:
         name: Your name
         password: New password
         password_confirmation: Confirm your new password
+        remove_avatar: Remove avatar
         user_group_document_number: Organization document number
         user_group_name: Organization name
         user_group_phone: Organization phone
-        remove_avatar: Remove avatar
   activerecord:
     attributes:
       decidim/user:


### PR DESCRIPTION
#### :tophat: What? Why?

The "Remove avatar" label was missing on the translations file.

#### :pushpin: Related Issues
- Fixes #1348 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
N/A

#### :ghost: GIF
![](https://media4.giphy.com/media/3owyoZfcgf7Ex4qUhO/giphy.gif)
