### PR TITLE
Fix re-seeding problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased](https://github.com/decidim/decidim/tree/HEAD)
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.4.3...HEAD)
 
+**Fixed**
+
+- **decidim-core**: Fixed crash when running migrations & seeding DB in the same ruby process. [\#1649](https://github.com/decidim/decidim/pull/1649).
+
 ## [v0.4.3](https://github.com/decidim/decidim/tree/v0.4.3) (2017-07-25)
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.4.2...v0.4.3)
 

--- a/Rakefile
+++ b/Rakefile
@@ -59,7 +59,7 @@ task :development_app do
   Dir.chdir("#{__dir__}/development_app") do
     Bundler.with_clean_env do
       sh "bundle exec spring stop"
-      sh "bundle exec rake db:seed"
+      sh "bundle exec rails db:seed"
       sh "bundle exec rails generate decidim:demo"
     end
   end

--- a/decidim-core/db/migrate/20170608142521_add_organization_to_user_groups.rb
+++ b/decidim-core/db/migrate/20170608142521_add_organization_to_user_groups.rb
@@ -1,12 +1,25 @@
 # frozen_string_literal: true
 
 class AddOrganizationToUserGroups < ActiveRecord::Migration[5.0]
+  class UserGroup < ApplicationRecord
+    self.table_name = :decidim_user_groups
+  end
+
   def change
     add_column :decidim_user_groups, :decidim_organization_id, :integer
 
-    Decidim::UserGroup.includes(:users).find_each do |user_group|
-      user_group.organization = user_group.users.first.organization
-      user_group.save!(validate: false)
+    UserGroup.find_each do |user_group|
+      execute <<~SQL.squish
+        UPDATE decidim_user_groups
+        SET decidim_organization_id = (
+          SELECT MIN(u.decidim_organization_id)
+          FROM decidim_users u
+          INNER JOIN decidim_user_group_memberships m
+          ON u.id = m.decidim_user_id
+          WHERE m.decidim_user_group_id = #{user_group.id}
+        )
+        WHERE id = #{user_group.id}
+      SQL
     end
 
     change_column :decidim_user_groups, :decidim_organization_id, :integer, null: false

--- a/lib/generators/decidim/docker_generator.rb
+++ b/lib/generators/decidim/docker_generator.rb
@@ -38,7 +38,7 @@ module Decidim
 
           run "rails generate decidim:demo"
           run "docker-compose build"
-          run "docker-compose run --rm app rake db:drop db:create db:migrate db:setup"
+          run "docker-compose run --rm app rails db:drop db:create db:migrate db:setup"
         end
       end
 

--- a/lib/generators/decidim/install_generator.rb
+++ b/lib/generators/decidim/install_generator.rb
@@ -24,7 +24,7 @@ module Decidim
       end
 
       def copy_migrations
-        rake "railties:install:migrations"
+        rails_command "railties:install:migrations"
         recreate_db if options[:recreate_db]
       end
 
@@ -111,10 +111,10 @@ module Decidim
       private
 
       def recreate_db
-        rake "db:environment:set db:drop" unless ENV["CI"]
-        rake "db:create"
-        rake "db:migrate"
-        rake "db:test:prepare"
+        rails_command "db:environment:set db:drop" unless ENV["CI"]
+        rails_command "db:create"
+        rails_command "db:migrate"
+        rails_command "db:test:prepare"
       end
 
       def scss_variables


### PR DESCRIPTION
#### :tophat: What? Why?

Fixes the following problem when re-seeding DB:

* Run `bundle exec development_app`.
* Switch to the generated app, `cd development_app`.
* Edit `config/initializers/decidim.rb` by uncommenting the
  `config.available_locales` line.
* Run `bundle exec rails db:drop db:create db:migrate db:seed`.

You will get

```
rails aborted!
ActiveModel::UnknownAttributeError: unknown attribute 'verified_at' for
Decidim::UserGroup.
```

This is because one of the migrations loads the `Decidim::UserGroup` model, _before_ the `verified_at` column has been added to the table. So when we want to use the model while seeding, we have an incorrect version of it.

I fixed it by using a dummy model in the migration instead of the real class, and using raw SQL for updating each element.

But this is an old migration and I doubt whether there'll be any installation with meaningful data stuck at decidim 0.2.0 that still needs to run this migration. If not, I would drop the data migration part altogether. 

#### :pushpin: Related Issues
- This is another example of why using models in migrations is no good :)
- This has come up at least one other time [here](https://gitter.im/decidim/decidim?at=5948f7866462d8493c2f3802).
- #1555 is somewhat related because one it is merged it won't be as necessary to change the locales after generating a sample app :smiley: .

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![underground_final](https://user-images.githubusercontent.com/2887858/28692370-917f0860-7320-11e7-89af-ee889275403f.gif)