### PR TITLE
Add 'evaluating' state to proposal answers

### DIFF
--- a/decidim-admin/app/assets/stylesheets/decidim/admin/_variables.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/_variables.scss
@@ -5,3 +5,5 @@ $brand: #9675ce !default;
 $twitter: #55acee !default;
 $facebook: #3b5998 !default;
 $google: #dd4b39 !default;
+
+$secondary: #599aa6 !default;

--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_typography.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_typography.scss
@@ -13,3 +13,7 @@
 .text-alert{
   color: $alert-color;
 }
+
+.text-info{
+  color: $secondary;
+}

--- a/decidim-core/app/assets/stylesheets/decidim/extras/_status-labels.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/extras/_status-labels.scss
@@ -1,0 +1,3 @@
+.proposal-status.label.secondary{
+  color: #fff;
+}

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposal_answer_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposal_answer_form.rb
@@ -11,7 +11,7 @@ module Decidim
         translatable_attribute :answer, String
         attribute :state, String
 
-        validates :state, presence: true, inclusion: { in: %w(accepted rejected) }
+        validates :state, presence: true, inclusion: { in: %w(accepted rejected evaluating) }
         validates :answer, translatable_presence: true, if: ->(form) { form.state == "rejected" }
       end
     end

--- a/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
@@ -17,10 +17,13 @@ module Decidim
       #
       # Returns a String.
       def humanize_proposal_state(state)
-        value = if state == "accepted"
+        value = case state
+                when "accepted"
                   "accepted"
-                elsif state == "rejected"
+                when "rejected"
                   "rejected"
+                when "evaluating"
+                  "evaluating"
                 else
                   "not_answered"
                 end
@@ -34,12 +37,32 @@ module Decidim
       #
       # Returns a String.
       def proposal_state_css_class(state)
-        if state == "accepted"
+        case state
+        when "accepted"
           "text-success"
-        elsif state == "rejected"
+        when "rejected"
           "text-alert"
+        when "evaluating"
+          "text-info"
         else
           "text-warning"
+        end
+      end
+
+      # Public: The css class applied based on the proposal state to
+      #         the proposal badge.
+      #
+      # state - The String state of the proposal.
+      #
+      # Returns a String.
+      def proposal_state_badge_css_class(state)
+        case state
+        when "accepted"
+          "success"
+        when "rejected"
+          "warning"
+        when "evaluating"
+          "secondary"
         end
       end
     end

--- a/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
@@ -17,18 +17,7 @@ module Decidim
       #
       # Returns a String.
       def humanize_proposal_state(state)
-        value = case state
-                when "accepted"
-                  "accepted"
-                when "rejected"
-                  "rejected"
-                when "evaluating"
-                  "evaluating"
-                else
-                  "not_answered"
-                end
-
-        I18n.t(value, scope: "decidim.proposals.answers")
+        I18n.t(state, scope: "decidim.proposals.answers", default: :not_answered)
       end
 
       # Public: The css class applied based on the proposal state.

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -23,6 +23,7 @@ module Decidim
 
       scope :accepted, -> { where(state: "accepted") }
       scope :rejected, -> { where(state: "rejected") }
+      scope :evaluating, -> { where(state: "evaluating") }
 
       def self.order_randomly(seed)
         transaction do
@@ -65,6 +66,13 @@ module Decidim
       # Returns Boolean.
       def rejected?
         state == "rejected"
+      end
+
+      # Public: Checks if the organization has marked the proposal as evaluating it.
+      #
+      # Returns Boolean.
+      def evaluating?
+        state == "evaluating"
       end
 
       # Public: Overrides the `commentable?` Commentable concern method.

--- a/decidim-proposals/app/services/decidim/proposals/proposal_search.rb
+++ b/decidim-proposals/app/services/decidim/proposals/proposal_search.rb
@@ -47,10 +47,13 @@ module Decidim
 
       # Handle the state filter
       def search_state
-        if state == "accepted"
+        case state
+        when "accepted"
           query.accepted
-        elsif state == "rejected"
+        when "rejected"
           query.rejected
+        when "evaluating"
+          query.evaluating
         else # Assume 'all'
           query
         end

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposal_answers/edit.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposal_answers/edit.html.erb
@@ -6,7 +6,7 @@
 
     <div class="card-section">
       <div class="row column">
