### PR TITLE
Move vote and unvote proposal to commands

### DIFF
--- a/decidim-proposals/app/commands/decidim/proposals/unvote_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/unvote_proposal.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    # A command with all the business logic when a user unvotes a proposal.
+    class UnvoteProposal < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # proposal     - A Decidim::Proposals::Proposal object.
+      # current_user - The current user.
+      def initialize(proposal, current_user)
+        @proposal = proposal
+        @current_user = current_user
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid, together with the proposal.
+      # - :invalid if the form wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        destroy_proposal_vote
+        broadcast(:ok, @proposal)
+      end
+      private
+
+      def destroy_proposal_vote
+        @proposal.votes.where(author: @current_user).destroy_all
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/commands/decidim/proposals/unvote_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/unvote_proposal.rb
@@ -23,6 +23,7 @@ module Decidim
         destroy_proposal_vote
         broadcast(:ok, @proposal)
       end
+
       private
 
       def destroy_proposal_vote

--- a/decidim-proposals/app/commands/decidim/proposals/vote_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/vote_proposal.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    # A command with all the business logic when a user votes a proposal.
+    class VoteProposal < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # proposal     - A Decidim::Proposals::Proposal object.
+      # current_user - The current user.
+      def initialize(proposal, current_user)
+        @proposal = proposal
+        @current_user = current_user
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid, together with the proposal vote.
+      # - :invalid if the form wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        build_proposal_vote
+        return broadcast(:invalid) unless vote.valid?
+
+        vote.save!
+        broadcast(:ok, vote)
+      end
+
+      attr_reader :vote
+
+      private
+
+      def build_proposal_vote
+        @vote = @proposal.votes.build(author: @current_user)
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/controllers/decidim/proposals/proposal_votes_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposal_votes_controller.rb
@@ -12,20 +12,30 @@ module Decidim
 
       def create
         authorize! :vote, proposal
-
-        proposal.votes.create!(author: current_user)
         @from_proposals_list = params[:from_proposals_list] == "true"
-        render :update_buttons_and_counters
+
+        VoteProposal.call(proposal, current_user) do
+          on(:ok) do |vote|
+            proposal.reload
+            render :update_buttons_and_counters
+          end
+
+          on(:invalid) do
+            render json: { error: I18n.t("proposal_votes.create.error", scope: "decidim.proposals") }, status: 422
+          end
+        end
       end
 
       def destroy
         authorize! :unvote, proposal
-
-        proposal.votes.where(author: current_user).destroy_all
-        proposal.reload
-
         @from_proposals_list = params[:from_proposals_list] == "true"
-        render :update_buttons_and_counters
+
+        UnvoteProposal.call(proposal, current_user) do
+          on(:ok) do
+            proposal.reload
+            render :update_buttons_and_counters
+          end
+        end
       end
 
       private

--- a/decidim-proposals/app/controllers/decidim/proposals/proposal_votes_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposal_votes_controller.rb
@@ -15,7 +15,7 @@ module Decidim
         @from_proposals_list = params[:from_proposals_list] == "true"
 
         VoteProposal.call(proposal, current_user) do
-          on(:ok) do |vote|
+          on(:ok) do
             proposal.reload
             render :update_buttons_and_counters
           end

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -81,6 +81,9 @@ en:
             scope: Scope
             state: State
             title: Title
+      proposal_votes:
+        create:
+          error: There's been errors when voting the proposal.
       proposals:
         author:
           deleted: Deleted user

--- a/decidim-proposals/spec/commands/decidim/proposals/unvote_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/unvote_proposal_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Proposals
+    describe UnvoteProposal do
+      describe "call" do
+        let(:proposal) { create(:proposal) }
+        let(:current_user) { create(:user, organization: proposal.feature.organization) }
+        let!(:proposal_vote) { create(:proposal_vote, author: current_user, proposal: proposal) }
+        let(:command) { described_class.new(proposal, current_user) }
+
+        it "broadcasts ok" do
+          expect { command.call }.to broadcast(:ok)
+        end
+
+        it "deletes the proposal vote for that user" do
+          expect {
+            command.call
+          }.to change { ProposalVote.count }.by(-1)
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/commands/decidim/proposals/unvote_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/unvote_proposal_spec.rb
@@ -16,9 +16,9 @@ module Decidim
         end
 
         it "deletes the proposal vote for that user" do
-          expect {
+          expect do
             command.call
-          }.to change { ProposalVote.count }.by(-1)
+          end.to change { ProposalVote.count }.by(-1)
         end
       end
     end

--- a/decidim-proposals/spec/commands/decidim/proposals/vote_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/vote_proposal_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Proposals
+    describe VoteProposal do
+      describe "call" do
+        let(:proposal) { create(:proposal) }
+        let(:current_user) { create(:user, organization: proposal.feature.organization) }
+        let(:command) { described_class.new(proposal, current_user) }
+
+        describe "when the vote is not valid" do
+          before do
+            allow_any_instance_of(ProposalVote).to receive(:valid?).and_return(false)
+          end
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+
+          it "doesn't create a new vote for the proposal" do
+            expect {
+              command.call
+            }.to change { ProposalVote.count }.by(0)
+          end
+        end
+
+        describe "when the vote is valid" do
+          before do
+            allow_any_instance_of(ProposalVote).to receive(:valid?).and_return(true)
+          end
+
+          it "broadcasts ok" do
+            expect { command.call }.to broadcast(:ok)
+          end
+
+          it "creates a new vote for the proposal" do
+            expect {
+              command.call
+            }.to change { ProposalVote.count }.by(1)
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/commands/decidim/proposals/vote_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/vote_proposal_spec.rb
@@ -20,9 +20,9 @@ module Decidim
           end
 
           it "doesn't create a new vote for the proposal" do
-            expect {
+            expect do
               command.call
-            }.to change { ProposalVote.count }.by(0)
+            end.to change { ProposalVote.count }.by(0)
           end
         end
 
@@ -36,9 +36,9 @@ module Decidim
           end
 
           it "creates a new vote for the proposal" do
-            expect {
+            expect do
               command.call
-            }.to change { ProposalVote.count }.by(1)
+            end.to change { ProposalVote.count }.by(1)
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

Sometimes voting a proposal cause a validation error (for example if someone try to vote two times and the UI is responding slowly).
I moved the logic for vote and unvote to commands and handle errors gracefully.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
N/A

#### :ghost: GIF
![](https://media2.giphy.com/media/RkmVPJ2k1aydi/giphy.gif)
