### PR TITLE
Fix default proposals order when votes are not enabled

### DIFF
--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
@@ -28,7 +28,7 @@ module Decidim
         end
 
         def default_order
-          if current_settings.votes_enabled?
+          if votes_visible?
             detect_order("most_voted")
           else
             "random"

--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
@@ -15,7 +15,7 @@ module Decidim
 
         # Gets how the proposals should be ordered based on the choice made by the user.
         def order
-          @order ||= detect_order(params[:order] || "most_voted") || "random"
+          @order ||= detect_order(params[:order]) || detect_order("most_voted") || "random"
         end
 
         # Available orders based on enabled settings

--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
@@ -15,7 +15,7 @@ module Decidim
 
         # Gets how the proposals should be ordered based on the choice made by the user.
         def order
-          @order ||= detect_order(params[:order]) || detect_order("most_voted") || "random"
+          @order ||= detect_order(params[:order]) || default_order
         end
 
         # Available orders based on enabled settings
@@ -27,8 +27,17 @@ module Decidim
           end
         end
 
+        def default_order
+          return detect_order("most_voted") if votes_blocked?
+          "random"
+        end
+
         def votes_visible?
           current_settings.votes_enabled? && !current_settings.votes_hidden?
+        end
+
+        def votes_blocked?
+          votes_visible? && current_settings.votes_blocked?
         end
 
         # Returns: A random float number between -1 and 1 to be used as a random seed at the database.

--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
@@ -15,7 +15,7 @@ module Decidim
 
         # Gets how the proposals should be ordered based on the choice made by the user.
         def order
-          @order ||= detect_order(params[:order]) || detect_order("most_voted")
+          @order ||= detect_order(params[:order] || "most_voted")
         end
 
         # Available orders based on enabled settings
@@ -37,7 +37,7 @@ module Decidim
         end
 
         def detect_order(candidate, default = "random")
-          available_orders.detect(lambda { default }) { |order| order == candidate }
+          available_orders.detect(-> { default }) { |order| order == candidate }
         end
 
         def reorder(proposals)

--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
@@ -37,7 +37,7 @@ module Decidim
         end
 
         def detect_order(candidate, default = "random")
-          available_orders.detect(default) { |order| order == candidate }
+          available_orders.detect(lambda { default }) { |order| order == candidate }
         end
 
         def reorder(proposals)

--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
@@ -28,7 +28,7 @@ module Decidim
         end
 
         def default_order
-          if current_settings.votes_blocked?
+          if current_settings.votes_enabled?
             detect_order("most_voted")
           else
             "random"
@@ -56,6 +56,8 @@ module Decidim
             proposals.order(proposal_votes_count: :desc)
           when "recent"
             proposals.order(created_at: :desc)
+          else
+            proposals
           end
         end
       end

--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
@@ -15,7 +15,7 @@ module Decidim
 
         # Gets how the proposals should be ordered based on the choice made by the user.
         def order
-          @order ||= detect_order(params[:order]) || default_order
+          @order ||= detect_order(params[:order]) || detect_order("most_voted")
         end
 
         # Available orders based on enabled settings
@@ -24,14 +24,6 @@ module Decidim
             available_orders = %w(random recent)
             available_orders << "most_voted" if votes_visible?
             available_orders
-          end
-        end
-
-        def default_order
-          if votes_visible?
-            detect_order("most_voted")
-          else
-            "random"
           end
         end
 
@@ -44,8 +36,8 @@ module Decidim
           @random_seed ||= (params[:random_seed] ? params[:random_seed].to_f : (rand * 2 - 1))
         end
 
-        def detect_order(candidate)
-          available_orders.detect { |order| order == candidate }
+        def detect_order(candidate, default = "random")
+          available_orders.detect(default) { |order| order == candidate }
         end
 
         def reorder(proposals)
@@ -56,8 +48,6 @@ module Decidim
             proposals.order(proposal_votes_count: :desc)
           when "recent"
             proposals.order(created_at: :desc)
-          else
-            proposals
           end
         end
       end

--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
@@ -15,7 +15,7 @@ module Decidim
 
         # Gets how the proposals should be ordered based on the choice made by the user.
         def order
-          @order ||= detect_order(params[:order] || "most_voted")
+          @order ||= detect_order(params[:order] || "most_voted") || "random"
         end
 
         # Available orders based on enabled settings
@@ -36,8 +36,8 @@ module Decidim
           @random_seed ||= (params[:random_seed] ? params[:random_seed].to_f : (rand * 2 - 1))
         end
 
-        def detect_order(candidate, default = "random")
-          available_orders.detect(-> { default }) { |order| order == candidate }
+        def detect_order(candidate)
+          available_orders.detect { |order| order == candidate }
         end
 
         def reorder(proposals)

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -408,6 +408,17 @@ describe "Proposals", type: :feature do
       expect(page).to have_css(".card--proposal", count: 3)
     end
 
+    it "lists the proposals ordered randomly by default" do
+      allow_any_instance_of(Decidim::Proposals::Proposal::ActiveRecord_Relation).to \
+        receive(:order_randomly) { |scope, _seed| scope.order(title: :asc) }
+
+      visit_feature
+
+      expect(page).to have_selector("a", text: "Random")
+      expect(page).to have_selector("#proposals .card-grid .column:first-child", text: lucky_proposal.title)
+      expect(page).to have_selector("#proposals .card-grid .column:last-child", text: unlucky_proposal.title)
+    end
+
     context "when voting phase is over" do
       let!(:feature) do
         create(:proposal_feature,

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -412,6 +412,9 @@ describe "Proposals", type: :feature do
       allow_any_instance_of(Decidim::Proposals::Proposal::ActiveRecord_Relation).to \
         receive(:order_randomly) { |scope, _seed| scope.order(title: :asc) }
 
+      lucky_proposal = create(:proposal, title: "A", feature: feature)
+      unlucky_proposal = create(:proposal, title: "B", feature: feature)
+
       visit_feature
 
       expect(page).to have_selector("a", text: "Random")


### PR DESCRIPTION
#### :tophat: What? Why?

The `default_order` was set to `nil` if the `votes_enabled` was false and `votes_blocked` was true so the `reorder` function wasn't working well.

We had a false positive in our test suite as well 😄  . I think the `votes_blocked` setting should not affect the visibility of the `most_voted` order.

#### :pushpin: Related Issues
- Fixes #1455

#### :clipboard: Subtasks
- [x] Fix bug
- [x] Fix specs

### :camera: Screenshots (optional)
N/A

#### :ghost: GIF
![](https://media2.giphy.com/media/QGSEGsTr04bPW/giphy.gif)
