### PR TITLE
Redirect to before participatory process creation updated

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/participatory_processes_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/participatory_processes_controller.rb
@@ -27,7 +27,7 @@ module Decidim
         CreateParticipatoryProcess.call(@form) do
           on(:ok) do |participatory_process|
             flash[:notice] = I18n.t("participatory_processes.create.success", scope: "decidim.admin")
-            redirect_to edit_participatory_process_path(participatory_process)
+            redirect_to participatory_process_steps_path(participatory_process)
           end
 
           on(:invalid) do

--- a/decidim-admin/spec/features/admin_manages_participatory_processes_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_participatory_processes_spec.rb
@@ -65,10 +65,9 @@ describe "Admin manage participatory processes", type: :feature do
     end
 
     within ".container" do
-      expect(page).to have_selector("input[value='My participatory process']")
-      expect(page).to have_selector("option[selected]", text: @group_name)
-      expect(page).to have_css("img[src*='#{image1_filename}']")
-      expect(page).to have_css("img[src*='#{image2_filename}']")
+      expect(current_path).to eq decidim_admin.participatory_process_steps_path(Decidim::ParticipatoryProcess.last)
+      expect(page).to have_content("STEPS")
+      expect(page).to have_content("Introduction")
     end
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?
This PR amends the `redirect_to` to steps pages after creating a participatory process to improve the admin experience, and match the behaviour with the confirmation message.

#### :pushpin: Related Issues
- Fixes #1509

#### :ghost: GIF
![](https://media4.giphy.com/media/3oKIPaEBW2xqa8VhOE/giphy.gif)
