### PR TITLE
Ensure the onpopstate events are caused by user actions

### DIFF
--- a/decidim-core/app/assets/javascripts/decidim/form_filter.component.test.js
+++ b/decidim-core/app/assets/javascripts/decidim/form_filter.component.test.js
@@ -70,14 +70,14 @@ describe('FormFilterComponent', () => {
       it('clears the form data', () => {
         spyOn(subject, '_clearForm');
 
-        window.onpopstate();
+        window.onpopstate({ isTrusted: true });
 
         expect(subject._clearForm).toHaveBeenCalled();
       });
 
       it('sets the correct form fields based on the current location', () => {
         spyOn(subject, '_getLocation').and.returnValue('/filters?filter[scope_id][]=1&scope_id[]=2&filter[category_id]=2');
-        window.onpopstate();
+        window.onpopstate({ isTrusted: true });
 
         expect($(selector).find('select').val()).toEqual('2');
         expect($(selector).find('input[name="filter[scope_id][]"][value="1"]')[0].checked).toBeTruthy();

--- a/decidim-core/app/assets/javascripts/decidim/history.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/history.js.es6
@@ -4,10 +4,13 @@
 ((exports) => {
   let callbacks = {};
 
-  exports.onpopstate = () => {
-    for (let callbackId in callbacks) {
-      if (callbacks.hasOwnProperty(callbackId)) {
-        callbacks[callbackId]();
+  exports.onpopstate = (event) => {
+    // Ensure the event is caused by user action
+    if (event.isTrusted) {
+      for (let callbackId in callbacks) {
+        if (callbacks.hasOwnProperty(callbackId)) {
+          callbacks[callbackId]();
+        }
       }
     }
   };


### PR DESCRIPTION
#### :tophat: What? Why?

This fixes a lot of problems with our test suite. After a few debugging I found that our `FormFilterComponent` was causing page reloads because `onpopstate` is fired on every page load by PhantomJS:

https://github.com/ariya/phantomjs/issues/12511

Fortunately the `onpopstate` event has a `isTrusted` property that we can use to ensure the event is fired by an user action.

https://developer.mozilla.org/en/docs/Web/API/Event/isTrusted

#### :pushpin: Related Issues
- Related to #1446, #1456 

#### :clipboard: Subtasks
Nope

### :camera: Screenshots (optional)
N/A

#### :ghost: GIF
![](https://media2.giphy.com/media/JwVWLRnZkh2M0/giphy.gif)
