### PR TITLE
Add notifications when a Result is commented

### DIFF
--- a/decidim-budgets/app/models/decidim/budgets/project.rb
+++ b/decidim-budgets/app/models/decidim/budgets/project.rb
@@ -11,6 +11,7 @@ module Decidim
       include Decidim::HasCategory
       include Decidim::HasAttachments
       include Decidim::HasReference
+      include Decidim::Notifiable
       include Decidim::Comments::Commentable
 
       feature_manifest_name "budgets"
@@ -35,6 +36,11 @@ module Decidim
       # Public: Returns the number of times an specific project have been checked out.
       def confirmed_orders_count
         orders.finished.count
+      end
+
+      # Public: Overrides the `notifiable?` Notifiable concern method.
+      def notifiable?(context)
+        false
       end
     end
   end

--- a/decidim-budgets/app/models/decidim/budgets/project.rb
+++ b/decidim-budgets/app/models/decidim/budgets/project.rb
@@ -11,7 +11,6 @@ module Decidim
       include Decidim::HasCategory
       include Decidim::HasAttachments
       include Decidim::HasReference
-      include Decidim::Notifiable
       include Decidim::Comments::Commentable
 
       feature_manifest_name "budgets"

--- a/decidim-budgets/app/models/decidim/budgets/project.rb
+++ b/decidim-budgets/app/models/decidim/budgets/project.rb
@@ -39,7 +39,7 @@ module Decidim
       end
 
       # Public: Overrides the `notifiable?` Notifiable concern method.
-      def notifiable?(context)
+      def notifiable?(_context)
         false
       end
     end

--- a/decidim-comments/app/commands/decidim/comments/create_comment.rb
+++ b/decidim-comments/app/commands/decidim/comments/create_comment.rb
@@ -43,9 +43,13 @@ module Decidim
 
       def send_notification
         if @comment.depth.positive?
-          CommentNotificationMailer.reply_created(@comment, @commentable, @comment.root_commentable).deliver_later
+          @commentable.users_to_notify.each do |user|
+            CommentNotificationMailer.reply_created(user, @comment, @commentable, @comment.root_commentable).deliver_later
+          end
         elsif @comment.depth.zero?
-          CommentNotificationMailer.comment_created(@comment, @commentable).deliver_later
+          @commentable.users_to_notify.each do |user|
+            CommentNotificationMailer.comment_created(user, @comment, @commentable).deliver_later
+          end
         end
       end
 

--- a/decidim-comments/app/commands/decidim/comments/create_comment.rb
+++ b/decidim-comments/app/commands/decidim/comments/create_comment.rb
@@ -23,7 +23,7 @@ module Decidim
         return broadcast(:invalid) if form.invalid?
 
         create_comment
-        send_notification_to_author if has_author? && !same_author?
+        send_notification if @commentable.notifiable?(author: @author)
 
         broadcast(:ok, @comment)
       end
@@ -41,20 +41,12 @@ module Decidim
                                    decidim_user_group_id: form.user_group_id)
       end
 
-      def send_notification_to_author
-        if @comment.depth.positive? && @commentable.author.replies_notifications?
+      def send_notification
+        if @comment.depth.positive?
           CommentNotificationMailer.reply_created(@comment, @commentable, @comment.root_commentable).deliver_later
-        elsif @comment.depth.zero? && @commentable.author.comments_notifications?
+        elsif @comment.depth.zero?
           CommentNotificationMailer.comment_created(@comment, @commentable).deliver_later
         end
-      end
-
-      def has_author?
-        @commentable.respond_to?(:author) && @commentable.author.present?
-      end
-
-      def same_author?
-        @author == @commentable.author
       end
 
       def root_commentable(commentable)

--- a/decidim-comments/app/mailers/decidim/comments/comment_notification_mailer.rb
+++ b/decidim-comments/app/mailers/decidim/comments/comment_notification_mailer.rb
@@ -9,26 +9,28 @@ module Decidim
 
       helper_method :commentable_title
 
-      def comment_created(comment, commentable)
-        with_user(commentable.author) do
+      def comment_created(user, comment, commentable)
+        with_user(user) do
+          @user = user
           @comment = comment
           @commentable = commentable
           @locator = Decidim::ResourceLocatorPresenter.new(@commentable)
           @organization = commentable.organization
           subject = I18n.t("comment_created.subject", scope: "decidim.comments.mailer.comment_notification")
