### PR TITLE
Add statistics to individual participatory processes.

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/update_participatory_process.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_participatory_process.rb
@@ -63,7 +63,8 @@ module Decidim
           participatory_structure: form.participatory_structure,
           meta_scope: form.meta_scope,
           end_date: form.end_date,
-          participatory_process_group: form.participatory_process_group
+          participatory_process_group: form.participatory_process_group,
+          show_statistics: form.show_statistics
         }
       end
     end

--- a/decidim-admin/app/forms/decidim/admin/participatory_process_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_process_form.rb
@@ -32,7 +32,7 @@ module Decidim
       attribute :remove_banner_image
       attribute :participatory_process_group_id, Integer
       attribute :show_statistics, Boolean
-      
+
       validates :slug, presence: true
       validates :title, :subtitle, :description, :short_description, translatable_presence: true
       validates :scope, presence: true, if: proc { |object| object.scope_id.present? }

--- a/decidim-admin/app/forms/decidim/admin/participatory_process_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_process_form.rb
@@ -31,7 +31,8 @@ module Decidim
       attribute :banner_image
       attribute :remove_banner_image
       attribute :participatory_process_group_id, Integer
-
+      attribute :show_statistics, Boolean
+      
       validates :slug, presence: true
       validates :title, :subtitle, :description, :short_description, translatable_presence: true
       validates :scope, presence: true, if: proc { |object| object.scope_id.present? }

--- a/decidim-admin/app/views/decidim/admin/participatory_processes/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_processes/_form.html.erb
@@ -88,5 +88,9 @@
         <%= form.select :participatory_process_group_id, process_groups_for_select, prompt: I18n.t("decidim.participatory_processes.participatory_process_groups.none") %>
       <% end %>
     </div>
+
+    <div class="row column">
+      <%= form.check_box :show_statistics %>
+    </div>
   </div>
 </div>

--- a/decidim-admin/spec/commands/update_participatory_process_spec.rb
+++ b/decidim-admin/spec/commands/update_participatory_process_spec.rb
@@ -33,7 +33,8 @@ module Decidim
               current_organization: my_process.organization,
               scope: my_process.scope,
               errors: my_process.errors,
-              participatory_process_group: my_process.participatory_process_group
+              participatory_process_group: my_process.participatory_process_group,
+              show_statistics: my_process.show_statistics
             }
           }
         end

--- a/decidim-admin/spec/forms/participatory_process_form_spec.rb
+++ b/decidim-admin/spec/forms/participatory_process_form_spec.rb
@@ -36,6 +36,7 @@ module Decidim
       end
       let(:slug) { "slug" }
       let(:attachment) { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
+      let(:show_statistics) { true }
       let(:attributes) do
         {
           "participatory_process" => {
@@ -53,7 +54,8 @@ module Decidim
             "short_description_ca" => short_description[:ca],
             "hero_image" => attachment,
             "banner_image" => attachment,
-            "slug" => slug
+            "slug" => slug,
+            "show_statistics" => show_statistics
           }
         }
       end

--- a/decidim-budgets/lib/decidim/budgets/feature.rb
+++ b/decidim-budgets/lib/decidim/budgets/feature.rb
@@ -19,20 +19,20 @@ Decidim.register_feature(:budgets) do |feature|
     resource.template = "decidim/budgets/projects/linked_projects"
   end
 
-  feature.register_stat :projects_count, primary: true do |features, start_at, end_at|
+  feature.register_stat :projects_count, primary: true, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |features, start_at, end_at|
     Decidim::Budgets::FilteredProjects.for(features, start_at, end_at).count
+  end
+
+  feature.register_stat :orders_count, priority: Decidim::StatsRegistry::MEDIUM_PRIORITY do |features, start_at, end_at|
+    orders = Decidim::Budgets::Order.where(feature: features)
+    orders = orders.where("created_at >= ?", start_at) if start_at.present?
+    orders = orders.where("created_at <= ?", end_at) if end_at.present?
+    orders.count
   end
 
   feature.register_stat :comments_count, tag: :comments do |features, start_at, end_at|
     projects = Decidim::Budgets::FilteredProjects.for(features, start_at, end_at)
     Decidim::Comments::Comment.where(root_commentable: projects).count
-  end
-
-  feature.register_stat :orders_count, primary: true do |features, start_at, end_at|
-    orders = Decidim::Budgets::Order.where(feature: features)
-    orders = orders.where("created_at >= ?", start_at) if start_at.present?
-    orders = orders.where("created_at <= ?", end_at) if end_at.present?
-    orders.count
   end
 
   feature.settings(:global) do |settings|

--- a/decidim-budgets/lib/decidim/budgets/feature.rb
+++ b/decidim-budgets/lib/decidim/budgets/feature.rb
@@ -23,7 +23,7 @@ Decidim.register_feature(:budgets) do |feature|
     Decidim::Budgets::FilteredProjects.for(features, start_at, end_at).count
   end
 
-  feature.register_stat :orders_count, priority: Decidim::StatsRegistry::MEDIUM_PRIORITY do |features, start_at, end_at|
+  feature.register_stat :orders_count do |features, start_at, end_at|
     orders = Decidim::Budgets::Order.where(feature: features)
     orders = orders.where("created_at >= ?", start_at) if start_at.present?
     orders = orders.where("created_at <= ?", end_at) if end_at.present?

--- a/decidim-budgets/lib/decidim/budgets/feature.rb
+++ b/decidim-budgets/lib/decidim/budgets/feature.rb
@@ -28,6 +28,13 @@ Decidim.register_feature(:budgets) do |feature|
     Decidim::Comments::Comment.where(root_commentable: projects).count
   end
 
+  feature.register_stat :orders_count, primary: true do |features, start_at, end_at|
+    orders = Decidim::Budgets::Order.where(feature: features)
+    orders = orders.where("created_at >= ?", start_at) if start_at.present?
+    orders = orders.where("created_at <= ?", end_at) if end_at.present?
+    orders.count
+  end
+
   feature.settings(:global) do |settings|
     settings.attribute :total_budget, type: :integer, default: 100_000_000
     settings.attribute :vote_threshold_percent, type: :integer, default: 70

--- a/decidim-core/app/assets/stylesheets/decidim/extras/_process_stats.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/extras/_process_stats.scss
@@ -1,0 +1,29 @@
+#participatory_process-statistics{
+  margin-bottom: 1.5rem;
+}
+
+.process_stats{
+  padding: 0;
+  .process_stats-item{
+    width: 33%;
+    display: inline-block;
+    padding: 1em;
+    border: $border;
+    background: $white;
+    .icon {
+      width: 1.5em;
+      height: 1.5em;
+      color: #599aa6;
+      vertical-align: middle;
+      margin-right: 0.5rem;
+    }
+    .process_stats-text{
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      font-size: 90%;
+      color: #3D393C;
+      font-weight: 600;
+      line-height: 1;
+    }
+  }
+}

