### PR TITLE
Fix/500 error in feature url

### DIFF
--- a/decidim-core/app/constraints/decidim/current_feature.rb
+++ b/decidim-core/app/constraints/decidim/current_feature.rb
@@ -24,15 +24,14 @@ module Decidim
 
       @participatory_process = env["decidim.current_participatory_process"]
 
-      feature = detect_current_feature(request.params)
-
-      return false unless feature
-
-      env["decidim.current_feature"] ||= feature
-      true
+      current_feature(env, request.params) ? true : false
     end
 
     private
+
+    def current_feature(env, params)
+      env["decidim.current_feature"] ||= detect_current_feature(params)
+    end
 
     def detect_current_feature(params)
       @participatory_process.features.find do |feature|

--- a/decidim-core/app/constraints/decidim/current_feature.rb
+++ b/decidim-core/app/constraints/decidim/current_feature.rb
@@ -28,6 +28,8 @@ module Decidim
 
       env["decidim.current_participatory_process"] ||= @participatory_process
 
+      return false unless @participatory_process
+
       feature = detect_current_feature(params)
 
       return false unless feature

--- a/decidim-core/app/constraints/decidim/current_feature.rb
+++ b/decidim-core/app/constraints/decidim/current_feature.rb
@@ -11,12 +11,13 @@ module Decidim
       @manifest = manifest
     end
 
-    # Public: Injects the current feature into the environment.
+    # Public: Matches the request against a feature and injects it into the
+    #         environment.
     #
     # request - The request that holds the current feature relevant
     #           information.
     #
-    # Returns nothing.
+    # Returns a true if the request matched, false otherwise
     def matches?(request)
       env = request.env
       params = request.params

--- a/decidim-core/app/constraints/decidim/current_feature.rb
+++ b/decidim-core/app/constraints/decidim/current_feature.rb
@@ -41,8 +41,6 @@ module Decidim
     private
 
     def detect_current_feature(params)
-      return nil unless params["feature_id"]
-
       @participatory_process.features.find do |feature|
         params["feature_id"] == feature.id.to_s && feature.manifest_name == @manifest.name.to_s
       end

--- a/decidim-core/app/constraints/decidim/current_feature.rb
+++ b/decidim-core/app/constraints/decidim/current_feature.rb
@@ -21,14 +21,9 @@ module Decidim
       env = request.env
       params = request.params
 
-      @organization = env["decidim.current_organization"]
+      return false unless CurrentParticipatoryProcess.new.matches?(request)
 
-      @participatory_process = env["decidim.current_participatory_process"] ||
-                               detect_current_participatory_process(params)
-
-      env["decidim.current_participatory_process"] ||= @participatory_process
-
-      return false unless @participatory_process
+      @participatory_process = env["decidim.current_participatory_process"]
 
       feature = detect_current_feature(params)
 
@@ -39,10 +34,6 @@ module Decidim
     end
 
     private
-
-    def detect_current_participatory_process(params)
-      @organization.participatory_processes.find_by_id(params["participatory_process_id"])
-    end
 
     def detect_current_feature(params)
       @participatory_process.features.find do |feature|

--- a/decidim-core/app/constraints/decidim/current_feature.rb
+++ b/decidim-core/app/constraints/decidim/current_feature.rb
@@ -21,10 +21,10 @@ module Decidim
       env = request.env
       params = request.params
 
-      organization = env["decidim.current_organization"]
+      @organization = env["decidim.current_organization"]
 
       @participatory_process = env["decidim.current_participatory_process"] ||
-                               organization.participatory_processes.find_by_id(params["participatory_process_id"])
+                               detect_current_participatory_process(params)
 
       env["decidim.current_participatory_process"] ||= @participatory_process
 
@@ -39,6 +39,10 @@ module Decidim
     end
 
     private
+
+    def detect_current_participatory_process(params)
+      @organization.participatory_processes.find_by_id(params["participatory_process_id"])
+    end
 
     def detect_current_feature(params)
       @participatory_process.features.find do |feature|

--- a/decidim-core/app/constraints/decidim/current_feature.rb
+++ b/decidim-core/app/constraints/decidim/current_feature.rb
@@ -23,7 +23,7 @@ module Decidim
 
       organization = env["decidim.current_organization"]
 
-      @participatory_process = request.env["decidim.current_participatory_process"] ||
+      @participatory_process = env["decidim.current_participatory_process"] ||
                                organization.participatory_processes.find_by_id(params["participatory_process_id"])
 
       env["decidim.current_participatory_process"] ||= @participatory_process