-          mail(to: commentable.author.email, subject: subject)
+          mail(to: user.email, subject: subject)
         end
       end
 
-      def reply_created(reply, comment, commentable)
-        with_user(comment.author) do
+      def reply_created(user, reply, comment, commentable)
+        with_user(user) do
+          @user = user
           @reply = reply
           @comment = comment
           @commentable = commentable
           @locator = Decidim::ResourceLocatorPresenter.new(@commentable)
           @organization = commentable.organization
           subject = I18n.t("reply_created.subject", scope: "decidim.comments.mailer.comment_notification")
-          mail(to: comment.author.email, subject: subject)
+          mail(to: user.email, subject: subject)
         end
       end
 

--- a/decidim-comments/app/models/decidim/comments/comment.rb
+++ b/decidim-comments/app/models/decidim/comments/comment.rb
@@ -6,8 +6,9 @@ module Decidim
     # comment on them. The will be able to create conversations between users
     # to discuss or share their thoughts about the resource.
     class Comment < ApplicationRecord
-      include Reportable
+      include Decidim::Reportable
       include Decidim::Authorable
+      include Decidim::Notifiable
       include Decidim::Comments::Commentable
 
       # Limit the max depth of a comment tree. If C is a comment and R is a reply:
@@ -57,6 +58,18 @@ module Decidim
       # Public: Overrides the `reported_content_url` Reportable concern method.
       def reported_content_url
         ResourceLocatorPresenter.new(root_commentable).url(anchor: "comment_#{id}")
+      end
+
+      # Public: Overrides the `notifiable?` Notifiable concern method.
+      # When a comment is commented the comment's author is notified if it is not the same
+      # who has replied the comment and if the comment's author has replied notifiations enabled.
+      def notifiable?(context)
+        context[:author] != author && author.replies_notifications?
+      end
+
+      # Public: Overrides the `users_to_notify` Notifiable concern method.
+      def users_to_notify
+        [author]
       end
 
       private

--- a/decidim-comments/app/models/decidim/comments/comment.rb
+++ b/decidim-comments/app/models/decidim/comments/comment.rb
@@ -8,7 +8,6 @@ module Decidim
     class Comment < ApplicationRecord
       include Decidim::Reportable
       include Decidim::Authorable
-      include Decidim::Notifiable
       include Decidim::Comments::Commentable
 
       # Limit the max depth of a comment tree. If C is a comment and R is a reply:

--- a/decidim-comments/app/views/decidim/comments/comment_notification_mailer/comment_created.html.erb
+++ b/decidim-comments/app/views/decidim/comments/comment_notification_mailer/comment_created.html.erb
@@ -1,4 +1,4 @@
-<p><%= t("decidim.comments.comment_notification_mailer.hello", name: @commentable.author.name) %></p>
+<p><%= t("decidim.comments.comment_notification_mailer.hello", name: @user.name) %></p>
 
 <p>
   <%=

--- a/decidim-comments/app/views/decidim/comments/comment_notification_mailer/reply_created.html.erb
+++ b/decidim-comments/app/views/decidim/comments/comment_notification_mailer/reply_created.html.erb
@@ -1,4 +1,4 @@
-<p><%= t("decidim.comments.comment_notification_mailer.hello", name: @comment.author.name) %></p>
+<p><%= t("decidim.comments.comment_notification_mailer.hello", name: @user.name) %></p>
 
 <p>
   <%=

--- a/decidim-comments/lib/decidim/comments/commentable.rb
+++ b/decidim-comments/lib/decidim/comments/commentable.rb
@@ -7,6 +7,7 @@ module Decidim
     # Shared behaviour for commentable models.
     module Commentable
       extend ActiveSupport::Concern
+      include Decidim::Notifiable
 
       included do
         has_many :comments, as: :commentable, foreign_key: "decidim_commentable_id", foreign_type: "decidim_commentable_type", class_name: "Decidim::Comments::Comment"

--- a/decidim-comments/spec/commands/create_comment_spec.rb
+++ b/decidim-comments/spec/commands/create_comment_spec.rb
@@ -9,6 +9,7 @@ module Decidim
         let(:organization) { create(:organization) }
         let(:participatory_process) { create(:participatory_process, organization: organization) }
         let(:feature) { create(:feature, participatory_process: participatory_process) }
+        let(:user) { create(:user, organization: organization) }
         let(:author) { create(:user, organization: organization) }
         let(:dummy_resource) { create :dummy_resource, feature: feature }
         let(:commentable) { dummy_resource }
