### PR TITLE
Create managed users

### DIFF
--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_cards.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_cards.scss
@@ -1,3 +1,5 @@
+$card-padding-small: 1rem;
+
 .card-title{
   @include smallcaps;
   font-size: 1rem;
@@ -26,4 +28,49 @@
   .card__icon-open{
     display: block;
   }
+}
+
+.card--list__item{
+  display: flex;
+  align-items: center;
+  padding-left: $card-padding-small;
+  .card--list--mini &{
+    padding-left: $card-padding-small;
+  }
+  @include breakpoint(medium){
+    padding-left: $card-padding;
+  }
+}
+
+.card--list__icon{
+  display: none;
+  fill: $anchor-color;
+  @include breakpoint(medium){
+    margin-right: 1rem;
+    display: block;
+    width: 30px;
+    height: 30px;
+    flex-shrink: 0;
+  }
+}
+
+.card--list__text{
+  flex-grow: 1;
+  flex-shrink: 1;
+  display: inline-flex;
+  overflow: hidden;
+  align-items: center;
+  padding: 1rem 1rem 1rem 0;
+  .card--list--mini &{
+    padding: .5rem .5rem .5rem 0;
+  }
+  .author{
+    margin-top: .3rem;
+    margin-right: 1rem;
+  }
+}
+
+.card--list__heading{
+  margin-bottom: 0;
+  display: block;
 }

--- a/decidim-admin/app/commands/decidim/admin/create_managed_user.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_managed_user.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # A command with all the business logic to create a new managed user in the
+    # admin panel.
+    class CreateManagedUser < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # form - A form object with the params.
+      def initialize(form)
+        @form = form
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid.
+      # - :invalid if the form wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        return broadcast(:invalid) if form.invalid?
+
+        transaction do
+          create_managed_user
+          raise ActiveRecord::Rollback unless authorize_user
+        end
+
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :form, :user
+
+      def create_managed_user
+        @user = Decidim::User.create!(
+          name: form.name,
+          organization: form.current_organization,
+          admin: false,
+          managed: true,
+          comments_notifications: true,
+          replies_notifications: true,
+          tos_agreement: true
+        )
+      end
+
+      def authorize_user
+        form.authorization.user = @user
+        AuthorizeUser.call(form.authorization) do
+          on(:ok) do
+            return true
+          end
+          on(:invalid) do
+            return false
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/app/controllers/decidim/admin/managed_users_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/managed_users_controller.rb
@@ -11,6 +11,7 @@ module Decidim
 
       def index
         authorize! :index, :managed_users
+        @managed_users = collection.page(params[:page]).per(15)
       end
 
       def new
@@ -39,6 +40,12 @@ module Decidim
             render :new
           end
         end
+      end
+
+      private
+
+      def collection
+        @collection ||= current_organization.users.managed
       end
     end
   end

--- a/decidim-admin/app/controllers/decidim/admin/managed_users_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/managed_users_controller.rb
@@ -15,7 +15,11 @@ module Decidim
 
       def new
         authorize! :new, :managed_users
-        @form = form(ManagedUserForm).instance
+        @form = form(ManagedUserForm).from_params(
+          authorization: {
+            handler: current_organization.available_authorizations.first # TODO: choose between all authorizations
+          }
+        )
       end
     end
   end

--- a/decidim-admin/app/controllers/decidim/admin/managed_users_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/managed_users_controller.rb
@@ -15,6 +15,7 @@ module Decidim
 
       def new
         authorize! :new, :managed_users
+        @form = form(ManagedUserForm).instance
       end
     end
   end

--- a/decidim-admin/app/controllers/decidim/admin/managed_users_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/managed_users_controller.rb
@@ -15,11 +15,30 @@ module Decidim
 
       def new
         authorize! :new, :managed_users
+
         @form = form(ManagedUserForm).from_params(
           authorization: {
-            handler: current_organization.available_authorizations.first # TODO: choose between all authorizations
+            handler_name: current_organization.available_authorizations.first # TODO: choose between all authorizations
           }
         )
