### PR TITLE
Fix share link url

### DIFF
--- a/decidim-core/app/views/decidim/shared/_share_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_share_modal.html.erb
@@ -29,5 +29,5 @@
       <span aria-hidden="true">&times;</span>
     </button>
   </div>
-  <h4 class="heading4"><%= "#{content_for(:meta_url)}" %></h4>
+  <h4 class="heading4"><%= "#{decidim_meta_url}" %></h4>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?

The share popup wasn't showing the correct url.

#### :pushpin: Related Issues
- Fixes #1589

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/106021/28111129-bda70394-66f4-11e7-9389-cca3fff2b707.png)

#### :ghost: GIF
![](https://media3.giphy.com/media/j3iGKfXRKlLqw/giphy.gif)