@@ -67,9 +68,9 @@ module Decidim
             end.to change { Comment.count }.by(1)
           end
 
-          context "and the commentable doesn't have an author" do
+          context "and the commentable is not notifiable" do
             before do
-              commentable.author = nil
+              expect(commentable).to receive(:notifiable?).and_return(false)
             end
 
             it "doesn't send an email" do
@@ -78,70 +79,37 @@ module Decidim
             end
           end
 
-          context "and the comment is a root comment" do
-            it "sends an email to the author of the commentable" do
-              expect(CommentNotificationMailer)
-                .to receive(:comment_created)
-                .with(an_instance_of(Comment), commentable)
-                .and_call_original
-
-              command.call
+          context "and the commentable is notifiable" do
+            before do
+              expect(commentable).to receive(:notifiable?).and_return(true)
+              expect(commentable).to receive(:users_to_notify).and_return([user])
             end
 
-            context "and I am the author of the commentable" do
-              let(:dummy_resource) { create :dummy_resource, feature: feature, author: author }
+            context "and the comment is a root comment" do
+              it "sends an email to the author of the commentable" do
+                expect(CommentNotificationMailer)
+                  .to receive(:comment_created)
+                  .with(user, an_instance_of(Comment), commentable)
+                  .and_call_original
 
-              it "doesn't send an email" do
-                expect(CommentNotificationMailer).not_to receive(:comment_created)
                 command.call
               end
             end
 
-            context "and the author has comment notifications disabled" do
-              before do
-                commentable.author.update_attributes!(comments_notifications: false)
-              end
+            context "and the comment is a reply" do
+              let(:commentable) { create(:comment, commentable: dummy_resource) }
 
-              it "doesn't send an email" do
-                expect(CommentNotificationMailer).not_to receive(:comment_created)
+              it "stores the root commentable" do
                 command.call
-              end
-            end
-          end
-
-          context "and the comment is a reply" do
-            let(:commentable) { create(:comment, commentable: dummy_resource) }
-
-            it "stores the root commentable" do
-              command.call
-              expect(Comment.last.root_commentable).to eq(dummy_resource)
-            end
-
-            it "sends an email to the author of the parent comment" do
-              expect(CommentNotificationMailer)
-                .to receive(:reply_created)
-                .with(an_instance_of(Comment), commentable, commentable.root_commentable)
-                .and_call_original
-
-              command.call
-            end
-
-            context "and I am the author of the parent comment" do
-              let(:commentable) { create(:comment, author: author, commentable: dummy_resource) }
-
-              it "doesn't send an email" do
-                expect(CommentNotificationMailer).not_to receive(:reply_created)
-                command.call
-              end
-            end
-
-            context "and the author has reply notifications disabled" do
-              before do
-                commentable.author.update_attribute(:replies_notifications, false)
+                expect(Comment.last.root_commentable).to eq(dummy_resource)
               end
 
-              it "doesn't send an email" do
-                expect(CommentNotificationMailer).not_to receive(:reply_created)
+              it "sends an email to the author of the parent comment" do
+                expect(CommentNotificationMailer)
+                  .to receive(:reply_created)
+                  .with(user, an_instance_of(Comment), commentable, commentable.root_commentable)
+                  .and_call_original
+
                 command.call
               end
             end

--- a/decidim-comments/spec/mailers/comment_notification_mailer_spec.rb
+++ b/decidim-comments/spec/mailers/comment_notification_mailer_spec.rb
@@ -25,7 +25,7 @@ module Decidim
         let(:body) { "Hi ha un nou comentari d" }
         let(:default_body) { "There is a new comment" }
 
-        include_examples "author localised email"
+        include_examples "user localised email"
       end
 
       describe "reply_created" do
@@ -37,7 +37,7 @@ module Decidim
         let(:body) { "Hi ha una nova resposta de" }
         let(:default_body) { "There is a new reply of your comment" }
 
-        include_examples "author localised email"
+        include_examples "user localised email"
       end
     end
   end

--- a/decidim-comments/spec/mailers/comment_notification_mailer_spec.rb
+++ b/decidim-comments/spec/mailers/comment_notification_mailer_spec.rb
@@ -11,12 +11,13 @@ module Decidim
       let(:feature) { create(:feature, participatory_process: participatory_process) }
       let(:commentable_author) { create(:user, organization: organization) }
       let(:commentable) { create(:dummy_resource, author: commentable_author, feature: feature) }