+      end
+
+      def create
+        authorize! :create, :managed_users
+
+        @form = form(ManagedUserForm).from_params(params)
+
+        CreateManagedUser.call(@form) do
+          on(:ok) do
+            flash[:notice] = I18n.t("managed_users.create.success", scope: "decidim.admin")
+            redirect_to managed_users_path
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("managed_users.create.error", scope: "decidim.admin")
+            render :new
+          end
+        end
       end
     end
   end

--- a/decidim-admin/app/forms/decidim/admin/managed_user_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/managed_user_form.rb
@@ -13,7 +13,7 @@ module Decidim
       def initialize(attributes)
         extend(Virtus.model)
 
-        attribute(:authorization, attributes.dig(:authorization, :handler).constantize)
+        attribute(:authorization, attributes.dig(:authorization, :handler_name).classify.constantize)
 
         super
       end

--- a/decidim-admin/app/forms/decidim/admin/managed_user_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/managed_user_form.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # A form object used to create managed users from the admin dashboard.
+    #
+    class ManagedUserForm < Form
+      attribute :name, String
+
+      validates :name, presence: true
+    end
+  end
+end

--- a/decidim-admin/app/forms/decidim/admin/managed_user_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/managed_user_form.rb
@@ -8,6 +8,15 @@ module Decidim
       attribute :name, String
 
       validates :name, presence: true
+      validates :authorization, presence: true
+
+      def initialize(attributes)
+        extend(Virtus.model)
+
+        attribute(:authorization, attributes.dig(:authorization, :handler).constantize)
+
+        super
+      end
     end
   end
 end

--- a/decidim-admin/app/forms/decidim/admin/managed_user_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/managed_user_form.rb
@@ -10,12 +10,24 @@ module Decidim
       validates :name, presence: true
       validates :authorization, presence: true
 
+      validate :authorization_uniqueness
+
       def initialize(attributes)
         extend(Virtus.model)
 
         attribute(:authorization, attributes.dig(:authorization, :handler_name).classify.constantize)
 
         super
+      end
+
+      private
+
+      def authorization_uniqueness
+        errors.add :authorization, :invalid if Authorization.where(
+          user: current_organization.users,
+          name: authorization.handler_name,
+          unique_id: authorization.unique_id
+        ).exists?
       end
     end
   end

--- a/decidim-admin/app/models/decidim/admin/abilities/admin_ability.rb
+++ b/decidim-admin/app/models/decidim/admin/abilities/admin_ability.rb
@@ -28,8 +28,7 @@ module Decidim
           can :manage, :admin_users
 
           can :manage, :managed_users
-          cannot [:new, :create], :managed_users if @context[:current_organization].available_authorizations.empty?
-
+          cannot [:new, :create], :managed_users if empty_available_authorizations?
           can :manage, Moderation
           can :manage, Attachment
           can :manage, Scope
@@ -41,6 +40,12 @@ module Decidim
           end
 
           can [:index, :verify, :reject], UserGroup
+        end
+
+        private
+
+        def empty_available_authorizations?
+          @context[:current_organization] && @context[:current_organization].available_authorizations.empty?
         end
       end
     end

--- a/decidim-admin/app/views/decidim/admin/managed_users/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/managed_users/_form.html.erb
@@ -1,0 +1,3 @@
+<div class="row column">
+  <%= form.text_field :name, label: t('.name') %>
+</div>

--- a/decidim-admin/app/views/decidim/admin/managed_users/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/managed_users/_form.html.erb
@@ -1,3 +1,11 @@
 <div class="row column">
   <%= form.text_field :name, label: t('.name') %>
+
+  <%= form.fields_for :authorization, form.object.authorization, builder: Decidim::AuthorizationFormBuilder do |f| %>
+    <% if lookup_context.exists?(form.object.authorization.to_partial_path, [], true) %>
+      <%= render partial: form.object.authorization.to_partial_path, locals: { handler: form.object.authorization, form: f } %>
+    <% else %>
+      <%= f.all_fields %>
+    <% end %>
+  <% end %>
 </div>

