### PR TITLE
User Group uniqueness verification per name and document number.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -59,7 +59,8 @@ task :development_app do
   Dir.chdir("#{__dir__}/development_app") do
     Bundler.with_clean_env do
       sh "bundle exec spring stop"
-      sh "bundle exec rake db:drop db:create db:migrate db:seed"
+      sh "bundle exec rake db:drop db:create db:migrate"
+      sh "bundle exec rake db:seed"
       sh "bundle exec rails generate decidim:demo"
     end
   end

--- a/decidim-admin/spec/commands/reject_user_group_spec.rb
+++ b/decidim-admin/spec/commands/reject_user_group_spec.rb
@@ -6,7 +6,7 @@ describe Decidim::Admin::RejectUserGroup do
   let(:organization) { create :organization }
 
   describe "User group validation is pending" do
-    let!(:user_group) { create(:user_group, users: [create(:user, organization: organization)]) }
+    let!(:user_group) { create(:user_group, decidim_organization_id: organization.id, users: [create(:user, organization: organization)]) }
 
     subject { described_class.new(user_group) }
 
@@ -33,7 +33,7 @@ describe Decidim::Admin::RejectUserGroup do
   end
 
   describe "User group is already rejected" do
-    let!(:user_group) { create(:user_group, verified_at: Time.current, users: [create(:user, organization: organization)]) }
+    let!(:user_group) { create(:user_group, decidim_organization_id: organization.id, verified_at: Time.current, users: [create(:user, organization: organization)]) }
 
     subject { described_class.new(user_group) }
 

--- a/decidim-core/app/commands/decidim/create_registration.rb
+++ b/decidim-core/app/commands/decidim/create_registration.rb
@@ -48,7 +48,8 @@ module Decidim
       UserGroupMembership.create!(user: @user,
                                   user_group: UserGroup.new(name: form.user_group_name,
                                                             document_number: form.user_group_document_number,
-                                                            phone: form.user_group_phone))
+                                                            phone: form.user_group_phone,
+                                                            decidim_organization_id: form.current_organization.id))
     end
   end
 end

--- a/decidim-core/app/forms/decidim/registration_form.rb
+++ b/decidim-core/app/forms/decidim/registration_form.rb
@@ -46,7 +46,10 @@ module Decidim
     end
 
     def user_group_document_number_unique_in_organization
-      errors.add :user_group_document_number, :taken if UserGroup.where(document_number: user_group_document_number, decidim_organization_id: current_organization.id).first.present?
+      errors.add :user_group_document_number, :taken if UserGroup.where(
+          document_number: user_group_document_number, 
+          decidim_organization_id: current_organization.id
+        ).first.present?
     end
   end
 end

--- a/decidim-core/app/forms/decidim/registration_form.rb
+++ b/decidim-core/app/forms/decidim/registration_form.rb
@@ -24,7 +24,7 @@ module Decidim
     validates :tos_agreement, allow_nil: false, acceptance: true
 
     validates :user_group_name, presence: true, if: :user_group?
-    validates :user_group_document_number, presence: true,  if: :user_group?
+    validates :user_group_document_number, presence: true, if: :user_group?
     validates :user_group_phone, presence: true, if: :user_group?
 
     validate :email_unique_in_organization

--- a/decidim-core/app/forms/decidim/registration_form.rb
+++ b/decidim-core/app/forms/decidim/registration_form.rb
@@ -24,10 +24,12 @@ module Decidim
     validates :tos_agreement, allow_nil: false, acceptance: true
 
     validates :user_group_name, presence: true, if: :user_group?
-    validates :user_group_document_number, presence: true, if: :user_group?
+    validates :user_group_document_number, presence: true,  if: :user_group?
     validates :user_group_phone, presence: true, if: :user_group?
 
     validate :email_unique_in_organization
+    validate :user_group_name_unique_in_organization
+    validate :user_group_document_number_unique_in_organization
 
     def user_group?
       sign_up_as == "user_group"
@@ -37,6 +39,14 @@ module Decidim
 
     def email_unique_in_organization
       errors.add :email, :taken if User.where(email: email, organization: current_organization).first.present?
+    end
+
+    def user_group_name_unique_in_organization
+      errors.add :user_group_name, :taken if UserGroup.where(name: user_group_name, decidim_organization_id: current_organization.id).first.present?
+    end
+
+    def user_group_document_number_unique_in_organization
+      errors.add :user_group_document_number, :taken if UserGroup.where(document_number: user_group_document_number, decidim_organization_id: current_organization.id).first.present?
     end
   end
 end

