### PR TITLE
Resend invitation instructions when reinviting process admin

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/create_participatory_process_admin.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_participatory_process_admin.rb
@@ -49,7 +49,7 @@ module Decidim
       end
 
       def create_or_invite_user
-        @user ||= (existing_user || new_user)
+        @user ||= existing_user || new_user
       end
 
       def existing_user
@@ -60,7 +60,7 @@ module Decidim
           organization: participatory_process.organization
         ).first
 
-        unless @existing_user.invitation_accepted?
+        if @existing_user && !@existing_user.invitation_accepted?
           InviteUserAgain.call(@existing_user, invitation_instructions)
         end
 

--- a/decidim-admin/spec/commands/create_participatory_process_admin_spec.rb
+++ b/decidim-admin/spec/commands/create_participatory_process_admin_spec.rb
@@ -21,7 +21,7 @@ describe Decidim::Admin::CreateParticipatoryProcessAdmin do
 
   subject { described_class.new(form, current_user, my_process) }
 
-  context "when to form is not valid" do
+  context "when the form is not valid" do
     let(:invalid) { true }
 
     it "is not valid" do
@@ -38,25 +38,6 @@ describe Decidim::Admin::CreateParticipatoryProcessAdmin do
     end
   end
 
-  context "when a user and a role already exist" do
-    before do
-      create(
-        :participatory_process_user_role,
-        user: user,
-        role: :admin,
-        participatory_process: my_process
-      )
-    end
-
-    it "is not valid" do
-      form_errors = double
-      expect(form_errors).to receive(:add).with(:email, :taken)
-      expect(form).to receive(:errors).and_return(form_errors)
-
-      expect { subject.call }.to broadcast(:invalid)
-    end
-  end
-
   context "when everything is ok" do
     it "creates the user role" do
       subject.call
@@ -64,6 +45,31 @@ describe Decidim::Admin::CreateParticipatoryProcessAdmin do
 
       expect(roles.count).to eq 1
       expect(roles.first.role).to eq "admin"
+    end
+  end
+
+  context "when a user and a role already exist" do
+    before do
+      subject.call
+    end
+
+    it "doesn't get created twice" do
+      expect { subject.call }.to broadcast(:ok)
+
+      roles = Decidim::Admin::ParticipatoryProcessUserRole.where(user: user)
+
+      expect(roles.count).to eq 1
+      expect(roles.first.role).to eq "admin"
+    end
+  end
+
+  context "when the user hasn't accepted the invitation" do
+    before do
+      user.invite!
+    end
+
+    it "gets the invitation resent" do
+      expect { subject.call }.to have_enqueued_job(ActionMailer::DeliveryJob)
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
This will resend invitation instructions when re-inviting process admin.

#### :pushpin: Related Issues
* Fixes #1573

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/3o7bu2PMhUljurpnWM/giphy.gif)