--- a/decidim-admin/app/views/decidim/admin/managed_users/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/managed_users/_form.html.erb
@@ -7,5 +7,6 @@
     <% else %>
       <%= f.all_fields %>
     <% end %>
+    <%= f.hidden_field :handler_name %>
   <% end %>
 </div>

--- a/decidim-admin/app/views/decidim/admin/managed_users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/managed_users/index.html.erb
@@ -17,9 +17,13 @@
       <table class="table-list">
         <thead>
           <tr>
+            <th><%= t("models.user.fields.name", scope: "decidim.admin") %></th>
           </tr>
         </thead>
         <tbody>
+          <% @managed_users.each do |user| %>
+            <td><%= user.name %></td>
+          <% end %>
         </tbody>
       </table>
     </div>

--- a/decidim-admin/app/views/decidim/admin/managed_users/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/managed_users/new.html.erb
@@ -1,14 +1,47 @@
-<%= decidim_form_for(@form, html: { class: "form new_managed_user" }) do |f| %>
-  <div class="card">
+<h2 class="process-title-summary">
+  <%= t('.new_managed_user') %>
+  <% if more_than_one_authorization? %>
+    <span class="text-muted float-right"><%= t('.step', current: params[:handler_name].present? ? 2 : 1, total: 2) %></span>
+  <% end %>
+</h2>
+
+<% if more_than_one_authorization? && params[:handler_name].nil? %>
+  <div class="card card--list">
     <div class="card-divider">
-      <h2 class="card-title"><%= t ".title" %></h2>
+      <h2 class="card-title"><%= t ".select_authorization_method" %></h2>
     </div>
     <div class="card-section">
-      <%= render partial: 'form', object: f %>
+      <% available_authorizations.each do |handler_name| %>
+        <div class="card--list__item">
+          <div class="card--list__text">
+            <a href="#">
+              <%= icon "lock-locked", class: "card--list__icon" %>
+            </a>
+            <div>
+              <h5 class="card--list__heading">
+                <%= link_to t("#{handler_name}.name", scope: "decidim.authorization_handlers"), new_managed_user_path(handler_name: handler_name) %>
+              </h5>
+            </div>
+          </div>
+          <div class="card--list__data">
+            <%= link_to new_managed_user_path(handler_name: handler_name), class: "card--list__data__icon" do %>
+              <%= icon "chevron-right" %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
     </div>
   </div>
+<% else %>
+  <%= decidim_form_for(@form, html: { class: "form new_managed_user" }) do |f| %>
+    <div class="card">
+      <div class="card-section">
+        <%= render partial: 'form', object: f %>
+      </div>
+    </div>
 
-  <div class="button--double form-general-submit">
-    <%= f.submit t(".create") %>
-  </div>
+    <div class="button--double form-general-submit">
+      <%= f.submit t(".create") %>
+    </div>
+  <% end %>
 <% end %>

--- a/decidim-admin/app/views/decidim/admin/managed_users/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/managed_users/new.html.erb
@@ -1,0 +1,14 @@
+<%= decidim_form_for(@form, html: { class: "form new_managed_user" }) do |f| %>
+  <div class="card">
+    <div class="card-divider">
+      <h2 class="card-title"><%= t ".title" %></h2>
+    </div>
+    <div class="card-section">
+      <%= render partial: 'form', object: f %>
+    </div>
+  </div>
+
+  <div class="button--double form-general-submit">
+    <%= f.submit t(".create") %>
+  </div>
+<% end %>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -223,8 +223,13 @@ en:
           error: There has been an error updating this feature.
           success: The feature was updated successfully.
       managed_users:
+        form:
+          name: Name
         index:
           needs_authoriation_warning: You need at least one authorization enabled for this organization.
+        new:
+          create: Create
+          title: Title
       menu:
         admins: Admins
         dashboard: Dashboard

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -223,6 +223,9 @@ en:
           error: There has been an error updating this feature.
           success: The feature was updated successfully.
       managed_users:
+        create:
+          error: There has been an error creating the managed user.
+          success: The managed user has been successfully created.
         form:
           name: Name
         index:

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -232,7 +232,9 @@ en:
           needs_authoriation_warning: You need at least one authorization enabled for this organization.
         new:
           create: Create