-        <%= f.collection_radio_buttons :state, [["accepted", t('.accepted')], ["rejected", t('.rejected')]], :first, :last, prompt: true %>
+        <%= f.collection_radio_buttons :state, [["accepted", t('.accepted')], ["rejected", t('.rejected')], ["evaluating", t('.evaluating')]], :first, :last, prompt: true %>
       </div>
 
       <div class="row column">

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
@@ -17,7 +17,7 @@
   <% end %>
 
   <% if feature_settings.proposal_answering_enabled && current_settings.proposal_answering_enabled %>
-    <%= form.collection_radio_buttons :state, [["all", t('.all')], ["accepted", t('.accepted')], ["rejected", t('.rejected')]], :first, :last, legend_title: t('.state') %>
+    <%= form.collection_radio_buttons :state, [["all", t('.all')], ["accepted", t('.accepted')], ["rejected", t('.rejected')], ["evaluating", t('.evaluating')]], :first, :last, legend_title: t('.state') %>
   <% end %>
 
   <% if linked_classes_for(Decidim::Proposals::Proposal).any? %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_proposal_badge.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_proposal_badge.html.erb
@@ -1,3 +1,3 @@
 <% if proposal.answered? %>
-  <span class="<%= (proposal.accepted? ? 'success' : 'warning') %> label proposal-status"><%= humanize_proposal_state proposal.state %></span>
+  <span class="<%= proposal_state_badge_css_class(proposal.state) %> label proposal-status"><%= humanize_proposal_state proposal.state %></span>
 <% end %>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -96,6 +96,7 @@ en:
             other: "%{count} proposals"
         filters:
           accepted: Accepted
+          evaluating: Evaluating
           activity: Activity
           all: All
           category: Category

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -50,6 +50,7 @@ en:
           edit:
             accepted: Accepted
             answer_proposal: Answer
+            evaluating: Evaluating
             rejected: Rejected
             title: Answer for proposal %{title}
         proposals:
@@ -68,6 +69,7 @@ en:
             title: Create proposal
       answers:
         accepted: Accepted
+        evaluating: Evaluating
         not_answered: Not answered
         rejected: Rejected
       create:

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -96,12 +96,12 @@ en:
             other: "%{count} proposals"
         filters:
           accepted: Accepted
-          evaluating: Evaluating
           activity: Activity
           all: All
           category: Category
           category_prompt: Select a category
           citizenship: Citizenship
+          evaluating: Evaluating
           official: Official
           origin: Origin
           rejected: Rejected

--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -114,6 +114,10 @@ Decidim.register_feature(:proposals) do |feature|
           proposal.answered_at = Time.current
           proposal.answer = Decidim::Faker::Localized.sentence(10)
           proposal.save!
+        elsif n > 6
+          proposal.state = "evaluating"
+          proposal.answered_at = Time.current
+          proposal.save!
         end
 
         rand(3).times do |m|

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -229,6 +229,27 @@ RSpec.shared_examples "manage proposals" do
         end
       end
 
+      it "can mark a proposal as evaluating" do
+        within find("tr", text: proposal.title) do
+          find("a.action-icon--edit-answer").click
+        end
+
+        within ".edit_proposal_answer" do
+          choose "Evaluating"
+          click_button "Answer"
+        end
+
+        within ".callout-wrapper" do
+          expect(page).to have_content("Proposal successfully answered")
+        end
+
+        within find("tr", text: proposal.title) do
+          within find("td:nth-child(4)") do
+            expect(page).to have_content("Evaluating")
+          end
+        end
+      end
+
       it "can edit a proposal answer" do
         proposal.update_attributes!(
           state: "rejected",


### PR DESCRIPTION
#### :tophat: What? Why?

Added `evaluating` state when answering a proposal.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
- [x] Add evaluating state to admin
- [x] Add evaluating state to public pages

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/106021/28359001-223847c4-6c71-11e7-8b5f-7028aad8931b.png)
![image](https://user-images.githubusercontent.com/106021/28359043-41fba736-6c71-11e7-8a22-54a824dee962.png)
![image](https://user-images.githubusercontent.com/106021/28359052-4c14a9e8-6c71-11e7-9666-2a6850fef4e0.png)

#### :ghost: GIF
None
