### PR TITLE
Fix some weird i18n keys

### DIFF
--- a/decidim-admin/app/views/decidim/admin/attachments/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/attachments/index.html.erb
@@ -1,7 +1,7 @@
 <div class='card' id="attachments">
   <div class="card-divider">
     <h2 class="card-title">
-      <%= t(".attachments_title", scope: "decidim.admin") %>
+      <%= t(".attachments_title") %>
       <% if can? :create, authorization_object %>
         <%= link_to t("actions.new", scope: "decidim.admin", name: t("models.attachment.name", scope: "decidim.admin")), url_for(action: :new), class: 'button tiny button--title new' %>
       <% end %>

--- a/decidim-admin/app/views/decidim/admin/categories/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/categories/index.html.erb
@@ -1,7 +1,7 @@
 <div class="card" id="categories">
   <div class="card-divider">
     <h2 class='card-title'>
-      <%= t(".categories_title", scope: "decidim.admin") %>
+      <%= t(".categories_title") %>
       <% if can? :create, Decidim::Category %>
         <%= link_to t("actions.new", scope: "decidim.admin", name: t("models.category.name", scope: "decidim.admin")), new_participatory_process_category_path(current_participatory_process), class: 'button tiny button--title new' %>
       <% end %>

--- a/decidim-admin/app/views/decidim/admin/participatory_process_steps/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_process_steps/index.html.erb
@@ -1,7 +1,7 @@
 <div class="card" id="steps">
   <div class="card-divider">
     <h2 class="card-title">
-      <%= t(".steps_title", scope: "decidim.admin") %>
+      <%= t(".steps_title") %>
       <% if can? :create, Decidim::ParticipatoryProcessStep %>
         <%= link_to t("actions.new", scope: "decidim.admin", name: t("models.participatory_process_step.name", scope: "decidim.admin")), new_participatory_process_step_path(current_participatory_process), class: 'button tiny button--title' %>
       <% end %>

--- a/decidim-admin/app/views/decidim/admin/participatory_process_user_roles/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_process_user_roles/index.html.erb
@@ -1,7 +1,7 @@
 <div class='card' id="process_admins">
   <div class="card-divider">
     <h2 class="card-title">
-      <%= t(".process_admins_title", scope: "decidim.admin") %>
+      <%= t(".process_admins_title") %>
       <% if can? :create, Decidim::ParticipatoryProcessUserRole %>
          <%= link_to t("actions.new", scope: "decidim.admin", name: t("models.participatory_process_user_role.name", scope: "decidim.admin")), new_participatory_process_user_role_path(current_participatory_process), class: 'button tiny button--title new' %>
       <% end %>

--- a/decidim-admin/config/locales/ca.yml
+++ b/decidim-admin/config/locales/ca.yml
@@ -139,6 +139,8 @@ ca:
         edit:
           title: Edita arxiu adjunt
           update: Actualitzar
+        index:
+          attachments_title: Adjunts
         new:
           create: Crea arxiu adjunt
           title: Nou arxiu adjunt
@@ -156,6 +158,7 @@ ca:
           title: Edita categoria
           update: Actualitzar
         index:
+          categories_title: Categories
           category_used: Aquesta categoria no es pot suprimir perquè és en ús.
         new:
           create: Crea una categoria
@@ -166,20 +169,6 @@ ca:
       dashboard:
         show:
           welcome: Benvingut al nou panell d'administració de Decidim.
-      decidim:
-        admin:
-          attachments:
-            index:
-              attachments_title: Adjunts
-          categories:
-            index:
-              categories_title: Categories
-          participatory_process_steps:
-            index:
-              steps_title: Fases
-          participatory_process_user_roles:
-            index:
-              process_admins_title: Usuaris del procés participatiu
       exports:
         export_as: "%{name} com a %{export_format}"
         notice: La teva exportació està actualment en curs. Rebràs un correu electrònic quan hagi finalitzat.
@@ -402,6 +391,8 @@ ca:
         edit:
           title: Editar fase de procés participatiu
           update: Actualitzar
+        index:
+          steps_title: Fases
         new:
           create: Crear
           title: Nova fase de procés participatiu
@@ -419,6 +410,8 @@ ca:
         edit:
           title: Editar usuari de procés participatiu.
           update: Actualitzar
+        index:
+          process_admins_title: Usuaris del procés participatiu
         new:
           create: Crear
           title: Nou usuari de procés participatiu.

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -140,6 +140,8 @@ en:
         edit:
           title: Edit attachment
           update: Update
+        index:
+          attachments_title: Attachments
         new:
           create: Create attachment
           title: New attachment
@@ -157,6 +159,7 @@ en:
           title: Edit category
           update: Update
         index:
+          categories_title: Categories
           category_used: This category cannot be removed because it is in use.
         new:
           create: Create category
@@ -167,20 +170,6 @@ en:
       dashboard:
         show:
           welcome: Welcome to the new Decidim Panel Admin.
