### PR TITLE
Replace Users with Participants in home counters

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -381,7 +381,7 @@ en:
         processes_count: Processes
         proposals_count: Proposals
         results_count: Results
-        users_count: Users
+        users_count: Participants
         votes_count: Votes
       sub_hero:
         register: Register

--- a/decidim-core/spec/features/homepage_spec.rb
+++ b/decidim-core/spec/features/homepage_spec.rb
@@ -123,7 +123,7 @@ describe "Homepage", type: :feature do
           within "#statistics" do
             expect(page).to have_content("Current state of #{organization.name}")
             expect(page).to have_content("PROCESSES")
-            expect(page).to have_content("USERS")
+            expect(page).to have_content("PARTICIPANTS")
           end
         end
 

--- a/decidim-core/spec/presenters/decidim/home_stats_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/home_stats_presenter_spec.rb
@@ -36,7 +36,7 @@ module Decidim
         expect(subject.highlighted).to eq(
           "<div class=\"home-pam__highlight\">" \
             "<div class=\"home-pam__data\">" \
-              "<h4 class=\"home-pam__title\">Users</h4>" \
+              "<h4 class=\"home-pam__title\">Participants</h4>" \
               "<span class=\"home-pam__number users_count\"> 1</span>" \
             "</div>" \
             "<div class=\"home-pam__data\">" \


### PR DESCRIPTION
#### :tophat: What? Why?
This PR replaces "Users" with "Participants" in home activity counters to recognize the contributor potential as a member of a community and not as a consumer.

#### :pushpin: Related Issues
- Fixes #1344

### :camera: Screenshots (optional)
![screen shot 2017-06-14 at 12 30 01](https://user-images.githubusercontent.com/953911/27128039-65912b88-50fd-11e7-8fc6-7a2b22cffb77.png)

#### :ghost: GIF
![](https://media3.giphy.com/media/UZaRAUyyUEFMY/giphy.gif)
