### PR TITLE
Add maxlength to fields with length validation

### DIFF
--- a/decidim-comments/app/models/decidim/comments/comment.rb
+++ b/decidim-comments/app/models/decidim/comments/comment.rb
@@ -27,6 +27,8 @@ module Decidim
       validates :depth, numericality: { greater_than_or_equal_to: 0 }
       validates :alignment, inclusion: { in: [0, 1, -1] }
 
+      validates :body, length: { maximum: 500 }
+
       validate :commentable_can_have_comments
 
       before_save :compute_depth

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -243,6 +243,7 @@ module Decidim
       validation_options = {}
       validation_options[:pattern] = "^(.|[\n\r]){#{min_length},#{max_length}}$" if min_length.to_i.positive? || max_length.to_i.positive?
       validation_options[:required] = options[:required] || attribute_required?(attribute)
+      validation_options[:maxlength] ||= max_length if max_length.to_i.positive?
       validation_options
     end
 

--- a/decidim-core/spec/lib/form_builder_spec.rb
+++ b/decidim-core/spec/lib/form_builder_spec.rb
@@ -299,7 +299,7 @@ module Decidim
 
         it "adds a pattern" do
           expect(parsed.css("input[pattern='^(.|[\n\r]){0,150}$']").first).to be
-          expect(output).not_to include("maxlength")
+          expect(parsed.css("input[maxlength='150']")).to be
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
This uses validations to automatically figure out the max length of fields, whenever possible, so the user has some feedback while filling in the field..

#### :pushpin: Related Issues
- Fixes #1279

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/cwTtbmUwzPqx2/giphy.gif)