--- a/decidim-core/app/forms/decidim/registration_form.rb
+++ b/decidim-core/app/forms/decidim/registration_form.rb
@@ -47,9 +47,9 @@ module Decidim
 
     def user_group_document_number_unique_in_organization
       errors.add :user_group_document_number, :taken if UserGroup.where(
-          document_number: user_group_document_number, 
-          decidim_organization_id: current_organization.id
-        ).first.present?
+        document_number: user_group_document_number,
+        decidim_organization_id: current_organization.id
+      ).first.present?
     end
   end
 end

--- a/decidim-core/app/models/decidim/user_group.rb
+++ b/decidim-core/app/models/decidim/user_group.rb
@@ -6,8 +6,8 @@ module Decidim
     has_many :memberships, class_name: "Decidim::UserGroupMembership", foreign_key: :decidim_user_group_id
     has_many :users, through: :memberships, class_name: "Decidim::User", foreign_key: :decidim_user_id
 
-    validates :name, presence: true
-    validates :document_number, presence: true
+    validates :name, presence: true, uniqueness: { scope: :decidim_organization_id }
+    validates :document_number, presence: true, uniqueness: { scope: :decidim_organization_id }
     validates :phone, presence: true
     validates :avatar, file_size: { less_than_or_equal_to: 5.megabytes }
 

--- a/decidim-core/app/models/decidim/user_group.rb
+++ b/decidim-core/app/models/decidim/user_group.rb
@@ -3,6 +3,8 @@
 module Decidim
   # A UserGroup is an organization of citizens
   class UserGroup < ApplicationRecord
+    belongs_to :organization, foreign_key: "decidim_organization_id", class_name: "Decidim::Organization"
+
     has_many :memberships, class_name: "Decidim::UserGroupMembership", foreign_key: :decidim_user_group_id
     has_many :users, through: :memberships, class_name: "Decidim::User", foreign_key: :decidim_user_id
 

--- a/decidim-core/db/migrate/20170608142521_add_organization_to_user_groups.rb
+++ b/decidim-core/db/migrate/20170608142521_add_organization_to_user_groups.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddOrganizationToUserGroups < ActiveRecord::Migration[5.0]
   def change
     add_column :decidim_user_groups, :decidim_organization_id, :integer

--- a/decidim-core/db/migrate/20170608142521_add_organization_to_user_groups.rb
+++ b/decidim-core/db/migrate/20170608142521_add_organization_to_user_groups.rb
@@ -1,0 +1,12 @@
+class AddOrganizationToUserGroups < ActiveRecord::Migration[5.0]
+  def change
+    add_column :decidim_user_groups, :decidim_organization_id, :integer
+
+    Decidim::UserGroup.includes(:users).find_each do |user_group|
+      user_group.organization = user_group.users.first.organization
+      user_group.save!
+    end
+
+    change_column :decidim_user_groups, :decidim_organization_id, :integer, null: false
+  end
+end

--- a/decidim-core/db/migrate/20170612070905_add_uniqueness_to_name_and_document_number_to_user_groups.rb
+++ b/decidim-core/db/migrate/20170612070905_add_uniqueness_to_name_and_document_number_to_user_groups.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddUniquenessToNameAndDocumentNumberToUserGroups < ActiveRecord::Migration[5.0]
   def change
     add_index :decidim_user_groups, [:decidim_organization_id, :name], unique: true, name: "index_decidim_user_groups_names_on_organization_id"

--- a/decidim-core/db/migrate/20170612070905_add_uniqueness_to_name_and_document_number_to_user_groups.rb
+++ b/decidim-core/db/migrate/20170612070905_add_uniqueness_to_name_and_document_number_to_user_groups.rb
@@ -1,0 +1,6 @@
+class AddUniquenessToNameAndDocumentNumberToUserGroups < ActiveRecord::Migration[5.0]
+  def change
+    add_index :decidim_user_groups, [:decidim_organization_id, :name], unique: true, name: "index_decidim_user_groups_names_on_organization_id"
+    add_index :decidim_user_groups, [:decidim_organization_id, :document_number], unique: true, name: "index_decidim_user_groups_document_number_on_organization_id"
+  end
+end

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -75,7 +75,8 @@ if !Rails.env.production? || ENV["SEED"]
         name: Faker::Company.name,
         document_number: Faker::Number.number(10),
         phone: Faker::PhoneNumber.phone_number,
