### PR TITLE
Validating slug format on static-pages

### DIFF
--- a/decidim-admin/app/forms/decidim/admin/static_page_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/static_page_form.rb
@@ -14,12 +14,15 @@ module Decidim
 
       validates :slug, presence: true
       validates :title, :content, translatable_presence: true
-      validates :slug, format: { with: /^[a-z0-9-]+$/, :multiline => true}
+      validates :slug, format: { with: /^[a-z0-9-]+$/, multiline: true }
 
       validate :slug, :slug_uniqueness
 
-
       alias organization current_organization
+
+      def slug
+        super.to_s.downcase
+      end
 
       private
 
@@ -27,10 +30,6 @@ module Decidim
         return unless organization && organization.static_pages.where(slug: slug).where.not(id: id).any?
 
         errors.add(:slug, :taken)
-      end
-
-      def slug
-        super.to_s.downcase
       end
     end
   end

--- a/decidim-admin/app/forms/decidim/admin/static_page_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/static_page_form.rb
@@ -14,7 +14,10 @@ module Decidim
 
       validates :slug, presence: true
       validates :title, :content, translatable_presence: true
+      validates :slug, format: { with: /^[a-z0-9-]+$/, :multiline => true}
+
       validate :slug, :slug_uniqueness
+
 
       alias organization current_organization
 
@@ -24,6 +27,10 @@ module Decidim
         return unless organization && organization.static_pages.where(slug: slug).where.not(id: id).any?
 
         errors.add(:slug, :taken)
+      end
+
+      def slug
+        super.to_s.downcase
       end
     end
   end

--- a/decidim-admin/app/forms/decidim/admin/static_page_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/static_page_form.rb
@@ -16,7 +16,7 @@ module Decidim
       validates :title, :content, translatable_presence: true
       validates :slug, format: { with: /\A[a-z0-9-]+/ }
 
-      validate :slug, :slug_uniquenesscd ,.
+      validate :slug, :slug_uniqueness
 
       alias organization current_organization
 

--- a/decidim-admin/app/forms/decidim/admin/static_page_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/static_page_form.rb
@@ -14,9 +14,9 @@ module Decidim
 
       validates :slug, presence: true
       validates :title, :content, translatable_presence: true
-      validates :slug, format: { with: /^[a-z0-9-]+$/, multiline: true }
+      validates :slug, format: { with: /\A[a-z0-9-]+/ }
 
-      validate :slug, :slug_uniqueness
+      validate :slug, :slug_uniquenesscd ,.
 
       alias organization current_organization
 

--- a/decidim-admin/spec/forms/static_page_form_spec.rb
+++ b/decidim-admin/spec/forms/static_page_form_spec.rb
@@ -70,13 +70,13 @@ module Decidim
       end
 
       context "when slug is invalid" do
-        let(:slug) { '#Slug.Invalid!' }
+        let(:slug) { "#Slug.Invalid!" }
 
         it { is_expected.to be_invalid }
       end
 
       context "when slug is not downcase" do
-        let(:slug) { 'SLUG' }
+        let(:slug) { "SLUG" }
 
         it { is_expected.to be_valid }
       end

--- a/decidim-admin/spec/forms/static_page_form_spec.rb
+++ b/decidim-admin/spec/forms/static_page_form_spec.rb
@@ -69,6 +69,18 @@ module Decidim
         it { is_expected.to be_invalid }
       end
 
+      context "when slug is invalid" do
+        let(:slug) { '#Slug.Invalid!' }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "when slug is not downcase" do
+        let(:slug) { 'SLUG' }
+
+        it { is_expected.to be_valid }
+      end
+
       context "when slug is not unique" do
         before do
           create(:static_page, organization: organization, slug: slug)

--- a/decidim-core/app/models/decidim/static_page.rb
+++ b/decidim-core/app/models/decidim/static_page.rb
@@ -11,7 +11,7 @@ module Decidim
     belongs_to :organization, foreign_key: "decidim_organization_id", class_name: "Decidim::Organization", inverse_of: :static_pages
 
     validates :slug, presence: true, uniqueness: { scope: :organization }
-    validates :slug, format: { with: /^[a-z0-9-]+$/, multiline: true }
+    validates :slug, format: { with: /\A[a-z0-9-]+/ }
 
     # These pages will be created by default when registering an organization
     # and cannot be deleted.

--- a/decidim-core/app/models/decidim/static_page.rb
+++ b/decidim-core/app/models/decidim/static_page.rb
@@ -11,6 +11,7 @@ module Decidim
     belongs_to :organization, foreign_key: "decidim_organization_id", class_name: "Decidim::Organization", inverse_of: :static_pages
 
     validates :slug, presence: true, uniqueness: { scope: :organization }
+    validates :slug, format: { with: /^[a-z0-9-]+$/, multiline: true }
 
     # These pages will be created by default when registering an organization
     # and cannot be deleted.

--- a/decidim-core/spec/models/decidim/static_page_spec.rb
+++ b/decidim-core/spec/models/decidim/static_page_spec.rb
@@ -7,6 +7,9 @@ module Decidim
     let(:page) { build(:static_page) }
 
     context "validations" do
+      let(:invalid_slug) { "#Invalid.Slug" }
+      let(:uppercase_slug) { "Uppercase-SLUG" }
+
       it "is valid" do
         expect(page).to be_valid
       end
@@ -23,6 +26,13 @@ module Decidim
         other_page = create(:static_page, slug: page.slug)
 
         expect(other_page).to be_valid
+      end
+
+      it "does not allow to create pages with an invalid slug" do
+        page = create(:static_page)
+        invalid_page = build(:static_page, slug: invalid_slug, organization: page.organization)
+
+        expect(invalid_page).not_to be_valid
       end
     end
 

--- a/decidim-core/spec/models/decidim/static_page_spec.rb
+++ b/decidim-core/spec/models/decidim/static_page_spec.rb
@@ -8,7 +8,6 @@ module Decidim
 
     context "validations" do
       let(:invalid_slug) { "#Invalid.Slug" }
-      let(:uppercase_slug) { "Uppercase-SLUG" }
 
       it "is valid" do
         expect(page).to be_valid


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds some formatting validation and sanitising to the slug field on static pages.

#### :pushpin: Related Issues
- Fixes #1498 

### :camera: Screenshots (optional)
![screen shot 2017-06-19 at 12 19 55](https://user-images.githubusercontent.com/953911/27280826-a2e15b30-54e9-11e7-9e5b-7b384b68baec.png)

#### :ghost: GIF
![](https://media1.giphy.com/media/EVfrP9aBxfz68/giphy.gif)
