### PR TITLE
Add language chooser to admin panel

### DIFF
--- a/decidim-admin/app/assets/stylesheets/decidim/admin/extra/_language-chooser.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/extra/_language-chooser.scss
@@ -1,0 +1,4 @@
+//Overrides position for the user-login block
+.user-login{ 
+  top: 30%;
+}

--- a/decidim-admin/app/controllers/decidim/admin/application_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/application_controller.rb
@@ -20,6 +20,7 @@ module Decidim
       helper Decidim::ReplaceButtonsHelper
       helper Decidim::OrganizationScopesHelper
       helper Decidim::TranslationsHelper
+      helper Decidim::LanguageChooserHelper
 
       protect_from_forgery with: :exception, prepend: true
 

--- a/decidim-admin/app/views/layouts/decidim/admin/_title_bar.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_title_bar.html.erb
@@ -8,6 +8,16 @@
     <% end %>
   <% end %>
   <div class="user-login">
+  <ul class="dropdown menu language-chooser" data-dropdown-menu>
+      <li class="is-dropdown-submenu-parent">
+        <%= link_to t("name", scope: "locale") %>
+        <ul class="menu is-dropdown-submenu">
+          <% (available_locales - [I18n.locale.to_s]).each do |locale| %>
+            <li><%= link_to locale_name(locale), decidim.locale_path(locale: locale), method: :post%></li>
+          <% end %>
+        </ul>
+      </li>
+    </ul>
     <ul class="dropdown menu" data-dropdown-menu>
       <li class="is-dropdown-submenu-parent">
         <a href="#"><%= current_user.email %></a>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds a language selector to the new admin panel so the users could change between language without need to visit the main platform.

#### :pushpin: Related Issues
- Fixes #1181 

### :camera: Screenshots 
![Top right corner](https://user-images.githubusercontent.com/953911/27175815-aba1df78-51c0-11e7-8b2f-2c8fb6c28395.png)

#### :ghost: GIF
![](https://media4.giphy.com/media/5cY7YHmiq7nPy/giphy.gif)