-          title: Title
+          new_managed_user: New managed user
+          select_authorization_method: Select an authorization method
+          step: Step %{current} of %{total}
       menu:
         admins: Admins
         dashboard: Dashboard

--- a/decidim-admin/spec/commands/create_managed_user_spec.rb
+++ b/decidim-admin/spec/commands/create_managed_user_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Admin
+    describe CreateManagedUser, :db do
+      describe "call" do
+        let(:available_authorizations) { ["Decidim::DummyAuthorizationHandler"] }
+        let(:organization) { create(:organization, available_authorizations: available_authorizations) }
+        let(:document_number) { "12345678X" }
+        let(:form_params) do
+          {
+            name: "Foo",
+            authorization: {
+              handler_name: "Decidim::DummyAuthorizationHandler",
+              document_number: document_number
+            }
+          }
+        end
+        let(:form) do
+          ManagedUserForm.from_params(
+            form_params
+          ).with_context(
+            current_organization: organization
+          )
+        end
+        let(:command) { described_class.new(form) }
+
+        describe "when the form is not valid" do
+          before do
+            expect(form).to receive(:invalid?).and_return(true)
+          end
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+
+          it "doesn't create a user" do
+            expect do
+              command.call
+            end.not_to change { User.count }
+          end
+        end
+
+        describe "when the form is valid" do
+          it "broadcasts ok" do
+            expect { command.call }.to broadcast(:ok)
+          end
+
+          it "creates a managed user" do
+            expect do
+              command.call
+            end.to change { User.count }.by(1)
+
+            user = Decidim::User.last
+            expect(user).to be_managed
+          end
+
+          it "authorizes the user" do
+            expect(AuthorizeUser).to receive(:call).with(form.authorization)
+            command.call
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/features/admin_manages_managed_users_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_managed_users_spec.rb
@@ -17,6 +17,18 @@ describe "Admin manages managed users", type: :feature do
     click_link "Managed users"
   end
 
+  def fill_in_the_managed_user_form
+    within "form.new_managed_user" do
+      fill_in :managed_user_name, with: "Foo"
+      fill_in :managed_user_authorization_document_number, with: "123456789X"
+      fill_in :managed_user_authorization_postal_code, with: "08224"
+      page.execute_script("$('#managed_user_authorization_birthday').siblings('input:first').focus()")
+    end
+
+    page.find(".datepicker-dropdown .day", text: "12").click
+    click_button "Create"
+  end
+
   context "when the organization doesn't have any authorization available" do
     let(:available_authorizations) { [] }
 
@@ -36,15 +48,29 @@ describe "Admin manages managed users", type: :feature do
 
       click_link "New"
 
-      within "form.new_managed_user" do
-        fill_in :managed_user_name, with: "Foo"
-        fill_in :managed_user_authorization_document_number, with: "123456789X"
-        fill_in :managed_user_authorization_postal_code, with: "08224"
-        page.execute_script("$('#managed_user_authorization_birthday').siblings('input:first').focus()")
-      end
+      fill_in_the_managed_user_form
 
-      page.find(".datepicker-dropdown .day", text: "12").click
-      click_button "Create"
+      expect(page).to have_content("successfully")
+      expect(page).to have_content("Foo")
+    end
+  end
+
+  context "when the organization has more than one authorization available" do
+    let(:available_authorizations) { ["Decidim::DummyAuthorizationHandler", "Decidim::DummyAuthorizationHandler"] }
+
+    it "selects an authorization method and creates a managed user filling in the authorization info" do
+      navigate_to_managed_users_page
+
+      click_link "New"
+
+      expect(page).to have_content(/Select an authorization method/i)
+      expect(page).to have_content(/Step 1 of 2/i)
+
+      click_link "Example authorization", match: :first
+
+      expect(page).to have_content(/Step 2 of 2/i)
+
+      fill_in_the_managed_user_form
 
       expect(page).to have_content("successfully")
       expect(page).to have_content("Foo")

