### PR TITLE
Redirect to home page from admin logo space

### DIFF
--- a/decidim-admin/app/views/layouts/decidim/admin/_title_bar.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_title_bar.html.erb
@@ -1,6 +1,6 @@
 <div class="title-bar">
   <a href="#menu" class="menu-trigger"><%= icon "menu" %></a>
-  <%= link_to root_path, class: "logo" do %>
+  <%= link_to decidim.root_path, class: "logo", target: "_blank" do %>
     <% if current_organization.logo.present? %>
       <%= image_tag current_organization.logo.url, alt: title %>
     <% else %>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds a way to the admin user to open the home page from admin panel, implemented with a `_blank` target.

#### :pushpin: Related Issues
- Fixes #1587 
#### :ghost: GIF
![](https://media1.giphy.com/media/7KwMyVvaNPXeU/giphy.gif)
