### PR TITLE
Add roles to users

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/users_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/users_controller.rb
@@ -21,7 +21,6 @@ module Decidim
         default_params = {
           organization: current_organization,
           invitation_instructions: "invite_admin",
-          admin: true,
           invited_by: current_user,
           comments_notifications: true,
           replies_notifications: true
@@ -81,7 +80,7 @@ module Decidim
       end
 
       def collection
-        @collection ||= current_organization.admins
+        @collection ||= current_organization.admins.or(current_organization.users_with_any_role)
       end
     end
   end

--- a/decidim-admin/app/models/decidim/admin/abilities/admin_ability.rb
+++ b/decidim-admin/app/models/decidim/admin/abilities/admin_ability.rb
@@ -30,10 +30,10 @@ module Decidim
           can :manage, :managed_users
           cannot [:new, :create], :managed_users if empty_available_authorizations?
           can :impersonate, Decidim::User do |user_to_impersonate|
-            user_to_impersonate.managed? && Decidim::ImpersonationLog.where(admin: user).active.empty?
+            user_to_impersonate.managed? && Decidim::ImpersonationLog.active.empty?
           end
           can :promote, Decidim::User do |user_to_promote|
-            user_to_promote.managed? && Decidim::ImpersonationLog.where(admin: user).active.empty?
+            user_to_promote.managed? && Decidim::ImpersonationLog.active.empty?
           end
 
           can :manage, Moderation

--- a/decidim-admin/app/models/decidim/admin/abilities/user_manager_ability.rb
+++ b/decidim-admin/app/models/decidim/admin/abilities/user_manager_ability.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    module Abilities
+      # Defines the abilities for a user with role 'user_manager' in the admin section.
+      # Intended to be used with `cancancan`.
+      class UserManagerAbility < Decidim::Abilities::UserManagerAbility
+        def define_abilities
+          super
+
+          can :manage, :managed_users
+          cannot [:new, :create], :managed_users if empty_available_authorizations?
+          can :impersonate, Decidim::User do |user_to_impersonate|
+            user_to_impersonate.managed? && Decidim::ImpersonationLog.where(admin: user).active.empty?
+          end
+          can :promote, Decidim::User do |user_to_promote|
+            user_to_promote.managed? && Decidim::ImpersonationLog.where(admin: user).active.empty?
+          end
+        end
+
+        private
+
+        def empty_available_authorizations?
+          @context[:current_organization] && @context[:current_organization].available_authorizations.empty?
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/app/models/decidim/admin/abilities/user_manager_ability.rb
+++ b/decidim-admin/app/models/decidim/admin/abilities/user_manager_ability.rb
@@ -12,10 +12,10 @@ module Decidim
           can :manage, :managed_users
           cannot [:new, :create], :managed_users if empty_available_authorizations?
           can :impersonate, Decidim::User do |user_to_impersonate|
-            user_to_impersonate.managed? && Decidim::ImpersonationLog.where(admin: user).active.empty?
+            user_to_impersonate.managed? && Decidim::ImpersonationLog.active.empty?
           end
           can :promote, Decidim::User do |user_to_promote|
-            user_to_promote.managed? && Decidim::ImpersonationLog.where(admin: user).active.empty?
+            user_to_promote.managed? && Decidim::ImpersonationLog.active.empty?
           end
         end
 

--- a/decidim-admin/app/views/decidim/admin/users/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/users/_form.html.erb
@@ -5,3 +5,7 @@
 <div class="row column">
   <%= form.email_field :email, label: t('.email') %>
 </div>
+
+<div class="row column">
+  <%= form.select :role, @form.available_roles_for_select, label: t('.role') %>
+</div>

--- a/decidim-admin/app/views/decidim/admin/users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/users/index.html.erb
@@ -23,7 +23,7 @@
         <tbody>
           <% @users.each do |user| %>
             <tr data-user-id="<%= user.id %>">
-              <td><%= user.admin? ? t("decidim.admin.models.user.fields.admin") : t(user.roles.first, scope: "decidim.admin.models.user.fields.roles") %></td>
+              <td><%= t(user.active_role, scope: "decidim.admin.models.user.fields.roles") %></td>
               <td><%= user.name %></td>
               <td><%= user.email %></td>
               <td>

--- a/decidim-admin/app/views/decidim/admin/users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/users/index.html.erb
@@ -10,6 +10,7 @@
       <table class="table-list">
         <thead>
           <tr>
+            <th><%= t("models.user.fields.role", scope: "decidim.admin") %></th>
             <th><%= t("models.user.fields.name", scope: "decidim.admin") %></th>
             <th><%= t("models.user.fields.email", scope: "decidim.admin") %></th>
             <th><%= t("models.user.fields.invitation_sent_at", scope: "decidim.admin") %></th>
@@ -22,6 +23,7 @@
         <tbody>
           <% @users.each do |user| %>
             <tr data-user-id="<%= user.id %>">
+              <td><%= user.admin? ? t("decidim.admin.models.user.fields.admin") : t(user.roles.first, scope: "decidim.admin.models.user.fields.roles") %></td>
               <td><%= user.name %></td>
               <td><%= user.email %></td>
               <td>

--- a/decidim-admin/app/views/layouts/decidim/admin/users.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/users.html.erb
@@ -4,9 +4,11 @@
       <%= t ".title" %>
     </div>
     <ul>
-      <li <% if is_active_link?(decidim_admin.users_path) %> class="is-active" <% end %>>
-        <%= link_to t("menu.admins", scope: "decidim.admin"), decidim_admin.users_path %>
-      </li>
+      <% if can? :index, Decidim::User %>
+        <li <% if is_active_link?(decidim_admin.users_path) %> class="is-active" <% end %>>
+          <%= link_to t("menu.admins", scope: "decidim.admin"), decidim_admin.users_path %>
+        </li>
+      <% end %>
       <% if can? :index, Decidim::UserGroup %>
         <li <% if is_active_link?(decidim_admin.user_groups_path) %> class="is-active" <% end %>>
           <%= link_to t("menu.user_groups", scope: "decidim.admin"), decidim_admin.user_groups_path %>

--- a/decidim-admin/config/i18n-tasks.yml
+++ b/decidim-admin/config/i18n-tasks.yml
@@ -95,6 +95,7 @@ ignore_unused:
  - activerecord.attributes.*
  - activemodel.attributes.*
  - decidim.admin.participatory_process_steps.default_title
+ - decidim.admin.models.user.fields.roles.*
  - activemodel.errors.messages.*
  - actions.confirm_destroy
  - time.formats.*

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -324,13 +324,13 @@ en:
             title: Title
         user:
           fields:
+            admin: Admin
             created_at: Creation date
             email: Email
             invitation_accepted_at: Invitation accepted date
             invitation_sent_at: Invitation sent date
             last_sign_in_at: Last sign in date
             name: Name
-            admin: Admin
             role: Role
             roles:
               user_manager: User manager

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -330,6 +330,10 @@ en:
             invitation_sent_at: Invitation sent date
             last_sign_in_at: Last sign in date
             name: Name
+            admin: Admin
+            role: Role
+            roles:
+              user_manager: User manager
           name: User
         user_group:
           fields:
@@ -560,6 +564,7 @@ en:
         form:
           email: Email
           name: Name
+          role: Role
         new:
           create: Invite
           title: Invite user as administrator

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -324,7 +324,6 @@ en:
             title: Title
         user:
           fields:
-            admin: Admin
             created_at: Creation date
             email: Email
             invitation_accepted_at: Invitation accepted date
@@ -333,6 +332,7 @@ en:
             name: Name
             role: Role
             roles:
+              admin: Admin
               user_manager: User manager
           name: User
         user_group:

--- a/decidim-admin/lib/decidim/admin/engine.rb
+++ b/decidim-admin/lib/decidim/admin/engine.rb
@@ -33,6 +33,7 @@ module Decidim
         Decidim.configure do |config|
           config.admin_abilities += [
             "Decidim::Admin::Abilities::AdminAbility",
+            "Decidim::Admin::Abilities::UserManagerAbility",
             "Decidim::Admin::Abilities::ParticipatoryProcessAdminAbility",
             "Decidim::Admin::Abilities::ParticipatoryProcessCollaboratorAbility",
             "Decidim::Admin::Abilities::ParticipatoryProcessModeratorAbility"
@@ -52,7 +53,8 @@ module Decidim
                     decidim_admin.participatory_processes_path,
                     icon_name: "target",
                     position: 2,
-                    active: :inclusive
+                    active: :inclusive,
+                    if: can?(:manage, Decidim::ParticipatoryProcess)
 
           menu.item I18n.t("menu.participatory_process_groups", scope: "decidim.admin"),
                     decidim_admin.participatory_process_groups_path,
@@ -69,11 +71,11 @@ module Decidim
                     if: can?(:read, Decidim::StaticPage)
 
           menu.item I18n.t("menu.users", scope: "decidim.admin"),
-                    decidim_admin.users_path,
+                    can?(:read, :admin_users) ? decidim_admin.users_path : decidim_admin.managed_users_path,
                     icon_name: "person",
                     position: 5,
                     active: [%w(decidim/admin/user_groups decidim/admin/users), []],
-                    if: can?(:read, :admin_users)
+                    if: can?(:read, :admin_users) || can?(:read, :managed_users)
 
           menu.item I18n.t("menu.newsletters", scope: "decidim.admin"),
                     decidim_admin.newsletters_path,

--- a/decidim-admin/spec/commands/promote_managed_user_spec.rb
+++ b/decidim-admin/spec/commands/promote_managed_user_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe Decidim::Admin::PromoteManagedUser do
   let(:organization) { create :organization }
-  let!(:current_user) { create :user, :admin, organization: organization}
+  let!(:current_user) { create :user, :admin, organization: organization }
   let(:email) { "foo@example.org" }
   let(:form_params) do
     {

--- a/decidim-admin/spec/features/admin_manages_organization_admins_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_organization_admins_spec.rb
@@ -41,6 +41,29 @@ describe "Organization admins", type: :feature do
       end
     end
 
+    it "can invite a user with a specific role" do
+      within ".card-title" do
+        find(".button--title").click
+      end
+
+      within ".new_user" do
+        fill_in :user_name, with: "New user manager"
+        fill_in :user_email, with: "newusermanager@example.org"
+        select "User manager", from: :user_role
+
+        find("*[type=submit]").click
+      end
+
+      within ".callout-wrapper" do
+        expect(page).to have_content("successfully")
+      end
+
+      within "table" do
+        expect(page).to have_content("New user manager")
+        expect(page).to have_content("User manager")
+      end
+    end
+
     context "with existing users" do
       let!(:user) do
         user = build(:user, :confirmed, :admin, organization: organization)

--- a/decidim-admin/spec/features/user_manager_managed_users_spec.rb
+++ b/decidim-admin/spec/features/user_manager_managed_users_spec.rb
@@ -2,13 +2,12 @@
 
 require "spec_helper"
 
-describe "Admin manages managed users", type: :feature do
-  let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+describe "User manager manages managed users", type: :feature do
+  let(:user) { create(:user, :user_manager, :confirmed, organization: organization) }
 
   def navigate_to_managed_users_page
     visit decidim_admin.root_path
     click_link "Users"
-    click_link "Managed users"
   end
 
   it_behaves_like "manage managed users examples"

--- a/decidim-admin/spec/models/abilities/user_manager_ability_spec.rb
+++ b/decidim-admin/spec/models/abilities/user_manager_ability_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Admin::Abilities::UserManagerAbility do
+  let(:user) { build(:user, :user_manager) }
+
+  subject { described_class.new(user, {}) }
+
+  context "when the user is not a user manager" do
+    let(:user) { build(:user) }
+
+    it "doesn't have any permission" do
+      expect(subject.permissions[:can]).to be_empty
+      expect(subject.permissions[:cannot]).to be_empty
+    end
+  end
+
+  it { is_expected.to be_able_to(:manage, :managed_users) }
+end

--- a/decidim-admin/spec/shared/manage_managed_users_examples.rb
+++ b/decidim-admin/spec/shared/manage_managed_users_examples.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "manage managed users examples" do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:organization) { create(:organization, available_authorizations: available_authorizations) }
+  let(:available_authorizations) { ["Decidim::DummyAuthorizationHandler"] }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+  end
+
+  def fill_in_the_managed_user_form
+    within "form.new_managed_user" do
+      fill_in :managed_user_name, with: "Foo"
+      fill_in :managed_user_authorization_document_number, with: "123456789X"
+      fill_in :managed_user_authorization_postal_code, with: "08224"
+      page.execute_script("$('#managed_user_authorization_birthday').siblings('input:first').focus()")
+    end
+
+    page.find(".datepicker-dropdown .day", text: "12").click
+    click_button "Create"
+  end
+
+  def fill_in_the_impersonation_form
+    within "form.new_managed_user_impersonation" do
+      fill_in :impersonate_managed_user_authorization_document_number, with: "123456789X"
+      fill_in :impersonate_managed_user_authorization_postal_code, with: "08224"
+      page.execute_script("$('#impersonate_managed_user_authorization_birthday').siblings('input:first').focus()")
+    end
+
+    page.find(".datepicker-dropdown .day", text: "12").click
+    click_button "Impersonate"
+  end
+
+  def impersonate_the_managed_user
+    navigate_to_managed_users_page
+
+    within find("tr", text: managed_user.name) do
+      page.find("a.action-icon--impersonate").click
+    end
+
+    fill_in_the_impersonation_form
+  end
+
+  def check_impersonation_logs
+    within find("tr", text: managed_user.name) do
+      page.find("a.action-icon--view-logs").click
+    end
+
+    expect(page).to have_selector("tbody tr", count: 1)
+  end
+
+  context "when the organization doesn't have any authorization available" do
+    let(:available_authorizations) { [] }
+
+    it "the managed users page displays a warning and creation is disabled" do
+      navigate_to_managed_users_page
+
+      expect(page).to have_selector("a.button.disabled", text: "NEW")
+      expect(page).to have_content("You need at least one authorization enabled for this organization.")
+    end
+  end
+
+  context "when the organization has one authorization available" do
+    it "creates a managed user filling in the authorization info" do
+      navigate_to_managed_users_page
+
+      click_link "New"
+
+      fill_in_the_managed_user_form
+
+      expect(page).to have_content("successfully")
+      expect(page).to have_content("Foo")
+    end
+  end
+
+  context "when the organization has more than one authorization available" do
+    let(:available_authorizations) { ["Decidim::DummyAuthorizationHandler", "Decidim::DummyAuthorizationHandler"] }
+
+    it "selects an authorization method and creates a managed user filling in the authorization info" do
+      navigate_to_managed_users_page
+
+      click_link "New"
+
+      expect(page).to have_content(/Select an authorization method/i)
+      expect(page).to have_content(/Step 1 of 2/i)
+
+      click_link "Example authorization", match: :first
+
+      expect(page).to have_content(/Step 2 of 2/i)
+
+      fill_in_the_managed_user_form
+
+      expect(page).to have_content("successfully")
+      expect(page).to have_content("Foo")
+    end
+  end
+
+  context "when a manager user already exists" do
+    let!(:managed_user) { create(:user, :managed, organization: organization) }
+    let!(:authorization) { create(:authorization, user: managed_user, name: "decidim/dummy_authorization_handler", unique_id: "123456789X") }
+
+    it "can impersonate the user filling in the correct authorization" do
+      impersonate_the_managed_user
+
+      expect(page).to have_content("You are impersonating the user #{managed_user.name}")
+      expect(page).to have_content("Your session will expire in #{Decidim::ImpersonationLog::SESSION_TIME_IN_MINUTES} minutes")
+    end
+
+    context "when the admin is impersonating that user" do
+      before do
+        impersonate_the_managed_user
+      end
+
+      it "closes the current session and check the logs" do
+        visit decidim.root_path
+
+        click_button "Close session"
+
+        expect(page).to have_content("successfully")
+
+        check_impersonation_logs
+      end
+
+      it "spends all the session time and is redirected automatically", perform_enqueued: true do
+        travel Decidim::ImpersonationLog::SESSION_TIME_IN_MINUTES.minutes
+
+        expect(page).to have_content("expired")
+
+        check_impersonation_logs
+      end
+    end
+
+    it "can promote the user inviting them to the application", perform_enqueued: true do
+      navigate_to_managed_users_page
+
+      within find("tr", text: managed_user.name) do
+        page.find("a.action-icon--promote").click
+      end
+
+      within "form.new_managed_user_promotion" do
+        fill_in :managed_user_promotion_email, with: "foo@example.org"
+      end
+
+      click_button "Promote"
+
+      expect(page).to have_content("successfully")
+      expect(page).not_to have_content("Foo")
+
+      logout :user
+
+      visit last_email_link
+
+      within "form.new_user" do
+        fill_in :user_password, with: "123456"
+        fill_in :user_password_confirmation, with: "123456"
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_content("successfully")
+      expect(page).to have_content(managed_user.name)
+    end
+  end
+end

--- a/decidim-core/app/commands/decidim/invite_user.rb
+++ b/decidim-core/app/commands/decidim/invite_user.rb
@@ -31,7 +31,9 @@ module Decidim
     end
 
     def update_user
-      user.admin = form.admin
+      user.admin = form.role == "admin"
+      user.roles << form.role if form.role != "admin"
+      user.roles = user.roles.uniq
       user.save!
     end
 
@@ -40,7 +42,8 @@ module Decidim
         name: form.name,
         email: form.email.downcase,
         organization: form.organization,
-        admin: form.admin,
+        admin: form.role == "admin",
+        roles: form.role == "admin" ? [] : [form.role],
         comments_notifications: true,
         replies_notifications: true
       )

--- a/decidim-core/app/forms/decidim/invite_user_form.rb
+++ b/decidim-core/app/forms/decidim/invite_user_form.rb
@@ -31,14 +31,12 @@ module Decidim
     end
 
     def available_roles_for_select
-      [[I18n.t("decidim.admin.models.user.fields.admin"), "admin"]].concat(
-        Decidim::User::ROLES.map do |role|
-          [
-            I18n.t(role, scope: "decidim.admin.models.user.fields.roles"),
-            role
-          ]
-        end
-      )
+      Decidim::User::ROLES.map do |role|
+        [
+          I18n.t(role, scope: "decidim.admin.models.user.fields.roles"),
+          role
+        ]
+      end
     end
 
     private

--- a/decidim-core/app/forms/decidim/invite_user_form.rb
+++ b/decidim-core/app/forms/decidim/invite_user_form.rb
@@ -11,9 +11,11 @@ module Decidim
     attribute :invitation_instructions, String
     attribute :organization, Decidim::Organization
     attribute :invited_by, Decidim::User
-    attribute :admin, Boolean
+    attribute :role, String
 
     validates :email, :name, :organization, :invitation_instructions, presence: true
+    validates :role, inclusion: { in: Decidim::User::ROLES }
+
     validate :admin_uniqueness
 
     def email
@@ -26,6 +28,17 @@ module Decidim
 
     def invited_by
       super || current_user
+    end
+
+    def available_roles_for_select
+      [[I18n.t("decidim.admin.models.user.fields.admin"), "admin"]].concat(
+        Decidim::User::ROLES.map do |role|
+          [
+            I18n.t(role, scope: "decidim.admin.models.user.fields.roles"),
+            role
+          ]
+        end
+      )
     end
 
     private

--- a/decidim-core/app/models/decidim/organization.rb
+++ b/decidim-core/app/models/decidim/organization.rb
@@ -12,6 +12,7 @@ module Decidim
     has_many :static_pages, foreign_key: "decidim_organization_id", class_name: "Decidim::StaticPage", inverse_of: :organization
     has_many :scopes, -> { order(name: :asc) }, foreign_key: "decidim_organization_id", class_name: "Decidim::Scope", inverse_of: :organization
     has_many :admins, -> { where(admin: true) }, foreign_key: "decidim_organization_id", class_name: "Decidim::User"
+    has_many :users_with_any_role, -> { where.not(roles: []) }, foreign_key: "decidim_organization_id", class_name: "Decidim::User"
     has_many :users, foreign_key: "decidim_organization_id", class_name: "Decidim::User"
 
     validates :name, :host, uniqueness: true

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -6,7 +6,7 @@ module Decidim
   # A User is a citizen that wants to join the platform to participate.
   class User < ApplicationRecord
     MAXIMUM_AVATAR_FILE_SIZE = 5.megabytes
-    ROLES = %w(user_manager).freeze
+    ROLES = %w(admin user_manager).freeze
 
     devise :invitable, :database_authenticatable, :registerable, :confirmable,
            :recoverable, :rememberable, :trackable, :decidim_validatable,
@@ -52,6 +52,11 @@ module Decidim
     # Returns a boolean.
     def role?(role)
       roles.include?(role.to_s)
+    end
+
+    # Public: Returns the active role of the user
+    def active_role
+      admin ? "admin" : roles.first
     end
 
     # Public: returns the user's name or the default one

--- a/decidim-core/db/migrate/20170727125445_add_roles_to_users.rb
+++ b/decidim-core/db/migrate/20170727125445_add_roles_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRolesToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_users, :roles, :string, array: true, default: []
+  end
+end

--- a/decidim-core/lib/decidim/abilities.rb
+++ b/decidim-core/lib/decidim/abilities.rb
@@ -3,6 +3,7 @@
 module Decidim
   module Abilities
     autoload :AdminAbility, "decidim/abilities/admin_ability"
+    autoload :UserManagerAbility, "decidim/abilities/user_manager_ability"
     autoload :ParticipatoryProcessRoleAbility, "decidim/abilities/participatory_process_role_ability"
     autoload :ParticipatoryProcessAdminAbility, "decidim/abilities/participatory_process_admin_ability"
     autoload :ParticipatoryProcessCollaboratorAbility, "decidim/abilities/participatory_process_collaborator_ability"

--- a/decidim-core/lib/decidim/abilities/user_manager_ability.rb
+++ b/decidim-core/lib/decidim/abilities/user_manager_ability.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Abilities
+    # Defines the abilities for an user with role 'user_manager'.
+    # Intended to be used with `cancancan`.
+    class UserManagerAbility
+      include CanCan::Ability
+
+      attr_reader :user
+
+      def initialize(user, context)
+        @user = user
+        @context = context
+
+        define_abilities if not_admin? && user_manager?
+      end
+
+      def define_abilities
+        can :read, :admin_dashboard
+        can :impersonate, :managed_users
+      end
+
+      # Whether the user is an admin or not.
+      def not_admin?
+        @user && !@user.admin?
+      end
+
+      # Whether the user has the user_manager role or not.
+      def user_manager?
+        @user.role? "user_manager"
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -81,6 +81,7 @@ module Decidim
         Decidim.configure do |config|
           config.abilities << "Decidim::Abilities::EveryoneAbility"
           config.abilities << "Decidim::Abilities::AdminAbility"
+          config.abilities << "Decidim::Abilities::UserManagerAbility"
           config.abilities << "Decidim::Abilities::ParticipatoryProcessAdminAbility"
           config.abilities << "Decidim::Abilities::ParticipatoryProcessCollaboratorAbility"
           config.abilities << "Decidim::Abilities::ParticipatoryProcessModeratorAbility"

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -152,6 +152,10 @@ FactoryGirl.define do
       admin { true }
     end
 
+    trait :user_manager do
+      roles { ["user_manager"] }
+    end
+
     trait :process_admin do
       transient { participatory_process nil }
 

--- a/decidim-core/spec/commands/decidim/invite_user_spec.rb
+++ b/decidim-core/spec/commands/decidim/invite_user_spec.rb
@@ -11,7 +11,7 @@ module Decidim
         name: "Old man",
         email: "oldman@email.com",
         organization: organization,
-        admin: true,
+        role: "admin",
         invited_by: admin,
         invitation_instructions: "invite_admin"
       )