--- a/decidim-core/app/constraints/decidim/current_feature.rb
+++ b/decidim-core/app/constraints/decidim/current_feature.rb
@@ -14,8 +14,7 @@ module Decidim
     # Public: Matches the request against a feature and injects it into the
     #         environment.
     #
-    # request - The request that holds the current feature relevant
-    #           information.
+    # request - The request that holds the current feature relevant information.
     #
     # Returns a true if the request matched, false otherwise
     def matches?(request)

--- a/decidim-core/app/constraints/decidim/current_feature.rb
+++ b/decidim-core/app/constraints/decidim/current_feature.rb
@@ -19,13 +19,12 @@ module Decidim
     # Returns a true if the request matched, false otherwise
     def matches?(request)
       env = request.env
-      params = request.params
 
       return false unless CurrentParticipatoryProcess.new.matches?(request)
 
       @participatory_process = env["decidim.current_participatory_process"]
 
-      feature = detect_current_feature(params)
+      feature = detect_current_feature(request.params)
 
       return false unless feature
 

--- a/decidim-core/app/constraints/decidim/current_participatory_process.rb
+++ b/decidim-core/app/constraints/decidim/current_participatory_process.rb
@@ -17,15 +17,15 @@ module Decidim
 
       @organization = env["decidim.current_organization"]
 
-      participatory_process = env["decidim.current_participatory_process"] ||
-                              detect_current_participatory_process(request.params)
-
-      env["decidim.current_participatory_process"] ||= participatory_process
-
-      participatory_process ? true : false
+      current_participatory_process(env, request.params) ? true : false
     end
 
     private
+
+    def current_participatory_process(env, params)
+      env["decidim.current_participatory_process"] ||=
+        detect_current_participatory_process(params)
+    end
 
     def detect_current_participatory_process(params)
       @organization.participatory_processes.find_by_id(params["participatory_process_id"])

--- a/decidim-core/app/constraints/decidim/current_participatory_process.rb
+++ b/decidim-core/app/constraints/decidim/current_participatory_process.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This class infers the current participatory process we're scoped to by
+  # looking at the request parameters and the organization in the request
+  # environment, and injects it into the environment.
+  class CurrentParticipatoryProcess
+    # Public: Matches the request against a participatory process and injects it
+    #         into the environment.
+    #
+    # request - The request that holds the participatory process relevant
+    #           information.
+    #
+    # Returns a true if the request matched, false otherwise
+    def matches?(request)
+      env = request.env
+
+      @organization = env["decidim.current_organization"]
+
+      participatory_process = env["decidim.current_participatory_process"] ||
+                              detect_current_participatory_process(request.params)
+
+      env["decidim.current_participatory_process"] ||= participatory_process
+
+      participatory_process ? true : false
+    end
+
+    private
+
+    def detect_current_participatory_process(params)
+      @organization.participatory_processes.find_by_id(params["participatory_process_id"])
+    end
+  end
+end

--- a/decidim-core/spec/lib/features/current_feature_spec.rb
+++ b/decidim-core/spec/lib/features/current_feature_spec.rb
@@ -60,6 +60,28 @@ module Decidim
         end
       end
 
+      context "when the params contain a non existing participatory process id" do
+        before do
+          params["participatory_process_id"] = "99999999"
+        end
+
+        context "when there's no feature" do
+          it "doesn't match" do
+            expect(subject.matches?(request)).to eq(false)
+          end
+        end
+
+        context "when there's feature" do
+          before do
+            params["feature_id"] = "1"
+          end
+
+          it "doesn't match" do
+            expect(subject.matches?(request)).to eq(false)
+          end
+        end
+      end
+
       context "when the params doesn't contain a participatory process id" do
         it "doesn't match" do
           expect(subject.matches?(request)).to eq(false)


### PR DESCRIPTION
#### :tophat: What? Why?

Fixes a crash for URLs of the form /processes/99999999/f/1, where 99999999 is a non existing participatory process id. If you've seen this crash in your servers, it was me :stuck_out_tongue:.

Since I was there, I refactored the route constraints a bit. The refactoring logic is easier to review "commit per commit", I think.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![funny-dog-dancing-samba](https://user-images.githubusercontent.com/2887858/27347221-19483f58-55f0-11e7-9234-218a3d1c2a55.gif)