### PR TITLE
Add default step settings

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/create_participatory_process_step.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_participatory_process_step.rb
@@ -38,7 +38,8 @@ module Decidim
           description: form.description,
           start_date: form.start_date,
           end_date: form.end_date,
-          participatory_process: @participatory_process
+          participatory_process: @participatory_process,
+          active: @participatory_process.steps.empty?
         )
       end
     end

--- a/decidim-admin/app/commands/decidim/admin/destroy_participatory_process_step.rb
+++ b/decidim-admin/app/commands/decidim/admin/destroy_participatory_process_step.rb
@@ -19,8 +19,7 @@ module Decidim
       #
       # Returns nothing.
       def call
-        return broadcast(:invalid, :last_step) if @participatory_process.steps.count == 1
-        return broadcast(:invalid, :active_step) if @step.active?
+        return broadcast(:invalid, :active_step) if active_step?
 
         @step.destroy!
         reorder_steps
@@ -28,6 +27,10 @@ module Decidim
       end
 
       private
+
+      def active_step?
+        @participatory_process.steps.count > 1 && @step.active?
+      end
 
       def reorder_steps
         steps = @participatory_process.steps.reload

--- a/decidim-admin/app/commands/decidim/admin/update_feature.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_feature.rb
@@ -36,6 +36,7 @@ module Decidim
         @feature.update_attributes(
           name: form.name,
           settings: form.settings,
+          default_step_settings: form.default_step_settings,
           step_settings: form.step_settings,
           weight: form.weight
         )

--- a/decidim-admin/app/forms/decidim/admin/feature_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/feature_form.rb
@@ -14,6 +14,7 @@ module Decidim
       validates :name, translatable_presence: true
 
       attribute :settings, Object
+      attribute :default_step_settings, Object
       attribute :manifest
       attribute :weight, Integer, default: 0
 
@@ -23,10 +24,15 @@ module Decidim
       def map_model(model)
         self.attributes = model.attributes
         self.settings = model.settings
+        self.default_step_settings = model.default_step_settings
       end
 
       def settings?
         settings.manifest.attributes.any?
+      end
+
+      def default_step_settings?
+        default_step_settings.manifest.attributes.any?
       end
 
       def step_settings?

--- a/decidim-admin/app/views/decidim/admin/features/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/features/_form.html.erb
@@ -55,6 +55,24 @@
             </div>
           </div>
         </fieldset>
+      <% elsif form.object.default_step_settings? %>
+        <fieldset class="default-step-settings">
+          <div class="card">
+            <div class="card-divider">
+              <legend><%= t ".default_step_settings" %></legend>
+            </div>
+            <div class="card-section">
+              <%= form.fields_for :default_step_settings, form.object.default_step_settings do |settings_fields| %>
+                <%= render partial: "decidim/admin/features/settings_fields",
+                          locals: {
+                            form: settings_fields,
+                            feature: @feature,
+                            settings_name: "step"
+                          } %>
+              <% end %>
+            </div>
+          </div>
+        </fieldset>
       <% end %>
     </div>
   </div>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -202,6 +202,7 @@ en:
           title: Edit feature
           update: Update
         form:
+          default_step_settings: Default step settings
           global_settings: Global settings
           step_settings: Step settings
         index:

--- a/decidim-admin/spec/commands/create_participatory_process_spec.rb
+++ b/decidim-admin/spec/commands/create_participatory_process_spec.rb
@@ -82,10 +82,11 @@ describe Decidim::Admin::CreateParticipatoryProcess do
       expect { subject.call }.to broadcast(:ok)
     end
 
-    it "adds the default step" do
+    it "adds the default active step" do
       subject.call do
         on(:ok) do |process|
           expect(process.steps.count).to eq(1)
+          expect(process.steps.first).to be_active
         end
       end
     end

--- a/decidim-admin/spec/commands/create_participatory_process_step_spec.rb
+++ b/decidim-admin/spec/commands/create_participatory_process_step_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Admin::CreateParticipatoryProcessStep do
+  let(:participatory_process) { create :participatory_process }
+  let(:form) do
+    instance_double(
+      Decidim::Admin::ParticipatoryProcessStepForm,
+      title: { en: "title" },
+      description: { en: "description" },
+      start_date: Time.current,
+      end_date: Time.current + 1.week,
+      invalid?: invalid
+    )
+  end
+  let(:invalid) { false }
+
+  subject { described_class.new(form, participatory_process) }
+
+  context "when the form is not valid" do
+    let(:invalid) { true }
+
+    it "broadcasts invalid" do
+      expect { subject.call }.to broadcast(:invalid)
+    end
+  end
+
+  context "when everything is ok" do
+    it "creates a participatory process step" do
+      expect { subject.call }.to change { Decidim::ParticipatoryProcessStep.count }.by(1)
+    end
+
+    it "broadcasts ok" do
+      expect { subject.call }.to broadcast(:ok)
+    end
+
+    context "when the process has no active steps" do
+      it "creates the step as active" do
+        subject.call
+        expect(Decidim::ParticipatoryProcessStep.last).to be_active
+      end
+    end
+
+    context "when the process has active steps" do
+      before do
+        create(:participatory_process_step, participatory_process: participatory_process, active: true)
+      end
+
+      it "creates the step as active" do
+        subject.call
+        expect(Decidim::ParticipatoryProcessStep.last).not_to be_active
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/commands/destroy_participatory_process_step_spec.rb
+++ b/decidim-admin/spec/commands/destroy_participatory_process_step_spec.rb
@@ -52,8 +52,8 @@ describe Decidim::Admin::DestroyParticipatoryProcessStep, class: true do
   end
 
   context "when trying to destroy the last step" do
