### PR TITLE
Less participatory process coupling in core

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/participatory_process_groups_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/participatory_process_groups_controller.rb
@@ -78,7 +78,8 @@ module Decidim
       end
 
       def collection
-        @collection ||= current_user.organization.participatory_process_groups
+        @collection ||=
+          Decidim::OrganizationParticipatoryProcessGroups.new(current_user.organization).query
       end
     end
   end

--- a/decidim-admin/app/forms/decidim/admin/participatory_process_copy_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_process_copy_form.rb
@@ -24,7 +24,7 @@ module Decidim
       private
 
       def slug_uniqueness
-        return unless current_organization.participatory_processes.where(slug: slug).where.not(id: id).any?
+        return unless OrganizationParticipatoryProcesses.new(current_organization).query.where(slug: slug).where.not(id: id).any?
 
         errors.add(:slug, :taken)
       end

--- a/decidim-admin/app/forms/decidim/admin/participatory_process_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_process_form.rb
@@ -58,7 +58,7 @@ module Decidim
       private
 
       def slug_uniqueness
-        return unless current_organization.participatory_processes.where(slug: slug).where.not(id: id).any?
+        return unless OrganizationParticipatoryProcesses.new(current_organization).query.where(slug: slug).where.not(id: id).any?
 
         errors.add(:slug, :taken)
       end

--- a/decidim-admin/app/helpers/decidim/admin/process_groups_for_select_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/process_groups_for_select_helper.rb
@@ -12,7 +12,7 @@ module Decidim
       # Returns an Array.
       def process_groups_for_select
         @process_groups_for_select ||=
-          current_organization.participatory_process_groups.map do |group|
+          OrganizationParticipatoryProcessGroups.new(current_organization).map do |group|
             [translated_attribute(group.name), group.id]
           end
       end

--- a/decidim-admin/app/helpers/decidim/admin/processes_for_select_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/processes_for_select_helper.rb
@@ -11,7 +11,7 @@ module Decidim
       #
       # Returns an Array.
       def processes_for_select
