### PR TITLE
Add missing build instruction on dockerfile for surveys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ ADD decidim-meetings/decidim-meetings.gemspec /tmp/decidim-meetings/decidim-meet
 ADD decidim-proposals/decidim-proposals.gemspec /tmp/decidim-proposals/decidim-proposals.gemspec
 ADD decidim-results/decidim-results.gemspec /tmp/decidim-results/decidim-results.gemspec
 ADD decidim-budgets/decidim-budgets.gemspec /tmp/decidim-proposals/decidim-budgets.gemspec
+ADD decidim-surveys/decidim-surveys.gemspec /tmp/decidim-surveys/decidim-surveys.gemspec
 
 ADD package.json /tmp/package.json
 ADD yarn.lock /tmp/yarn.lock


### PR DESCRIPTION
#### :tophat: What? Why?

The gemspec for `decidim-surveys` wasn't included in the docker image so it returned an error when anyone tried to build it.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
N/A

#### :ghost: GIF
![](https://media4.giphy.com/media/Z0t4XTK8THkre/giphy.gif)
