### PR TITLE
Fix proposal submission phase ordering

### DIFF
--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
@@ -29,7 +29,7 @@ module Decidim
 
         def default_order
           if order_by_votes?
-            detect_order("most_voted")
+            "most_voted"
           else
             "random"
           end

--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
@@ -30,8 +30,10 @@ module Decidim
         def default_order
           if order_by_votes?
             "most_voted"
-          else
+          elsif order_randomly?
             "random"
+          else
+            "recent"
           end
         end
 
@@ -41,6 +43,10 @@ module Decidim
 
         def order_by_votes?
           most_voted_order_available? && current_settings.votes_blocked?
+        end
+
+        def order_randomly?
+          most_voted_order_available? && !current_settings.votes_blocked?
         end
 
         # Returns: A random float number between -1 and 1 to be used as a random seed at the database.

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -719,7 +719,7 @@ describe "Proposals", type: :feature do
         end
       end
 
-      context "by 'recent'" do
+      context "by 'most_recent'" do
         let!(:older_proposal) { create(:proposal, feature: feature, created_at: 1.month.ago) }
         let!(:recent_proposal) { create(:proposal, feature: feature) }
 

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -709,11 +709,15 @@ describe "Proposals", type: :feature do
                  participatory_process: participatory_process)
         end
 
-        it "lists the proposals ordered by votes" do
-          most_voted_proposal = create(:proposal, feature: feature)
-          create_list(:proposal_vote, 3, proposal: most_voted_proposal)
-          less_voted_proposal = create(:proposal, feature: feature)
+        let!(:most_voted_proposal) do
+          proposal = create(:proposal, feature: feature)
+          create_list(:proposal_vote, 3, proposal: proposal)
+          proposal
+        end
 
+        let!(:less_voted_proposal) { create(:proposal, feature: feature) }
+
+        it "lists the proposals ordered by votes" do
           visit_feature
 
           within ".order-by" do
@@ -728,10 +732,10 @@ describe "Proposals", type: :feature do
       end
 
       context "by 'recent'" do
-        it "lists the proposals ordered by created at" do
-          older_proposal = create(:proposal, feature: feature, created_at: 1.month.ago)
-          recent_proposal = create(:proposal, feature: feature)
+        let!(:older_proposal) { create(:proposal, feature: feature, created_at: 1.month.ago) }
+        let!(:recent_proposal) { create(:proposal, feature: feature) }
 
+        it "lists the proposals ordered by created at" do
           visit_feature
 
           within ".order-by" do

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -709,11 +709,11 @@ describe "Proposals", type: :feature do
           visit_feature
 
           within ".order-by" do
-            expect(page).to have_selector("ul[data-dropdown-menu$=dropdown-menu]", text: "Random")
-            page.find("a", text: "Random").click
+            page.find("ul[data-dropdown-menu$=dropdown-menu] a").click
             click_link "Most voted"
           end
 
+          expect(page).to have_selector("a", text: "Most voted")
           expect(page).to have_selector("#proposals .card-grid .column:first-child", text: most_voted_proposal.title)
           expect(page).to have_selector("#proposals .card-grid .column:last-child", text: less_voted_proposal.title)
         end
@@ -727,11 +727,11 @@ describe "Proposals", type: :feature do
           visit_feature
 
           within ".order-by" do
-            expect(page).to have_selector("ul[data-dropdown-menu$=dropdown-menu]", text: "Random")
-            page.find("a", text: "Random").click
+            page.find("ul[data-dropdown-menu$=dropdown-menu] a").click
             click_link "Recent"
           end
 
+          expect(page).to have_selector("a", text: "Recent")
           expect(page).to have_selector("#proposals .card-grid .column:first-child", text: recent_proposal.title)
           expect(page).to have_selector("#proposals .card-grid .column:last-child", text: older_proposal.title)
         end

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -730,6 +730,22 @@ describe "Proposals", type: :feature do
           expect(page).to have_selector("#proposals .card-grid .column:last-child", text: older_proposal.title)
         end
       end
