### PR TITLE
Fix/flaky comments tests

### DIFF
--- a/decidim-comments/spec/features/notifications_spec.rb
+++ b/decidim-comments/spec/features/notifications_spec.rb
@@ -7,11 +7,7 @@ describe "Comment notifications", type: :feature do
   let!(:feature) { create(:feature, manifest_name: :dummy, organization: organization) }
   let!(:user) { create(:user, :confirmed, organization: organization) }
   let!(:commentable) { create(:dummy_resource, feature: feature) }
-  let!(:comments) do
-    Array.new(3) do
-      create(:comment, commentable: commentable)
-    end
-  end
+  let!(:comments) { create_list(:comment, 3, commentable: commentable) }
 
   before do
     switch_to_host(organization.host)

--- a/decidim-comments/spec/features/notifications_spec.rb
+++ b/decidim-comments/spec/features/notifications_spec.rb
@@ -30,7 +30,7 @@ describe "Comment notifications", type: :feature do
 
     wait_for_email subject: "a new comment"
 
-    login_as commentable.author, scope: :user
+    relogin_as commentable.author, scope: :user
 
     visit last_email_first_link
 

--- a/decidim-comments/spec/models/comment_spec.rb
+++ b/decidim-comments/spec/models/comment_spec.rb
@@ -7,7 +7,7 @@ module Decidim
     describe Comment do
       let!(:commentable) { create(:dummy_resource) }
       let!(:comment) { create(:comment, commentable: commentable) }
-      let!(:replies) { Array.new(3) { create(:comment, commentable: comment, root_commentable: commentable) } }
+      let!(:replies) { create_list(:comment, 3, commentable: comment, root_commentable: commentable) }
       let!(:up_vote) { create(:comment_vote, :up_vote, comment: comment) }
       let!(:down_vote) { create(:comment_vote, :down_vote, comment: comment) }
 

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -9,19 +9,13 @@ RSpec.shared_examples "comments" do
       create(:comment, commentable: commentable)
     end
   end
-  let(:authenticated) { false }
-
-  def visit_commentable_path
-    login_as user, scope: :user if authenticated
-    visit resource_path
-  end
 
   before do
     switch_to_host(organization.host)
   end
 
   it "user should see a list of comments" do
-    visit_commentable_path
+    visit resource_path
 
     expect(page).to have_selector("#comments")
     expect(page).to have_selector("article.comment", count: comments.length)
@@ -38,7 +32,7 @@ RSpec.shared_examples "comments" do
     comment = create(:comment, commentable: commentable, body: "Most Rated Comment")
     create(:comment_vote, comment: comment, author: user, weight: 1)
 
-    visit_commentable_path
+    visit resource_path
 
     within ".order-by" do
       page.find(".dropdown.menu .is-dropdown-submenu-parent").hover
@@ -53,23 +47,25 @@ RSpec.shared_examples "comments" do
 
   context "when not authenticated" do
     it "user should not see the form to add comments" do
-      visit_commentable_path
+      visit resource_path
       expect(page).not_to have_selector(".add-comment form")
     end
   end
 
   context "when authenticated" do
-    let(:authenticated) { true }
+    before do
+      login_as user, scope: :user
+    end
 
     it "user sees the form to add comments" do
-      visit_commentable_path
+      visit resource_path
 
       expect(page).to have_selector(".add-comment form")
     end
 
     context "when user adds a new comment" do
       before do
-        visit_commentable_path
+        visit resource_path
 
         expect(page).to have_selector(".add-comment form")
 
@@ -112,7 +108,7 @@ RSpec.shared_examples "comments" do
       end
 
       it "user can add a new comment as a user group" do
-        visit_commentable_path
+        visit resource_path
 
         expect(page).to have_selector(".add-comment form")
 
@@ -134,7 +130,7 @@ RSpec.shared_examples "comments" do
       let!(:comment) { create(:comment, commentable: commentable, author: comment_author) }
 
       before do
-        visit_commentable_path
+        visit resource_path
 
         expect(page).to have_selector(".comment__reply")
 