-        verified_at: Time.current
+        verified_at: Time.current,
+        decidim_organization_id: user.organization.id
       )
 
       Decidim::UserGroupMembership.create!(
@@ -86,7 +87,8 @@ if !Rails.env.production? || ENV["SEED"]
       user_group = Decidim::UserGroup.create!(
         name: Faker::Company.name,
         document_number: Faker::Number.number(10),
-        phone: Faker::PhoneNumber.phone_number
+        phone: Faker::PhoneNumber.phone_number,
+        decidim_organization_id: user.organization.id
       )
 
       Decidim::UserGroupMembership.create!(

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -173,8 +173,8 @@ FactoryGirl.define do
     document_number { Faker::Number.number(8) + "X" }
     phone { Faker::PhoneNumber.phone_number }
     avatar { test_file("avatar.jpg", "image/jpeg") }
-    organization { user.organization }
-
+    organization
+    
     transient do
       users []
     end

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -174,7 +174,7 @@ FactoryGirl.define do
     phone { Faker::PhoneNumber.phone_number }
     avatar { test_file("avatar.jpg", "image/jpeg") }
     organization
-    
+
     transient do
       users []
     end

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -173,6 +173,7 @@ FactoryGirl.define do
     document_number { Faker::Number.number(8) + "X" }
     phone { Faker::PhoneNumber.phone_number }
     avatar { test_file("avatar.jpg", "image/jpeg") }
+    organization
 
     transient do
       users []

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -173,7 +173,7 @@ FactoryGirl.define do
     document_number { Faker::Number.number(8) + "X" }
     phone { Faker::PhoneNumber.phone_number }
     avatar { test_file("avatar.jpg", "image/jpeg") }
-    organization
+    organization { user.organization }
 
     transient do
       users []

--- a/decidim-core/spec/commands/decidim/create_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_registration_spec.rb
@@ -20,7 +20,6 @@ module Decidim
         let(:user_group_document_number) { "123456789Z" }
         let(:user_group_phone) { "333-333-333" }
 
-
         let(:form_params) do
           {
             "user" => {
@@ -90,7 +89,7 @@ module Decidim
           let(:user_group_name) { "My organization" }
           let(:user_group_document_number) { "123456789Z" }
           let(:user_group_phone) { "333-333-333" }
-          let(:user_group_decidim_organization_id ) { organization.id }
+          let(:user_group_decidim_organization_id) { organization.id }
 
           describe "when the form is not valid" do
             before do

--- a/decidim-core/spec/commands/decidim/create_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_registration_spec.rb
@@ -16,9 +16,10 @@ module Decidim
         let(:tos_agreement) { "1" }
         let(:newsletter_notifications) { "1" }
 
-        let(:user_group_name) { nil }
-        let(:user_group_document_number) { nil }
-        let(:user_group_phone) { nil }
+        let(:user_group_name) { "My organization" }
+        let(:user_group_document_number) { "123456789Z" }
+        let(:user_group_phone) { "333-333-333" }
+
 
         let(:form_params) do
           {
@@ -89,6 +90,7 @@ module Decidim
           let(:user_group_name) { "My organization" }
           let(:user_group_document_number) { "123456789Z" }
           let(:user_group_phone) { "333-333-333" }
+          let(:user_group_decidim_organization_id ) { organization.id }
 
           describe "when the form is not valid" do
             before do
@@ -113,7 +115,8 @@ module Decidim
               expect(UserGroup).to receive(:new).with(
                 name: form.user_group_name,
                 document_number: form.user_group_document_number,
-                phone: form.user_group_phone
+                phone: form.user_group_phone,
+                decidim_organization_id: organization.id
               ).and_call_original
 
               expect do

--- a/decidim-core/spec/forms/registration_form_spec.rb
+++ b/decidim-core/spec/forms/registration_form_spec.rb
@@ -90,6 +90,7 @@ module Decidim
       let(:user_group_document_number) { "123456789Z" }
       let(:user_group_phone) { "333-333-333" }
 
+
       context "when everything is OK" do
         it { is_expected.to be_valid }
       end
@@ -106,6 +107,18 @@ module Decidim
 
       context "when user_group_phone is not present" do
         let(:user_group_phone) { nil }
+        it { is_expected.to be_invalid }
+      end
+
+      context "when user_group_name is already taken" do
+        let!(:user_group) { create(:user_group, name: user_group_name, decidim_organization_id: organization.id) }
+        let(:user_group_name) { "Taken User Name" }
+        it { is_expected.to be_invalid }
+      end
+
+      context "when user_group_document_number is already taken" do
+        let!(:user_group) { create(:user_group, document_number: user_group_document_number, decidim_organization_id: organization.id) }
+        let(:user_group_document_number) { "Y12345678" }
         it { is_expected.to be_invalid }
       end
     end

--- a/decidim-core/spec/forms/registration_form_spec.rb
+++ b/decidim-core/spec/forms/registration_form_spec.rb
@@ -90,7 +90,6 @@ module Decidim
       let(:user_group_document_number) { "123456789Z" }
       let(:user_group_phone) { "333-333-333" }
 
-
       context "when everything is OK" do
         it { is_expected.to be_valid }
       end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds a unique validation on document number and name fields per users groups so i'll prevent duplications.

#### :pushpin: Related Issues
- Fixes #1362

#### :ghost: GIF
![](https://media2.giphy.com/media/tr1ROo39eG0Za/giphy.gif)
