### PR TITLE
Prevent category deletion when is not unused

### DIFF
--- a/decidim-admin/app/views/decidim/admin/categories/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/categories/index.html.erb
@@ -33,7 +33,7 @@
                     <% if category.unused? %>
                       <%= icon_link_to "circle-x", participatory_process_category_path(participatory_process, category), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
                     <% else %>
-                      <%= icon "circle-x", class: "action-icon action-icon--disabled" %>
+                      <%= icon "circle-x", class: "action-icon action-icon--disabled", title: "shed" %>
                     <% end %>
                   <% end %>
                 </td>

--- a/decidim-admin/app/views/decidim/admin/categories/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/categories/index.html.erb
@@ -30,7 +30,11 @@
                   <% end %>
 
                   <% if can? :destroy, category %>
-                    <%= icon_link_to "circle-x", participatory_process_category_path(participatory_process, category), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
+                    <% if category.unused? %>
+                      <%= icon_link_to "circle-x", participatory_process_category_path(participatory_process, category), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
+                    <% else %>
+                      <%= icon "circle-x", class: "action-icon action-icon--disabled" %>
+                    <% end %>
                   <% end %>
                 </td>
               </tr>

--- a/decidim-admin/app/views/decidim/admin/categories/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/categories/index.html.erb
@@ -33,7 +33,9 @@
                     <% if category.unused? %>
                       <%= icon_link_to "circle-x", participatory_process_category_path(participatory_process, category), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
                     <% else %>
-                      <%= icon "circle-x", class: "action-icon action-icon--disabled", title: "shed" %>
+                      <span class="action-icon" title="<%= t('.category_used') %>" data-tooltip="true" data-disable-hover="false">
+                        <%= icon "circle-x", class: "action-icon action-icon--disabled" %>
+                      </span>
                     <% end %>
                   <% end %>
                 </td>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -156,6 +156,8 @@ en:
         edit:
           title: Edit category
           update: Update
+        index:
+          category_used: This category cannot be removed because it is in use.
         new:
           create: Create category
           title: New category

--- a/decidim-admin/spec/shared/manage_process_categories_examples.rb
+++ b/decidim-admin/spec/shared/manage_process_categories_examples.rb
@@ -124,7 +124,6 @@ RSpec.shared_examples "manage process categories examples" do
 
         within find("tr", text: translated(category.name)) do
           expect(page).not_to have_selector("a.action-icon--remove")
-          expect(page).to have_selector(".action-icon--disabled")
         end
       end
     end

--- a/decidim-budgets/db/migrate/20170612101846_migrate_projects_category.rb
+++ b/decidim-budgets/db/migrate/20170612101846_migrate_projects_category.rb
@@ -3,20 +3,20 @@
 class MigrateProjectsCategory < ActiveRecord::Migration[5.1]
   def change
     # Ensure database integrity updating projects with an invalid category
-    ActiveRecord::Base.connection.execute("""
+    ActiveRecord::Base.connection.execute('
       UPDATE decidim_budgets_projects SET decidim_category_id = NULL where id IN (
         SELECT t.id FROM decidim_budgets_projects as t WHERE t.decidim_category_id NOT IN (
           SELECT c.id FROM decidim_categories as c
         )
       )
-    """)
+    ')
     # Create categorizations
-    ActiveRecord::Base.connection.execute("""
+    ActiveRecord::Base.connection.execute('
       INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type, created_at, updated_at)
-        SELECT decidim_category_id, id, 'Decidim::Budgets::Project', NOW(), NOW()
+        SELECT decidim_category_id, id, "Decidim::Budgets::Project", NOW(), NOW()
         FROM decidim_budgets_projects
         WHERE decidim_category_id IS NOT NULL
-    """)
+    ')
     # Remove unused column
     remove_column :decidim_budgets_projects, :decidim_category_id
   end

--- a/decidim-budgets/db/migrate/20170612101846_migrate_projects_category.rb
+++ b/decidim-budgets/db/migrate/20170612101846_migrate_projects_category.rb
@@ -2,16 +2,22 @@
 
 class MigrateProjectsCategory < ActiveRecord::Migration[5.1]
   def change
