### PR TITLE
Process admins are not application admins

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/create_participatory_process_admin.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_participatory_process_admin.rb
@@ -68,7 +68,9 @@ module Decidim
       end
 
       def new_user
-        @new_user ||= InviteUser.call(user_form) do
+        new_user_form = user_form.dup
+        new_user_form.roles = []
+        @new_user ||= InviteUser.call(new_user_form) do
           on(:ok) do |user|
             return user
           end

--- a/decidim-admin/app/controllers/decidim/admin/participatory_process_user_roles_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/participatory_process_user_roles_controller.rb
@@ -70,6 +70,23 @@ module Decidim
         redirect_to participatory_process_user_roles_path(@participatory_process_user_role.participatory_process)
       end
 
+      def resend_invitation
+        @user_role = collection.find(params[:id])
+        authorize! :invite, @user_role
+
+        InviteUserAgain.call(@user_role.user, "invite_admin") do
+          on(:ok) do
+            flash[:notice] = I18n.t("users.resend_invitation.success", scope: "decidim.admin")
+          end
+
+          on(:invalid) do
+            flash[:alert] = I18n.t("users.resend_invitation.error", scope: "decidim.admin")
+          end
+        end
+
+        redirect_to participatory_process_user_roles_path(participatory_process)
+      end
+
       private
 
       def collection

--- a/decidim-admin/app/views/decidim/admin/participatory_process_user_roles/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_process_user_roles/index.html.erb
@@ -15,6 +15,8 @@
           <tr>
             <th><%= t("models.participatory_process_user_role.fields.name", scope: "decidim.admin") %></th>
             <th><%= t("models.participatory_process_user_role.fields.email", scope: "decidim.admin") %></th>
+            <th><%= t("models.user.fields.invitation_sent_at", scope: "decidim.admin") %></th>
+            <th><%= t("models.user.fields.invitation_accepted_at", scope: "decidim.admin") %></th>
             <th><%= t("models.participatory_process_user_role.fields.role", scope: "decidim.admin") %></th>
             <th class="actions"></th>
           </tr>
@@ -29,9 +31,23 @@
                 <%= role.user.email %><br />
               </td>
               <td>
+                <% if role.user.invitation_sent_at %>
+                  <%= l role.user.invitation_sent_at, format: :short %>
+                <% end %>
+              </td>
+              <td>
+                <% if role.user.invitation_accepted_at %>
+                  <%= l role.user.invitation_accepted_at, format: :short %>
+                <% end %>
+              </td>
+              <td>
                 <%= t("#{role.role}", scope: "decidim.admin.models.participatory_process_user_role.roles") %><br />
               </td>
               <td class="table-list__actions">
+                <% if can?(:invite, role) && role.user.invited_to_sign_up? %>
+                  <%= icon_link_to "reload", resend_invitation_participatory_process_user_role_path(participatory_process, role), t("actions.resend_invitation", scope: "decidim.admin"), class: "resend-invitation", method: :post %>
+                <% end %>
+
                 <% if can? :update, role %>
                   <%= icon_link_to "pencil", edit_participatory_process_user_role_path(participatory_process, role), t("actions.edit", scope: "decidim.admin"), class: "action-icon--edit" %>
                 <% end %>

--- a/decidim-admin/config/routes.rb
+++ b/decidim-admin/config/routes.rb
@@ -16,7 +16,11 @@ Decidim::Admin::Engine.routes.draw do
           post :ordering, to: "participatory_process_step_ordering#create"
         end
       end
-      resources :user_roles, controller: "participatory_process_user_roles"
+      resources :user_roles, controller: "participatory_process_user_roles" do
+        member do
+          post :resend_invitation, to: "participatory_process_user_roles#resend_invitation"
+        end
+      end
       resources :attachments, controller: "participatory_process_attachments"
 
       resources :features do

--- a/decidim-admin/spec/shared/manage_process_admins_examples.rb
+++ b/decidim-admin/spec/shared/manage_process_admins_examples.rb
@@ -81,11 +81,9 @@ RSpec.shared_examples "manage process admins examples" do
 
     context "when the user has not accepted the invitation" do
       before do
-        form = Decidim::Admin::ParticipatoryProcessUserRoleForm.from_params({
-          name: "test",
-          email: "test@example.org",
-          role: "admin"
-        })
+        form = Decidim::Admin::ParticipatoryProcessUserRoleForm.from_params(name: "test",
+                                                                            email: "test@example.org",
+                                                                            role: "admin")
         Decidim::Admin::CreateParticipatoryProcessAdmin.call(form, user, participatory_process)
         visit current_path
       end

--- a/decidim-admin/spec/shared/manage_process_admins_examples.rb
+++ b/decidim-admin/spec/shared/manage_process_admins_examples.rb
@@ -78,5 +78,29 @@ RSpec.shared_examples "manage process admins examples" do
         expect(page).not_to have_content(other_user.email)
       end
     end
+
+    context "when the user has not accepted the invitation" do
+      before do
+        form = Decidim::Admin::ParticipatoryProcessUserRoleForm.from_params({
+          name: "test",
+          email: "test@example.org",
+          role: "admin"
+        })
+        Decidim::Admin::CreateParticipatoryProcessAdmin.call(form, user, participatory_process)
+        visit current_path
+      end
+
+      it "resends the invitation to the user" do
+        within "#process_admins" do
+          within find("#process_admins tr", text: "test@example.org") do
+            page.find(".action-icon.resend-invitation").click
+          end
+        end
+
+        within ".callout-wrapper" do
+          expect(page).to have_content("successfully")
+        end
+      end
+    end
   end
 end

--- a/decidim-core/app/commands/decidim/invite_user.rb
+++ b/decidim-core/app/commands/decidim/invite_user.rb
@@ -36,7 +36,7 @@ module Decidim
     end
 
     def invite_user
-      @user = Decidim::User.create(
+      @user = Decidim::User.new(
         name: form.name,
         email: form.email.downcase,
         organization: form.organization,


### PR DESCRIPTION
#### :tophat: What? Why?

When a user invited a participatory process admin it became also an admin. I fixed this and included a resend invitation button for process roles as well.

I think we need to clean up some common logic between users and process roles but I leave this for another PR.

#### :pushpin: Related Issues
- Fixes #1557 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/106021/28118531-adf9240a-6711-11e7-9125-8646d01bea1f.png)

#### :ghost: GIF
![](https://media1.giphy.com/media/LfCt1sR1VweBy/giphy.gif)
