### PR TITLE
Send newsletters to not deleted users from the newsletter organization

### DIFF
--- a/decidim-admin/spec/jobs/newsletter_job_spec.rb
+++ b/decidim-admin/spec/jobs/newsletter_job_spec.rb
@@ -7,9 +7,12 @@ module Decidim
     describe NewsletterJob do
       let!(:newsletter) { create(:newsletter, organization: organization, total_deliveries: 0) }
       let!(:organization) { create(:organization) }
+      let!(:another_organization) { create(:organization) }
       let!(:deliverable_user) { create(:user, :confirmed, newsletter_notifications: true, organization: organization) }
+      let!(:another_deliverable_user) { create(:user, :confirmed, newsletter_notifications: true, organization: another_organization) }
       let!(:undeliverable_user) { create(:user, newsletter_notifications: true, organization: organization) }
       let!(:non_deliverable_user) { create(:user, :confirmed, newsletter_notifications: false, organization: organization) }
+      let!(:deleted_user) { create(:user, :confirmed, :deleted, newsletter_notifications: true, organization: organization) }
 
       it "delivers a newsletter to a the eligible users" do
         expect(NewsletterDeliveryJob).to receive(:perform_later).with(deliverable_user, newsletter)

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -28,6 +28,8 @@ module Decidim
     validate :all_roles_are_valid
     mount_uploader :avatar, Decidim::AvatarUploader
 
+    scope :not_deleted, -> { where(deleted_at: nil) }
+
     # Public: Allows customizing the invitation instruction email content when
     # inviting a user.
     #

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -141,6 +141,11 @@ FactoryGirl.define do
       confirmed_at { Time.current }
     end
 
+    trait :deleted do
+      email ""
+      deleted_at { Time.current }
+    end
+
     trait :admin do
       roles ["admin"]
     end


### PR DESCRIPTION
#### :tophat: What? Why?

A newsletter must be sent to the users from the same organization. I also filter the deleted users.

#### :pushpin: Related Issues
- Fixes #1538 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
N/A

#### :ghost: GIF
![](https://media3.giphy.com/media/3boPPdHk2ueo8/giphy.gif)