-    it "broadcasts invalid" do
-      expect { subject.call(active_step) }.to broadcast(:invalid, :last_step)
+    it "broadcasts ok" do
+      expect { subject.call(active_step) }.to broadcast(:ok)
     end
   end
 end

--- a/decidim-admin/spec/commands/update_feature_spec.rb
+++ b/decidim-admin/spec/commands/update_feature_spec.rb
@@ -25,6 +25,12 @@ module Decidim
             dummy_global_attribute_1: true,
             dummy_global_attribute_2: false
           },
+          default_step_settings: {
+            step.id.to_s => {
+              dummy_step_attribute_1: true,
+              dummy_step_attribute_2: false
+            }
+          },
           step_settings: {
             step.id.to_s => {
               dummy_step_attribute_1: true,

--- a/decidim-admin/spec/features/admin_manages_features_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_features_spec.rb
@@ -127,6 +127,38 @@ describe "Admin manages features", type: :feature do
         expect(all("input[type=checkbox]").first).to be_checked
       end
     end
+
+    context "when the process doesn't have active steps" do
+      let!(:participatory_process) do
+        create(:participatory_process, organization: organization)
+      end
+
+      it "updates the default step settings" do
+        within ".feature-#{feature.id}" do
+          page.find(".action-icon--configure").click
+        end
+
+        within ".edit_feature" do
+          within ".default-step-settings" do
+            all("input[type=checkbox]").first.click
+          end
+
+          find("*[type=submit]").click
+        end
+
+        within ".callout-wrapper" do
+          expect(page).to have_content("successfully")
+        end
+
+        within find("tr", text: "My feature") do
+          page.find(".action-icon--configure").click
+        end
+
+        within ".default-step-settings" do
+          expect(all("input[type=checkbox]").first).to be_checked
+        end
+      end
+    end
   end
 
   describe "remove a feature" do

--- a/decidim-core/app/models/decidim/feature.rb
+++ b/decidim-core/app/models/decidim/feature.rb
@@ -61,6 +61,14 @@ module Decidim
       self[:settings]["global"] = serialize_settings(settings_schema(:global), data)
     end
 
+    def default_step_settings
+      settings_schema(:step).new(self[:settings]["default_step"])
+    end
+
+    def default_step_settings=(data)
+      self[:settings]["default_step"] = serialize_settings(settings_schema(:step), data)
+    end
+
     def step_settings
       participatory_process.steps.each_with_object({}) do |step, result|
         result[step.id.to_s] = settings_schema(:step).new(self[:settings].dig("steps", step.id.to_s))
@@ -75,7 +83,7 @@ module Decidim
 
     def active_step_settings
       active_step = participatory_process.active_step
-      return nil unless active_step
+      return default_step_settings unless active_step
 
       step_settings.fetch(active_step.id.to_s)
     end

--- a/decidim-core/spec/controllers/concerns/feature_settings_spec.rb
+++ b/decidim-core/spec/controllers/concerns/feature_settings_spec.rb
@@ -26,8 +26,8 @@ module Decidim
 
     describe "current_settings" do
       context "when no step is active" do
-        it "returns nil" do
-          expect(controller.current_settings).to eq(nil)
+        it "returns the default step settings" do
+          expect(controller.current_settings).to eq(feature.default_step_settings)
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

If a participatory process doesn't have any steps a feature uses the "Default Step Settings". When a user adds the first step to the process then it uses the step settings as usual.

Since participatory processes now can have no active steps an admin can delete the last step from a process.

#### :pushpin: Related Issues
- Fixes #1515 

#### :clipboard: Subtasks
- [x] Add default step settings
- [x] The first created step should be active
- [x] User can delete the last step

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/106021/27334197-c853bdce-55c8-11e7-9e72-be1588c58254.png)


#### :ghost: GIF
![](https://media4.giphy.com/media/12R8SvDcbEiMG4/giphy.gif)
