### PR TITLE
Fix proposals category filter when user is logged in

### DIFF
--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -24,7 +24,7 @@ module Decidim
         @voted_proposals = if current_user
                              ProposalVote.where(
                                author: current_user,
-                               proposal: @proposals
+                               proposal: @proposals.pluck(:id)
                              ).pluck(:decidim_proposal_id)
                            else
                              []

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -679,6 +679,25 @@ describe "Proposals", type: :feature do
           end
         end
       end
+
+      context "when the user is logged in" do
+        before do
+          login_as user, scope: :user
+        end
+
+        it "can be filtered by category" do
+          create_list(:proposal, 3, feature: feature)
+          create(:proposal, feature: feature, category: category)
+
+          visit_feature
+
+          within "form.new_filter" do
+            select category.name[I18n.locale.to_s], from: "filter_category_id"
+          end
+
+          expect(page).to have_css(".card--proposal", count: 1)
+        end
+      end
     end
 
     context "when ordering" do


### PR DESCRIPTION
#### :tophat: What? Why?

When the user was logged in the query which computes proposals voted by the user was failing. I fixed it and add a test case.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
N/A

#### :ghost: GIF
None
