### PR TITLE
Improve resource locator presenter tests

### DIFF
--- a/decidim-core/spec/presenters/decidim/resource_locator_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/resource_locator_presenter_spec.rb
@@ -4,35 +4,30 @@ require "spec_helper"
 
 module Decidim
   describe ResourceLocatorPresenter, type: :helper do
-    let(:feature) { create(:feature) }
-    let(:resource) { create(:dummy_resource, feature: feature) }
+    let(:organization) { create(:organization, host: "1.lvh.me") }
+
+    let(:participatory_process) do
+      create(:participatory_process, id: 1, organization: organization)
+    end
+
+    let(:feature) do
+      create(:feature, id: 1, participatory_process: participatory_process)
+    end
+
+    let(:resource) do
+      create(:dummy_resource, id: 1, feature: feature)
+    end
 
     describe "#url" do
       subject { described_class.new(resource).url }
 
-      let(:expected_resource_url) do
-        helper.decidim_dummy.dummy_resource_url(
-          participatory_process_id: feature.participatory_process.id,
-          feature_id: feature.id,
-          id: resource.id,
-          host: feature.organization.host
-        )
-      end
-
-      it { is_expected.to eq(expected_resource_url) }
+      it { is_expected.to eq("http://1.lvh.me/processes/1/f/1/dummy_resources/1") }
     end
 
     describe "#path" do
       subject { described_class.new(resource).path }
 
-      let(:expected_resource_path) do
-        helper.decidim_dummy.dummy_resource_path(
-          participatory_process_id: feature.participatory_process.id,
-          feature_id: feature.id, id: resource.id
-        )
-      end
-
-      it { is_expected.to eq(expected_resource_path) }
+      it { is_expected.to eq("/processes/1/f/1/dummy_resources/1") }
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR improves resource locator tests. The previous version was duplicating the tested functionality in the test itself. That's not usually a good thing, because it's not dry and because you wonder what you're actually testing... This makes the tests more explicit in my opinion.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![acrobatics](https://user-images.githubusercontent.com/2887858/27685468-9335cb70-5cce-11e7-9399-e31264b411dc.gif)
