### PR TITLE
Include only what's needed in participatory processes controller

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ RSpec::Core::RakeTask.new(:spec)
 task default: :spec
 
 desc "Runs all tests in all Decidim engines"
-task test_all: ["decidim:generate_test_app"] do
+task :test_all do
   DECIDIM_GEMS.each do |gem_name|
     next if gem_name == "dev"
 

--- a/decidim-core/app/controllers/concerns/decidim/needs_authorization.rb
+++ b/decidim-core/app/controllers/concerns/decidim/needs_authorization.rb
@@ -30,8 +30,7 @@ module Decidim
           current_settings: try(:current_settings),
           feature_settings: try(:feature_settings),
           current_organization: try(:current_organization),
-          current_feature: try(:current_feature),
-          current_participatory_process: try(:current_participatory_process)
+          current_feature: try(:current_feature)
         }
       end
 

--- a/decidim-core/app/controllers/concerns/decidim/needs_participatory_process.rb
+++ b/decidim-core/app/controllers/concerns/decidim/needs_participatory_process.rb
@@ -1,19 +1,29 @@
 # frozen_string_literal: true
 
-require "active_support/concern"
-
 module Decidim
   # This module, when injected into a controller, ensures there's a
   # Participatory Process available and deducts it from the context.
   module NeedsParticipatoryProcess
-    extend ActiveSupport::Concern
+    def self.enhance_controller(instance_or_module)
+      instance_or_module.class_eval do
+        after_action :verify_participatory_process
+        helper_method :current_participatory_process
+      end
+    end
 
-    include NeedsOrganization
+    def self.extended(base)
+      base.extend NeedsOrganization, InstanceMethods
 
-    included do
-      after_action :verify_participatory_process
-      helper_method :current_participatory_process
+      enhance_controller(base)
+    end
 
+    def self.included(base)
+      base.include NeedsOrganization, InstanceMethods
+
+      enhance_controller(base)
+    end
+
+    module InstanceMethods
       # Public: Finds the current Participatory Process given this controller's
       # context.
       #
@@ -26,6 +36,10 @@ module Decidim
 
       def verify_participatory_process
         raise ActionController::RoutingError, "Participatory process not found." unless current_participatory_process
+      end
+
+      def ability_context
+        super.merge(current_participatory_process: current_participatory_process)
       end
 
       def detect_participatory_process

--- a/decidim-core/app/controllers/decidim/participatory_processes_controller.rb
+++ b/decidim-core/app/controllers/decidim/participatory_processes_controller.rb
@@ -6,11 +6,9 @@ module Decidim
   # A controller that holds the logic to show ParticipatoryProcesses in a
   # public layout.
   class ParticipatoryProcessesController < ApplicationController
-    include NeedsParticipatoryProcess
-
     layout "layouts/decidim/participatory_process", only: [:show]
 
-    skip_after_action :verify_participatory_process, only: [:index]
+    before_action -> { extend(NeedsParticipatoryProcess) }, only: [:show]
 
     helper Decidim::AttachmentsHelper
     helper Decidim::ParticipatoryProcessHelper

--- a/decidim-core/app/views/pages/404.html.erb
+++ b/decidim-core/app/views/pages/404.html.erb
@@ -8,6 +8,6 @@
           <%= link_to t(".back_home"), root_path, class: "button" %>
         </div>
       </div>
+    </div>
   </div>
-</div>
 </main>

--- a/decidim-core/spec/features/participatory_processes_spec.rb
+++ b/decidim-core/spec/features/participatory_processes_spec.rb
@@ -22,7 +22,7 @@ describe "Participatory Processes", type: :feature do
       visit decidim.participatory_processes_path
     end
 
-    it "shows a messages about the lack of processes" do
+    it "shows a message about the lack of processes" do
       expect(page).to have_content("No participatory processes yet!")
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

I'm extracting these changes from #1524 so they're easier to review and test in isolation.

Including the `NeedsParticipatoryProcess` module unconditionally in the `ParticipatoryProcessesController` could cause problems in the index action. And it doesn't really make sense for the index action.

This presents a solution that allows including the module globally in a controller when in makes sense for all actions, or extending the controller instance for a specific action, when it only makes sense for that specific action.

This also reduces the global dependency on participatory processes, which will help future features.
 
#### :pushpin: Related Issues
- Related to #1524.

#### :clipboard: Subtasks
- [ ] Get it tested in a real production environment?

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![double](https://user-images.githubusercontent.com/2887858/27632498-1ad4c3a2-5bfc-11e7-995d-038c83ef5d2f.gif)