-        @processes_for_select ||= current_organization.participatory_processes.map do |process|
+        @processes_for_select ||= OrganizationParticipatoryProcesses.new(current_organization).map do |process|
           [
             translated_attribute(process.title),
             process.id

--- a/decidim-core/app/constraints/decidim/current_participatory_process.rb
+++ b/decidim-core/app/constraints/decidim/current_participatory_process.rb
@@ -29,7 +29,7 @@ module Decidim
     end
 
     def detect_current_participatory_process(params)
-      @organization.participatory_processes.find_by_id(params["participatory_process_id"])
+      OrganizationParticipatoryProcesses.new(@organization).query.find_by_id(params["participatory_process_id"])
     end
   end
 end

--- a/decidim-core/app/controllers/concerns/decidim/needs_participatory_process.rb
+++ b/decidim-core/app/controllers/concerns/decidim/needs_participatory_process.rb
@@ -39,7 +39,7 @@ module Decidim
 
       def detect_participatory_process
         request.env["current_participatory_process"] ||
-          current_organization.participatory_processes.find(params[:participatory_process_id] || params[:id])
+          OrganizationParticipatoryProcesses.new(current_organization).query.find(params[:participatory_process_id] || params[:id])
       end
     end
   end

--- a/decidim-core/app/controllers/decidim/pages_controller.rb
+++ b/decidim-core/app/controllers/decidim/pages_controller.rb
@@ -30,7 +30,7 @@ module Decidim
 
     def highlighted_participatory_processes
       @highlighted_participatory_processes ||=
-        OrganizationParticipatoryProcesses.new(current_organization) | HighlightedParticipatoryProcesses.new
+        OrganizationPublishedParticipatoryProcesses.new(current_organization) | HighlightedParticipatoryProcesses.new
     end
 
     private

--- a/decidim-core/app/models/decidim/organization.rb
+++ b/decidim-core/app/models/decidim/organization.rb
@@ -7,7 +7,6 @@ module Decidim
   class Organization < ApplicationRecord
     SOCIAL_HANDLERS = [:twitter, :facebook, :instagram, :youtube, :github].freeze
 
-    has_many :participatory_process_groups, foreign_key: "decidim_organization_id", class_name: "Decidim::ParticipatoryProcessGroup", inverse_of: :organization
     has_many :static_pages, foreign_key: "decidim_organization_id", class_name: "Decidim::StaticPage", inverse_of: :organization
     has_many :scopes, -> { order(name: :asc) }, foreign_key: "decidim_organization_id", class_name: "Decidim::Scope", inverse_of: :organization
     has_many :admins, -> { where(admin: true) }, foreign_key: "decidim_organization_id", class_name: "Decidim::User"

--- a/decidim-core/app/models/decidim/organization.rb
+++ b/decidim-core/app/models/decidim/organization.rb
@@ -8,7 +8,6 @@ module Decidim
     SOCIAL_HANDLERS = [:twitter, :facebook, :instagram, :youtube, :github].freeze
 
     has_many :participatory_process_groups, foreign_key: "decidim_organization_id", class_name: "Decidim::ParticipatoryProcessGroup", inverse_of: :organization
-    has_many :participatory_processes, foreign_key: "decidim_organization_id", class_name: "Decidim::ParticipatoryProcess", inverse_of: :organization
     has_many :static_pages, foreign_key: "decidim_organization_id", class_name: "Decidim::StaticPage", inverse_of: :organization
     has_many :scopes, -> { order(name: :asc) }, foreign_key: "decidim_organization_id", class_name: "Decidim::Scope", inverse_of: :organization
     has_many :admins, -> { where(admin: true) }, foreign_key: "decidim_organization_id", class_name: "Decidim::User"

--- a/decidim-core/app/models/decidim/participatory_process.rb
+++ b/decidim-core/app/models/decidim/participatory_process.rb
@@ -11,8 +11,7 @@ module Decidim
 
     belongs_to :organization,
                foreign_key: "decidim_organization_id",
-               class_name: "Decidim::Organization",
-               inverse_of: :participatory_processes
+               class_name: "Decidim::Organization"
     belongs_to :participatory_process_group,
                foreign_key: "decidim_participatory_process_group_id",
                class_name: "Decidim::ParticipatoryProcessGroup",

--- a/decidim-core/app/models/decidim/participatory_process_group.rb
+++ b/decidim-core/app/models/decidim/participatory_process_group.rb
@@ -8,8 +8,7 @@ module Decidim
              inverse_of: :participatory_process_group
     belongs_to :organization,
                foreign_key: "decidim_organization_id",
-               class_name: "Decidim::Organization",
-               inverse_of: :participatory_process_groups
+               class_name: "Decidim::Organization"
 
     mount_uploader :hero_image, Decidim::HeroImageUploader
   end

--- a/decidim-core/app/presenters/decidim/home_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/home_stats_presenter.rb
@@ -75,7 +75,7 @@ module Decidim
     end
 
     def published_features
-      @published_features ||= Feature.where(participatory_process: organization.participatory_processes.published).published
+      @published_features ||= Feature.where(participatory_process: OrganizationPublishedParticipatoryProcesses.new(organization).query).published
     end
   end
 end

--- a/decidim-core/app/queries/decidim/organization_participatory_process_groups.rb
+++ b/decidim-core/app/queries/decidim/organization_participatory_process_groups.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This query class returns the participatory process groups given an
+  # Organization.
+  class OrganizationParticipatoryProcessGroups < Rectify::Query
+    def initialize(organization)
+      @organization = organization
+    end
+
+    def query
+      ParticipatoryProcessGroup.where(organization: @organization)
+    end
+  end
+end

--- a/decidim-core/app/queries/decidim/organization_participatory_processes.rb
+++ b/decidim-core/app/queries/decidim/organization_participatory_processes.rb
@@ -9,7 +9,7 @@ module Decidim
     end
 
     def query
-      ParticipatoryProcess.where(organization: @organization).published
+      ParticipatoryProcess.where(organization: @organization)
     end
   end
 end

--- a/decidim-core/app/queries/decidim/organization_participatory_processes.rb
+++ b/decidim-core/app/queries/decidim/organization_participatory_processes.rb
@@ -9,10 +9,7 @@ module Decidim
     end
 
     def query
-      raise MandatoryOrganization unless @organization
       ParticipatoryProcess.where(organization: @organization).published
     end
-
-    class MandatoryOrganization < StandardError; end
   end
 end

--- a/decidim-core/app/queries/decidim/organization_prioritized_participatory_processes.rb
+++ b/decidim-core/app/queries/decidim/organization_prioritized_participatory_processes.rb
@@ -10,7 +10,7 @@ module Decidim
 
     def query
       Rectify::Query.merge(
-        OrganizationParticipatoryProcesses.new(@organization),
+        OrganizationPublishedParticipatoryProcesses.new(@organization),
         PrioritizedParticipatoryProcesses.new
       ).query
     end

--- a/decidim-core/app/queries/decidim/organization_published_participatory_processes.rb
+++ b/decidim-core/app/queries/decidim/organization_published_participatory_processes.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This query class returns the Participatory Processes given an Organization.
+  class OrganizationPublishedParticipatoryProcesses < Rectify::Query
+    def initialize(organization)
+      @organization = organization
+    end
+
+    def query
+      Rectify::Query.merge(
+        OrganizationParticipatoryProcesses.new(@organization),
+        PublishedParticipatoryProcesses.new
+      ).query
+    end
+  end
+end

--- a/decidim-core/app/queries/decidim/participatory_processes_with_user_role.rb
+++ b/decidim-core/app/queries/decidim/participatory_processes_with_user_role.rb
@@ -28,7 +28,7 @@ module Decidim
     # Returns an ActiveRecord::Relation.
     def query
       # Admin users have all role privileges for all organization processes
-      return user.organization.participatory_processes if user.admin?
+      return OrganizationParticipatoryProcesses.new(user.organization).query if user.admin?
 
       ParticipatoryProcess.where(id: process_ids)
     end

--- a/decidim-core/app/queries/decidim/published_participatory_processes.rb
+++ b/decidim-core/app/queries/decidim/published_participatory_processes.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This query orders processes by importance, prioritizing promoted processes
+  # first, and closest to finalization date second.
+  class PublishedParticipatoryProcesses < Rectify::Query
+    def query
+      ParticipatoryProcess.published
+    end
+  end
+end

--- a/decidim-core/lib/decidim/query_extensions.rb
+++ b/decidim-core/lib/decidim/query_extensions.rb
@@ -16,7 +16,7 @@ module Decidim
           description "Lists all processes."
 
           resolve lambda { |_obj, _args, ctx|
-            OrganizationParticipatoryProcesses.new(ctx[:current_organization])
+            OrganizationPublishedParticipatoryProcesses.new(ctx[:current_organization])
           }
         end
 

--- a/decidim-core/spec/queries/decidim/organization_participatory_process_groups_spec.rb
+++ b/decidim-core/spec/queries/decidim/organization_participatory_process_groups_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe OrganizationParticipatoryProcessGroups do
+    subject { described_class.new(organization) }
+
+    let!(:organization) { create(:organization) }
+
+    let!(:local_participatory_process_groups) do
+      create_list(:participatory_process_group, 3, organization: organization)
+    end
+
+    let!(:foreign_participatory_process_groups) do
+      create_list(:participatory_process_group, 3)
+    end
+
+    describe "query" do
+      it "includes the organization's processes" do
+        expect(subject).to include(*local_participatory_process_groups)
+      end
+
+      it "excludes the external processes" do
+        expect(subject).not_to include(*foreign_participatory_process_groups)
+      end
+    end
+  end
+end

--- a/decidim-core/spec/queries/decidim/organization_participatory_processes_spec.rb
+++ b/decidim-core/spec/queries/decidim/organization_participatory_processes_spec.rb
@@ -28,28 +28,16 @@ module Decidim
     end
 
     describe "query" do
-      context "with an organization" do
-        it "includes the organization's published processes" do
-          expect(subject).to include(*published_participatory_processes)
-        end
-
-        it "excludes the organization's unpublished processes" do
-          expect(subject).not_to include(*unpublished_participatory_processes)
-        end
-
-        it "excludes other organization's published processes" do
-          expect(subject).not_to include(*foreign_participatory_processes)
-        end
+      it "includes the organization's published processes" do
+        expect(subject).to include(*published_participatory_processes)
       end
 
-      context "without an organization" do
-        subject { described_class.new(nil) }
+      it "excludes the organization's unpublished processes" do
+        expect(subject).not_to include(*unpublished_participatory_processes)
+      end
 
-        it "raises an exception" do
-          expect do
-            subject.to_a
-          end.to raise_error(OrganizationParticipatoryProcesses::MandatoryOrganization)
-        end
+      it "excludes other organization's published processes" do
+        expect(subject).not_to include(*foreign_participatory_processes)
       end
     end
   end

--- a/decidim-core/spec/queries/decidim/organization_participatory_processes_spec.rb
+++ b/decidim-core/spec/queries/decidim/organization_participatory_processes_spec.rb
@@ -7,36 +7,20 @@ module Decidim
     subject { described_class.new(organization) }
 
     let!(:organization) { create(:organization) }
-    let!(:published_participatory_processes) do
-      create_list(:participatory_process,
-                  3,
-                  :published,
-                  organization: organization)
-    end
-
-    let!(:unpublished_participatory_processes) do
-      create_list(:participatory_process,
-                  3,
-                  :unpublished,
-                  organization: organization)
+    let!(:local_participatory_processes) do
+      create_list(:participatory_process, 3, organization: organization)
     end
 
     let!(:foreign_participatory_processes) do
-      create_list(:participatory_process,
-                  3,
-                  :published)
+      create_list(:participatory_process, 3)
     end
 
     describe "query" do
-      it "includes the organization's published processes" do
-        expect(subject).to include(*published_participatory_processes)
+      it "includes the organization's processes" do
+        expect(subject).to include(*local_participatory_processes)
       end
 
-      it "excludes the organization's unpublished processes" do
-        expect(subject).not_to include(*unpublished_participatory_processes)
-      end
-
-      it "excludes other organization's published processes" do
+      it "excludes the external processes" do
         expect(subject).not_to include(*foreign_participatory_processes)
       end
     end

--- a/decidim-core/spec/queries/decidim/organization_published_participatory_processes_spec.rb
+++ b/decidim-core/spec/queries/decidim/organization_published_participatory_processes_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe OrganizationPublishedParticipatoryProcesses do
+    subject { described_class.new(organization) }
+
+    let!(:organization) { create(:organization) }
+    let!(:published_participatory_processes) do
+      create_list(:participatory_process,
+                  3,
+                  :published,
+                  organization: organization)
+    end
+
+    let!(:unpublished_participatory_processes) do
+      create_list(:participatory_process,
+                  3,
+                  :unpublished,
+                  organization: organization)
+    end
+
+    let!(:foreign_participatory_processes) do
+      create_list(:participatory_process, 3, :published)
+    end
+
+    describe "query" do
+      it "includes the organization's published processes" do
+        expect(subject).to include(*published_participatory_processes)
+      end
+
+      it "excludes the organization's unpublished processes" do
+        expect(subject).not_to include(*unpublished_participatory_processes)
+      end
+
+      it "excludes other organization's published processes" do
+        expect(subject).not_to include(*foreign_participatory_processes)
+      end
+    end
+  end
+end

--- a/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
+++ b/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
@@ -5,7 +5,6 @@ module Decidim
     # This class serializes a Proposal so can be exported to CSV, JSON or other
     # formats.
     class ProposalSerializer < Decidim::Exporters::Serializer
-      include Rails.application.routes.url_helpers
       include Decidim::ResourceHelper
 
       # Public: Initializes the serializer with a proposal.
@@ -44,27 +43,14 @@ module Decidim
         proposal.feature
       end
 
-      def organization
-        feature.organization
-      end
-
       def meetings
         @proposal.linked_resources(:meetings, "proposals_from_meeting").map do |meeting|
           Decidim::ResourceLocatorPresenter.new(meeting).url
         end
       end
 
-      def participatory_process
-        feature.participatory_process
-      end
-
       def url
-        Decidim::Proposals::Engine.routes.url_helpers.proposal_url(
-          proposal,
-          feature_id: feature,
-          participatory_process_id: participatory_process,
-          host: organization.host
-        )
+        Decidim::ResourceLocatorPresenter.new(proposal).url
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR keeps getting decidim's core ready for adding support for multiple participatory spaces (featurables).

The idea here is to removing coupling between the `Organization` model and participatory processes and move the logic to a separate query class. Custom featurable objects should implement equivalent queries themselves without the organization model having to know about them.

#### :pushpin: Related Issues
- Related to #1346.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![more_ska_paquito](https://user-images.githubusercontent.com/2887858/28726900-5521f492-73c3-11e7-833d-857e52366b13.gif)

