### PR TITLE
Use url instead of path for managing moderations link

### DIFF
--- a/decidim-core/app/mailers/decidim/reported_mailer.rb
+++ b/decidim-core/app/mailers/decidim/reported_mailer.rb
@@ -5,7 +5,7 @@ module Decidim
   class ReportedMailer < Decidim::ApplicationMailer
     helper Decidim::ResourceHelper
 
-    helper_method :reported_content_url
+    helper_method :reported_content_url, :manage_moderations_url
 
     def report(user, report)
       with_user(user) do
@@ -33,6 +33,10 @@ module Decidim
 
     def reported_content_url
       @reported_content_url ||= @report.moderation.reportable.reported_content_url
+    end
+
+    def manage_moderations_url
+      @manage_moderations_url ||= decidim_admin.participatory_process_moderations_url(@participatory_process.id, host: @organization.host)
     end
   end
 end

--- a/decidim-core/app/views/decidim/reported_mailer/hide.html.erb
+++ b/decidim-core/app/views/decidim/reported_mailer/hide.html.erb
@@ -5,5 +5,5 @@
 </p>
 
 <p>
-  <%= link_to t(".manage_moderations"), decidim_admin.participatory_process_moderations_url(@participatory_process.id) %>
+  <%= link_to t(".manage_moderations"), manage_moderations_url %>
 </p>

--- a/decidim-core/app/views/decidim/reported_mailer/hide.html.erb
+++ b/decidim-core/app/views/decidim/reported_mailer/hide.html.erb
@@ -5,5 +5,5 @@
 </p>
 
 <p>
-  <%= link_to t(".manage_moderations"), decidim_admin.participatory_process_moderations_path(@participatory_process.id) %>
+  <%= link_to t(".manage_moderations"), decidim_admin.participatory_process_moderations_url(@participatory_process.id) %>
 </p>

--- a/decidim-core/app/views/decidim/reported_mailer/report.html.erb
+++ b/decidim-core/app/views/decidim/reported_mailer/report.html.erb
@@ -5,5 +5,5 @@
 </p>
 
 <p>
-  <%= link_to t(".manage_moderations"), decidim_admin.participatory_process_moderations_url(@participatory_process.id) %>
+  <%= link_to t(".manage_moderations"), manage_moderations_url %>
 </p>

--- a/decidim-core/app/views/decidim/reported_mailer/report.html.erb
+++ b/decidim-core/app/views/decidim/reported_mailer/report.html.erb
@@ -5,5 +5,5 @@
 </p>
 
 <p>
-  <%= link_to t(".manage_moderations"), decidim_admin.participatory_process_moderations_path(@participatory_process.id) %>
+  <%= link_to t(".manage_moderations"), decidim_admin.participatory_process_moderations_url(@participatory_process.id) %>
 </p>


### PR DESCRIPTION
#### :tophat: What? Why?

This fixes the usage of `path` instead of `url` in managing moderation links.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
N/A

#### :ghost: GIF
None