@@ -168,7 +164,7 @@ RSpec.shared_examples "comments" do
       end
 
       it "user can comment in favor" do
-        visit_commentable_path
+        visit resource_path
 
         expect(page).to have_selector(".add-comment form")
 
@@ -191,7 +187,7 @@ RSpec.shared_examples "comments" do
       end
 
       it "user can upvote a comment" do
-        visit_commentable_path
+        visit resource_path
 
         within "#comment_#{comments[0].id}" do
           expect(page).to have_selector(".comment__votes--up", text: /0/)
@@ -201,7 +197,7 @@ RSpec.shared_examples "comments" do
       end
 
       it "user can downvote a comment" do
-        visit_commentable_path
+        visit resource_path
 
         within "#comment_#{comments[0].id}" do
           expect(page).to have_selector(".comment__votes--down", text: /0/)

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -82,7 +82,7 @@ RSpec.shared_examples "comments" do
         end
       end
 
-      it "commentable's author receives notificatione" do
+      it "commentable's author receives notifications" do
         if commentable.respond_to? :author
           wait_for_email subject: "new comment"
           login_as commentable.author, scope: :user

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -76,7 +76,7 @@ RSpec.shared_examples "comments" do
       it "sends notifications received by commentable's author" do
         if commentable.respond_to? :author
           wait_for_email subject: "new comment"
-          login_as commentable.author, scope: :user
+          relogin_as commentable.author, scope: :user
           visit last_email_first_link
 
           within "#comments" do
@@ -140,7 +140,7 @@ RSpec.shared_examples "comments" do
 
       it "sends notifications received by commentable's author" do
         wait_for_email subject: "new reply"
-        login_as comment.author, scope: :user
+        relogin_as comment.author, scope: :user
         visit last_email_first_link
 
         within "#comments #comment_#{comment.id}" do

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -4,11 +4,7 @@
 RSpec.shared_examples "comments" do
   let!(:organization) { create(:organization) }
   let!(:user) { create(:user, :confirmed, organization: organization) }
-  let!(:comments) do
-    Array.new(3) do
-      create(:comment, commentable: commentable)
-    end
-  end
+  let!(:comments) { create_list(:comment, 3, commentable: commentable) }
 
   before do
     switch_to_host(organization.host)

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples "comments" do
     switch_to_host(organization.host)
   end
 
-  it "user should see a list of comments" do
+  it "shows the list of comments for the resorce" do
     visit resource_path
 
     expect(page).to have_selector("#comments")
@@ -24,7 +24,7 @@ RSpec.shared_examples "comments" do
     end
   end
 
-  it "user should be able to sort the comments" do
+  it "allows user to sort the comments" do
     comment = create(:comment, commentable: commentable, body: "Most Rated Comment")
     create(:comment_vote, comment: comment, author: user, weight: 1)
 
@@ -42,7 +42,7 @@ RSpec.shared_examples "comments" do
   end
 
   context "when not authenticated" do
-    it "user should not see the form to add comments" do
+    it "does not show form to add comments to user" do
       visit resource_path
       expect(page).not_to have_selector(".add-comment form")
     end
@@ -53,7 +53,7 @@ RSpec.shared_examples "comments" do
       login_as user, scope: :user
     end
 
-    it "user sees the form to add comments" do
+    it "shows form to add comments to user" do
       visit resource_path
 
       expect(page).to have_selector(".add-comment form")
@@ -71,14 +71,14 @@ RSpec.shared_examples "comments" do
         end
       end
 
-      it "user visualize the comment" do
+      it "shows comment to the user" do
         within "#comments" do
           expect(page).to have_content user.name
           expect(page).to have_content "This is a new comment"
         end
       end
 
-      it "commentable's author receives notifications" do
+      it "sends notifications received by commentable's author" do
         if commentable.respond_to? :author
           wait_for_email subject: "new comment"
           login_as commentable.author, scope: :user
