### PR TITLE
Truncate meeting's description

### DIFF
--- a/decidim-core/app/helpers/decidim/application_helper.rb
+++ b/decidim-core/app/helpers/decidim/application_helper.rb
@@ -19,6 +19,7 @@ module Decidim
       options[:tail] = options.delete(:separator) || options[:tail] || "..."
       options[:count_tags] ||= false
       options[:count_tail] ||= false
+      options[:tail_before_final_tag] ||= true
 
       Truncato.truncate(text, options)
     end

--- a/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
@@ -8,6 +8,7 @@ module Decidim
       include PaginateHelper
       include Decidim::MapHelper
       include Decidim::Meetings::MapHelper
+      include Decidim::Meetings::MeetingsHelper
     end
   end
 end

--- a/decidim-meetings/app/helpers/decidim/meetings/meetings_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/meetings_helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    # Custom helpers used in meetings views
+    module MeetingsHelper
+      include Decidim::ApplicationHelper
+      include Decidim::TranslationsHelper
+
+      # Public: truncates the meeting description
+      #
+      # meeting - a Decidim::Meeting instance
+      # max_length - a number to limit the length of the description
+      #
+      # Returns the meeting's description truncated.
+      def meeting_description(meeting, max_length = 120)
+        link = decidim_meetings.meeting_path(meeting, feature_id: meeting.feature, participatory_process_id: meeting.feature.participatory_process)
+        description = translated_attribute(meeting.description)
+        tail = "... #{link_to(t('read_more', scope: "decidim.meetings"), link)}".html_safe
+        CGI.unescapeHTML html_truncate(description, max_length: max_length, tail: tail)
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/helpers/decidim/meetings/meetings_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/meetings_helper.rb
@@ -16,7 +16,7 @@ module Decidim
       def meeting_description(meeting, max_length = 120)
         link = decidim_meetings.meeting_path(meeting, feature_id: meeting.feature, participatory_process_id: meeting.feature.participatory_process)
         description = translated_attribute(meeting.description)
-        tail = "... #{link_to(t('read_more', scope: "decidim.meetings"), link)}".html_safe
+        tail = "... #{link_to(t("read_more", scope: "decidim.meetings"), link)}".html_safe
         CGI.unescapeHTML html_truncate(description, max_length: max_length, tail: tail)
       end
     end

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
@@ -17,7 +17,7 @@
             <h5 class="card__title"><%= translated_attribute meeting.title %></h5>
           <% end %>
           <%= render partial: "datetime", locals: { meeting: meeting } %>
-          <%== translated_attribute meeting.description %>
+          <%== meeting_description(meeting) %>
           <%= render partial: "tags", locals: { meeting: meeting } %>
           <div class="address card__extra">
             <div class="address__icon">

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -51,7 +51,7 @@ en:
           index:
             title: Meetings
           new:
-            create: Create 
+            create: Create
             title: Create meeting
           update:
             invalid: There's been a problem updating this meeting
@@ -93,6 +93,7 @@ en:
             map: Map
             start_time: Start date
             title: Title
+      read_more: "(read more)"
     resource_links:
       meetings_through_proposals:
         meeting_results: 'Related results:'

--- a/decidim-meetings/spec/helpers/meetings_helper_spec.rb
+++ b/decidim-meetings/spec/helpers/meetings_helper_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Meetings
+    describe MeetingsHelper do
+      describe "meeting_description" do
+        it "truncates meeting description respecting the html tags" do
+          meeting = create(:meeting, description: { "en" => "<p>This is a long description with some <b>bold text</b></p>" })
+          expect(helper.meeting_description(meeting, 40)).to match("<p>This is a long description with some <b>bol</b>...")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

The meeting's description wasn't truncated on the meetings page and that broke the design when the description was very long.

#### :pushpin: Related Issues
- Fixes #1578 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/106021/28110324-4f3a5a0c-66f2-11e7-966f-3ab5182038ad.png)

#### :ghost: GIF
![](https://media4.giphy.com/media/yoJC2qNujv3gJWP504/giphy.gif)
