### PR TITLE
Missing validation on Survey Question model

### DIFF
--- a/decidim-surveys/app/models/decidim/surveys/survey_question.rb
+++ b/decidim-surveys/app/models/decidim/surveys/survey_question.rb
@@ -8,6 +8,8 @@ module Decidim
 
       belongs_to :survey, class_name: "Survey", foreign_key: "decidim_survey_id"
 
+      validates :question_type, inclusion: { in: TYPES }
+
       # Rectify can't handle a hash when using the from_model method so
       # the answer options must be converted to struct.
       def answer_options

--- a/decidim-surveys/lib/decidim/surveys/feature.rb
+++ b/decidim-surveys/lib/decidim/surveys/feature.rb
@@ -77,7 +77,8 @@ Decidim.register_feature(:surveys) do |feature|
       3.times do
         Decidim::Surveys::SurveyQuestion.create!(
           survey: survey,
-          body: Decidim::Faker::Localized.paragraph
+          body: Decidim::Faker::Localized.paragraph,
+          question_type: "short_answer"
         )
       end
     end

--- a/decidim-surveys/spec/forms/decidim/surveys/admin/survey_question_form_spec.rb
+++ b/decidim-surveys/spec/forms/decidim/surveys/admin/survey_question_form_spec.rb
@@ -9,7 +9,7 @@ module Decidim
         let!(:survey) { create(:survey) }
         let!(:position) { 0 }
         let!(:question_type) { SurveyQuestion::TYPES.first }
-        let!(:survey_question) { create(:survey_question, survey: survey, position: position, question_type: question_type) }
+        let!(:survey_question) { build(:survey_question, survey: survey, position: position, question_type: question_type) }
 
         subject do
           described_class.from_model(survey_question).with_context(current_feature: survey.feature)

--- a/decidim-surveys/spec/models/decidim/surveys/survey_question_spec.rb
+++ b/decidim-surveys/spec/models/decidim/surveys/survey_question_spec.rb
@@ -6,13 +6,19 @@ module Decidim
   module Surveys
     describe SurveyQuestion do
       let(:survey) { create(:survey) }
-      let(:survey_question) { create(:survey_question, survey: survey) }
+      let(:question_type) { "short_answer" }
+      let(:survey_question) { build(:survey_question, survey: survey, question_type: question_type) }
       subject { survey_question }
 
       it { is_expected.to be_valid }
 
       it "has an association of survey" do
         expect(subject.survey).to eq(survey)
+      end
+
+      context "when question type doesn't exists in allowed types" do
+        let(:question_type) { "foo" }
+        it { is_expected.not_to be_valid }
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

The `SurveyQuestion` model was missing a validation included in its form. That causes the wrong generation of `decidim-surveys` seeds.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None

#### :ghost: GIF
![](https://media1.giphy.com/media/7pY7FRdqpWM48/giphy.gif)