@@ -103,7 +103,7 @@ RSpec.shared_examples "comments" do
         create(:user_group_membership, user: user, user_group: user_group)
       end
 
-      it "user can add a new comment as a user group" do
+      it "adds new comment as a user group" do
         visit resource_path
 
         expect(page).to have_selector(".add-comment form")
@@ -121,7 +121,7 @@ RSpec.shared_examples "comments" do
       end
     end
 
-    context "when a user replies a coment" do
+    context "when a user replies to a comment" do
       let!(:comment_author) { create(:user, :confirmed, organization: organization) }
       let!(:comment) { create(:comment, commentable: commentable, author: comment_author) }
 
@@ -137,13 +137,13 @@ RSpec.shared_examples "comments" do
         end
       end
 
-      it "user visualize the reply" do
+      it "shows reply to the user" do
         within "#comments #comment_#{comment.id}" do
           expect(page).to have_content "This is a reply"
         end
       end
 
-      it "comment's author receives notification" do
+      it "sends notifications received by commentable's author" do
         wait_for_email subject: "new reply"
         login_as comment.author, scope: :user
         visit last_email_first_link
@@ -159,7 +159,7 @@ RSpec.shared_examples "comments" do
         expect_any_instance_of(commentable.class).to receive(:comments_have_alignment?).and_return(true)
       end
 
-      it "user can comment in favor" do
+      it "allows user to comment in favor" do
         visit resource_path
 
         expect(page).to have_selector(".add-comment form")
@@ -182,7 +182,7 @@ RSpec.shared_examples "comments" do
         expect_any_instance_of(commentable.class).to receive(:comments_have_votes?).and_return(true)
       end
 
-      it "user can upvote a comment" do
+      it "allows user to upvote a comment" do
         visit resource_path
 
         within "#comment_#{comments[0].id}" do
@@ -192,7 +192,7 @@ RSpec.shared_examples "comments" do
         end
       end
 
-      it "user can downvote a comment" do
+      it "allows user to downvote a comment" do
         visit resource_path
 
         within "#comment_#{comments[0].id}" do

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -154,51 +154,67 @@ RSpec.shared_examples "comments" do
       end
     end
 
-    context "when arguable option is enabled" do
-      before do
-        expect_any_instance_of(commentable.class).to receive(:comments_have_alignment?).and_return(true)
-      end
+    describe "arguable option" do
+      context "commenting with alignment" do
+        before do
+          visit resource_path
 
-      it "allows user to comment in favor" do
-        visit resource_path
-
-        expect(page).to have_selector(".add-comment form")
-
-        page.find(".opinion-toggle--ok").click
-
-        within ".add-comment form" do
-          fill_in "add-comment-#{commentable.commentable_type}-#{commentable.id}", with: "I am in favor about this!"
-          click_button "Send"
+          expect(page).to have_selector(".add-comment form")
         end
 
-        within "#comments" do
-          expect(page).to have_selector "span.success.label", text: "In favor"
+        it "works according to the setting in the commentable" do
+          if commentable.comments_have_alignment?
+            page.find(".opinion-toggle--ok").click
+
+            within ".add-comment form" do
+              fill_in "add-comment-#{commentable.commentable_type}-#{commentable.id}", with: "I am in favor about this!"
+              click_button "Send"
+            end
+
+            within "#comments" do
+              expect(page).to have_selector "span.success.label", text: "In favor"
+            end
+          else
+            expect(page).not_to have_selector(".opinion-toggle--ok")
+          end
         end
       end
     end
 
-    context "when votable option is enabled" do
+    describe "votable option" do
       before do
-        expect_any_instance_of(commentable.class).to receive(:comments_have_votes?).and_return(true)
+        visit resource_path
       end
 
