### PR TITLE
Temporarily disable button while sending proposals

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/proposals/new.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/new.html.erb
@@ -43,7 +43,7 @@
           <% end %>
 
           <div class="actions">
-            <%= form.submit t(".send"), class: "button expanded" %>
+            <%= form.submit t(".send"), class: "button expanded", "data-disable-with" => "#{t('.send')}..." %>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
#### :tophat: What? Why?
This disables the proposal send button after clicking in order to prevent double clicks (that end up in duplicate proposals).

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/OEImtFTJv2fpS/giphy.gif)
