### PR TITLE
Missing form helper on system forgot password page

### DIFF
--- a/decidim-system/app/controllers/decidim/system/devise/passwords_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/devise/passwords_controller.rb
@@ -6,6 +6,8 @@ module Decidim
       # Custom Passwords controller for Devise in order to use a custom layout
       # and views.
       class PasswordsController < ::Devise::PasswordsController
+        helper Decidim::DecidimFormHelper
+
         layout "decidim/system/login"
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

System forgot password page was broken because we forgot to include the form helper.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
N/A

#### :ghost: GIF
![](https://media4.giphy.com/media/xTiTnf9SCIVk8HIvE4/giphy.gif)