+      let(:user) { create(:user, organization: organization) }
       let(:author) { create(:user, organization: organization) }
       let(:comment) { create(:comment, author: author, commentable: commentable) }
       let(:reply) { create(:comment, author: author, commentable: comment) }
 
       describe "comment_created" do
-        let(:mail) { described_class.comment_created(comment, commentable) }
+        let(:mail) { described_class.comment_created(user, comment, commentable) }
 
         let(:subject) { "Tens un nou comentari" }
         let(:default_subject) { "You have a new comment" }
@@ -28,7 +29,7 @@ module Decidim
       end
 
       describe "reply_created" do
-        let(:mail) { described_class.reply_created(reply, comment, commentable) }
+        let(:mail) { described_class.reply_created(user, reply, comment, commentable) }
 
         let(:subject) { "Tens una nova resposta del teu comentari" }
         let(:default_subject) { "You have a new reply of your comment" }

--- a/decidim-comments/spec/shared/author_localised_email.rb
+++ b/decidim-comments/spec/shared/author_localised_email.rb
@@ -2,9 +2,8 @@
 
 require "spec_helper"
 
-shared_examples "author localised email" do
-  let(:author) { create(:user, locale: locale, organization: organization) }
-  let(:commentable_author) { create(:user, locale: locale, organization: organization) }
+shared_examples "user localised email" do
+  let(:user) { create(:user, locale: locale, organization: organization) }
 
   context "when the user has a custom locale" do
     let(:locale) { "ca" }

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -17,6 +17,7 @@ module Decidim
   autoload :Resourceable, "decidim/resourceable"
   autoload :Reportable, "decidim/reportable"
   autoload :Authorable, "decidim/authorable"
+  autoload :Notifiable, "decidim/notifiable"
   autoload :Features, "decidim/features"
   autoload :HasAttachments, "decidim/has_attachments"
   autoload :FeatureValidator, "decidim/feature_validator"

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -73,7 +73,7 @@ RSpec.shared_examples "comments" do
         end
       end
 
-      it "sends notifications received by commentable's author" do
+      it "send notifications" do
         if commentable.notifiable?
           wait_for_email subject: "new comment"
           relogin_as commentable.users_to_notify.first, scope: :user

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -74,9 +74,9 @@ RSpec.shared_examples "comments" do
       end
 
       it "sends notifications received by commentable's author" do
-        if commentable.respond_to? :author
+        if commentable.notifiable?
           wait_for_email subject: "new comment"
-          relogin_as commentable.author, scope: :user
+          relogin_as commentable.users_to_notify.first, scope: :user
           visit last_email_first_link
 
           within "#comments" do

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -74,7 +74,7 @@ RSpec.shared_examples "comments" do
       end
 
       it "send notifications" do
-        if commentable.notifiable?
+        if commentable.notifiable?(author: user)
           wait_for_email subject: "new comment"
           relogin_as commentable.users_to_notify.first, scope: :user
           visit last_email_first_link

--- a/decidim-core/lib/decidim/notifiable.rb
+++ b/decidim-core/lib/decidim/notifiable.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  # Shared behaviour for notifiable models.
+  module Notifiable
+    extend ActiveSupport::Concern
+
+    included do
+      # Public: Whether the object's comments are visible or not.
+      def notifiable?(context)
+        true
+      end
+
+      # Public: A collection of users to send the notifications.
+      def users_to_notify
+        []
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/notifiable.rb
+++ b/decidim-core/lib/decidim/notifiable.rb
@@ -9,7 +9,7 @@ module Decidim
 
     included do
       # Public: Whether the object's comments are visible or not.
-      def notifiable?(context)
+      def notifiable?(_context)
         true
       end
 

--- a/decidim-core/lib/decidim/notifiable.rb
+++ b/decidim-core/lib/decidim/notifiable.rb
@@ -8,7 +8,7 @@ module Decidim
     extend ActiveSupport::Concern
 
     included do
-      # Public: Whether the object's comments are visible or not.
+      # Public: Whether the object is notifiable or not.
       def notifiable?(_context)
         true
       end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
@@ -38,7 +38,11 @@ module Decidim
     end
 
     def notifiable?(_context)
-      false
+      true
+    end
+
+    def users_to_notify
+      [author]
     end
   end
 

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
@@ -37,7 +37,7 @@ module Decidim
       ResourceLocatorPresenter.new(self).url
     end
 
