### PR TITLE
Lock sass version to 3.4.24

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ PATH
       rectify (~> 0.9.1)
       redis (~> 3.3.3)
       rubyzip (= 1.2.1)
+      sass (= 3.4.24)
       sassc-rails (~> 1.3.0)
       sprockets-es6 (~> 0.9.2)
       truncato (~> 0.7.9)
@@ -186,7 +187,7 @@ GEM
       public_suffix (~> 2.0, >= 2.0.2)
     arel (8.0.0)
     ast (2.3.0)
-    autoprefixer-rails (7.1.1.2)
+    autoprefixer-rails (7.1.2.1)
       execjs
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -394,7 +395,7 @@ GEM
       addressable
       css_parser (>= 1.4.10)
       htmlentities (>= 4.0.0)
-    premailer-rails (1.9.6)
+    premailer-rails (1.9.7)
       actionmailer (>= 3, < 6)
       premailer (~> 1.7, >= 1.7.9)
     public_suffix (2.0.5)

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "devise-i18n", "~> 1.1.0"
   s.add_dependency "invisible_captcha", "~> 0.9.2"
   s.add_dependency "rectify", "~> 0.9.1"
+  s.add_dependency "sass", "3.4.24"
   s.add_dependency "sassc-rails", "~> 1.3.0"
   s.add_dependency "foundation-rails", "~> 6.3.1.0"
   s.add_dependency "autoprefixer-rails", "~> 7.1.1"


### PR DESCRIPTION
#### :tophat: What? Why?

I had problems generating the development app because this exeception was raised:
```
NameError: uninitialized constant Sass::Deprecation
```

The problem is we are using `sassc-rails` but that gem doesn't have a lock version of `sass` so it is using the latest version.

`sassc-rails` is using `sassc-ruby` and it is including sass modules one by one and not including `sass/deprecations`.

#### :pushpin: Related Issues
- https://github.com/sass/sassc-ruby/pull/68

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None

#### :ghost: GIF
None
