### PR TITLE
Fix weird menu reloading issue

### DIFF
--- a/decidim-admin/app/helpers/decidim/admin/menu_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/menu_helper.rb
@@ -6,7 +6,7 @@ module Decidim
     module MenuHelper
       # Public: Returns the main menu presenter object
       def main_menu
-        @main_menu ||= MenuPresenter.new(
+        @main_menu ||= ::Decidim::MenuPresenter.new(
           :admin_menu,
           self,
           active_class: "is-active"

--- a/decidim-core/app/helpers/decidim/menu_helper.rb
+++ b/decidim-core/app/helpers/decidim/menu_helper.rb
@@ -5,7 +5,7 @@ module Decidim
   module MenuHelper
     # Public: Returns the main menu presenter object
     def main_menu
-      @main_menu ||= MenuPresenter.new(
+      @main_menu ||= ::Decidim::MenuPresenter.new(
         :menu,
         self,
         element_class: "main-nav__link",

--- a/decidim-system/app/helpers/decidim/system/menu_helper.rb
+++ b/decidim-system/app/helpers/decidim/system/menu_helper.rb
@@ -6,7 +6,7 @@ module Decidim
     module MenuHelper
       # Public: Returns the main menu presenter object
       def main_menu
-        @main_menu ||= MenuPresenter.new(:system_menu, self)
+        @main_menu ||= ::Decidim::MenuPresenter.new(:system_menu, self)
       end
     end
   end


### PR DESCRIPTION

#### :tophat: What? Why?

In the development app, do this:

* Load http://localhost:3000/admin/participatory_processes/2/features/8/manage
* Remove letter_opener related routes (or anything else, I guess) from core routes file.
* Reload the page.

You get the error

```
A copy of Decidim::Admin::MenuHelper has been removed from the module
tree but is still active!
```

This seems like some bad interaction between ruby's built-in autoload
and Rails autoloading mechanism based on const_missing.

I don't fully understand it, but this fixes the issue.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
![error](https://user-images.githubusercontent.com/2887858/27710313-9aad3dec-5d1f-11e7-9d68-a1661acbbdff.png)

#### :ghost: GIF
![dancing_in_the_rain](https://user-images.githubusercontent.com/2887858/27710625-b69f5084-5d20-11e7-999f-efc6950f6ca0.gif)