--- a/decidim-core/app/assets/stylesheets/decidim/extras/_process_stats.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/extras/_process_stats.scss
@@ -5,7 +5,16 @@
 .process_stats{
   padding: 0;
   .process_stats-item{
-    width: 33%;
+    width: 33.3%;
+    @include breakpoint(large down){
+      width: 33.3%;
+    }
+    @include breakpoint(medium down){
+      width: 49.9%;
+    }
+    @include breakpoint(smallmedium down){
+      width: 100%;
+    }
     display: inline-block;
     padding: 1em;
     border: $border;

--- a/decidim-core/app/assets/stylesheets/decidim/layouts/_home.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/layouts/_home.scss
@@ -91,7 +91,7 @@
 .subhero{
   padding: 4rem 0;
   text-align: center;
-  
+
   .heading3{
     @include breakpoint(medium down){
       font-size: 1.3em;
@@ -202,7 +202,7 @@
       border-bottom: $border;
       border-right: $border;
     }
-    
+
     &:last-child{
       border-right: none;
     }

--- a/decidim-core/app/controllers/decidim/participatory_processes_controller.rb
+++ b/decidim-core/app/controllers/decidim/participatory_processes_controller.rb
@@ -15,7 +15,7 @@ module Decidim
     helper Decidim::IconHelper
     helper Decidim::WidgetUrlsHelper
 
-    helper_method :collection, :promoted_participatory_processes, :participatory_processes
+    helper_method :collection, :promoted_participatory_processes, :participatory_processes, :stats
 
     def index
       authorize! :read, ParticipatoryProcess
@@ -42,6 +42,10 @@ module Decidim
 
     def participatory_process_groups
       @process_groups ||= Decidim::ParticipatoryProcessGroup.where(organization: current_organization)
+    end
+
+    def stats
+      @stats ||= ParticipatoryProcessStatsPresenter.new(participatory_process: current_participatory_process)
     end
   end
 end

--- a/decidim-core/app/helpers/decidim/participatory_process_helper.rb
+++ b/decidim-core/app/helpers/decidim/participatory_process_helper.rb
@@ -13,5 +13,29 @@ module Decidim
       dates = [participatory_process_step.start_date, participatory_process_step.end_date]
       dates.map { |date| date ? localize(date.to_date, format: :default) : "?" }.join(" - ")
     end
+
+    # Public: Returns an icon given an instance of a Feature. It defaults to
+    # a question mark when no icon is found.
+    #
+    # feature - The feature to generate the icon for.
+    #
+    # Returns an HTML tag with the icon.
+    def feature_icon(feature)
+      feature_manifest_icon(feature.manifest)
+    end
+
+    # Public: Returns an icon given an instance of a Feature Manifest. It defaults to
+    # a question mark when no icon is found.
+    #
+    # feature_manifest - The feature manifest to generate the icon for.
+    #
+    # Returns an HTML tag with the icon.
+    def feature_manifest_icon(feature_manifest)
+      if feature_manifest.icon
+        external_icon feature_manifest.icon
+      else
+        icon "question-mark"
+      end
+    end
   end
 end

--- a/decidim-core/app/presenters/decidim/home_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/home_stats_presenter.rb
@@ -32,7 +32,7 @@ module Decidim
       not_highlighted_stats = not_highlighted_stats.reject(&:empty?)
 
       safe_join(
-        not_highlighted_stats.in_groups_of(3, false).map do |stats|
+        not_highlighted_stats.in_groups_of(3, [:empty]).map do |stats|
           content_tag :div, class: "home-pam__lowlight" do
             safe_join(
               stats.map do |name, data|
@@ -61,10 +61,14 @@ module Decidim
 
     def render_stats_data(name, data)
       content_tag :div, "", class: "home-pam__data" do
-        safe_join([
-                    content_tag(:h4, I18n.t(name, scope: "pages.home.statistics"), class: "home-pam__title"),
-                    content_tag(:span, " #{number_with_delimiter(data)}", class: "home-pam__number #{name}")
-                  ])
+        if name == :empty
+          "&nbsp;".html_safe
+        else
+          safe_join([
+                      content_tag(:h4, I18n.t(name, scope: "pages.home.statistics"), class: "home-pam__title"),
+                      content_tag(:span, " #{number_with_delimiter(data)}", class: "home-pam__number #{name}")
+                    ])
+        end
       end
     end
 

--- a/decidim-core/app/presenters/decidim/home_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/home_stats_presenter.rb
@@ -11,7 +11,7 @@ module Decidim
       highlighted_stats = highlighted_stats.concat(global_stats(priority: StatsRegistry::HIGH_PRIORITY))
       highlighted_stats = highlighted_stats.concat(feature_stats(priority: StatsRegistry::HIGH_PRIORITY))
       highlighted_stats = highlighted_stats.reject(&:empty?)
-      highlighted_stats = highlighted_stats.reject { |name, data| data.zero? }
+      highlighted_stats = highlighted_stats.reject { |_name, data| data.zero? }
 
       safe_join(
         highlighted_stats.in_groups_of(2, false).map do |stats|
@@ -31,7 +31,7 @@ module Decidim
       not_highlighted_stats = global_stats(priority: StatsRegistry::MEDIUM_PRIORITY)
       not_highlighted_stats = not_highlighted_stats.concat(feature_stats(priority: StatsRegistry::MEDIUM_PRIORITY))
       not_highlighted_stats = not_highlighted_stats.reject(&:empty?)
-      not_highlighted_stats = not_highlighted_stats.reject { |name, data| data.zero? }
+      not_highlighted_stats = not_highlighted_stats.reject { |_name, data| data.zero? }
 
       safe_join(
         not_highlighted_stats.in_groups_of(3, [:empty]).map do |stats|

--- a/decidim-core/app/presenters/decidim/home_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/home_stats_presenter.rb
@@ -11,6 +11,7 @@ module Decidim
       highlighted_stats = highlighted_stats.concat(global_stats(priority: StatsRegistry::HIGH_PRIORITY))
       highlighted_stats = highlighted_stats.concat(feature_stats(priority: StatsRegistry::HIGH_PRIORITY))
       highlighted_stats = highlighted_stats.reject(&:empty?)
+      highlighted_stats = highlighted_stats.reject { |name, data| data.zero? }
 
       safe_join(
         highlighted_stats.in_groups_of(2, false).map do |stats|
@@ -30,6 +31,7 @@ module Decidim
       not_highlighted_stats = global_stats(priority: StatsRegistry::MEDIUM_PRIORITY)
       not_highlighted_stats = not_highlighted_stats.concat(feature_stats(priority: StatsRegistry::MEDIUM_PRIORITY))
       not_highlighted_stats = not_highlighted_stats.reject(&:empty?)
+      not_highlighted_stats = not_highlighted_stats.reject { |name, data| data.zero? }
 
       safe_join(
         not_highlighted_stats.in_groups_of(3, [:empty]).map do |stats|
@@ -73,7 +75,7 @@ module Decidim
     end
 
     def published_features
-      @published_features ||= Feature.where(participatory_process: organization.participatory_processes.published)
+      @published_features ||= Feature.where(participatory_process: organization.participatory_processes.published).published
     end
   end
 end

--- a/decidim-core/app/presenters/decidim/participatory_process_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/participatory_process_stats_presenter.rb
@@ -11,8 +11,7 @@ module Decidim
       highlighted_stats = feature_stats(priority: StatsRegistry::HIGH_PRIORITY)
       highlighted_stats = highlighted_stats.concat(feature_stats(priority: StatsRegistry::MEDIUM_PRIORITY))
       highlighted_stats = highlighted_stats.reject(&:empty?)
-
-      grouped_highlighted_stats = highlighted_stats.group_by { |stats| stats.first.name } # hash
+      grouped_highlighted_stats = highlighted_stats.group_by { |stats| stats.first.name }
 
       safe_join(
         grouped_highlighted_stats.map do |manifest_name, stats|
@@ -36,12 +35,10 @@ module Decidim
     end
 
     def render_stats_data(feature_manifest, name, data, index)
-      content_tag :span, "", class: "" do
         safe_join([
                     index == 0 ? feature_manifest_icon(feature_manifest) : " /&nbsp".html_safe,
                     content_tag(:span, "#{number_with_delimiter(data)} " + I18n.t("#{name}", scope: "decidim.participatory_processes.statistics"), class: "#{name} process_stats-text")
                   ])
-      end
     end
 
     def published_features

--- a/decidim-core/app/presenters/decidim/participatory_process_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/participatory_process_stats_presenter.rb
@@ -11,6 +11,7 @@ module Decidim
       highlighted_stats = feature_stats(priority: StatsRegistry::HIGH_PRIORITY)
       highlighted_stats = highlighted_stats.concat(feature_stats(priority: StatsRegistry::MEDIUM_PRIORITY))
       highlighted_stats = highlighted_stats.reject(&:empty?)
+      highlighted_stats = highlighted_stats.reject { |manifest, name, data| data.zero? }
       grouped_highlighted_stats = highlighted_stats.group_by { |stats| stats.first.name }
 
       safe_join(
@@ -37,13 +38,13 @@ module Decidim
     def render_stats_data(feature_manifest, name, data, index)
       safe_join([
                   index.zero? ? feature_manifest_icon(feature_manifest) : " /&nbsp".html_safe,
-                  content_tag(:span, "#{number_with_delimiter(data)} " + I18n.t(name.to_s, scope: "decidim.participatory_processes.statistics"),
+                  content_tag(:span, "#{number_with_delimiter(data)} " + I18n.t(name, scope: "decidim.participatory_processes.statistics"),
                   class: "#{name} process_stats-text")
                 ])
     end
 
     def published_features
-      @published_features ||= Feature.where(participatory_process: participatory_process)
+      @published_features ||= Feature.where(participatory_process: participatory_process).published
     end
   end
 end

--- a/decidim-core/app/presenters/decidim/participatory_process_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/participatory_process_stats_presenter.rb
@@ -8,12 +8,29 @@ module Decidim
     # Public: Render a collection of primary stats.
     def highlighted
       highlighted_stats = Decidim.stats.only([:comments_count]).with_context(published_features).map { |name, data| [:global, name, data] }
-      highlighted_stats = highlighted_stats.concat(feature_stats)
+      highlighted_stats = highlighted_stats.concat(feature_stats(feature_stats_list))
       highlighted_stats = highlighted_stats.reject(&:empty?)
 
       safe_join(
-        highlighted_stats.in_groups_of(2, false).map do |stats|
-          content_tag :div, class: "column small-3" do
+        highlighted_stats.in_groups_of(4, false).map do |stats|
+          content_tag :div, class: "home-pam__highlight" do
+            safe_join(
+              stats.map do |scope, name, data|
+                render_stats_data(scope, name, data)
+              end
+            )
+          end
+        end
+      )
+    end
+
+    def not_highlighted
+      not_highlighted_stats = feature_stats(stats_list)
+      not_highlighted_stats = not_highlighted_stats.reject(&:empty?)
+
+      safe_join(
+        not_highlighted_stats.in_groups_of(4, false).map do |stats|
+          content_tag :div, class: "home-pam__lowlight" do
             safe_join(
               stats.map do |scope, name, data|
                 render_stats_data(scope, name, data)
@@ -26,7 +43,7 @@ module Decidim
 
     private
 
-    def which_stats
+    def feature_stats_list
       {
         :proposals => [:proposals_count],
         :meetings => [:meetings_count],
@@ -36,20 +53,29 @@ module Decidim
       }
     end
 
-    def feature_stats
-      Decidim.feature_manifests.to_a.select { |feature| which_stats.keys.include? feature.name }.map do |feature|
+    def stats_list
+      {
+        :proposals => [:comments_count],
+        :meetings => [:comments_count],
+        :pages => [:comments_count],
+        :results => [:comments_count]
+      }
+    end
+
+    def feature_stats(list)
+      Decidim.feature_manifests.to_a.select { |feature| list.keys.include? feature.name }.map do |feature|
         feature.stats
-          .only(which_stats[feature.name])
+          .only(list[feature.name])
           .with_context(published_features)
           .map { |name, data| [feature.name, name, data] }
       end.flatten(1)
     end
 
     def render_stats_data(scope, name, data)
-      content_tag :div, "", class: "card" do
+      content_tag :div, "", class: "home-pam__data" do
         safe_join([
-                    content_tag(:h1, "#{number_with_delimiter(data)} ", class: "#{scope} #{name} text-center"),
-                    content_tag(:p, I18n.t("#{scope}.#{name}", scope: "decidim.participatory_processes.statistics"), class: "text-center card-divider")
+                    content_tag(:h4, I18n.t("#{scope}.#{name}", scope: "decidim.participatory_processes.statistics"), class: "text-center home-pam__title"),
+                    content_tag(:span, " #{number_with_delimiter(data)} ", class: "#{scope} #{name} home-pam__number")
                   ])
       end
     end

--- a/decidim-core/app/presenters/decidim/participatory_process_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/participatory_process_stats_presenter.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Decidim
+  # A presenter to render statistics in the homepage.
+  class ParticipatoryProcessStatsPresenter < Rectify::Presenter
+    attribute :participatory_process, Decidim::ParticipatoryProcess
+
+    # Public: Render a collection of primary stats.
+    def highlighted
+      highlighted_stats = Decidim.stats.only([:comments_count]).with_context(published_features).map { |name, data| [:global, name, data] }
+      highlighted_stats = highlighted_stats.concat(feature_stats)
+      highlighted_stats = highlighted_stats.reject(&:empty?)
+
+      safe_join(
+        highlighted_stats.in_groups_of(2, false).map do |stats|
+          content_tag :div, class: "home-pam__highlight" do
+            safe_join(
+              stats.map do |scope, name, data|
+                render_stats_data(scope, name, data)
+              end
+            )
+          end
+        end
+      )
+    end
+
+    private
+
+    def which_stats
+      {
+        :proposals => [:proposals_count],
+        :meetings => [:meetings_count],
+        :budgets => [:projects_count, :orders_count],
+        :pages => [:pages_count],
+        :surveys => [:surveys_count, :answers_count]
+      }
+    end
+
+    def feature_stats
+      Decidim.feature_manifests.to_a.select { |feature| which_stats.keys.include? feature.name }.map do |feature|
+        feature.stats
+          .only(which_stats[feature.name])
+          .with_context(published_features)
+          .map { |name, data| [feature.name, name, data] }
+      end.flatten(1)
+    end
+
+    def render_stats_data(scope, name, data)
+      content_tag :div, "", class: "home-pam__data" do
+        safe_join([
+                    content_tag(:h4, I18n.t("#{scope}.#{name}", scope: "decidim.participatory_processes.statistics"), class: "home-pam__title"),
+                    content_tag(:span, " #{number_with_delimiter(data)}", class: "home-pam__number #{scope} #{name}")
+                  ])
+      end
+    end
+
+    def published_features
+      @published_features ||= Feature.where(participatory_process: participatory_process)
+    end
+  end
+end

--- a/decidim-core/app/presenters/decidim/participatory_process_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/participatory_process_stats_presenter.rb
@@ -36,7 +36,7 @@ module Decidim
 
     def render_stats_data(feature_manifest, name, data, index)
       safe_join([
-                  index.zero? feature_manifest_icon(feature_manifest) : " /&nbsp".html_safe,
+                  index.zero? ? feature_manifest_icon(feature_manifest) : " /&nbsp".html_safe,
                   content_tag(:span, "#{number_with_delimiter(data)} " + I18n.t(name.to_s, scope: "decidim.participatory_processes.statistics"),
                   class: "#{name} process_stats-text")
                 ])

--- a/decidim-core/app/presenters/decidim/participatory_process_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/participatory_process_stats_presenter.rb
@@ -11,7 +11,7 @@ module Decidim
       highlighted_stats = feature_stats(priority: StatsRegistry::HIGH_PRIORITY)
       highlighted_stats = highlighted_stats.concat(feature_stats(priority: StatsRegistry::MEDIUM_PRIORITY))
       highlighted_stats = highlighted_stats.reject(&:empty?)
-      highlighted_stats = highlighted_stats.reject { |manifest, name, data| data.zero? }
+      highlighted_stats = highlighted_stats.reject { |_manifest, _name, data| data.zero? }
       grouped_highlighted_stats = highlighted_stats.group_by { |stats| stats.first.name }
 
       safe_join(
@@ -39,7 +39,7 @@ module Decidim
       safe_join([
                   index.zero? ? feature_manifest_icon(feature_manifest) : " /&nbsp".html_safe,
                   content_tag(:span, "#{number_with_delimiter(data)} " + I18n.t(name, scope: "decidim.participatory_processes.statistics"),
-                  class: "#{name} process_stats-text")
+                              class: "#{name} process_stats-text")
                 ])
     end
 

--- a/decidim-core/app/presenters/decidim/participatory_process_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/participatory_process_stats_presenter.rb
@@ -36,8 +36,9 @@ module Decidim
 
     def render_stats_data(feature_manifest, name, data, index)
       safe_join([
-                  index == 0 ? feature_manifest_icon(feature_manifest) : " /&nbsp".html_safe,
-                  content_tag(:span, "#{number_with_delimiter(data)} " + I18n.t(name.to_s, scope: "decidim.participatory_processes.statistics"), class: "#{name} process_stats-text")
+                  index.zero? feature_manifest_icon(feature_manifest) : " /&nbsp".html_safe,
+                  content_tag(:span, "#{number_with_delimiter(data)} " + I18n.t(name.to_s, scope: "decidim.participatory_processes.statistics"),
+                  class: "#{name} process_stats-text")
                 ])
     end
 

--- a/decidim-core/app/presenters/decidim/participatory_process_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/participatory_process_stats_presenter.rb
@@ -13,7 +13,7 @@ module Decidim
 
       safe_join(
         highlighted_stats.in_groups_of(2, false).map do |stats|
-          content_tag :div, class: "home-pam__highlight" do
+          content_tag :div, class: "column small-3" do
             safe_join(
               stats.map do |scope, name, data|
                 render_stats_data(scope, name, data)
@@ -46,10 +46,10 @@ module Decidim
     end
 
     def render_stats_data(scope, name, data)
-      content_tag :div, "", class: "home-pam__data" do
+      content_tag :div, "", class: "card" do
         safe_join([
-                    content_tag(:h4, I18n.t("#{scope}.#{name}", scope: "decidim.participatory_processes.statistics"), class: "home-pam__title"),
-                    content_tag(:span, " #{number_with_delimiter(data)}", class: "home-pam__number #{scope} #{name}")
+                    content_tag(:h1, "#{number_with_delimiter(data)} ", class: "#{scope} #{name} text-center"),
+                    content_tag(:p, I18n.t("#{scope}.#{name}", scope: "decidim.participatory_processes.statistics"), class: "text-center card-divider")
                   ])
       end
     end

--- a/decidim-core/app/presenters/decidim/participatory_process_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/participatory_process_stats_presenter.rb
@@ -14,7 +14,7 @@ module Decidim
       grouped_highlighted_stats = highlighted_stats.group_by { |stats| stats.first.name }
 
       safe_join(
-        grouped_highlighted_stats.map do |manifest_name, stats|
+        grouped_highlighted_stats.map do |_manifest_name, stats|
           content_tag :div, class: "process_stats-item" do
             safe_join(
               stats.each_with_index.map do |stat, index|
@@ -35,10 +35,10 @@ module Decidim
     end
 
     def render_stats_data(feature_manifest, name, data, index)
-        safe_join([
-                    index == 0 ? feature_manifest_icon(feature_manifest) : " /&nbsp".html_safe,
-                    content_tag(:span, "#{number_with_delimiter(data)} " + I18n.t("#{name}", scope: "decidim.participatory_processes.statistics"), class: "#{name} process_stats-text")
-                  ])
+      safe_join([
+                  index == 0 ? feature_manifest_icon(feature_manifest) : " /&nbsp".html_safe,
+                  content_tag(:span, "#{number_with_delimiter(data)} " + I18n.t(name.to_s, scope: "decidim.participatory_processes.statistics"), class: "#{name} process_stats-text")
+                ])
     end
 
     def published_features

--- a/decidim-core/app/views/decidim/application/_attachments.html.erb
+++ b/decidim-core/app/views/decidim/application/_attachments.html.erb
@@ -1,6 +1,6 @@
 <% if attached_to.attachments.any? %>
   <div class="row attachments">
-    <div class="columns large-8">
+    <div class="columns large-12">
       <%= render partial: "documents", locals: { documents: attached_to.documents } %>
       <%= render partial: "photos", locals: { photos: attached_to.photos } %>
     </div>

--- a/decidim-core/app/views/decidim/participatory_processes/_statistics.html.erb
+++ b/decidim-core/app/views/decidim/participatory_processes/_statistics.html.erb
@@ -1,11 +1,10 @@
-<section class="extended" id="statistics">
+<section class="extended" id="participatory_process-statistics statistics">
   <div class="row column">
     <h4 class="section-heading"><%= t(".headline", participatory_process: translated_attribute(current_participatory_process.title)) %></h3>
   </div>
-  <br>
   <div class="row">
-    <%= stats.highlighted %>
-    <%= stats.not_highlighted %>
-
+    <div class="columns small-centered mediumlarge-12 large-12 process_stats">
+      <%= stats.highlighted %>
+    </div>
   </div>
 </section>

--- a/decidim-core/app/views/decidim/participatory_processes/_statistics.html.erb
+++ b/decidim-core/app/views/decidim/participatory_processes/_statistics.html.erb
@@ -5,5 +5,7 @@
   <br>
   <div class="row">
     <%= stats.highlighted %>
+    <%= stats.not_highlighted %>
+
   </div>
 </section>

--- a/decidim-core/app/views/decidim/participatory_processes/_statistics.html.erb
+++ b/decidim-core/app/views/decidim/participatory_processes/_statistics.html.erb
@@ -1,0 +1,12 @@
+<section class="extended" id="statistics">
+  <div class="row column text-center">
+    <h3 class="heading3"><%= t(".headline", participatory_process: translated_attribute(current_participatory_process.title)) %></h3>
+  </div>
+  <div class="row">
+    <div class="columns large-12">
+      <div class="home-pam">
+        <%= stats.highlighted %>
+      </div>
+    </div>
+  </div>
+</section>

--- a/decidim-core/app/views/decidim/participatory_processes/_statistics.html.erb
+++ b/decidim-core/app/views/decidim/participatory_processes/_statistics.html.erb
@@ -1,4 +1,4 @@
-<section class="extended" id="participatory_process-statistics statistics">
+<section class="extended" id="participatory_process-statistics" class="statistics">
   <div class="row column">
     <h4 class="section-heading"><%= t(".headline", participatory_process: translated_attribute(current_participatory_process.title)) %></h3>
   </div>

--- a/decidim-core/app/views/decidim/participatory_processes/_statistics.html.erb
+++ b/decidim-core/app/views/decidim/participatory_processes/_statistics.html.erb
@@ -1,12 +1,9 @@
 <section class="extended" id="statistics">
-  <div class="row column text-center">
-    <h3 class="heading3"><%= t(".headline", participatory_process: translated_attribute(current_participatory_process.title)) %></h3>
+  <div class="row column">
+    <h4 class="section-heading"><%= t(".headline", participatory_process: translated_attribute(current_participatory_process.title)) %></h3>
   </div>
+  <br>
   <div class="row">
-    <div class="columns large-12">
-      <div class="home-pam">
-        <%= stats.highlighted %>
-      </div>
-    </div>
+    <%= stats.highlighted %>
   </div>
 </section>

--- a/decidim-core/app/views/decidim/participatory_processes/show.html.erb
+++ b/decidim-core/app/views/decidim/participatory_processes/show.html.erb
@@ -72,7 +72,6 @@
       <%= embed_modal_for participatory_process_participatory_process_widget_url(current_participatory_process, format: :js) %>
     </div>
   </div>
-  
   <%= render partial: 'statistics' %>
 </div>
 

--- a/decidim-core/app/views/decidim/participatory_processes/show.html.erb
+++ b/decidim-core/app/views/decidim/participatory_processes/show.html.erb
@@ -72,7 +72,9 @@
       <%= embed_modal_for participatory_process_participatory_process_widget_url(current_participatory_process, format: :js) %>
     </div>
   </div>
-  <%= render partial: 'statistics' %>
+  <% if current_participatory_process.show_statistics? %>
+    <%= render partial: 'statistics' %>
+  <% end %>
 </div>
 
 <%= javascript_include_tag "decidim/proposals/social_share" %>

--- a/decidim-core/app/views/decidim/participatory_processes/show.html.erb
+++ b/decidim-core/app/views/decidim/participatory_processes/show.html.erb
@@ -15,6 +15,7 @@
         </div>
         <%== translated_attribute(current_participatory_process.description) %>
       </div>
+      <%= attachments_for current_participatory_process %>
     </div>
     <div class="section columns medium-5 mediumlarge-4 large-3">
       <div class="card extra definition-data">
@@ -67,17 +68,12 @@
           </div>
         <% end %>
       </div>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="columns section view-side mediumlarge-4 mediumlarge-push-8 large-3 large-push-9">
       <%= render partial: "decidim/shared/share_modal" %>
       <%= embed_modal_for participatory_process_participatory_process_widget_url(current_participatory_process, format: :js) %>
     </div>
   </div>
-
-  <%= attachments_for current_participatory_process %>
+  
+  <%= render partial: 'statistics' %>
 </div>
 
 <%= javascript_include_tag "decidim/proposals/social_share" %>

--- a/decidim-core/config/i18n-tasks.yml
+++ b/decidim-core/config/i18n-tasks.yml
@@ -105,8 +105,8 @@ ignore_unused:
   - decidim.participatory_processes.scopes.global
   - decidim.participatory_processes.participatory_process_groups.none
   - pages.home.statistics.*
+  - decidim.participatory_processes.statistics.*
   - forms.*
-
 # - 'activerecord.attributes.*'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -207,17 +207,17 @@ en:
         scope: Scope
         target: Target
       statistics:
-          comments_count: Proposals comments
-          orders_count: Orders
-          projects_count: Projects
-          headline: Activity
-          meetings_count: Meetings
-          pages_count: Pages
-          proposals_count: Proposals
-          votes_count: Votes
-          results_count: Results
-          answers_count: Answers
-          surveys_count: Surveys
+        answers_count: Answers
+        comments_count: Proposals comments
+        headline: Activity
+        meetings_count: Meetings
+        orders_count: Orders
+        pages_count: Pages
+        projects_count: Projects
+        proposals_count: Proposals
+        results_count: Results
+        surveys_count: Surveys
+        votes_count: Votes
     reported_mailer:
       hide:
         hello: Hello %{name},

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -207,17 +207,7 @@ en:
         scope: Scope
         target: Target
       statistics:
-        answers_count: Answers
-        comments_count: Proposals comments
         headline: Activity
-        meetings_count: Meetings
-        orders_count: Orders
-        pages_count: Pages
-        projects_count: Projects
-        proposals_count: Proposals
-        results_count: Results
-        surveys_count: Surveys
-        votes_count: Votes
     reported_mailer:
       hide:
         hello: Hello %{name},

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -217,8 +217,6 @@ en:
         results:
           results_count: Results
           comments_count: Results comments
-        pages:
-          comments_count: Pages comments
         meetings:
           meetings_count: Meetings
         budgets:
@@ -227,6 +225,7 @@ en:
           orders_count: Orders
         pages:
           pages_count: Pages
+          comments_count: Pages comments
         surveys:
           surveys_count: Surveys
           answers_count: Answers

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -207,7 +207,19 @@ en:
         scope: Scope
         target: Target
       statistics:
+        answers_count: Answers
+        comments_count: Comments
         headline: Activity
+        meetings_count: Meetings
+        orders_count: Orders
+        pages_count: Pages
+        processes_count: Processes
+        projects_count: Projects
+        proposals_count: Proposals
+        results_count: Results
+        surveys_count: Surveys
+        users_count: Participants
+        votes_count: Votes
     reported_mailer:
       hide:
         hello: Hello %{name},

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -206,6 +206,30 @@ en:
         participatory_structure: Participatory structure
         scope: Scope
         target: Target
+      statistics:
+        headline: Current state of %{participatory_process}
+        global:
+          comments_count: Comments
+        proposals:
+          proposals_count: Proposals
+          votes_count: Proposals votes
+          comments_count: Proposals comments
+        results:
+          results_count: Results
+          comments_count: Results comments
+        pages:
+          comments_count: Pages comments
+        meetings:
+          meetings_count: Meetings
+        budgets:
+          projects_count: Projects
+          comments_count: Proposals comments
+          orders_count: Orders
+        pages:
+          pages_count: Pages
+        surveys:
+          surveys_count: Surveys
+          answers_count: Answers
     reported_mailer:
       hide:
         hello: Hello %{name},

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -207,28 +207,17 @@ en:
         scope: Scope
         target: Target
       statistics:
-        headline: Current state of "%{participatory_process}"
-        global:
-          comments_count: Comments
-        proposals:
-          proposals_count: Proposals
-          votes_count: Proposals votes
-          comments_count: Proposals comments
-        results:
-          results_count: Results
-          comments_count: Results comments
-        meetings:
-          meetings_count: Meetings
-        budgets:
-          projects_count: Projects
           comments_count: Proposals comments
           orders_count: Orders
-        pages:
+          projects_count: Projects
+          headline: Activity
+          meetings_count: Meetings
           pages_count: Pages
-          comments_count: Pages comments
-        surveys:
-          surveys_count: Surveys
+          proposals_count: Proposals
+          votes_count: Votes
+          results_count: Results
           answers_count: Answers
+          surveys_count: Surveys
     reported_mailer:
       hide:
         hello: Hello %{name},
@@ -406,12 +395,17 @@ en:
         active_step: Active step
         see_all_processes: See all processes
       statistics:
+        answers_count: Answers
         comments_count: Comments
         headline: Current state of %{organization}
         meetings_count: Meetings
+        orders_count: Orders
+        pages_count: Pages
         processes_count: Processes
+        projects_count: Projects
         proposals_count: Proposals
         results_count: Results
+        surveys_count: Surveys
         users_count: Participants
         votes_count: Votes
       sub_hero:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -207,7 +207,7 @@ en:
         scope: Scope
         target: Target
       statistics:
-        headline: Current state of %{participatory_process}
+        headline: Current state of "%{participatory_process}"
         global:
           comments_count: Comments
         proposals:

--- a/decidim-core/db/migrate/20170725085104_add_show_statistics_to_participatory_processes.rb
+++ b/decidim-core/db/migrate/20170725085104_add_show_statistics_to_participatory_processes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddShowStatisticsToParticipatoryProcesses < ActiveRecord::Migration[5.1]
   def change
     add_column :decidim_participatory_processes, :show_statistics, :boolean, default: true

--- a/decidim-core/db/migrate/20170725085104_add_show_statistics_to_participatory_processes.rb
+++ b/decidim-core/db/migrate/20170725085104_add_show_statistics_to_participatory_processes.rb
@@ -1,0 +1,5 @@
+class AddShowStatisticsToParticipatoryProcesses < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_participatory_processes, :show_statistics, :boolean, default: true
+  end
+end

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -67,6 +67,8 @@ FactoryGirl.define do
     participatory_scope { Decidim::Faker::Localized.sentence(1) }
     participatory_structure { Decidim::Faker::Localized.sentence(2) }
     end_date 2.month.from_now.at_midnight
+    show_statistics true
+
     trait :promoted do
       promoted true
     end

--- a/decidim-core/spec/features/participatory_processes_spec.rb
+++ b/decidim-core/spec/features/participatory_processes_spec.rb
@@ -92,10 +92,13 @@ describe "Participatory Processes", type: :feature do
 
   describe "when going to the participatory process page" do
     let!(:participatory_process) { base_process }
-    let!(:published_feature) { create(:feature, :published, participatory_process: participatory_process) }
-    let!(:unpublished_feature) { create(:feature, :unpublished, participatory_process: participatory_process) }
+    let!(:proposals_feature) { create(:feature, :published, participatory_process: participatory_process, manifest_name: :proposals) }
+    let!(:meetings_feature) { create(:feature, :unpublished, participatory_process: participatory_process, manifest_name: :meetings) }
 
     before do
+      create_list(:proposal, 3, feature: proposals_feature)
+      allow(Decidim).to receive(:feature_manifests).and_return([proposals_feature.manifest, meetings_feature.manifest])
+
       visit decidim.participatory_process_path(participatory_process)
     end
 
@@ -122,8 +125,15 @@ describe "Participatory Processes", type: :feature do
     context "when the process has some features" do
       it "shows the features" do
         within ".process-nav" do
-          expect(page).to have_content(translated(published_feature.name, locale: :en).upcase)
-          expect(page).to have_no_content(translated(unpublished_feature.name, locale: :en).upcase)
+          expect(page).to have_content(translated(proposals_feature.name, locale: :en).upcase)
+          expect(page).to have_no_content(translated(meetings_feature.name, locale: :en).upcase)
+        end
+      end
+
+      it "shows the stats for those features" do
+        within ".process_stats" do
+          expect(page).to have_content("3 PROPOSALS")
+          expect(page).to_not have_content("0 MEETINGS")
         end
       end
     end

--- a/decidim-core/spec/features/participatory_processes_spec.rb
+++ b/decidim-core/spec/features/participatory_processes_spec.rb
@@ -4,12 +4,14 @@ require "spec_helper"
 
 describe "Participatory Processes", type: :feature do
   let(:organization) { create(:organization) }
+  let(:show_statistics) { true }
   let(:base_process) do
     create(
       :participatory_process,
       organization: organization,
       description: { en: "Description", ca: "Descripció", es: "Descripción" },
-      short_description: { en: "Short description", ca: "Descripció curta", es: "Descripción corta" }
+      short_description: { en: "Short description", ca: "Descripció curta", es: "Descripción corta" },
+      show_statistics: show_statistics
     )
   end
 
@@ -134,6 +136,14 @@ describe "Participatory Processes", type: :feature do
         within ".process_stats" do
           expect(page).to have_content("3 PROPOSALS")
           expect(page).to_not have_content("0 MEETINGS")
+        end
+      end
+
+      context "when the process stats are not enabled" do
+        let(:show_statistics) { false }
+
+        it "the stats for those features are not visible" do
+          expect(page).not_to have_content("3 PROPOSALS")
         end
       end
     end

--- a/decidim-core/spec/presenters/decidim/home_stats_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/home_stats_presenter_spec.rb
@@ -59,12 +59,11 @@ module Decidim
         expect(subject.not_highlighted).to eq(
           "<div class=\"home-pam__lowlight\">" \
             "<div class=\"home-pam__data\">" \
-              "<h4 class=\"home-pam__title\">Comments</h4>" \
-              "<span class=\"home-pam__number comments_count\"> 0</span>" \
-            "</div>" \
-            "<div class=\"home-pam__data\">" \
               "<h4 class=\"home-pam__title\">Bar</h4>" \
               "<span class=\"home-pam__number bar\"> 20</span>" \
+            "</div>" \
+            "<div class=\"home-pam__data\">" \
+              "&nbsp;" \
             "</div>" \
             "<div class=\"home-pam__data\">" \
               "&nbsp;" \

--- a/decidim-core/spec/presenters/decidim/home_stats_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/home_stats_presenter_spec.rb
@@ -66,6 +66,9 @@ module Decidim
               "<h4 class=\"home-pam__title\">Bar</h4>" \
               "<span class=\"home-pam__number bar\"> 20</span>" \
             "</div>" \
+            "<div class=\"home-pam__data\">" \
+              "&nbsp;" \
+            "</div>" \
           "</div>"
         )
       end

--- a/decidim-core/spec/presenters/decidim/participatory_process_stats_presenter.spec.rb
+++ b/decidim-core/spec/presenters/decidim/participatory_process_stats_presenter.spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe ParticipatoryProcessStatsPresenter do
+    let!(:organization) { create(:organization) }
+    let!(:user) { create(:user, :confirmed, organization: organization) }
+    let!(:process) { create(:participatory_process, organization: organization) }
+    let!(:feature) { create(:feature, participatory_process: process) }
+    let!(:feature2) { create(:feature, participatory_process: process) }
+    let!(:feature3) { create(:feature, participatory_process: process) }
+
+    subject { described_class.new(participatory_process: process) }
+
+    before do
+      feature.manifest.stats.register :foo, priority: StatsRegistry::HIGH_PRIORITY, &proc { 10 }
+      feature2.manifest.stats.register :bar, priority: StatsRegistry::MEDIUM_PRIORITY, &proc { 20 }
+      feature3.manifest.stats.register :baz, priority: StatsRegistry::LOW_PRIORITY, &proc { 30 }
+      I18n.backend.store_translations(
+        :en,
+        decidim: {
+          participatory_processes: {
+            statistics: {
+              foo: "Foo",
+              bar: "Bar",
+              baz: "Baz"
+            }
+          }
+        }
+      )
+
+      allow(Decidim).to receive(:feature_manifests).and_return([feature.manifest,feature2.manifest,feature3.manifest])
+    end
+
+    describe "#highlighted" do
+      it "renders a collection of stats including users and proceses" do
+        expect(subject.highlighted).to include("10 Foo")
+        expect(subject.highlighted).to include("20 Bar")
+        expect(subject.highlighted).to_not include("30 Baz")
+      end
+    end
+  end
+end

--- a/decidim-core/spec/presenters/decidim/participatory_process_stats_presenter.spec.rb
+++ b/decidim-core/spec/presenters/decidim/participatory_process_stats_presenter.spec.rb
@@ -30,7 +30,7 @@ module Decidim
         }
       )
 
-      allow(Decidim).to receive(:feature_manifests).and_return([feature.manifest,feature2.manifest,feature3.manifest])
+      allow(Decidim).to receive(:feature_manifests).and_return([feature.manifest, feature2.manifest, feature3.manifest])
     end
 
     describe "#highlighted" do

--- a/decidim-pages/lib/decidim/pages/feature.rb
+++ b/decidim-pages/lib/decidim/pages/feature.rb
@@ -24,8 +24,8 @@ Decidim.register_feature(:pages) do |feature|
       on(:invalid) { raise "Can't duplicate page" }
     end
   end
-  
-  feature.register_stat :pages_count, tag: :pages do |features, start_at, end_at|
+
+  feature.register_stat :pages_count, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |features, start_at, end_at|
     pages = Decidim::Pages::Page.where(feature: features)
     pages = pages.where("created_at >= ?", start_at) if start_at.present?
     pages = pages.where("created_at <= ?", end_at) if end_at.present?

--- a/decidim-pages/lib/decidim/pages/feature.rb
+++ b/decidim-pages/lib/decidim/pages/feature.rb
@@ -24,6 +24,13 @@ Decidim.register_feature(:pages) do |feature|
       on(:invalid) { raise "Can't duplicate page" }
     end
   end
+  
+  feature.register_stat :pages_count, tag: :pages do |features, start_at, end_at|
+    pages = Decidim::Pages::Page.where(feature: features)
+    pages = pages.where("created_at >= ?", start_at) if start_at.present?
+    pages = pages.where("created_at <= ?", end_at) if end_at.present?
+    pages.count
+  end
 
   feature.register_stat :comments_count, tag: :comments do |features, start_at, end_at|
     pages = Decidim::Pages::Page.where(feature: features)

--- a/decidim-pages/lib/decidim/pages/feature.rb
+++ b/decidim-pages/lib/decidim/pages/feature.rb
@@ -25,7 +25,7 @@ Decidim.register_feature(:pages) do |feature|
     end
   end
 
-  feature.register_stat :pages_count, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |features, start_at, end_at|
+  feature.register_stat :pages_count do |features, start_at, end_at|
     pages = Decidim::Pages::Page.where(feature: features)
     pages = pages.where("created_at >= ?", start_at) if start_at.present?
     pages = pages.where("created_at <= ?", end_at) if end_at.present?

--- a/decidim-surveys/lib/decidim/surveys/feature.rb
+++ b/decidim-surveys/lib/decidim/surveys/feature.rb
@@ -21,7 +21,7 @@ Decidim.register_feature(:surveys) do |feature|
   end
 
   feature.register_stat :surveys_count do |features, start_at, end_at|
-  surveys = Decidim::Surveys::Survey.where(feature: featuresa)
+    surveys = Decidim::Surveys::Survey.where(feature: features)
     surveys = surveys.where("created_at >= ?", start_at) if start_at.present?
     surveys = surveys.where("created_at <= ?", end_at) if end_at.present?
     surveys.count

--- a/decidim-surveys/lib/decidim/surveys/feature.rb
+++ b/decidim-surveys/lib/decidim/surveys/feature.rb
@@ -20,6 +20,21 @@ Decidim.register_feature(:surveys) do |feature|
     end
   end
 
+  feature.register_stat :surveys_count, tag: :surveys do |features, start_at, end_at|
+    surveys = Decidim::Surveys::Survey.where(feature: features)
+    surveys = surveys.where("created_at >= ?", start_at) if start_at.present?
+    surveys = surveys.where("created_at <= ?", end_at) if end_at.present?
+    surveys.count
+  end
+
+  feature.register_stat :answers_count, tag: :answers do |features, start_at, end_at|
+    surveys = Decidim::Surveys::Survey.where(feature: features)
+    answers = Decidim::Surveys::SurveyAnswer.where(survey: surveys)
+    answers = answers.where("created_at >= ?", start_at) if start_at.present?
+    answers = answers.where("created_at <= ?", end_at) if end_at.present?
+    answers.group(:decidim_user_id).count.size
+  end
+
   # These actions permissions can be configured in the admin panel
   feature.actions = %w(answer)
 

--- a/decidim-surveys/lib/decidim/surveys/feature.rb
+++ b/decidim-surveys/lib/decidim/surveys/feature.rb
@@ -20,14 +20,14 @@ Decidim.register_feature(:surveys) do |feature|
     end
   end
 
-  feature.register_stat :surveys_count, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |features, start_at, end_at|
-    surveys = Decidim::Surveys::Survey.where(feature: features)
+  feature.register_stat :surveys_count do |features, start_at, end_at|
+  surveys = Decidim::Surveys::Survey.where(feature: featuresa)
     surveys = surveys.where("created_at >= ?", start_at) if start_at.present?
     surveys = surveys.where("created_at <= ?", end_at) if end_at.present?
     surveys.count
   end
 
-  feature.register_stat :answers_count, priority: Decidim::StatsRegistry::MEDIUM_PRIORITY do |features, start_at, end_at|
+  feature.register_stat :answers_count, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |features, start_at, end_at|
     surveys = Decidim::Surveys::Survey.where(feature: features)
     answers = Decidim::Surveys::SurveyAnswer.where(survey: surveys)
     answers = answers.where("created_at >= ?", start_at) if start_at.present?

--- a/decidim-surveys/lib/decidim/surveys/feature.rb
+++ b/decidim-surveys/lib/decidim/surveys/feature.rb
@@ -20,14 +20,14 @@ Decidim.register_feature(:surveys) do |feature|
     end
   end
 
-  feature.register_stat :surveys_count, tag: :surveys do |features, start_at, end_at|
+  feature.register_stat :surveys_count, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |features, start_at, end_at|
     surveys = Decidim::Surveys::Survey.where(feature: features)
     surveys = surveys.where("created_at >= ?", start_at) if start_at.present?
     surveys = surveys.where("created_at <= ?", end_at) if end_at.present?
     surveys.count
   end
 
-  feature.register_stat :answers_count, tag: :answers do |features, start_at, end_at|
+  feature.register_stat :answers_count, priority: Decidim::StatsRegistry::MEDIUM_PRIORITY do |features, start_at, end_at|
     surveys = Decidim::Surveys::Survey.where(feature: features)
     answers = Decidim::Surveys::SurveyAnswer.where(survey: surveys)
     answers = answers.where("created_at >= ?", start_at) if start_at.present?


### PR DESCRIPTION
#### :tophat: What? Why?
This PR will implement some stats per individual participatory process to display on the show page, also i'll take the opportunity to fix the embedded/share component that wasn't properly styled.

#### :pushpin: Related Issues
- Fixes #1517 
- Fixes #1528

#### :clipboard: Subtasks
- [x] Create a presenter for participatory stats
- [x] Update layout and styles
- [x]  Add specs.
- [x] Add flag for enable/disable statistics per process

### :camera: Screenshots
![screen shot 2017-06-26 at 09 41 52](https://user-images.githubusercontent.com/953911/27529176-c8ab6f94-5a53-11e7-8ccc-9d00399609b0.png)
![screen shot 2017-06-26 at 09 42 01](https://user-images.githubusercontent.com/953911/27529175-c8a8ed64-5a53-11e7-8cff-d874308d7650.png)
![screen shot 2017-06-26 at 09 42 08](https://user-images.githubusercontent.com/953911/27529177-c8ade198-5a53-11e7-913a-79677e3a1beb.png)

#### :ghost: GIF
![]()