-      it "allows user to upvote a comment" do
-        visit resource_path
-
-        within "#comment_#{comments[0].id}" do
-          expect(page).to have_selector(".comment__votes--up", text: /0/)
-          page.find(".comment__votes--up").click
-          expect(page).to have_selector(".comment__votes--up", text: /1/)
+      context "upvoting a comment" do
+        it "works according to the setting in the commentable" do
+          within "#comment_#{comments[0].id}" do
+            if commentable.comments_have_votes?
+              expect(page).to have_selector(".comment__votes--up", text: /0/)
+              page.find(".comment__votes--up").click
+              expect(page).to have_selector(".comment__votes--up", text: /1/)
+            else
+              expect(page).to_not have_selector(".comment__votes--up", text: /0/)
+            end
+          end
         end
       end
 
-      it "allows user to downvote a comment" do
-        visit resource_path
+      context "downvoting a comment" do
+        before do
+          visit resource_path
+        end
 
-        within "#comment_#{comments[0].id}" do
-          expect(page).to have_selector(".comment__votes--down", text: /0/)
-          page.find(".comment__votes--down").click
-          expect(page).to have_selector(".comment__votes--down", text: /1/)
+        it "works according to the setting in the commentable" do
+          within "#comment_#{comments[0].id}" do
+            if commentable.comments_have_votes?
+              expect(page).to have_selector(".comment__votes--down", text: /0/)
+              page.find(".comment__votes--down").click
+              expect(page).to have_selector(".comment__votes--down", text: /1/)
+            else
+              expect(page).to_not have_selector(".comment__votes--down", text: /0/)
+            end
+          end
         end
       end
     end

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -51,18 +51,15 @@ RSpec.shared_examples "comments" do
   context "when authenticated" do
     before do
       login_as user, scope: :user
+      visit resource_path
     end
 
     it "shows form to add comments to user" do
-      visit resource_path
-
       expect(page).to have_selector(".add-comment form")
     end
 
     context "when user adds a new comment" do
       before do
-        visit resource_path
-
         expect(page).to have_selector(".add-comment form")
 
         within ".add-comment form" do

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -60,8 +60,6 @@ RSpec.shared_examples "comments" do
 
     context "when user adds a new comment" do
       before do
-        expect(page).to have_selector(".add-comment form")
-
         within ".add-comment form" do
           fill_in "add-comment-#{commentable.commentable_type}-#{commentable.id}", with: "This is a new comment"
           click_button "Send"

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/warden.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/warden.rb
@@ -1,7 +1,23 @@
 # frozen_string_literal: true
 
+module Decidim
+  module WardenTestHelpers
+    include Warden::Test::Helpers
+
+    #
+    # Utility method to login in the middle of a test as a different user from
+    # the current one.
+    #
+    def relogin_as(user, scope:)
+      logout :user
+
+      login_as user, scope: scope
+    end
+  end
+end
+
 RSpec.configure do |config|
-  config.include Warden::Test::Helpers, type: :feature
+  config.include Decidim::WardenTestHelpers, type: :feature
   config.include Devise::Test::ControllerHelpers, type: :controller
 
   config.after :each, type: :feature do

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/warden.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/warden.rb
@@ -8,8 +8,8 @@ module Decidim
     # Utility method to login in the middle of a test as a different user from
     # the current one.
     #
-    def relogin_as(user, scope:)
-      logout :user
+    def relogin_as(user, scope: :user)
+      logout scope
 
       login_as user, scope: scope
     end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR should get rid of the last flaky test failures in our test suite. This is good because you don't have to wonder whether the flaky failures are actually real issues, or whether is it your changes or the flaky failures that are failing. And because all dots are green :).

I detected two potential problems, based on the similarities between the flaky tests.

* Using `allow_any_instance_of`, which is discouraged by RSpec unless you're dealing with legacy code and known to be buggy. See [here](https://relishapp.com/rspec/rspec-mocks/docs/working-with-legacy-code/any-instance) for reference.

* Using `login_as` twice in the same test without explicit logout. There were only two tests doing this in the whole suite, and both were getting flaky failures.

So I stopped doing both things and it seemed to work...

#### :pushpin: Related Issues
- Fixes #1402.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![everest](https://user-images.githubusercontent.com/2887858/27507444-eb97ba38-58cf-11e7-8388-4043e06cc10e.gif)
