### PR TITLE
Fixed some typos for resource reference generator

### DIFF
--- a/decidim-core/lib/decidim/core/test/shared_examples/has_reference.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/has_reference.rb
@@ -2,7 +2,7 @@
 
 shared_examples_for "has reference" do
   before do
-    allow(Decidim).to receive(:calculate_reference_method).and_return(nil)
+    allow(Decidim).to receive(:resource_reference_generator).and_return(nil)
   end
 
   context "when the reference is nil" do

--- a/decidim-core/lib/decidim/core/test/shared_examples/has_reference.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/has_reference.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 shared_examples_for "has reference" do
-  before do
-    allow(Decidim).to receive(:resource_reference_generator).and_return(nil)
-  end
-
   context "when the reference is nil" do
     before do
       subject[:reference] = nil

--- a/lib/generators/decidim/templates/initializer.rb
+++ b/lib/generators/decidim/templates/initializer.rb
@@ -17,7 +17,7 @@ Decidim.configure do |config|
   # }
 
   # Custom resource reference generator method
-  # config.resource_reference_generator = lambda do |resource|
+  # config.resource_reference_generator = lambda do |resource, feature|
   #   # Implement your custom method to generate resources references
   #   "1234-#{resource.id}"
   # end

--- a/lib/generators/decidim/templates/initializer.rb
+++ b/lib/generators/decidim/templates/initializer.rb
@@ -16,8 +16,8 @@ Decidim.configure do |config|
   #   here_app_code: Rails.application.secrets.geocoder[:here_app_code]
   # }
 
-  # Custom calculate reference method
-  # config.calculate_reference_method = lambda do |resource|
+  # Custom resource reference generator method
+  # config.resource_reference_generator = lambda do |resource|
   #   # Implement your custom method to generate resources references
   #   "1234-#{resource.id}"
   # end


### PR DESCRIPTION
#### :tophat: What? Why?

I renamed the `calculate_reference_method` method to `resource_reference_generator` and I forgot to change some things.

#### :pushpin: Related Issues
- Related to #1553 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
N/A

#### :ghost: GIF
None