-      decidim:
-        admin:
-          attachments:
-            index:
-              attachments_title: Attachments
-          categories:
-            index:
-              categories_title: Categories
-          participatory_process_steps:
-            index:
-              steps_title: Steps
-          participatory_process_user_roles:
-            index:
-              process_admins_title: Participatory process users
       exports:
         export_as: "%{name} as %{export_format}"
         notice: Your export is currently in progress. You'll receive an email when it's complete.
@@ -403,6 +392,8 @@ en:
         edit:
           title: Edit participatory process step
           update: Update
+        index:
+          steps_title: Steps
         new:
           create: Create
           title: New participatory process step
@@ -420,6 +411,8 @@ en:
         edit:
           title: Update participatory process user.
           update: Update
+        index:
+          process_admins_title: Participatory process users
         new:
           create: Create
           title: New participatory process user.

--- a/decidim-admin/config/locales/es.yml
+++ b/decidim-admin/config/locales/es.yml
@@ -139,6 +139,8 @@ es:
         edit:
           title: Editar archivo adjunto
           update: Actualizar
+        index:
+          attachments_title: Archivos adjuntos
         new:
           create: Crear archivo adjunto
           title: Nuevo archivo adjunto
@@ -156,6 +158,8 @@ es:
           title: Editar categoría
           update: Actualizar
         index:
+          categories_title: Categorías
+        index:
           category_used: Esta categoría no se puede eliminar porque está en uso.
         new:
           create: Crear categoría
@@ -166,20 +170,6 @@ es:
       dashboard:
         show:
           welcome: Bienvenido al nuevo panel de administración de Decidim.
-      decidim:
-        admin:
-          attachments:
-            index:
-              attachments_title: Archivos adjuntos
-          categories:
-            index:
-              categories_title: Categorías
-          participatory_process_steps:
-            index:
-              steps_title: Fases
-          participatory_process_user_roles:
-            index:
-              process_admins_title: Usuarios del proceso
       exports:
         export_as: "%{name} como %{export_format}"
         notice: Su exportación está actualmente en curso. Recibirá un correo electrónico cuando esté completo.
@@ -402,6 +392,8 @@ es:
         edit:
           title: Editar fase de proceso participativo
           update: Actualizar
+        index:
+          steps_title: Fases
         new:
           create: Crear
           title: Nuevo fase de proceso participativo
@@ -419,6 +411,8 @@ es:
         edit:
           title: Editar usuario del proceso
           update: Actualizar
+        index:
+          process_admins_title: Usuarios del proceso
         new:
           create: Crear
           title: Nuevo usuario del proceso

--- a/decidim-admin/config/locales/eu.yml
+++ b/decidim-admin/config/locales/eu.yml
@@ -135,6 +135,8 @@ eu:
         edit:
           title: Editatu fitxategi erantsia
           update: Eguneratu
+        index:
+          attachments_title: Fitxategi erantsiak
         new:
           create: Sortu fitxategi erantsia
           title: Fitxategi erantsi berria
@@ -151,6 +153,8 @@ eu:
         edit:
           title: Editatu kategoria
           update: Eguneratu
+        index:
+          categories_title: Kategoriak
         new:
           create: Sortu kategoria
           title: Kategoria berria
@@ -160,20 +164,6 @@ eu:
       dashboard:
         show:
           welcome: Ongi etorri Decidim administrazio-panel berrira.
-      decidim:
-        admin:
-          attachments:
-            index:
-              attachments_title: Fitxategi erantsiak
-          categories:
-            index:
-              categories_title: Kategoriak
-          participatory_process_steps:
-            index:
-              steps_title: Faseak
-          participatory_process_user_roles:
-            index:
-              process_admins_title: Prozesu partizipatiboko erabiltzaileak
       exports:
         export_as: "%{name} honako hau gisa: %{export_format}"
         notice: Zure esportazioa bidean da. Mezu elektroniko bat jasoko duzu bukatutakoan.
@@ -387,6 +377,8 @@ eu:
         edit:
           title: Editatu prozesu partizipatiboaren fasea
           update: Eguneratu
+        index:
+          steps_title: Faseak
         new:
           create: Sortu
           title: Prozesu partizipatiboaren fase berria
@@ -404,6 +396,8 @@ eu:
         edit:
           title: Prozesu partizipatiboko erabiltzailea eguneratzea.
           update: Eguneratu
+        index:
+          process_admins_title: Prozesu partizipatiboko erabiltzaileak
         new:
           create: Sortu
           title: Partaidetza-prozesu berriko erabiltzailea.

--- a/decidim-admin/config/locales/fi.yml
+++ b/decidim-admin/config/locales/fi.yml
@@ -111,6 +111,8 @@ fi:
           success: Liite tuhottu onnistuneesti.
         edit:
           title: Muokkaa liitettä
