### PR TITLE
Fix i18n pluralizations

### DIFF
--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -84,10 +84,13 @@ module Decidim
     []
   end
 
-  # Exposes a configuration option: The application name String.
+  # Exposes a configuration option: The application available locales.
   config_accessor :available_locales do
     %w(en ca es eu it fi fr nl)
   end
+
+  # Exposes a configuration option: The application default locale.
+  config_accessor :default_locale { :en }
 
   # Exposes a configuration option: an object to configure geocoder
   config_accessor :geocoder

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -84,7 +84,6 @@ module Decidim
       end
 
       initializer "decidim.locales" do |app|
-        app.config.i18n.available_locales = Decidim.config.available_locales
         app.config.i18n.fallbacks = true
       end
 

--- a/lib/generators/decidim/app_generator.rb
+++ b/lib/generators/decidim/app_generator.rb
@@ -96,7 +96,7 @@ module Decidim
 
       def set_locales
         inject_into_file "config/application.rb", after: "class Application < Rails::Application" do
-          "\n    config.i18n.available_locales = %w(en ca es)\n    config.i18n.default_locale = :en"
+          "\n    config.i18n.available_locales = Decidim.available_locales\n    config.i18n.default_locale = Decidim.default_locale"
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

We had problems with some locales because the pluralization didn't work. It was reported as a problem with the french locale (see #1519) but I detected problems with other locales.

This was caused because `rails-i18n` loads the pluralizations like this:

```
pattern = pattern_from app.config.i18n.available_locales
```

The problem was `i18n.available_locales` was initialized as `%w(ca es en)` in the `config/application.rb` file generated in our development app. This value was then replaced by `Decidim.available_locales` but it was **after** `rails-i18n` initializer kicked in.

I changed the generator to use always `Decidim.available_locales` instead of the previous hardcoded value.

Kudos to @mrcasals for helping me on this 😄 

#### :pushpin: Related Issues
- Fixes #1519  

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
N/A

#### :ghost: GIF
![](https://media3.giphy.com/media/jDcTDYYrjGb9C/giphy.gif)
