### PR TITLE
Fix warnings about class_name

### DIFF
--- a/decidim-surveys/app/models/decidim/surveys/survey.rb
+++ b/decidim-surveys/app/models/decidim/surveys/survey.rb
@@ -8,8 +8,8 @@ module Decidim
 
       feature_manifest_name "surveys"
 
-      has_many :questions, -> { order(:position) }, class_name: SurveyQuestion, foreign_key: "decidim_survey_id"
-      has_many :answers, class_name: SurveyAnswer, foreign_key: "decidim_survey_id"
+      has_many :questions, -> { order(:position) }, class_name: "SurveyQuestion", foreign_key: "decidim_survey_id"
+      has_many :answers, class_name: "SurveyAnswer", foreign_key: "decidim_survey_id"
 
       # Public: returns whether the survey questions can be modified or not.
       def questions_editable?

--- a/decidim-surveys/app/models/decidim/surveys/survey_answer.rb
+++ b/decidim-surveys/app/models/decidim/surveys/survey_answer.rb
@@ -4,9 +4,9 @@ module Decidim
   module Surveys
     # The data store for a SurveyAnswer in the Decidim::Surveys component.
     class SurveyAnswer < Surveys::ApplicationRecord
-      belongs_to :user, class_name: Decidim::User, foreign_key: "decidim_user_id"
-      belongs_to :survey, class_name: Survey, foreign_key: "decidim_survey_id"
-      belongs_to :question, class_name: SurveyQuestion, foreign_key: "decidim_survey_question_id"
+      belongs_to :user, class_name: "Decidim::User", foreign_key: "decidim_user_id"
+      belongs_to :survey, class_name: "Survey", foreign_key: "decidim_survey_id"
+      belongs_to :question, class_name: "SurveyQuestion", foreign_key: "decidim_survey_question_id"
 
       validates :body, presence: true, if: -> { question.mandatory? }
       validate :user_survey_same_organization

--- a/decidim-surveys/app/models/decidim/surveys/survey_question.rb
+++ b/decidim-surveys/app/models/decidim/surveys/survey_question.rb
@@ -6,7 +6,7 @@ module Decidim
     class SurveyQuestion < Surveys::ApplicationRecord
       TYPES = %w(short_answer long_answer single_option multiple_option).freeze
 
-      belongs_to :survey, class_name: Survey, foreign_key: "decidim_survey_id"
+      belongs_to :survey, class_name: "Survey", foreign_key: "decidim_survey_id"
 
       # Rectify can't handle a hash when using the from_model method so
       # the answer options must be converted to struct.


### PR DESCRIPTION
#### :tophat: What? Why?

This fixes several Rails deprecation warnings because of passing `class_name` as a constant.

#### :pushpin: Related Issues
- Related to #1377.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![more_lindy](https://user-images.githubusercontent.com/2887858/26978101-9264cbde-4d00-11e7-8560-e5b00f9782e8.gif)

