### PR TITLE
Add missing datepicker locales

### DIFF
--- a/decidim-core/config/locales/nl.yml
+++ b/decidim-core/config/locales/nl.yml
@@ -305,7 +305,7 @@ nl:
         title: Gebruikersinstellingen
         user_groups: Organisaties
   locale:
-    name: Nederlands
+    name: Dutch
   pages:
     '404':
       back_home: Terug naar huis

--- a/decidim-core/config/locales/nl.yml
+++ b/decidim-core/config/locales/nl.yml
@@ -305,7 +305,7 @@ nl:
         title: Gebruikersinstellingen
         user_groups: Organisaties
   locale:
-    name: Dutch
+    name: Nederlands
   pages:
     '404':
       back_home: Terug naar huis

--- a/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.fr.js
+++ b/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.fr.js
@@ -1,0 +1,14 @@
+/**
+ * French translation for foundation-datepicker
+ * Nico Mollet <nico.mollet@gmail.com>
+ */
+;(function($){
+	$.fn.fdatepicker.dates['fr'] = {
+		days: ["Dimanche", "Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi", "Dimanche"],
+		daysShort: ["Dim", "Lun", "Mar", "Mer", "Jeu", "Ven", "Sam", "Dim"],
+		daysMin: ["D", "L", "Ma", "Me", "J", "V", "S", "D"],
+		months: ["Janvier", "Février", "Mars", "Avril", "Mai", "Juin", "Juillet", "Août", "Septembre", "Octobre", "Novembre", "Décembre"],
+		monthsShort: ["Jan", "Fev", "Mar", "Avr", "Mai", "Jui", "Jul", "Aou", "Sep", "Oct", "Nov", "Dec"],
+		today: "Aujourd'hui"
+	};
+}(jQuery));

--- a/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.it.js
+++ b/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.it.js
@@ -1,0 +1,14 @@
+/**
+ * Italian translation for foundation-datepicker
+ * Enrico Rubboli <rubboli@gmail.com>
+ */
+;(function($){
+	$.fn.fdatepicker.dates['it'] = {
+		days: ["Domenica", "Lunedi", "Martedi", "Mercoledi", "Giovedi", "Venerdi", "Sabato", "Domenica"],
+		daysShort: ["Dom", "Lun", "Mar", "Mer", "Gio", "Ven", "Sab", "Dom"],
+		daysMin: ["Do", "Lu", "Ma", "Me", "Gi", "Ve", "Sa", "Do"],
+		months: ["Gennaio", "Febbraio", "Marzo", "Aprile", "Maggio", "Giugno", "Luglio", "Agosto", "Settembre", "Ottobre", "Novembre", "Dicembre"],
+		monthsShort: ["Gen", "Feb", "Mar", "Apr", "Mag", "Giu", "Lug", "Ago", "Set", "Ott", "Nov", "Dic"],
+		today: "Oggi"
+	};
+}(jQuery));

--- a/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.nl.js
+++ b/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.nl.js
@@ -1,0 +1,14 @@
+/**
+ * Dutch translation for foundation-datepicker
+ * Reinier Goltstein <mrgoltstein@gmail.com>
+ */
+;(function($){
+	$.fn.fdatepicker.dates['nl'] = {
+		days: ["Zondag", "Maandag", "Dinsdag", "Woensdag", "Donderdag", "Vrijdag", "Zaterdag", "Zondag"],
+		daysShort: ["Zo", "Ma", "Di", "Wo", "Do", "Vr", "Za", "Zo"],
+		daysMin: ["Zo", "Ma", "Di", "Wo", "Do", "Vr", "Za", "Zo"],
+		months: ["Januari", "Februari", "Maart", "April", "Mei", "Juni", "Juli", "Augustus", "September", "Oktober", "November", "December"],
+		monthsShort: ["Jan", "Feb", "Mrt", "Apr", "Mei", "Jun", "Jul", "Aug", "Sep", "Okt", "Nov", "Dec"],
+		today: "Vandaag"
+	};
+}(jQuery));


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds the missing locales for the datepicker at the admin panel. Also it corrects the Dutch language label.

#### :pushpin: Related Issues
- Fixes #1492

#### :ghost: GIF
![](https://media.giphy.com/media/Zaeyj0lscMhA4/giphy.gif)
