### PR TITLE
Refactor manifests and settings

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/application_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/application_controller.rb
@@ -12,7 +12,7 @@ module Decidim
 
       helper Decidim::Admin::ApplicationHelper
       helper Decidim::Admin::AttributesDisplayHelper
-      helper Decidim::Admin::FeatureSettingsHelper
+      helper Decidim::Admin::SettingsHelper
       helper Decidim::Admin::ProcessGroupsForSelectHelper
       helper Decidim::Admin::ProcessesForSelectHelper
       helper Decidim::Admin::IconLinkHelper

--- a/decidim-admin/app/controllers/decidim/admin/features/base_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/features/base_controller.rb
@@ -8,7 +8,7 @@ module Decidim
       class BaseController < Admin::ApplicationController
         skip_authorize_resource
         include Concerns::ParticipatoryProcessAdmin
-        include FeatureSettings
+        include Settings
 
         helper Decidim::Admin::ExportsHelper
 

--- a/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
@@ -4,7 +4,7 @@ module Decidim
   module Admin
     # This class contains helpers needed in order for feature settings to
     # properly render.
-    module FeatureSettingsHelper
+    module SettingsHelper
       TYPES = {
         boolean: :check_box,
         integer: :number_field,
@@ -16,7 +16,7 @@ module Decidim
       # type.
       #
       # form      - The form in which to render the field.
-      # attribute - The FeatureSettings::Attribute instance with the
+      # attribute - The Settings::Attribute instance with the
       #             description of the attribute.
       # name      - The name of the field.
       # options   - Extra options to be passed to the field helper.

--- a/decidim-admin/spec/helpers/settings_helper_spec.rb
+++ b/decidim-admin/spec/helpers/settings_helper_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 module Decidim
   module Admin
-    describe FeatureSettingsHelper do
+    describe SettingsHelper do
       let(:options) { double }
       let(:attribute) { double(type: type) }
       let(:type) { :boolean }

--- a/decidim-core/app/controllers/concerns/decidim/settings.rb
+++ b/decidim-core/app/controllers/concerns/decidim/settings.rb
@@ -5,7 +5,7 @@ require "active_support/concern"
 module Decidim
   # This concern groups methods and helpers related to accessing the settings
   # of a feature from a controller.
-  module FeatureSettings
+  module Settings
     extend ActiveSupport::Concern
 
     included do

--- a/decidim-core/app/controllers/decidim/features/base_controller.rb
+++ b/decidim-core/app/controllers/decidim/features/base_controller.rb
@@ -8,7 +8,7 @@ module Decidim
     class BaseController < Decidim::ApplicationController
       layout "layouts/decidim/participatory_process"
       include NeedsParticipatoryProcess
-      include FeatureSettings
+      include Settings
       include ActionAuthorization
 
       helper Decidim::FiltersHelper

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -163,6 +163,13 @@ module Decidim
     feature_manifests.find { |manifest| manifest.name == name }
   end
 
+  # Public: Stores all the resource manifest across all feature manifest.
+  #
+  # Returns an Array[ResourceManifest]
+  def self.resource_manifests
+    @resource_manifests ||= feature_manifests.flat_map(&:resource_manifests)
+  end
+
   # Public: Finds a resource manifest by the resource's name.
   #
   # resource_name_or_class - The String of the ResourceManifest name or the class of
@@ -173,13 +180,6 @@ module Decidim
     resource_manifests.find do |manifest|
       manifest.model_class == resource_name_or_klass || manifest.name.to_s == resource_name_or_klass.to_s
     end
-  end
-
-  # Public: Stores all the resource manifest across all feature manifest.
-  #
-  # Returns an Array[ResourceManifest]
-  def self.resource_manifests
-    @resource_manifests ||= feature_manifests.flat_map(&:resource_manifests)
   end
 
   # Public: Stores an instance of StatsRegistry

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -175,7 +175,7 @@ module Decidim
     end
   end
 
-  # Private: Stores all the resource manifest across all feature manifest.
+  # Public: Stores all the resource manifest across all feature manifest.
   #
   # Returns an Array[ResourceManifest]
   def self.resource_manifests

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -21,6 +21,7 @@ module Decidim
   autoload :Features, "decidim/features"
   autoload :HasAttachments, "decidim/has_attachments"
   autoload :FeatureValidator, "decidim/feature_validator"
+  autoload :HasSettings, "decidim/has_settings"
   autoload :HasFeature, "decidim/has_feature"
   autoload :HasScope, "decidim/has_scope"
   autoload :HasCategory, "decidim/has_category"

--- a/decidim-core/lib/decidim/feature_manifest.rb
+++ b/decidim-core/lib/decidim/feature_manifest.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "decidim/features/settings_manifest"
+require "decidim/settings_manifest"
 require "decidim/features/export_manifest"
 
 module Decidim
@@ -97,10 +97,10 @@ module Decidim
     end
 
     # Public: Adds configurable attributes for this feature, scoped to a name. It
-    # uses the DSL specified under `Decidim::FeatureSettingsManifest`.
+    # uses the DSL specified under `Decidim::SettingsManifest`.
     #
     # name - Either `global` or `step`
-    # &block - The DSL present on `Decidim::FeatureSettingsManifest`
+    # &block - The DSL present on `Decidim::SettingsManifest`
     #
     # Examples:
     #
@@ -112,7 +112,7 @@ module Decidim
     def settings(name = :global, &block)
       @settings ||= {}
       name = name.to_sym
-      settings = (@settings[name] ||= FeatureSettingsManifest.new)
+      settings = (@settings[name] ||= SettingsManifest.new)
       yield(settings) if block
       settings
     end

--- a/decidim-core/lib/decidim/has_settings.rb
+++ b/decidim-core/lib/decidim/has_settings.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  module HasSettings
+    extend ActiveSupport::Concern
+
+    included do
+      after_initialize :default_values
+    end
+
+    def settings
+      settings_schema(:global).new(self[:settings]["global"])
+    end
+
+    def settings=(data)
+      self[:settings]["global"] = serialize_settings(settings_schema(:global), data)
+    end
+
+    def default_step_settings
+      settings_schema(:step).new(self[:settings]["default_step"])
+    end
+
+    def default_step_settings=(data)
+      self[:settings]["default_step"] = serialize_settings(settings_schema(:step), data)
+    end
+
+    def step_settings
+      participatory_process.steps.each_with_object({}) do |step, result|
+        result[step.id.to_s] = settings_schema(:step).new(self[:settings].dig("steps", step.id.to_s))
+      end
+    end
+
+    def step_settings=(data)
+      self[:settings]["steps"] = data.each_with_object({}) do |(key, value), result|
+        result[key.to_s] = serialize_settings(settings_schema(:step), value)
+      end
+    end
+
+    def active_step_settings
+      active_step = participatory_process.active_step
+      return default_step_settings unless active_step
+
+      step_settings.fetch(active_step.id.to_s)
+    end
+
+    private
+
+    def serialize_settings(schema, value)
+      if value.respond_to?(:attributes)
+        value.attributes
+      else
+        schema.new(value)
+      end
+    end
+
+    def settings_schema(name)
+      manifest.settings(name.to_sym).schema
+    end
+
+    def default_values
+      self[:settings] ||= {}
+    end
+  end
+end

--- a/decidim-core/lib/decidim/manifest_registry.rb
+++ b/decidim-core/lib/decidim/manifest_registry.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Decidim
+  #
+  # Takes care of holding and serving globally registered manifests.
+  #
+  class ManifestRegistry
+    def initialize(entity)
+      @entity = entity
+    end
+
+    def register(name)
+      manifest = manifest_class.new(name: name.to_sym)
+      yield(manifest)
+      manifest.validate!
+      manifests << manifest
+    end
+
+    def manifests
+      @manifests ||= Set.new
+    end
+
+    def find(name)
+      manifests.find { |manifest| manifest.name == name }
+    end
+
+    def resource_manifests
+      @resource_manifests ||= manifests.flat_map(&:resource_manifests)
+    end
+
+    def find_resource_manifest(resource_name_or_klass)
+      resource_manifests.find do |manifest|
+        manifest.model_class == resource_name_or_klass || manifest.name.to_s == resource_name_or_klass.to_s
+      end
+    end
+
+    private
+
+    def manifest_class
+      case @entity
+      when :features then FeatureManifest
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/settings_manifest.rb
+++ b/decidim-core/lib/decidim/settings_manifest.rb
@@ -4,15 +4,15 @@ module Decidim
   # This class serves as a DSL that enables specifying an arbitrary settings
   # to a feature, so the admin panel can show a standarized UI to configure them.
   #
-  class FeatureSettingsManifest
+  class SettingsManifest
     attr_reader :attributes
 
-    # Initializes a FeatureSettingsManifest.
+    # Initializes a SettingsManifest.
     def initialize
       @attributes = {}
     end
 
-    # Public: Adds a new attribute field to the FeatureSettingsManifest.
+    # Public: Adds a new attribute field to the SettingsManifest.
     #
     # name - The name of the attribute to inject.
     # options - A set of options to configure the attribute.
@@ -44,7 +44,7 @@ module Decidim
         cattr_accessor :manifest
 
         def self.model_name
-          ActiveModel::Name.new(self, nil, "FeatureSettings")
+          ActiveModel::Name.new(self, nil, "Settings")
         end
 
         def manifest
@@ -65,7 +65,7 @@ module Decidim
       @schema
     end
 
-    # Semi-private: Attributes are an abstraction used by FeatureSettingsManifest
+    # Semi-private: Attributes are an abstraction used by SettingsManifest
     # to encapsulate behavior related to each individual settings field. Shouldn't
     # be used from the outside.
     class Attribute

--- a/decidim-core/spec/controllers/concerns/settings_spec.rb
+++ b/decidim-core/spec/controllers/concerns/settings_spec.rb
@@ -12,7 +12,7 @@ module Decidim
     end
 
     controller do
-      include Decidim::FeatureSettings
+      include Decidim::Settings
     end
 
     describe "#feature_settings" do

--- a/decidim-core/spec/lib/settings_manifest_spec.rb
+++ b/decidim-core/spec/lib/settings_manifest_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 module Decidim
-  describe FeatureSettingsManifest do
+  describe SettingsManifest do
     subject { described_class.new }
 
     describe "attribute" do
@@ -25,25 +25,25 @@ module Decidim
 
       describe "supported types" do
         it "supports booleans" do
-          attribute = FeatureSettingsManifest::Attribute.new(type: :boolean)
+          attribute = SettingsManifest::Attribute.new(type: :boolean)
           expect(attribute.type_class).to eq(Virtus::Attribute::Boolean)
           expect(attribute.default_value).to eq(false)
         end
 
         it "supports integers" do
-          attribute = FeatureSettingsManifest::Attribute.new(type: :integer)
+          attribute = SettingsManifest::Attribute.new(type: :integer)
           expect(attribute.type_class).to eq(Integer)
           expect(attribute.default_value).to eq(0)
         end
 
         it "supports strings" do
-          attribute = FeatureSettingsManifest::Attribute.new(type: :string)
+          attribute = SettingsManifest::Attribute.new(type: :string)
           expect(attribute.type_class).to eq(String)
           expect(attribute.default_value).to eq(nil)
         end
 
         it "supports texts" do
-          attribute = FeatureSettingsManifest::Attribute.new(type: :text)
+          attribute = SettingsManifest::Attribute.new(type: :text)
           expect(attribute.type_class).to eq(String)
           expect(attribute.default_value).to eq(nil)
         end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR does some refactoring in preparation for adding featurables. No user facing changes whatsoever, just refactoring.

* Extracts some logic in `core.rb` to a separate `ManifestRegistry` class. I think it's good to keep `core.rb` light. I will reuse this new class in future PR's to hold the array of globally registered featurable manifests when I introduce those.

* Extract some logic in `feature.rb` related to settings to a separate module.

* Rename the `FeatureSettings` class to `Settings` since it's not really dependent on features, and I will reuse it for featurables.

#### :pushpin: Related Issues
- Related to #1346. Getting ready for it.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![reflecting](https://user-images.githubusercontent.com/2887858/28595688-3fca6e42-7195-11e7-828e-ebf0e99caab3.gif)