-    def notifiable?(context)
+    def notifiable?(_context)
       false
     end
   end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
@@ -28,12 +28,17 @@ module Decidim
     include Reportable
     include Authorable
     include HasCategory
+    include Notifiable
     include Decidim::Comments::Commentable
 
     feature_manifest_name "dummy"
 
     def reported_content_url
       ResourceLocatorPresenter.new(self).url
+    end
+
+    def notifiable?(context)
+      false
     end
   end
 

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
@@ -28,7 +28,6 @@ module Decidim
     include Reportable
     include Authorable
     include HasCategory
-    include Notifiable
     include Decidim::Comments::Commentable
 
     feature_manifest_name "dummy"

--- a/decidim-pages/app/models/decidim/pages/page.rb
+++ b/decidim-pages/app/models/decidim/pages/page.rb
@@ -38,7 +38,7 @@ module Decidim
       end
 
       # Public: Overrides the `notifiable?` Notifiable concern method.
-      def notifiable?(context)
+      def notifiable?(_context)
         false
       end
     end

--- a/decidim-pages/app/models/decidim/pages/page.rb
+++ b/decidim-pages/app/models/decidim/pages/page.rb
@@ -7,6 +7,7 @@ module Decidim
     class Page < Pages::ApplicationRecord
       include Decidim::Resourceable
       include Decidim::HasFeature
+      include Decidim::Notifiable
       include Decidim::Comments::Commentable
 
       feature_manifest_name "pages"
@@ -34,6 +35,11 @@ module Decidim
       # Public: Overrides the `comments_have_votes?` Commentable concern method.
       def comments_have_votes?
         true
+      end
+
+      # Public: Overrides the `notifiable?` Notifiable concern method.
+      def notifiable?(context)
+        false
       end
     end
   end

--- a/decidim-pages/app/models/decidim/pages/page.rb
+++ b/decidim-pages/app/models/decidim/pages/page.rb
@@ -7,7 +7,6 @@ module Decidim
     class Page < Pages::ApplicationRecord
       include Decidim::Resourceable
       include Decidim::HasFeature
-      include Decidim::Notifiable
       include Decidim::Comments::Commentable
 
       feature_manifest_name "pages"

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -11,7 +11,6 @@ module Decidim
       include Decidim::HasReference
       include Decidim::HasCategory
       include Decidim::Reportable
-      include Decidim::Notifiable
       include Decidim::Comments::Commentable
 
       feature_manifest_name "proposals"
@@ -95,7 +94,7 @@ module Decidim
 
       # Public: Overrides the `notifiable?` Notifiable concern method.
       # When a proposal is commented the proposal's author is notified if it is not the same
-      # who has commented the proposal and if the proposal's author has comment notifiations enabled.
+      # who has commented the proposal and if the proposal's author has comment notifications enabled.
       def notifiable?(context)
         context[:author] != author && author.comments_notifications?
       end

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -11,6 +11,7 @@ module Decidim
       include Decidim::HasReference
       include Decidim::HasCategory
       include Decidim::Reportable
+      include Decidim::Notifiable
       include Decidim::Comments::Commentable
 
       feature_manifest_name "proposals"
@@ -90,6 +91,18 @@ module Decidim
       # Public: Overrides the `reported_content_url` Reportable concern method.
       def reported_content_url
         ResourceLocatorPresenter.new(self).url
+      end
+
+      # Public: Overrides the `notifiable?` Notifiable concern method.
+      # When a proposal is commented the proposal's author is notified if it is not the same
+      # who has commented the proposal and if the proposal's author has comment notifiations enabled.
+      def notifiable?(context)
+        context[:author] != author && author.comments_notifications?
+      end
+
+      # Public: Overrides the `users_to_notify` Notifiable concern method.
+      def users_to_notify
+        [author]
       end
     end
   end

--- a/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
@@ -5,6 +5,7 @@ require "spec_helper"
 module Decidim
   module Proposals
     describe Proposal do
+      let(:comments_notifications) { true }
       let(:proposal) { build(:proposal) }
       subject { proposal }
 
@@ -46,6 +47,40 @@ module Decidim
 
         it { is_expected.to be_answered }
         it { is_expected.to be_rejected }
