### PR TITLE
Improve decidim's i18n

### DIFF
--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -17,7 +17,7 @@ if !Rails.env.production? || ENV["SEED"]
     end,
     homepage_image: File.new(File.join(__dir__, "seeds", "homepage_image.jpg")),
     default_locale: I18n.default_locale,
-    available_locales: Decidim.available_locales,
+    available_locales: [:en, :ca, :es],
     reference_prefix: Faker::Name.suffix
   )
 

--- a/decidim-core/spec/helpers/decidim/translations_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/translations_helper_spec.rb
@@ -7,17 +7,19 @@ module Decidim
     describe "#translated_attribute" do
       it "translates the attribute against the current locale" do
         attribute = { "ca" => "Hola", "zh-CN" => "你好" }
-        I18n.locale = :'zh-CN'
 
-        expect(helper.translated_attribute(attribute)).to eq("你好")
+        I18n.with_locale(:'zh-CN') do
+          expect(helper.translated_attribute(attribute)).to eq("你好")
+        end
       end
 
       context "when therte is no translation for the given locale" do
         it "returns an empty string" do
           attribute = { "ca" => "Hola" }
-          I18n.locale = :'zh-CN'
 
-          expect(helper.translated_attribute(attribute)).to eq("")
+          I18n.with_locale(:'zh-CN') do
+            expect(helper.translated_attribute(attribute)).to eq("")
+          end
         end
       end
     end

--- a/decidim-core/spec/lib/faker_localized_spec.rb
+++ b/decidim-core/spec/lib/faker_localized_spec.rb
@@ -24,7 +24,7 @@ module Decidim
       let(:available_locales) { [:en, :ca] }
 
       before do
-        I18n.available_locales = available_locales
+        allow(I18n).to receive(:available_locales).and_return available_locales
       end
 
       it_behaves_like "a localized Faker method", :name

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/i18n.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/i18n.rb
@@ -3,14 +3,7 @@
 RSpec.configure do |config|
   config.before(:suite) do
     I18n.config.enforce_available_locales = false
-  end
-
-  config.around(:each) do |example|
     I18n.available_locales = %w(en ca es)
     Decidim.available_locales = %w(en ca es)
-
-    previous_locale = I18n.locale
-    example.run
-    I18n.locale = previous_locale
   end
 end

--- a/decidim-system/spec/commands/decidim/system/create_default_pages_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/create_default_pages_spec.rb
@@ -15,7 +15,7 @@ module Decidim
       end
 
       it "sets the content with each locale" do
-        I18n.available_locales = [:en, :ca]
+        allow(Decidim).to receive(:available_locales).and_return [:en, :ca]
 
         subject
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -142,4 +142,4 @@ $ bin/rails decidim:check_locales
 ```
 
 Be aware that this task might not be able to detect everything, so make sure you
-also manually check your application before uprading.
+also manually check your application before upgrading.

--- a/lib/generators/decidim/app_generator.rb
+++ b/lib/generators/decidim/app_generator.rb
@@ -90,12 +90,6 @@ module Decidim
         end
       end
 
-      def set_locales
-        inject_into_file "config/application.rb", after: "class Application < Rails::Application" do
-          "\n    config.i18n.available_locales = Decidim.available_locales\n    config.i18n.default_locale = Decidim.default_locale"
-        end
-      end
-
       def remove_default_error_pages
         remove_file "public/404.html"
         remove_file "public/500.html"

--- a/lib/generators/decidim/templates/initializer.rb
+++ b/lib/generators/decidim/templates/initializer.rb
@@ -7,7 +7,7 @@ Decidim.configure do |config|
   config.authorization_handlers = [ExampleAuthorizationHandler]
 
   # Uncomment this lines to set your preferred locales
-  # config.available_locales = %i{en ca es}
+  # config.available_locales = [:en, :ca, :es]
 
   # Geocoder configuration
   # config.geocoder = {

--- a/lib/generators/decidim/templates/initializer.rb
+++ b/lib/generators/decidim/templates/initializer.rb
@@ -28,3 +28,6 @@ Decidim.configure do |config|
   # The number of reports which an object can receive before hiding it
   # config.max_reports_before_hiding = 3
 end
+
+Rails.application.config.i18n.available_locales = Decidim.available_locales
+Rails.application.config.i18n.default_locale = Decidim.default_locale


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes several things regarding decidim languages:

* ~Adds docs! :tada:~

* Allows configuring locales. At the moment, by the time decidim's configuration is run, the `config.available_locales = Decidim.available_locales` assignment in `application.rb` has already been run. So custom locales are not picked up. I fixed it by changing the order these are run.

* ~Changes generated application locales to be `:en`, `:ca` & `:es`, instead of all available locales. At the moment, playing around with the generated application is a PITA because until we fix #1127, all languages are required. And the generated application uses all 8 languages by default! Even if #1127 was no longer a problem, I'm not sure we want to generate applications with all languages enabled, since it would be a pretty unrealistic application. I think enabling English + decidim original languages is a good compromise.~. I finally used those locales not globally but for the sample organizations as suggested by @mrcasals.

* ~Makes it easier to remove locales from an app by providing a rake task, `decidim:sanitize_locales`, that cleans up DB from no longer available locales. Without running this task, decidim can crash after removing locales, because the locales available for each organization might no longer be available.~

#### :pushpin: Related Issues
- ~Fixes #1439~.
- Related to #1495. ~Doesn't completely fix it, but gets it started.~
- ~Blocked on #1554, since decidim can't provide tasks to applications until that one is merged. It's currently built on top of it.~ That PR was merged.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![catcold](https://user-images.githubusercontent.com/2887858/27731508-761fef4c-5d8d-11e7-936f-67cec6b86904.gif)