### PR TITLE
Fix engine binstubs

### DIFF
--- a/decidim-admin/bin/rails
+++ b/decidim-admin/bin/rails
@@ -8,7 +8,7 @@ ENGINE_ROOT = File.expand_path("..", __dir__)
 ENGINE_PATH = File.expand_path("../lib/decidim/admin/engine", __dir__)
 
 # Set up gems listed in the Gemfile.
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
 require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 
 require "rails/all"

--- a/decidim-admin/bin/rails
+++ b/decidim-admin/bin/rails
@@ -9,7 +9,7 @@ ENGINE_PATH = File.expand_path("../lib/decidim/admin/engine", __dir__)
 
 # Set up gems listed in the Gemfile.
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
-require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+require "bundler/setup"
 
 require "rails/all"
 require "rails/engine/commands"

--- a/decidim-api/bin/rails
+++ b/decidim-api/bin/rails
@@ -8,7 +8,7 @@ ENGINE_ROOT = File.expand_path("..", __dir__)
 ENGINE_PATH = File.expand_path("../lib/decidim/api/engine", __dir__)
 
 # Set up gems listed in the Gemfile.
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
 require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 
 require "rails/all"

--- a/decidim-api/bin/rails
+++ b/decidim-api/bin/rails
@@ -9,7 +9,7 @@ ENGINE_PATH = File.expand_path("../lib/decidim/api/engine", __dir__)
 
 # Set up gems listed in the Gemfile.
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
-require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+require "bundler/setup"
 
 require "rails/all"
 require "rails/engine/commands"

--- a/decidim-budgets/bin/rails
+++ b/decidim-budgets/bin/rails
@@ -9,7 +9,7 @@ ENGINE_PATH = File.expand_path("../lib/decidim/budgets/engine", __dir__)
 
 # Set up gems listed in the Gemfile.
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
-require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+require "bundler/setup"
 
 require "rails/all"
 require "rails/engine/commands"

--- a/decidim-budgets/bin/rails
+++ b/decidim-budgets/bin/rails
@@ -8,7 +8,7 @@ ENGINE_ROOT = File.expand_path("..", __dir__)
 ENGINE_PATH = File.expand_path("../lib/decidim/budgets/engine", __dir__)
 
 # Set up gems listed in the Gemfile.
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
 require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 
 require "rails/all"

--- a/decidim-comments/bin/rails
+++ b/decidim-comments/bin/rails
@@ -9,7 +9,7 @@ ENGINE_PATH = File.expand_path("../lib/decidim/comments/engine", __dir__)
 
 # Set up gems listed in the Gemfile.
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
-require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+require "bundler/setup"
 
 require "rails/all"
 require "rails/engine/commands"

--- a/decidim-comments/bin/rails
+++ b/decidim-comments/bin/rails
@@ -8,7 +8,7 @@ ENGINE_ROOT = File.expand_path("..", __dir__)
 ENGINE_PATH = File.expand_path("../lib/decidim/comments/engine", __dir__)
 
 # Set up gems listed in the Gemfile.
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
 require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 
 require "rails/all"

--- a/decidim-core/bin/rails
+++ b/decidim-core/bin/rails
@@ -8,7 +8,7 @@ ENGINE_ROOT = File.expand_path("..", __dir__)
 ENGINE_PATH = File.expand_path("../lib/decidim/core/engine", __dir__)
 
 # Set up gems listed in the Gemfile.
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
 require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 
 require "rails/all"

--- a/decidim-core/bin/rails
+++ b/decidim-core/bin/rails
@@ -9,7 +9,7 @@ ENGINE_PATH = File.expand_path("../lib/decidim/core/engine", __dir__)
 
 # Set up gems listed in the Gemfile.
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
-require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+require "bundler/setup"
 
 require "rails/all"
 require "rails/engine/commands"

--- a/decidim-meetings/bin/rails
+++ b/decidim-meetings/bin/rails
@@ -9,7 +9,7 @@ ENGINE_PATH = File.expand_path("../lib/decidim/meetings/engine", __dir__)
 
 # Set up gems listed in the Gemfile.
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
-require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+require "bundler/setup"
 
 require "rails/all"
 require "rails/engine/commands"

--- a/decidim-meetings/bin/rails
+++ b/decidim-meetings/bin/rails
@@ -8,7 +8,7 @@ ENGINE_ROOT = File.expand_path("..", __dir__)
 ENGINE_PATH = File.expand_path("../lib/decidim/meetings/engine", __dir__)
 
 # Set up gems listed in the Gemfile.
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
 require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 
 require "rails/all"