+        index:
+          attachments_title: Liitteet
         new:
           create: Luo liite
           title: Uusi liite
@@ -126,23 +128,14 @@ fi:
           success: Kategoria poistettu onnistuneesti.
         edit:
           title: Muokkaa kategoriaa
+        index:
+          categories_title: Kategoriat
         new:
           create: Luo kategoria
           title: Uusi kategoria
         update:
           error: Tämän kategorian luonnissa tapahtui virhe.
           success: Kategoria päivitetty onnistuneesti.
-      decidim:
-        admin:
-          attachments:
-            index:
-              attachments_title: Liitteet
-          categories:
-            index:
-              categories_title: Kategoriat
-          participatory_process_steps:
-            index:
-              steps_title: Vaihe
       feature_permissions:
         edit:
           everyone: Kaikki
@@ -320,6 +313,8 @@ fi:
           success: Osallistumisprosessin vaihe tuhottu onnistuneesti.
         edit:
           title: Muokkaa osallistumisprosessin vaihetta
+        index:
+          steps_title: Vaihe
         new:
           title: Uusi osallistumisprosessin vaihe
         ordering:

--- a/decidim-admin/config/locales/fr.yml
+++ b/decidim-admin/config/locales/fr.yml
@@ -133,6 +133,8 @@ fr:
         edit:
           title: Modifier le document lié
           update: Mettre à jour
+        index:
+          attachments_title: Pièces jointes
         new:
           create: Lier un document
           title: Nouveau document lié
@@ -149,6 +151,8 @@ fr:
         edit:
           title: Modifier la catégorie
           update: Mettre à jour
+        index:
+          categories_title: Catégories
         new:
           create: Créer une catégorie
           title: Nouvelle catégorie
@@ -158,20 +162,6 @@ fr:
       dashboard:
         show:
           welcome: Bienvenue dans le nouveau panneau d’administration Decidim.
-      decidim:
-        admin:
-          attachments:
-            index:
-              attachments_title: Pièces jointes
-          categories:
-            index:
-              categories_title: Catégories
-          participatory_process_steps:
-            index:
-              steps_title: Etapes
-          participatory_process_user_roles:
-            index:
-              process_admins_title: Administrateurs du processus participatifs
       feature_permissions:
         edit:
           everyone: Tout le monde
@@ -377,6 +367,8 @@ fr:
         edit:
           title: Modifier l'étape du processus participatif
           update: Mettre à jour
+        index:
+          steps_title: Etapes
         new:
           create: Créer
           title: Nouvelle étape du processus participatif
@@ -394,6 +386,8 @@ fr:
         edit:
           title: Mettre à jour l'utilisateur du processus participatif.
           update: Mettre à jour
+        index:
+          process_admins_title: Administrateurs du processus participatifs
         new:
           create: Créer
           title: Nouvel utilisateur de processus participatif.

--- a/decidim-admin/config/locales/it.yml
+++ b/decidim-admin/config/locales/it.yml
@@ -111,6 +111,8 @@ it:
         edit:
           title: Modifica allegato
           update: Aggiorna
+        index:
+          attachments_title: Allegati
         new:
           create: Crea allegato
           title: Nuovo allegato
@@ -127,6 +129,8 @@ it:
         edit:
           title: Modifica categoria
           update: Aggiorna
+        index:
+          categories_title: Categorie
         new:
           create: Crea nuova categoria
           title: Nuova categoria
@@ -136,20 +140,6 @@ it:
       dashboard:
         show:
           welcome: Benvenuto nel nuovo pannello di amministarzione.
-      decidim:
-        admin:
-          attachments:
-            index:
-              attachments_title: Allegati
-          categories:
-            index:
-              categories_title: Categorie
-          participatory_process_steps:
-            index:
-              steps_title: Fasi
-          participatory_process_user_roles:
-            index:
-              process_admins_title: Utenti del processo partecipativo.
       exports:
         export_as: "%{name} esporta come %{export_format}"
         notice: Export in fase di elaborazione.  Riceverai un'email quando l'export sarà terminato.
@@ -347,6 +337,8 @@ it:
         edit:
           title: Modifica una fase del processo partecipativo.
           update: Aggiorna
+        index:
+          steps_title: Fasi
         new:
           create: Crea
           title: Nuova fase del processo partecipativo.
@@ -364,6 +356,8 @@ it:
         edit:
           title: Aggiornamento utente di un processo partecipativo.
           update: Aggiorna
+        index:
+          process_admins_title: Utenti del processo partecipativo.
         new:
           create: Crea
           title: Nuovo utente per un processo partecipativo.


### PR DESCRIPTION
#### :tophat: What? Why?
These keys were very nested (with a double "decidim.admin" inside the
key) for no reason. This PR normalizes them.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![buongiorno](https://user-images.githubusercontent.com/2887858/28595909-5a02eb12-7196-11e7-81ba-f9ed2d6e4552.gif)
