### PR TITLE
Follow up to ordering fixes

### DIFF
--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
@@ -28,8 +28,11 @@ module Decidim
         end
 
         def default_order
-          return detect_order("most_voted") if votes_blocked?
-          "random"
+          if votes_blocked?
+            detect_order("most_voted")
+          else
+            "random"
+          end
         end
 
         def votes_visible?

--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
@@ -22,25 +22,25 @@ module Decidim
         def available_orders
           @available_orders ||= begin
             available_orders = %w(random recent)
-            available_orders << "most_voted" if votes_visible?
+            available_orders << "most_voted" if most_voted_order_available?
             available_orders
           end
         end
 
         def default_order
-          if votes_blocked?
+          if order_by_votes?
             detect_order("most_voted")
           else
             "random"
           end
         end
 
-        def votes_visible?
+        def most_voted_order_available?
           current_settings.votes_enabled? && !current_settings.votes_hidden?
         end
 
-        def votes_blocked?
-          votes_visible? && current_settings.votes_blocked?
+        def order_by_votes?
+          most_voted_order_available? && current_settings.votes_blocked?
         end
 
         # Returns: A random float number between -1 and 1 to be used as a random seed at the database.

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -397,6 +397,20 @@ describe "Proposals", type: :feature do
   end
 
   context "listing proposals in a participatory process" do
+    shared_examples_for "a random proposal ordering" do
+      let!(:lucky_proposal) { create(:proposal, feature: feature) }
+      let!(:unlucky_proposal) { create(:proposal, feature: feature) }
+
+      it "lists the proposals ordered randomly by default" do
+        visit_feature
+
+        expect(page).to have_selector("a", text: "Random")
+        expect(page).to have_selector("#proposals .card-grid .column", count: 2)
+        expect(page).to have_selector("#proposals .card-grid .column", text: lucky_proposal.title)
+        expect(page).to have_selector("#proposals .card-grid .column", text: unlucky_proposal.title)
+      end
+    end
+
     it "lists all the proposals" do
       create(:proposal_feature,
              manifest: manifest,
@@ -408,17 +422,8 @@ describe "Proposals", type: :feature do
       expect(page).to have_css(".card--proposal", count: 3)
     end
 
-    it "lists the proposals ordered randomly by default" do
-      allow_any_instance_of(Decidim::Proposals::Proposal).to receive(:order_randomly) { |scope, _seed| scope.order(title: :asc) }
-
-      lucky_proposal = create(:proposal, title: "A", feature: feature)
-      unlucky_proposal = create(:proposal, title: "B", feature: feature)
-
-      visit_feature
-
-      expect(page).to have_selector("a", text: "Random")
-      expect(page).to have_selector("#proposals .card-grid .column:first-child", text: lucky_proposal.title)
-      expect(page).to have_selector("#proposals .card-grid .column:last-child", text: unlucky_proposal.title)
+    describe "default ordering" do
+      it_behaves_like "a random proposal ordering"
     end
 
     context "when voting phase is over" do
@@ -459,19 +464,13 @@ describe "Proposals", type: :feature do
                participatory_process: participatory_process)
       end
 
-      let!(:lucky_proposal) { create(:proposal, feature: feature) }
-      let!(:unlucky_proposal) { create(:proposal, feature: feature) }
-
-      it "lists the proposals ordered randomly by default" do
-        visit_feature
-
-        expect(page).to have_selector("a", text: "Random")
-        expect(page).to have_selector("#proposals .card-grid .column", count: 2)
-        expect(page).to have_selector("#proposals .card-grid .column", text: lucky_proposal.title)
-        expect(page).to have_selector("#proposals .card-grid .column", text: unlucky_proposal.title)
+      describe "order" do
+        it_behaves_like "a random proposal ordering"
       end
 
       it "shows only links to full proposals" do
+        create_list(:proposal, 2, feature: feature)
+
         visit_feature
 
         expect(page).to have_no_button("Voting disabled", disabled: true)

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -459,8 +459,8 @@ describe "Proposals", type: :feature do
                participatory_process: participatory_process)
       end
 
-      let!(:lucky_proposal) { create(:proposal, title: "A", feature: feature) }
-      let!(:unlucky_proposal) { create(:proposal, title: "B", feature: feature) }
+      let!(:lucky_proposal) { create(:proposal, feature: feature) }
+      let!(:unlucky_proposal) { create(:proposal, feature: feature) }
 
       it "lists the proposals ordered randomly by default" do
         visit_feature


### PR DESCRIPTION
#### :tophat: What? Why?

This is a follow up to #1456. The stubbing of random ordering does not actually work (it passes around... 50% of the times), so I used the other approach (check that the expected proposals are there, but allow any order).
 
#### :pushpin: Related Issues
- Related to #1456.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![swing](https://user-images.githubusercontent.com/2887858/26974875-adc2c7e4-4cf3-11e7-929d-314b32020f6a.gif)