### PR TITLE
Fix/typos++

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ After you create a development app (`bundle exec rake development_app`):
 - Login data: admin@example.org | decidim123456
 
 
-## Components
+## Officially supported libraries
 
 
-| Component        | Description           |
+| Library        | Description           |
 | ------------- |-------------|
 | [Admin](https://github.com/decidim/decidim/tree/master/decidim-admin)      | This library adds an administration dashboard so users can manage their organization, participatory processes and all other entities. |
 | [API](https://github.com/decidim/decidim/tree/master/decidim-api)      | This library exposes a GraphQL API to programatically interact with the Decidim platform via HTTP      |

--- a/decidim-budgets/app/controllers/decidim/budgets/application_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/application_controller.rb
@@ -5,7 +5,7 @@ module Decidim
     # This controller is the abstract class from which all other controllers of
     # this engine inherit.
     #
-    # Note that it inherits from `Decidim::Components::BaseController`, which
+    # Note that it inherits from `Decidim::Features::BaseController`, which
     # override its layout and provide all kinds of useful methods.
     class ApplicationController < Decidim::Features::BaseController
     end

--- a/decidim-core/app/models/decidim/feature.rb
+++ b/decidim-core/app/models/decidim/feature.rb
@@ -2,8 +2,8 @@
 
 module Decidim
   # A Feature represents a self-contained group of functionalities usually
-  # defined via a FeatureManifest and its Components. It's meant to be able to
-  # provide a single feature that spans over several steps, each one with its component.
+  # defined via a FeatureManifest. It's meant to be able to provide a single
+  # feature that spans over several steps.
   class Feature < ApplicationRecord
     belongs_to :participatory_process, foreign_key: "decidim_participatory_process_id"
     has_one :organization, through: :participatory_process

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -77,7 +77,7 @@ module Decidim
         app.config.exceptions_app = Decidim::Core::Engine.routes
       end
 
-      initializer "decidim_admin.inject_abilities_to_user" do |_app|
+      initializer "decidim.inject_abilities_to_user" do |_app|
         Decidim.configure do |config|
           config.abilities << "Decidim::Abilities::Everyone"
         end

--- a/decidim-core/lib/decidim/feature_manifest.rb
+++ b/decidim-core/lib/decidim/feature_manifest.rb
@@ -64,8 +64,7 @@ module Decidim
     #
     # event_name - A String or Symbol with the event name.
     # context    - An optional context that will be provided to the block as a
-    #              parameter. Usually the subject of the hook, mostly the
-    #              Component.
+    #              parameter. Usually the subject of the hook.
     #
     # Returns nothing.
     def run_hooks(event_name, context = nil)

--- a/decidim-core/lib/decidim/has_scope.rb
+++ b/decidim-core/lib/decidim/has_scope.rb
@@ -3,7 +3,7 @@
 require "active_support/concern"
 
 module Decidim
-  # A concern with the features needed when you want a model to be have a scope.
+  # A concern with the features needed when you want a model to have a scope.
   module HasScope
     extend ActiveSupport::Concern
 

--- a/decidim-core/spec/features/homepage_spec.rb
+++ b/decidim-core/spec/features/homepage_spec.rb
@@ -151,7 +151,7 @@ describe "Homepage", type: :feature do
         visit current_path
       end
 
-      it "includes the linsk to social networks" do
+      it "includes the links to social networks" do
         expect(page).to have_xpath("//a[@href = 'https://twitter.com/twitter_handler']")
         expect(page).to have_xpath("//a[@href = 'https://www.facebook.com/facebook_handler']")
         expect(page).to have_xpath("//a[@href = 'https://www.youtube.com/youtube_handler']")

--- a/decidim-meetings/app/controllers/decidim/meetings/application_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/application_controller.rb
@@ -5,7 +5,7 @@ module Decidim
     # This controller is the abstract class from which all other controllers of
     # this engine inherit.
     #
-    # Note that it inherits from `Decidim::Components::BaseController`, which
+    # Note that it inherits from `Decidim::Features::BaseController`, which
     # override its layout and provide all kinds of useful methods.
     class ApplicationController < Decidim::Features::BaseController
       helper Decidim::Meetings::ApplicationHelper

--- a/decidim-results/app/controllers/decidim/results/application_controller.rb
+++ b/decidim-results/app/controllers/decidim/results/application_controller.rb
@@ -5,7 +5,7 @@ module Decidim
     # This controller is the abstract class from which all other controllers of
     # this engine inherit.
     #
-    # Note that it inherits from `Decidim::Components::BaseController`, which
+    # Note that it inherits from `Decidim::Features::BaseController`, which
     # override its layout and provide all kinds of useful methods.
     class ApplicationController < Decidim::Features::BaseController
     end

--- a/lib/generators/decidim/install_generator.rb
+++ b/lib/generators/decidim/install_generator.rb
@@ -19,7 +19,7 @@ module Decidim
       class_option :migrate, type: :boolean, default: false,
                              desc: "Run migrations after installing decidim"
       class_option :recreate_db, type: :boolean, default: false,
-                                 desc: "Run migrations after installing decidim"
+                                 desc: "Recreate db after installing decidim"
 
       def install
         route "mount Decidim::Core::Engine => '/'"


### PR DESCRIPTION
#### :tophat: What? Why?
Typos and other doc improvements.

I removed the references to "Component" at the Ruby level. I think they were leftovers of a previous implementation of features. This helps addressing https://github.com/decidim/decidim/pull/1253#discussion_r112261960.

I'm not convinced "library" is the right word for the README, maybe "plugin" (although this is an old Rails term, nowadays "gem" would be better), or maybe actually leave "component" (I removed it because after my changes it was the only reference in the repo to that word other than in JS files). Not sure, let me know (but without too much bikeshedding :stuck_out_tongue:).

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![cat-looking](https://user-images.githubusercontent.com/2887858/26995678-5e207b5e-4d44-11e7-863d-7f23ba8f7c3c.gif)