--- a/decidim-admin/spec/features/admin_manages_managed_users_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_managed_users_spec.rb
@@ -38,12 +38,12 @@ describe "Admin manages managed users", type: :feature do
 
       within "form.new_managed_user" do
         fill_in :managed_user_name, with: "Foo"
-        fill_in :managed_user_authorization_handler_document_number, with: "123456789X"
-        fill_in :managed_user_authorization_handler_postal_code, with: "08224"
-        page.execute_script("$('#date_field_authorization_handler_birthday').focus()")
-        page.find(".datepicker-dropdown .day", text: "12").click
+        fill_in :managed_user_authorization_document_number, with: "123456789X"
+        fill_in :managed_user_authorization_postal_code, with: "08224"
+        page.execute_script("$('#managed_user_authorization_birthday').siblings('input:first').focus()")
       end
 
+      page.find(".datepicker-dropdown .day", text: "12").click
       click_button "Create"
 
       expect(page).to have_content("successfully")

--- a/decidim-admin/spec/features/admin_manages_managed_users_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_managed_users_spec.rb
@@ -27,4 +27,27 @@ describe "Admin manages managed users", type: :feature do
       expect(page).to have_content("You need at least one authorization enabled for this organization.")
     end
   end
+
+  context "when the organization has one authorization available" do
+    let(:available_authorizations) { ["Decidim::DummyAuthorizationHandler"] }
+
+    it "creates a managed user filling in the authorization info" do
+      navigate_to_managed_users_page
+
+      click_link "New"
+
+      within "form.new_managed_user" do
+        fill_in :managed_user_name, with: "Foo"
+        fill_in :managed_user_authorization_handler_document_number, with: "123456789X"
+        fill_in :managed_user_authorization_handler_postal_code, with: "08224"
+        page.execute_script("$('#date_field_authorization_handler_birthday').focus()")
+        page.find(".datepicker-dropdown .day", text: "12").click
+      end
+
+      click_button "Create"
+
+      expect(page).to have_content("successfully")
+      expect(page).to have_content("Foo")
+    end
+  end
 end

--- a/decidim-admin/spec/forms/managed_user_form_spec.rb
+++ b/decidim-admin/spec/forms/managed_user_form_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Admin
+    describe ManagedUserForm do
+      let(:organization) { create :organization }
+      let(:name) { "Foo" }
+      let(:attributes) do
+        {
+          name: name
+        }
+      end
+      subject do
+        described_class.from_params(
+          attributes
+        ).with_context(
+          current_organization: organization
+        )
+      end
+
+      context "when everything is OK" do
+        it { is_expected.to be_valid }
+      end
+
+      context "when the name is not present" do
+        let(:name) { nil }
+
+        it { is_expected.not_to be_valid }
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/forms/managed_user_form_spec.rb
+++ b/decidim-admin/spec/forms/managed_user_form_spec.rb
@@ -7,13 +7,16 @@ module Decidim
     describe ManagedUserForm do
       let(:organization) { create :organization }
       let(:name) { "Foo" }
+      let(:authorization) do
+        {
+          handler_name: "decidim/dummy_authorization_handler",
+          document_number: "12345678X"
+        }
+      end
       let(:attributes) do
         {
           name: name,
-          authorization: {
-            handler_name: "Decidim::DummyAuthorizationHandler",
-            document_number: "12345678X"
-          }
+          authorization: authorization
         }
       end
       subject do
@@ -30,6 +33,18 @@ module Decidim
 
       context "when the name is not present" do
         let(:name) { nil }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when the authorization already exists for another user" do
+        before do
+          Authorization.create!(
+            user: create(:user, organization: organization),
+            name: authorization[:handler_name],
+            unique_id: authorization[:document_number]
+          )
+        end
 
         it { is_expected.not_to be_valid }
       end

--- a/decidim-admin/spec/forms/managed_user_form_spec.rb
+++ b/decidim-admin/spec/forms/managed_user_form_spec.rb
@@ -9,7 +9,11 @@ module Decidim
       let(:name) { "Foo" }
       let(:attributes) do
         {
-          name: name
+          name: name,
+          authorization: {
+            handler: "Decidim::DummyAuthorizationHandler",
+            document_number: "12345678X"
+          }
         }
       end
       subject do

