### PR TITLE
Close meetings show page spec failure

### DIFF
--- a/decidim-meetings/spec/features/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/features/explore_meetings_spec.rb
@@ -233,9 +233,9 @@ describe "Explore meetings", type: :feature do
         expect(page).to have_i18n_content(meeting.closing_report)
 
         within ".definition-data" do
-          expect(page).to have_content(meeting.attendees_count)
-          expect(page).to have_content(meeting.contributions_count)
-          expect(page).to have_content(meeting.attending_organizations)
+          expect(page).to have_content("ATTENDEES COUNT #{meeting.attendees_count}")
+          expect(page).to have_content("CONTRIBUTIONS COUNT #{meeting.contributions_count}")
+          expect(page).to have_content("ATTENDING ORGANIZATIONS #{meeting.attending_organizations}")
         end
       end
     end

--- a/decidim-meetings/spec/features/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/features/explore_meetings_spec.rb
@@ -224,9 +224,7 @@ describe "Explore meetings", type: :feature do
     let(:attached_to) { meeting }
     it_behaves_like "has attachments"
 
-    context "when the meeting is closed" do
-      let!(:meeting) { create(:meeting, :closed, feature: feature) }
-
+    shared_examples_for "a closing report page" do
       it "shows the closing report" do
         visit_feature
         click_link translated(meeting.title)
@@ -234,8 +232,31 @@ describe "Explore meetings", type: :feature do
 
         within ".definition-data" do
           expect(page).to have_content("ATTENDEES COUNT #{meeting.attendees_count}")
-          expect(page).to have_content("CONTRIBUTIONS COUNT #{meeting.contributions_count}")
           expect(page).to have_content("ATTENDING ORGANIZATIONS #{meeting.attending_organizations}")
+        end
+      end
+    end
+
+    context "when the meeting is closed and had no contributions" do
+      let!(:meeting) { create(:meeting, :closed, contributions_count: 0, feature: feature) }
+
+      it_behaves_like "a closing report page"
+
+      it "does not show contributions count" do
+        within ".definition-data" do
+          expect(page).to have_no_content("CONTRIBUTIONS COUNT 0")
+        end
+      end
+    end
+
+    context "when the meeting is closed and had contributions" do
+      let!(:meeting) { create(:meeting, :closed, contributions_count: 1, feature: feature) }
+
+      it_behaves_like "a closing report page"
+
+      it "shows contributions count" do
+        within ".definition-data" do
+          expect(page).to have_content("CONTRIBUTIONS COUNT 1")
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

Fixes a random spec failure in the close meeting show page. Sometimes the meeting used by the spec had zero contributions and asserted for the number of contributions to be in the page. However, when there are zero contributions, the number should not be displayed.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![button](https://user-images.githubusercontent.com/2887858/27007404-b7a283d6-4e28-11e7-9c9c-55dd90a013cb.gif)