+
+      context "randomly" do
+        let!(:lucky_proposal) { create(:proposal, feature: feature) }
+        let!(:unlucky_proposal) { create(:proposal, feature: feature) }
+
+        it "lists the proposals ordered randomly" do
+          visit_feature
+
+          order_proposals_by("Random")
+
+          expect(page).to have_selector("a", text: "Random")
+          expect(page).to have_selector("#proposals .card-grid .column", count: 2)
+          expect(page).to have_selector("#proposals .card-grid .column", text: lucky_proposal.title)
+          expect(page).to have_selector("#proposals .card-grid .column", text: unlucky_proposal.title)
+        end
+      end
     end
 
     private

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -446,16 +446,15 @@ describe "Proposals", type: :feature do
                participatory_process: participatory_process)
       end
 
-      let!(:lucky_proposal) { create(:proposal, feature: feature) }
-      let!(:unlucky_proposal) { create(:proposal, feature: feature) }
+      let!(:older_proposal) { create(:proposal, feature: feature, created_at: 1.month.ago) }
+      let!(:recent_proposal) { create(:proposal, feature: feature) }
 
-      it "lists the proposals ordered randomly" do
+      it "lists the proposals ordered by created at" do
         visit_feature
 
-        expect(page).to have_selector("a", text: "Random")
-        expect(page).to have_selector("#proposals .card-grid .column", count: 2)
-        expect(page).to have_selector("#proposals .card-grid .column", text: lucky_proposal.title)
-        expect(page).to have_selector("#proposals .card-grid .column", text: unlucky_proposal.title)
+        expect(page).to have_selector("a", text: "Recent")
+        expect(page).to have_selector("#proposals .card-grid .column:first-child", text: recent_proposal.title)
+        expect(page).to have_selector("#proposals .card-grid .column:last-child", text: older_proposal.title)
       end
 
       it "shows only links to full proposals" do

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -401,7 +401,7 @@ describe "Proposals", type: :feature do
       let!(:lucky_proposal) { create(:proposal, feature: feature) }
       let!(:unlucky_proposal) { create(:proposal, feature: feature) }
 
-      it "lists the proposals ordered randomly by default" do
+      it "lists the proposals ordered randomly" do
         visit_feature
 
         expect(page).to have_selector("a", text: "Random")

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -397,20 +397,6 @@ describe "Proposals", type: :feature do
   end
 
   context "listing proposals in a participatory process" do
-    shared_examples_for "a random proposal ordering" do
-      let!(:lucky_proposal) { create(:proposal, feature: feature) }
-      let!(:unlucky_proposal) { create(:proposal, feature: feature) }
-
-      it "lists the proposals ordered randomly" do
-        visit_feature
-
-        expect(page).to have_selector("a", text: "Random")
-        expect(page).to have_selector("#proposals .card-grid .column", count: 2)
-        expect(page).to have_selector("#proposals .card-grid .column", text: lucky_proposal.title)
-        expect(page).to have_selector("#proposals .card-grid .column", text: unlucky_proposal.title)
-      end
-    end
-
     it "lists all the proposals" do
       create(:proposal_feature,
              manifest: manifest,
@@ -420,10 +406,6 @@ describe "Proposals", type: :feature do
 
       visit_feature
       expect(page).to have_css(".card--proposal", count: 3)
-    end
-
-    describe "default ordering" do
-      it_behaves_like "a random proposal ordering"
     end
 
     context "when voting phase is over" do
@@ -465,7 +447,17 @@ describe "Proposals", type: :feature do
       end
 
       describe "order" do
-        it_behaves_like "a random proposal ordering"
+        let!(:lucky_proposal) { create(:proposal, feature: feature) }
+        let!(:unlucky_proposal) { create(:proposal, feature: feature) }
+
+        it "lists the proposals ordered randomly" do
+          visit_feature
+
+          expect(page).to have_selector("a", text: "Random")
+          expect(page).to have_selector("#proposals .card-grid .column", count: 2)
+          expect(page).to have_selector("#proposals .card-grid .column", text: lucky_proposal.title)
+          expect(page).to have_selector("#proposals .card-grid .column", text: unlucky_proposal.title)
+        end
       end
 
       it "shows only links to full proposals" do

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -731,8 +731,8 @@ describe "Proposals", type: :feature do
       end
 
       context "randomly" do
-        let!(:lucky_proposal) { create(:proposal, feature: feature) }
-        let!(:unlucky_proposal) { create(:proposal, feature: feature) }
+        let!(:one_proposal) { create(:proposal, feature: feature) }
+        let!(:another_proposal) { create(:proposal, feature: feature) }
 
         it "lists the proposals ordered randomly" do
           visit_feature
@@ -741,8 +741,8 @@ describe "Proposals", type: :feature do
 
           expect(page).to have_selector("a", text: "Random")
           expect(page).to have_selector("#proposals .card-grid .column", count: 2)
-          expect(page).to have_selector("#proposals .card-grid .column", text: lucky_proposal.title)
-          expect(page).to have_selector("#proposals .card-grid .column", text: unlucky_proposal.title)
+          expect(page).to have_selector("#proposals .card-grid .column", text: one_proposal.title)
+          expect(page).to have_selector("#proposals .card-grid .column", text: another_proposal.title)
         end
       end
     end

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -446,23 +446,19 @@ describe "Proposals", type: :feature do
                participatory_process: participatory_process)
       end
 