-    records = ActiveRecord::Base.connection.execute("SELECT id, decidim_category_id FROM decidim_budgets_projects")
-    now = Time.current
-    values = records.to_a.reject!{ |record| record["decidim_category_id"].blank? }.map do |record|
-      "(#{record["id"]}, #{record["decidim_category_id"]}, 'Decidim::Budgets::Project', '#{now}', '#{now}')"
-    end
-    if values.any?
-      ActiveRecord::Base.connection.execute(
-        "INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type, created_at, updated_at) VALUES #{values.join(', ')}"
+    # Ensure database integrity updating projects with an invalid category
+    ActiveRecord::Base.connection.execute("""
+      UPDATE decidim_budgets_projects SET decidim_category_id = NULL where id IN (
+        SELECT t.id FROM decidim_budgets_projects as t WHERE t.decidim_category_id NOT IN (
+          SELECT c.id FROM decidim_categories as c
+        )
       )
-    end
+    """)
+    # Create categorizations
+    ActiveRecord::Base.connection.execute("""
+      INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type, created_at, updated_at)
+        SELECT decidim_category_id, id, 'Decidim::Budgets::Project', NOW(), NOW()
+        FROM decidim_budgets_projects
+        WHERE decidim_category_id IS NOT NULL
+    """)
+    # Remove unused column
     remove_column :decidim_budgets_projects, :decidim_category_id
   end
 end

--- a/decidim-budgets/db/migrate/20170612101846_migrate_projects_category.rb
+++ b/decidim-budgets/db/migrate/20170612101846_migrate_projects_category.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MigrateProjectsCategory < ActiveRecord::Migration[5.1]
   def change
     Decidim::Budgets::Project.find_each do |project|

--- a/decidim-budgets/db/migrate/20170612101846_migrate_projects_category.rb
+++ b/decidim-budgets/db/migrate/20170612101846_migrate_projects_category.rb
@@ -3,12 +3,13 @@
 class MigrateProjectsCategory < ActiveRecord::Migration[5.1]
   def change
     records = ActiveRecord::Base.connection.execute("SELECT id, decidim_category_id FROM decidim_budgets_projects")
-    values = records.map do |record|
-      "(#{record[:id]}, #{record[:decidim_category_id]}, 'Decidim::Budgets::Project')"
+    now = Time.current
+    values = records.to_a.reject!{ |record| record["decidim_category_id"].blank? }.map do |record|
+      "(#{record["id"]}, #{record["decidim_category_id"]}, 'Decidim::Budgets::Project', '#{now}', '#{now}')"
     end
     if values.any?
       ActiveRecord::Base.connection.execute(
-        "INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type) VALUES #{values.join(', ')}"
+        "INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type, created_at, updated_at) VALUES #{values.join(', ')}"
       )
     end
     remove_column :decidim_budgets_projects, :decidim_category_id

--- a/decidim-budgets/db/migrate/20170612101846_migrate_projects_category.rb
+++ b/decidim-budgets/db/migrate/20170612101846_migrate_projects_category.rb
@@ -1,0 +1,11 @@
+class MigrateProjectsCategory < ActiveRecord::Migration[5.1]
+  def change
+    Decidim::Budgets::Project.find_each do |project|
+      Decidim::Categorization.create!(
+        decidim_category_id: project.category.id,
+        categorizable: project
+      )
+    end
+    remove_column :decidim_budgets_projects, :decidim_category_id
+  end
+end

--- a/decidim-budgets/db/migrate/20170612101846_migrate_projects_category.rb
+++ b/decidim-budgets/db/migrate/20170612101846_migrate_projects_category.rb
@@ -13,7 +13,7 @@ class MigrateProjectsCategory < ActiveRecord::Migration[5.1]
     # Create categorizations
     ActiveRecord::Base.connection.execute('
       INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type, created_at, updated_at)
-        SELECT decidim_category_id, id, "Decidim::Budgets::Project", NOW(), NOW()
+        SELECT decidim_category_id, id, \'Decidim::Budgets::Project\', NOW(), NOW()
         FROM decidim_budgets_projects
         WHERE decidim_category_id IS NOT NULL
     ')

--- a/decidim-budgets/db/migrate/20170612101846_migrate_projects_category.rb
+++ b/decidim-budgets/db/migrate/20170612101846_migrate_projects_category.rb
@@ -2,20 +2,12 @@
 
 class MigrateProjectsCategory < ActiveRecord::Migration[5.1]
   def change
-    # Ensure database integrity updating projects with an invalid category
-    ActiveRecord::Base.connection.execute('
-      UPDATE decidim_budgets_projects SET decidim_category_id = NULL where id IN (
-        SELECT t.id FROM decidim_budgets_projects as t WHERE t.decidim_category_id NOT IN (
-          SELECT c.id FROM decidim_categories as c
-        )
-      )
-    ')
-    # Create categorizations
-    ActiveRecord::Base.connection.execute('
+    # Create categorizations ensuring database integrity
+    execute('
       INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type, created_at, updated_at)
-        SELECT decidim_category_id, id, \'Decidim::Budgets::Project\', NOW(), NOW()
+        SELECT decidim_category_id, decidim_budgets_projects.id, \'Decidim::Budgets::Project\', NOW(), NOW()
         FROM decidim_budgets_projects
-        WHERE decidim_category_id IS NOT NULL
+        INNER JOIN decidim_categories ON decidim_categories.id = decidim_budgets_projects.decidim_category_id
     ')
     # Remove unused column
     remove_column :decidim_budgets_projects, :decidim_category_id

--- a/decidim-budgets/db/migrate/20170612101846_migrate_projects_category.rb
+++ b/decidim-budgets/db/migrate/20170612101846_migrate_projects_category.rb
@@ -2,10 +2,13 @@
 
 class MigrateProjectsCategory < ActiveRecord::Migration[5.1]
   def change
-    Decidim::Budgets::Project.find_each do |project|
-      Decidim::Categorization.create!(
-        decidim_category_id: project.category.id,
-        categorizable: project
+    records = ActiveRecord::Base.connection.execute("SELECT id, decidim_category_id FROM decidim_budgets_projects")
+    values = records.map do |record|
+      "(#{record[:id]}, #{record[:decidim_category_id]}, 'Decidim::Budgets::Project')"
+    end
+    if values.any?
+      ActiveRecord::Base.connection.execute(
+        "INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type) VALUES #{values.join(', ')}"
       )
     end
     remove_column :decidim_budgets_projects, :decidim_category_id

--- a/decidim-core/app/models/decidim/categorization.rb
+++ b/decidim-core/app/models/decidim/categorization.rb
@@ -1,0 +1,6 @@
+module Decidim
+  class Categorization < ApplicationRecord
+    belongs_to :category, foreign_key: :decidim_category_id
+    belongs_to :categorizable, polymorphic: true
+  end
+end

--- a/decidim-core/app/models/decidim/categorization.rb
+++ b/decidim-core/app/models/decidim/categorization.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Decidim
   class Categorization < ApplicationRecord
     belongs_to :category, foreign_key: :decidim_category_id

--- a/decidim-core/app/models/decidim/category.rb
+++ b/decidim-core/app/models/decidim/category.rb
@@ -19,6 +19,9 @@ module Decidim
       where(parent_id: nil)
     end
 
+    def unused?
+    end
+
     private
 
     def forbid_deep_nesting

--- a/decidim-core/app/models/decidim/category.rb
+++ b/decidim-core/app/models/decidim/category.rb
@@ -7,6 +7,7 @@ module Decidim
     belongs_to :participatory_process, foreign_key: "decidim_participatory_process_id", class_name: "Decidim::ParticipatoryProcess", inverse_of: :categories
     has_many :subcategories, foreign_key: "parent_id", class_name: "Decidim::Category", dependent: :destroy, inverse_of: :parent
     belongs_to :parent, class_name: "Decidim::Category", foreign_key: "parent_id", inverse_of: :subcategories, optional: true
+    has_many :categorizations, foreign_key: "decidim_category_id", class_name: "Decidim::Categorization", dependent: :destroy
 
     validate :forbid_deep_nesting
     before_validation :subcategories_have_same_process
@@ -20,6 +21,7 @@ module Decidim
     end
 
     def unused?
+      categorizations.empty?
     end
 
     private

--- a/decidim-core/app/services/decidim/resource_search.rb
+++ b/decidim-core/app/services/decidim/resource_search.rb
@@ -26,7 +26,9 @@ module Decidim
 
     # Handle the category_id filter
     def search_category_id
-      query.where(decidim_category_id: category_ids)
+      query
+        .includes(:categorization)
+        .where(decidim_categorizations: { decidim_category_id: category_ids })
     end
 
     # Handles the scope_id filter. When we want to show only those that do not

--- a/decidim-core/db/migrate/20170612100253_create_decidim_categorizations.rb
+++ b/decidim-core/db/migrate/20170612100253_create_decidim_categorizations.rb
@@ -1,0 +1,10 @@
+class CreateDecidimCategorizations < ActiveRecord::Migration[5.1]
+  def change
+    create_table :decidim_categorizations do |t|
+      t.references :decidim_category, foreign_key: true, null: false
+      t.references :categorizable, polymorphic: true, null: false, index: { name: "decidim_categorizations_categorizable_id_and_type" }
+
+      t.timestamps
+    end
+  end
+end

--- a/decidim-core/db/migrate/20170612100253_create_decidim_categorizations.rb
+++ b/decidim-core/db/migrate/20170612100253_create_decidim_categorizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateDecidimCategorizations < ActiveRecord::Migration[5.1]
   def change
     create_table :decidim_categorizations do |t|

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -276,6 +276,7 @@ FactoryGirl.define do
     title { generate(:name) }
     feature { create(:feature, manifest_name: "dummy") }
     author { create(:user, :confirmed, organization: feature.organization) }
+    category { create(:category, participatory_process: feature.participatory_process) }
   end
 
   factory :resource_link, class: Decidim::ResourceLink do

--- a/decidim-core/lib/decidim/has_category.rb
+++ b/decidim-core/lib/decidim/has_category.rb
@@ -8,10 +8,9 @@ module Decidim
     extend ActiveSupport::Concern
 
     included do
-      belongs_to :category,
-                 foreign_key: "decidim_category_id",
-                 class_name: "Decidim::Category",
-                 optional: true
+      has_one :categorization, as: :categorizable
+      has_one :category, through: :categorization
+
       validate :category_belongs_to_organization
 
       private

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
@@ -27,6 +27,7 @@ module Decidim
     include Resourceable
     include Reportable
     include Authorable
+    include HasCategory
     include Decidim::Comments::Commentable
 
     feature_manifest_name "dummy"
@@ -110,6 +111,7 @@ RSpec.configure do |config|
 
         t.references :decidim_feature, index: true
         t.references :decidim_author, index: true
+        t.references :decidim_category, index: true
 
         t.timestamps
       end

--- a/decidim-meetings/db/migrate/20170612101925_migrate_meetings_category.rb
+++ b/decidim-meetings/db/migrate/20170612101925_migrate_meetings_category.rb
@@ -3,20 +3,20 @@
 class MigrateMeetingsCategory < ActiveRecord::Migration[5.1]
   def change
     # Ensure database integrity updating meetings with an invalid category
-    ActiveRecord::Base.connection.execute("""
+    ActiveRecord::Base.connection.execute('
       UPDATE decidim_meetings_meetings SET decidim_category_id = NULL where id IN (
         SELECT t.id FROM decidim_meetings_meetings as t WHERE t.decidim_category_id NOT IN (
           SELECT c.id FROM decidim_categories as c
         )
       )
-    """)
+    ')
     # Create categorizations
-    ActiveRecord::Base.connection.execute("""
+    ActiveRecord::Base.connection.execute('
       INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type, created_at, updated_at)
-        SELECT decidim_category_id, id, 'Decidim::Meetings::Meeting', NOW(), NOW()
+        SELECT decidim_category_id, id, "Decidim::Meetings::Meeting", NOW(), NOW()
         FROM decidim_meetings_meetings
         WHERE decidim_category_id IS NOT NULL
-    """)
+    ')
     # Remove unused column
     remove_column :decidim_meetings_meetings, :decidim_category_id
   end

--- a/decidim-meetings/db/migrate/20170612101925_migrate_meetings_category.rb
+++ b/decidim-meetings/db/migrate/20170612101925_migrate_meetings_category.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MigrateMeetingsCategory < ActiveRecord::Migration[5.1]
   def change
     Decidim::Meetings::Meeting.find_each do |meeting|

--- a/decidim-meetings/db/migrate/20170612101925_migrate_meetings_category.rb
+++ b/decidim-meetings/db/migrate/20170612101925_migrate_meetings_category.rb
@@ -2,16 +2,22 @@
 
 class MigrateMeetingsCategory < ActiveRecord::Migration[5.1]
   def change
-    records = ActiveRecord::Base.connection.execute("SELECT id, decidim_category_id FROM decidim_meetings_meetings")
-    now = Time.current
-    values = records.to_a.reject!{ |record| record["decidim_category_id"].blank? }.map do |record|
-      "(#{record["id"]}, #{record["decidim_category_id"]}, 'Decidim::Meetings::Meeting', '#{now}', '#{now}')"
-    end
-    if values.any?
-      ActiveRecord::Base.connection.execute(
-        "INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type, created_at, updated_at) VALUES #{values.join(', ')}"
+    # Ensure database integrity updating meetings with an invalid category
+    ActiveRecord::Base.connection.execute("""
+      UPDATE decidim_meetings_meetings SET decidim_category_id = NULL where id IN (
+        SELECT t.id FROM decidim_meetings_meetings as t WHERE t.decidim_category_id NOT IN (
+          SELECT c.id FROM decidim_categories as c
+        )
       )
-    end
+    """)
+    # Create categorizations
+    ActiveRecord::Base.connection.execute("""
+      INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type, created_at, updated_at)
+        SELECT decidim_category_id, id, 'Decidim::Meetings::Meeting', NOW(), NOW()
+        FROM decidim_meetings_meetings
+        WHERE decidim_category_id IS NOT NULL
+    """)
+    # Remove unused column
     remove_column :decidim_meetings_meetings, :decidim_category_id
   end
 end

--- a/decidim-meetings/db/migrate/20170612101925_migrate_meetings_category.rb
+++ b/decidim-meetings/db/migrate/20170612101925_migrate_meetings_category.rb
@@ -13,7 +13,7 @@ class MigrateMeetingsCategory < ActiveRecord::Migration[5.1]
     # Create categorizations
     ActiveRecord::Base.connection.execute('
       INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type, created_at, updated_at)
-        SELECT decidim_category_id, id, "Decidim::Meetings::Meeting", NOW(), NOW()
+        SELECT decidim_category_id, id, \'Decidim::Meetings::Meeting\', NOW(), NOW()
         FROM decidim_meetings_meetings
         WHERE decidim_category_id IS NOT NULL
     ')

--- a/decidim-meetings/db/migrate/20170612101925_migrate_meetings_category.rb
+++ b/decidim-meetings/db/migrate/20170612101925_migrate_meetings_category.rb
@@ -1,0 +1,11 @@
+class MigrateMeetingsCategory < ActiveRecord::Migration[5.1]
+  def change
+    Decidim::Meetings::Meeting.find_each do |meeting|
+      Decidim::Categorization.create!(
+        decidim_category_id: meeting.category.id,
+        categorizable: meeting
+      )
+    end
+    remove_column :decidim_meetings_meetings, :decidim_category_id
+  end
+end

--- a/decidim-meetings/db/migrate/20170612101925_migrate_meetings_category.rb
+++ b/decidim-meetings/db/migrate/20170612101925_migrate_meetings_category.rb
@@ -2,20 +2,12 @@
 
 class MigrateMeetingsCategory < ActiveRecord::Migration[5.1]
   def change
-    # Ensure database integrity updating meetings with an invalid category
-    ActiveRecord::Base.connection.execute('
-      UPDATE decidim_meetings_meetings SET decidim_category_id = NULL where id IN (
-        SELECT t.id FROM decidim_meetings_meetings as t WHERE t.decidim_category_id NOT IN (
-          SELECT c.id FROM decidim_categories as c
-        )
-      )
-    ')
-    # Create categorizations
-    ActiveRecord::Base.connection.execute('
+    # Create categorizations ensuring database integrity
+    execute('
       INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type, created_at, updated_at)
-        SELECT decidim_category_id, id, \'Decidim::Meetings::Meeting\', NOW(), NOW()
+        SELECT decidim_category_id, decidim_meetings_meetings.id, \'Decidim::Meetings::Meeting\', NOW(), NOW()
         FROM decidim_meetings_meetings
-        WHERE decidim_category_id IS NOT NULL
+        INNER JOIN decidim_categories ON decidim_categories.id = decidim_meetings_meetings.decidim_category_id
     ')
     # Remove unused column
     remove_column :decidim_meetings_meetings, :decidim_category_id

--- a/decidim-meetings/db/migrate/20170612101925_migrate_meetings_category.rb
+++ b/decidim-meetings/db/migrate/20170612101925_migrate_meetings_category.rb
@@ -2,10 +2,13 @@
 
 class MigrateMeetingsCategory < ActiveRecord::Migration[5.1]
   def change
-    Decidim::Meetings::Meeting.find_each do |meeting|
-      Decidim::Categorization.create!(
-        decidim_category_id: meeting.category.id,
-        categorizable: meeting
+    records = ActiveRecord::Base.connection.execute("SELECT id, decidim_category_id FROM decidim_meetings_meetings")
+    values = records.map do |record|
+      "(#{record[:id]}, #{record[:decidim_category_id]}, 'Decidim::Meetings::Meeting')"
+    end
+    if values.any?
+      ActiveRecord::Base.connection.execute(
+        "INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type) VALUES #{values.join(', ')}"
       )
     end
     remove_column :decidim_meetings_meetings, :decidim_category_id

--- a/decidim-meetings/db/migrate/20170612101925_migrate_meetings_category.rb
+++ b/decidim-meetings/db/migrate/20170612101925_migrate_meetings_category.rb
@@ -3,12 +3,13 @@
 class MigrateMeetingsCategory < ActiveRecord::Migration[5.1]
   def change
     records = ActiveRecord::Base.connection.execute("SELECT id, decidim_category_id FROM decidim_meetings_meetings")
-    values = records.map do |record|
-      "(#{record[:id]}, #{record[:decidim_category_id]}, 'Decidim::Meetings::Meeting')"
+    now = Time.current
+    values = records.to_a.reject!{ |record| record["decidim_category_id"].blank? }.map do |record|
+      "(#{record["id"]}, #{record["decidim_category_id"]}, 'Decidim::Meetings::Meeting', '#{now}', '#{now}')"
     end
     if values.any?
       ActiveRecord::Base.connection.execute(
-        "INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type) VALUES #{values.join(', ')}"
+        "INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type, created_at, updated_at) VALUES #{values.join(', ')}"
       )
     end
     remove_column :decidim_meetings_meetings, :decidim_category_id

--- a/decidim-proposals/db/migrate/20170612101809_migrate_proposals_category.rb
+++ b/decidim-proposals/db/migrate/20170612101809_migrate_proposals_category.rb
@@ -2,16 +2,22 @@
 
 class MigrateProposalsCategory < ActiveRecord::Migration[5.1]
   def change
-    records = ActiveRecord::Base.connection.execute("SELECT id, decidim_category_id FROM decidim_proposals_proposals")
-    now = Time.current
-    values = records.to_a.reject!{ |record| record["decidim_category_id"].blank? }.map do |record|
-      "(#{record["id"]}, #{record["decidim_category_id"]}, 'Decidim::Proposals::Proposal', '#{now}', '#{now}')"
-    end
-    if values.any?
-      ActiveRecord::Base.connection.execute(
-        "INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type, created_at, updated_at) VALUES #{values.join(', ')}"
+    # Ensure database integrity updating proposals with an invalid category
+    ActiveRecord::Base.connection.execute("""
+      UPDATE decidim_proposals_proposals SET decidim_category_id = NULL where id IN (
+        SELECT t.id FROM decidim_proposals_proposals as t WHERE t.decidim_category_id NOT IN (
+          SELECT c.id FROM decidim_categories as c
+        )
       )
-    end
+    """)
+    # Create categorizations
+    ActiveRecord::Base.connection.execute("""
+      INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type, created_at, updated_at)
+        SELECT decidim_category_id, id, 'Decidim::Proposals::Proposal', NOW(), NOW()
+        FROM decidim_proposals_proposals
+        WHERE decidim_category_id IS NOT NULL
+    """)
+    # Remove unused column
     remove_column :decidim_proposals_proposals, :decidim_category_id
   end
 end

--- a/decidim-proposals/db/migrate/20170612101809_migrate_proposals_category.rb
+++ b/decidim-proposals/db/migrate/20170612101809_migrate_proposals_category.rb
@@ -3,12 +3,13 @@
 class MigrateProposalsCategory < ActiveRecord::Migration[5.1]
   def change
     records = ActiveRecord::Base.connection.execute("SELECT id, decidim_category_id FROM decidim_proposals_proposals")
-    values = records.map do |record|
-      "(#{record[:id]}, #{record[:decidim_category_id]}, 'Decidim::Proposals::Proposal')"
+    now = Time.current
+    values = records.to_a.reject!{ |record| record["decidim_category_id"].blank? }.map do |record|
+      "(#{record["id"]}, #{record["decidim_category_id"]}, 'Decidim::Proposals::Proposal', '#{now}', '#{now}')"
     end
     if values.any?
       ActiveRecord::Base.connection.execute(
-        "INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type) VALUES #{values.join(', ')}"
+        "INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type, created_at, updated_at) VALUES #{values.join(', ')}"
       )
     end
     remove_column :decidim_proposals_proposals, :decidim_category_id

--- a/decidim-proposals/db/migrate/20170612101809_migrate_proposals_category.rb
+++ b/decidim-proposals/db/migrate/20170612101809_migrate_proposals_category.rb
@@ -13,7 +13,7 @@ class MigrateProposalsCategory < ActiveRecord::Migration[5.1]
     # Create categorizations
     ActiveRecord::Base.connection.execute('
       INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type, created_at, updated_at)
-        SELECT decidim_category_id, id, "Decidim::Proposals::Proposal", NOW(), NOW()
+        SELECT decidim_category_id, id, \'Decidim::Proposals::Proposal\', NOW(), NOW()
         FROM decidim_proposals_proposals
         WHERE decidim_category_id IS NOT NULL
     ')

--- a/decidim-proposals/db/migrate/20170612101809_migrate_proposals_category.rb
+++ b/decidim-proposals/db/migrate/20170612101809_migrate_proposals_category.rb
@@ -3,20 +3,20 @@
 class MigrateProposalsCategory < ActiveRecord::Migration[5.1]
   def change
     # Ensure database integrity updating proposals with an invalid category
-    ActiveRecord::Base.connection.execute("""
+    ActiveRecord::Base.connection.execute('
       UPDATE decidim_proposals_proposals SET decidim_category_id = NULL where id IN (
         SELECT t.id FROM decidim_proposals_proposals as t WHERE t.decidim_category_id NOT IN (
           SELECT c.id FROM decidim_categories as c
         )
       )
-    """)
+    ')
     # Create categorizations
-    ActiveRecord::Base.connection.execute("""
+    ActiveRecord::Base.connection.execute('
       INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type, created_at, updated_at)
-        SELECT decidim_category_id, id, 'Decidim::Proposals::Proposal', NOW(), NOW()
+        SELECT decidim_category_id, id, "Decidim::Proposals::Proposal", NOW(), NOW()
         FROM decidim_proposals_proposals
         WHERE decidim_category_id IS NOT NULL
-    """)
+    ')
     # Remove unused column
     remove_column :decidim_proposals_proposals, :decidim_category_id
   end

--- a/decidim-proposals/db/migrate/20170612101809_migrate_proposals_category.rb
+++ b/decidim-proposals/db/migrate/20170612101809_migrate_proposals_category.rb
@@ -2,10 +2,13 @@
 
 class MigrateProposalsCategory < ActiveRecord::Migration[5.1]
   def change
-    Decidim::Proposals::Proposal.find_each do |proposal|
-      Decidim::Categorization.create!(
-        decidim_category_id: proposal.category.id,
-        categorizable: proposal
+    records = ActiveRecord::Base.connection.execute("SELECT id, decidim_category_id FROM decidim_proposals_proposals")
+    values = records.map do |record|
+      "(#{record[:id]}, #{record[:decidim_category_id]}, 'Decidim::Proposals::Proposal')"
+    end
+    if values.any?
+      ActiveRecord::Base.connection.execute(
+        "INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type) VALUES #{values.join(', ')}"
       )
     end
     remove_column :decidim_proposals_proposals, :decidim_category_id

--- a/decidim-proposals/db/migrate/20170612101809_migrate_proposals_category.rb
+++ b/decidim-proposals/db/migrate/20170612101809_migrate_proposals_category.rb
@@ -1,0 +1,11 @@
+class MigrateProposalsCategory < ActiveRecord::Migration[5.1]
+  def change
+    Decidim::Proposals::Proposal.find_each do |proposal|
+      Decidim::Categorization.create!(
+        decidim_category_id: proposal.category.id,
+        categorizable: proposal
+      )
+    end
+    remove_column :decidim_proposals_proposals, :decidim_category_id
+  end
+end

--- a/decidim-proposals/db/migrate/20170612101809_migrate_proposals_category.rb
+++ b/decidim-proposals/db/migrate/20170612101809_migrate_proposals_category.rb
@@ -2,20 +2,12 @@
 
 class MigrateProposalsCategory < ActiveRecord::Migration[5.1]
   def change
-    # Ensure database integrity updating proposals with an invalid category
-    ActiveRecord::Base.connection.execute('
-      UPDATE decidim_proposals_proposals SET decidim_category_id = NULL where id IN (
-        SELECT t.id FROM decidim_proposals_proposals as t WHERE t.decidim_category_id NOT IN (
-          SELECT c.id FROM decidim_categories as c
-        )
-      )
-    ')
-    # Create categorizations
-    ActiveRecord::Base.connection.execute('
+    # Create categorizations ensuring database integrity
+    execute('
       INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type, created_at, updated_at)
-        SELECT decidim_category_id, id, \'Decidim::Proposals::Proposal\', NOW(), NOW()
+        SELECT decidim_category_id, decidim_proposals_proposals.id, \'Decidim::Proposals::Proposal\', NOW(), NOW()
         FROM decidim_proposals_proposals
-        WHERE decidim_category_id IS NOT NULL
+        INNER JOIN decidim_categories ON decidim_categories.id = decidim_proposals_proposals.decidim_category_id
     ')
     # Remove unused column
     remove_column :decidim_proposals_proposals, :decidim_category_id

--- a/decidim-proposals/db/migrate/20170612101809_migrate_proposals_category.rb
+++ b/decidim-proposals/db/migrate/20170612101809_migrate_proposals_category.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MigrateProposalsCategory < ActiveRecord::Migration[5.1]
   def change
     Decidim::Proposals::Proposal.find_each do |proposal|

--- a/decidim-results/db/migrate/20170612101951_migrate_results_category.rb
+++ b/decidim-results/db/migrate/20170612101951_migrate_results_category.rb
@@ -13,7 +13,7 @@ class MigrateResultsCategory < ActiveRecord::Migration[5.1]
     # Create categorizations
     ActiveRecord::Base.connection.execute('
       INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type, created_at, updated_at)
-        SELECT decidim_category_id, id, "Decidim::Results::Result", NOW(), NOW()
+        SELECT decidim_category_id, id, \'Decidim::Results::Result\', NOW(), NOW()
         FROM decidim_results_results
         WHERE decidim_category_id IS NOT NULL
     ')

--- a/decidim-results/db/migrate/20170612101951_migrate_results_category.rb
+++ b/decidim-results/db/migrate/20170612101951_migrate_results_category.rb
@@ -2,16 +2,22 @@
 
 class MigrateResultsCategory < ActiveRecord::Migration[5.1]
   def change
-    records = ActiveRecord::Base.connection.execute("SELECT id, decidim_category_id FROM decidim_results_results")
-    now = Time.current
-    values = records.to_a.reject!{ |record| record["decidim_category_id"].blank? }.map do |record|
-      "(#{record["id"]}, #{record["decidim_category_id"]}, 'Decidim::Results::Result', '#{now}', '#{now}')"
-    end
-    if values.any?
-      ActiveRecord::Base.connection.execute(
-        "INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type, created_at, updated_at) VALUES #{values.join(', ')}"
+    # Ensure database integrity updating results with an invalid category
+    ActiveRecord::Base.connection.execute("""
+      UPDATE decidim_results_results SET decidim_category_id = NULL where id IN (
+        SELECT t.id FROM decidim_results_results as t WHERE t.decidim_category_id NOT IN (
+          SELECT c.id FROM decidim_categories as c
+        )
       )
-    end
+    """)
+    # Create categorizations
+    ActiveRecord::Base.connection.execute("""
+      INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type, created_at, updated_at)
+        SELECT decidim_category_id, id, 'Decidim::Results::Result', NOW(), NOW()
+        FROM decidim_results_results
+        WHERE decidim_category_id IS NOT NULL
+    """)
+    # Remove unused column
     remove_column :decidim_results_results, :decidim_category_id
   end
 end

--- a/decidim-results/db/migrate/20170612101951_migrate_results_category.rb
+++ b/decidim-results/db/migrate/20170612101951_migrate_results_category.rb
@@ -3,20 +3,20 @@
 class MigrateResultsCategory < ActiveRecord::Migration[5.1]
   def change
     # Ensure database integrity updating results with an invalid category
-    ActiveRecord::Base.connection.execute("""
+    ActiveRecord::Base.connection.execute('
       UPDATE decidim_results_results SET decidim_category_id = NULL where id IN (
         SELECT t.id FROM decidim_results_results as t WHERE t.decidim_category_id NOT IN (
           SELECT c.id FROM decidim_categories as c
         )
       )
-    """)
+    ')
     # Create categorizations
-    ActiveRecord::Base.connection.execute("""
+    ActiveRecord::Base.connection.execute('
       INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type, created_at, updated_at)
-        SELECT decidim_category_id, id, 'Decidim::Results::Result', NOW(), NOW()
+        SELECT decidim_category_id, id, "Decidim::Results::Result", NOW(), NOW()
         FROM decidim_results_results
         WHERE decidim_category_id IS NOT NULL
-    """)
+    ')
     # Remove unused column
     remove_column :decidim_results_results, :decidim_category_id
   end

--- a/decidim-results/db/migrate/20170612101951_migrate_results_category.rb
+++ b/decidim-results/db/migrate/20170612101951_migrate_results_category.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MigrateResultsCategory < ActiveRecord::Migration[5.1]
   def change
     Decidim::Results::Result.find_each do |result|

--- a/decidim-results/db/migrate/20170612101951_migrate_results_category.rb
+++ b/decidim-results/db/migrate/20170612101951_migrate_results_category.rb
@@ -3,12 +3,13 @@
 class MigrateResultsCategory < ActiveRecord::Migration[5.1]
   def change
     records = ActiveRecord::Base.connection.execute("SELECT id, decidim_category_id FROM decidim_results_results")
-    values = records.map do |record|
-      "(#{record[:id]}, #{record[:decidim_category_id]}, 'Decidim::Results::Result')"
+    now = Time.current
+    values = records.to_a.reject!{ |record| record["decidim_category_id"].blank? }.map do |record|
+      "(#{record["id"]}, #{record["decidim_category_id"]}, 'Decidim::Results::Result', '#{now}', '#{now}')"
     end
     if values.any?
       ActiveRecord::Base.connection.execute(
-        "INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type) VALUES #{values.join(', ')}"
+        "INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type, created_at, updated_at) VALUES #{values.join(', ')}"
       )
     end
     remove_column :decidim_results_results, :decidim_category_id

--- a/decidim-results/db/migrate/20170612101951_migrate_results_category.rb
+++ b/decidim-results/db/migrate/20170612101951_migrate_results_category.rb
@@ -1,0 +1,11 @@
+class MigrateResultsCategory < ActiveRecord::Migration[5.1]
+  def change
+    Decidim::Results::Result.find_each do |result|
+      Decidim::Categorization.create!(
+        decidim_category_id: result.category.id,
+        categorizable: result
+      )
+    end
+    remove_column :decidim_results_results, :decidim_category_id
+  end
+end

--- a/decidim-results/db/migrate/20170612101951_migrate_results_category.rb
+++ b/decidim-results/db/migrate/20170612101951_migrate_results_category.rb
@@ -2,20 +2,12 @@
 
 class MigrateResultsCategory < ActiveRecord::Migration[5.1]
   def change
-    # Ensure database integrity updating results with an invalid category
-    ActiveRecord::Base.connection.execute('
-      UPDATE decidim_results_results SET decidim_category_id = NULL where id IN (
-        SELECT t.id FROM decidim_results_results as t WHERE t.decidim_category_id NOT IN (
-          SELECT c.id FROM decidim_categories as c
-        )
-      )
-    ')
-    # Create categorizations
-    ActiveRecord::Base.connection.execute('
+    # Create categorizations ensuring database integrity
+    execute('
       INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type, created_at, updated_at)
-        SELECT decidim_category_id, id, \'Decidim::Results::Result\', NOW(), NOW()
+        SELECT decidim_category_id, decidim_results_results.id, \'Decidim::Results::Result\', NOW(), NOW()
         FROM decidim_results_results
-        WHERE decidim_category_id IS NOT NULL
+        INNER JOIN decidim_categories ON decidim_categories.id = decidim_results_results.decidim_category_id
     ')
     # Remove unused column
     remove_column :decidim_results_results, :decidim_category_id

--- a/decidim-results/db/migrate/20170612101951_migrate_results_category.rb
+++ b/decidim-results/db/migrate/20170612101951_migrate_results_category.rb
@@ -2,10 +2,13 @@
 
 class MigrateResultsCategory < ActiveRecord::Migration[5.1]
   def change
-    Decidim::Results::Result.find_each do |result|
-      Decidim::Categorization.create!(
-        decidim_category_id: result.category.id,
-        categorizable: result
+    records = ActiveRecord::Base.connection.execute("SELECT id, decidim_category_id FROM decidim_results_results")
+    values = records.map do |record|
+      "(#{record[:id]}, #{record[:decidim_category_id]}, 'Decidim::Results::Result')"
+    end
+    if values.any?
+      ActiveRecord::Base.connection.execute(
+        "INSERT INTO decidim_categorizations(decidim_category_id, categorizable_id, categorizable_type) VALUES #{values.join(', ')}"
       )
     end
     remove_column :decidim_results_results, :decidim_category_id


### PR DESCRIPTION
#### :tophat: What? Why?

I needed to prevent the deletion of a category if it was used by some resource. The problem was we didn't have that information available from the category perspective.

After trying a few solutions I finally decided to create a `Categorization` model which has a `categorizable` polymorphic member. With this the problem is solved and as an extra bonus any model can be categorizable right now and we can support multiple categories.

#### :pushpin: Related Issues
- Fixes #1255

#### :clipboard: Subtasks
- [x] Add categorizations
- [x] Add tooltip explaining why delete is disable

### :camera: Screenshots (optional)

![image](https://user-images.githubusercontent.com/106021/27033772-160a3d26-4f7b-11e7-8e21-74565b0ac38f.png)

#### :ghost: GIF
![](https://media2.giphy.com/media/kqebjbMRSaVWw/giphy.gif)
