### PR TITLE
Make location optional at proposal creation.

### DIFF
--- a/decidim-proposals/app/assets/config/decidim_proposals_manifest.js
+++ b/decidim-proposals/app/assets/config/decidim_proposals_manifest.js
@@ -1,1 +1,2 @@
 //= link decidim/proposals/social_share.js
+//= link decidim/proposals/add_proposal.js

--- a/decidim-proposals/app/assets/javascripts/decidim/proposals/add_proposal.js.es6
+++ b/decidim-proposals/app/assets/javascripts/decidim/proposals/add_proposal.js.es6
@@ -1,25 +1,23 @@
 $(() => {
   window.DecidimProposals = window.DecidimProposals || {};
 
-  window.DecidimProposals.foo = () => {
-    const $checkbox = $('#toggle_address');
+  window.DecidimProposals.bindProposalAddress = () => {
+    const $checkbox = $('#proposal_has_address');
     const $addressInput = $('#address_input');
 
-    const toggleInput = () => {
-      if ($checkbox[0].checked) {
-        $addressInput.show();
-      } else {
-        $addressInput.hide();
+    if ($checkbox.length > 0) {
+      const toggleInput = () => {
+        if ($checkbox[0].checked) {
+          $addressInput.show();
+        } else {
+          $addressInput.hide();
+        }
       }
-    }
-
-    toggleInput();
-
-    $checkbox.on('change', () => {
       toggleInput();
-    });
+      $checkbox.on('change', toggleInput);
+    }
   };
 
-  window.DecidimProposals.foo();
+  window.DecidimProposals.bindProposalAddress();
 });
 

--- a/decidim-proposals/app/assets/javascripts/decidim/proposals/add_proposal.js.es6
+++ b/decidim-proposals/app/assets/javascripts/decidim/proposals/add_proposal.js.es6
@@ -1,0 +1,25 @@
+$(() => {
+  window.DecidimProposals = window.DecidimProposals || {};
+
+  window.DecidimProposals.foo = () => {
+    const $checkbox = $('#toggle_address');
+    const $addressInput = $('#address_input');
+
+    const toggleInput = () => {
+      if ($checkbox[0].checked) {
+        $addressInput.show();
+      } else {
+        $addressInput.hide();
+      }
+    }
+
+    toggleInput();
+
+    $checkbox.on('change', () => {
+      toggleInput();
+    });
+  };
+
+  window.DecidimProposals.foo();
+});
+

--- a/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
@@ -14,11 +14,13 @@ module Decidim
       attribute :category_id, Integer
       attribute :scope_id, Integer
       attribute :user_group_id, Integer
+      attribute :has_address, Boolean
 
       validates :title, :body, presence: true, etiquette: true
       validates :title, length: { maximum: 150 }
       validates :body, length: { maximum: 500 }, etiquette: true
-      validates :address, geocoding: true, if: -> { current_feature.settings.geocoding_enabled? }
+      validates :address, presence: true, if: ->(form) { form.has_address? }
+      validates :address, geocoding: true, if: ->(form) { Decidim.geocoder.present? && form.has_address? }
       validates :category, presence: true, if: ->(form) { form.category_id.present? }
       validates :scope, presence: true, if: ->(form) { form.scope_id.present? }
 
@@ -46,6 +48,10 @@ module Decidim
       # Returns a Decidim::Scope
       def scope
         @scope ||= process_scope || organization_scopes.where(id: scope_id).first
+      end
+
+      def has_address?
+        current_feature.settings.geocoding_enabled? && has_address
       end
     end
   end

--- a/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
@@ -19,8 +19,8 @@ module Decidim
       validates :title, :body, presence: true, etiquette: true
       validates :title, length: { maximum: 150 }
       validates :body, length: { maximum: 500 }, etiquette: true
-      validates :address, presence: true, if: ->(form) { form.has_address? }
       validates :address, geocoding: true, if: ->(form) { Decidim.geocoder.present? && form.has_address? }
+      validates :address, presence: true, if: ->(form) { form.has_address? }
       validates :category, presence: true, if: ->(form) { form.category_id.present? }
       validates :scope, presence: true, if: ->(form) { form.scope_id.present? }
 

--- a/decidim-proposals/app/views/decidim/proposals/proposals/new.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/new.html.erb
@@ -20,6 +20,9 @@
 
           <% if feature_settings.geocoding_enabled? %>
             <div class="field">
+              <%= form.check_box :has_address, id:"toggle_address"%>
+            </div>
+            <div class="field" id="address_input">
               <%= form.text_field :address %>
             </div>
           <% end %>
@@ -50,3 +53,5 @@
     </div>
   </div>
 </div>
+
+<%= javascript_include_tag "decidim/proposals/add_proposal" %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/new.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/new.html.erb
@@ -20,7 +20,7 @@
 
           <% if feature_settings.geocoding_enabled? %>
             <div class="field">
-              <%= form.check_box :has_address, id:"toggle_address"%>
+              <%= form.check_box :has_address %>
             </div>
             <div class="field" id="address_input">
               <%= form.text_field :address %>

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -103,6 +103,9 @@ describe "Proposals", type: :feature do
             within ".new_proposal" do
               fill_in :proposal_title, with: "Oriol for president"
               fill_in :proposal_body, with: "He will solve everything"
+
+              check :proposal_has_address
+
               fill_in :proposal_address, with: address
               select category.name["en"], from: :proposal_category_id
               select scope.name, from: :proposal_scope_id
@@ -165,6 +168,9 @@ describe "Proposals", type: :feature do
               within ".new_proposal" do
                 fill_in :proposal_title, with: "Oriol for president"
                 fill_in :proposal_body, with: "He will solve everything"
+
+                check :proposal_has_address
+
                 fill_in :proposal_address, with: address
                 select category.name["en"], from: :proposal_category_id
                 select scope.name, from: :proposal_scope_id

--- a/decidim-proposals/spec/shared/create_proposal_examples.rb
+++ b/decidim-proposals/spec/shared/create_proposal_examples.rb
@@ -24,7 +24,8 @@ RSpec.shared_examples "create a proposal" do |with_author|
       {
         title: "A reasonable proposal title",
         body: "A reasonable proposal body",
-        address: address
+        address: address,
+        has_address: has_address
       }
     end
 
@@ -76,7 +77,7 @@ RSpec.shared_examples "create a proposal" do |with_author|
         let(:feature) { create(:proposal_feature, :with_geocoding_enabled) }
 
         context "when the has address checkbox is checked" do
-        let(:has_address) { true }
+          let(:has_address) { true }
 
           context "when the address is present" do
             let(:address) { "Carrer Pare Llaurador 113, baixos, 08224 Terrassa" }

--- a/decidim-proposals/spec/shared/create_proposal_examples.rb
+++ b/decidim-proposals/spec/shared/create_proposal_examples.rb
@@ -14,6 +14,7 @@ RSpec.shared_examples "create a proposal" do |with_author|
   end
   let(:author) { create(:user, organization: organization) } if with_author
 
+  let(:has_address) { false }
   let(:address) { nil }
   let(:latitude) { 40.1234 }
   let(:longitude) { 2.1234 }
@@ -74,22 +75,26 @@ RSpec.shared_examples "create a proposal" do |with_author|
       context "when geocoding is enabled" do
         let(:feature) { create(:proposal_feature, :with_geocoding_enabled) }
 
-        context "when the address is present" do
-          let(:address) { "Carrer Pare Llaurador 113, baixos, 08224 Terrassa" }
+        context "when the has address checkbox is checked" do
+        let(:has_address) { true }
 
-          before do
-            Geocoder::Lookup::Test.add_stub(
-              address,
-              [{ "latitude" => latitude, "longitude" => longitude }]
-            )
-          end
+          context "when the address is present" do
+            let(:address) { "Carrer Pare Llaurador 113, baixos, 08224 Terrassa" }
 
-          it "sets the latitude and longitude" do
-            command.call
-            proposal = Decidim::Proposals::Proposal.last
+            before do
+              Geocoder::Lookup::Test.add_stub(
+                address,
+                [{ "latitude" => latitude, "longitude" => longitude }]
+              )
+            end
 
-            expect(proposal.latitude).to eq(latitude)
-            expect(proposal.longitude).to eq(longitude)
+            it "sets the latitude and longitude" do
+              command.call
+              proposal = Decidim::Proposals::Proposal.last
+
+              expect(proposal.latitude).to eq(latitude)
+              expect(proposal.longitude).to eq(longitude)
+            end
           end
         end
       end

--- a/decidim-proposals/spec/shared/proposal_form_examples.rb
+++ b/decidim-proposals/spec/shared/proposal_form_examples.rb
@@ -21,7 +21,8 @@ RSpec.shared_examples "a proposal form" do
       author: author,
       category_id: category_id,
       scope_id: scope_id,
-      address: address
+      address: address,
+      has_address: has_address
     }
   end
 

--- a/decidim-proposals/spec/shared/proposal_form_examples.rb
+++ b/decidim-proposals/spec/shared/proposal_form_examples.rb
@@ -12,6 +12,7 @@ RSpec.shared_examples "a proposal form" do
   let(:scope_id) { scope.try(:id) }
   let(:latitude) { 40.1234 }
   let(:longitude) { 2.1234 }
+  let(:has_address) { false }
   let(:address) { nil }
   let(:params) do
     {
@@ -70,24 +71,28 @@ RSpec.shared_examples "a proposal form" do
   context "when geocoding is enabled" do
     let(:feature) { create(:proposal_feature, :with_geocoding_enabled) }
 
-    context "when the address is not present" do
-      it { is_expected.to be_invalid }
-    end
+    context "when the has address checkbox is checked" do
+      let(:has_address) { true }
 
-    context "when the address is present" do
-      let(:address) { "Carrer Pare Llaurador 113, baixos, 08224 Terrassa" }
-
-      before do
-        Geocoder::Lookup::Test.add_stub(
-          address,
-          [{ "latitude" => latitude, "longitude" => longitude }]
-        )
+      context "when the address is not present" do
+        it { is_expected.to be_invalid }
       end
 
-      it "validates the address and store its coordinates" do
-        expect(subject).to be_valid
-        expect(subject.latitude).to eq(latitude)
-        expect(subject.longitude).to eq(longitude)
+      context "when the address is present" do
+        let(:address) { "Carrer Pare Llaurador 113, baixos, 08224 Terrassa" }
+
+        before do
+          Geocoder::Lookup::Test.add_stub(
+            address,
+            [{ "latitude" => latitude, "longitude" => longitude }]
+          )
+        end
+
+        it "validates the address and store its coordinates" do
+          expect(subject).to be_valid
+          expect(subject.latitude).to eq(latitude)
+          expect(subject.longitude).to eq(longitude)
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds the option to toggle the adress input to a proposal creation, so it's possible to create proposals without it.

#### :pushpin: Related Issues
- Fixes #1150

### :camera: Screenshots 
![screen shot 2017-07-10 at 12 35 56](https://user-images.githubusercontent.com/953911/28020113-7e46adf2-6583-11e7-92c4-9bdf6b97e632.png)
![screen shot 2017-07-10 at 12 35 47](https://user-images.githubusercontent.com/953911/28020114-7e4d0f4e-6583-11e7-9dcc-5c386206af59.png)

#### :ghost: GIF
![](https://media2.giphy.com/media/yoJC2qNujv3gJWP504/giphy.gif)