-      describe "order" do
-        let!(:lucky_proposal) { create(:proposal, feature: feature) }
-        let!(:unlucky_proposal) { create(:proposal, feature: feature) }
+      let!(:lucky_proposal) { create(:proposal, feature: feature) }
+      let!(:unlucky_proposal) { create(:proposal, feature: feature) }
 
-        it "lists the proposals ordered randomly" do
-          visit_feature
+      it "lists the proposals ordered randomly" do
+        visit_feature
 
-          expect(page).to have_selector("a", text: "Random")
-          expect(page).to have_selector("#proposals .card-grid .column", count: 2)
-          expect(page).to have_selector("#proposals .card-grid .column", text: lucky_proposal.title)
-          expect(page).to have_selector("#proposals .card-grid .column", text: unlucky_proposal.title)
-        end
+        expect(page).to have_selector("a", text: "Random")
+        expect(page).to have_selector("#proposals .card-grid .column", count: 2)
+        expect(page).to have_selector("#proposals .card-grid .column", text: lucky_proposal.title)
+        expect(page).to have_selector("#proposals .card-grid .column", text: unlucky_proposal.title)
       end
 
       it "shows only links to full proposals" do
-        create_list(:proposal, 2, feature: feature)
-
         visit_feature
 
         expect(page).to have_no_button("Voting disabled", disabled: true)

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -708,10 +708,7 @@ describe "Proposals", type: :feature do
         it "lists the proposals ordered by votes" do
           visit_feature
 
-          within ".order-by" do
-            page.find("ul[data-dropdown-menu$=dropdown-menu] a").click
-            click_link "Most voted"
-          end
+          order_proposals_by("Most voted")
 
           expect(page).to have_selector("a", text: "Most voted")
           expect(page).to have_selector("#proposals .card-grid .column:first-child", text: most_voted_proposal.title)
@@ -726,15 +723,21 @@ describe "Proposals", type: :feature do
         it "lists the proposals ordered by created at" do
           visit_feature
 
-          within ".order-by" do
-            page.find("ul[data-dropdown-menu$=dropdown-menu] a").click
-            click_link "Recent"
-          end
+          order_proposals_by("Recent")
 
           expect(page).to have_selector("a", text: "Recent")
           expect(page).to have_selector("#proposals .card-grid .column:first-child", text: recent_proposal.title)
           expect(page).to have_selector("#proposals .card-grid .column:last-child", text: older_proposal.title)
         end
+      end
+    end
+
+    private
+
+    def order_proposals_by(criteria)
+      within ".order-by" do
+        page.find("ul[data-dropdown-menu$=dropdown-menu] a").click
+        click_link criteria
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

I changed <strike>comment</strike> proposal ordering to only be "random" when voting is in process, and votes are not hidden. Rest of the times we default to "recent".

Also did some spec refactoring.

#### :pushpin: Related Issues
- Fixes #1571.

#### :clipboard: Subtasks
_None_

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![it_crowd](https://user-images.githubusercontent.com/2887858/27948287-9d53b50a-62f9-11e7-9689-e54ceb29f163.gif)