### PR TITLE
Extract icon method to a separate helper

### DIFF
--- a/decidim-core/app/controllers/decidim/features/base_controller.rb
+++ b/decidim-core/app/controllers/decidim/features/base_controller.rb
@@ -16,6 +16,7 @@ module Decidim
       helper Decidim::FeatureReferenceHelper
       helper Decidim::TranslationsHelper
       helper Decidim::ParticipatoryProcessHelper
+      helper Decidim::IconHelper
       helper Decidim::ResourceHelper
       helper Decidim::OrganizationScopesHelper
       helper Decidim::ActionAuthorizationHelper

--- a/decidim-core/app/controllers/decidim/participatory_process_steps_controller.rb
+++ b/decidim-core/app/controllers/decidim/participatory_process_steps_controller.rb
@@ -11,6 +11,7 @@ module Decidim
     include NeedsParticipatoryProcess
 
     helper Decidim::ParticipatoryProcessHelper
+    helper Decidim::IconHelper
 
     def index
       authorize! :read, ParticipatoryProcess

--- a/decidim-core/app/controllers/decidim/participatory_processes_controller.rb
+++ b/decidim-core/app/controllers/decidim/participatory_processes_controller.rb
@@ -14,6 +14,7 @@ module Decidim
 
     helper Decidim::AttachmentsHelper
     helper Decidim::ParticipatoryProcessHelper
+    helper Decidim::IconHelper
     helper Decidim::WidgetUrlsHelper
     helper_method :collection, :promoted_participatory_processes, :participatory_processes
 

--- a/decidim-core/app/helpers/decidim/icon_helper.rb
+++ b/decidim-core/app/helpers/decidim/icon_helper.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Decidim
+  # Helpers related to icons
+  module IconHelper
+    # Public: Returns an icon given an instance of a Feature. It defaults to
+    # a question mark when no icon is found.
+    #
+    # feature - The feature to generate the icon for.
+    #
+    # Returns an HTML tag with the icon.
+    def feature_icon(feature)
+      if feature.manifest.icon
+        external_icon feature.manifest.icon
+      else
+        icon "question-mark"
+      end
+    end
+  end
+end

--- a/decidim-core/app/helpers/decidim/participatory_process_helper.rb
+++ b/decidim-core/app/helpers/decidim/participatory_process_helper.rb
@@ -13,19 +13,5 @@ module Decidim
       dates = [participatory_process_step.start_date, participatory_process_step.end_date]
       dates.map { |date| date ? localize(date.to_date, format: :default) : "?" }.join(" - ")
     end
-
-    # Public: Returns an icon given an instance of a Feature. It defaults to
-    # a question mark when no icon is found.
-    #
-    # feature - The feature to generate the icon for.
-    #
-    # Returns an HTML tag with the icon.
-    def feature_icon(feature)
-      if feature.manifest.icon
-        external_icon feature.manifest.icon
-      else
-        icon "question-mark"
-      end
-    end
   end
 end

--- a/decidim-core/spec/helpers/decidim/icon_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/icon_helper_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe IconHelper do
+    describe "#feature_icon" do
+      let(:feature) do
+        double(manifest: double(icon: icon))
+      end
+
+      let(:icon) { "a/fake/icon.svg" }
+
+      describe "when the feature has no icon" do
+        let(:icon) { nil }
+
+        it "returns a fallback" do
+          result = helper.feature_icon(feature)
+          expect(result).to include("question-mark")
+        end
+      end
+
+      describe "when the feature has no icon" do
+        it "returns a fallback" do
+          result = helper.feature_icon(feature)
+          expect(result).to include("a/fake/icon.svg")
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/helpers/decidim/participatory_process_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/participatory_process_helper_spec.rb
@@ -37,29 +37,5 @@ module Decidim
         end
       end
     end
-
-    describe "#feature_icon" do
-      let(:feature) do
-        double(manifest: double(icon: icon))
-      end
-
-      let(:icon) { "a/fake/icon.svg" }
-
-      describe "when the feature has no icon" do
-        let(:icon) { nil }
-
-        it "returns a fallback" do
-          result = helper.feature_icon(feature)
-          expect(result).to include("question-mark")
-        end
-      end
-
-      describe "when the feature has no icon" do
-        it "returns a fallback" do
-          result = helper.feature_icon(feature)
-          expect(result).to include("a/fake/icon.svg")
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

This is just a tiny refactor that moves a method that has nothing to do with participatory processes out of `ParticipatoryProcessHelper` into a different helper.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![turtle](https://user-images.githubusercontent.com/2887858/27684154-0280dd04-5cc9-11e7-8567-34064b2a6817.gif)