### PR TITLE
Fix decidim dev tasks not being exposed

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ require "generators/decidim/docker_generator"
 require "decidim/dev"
 
 load "decidim-core/lib/tasks/decidim_tasks.rake"
-Decidim::Dev.install_tasks
+load "decidim-dev/lib/tasks/test_app.rake"
 
 DECIDIM_GEMS = %w(core system admin api pages meetings proposals comments results budgets surveys dev).freeze
 

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,6 @@ require "generators/decidim/app_generator"
 require "generators/decidim/docker_generator"
 require "decidim/dev"
 
-load "decidim-core/lib/tasks/decidim_tasks.rake"
 load "decidim-dev/lib/tasks/test_app.rake"
 
 DECIDIM_GEMS = %w(core system admin api pages meetings proposals comments results budgets surveys dev).freeze

--- a/decidim-dev/lib/decidim/dev.rb
+++ b/decidim-dev/lib/decidim/dev.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "decidim/dev/railtie"
+
 module Decidim
   # Decidim::Dev holds all the convenience logic and libraries to be able to
   # create external libraries that create test apps and test themselves against

--- a/decidim-dev/lib/decidim/dev/railtie.rb
+++ b/decidim-dev/lib/decidim/dev/railtie.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rails"
+
 module Decidim
   module Dev
     class Railtie < Rails::Railtie


### PR DESCRIPTION
#### :tophat: What? Why?

Since #1527, decidim-dev's railtie was not being required. That means its tasks `decidim:check_locales` and `decidim:generate_test_app` were no longer being exposed to the application.

This change fixes it.

It also stops exposing some "app only tasks" that don't make sense in the development repo side.

### Before (in main repo):

```shell
$ bundle exec rake -T decidim
rake decidim:check_locales      # Allows a decidim installation to check whether its locales are complete
rake decidim:generate_test_app  # Generates a dummy app for testing
rake decidim:upgrade            # Install migrations from Decidim to the app
```

### Before (in end application):

```shell
$ bundle exec rake -T decidim
rake decidim:install:migrations            # Copy migrations from decidim to application
rake decidim:upgrade                       # Install migrations from Decidim to the app
rake decidim_admin:install:migrations      # Copy migrations from decidim_admin to application
rake decidim_budgets:install:migrations    # Copy migrations from decidim_budgets to application
rake decidim_comments:install:migrations   # Copy migrations from decidim_comments to application
rake decidim_meetings:install:migrations   # Copy migrations from decidim_meetings to application
rake decidim_pages:install:migrations      # Copy migrations from decidim_pages to application
rake decidim_proposals:install:migrations  # Copy migrations from decidim_proposals to application
rake decidim_results:install:migrations    # Copy migrations from decidim_results to application
rake decidim_surveys:install:migrations    # Copy migrations from decidim_surveys to application
rake decidim_system:install:migrations     # Copy migrations from decidim_system to application
```

### After (in main repo):

```shell
$ bundle exec rake -T decidim
rake decidim:generate_test_app  # Generates a dummy app for testing
```

### After (in end application):

```shell
$ bundle exec rake -T decidim
rake decidim:check_locales                 # Allows a decidim installation to check whether its locales are complete
rake decidim:generate_test_app             # Generates a dummy app for testing
rake decidim:install:migrations            # Copy migrations from decidim to application
rake decidim:upgrade                       # Install migrations from Decidim to the app
rake decidim_admin:install:migrations      # Copy migrations from decidim_admin to application
rake decidim_budgets:install:migrations    # Copy migrations from decidim_budgets to application
rake decidim_comments:install:migrations   # Copy migrations from decidim_comments to application
rake decidim_meetings:install:migrations   # Copy migrations from decidim_meetings to application
rake decidim_pages:install:migrations      # Copy migrations from decidim_pages to application
rake decidim_proposals:install:migrations  # Copy migrations from decidim_proposals to application
rake decidim_results:install:migrations    # Copy migrations from decidim_results to application
rake decidim_surveys:install:migrations    # Copy migrations from decidim_surveys to application
rake decidim_system:install:migrations     # Copy migrations from decidim_system to application
```

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![food](https://user-images.githubusercontent.com/2887858/27735789-958ab236-5da1-11e7-9dfa-93da63f07525.gif)