### PR TITLE
Handling vote comment errors correctly

### DIFF
--- a/decidim-comments/app/resolvers/decidim/comments/vote_comment_resolver.rb
+++ b/decidim-comments/app/resolvers/decidim/comments/vote_comment_resolver.rb
@@ -15,7 +15,7 @@ module Decidim
             return comment
           end
           on(:invalid) do
-            return GraphQL::ExecutionError.new(I18n.t('votes.create.error', scope: 'decidim.comments'))
+            return GraphQL::ExecutionError.new(I18n.t("votes.create.error", scope: "decidim.comments"))
           end
         end
       end

--- a/decidim-comments/app/resolvers/decidim/comments/vote_comment_resolver.rb
+++ b/decidim-comments/app/resolvers/decidim/comments/vote_comment_resolver.rb
@@ -14,6 +14,9 @@ module Decidim
           on(:ok) do |comment|
             return comment
           end
+          on(:invalid) do
+            return GraphQL::ExecutionError.new(I18n.t('votes.create.error', scope: 'decidim.comments'))
+          end
         end
       end
     end

--- a/decidim-comments/config/locales/en.yml
+++ b/decidim-comments/config/locales/en.yml
@@ -6,6 +6,9 @@ en:
         cannot_have_comments: can't have comments
   decidim:
     comments:
+      votes:
+        create:
+          error: "There's been errors when voting the comment."
       comment_notification_mailer:
         comment_created:
           new_comment_html: There is a new comment from <b>%{commenter}</b> in <b>%{commentable_link}</b>

--- a/decidim-comments/config/locales/en.yml
+++ b/decidim-comments/config/locales/en.yml
@@ -6,9 +6,6 @@ en:
         cannot_have_comments: can't have comments
   decidim:
     comments:
-      votes:
-        create:
-          error: "There's been errors when voting the comment."
       comment_notification_mailer:
         comment_created:
           new_comment_html: There is a new comment from <b>%{commenter}</b> in <b>%{commentable_link}</b>
@@ -23,6 +20,9 @@ en:
             subject: You have a new comment
           reply_created:
             subject: You have a new reply of your comment
+      votes:
+        create:
+          error: There's been errors when voting the comment.
     components:
       add_comment_form:
         account_message: '<a href="%{sign_in_url}">Sign in with your account</a> or <a href="%{sign_up_url}">sign up</a> to add your comment. '


### PR DESCRIPTION
#### :tophat: What? Why?

When voting a comment fails the error is not handled and raises a 500 error.

```
NoMethodError: undefined method `id' for #<Decidim::Comments::VoteComment:0x007f6009404280>
  from rectify/command.rb:24:in `method_missing'
  from graphql/field/resolve.rb:54:in `public_send'
  from graphql/field/resolve.rb:54:in `call'
  from graphql/field.rb:215:in `resolve'
  from graphql/execution/execute.rb:221:in `call'
```

I handled the error so it's frontend responsibility now. Apollo is just undoing the optimistic UI so I think it is fine.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
N/A

#### :ghost: GIF
![](https://media4.giphy.com/media/ocRPZvXug2wW4/giphy.gif)