+      end
+
+      describe "#notifiable?" do
+        let(:context_author) { create(:user, organization: subject.author.organization) }
+
+        context "when the context author is the same as the proposal's author" do
+          let(:context_author) { subject.author }
+
+          it "is not notifiable" do
+            expect(subject.notifiable?(author: context_author)).to be_falsy
+          end
+        end
+
+        context "when the context author is not the same as the proposal's author" do
+          context "when the comment's author has not comments notifications enabled" do
+            before do
+              expect(subject.author).to receive(:comments_notifications?).and_return(false)
+            end
+
+            it "is not notifiable" do
+              expect(subject.notifiable?(author: context_author)).to be_falsy
+            end
+          end
+
+          context "when the comment's author has comments notifications enabled" do
+            before do
+              expect(subject.author).to receive(:comments_notifications?).and_return(true)
+            end
+
+            it "is not notifiable" do
+              expect(subject.notifiable?(author: context_author)).to be_truthy
+            end
+          end
+        end
       end
     end
   end

--- a/decidim-results/app/models/decidim/results/result.rb
+++ b/decidim-results/app/models/decidim/results/result.rb
@@ -36,7 +36,7 @@ module Decidim
       end
 
       # Public: Overrides the `notifiable?` Notifiable concern method.
-      def notifiable?(context)
+      def notifiable?(_context)
         true
       end
 

--- a/decidim-results/app/models/decidim/results/result.rb
+++ b/decidim-results/app/models/decidim/results/result.rb
@@ -10,6 +10,7 @@ module Decidim
       include Decidim::HasScope
       include Decidim::HasCategory
       include Decidim::HasReference
+      include Decidim::Notifiable
       include Decidim::Comments::Commentable
 
       feature_manifest_name "results"
@@ -32,6 +33,16 @@ module Decidim
       # Public: Overrides the `comments_have_votes?` Commentable concern method.
       def comments_have_votes?
         true
+      end
+
+      # Public: Overrides the `notifiable?` Notifiable concern method.
+      def notifiable?(context)
+        true
+      end
+
+      # Public: Overrides the `users_to_notify` Notifiable concern method.
+      def users_to_notify
+        Decidim::Admin::ProcessAdmins.for(participatory_process)
       end
     end
   end

--- a/decidim-results/app/models/decidim/results/result.rb
+++ b/decidim-results/app/models/decidim/results/result.rb
@@ -10,7 +10,6 @@ module Decidim
       include Decidim::HasScope
       include Decidim::HasCategory
       include Decidim::HasReference
-      include Decidim::Notifiable
       include Decidim::Comments::Commentable
 
       feature_manifest_name "results"
@@ -42,7 +41,7 @@ module Decidim
 
       # Public: Overrides the `users_to_notify` Notifiable concern method.
       def users_to_notify
-        Decidim::Admin::ProcessAdmins.for(participatory_process)
+        Decidim::Admin::ProcessAdmins.for(feature.participatory_process)
       end
     end
   end

--- a/decidim-results/spec/features/comments_spec.rb
+++ b/decidim-results/spec/features/comments_spec.rb
@@ -4,6 +4,16 @@ require "spec_helper"
 
 describe "Comments", type: :feature, perform_enqueued: true do
   let!(:feature) { create(:result_feature, organization: organization) }
+  let!(:participatory_process) { feature.participatory_process }
+  let!(:participatory_process_admin) do
+    user = create(:user, :confirmed, organization: organization)
+    Decidim::Admin::ParticipatoryProcessUserRole.create!(
+      role: :admin,
+      user: user,
+      participatory_process: participatory_process
+    )
+    user
+  end
   let!(:commentable) { create(:result, feature: feature) }
 
   let(:resource_path) { decidim_results.result_path(commentable, feature_id: feature, participatory_process_id: feature.participatory_process) }


### PR DESCRIPTION
#### :tophat: What? Why?

When a `Result` is commented all participatory process admins should be notified. As @josepjaume suggested I created an abstraction called `Notifiable` with two methods:

- `notifiable?`: Whether a notification should be sent or not.
- `users_to_notify`: A collection of users to notify.

I implemented the `Notifiable` concern methods to all the `Commentable` resources so the `author` is not checked to sent notifications.
I refactored the `CreateComment` command code so it doesn't check flags anymore. The code was pushed to the model.

#### :pushpin: Related Issues
- Closes #1536

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
N/A

#### :ghost: GIF
![](https://media1.giphy.com/media/swcMBl9JvOKfC/giphy.gif)