--- a/decidim-admin/spec/forms/managed_user_form_spec.rb
+++ b/decidim-admin/spec/forms/managed_user_form_spec.rb
@@ -11,7 +11,7 @@ module Decidim
         {
           name: name,
           authorization: {
-            handler: "Decidim::DummyAuthorizationHandler",
+            handler_name: "Decidim::DummyAuthorizationHandler",
             document_number: "12345678X"
           }
         }

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -70,13 +70,15 @@ module Decidim
     # Overrides devise email required validation.
     # If the user has been deleted or it is managed the email field is not required anymore.
     def email_required?
-      !deleted? && !managed?
+      return false if deleted? || managed?
+      super
     end
 
     # Overrides devise password required validation.
     # If the user is managed the password field is not required anymore.
     def password_required?
-      !managed?
+      return false if managed?
+      super
     end
 
     private

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -22,10 +22,11 @@ module Decidim
     validates :locale, inclusion: { in: I18n.available_locales.map(&:to_s) }, allow_blank: true
     validates :tos_agreement, acceptance: true, allow_nil: false, on: :create
     validates :avatar, file_size: { less_than_or_equal_to: MAXIMUM_AVATAR_FILE_SIZE }
-    validates :email, uniqueness: { scope: :organization }, unless: -> { deleted? }
+    validates :email, uniqueness: { scope: :organization }, unless: -> { deleted? || managed? }
     mount_uploader :avatar, Decidim::AvatarUploader
 
     scope :not_deleted, -> { where(deleted_at: nil) }
+    scope :managed, -> { where(managed: true) }
 
     # Public: Allows customizing the invitation instruction email content when
     # inviting a user.
@@ -67,9 +68,15 @@ module Decidim
     protected
 
     # Overrides devise email required validation.
-    # If the user has been deleted the email field is not required anymore.
+    # If the user has been deleted or it is managed the email field is not required anymore.
     def email_required?
-      !deleted?
+      !deleted? && !managed?
+    end
+
+    # Overrides devise password required validation.
+    # If the user is managed the password field is not required anymore.
+    def password_required?
+      !managed?
     end
 
     private

--- a/decidim-core/db/migrate/20170720135441_add_managed_to_users.rb
+++ b/decidim-core/db/migrate/20170720135441_add_managed_to_users.rb
@@ -1,0 +1,5 @@
+class AddManagedToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_users, :managed, :boolean, null: false, default: false
+  end
+end

--- a/decidim-core/db/migrate/20170720140610_set_email_unique_in_organization_condition_for_managed_users.rb
+++ b/decidim-core/db/migrate/20170720140610_set_email_unique_in_organization_condition_for_managed_users.rb
@@ -1,0 +1,10 @@
+class SetEmailUniqueInOrganizationConditionForManagedUsers < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :decidim_users, %w(email decidim_organization_id)
+    add_index :decidim_users,
+              %w(email decidim_organization_id),
+              where: "(deleted_at IS NULL) OR (managed = true)",
+              name: "index_decidim_users_on_email_and_decidim_organization_id",
+              unique: true
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

As an admin I should be able to create managed users if at least there is one authorization enabled in the organization.

When creating a managed user if there is one authorization available the admin will fill in the name and the authorization info to create the user.
If there is more than one available the admin should select one first and then fill in the form

#### :pushpin: Related Issues
- Related to #1621 

#### :clipboard: Subtasks
- [x] Admin can create managed users if one authorization is available
- [x] Admin can select an authorization and then create the managed user if there is more than one authorization

### :camera: Screenshots (optional)

![image](https://user-images.githubusercontent.com/106021/28517465-bfcbb330-7064-11e7-9d0e-baa4e4117194.png)
![image](https://user-images.githubusercontent.com/106021/28517476-c91f40c8-7064-11e7-97a9-d0a23b35bbca.png)


#### :ghost: GIF
None