--- a/decidim-pages/bin/rails
+++ b/decidim-pages/bin/rails
@@ -9,7 +9,7 @@ ENGINE_PATH = File.expand_path("../lib/decidim/pages/engine", __dir__)
 
 # Set up gems listed in the Gemfile.
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
-require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+require "bundler/setup"
 
 require "rails/all"
 require "rails/engine/commands"

--- a/decidim-pages/bin/rails
+++ b/decidim-pages/bin/rails
@@ -8,7 +8,7 @@ ENGINE_ROOT = File.expand_path("..", __dir__)
 ENGINE_PATH = File.expand_path("../lib/decidim/pages/engine", __dir__)
 
 # Set up gems listed in the Gemfile.
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
 require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 
 require "rails/all"

--- a/decidim-proposals/bin/rails
+++ b/decidim-proposals/bin/rails
@@ -9,7 +9,7 @@ ENGINE_PATH = File.expand_path("../lib/decidim/proposals/engine", __dir__)
 
 # Set up gems listed in the Gemfile.
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
-require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+require "bundler/setup"
 
 require "rails/all"
 require "rails/engine/commands"

--- a/decidim-proposals/bin/rails
+++ b/decidim-proposals/bin/rails
@@ -8,7 +8,7 @@ ENGINE_ROOT = File.expand_path("..", __dir__)
 ENGINE_PATH = File.expand_path("../lib/decidim/proposals/engine", __dir__)
 
 # Set up gems listed in the Gemfile.
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
 require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 
 require "rails/all"

--- a/decidim-results/bin/rails
+++ b/decidim-results/bin/rails
@@ -8,7 +8,7 @@ ENGINE_ROOT = File.expand_path("..", __dir__)
 ENGINE_PATH = File.expand_path("../lib/decidim/results/engine", __dir__)
 
 # Set up gems listed in the Gemfile.
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
 require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 
 require "rails/all"

--- a/decidim-results/bin/rails
+++ b/decidim-results/bin/rails
@@ -9,7 +9,7 @@ ENGINE_PATH = File.expand_path("../lib/decidim/results/engine", __dir__)
 
 # Set up gems listed in the Gemfile.
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
-require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+require "bundler/setup"
 
 require "rails/all"
 require "rails/engine/commands"

--- a/decidim-surveys/bin/rails
+++ b/decidim-surveys/bin/rails
@@ -8,7 +8,7 @@ ENGINE_ROOT = File.expand_path("..", __dir__)
 ENGINE_PATH = File.expand_path("../lib/decidim/surveys/engine", __dir__)
 
 # Set up gems listed in the Gemfile.
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
 require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 
 require "rails/all"

--- a/decidim-surveys/bin/rails
+++ b/decidim-surveys/bin/rails
@@ -9,7 +9,7 @@ ENGINE_PATH = File.expand_path("../lib/decidim/surveys/engine", __dir__)
 
 # Set up gems listed in the Gemfile.
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
-require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+require "bundler/setup"
 
 require "rails/all"
 require "rails/engine/commands"

--- a/decidim-system/bin/rails
+++ b/decidim-system/bin/rails
@@ -9,7 +9,7 @@ ENGINE_PATH = File.expand_path("../lib/decidim/system/engine", __dir__)
 
 # Set up gems listed in the Gemfile.
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
-require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+require "bundler/setup"
 
 require "rails/all"
 require "rails/engine/commands"

--- a/decidim-system/bin/rails
+++ b/decidim-system/bin/rails
@@ -8,7 +8,7 @@ ENGINE_ROOT = File.expand_path("..", __dir__)
 ENGINE_PATH = File.expand_path("../lib/decidim/system/engine", __dir__)
 
 # Set up gems listed in the Gemfile.
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
 require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 
 require "rails/all"

--- a/docs/how_to_create_a_plugin.md
+++ b/docs/how_to_create_a_plugin.md
@@ -44,7 +44,7 @@
     ENGINE_PATH = File.expand_path("..lib/decidim/<engine_name>/engine", __dir__)
 
     # Set up gems listed in the Gemfile.
-    ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+    ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
     require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 
     require "rails/all"

--- a/docs/how_to_create_a_plugin.md
+++ b/docs/how_to_create_a_plugin.md
@@ -45,7 +45,7 @@
 
     # Set up gems listed in the Gemfile.
     ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
-    require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+    require "bundler/setup"
 
     require "rails/all"
     require "rails/engine/commands"


### PR DESCRIPTION
#### :tophat: What? Why?

Each plugin's `rails` binstub was pointing to a `Gemfile` inside the plugin's folder, but our plugins don't currently include a `Gemfile`. They should point to the common `Gemfile` one level higher up in the folder hierarchy.

This was preventing the binstubs from working.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![janis](https://user-images.githubusercontent.com/2887858/27827888-b8387d84-60b9-11e7-8810-2902f187b93c.gif)