--- a/decidim-core/spec/forms/invite_user_form_spec.rb
+++ b/decidim-core/spec/forms/invite_user_form_spec.rb
@@ -23,7 +23,7 @@ module Decidim
         email: "NewAdmin@example.org",
         name: "New Admin",
         invitation_instructions: "invite_admin",
-        admin: true,
+        role: "admin",
         organization: form_organization,
         invited_by: form_user
       }

--- a/decidim-system/app/commands/decidim/system/register_organization.rb
+++ b/decidim-system/app/commands/decidim/system/register_organization.rb
@@ -55,7 +55,7 @@ module Decidim
         Decidim::InviteUserForm.from_params(
           name: form.organization_admin_name,
           email: form.organization_admin_email,
-          admin: true,
+          role: "admin",
           invitation_instructions: "organization_admin_invitation_instructions"
         ).with_context(
           current_user: form.current_user,


### PR DESCRIPTION
#### :tophat: What? Why?

I need user roles at organization level because users with `user_manager` role should be able to manage a `ManagedUser`.

#### :pushpin: Related Issues
- Related to #1621 

#### :clipboard: Subtasks
- [x] Add `user_manager` role
- [x] Refactor all the things

### :camera: Screenshots (optional)

![image](https://user-images.githubusercontent.com/106021/28673559-2352a8de-72e3-11e7-8d1d-d2a8fc3dc839.png)
![image](https://user-images.githubusercontent.com/106021/28674679-6aef969a-72e6-11e7-9dc9-a4162251546c.png)

#### :ghost: GIF

None