### PR TITLE
Fixing variables names on documentation

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -99,7 +99,7 @@ Once you've successfully deployed your app to your favorite platform, you'll nee
 ```ruby
 email = <your email>
 password = <a secure password>
-user = Decidim::System::Admin.new(email: my_email, password: my_password, password_confirmation: my_password)
+user = Decidim::System::Admin.new(email: email, password: password, password_confirmation: password)
 user.save!
 ```
 


### PR DESCRIPTION
#### :tophat: What? Why?

Following the getting started guide, there's a small typo. 

#### :ghost: GIF
![typo](https://media0.giphy.com/media/hlsqt0mgBKnu0/giphy.gif)
