### PR TITLE
Missing translations on participatory process copy form

### DIFF
--- a/decidim-admin/app/forms/decidim/admin/participatory_process_copy_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_process_copy_form.rb
@@ -10,12 +10,11 @@ module Decidim
 
       translatable_attribute :title, String
 
+      mimic :participatory_process
+
       attribute :slug, String
       attribute :copy_steps, Boolean
       attribute :copy_categories, Boolean
-      attribute :copy_process_users, Boolean
-      attribute :copy_moderations, Boolean
-      attribute :copy_pages, Boolean
       attribute :copy_features, Boolean
 
       validates :slug, presence: true

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -33,6 +33,9 @@ en:
         welcome_text: Welcome text
       participatory_process:
         banner_image: Banner image
+        copy_categories: Copy categories
+        copy_features: Copy features
+        copy_steps: Copy steps
         description: Description
         developer_group: Developer group
         domain: Domain

--- a/decidim-admin/spec/features/admin_copy_participatory_process_spec.rb
+++ b/decidim-admin/spec/features/admin_copy_participatory_process_spec.rb
@@ -25,13 +25,13 @@ describe "Admin copy participatory process", type: :feature do
 
       within ".copy_participatory_process" do
         fill_in_i18n(
-          :participatory_process_copy_title,
-          "#participatory_process_copy-title-tabs",
+          :participatory_process_title,
+          "#participatory_process-title-tabs",
           en: "Copy participatory process",
           es: "Copia del proceso participativo",
           ca: "Còpia del procés participatiu"
         )
-        fill_in :participatory_process_copy_slug, with: "pp-copy"
+        fill_in :participatory_process_slug, with: "pp-copy"
         click_button "Copy"
       end
 
@@ -47,18 +47,18 @@ describe "Admin copy participatory process", type: :feature do
 
       within ".copy_participatory_process" do
         fill_in_i18n(
-          :participatory_process_copy_title,
-          "#participatory_process_copy-title-tabs",
+          :participatory_process_title,
+          "#participatory_process-title-tabs",
           en: "Copy participatory process",
           es: "Copia del proceso participativo",
           ca: "Còpia del procés participatiu"
         )
-        fill_in :participatory_process_copy_slug, with: "pp-copy-with-steps"
+        fill_in :participatory_process_slug, with: "pp-copy-with-steps"
       end
     end
 
     it "copies the process with steps" do
-      page.check("participatory_process_copy[copy_steps]")
+      page.check("participatory_process[copy_steps]")
       click_button "Copy"
 
       expect(page).to have_content("successfully")
@@ -74,7 +74,7 @@ describe "Admin copy participatory process", type: :feature do
     end
 
     it "copies the process with categories" do
-      page.check("participatory_process_copy[copy_categories]")
+      page.check("participatory_process[copy_categories]")
       click_button "Copy"
 
       expect(page).to have_content("successfully")
@@ -90,7 +90,7 @@ describe "Admin copy participatory process", type: :feature do
     end
 
     it "copies the process with features" do
-      page.check("participatory_process_copy[copy_features]")
+      page.check("participatory_process[copy_features]")
       click_button "Copy"
 
       expect(page).to have_content("successfully")


### PR DESCRIPTION
#### :tophat: What? Why?

I added some missing translations and clean up a bit the `ParticipatoryProcessCopyForm`.

#### :pushpin: Related Issues
- Fixes #1516 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
N/A

#### :ghost: GIF
![](https://media1.giphy.com/media/Lr2YomhIBU8LK/giphy.gif)
