### PR TITLE
Fix attachment delete method redirection. 

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/participatory_process_attachments_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/participatory_process_attachments_controller.rb
@@ -11,6 +11,10 @@ module Decidim
       include Concerns::ParticipatoryProcessAdmin
       include Concerns::HasAttachments
 
+      def after_destroy_path
+        participatory_process_attachments_path(participatory_process.id)
+      end
+
       def attached_to
         participatory_process
       end


### PR DESCRIPTION
#### :tophat: What? Why?
When the admin user tries to delete an attachment It should stay on attachments index view. So this PR redefines the method ```after_destroy_path``` at controller level to force to stay on index view on attachment destroy.

#### :pushpin: Related Issues
- Fixes #1163 

#### :ghost: GIF
![](https://media3.giphy.com/media/84CRvhy2DJlwA/giphy.gif)
