### PR TITLE
Remove seed coupling on participatory processes

### DIFF
--- a/decidim-budgets/lib/decidim/budgets/feature.rb
+++ b/decidim-budgets/lib/decidim/budgets/feature.rb
@@ -49,8 +49,6 @@ Decidim.register_feature(:budgets) do |feature|
 
   feature.seeds do
     Decidim::ParticipatoryProcess.find_each do |process|
-      next unless process.steps.any?
-
       feature = Decidim::Feature.create!(
         name: Decidim::Features::Namer.new(process.organization.available_locales, :budgets).i18n_name,
         manifest_name: :budgets,

--- a/decidim-budgets/lib/decidim/budgets/feature.rb
+++ b/decidim-budgets/lib/decidim/budgets/feature.rb
@@ -47,40 +47,38 @@ Decidim.register_feature(:budgets) do |feature|
     settings.attribute :show_votes, type: :boolean, default: false
   end
 
-  feature.seeds do
-    Decidim::ParticipatoryProcess.find_each do |process|
-      feature = Decidim::Feature.create!(
-        name: Decidim::Features::Namer.new(process.organization.available_locales, :budgets).i18n_name,
-        manifest_name: :budgets,
-        published_at: Time.current,
-        participatory_process: process
-      )
+  feature.seeds do |process|
+    feature = Decidim::Feature.create!(
+      name: Decidim::Features::Namer.new(process.organization.available_locales, :budgets).i18n_name,
+      manifest_name: :budgets,
+      published_at: Time.current,
+      participatory_process: process
+    )
 
-      3.times do
-        project = Decidim::Budgets::Project.create!(
-          feature: feature,
-          scope: process.organization.scopes.sample,
-          category: process.categories.sample,
-          title: Decidim::Faker::Localized.sentence(2),
-          description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-            Decidim::Faker::Localized.paragraph(3)
-          end,
-          budget: Faker::Number.number(8)
-        )
-        Decidim::Attachment.create!(
-          title: Decidim::Faker::Localized.sentence(2),
-          description: Decidim::Faker::Localized.sentence(5),
-          file: File.new(File.join(__dir__, "seeds", "city.jpeg")),
-          attached_to: project
-        )
-        Decidim::Attachment.create!(
-          title: Decidim::Faker::Localized.sentence(2),
-          description: Decidim::Faker::Localized.sentence(5),
-          file: File.new(File.join(__dir__, "seeds", "Exampledocument.pdf")),
-          attached_to: project
-        )
-        Decidim::Comments::Seed.comments_for(project)
-      end
+    3.times do
+      project = Decidim::Budgets::Project.create!(
+        feature: feature,
+        scope: process.organization.scopes.sample,
+        category: process.categories.sample,
+        title: Decidim::Faker::Localized.sentence(2),
+        description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+          Decidim::Faker::Localized.paragraph(3)
+        end,
+        budget: Faker::Number.number(8)
+      )
+      Decidim::Attachment.create!(
+        title: Decidim::Faker::Localized.sentence(2),
+        description: Decidim::Faker::Localized.sentence(5),
+        file: File.new(File.join(__dir__, "seeds", "city.jpeg")),
+        attached_to: project
+      )
+      Decidim::Attachment.create!(
+        title: Decidim::Faker::Localized.sentence(2),
+        description: Decidim::Faker::Localized.sentence(5),
+        file: File.new(File.join(__dir__, "seeds", "Exampledocument.pdf")),
+        attached_to: project
+      )
+      Decidim::Comments::Seed.comments_for(project)
     end
   end
 end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -51,7 +51,11 @@ module Decidim
       railtie.load_seed
     end
 
-    Decidim.feature_manifests.each(&:seed!)
+    Decidim::ParticipatoryProcess.find_each do |process|
+      Decidim.feature_manifests.each do |feature|
+        feature.seed!(process)
+      end
+    end
 
     I18n.available_locales = original_locale
   end

--- a/decidim-core/lib/decidim/feature_manifest.rb
+++ b/decidim-core/lib/decidim/feature_manifest.rb
@@ -92,8 +92,8 @@ module Decidim
     # Public: Creates the seeds for this features in order to populate the database.
     #
     # Returns nothing.
-    def seed!
-      @seeds&.call
+    def seed!(process)
+      @seeds&.call(process)
     end
 
     # Public: Adds configurable attributes for this feature, scoped to a name. It

--- a/decidim-core/spec/lib/feature_manifest_spec.rb
+++ b/decidim-core/spec/lib/feature_manifest_spec.rb
@@ -9,11 +9,11 @@ module Decidim
     describe "seed" do
       it "registers a block of seeds to be run on development" do
         data = {}
-        subject.seeds do
+        subject.seeds do |_process|
           data[:foo] = :bar
         end
 
-        subject.seed!
+        subject.seed!(nil)
 
         expect(data[:foo]).to eq(:bar)
       end

--- a/decidim-core/spec/lib/seed_spec.rb
+++ b/decidim-core/spec/lib/seed_spec.rb
@@ -13,5 +13,32 @@ describe Decidim do
     it "actually seeds" do
       expect { described_class.seed! }.not_to raise_error
     end
+
+    it "loads seeds for every engine" do
+      decidim_railties = [
+        double(load_seed: nil, class: double(name: "Decidim::EngineA")),
+        double(load_seed: nil, class: double(name: "Decidim::EngineB"))
+      ]
+
+      other_railties = [
+        double(load_seed: nil, class: double(name: "Something::EngineA")),
+        double(load_seed: nil, class: double(name: "Something::EngineB"))
+      ]
+
+      decidim_railties.each { |r| expect(r).to receive(:load_seed) }
+      other_railties.each { |r| expect(r).not_to receive(:load_seed) }
+
+      manifests = [double(name: "Feature A"), double(name: "Feature B")]
+      expect(Decidim).to receive(:feature_manifests).and_return(manifests)
+
+      manifests.each do |manifest|
+        expect(manifest).to receive(:seed!).once
+      end
+
+      application = double(railties: (decidim_railties + other_railties))
+      expect(Rails).to receive(:application).and_return application
+
+      Decidim.seed!
+    end
   end
 end

--- a/decidim-core/spec/lib/seed_spec.rb
+++ b/decidim-core/spec/lib/seed_spec.rb
@@ -4,6 +4,8 @@ require "spec_helper"
 
 describe Decidim do
   describe "seed!" do
+    let!(:participatory_process) { create(:participatory_process) }
+
     around do |example|
       Decidim::AttachmentUploader.enable_processing = true
       example.run
@@ -32,7 +34,7 @@ describe Decidim do
       expect(Decidim).to receive(:feature_manifests).and_return(manifests)
 
       manifests.each do |manifest|
-        expect(manifest).to receive(:seed!).once
+        expect(manifest).to receive(:seed!).with(participatory_process).once
       end
 
       application = double(railties: (decidim_railties + other_railties))

--- a/decidim-meetings/lib/decidim/meetings/feature.rb
+++ b/decidim-meetings/lib/decidim/meetings/feature.rb
@@ -23,45 +23,43 @@ Decidim.register_feature(:meetings) do |feature|
     meetings.count
   end
 
-  feature.seeds do
-    Decidim::ParticipatoryProcess.find_each do |process|
-      feature = Decidim::Feature.create!(
-        name: Decidim::Features::Namer.new(process.organization.available_locales, :meetings).i18n_name,
-        published_at: Time.current,
-        manifest_name: :meetings,
-        participatory_process: process
-      )
+  feature.seeds do |process|
+    feature = Decidim::Feature.create!(
+      name: Decidim::Features::Namer.new(process.organization.available_locales, :meetings).i18n_name,
+      published_at: Time.current,
+      manifest_name: :meetings,
+      participatory_process: process
+    )
 
-      3.times do
-        meeting = Decidim::Meetings::Meeting.create!(
-          feature: feature,
-          scope: process.organization.scopes.sample,
-          category: process.categories.sample,
-          title: Decidim::Faker::Localized.sentence(2),
-          description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-            Decidim::Faker::Localized.paragraph(3)
-          end,
-          location: Decidim::Faker::Localized.sentence,
-          location_hints: Decidim::Faker::Localized.sentence,
-          start_time: 3.weeks.from_now,
-          end_time: 3.weeks.from_now + 4.hours,
-          address: "#{Faker::Address.street_address} #{Faker::Address.zip} #{Faker::Address.city}",
-          latitude: Faker::Address.latitude,
-          longitude: Faker::Address.longitude
-        )
-        Decidim::Attachment.create!(
-          title: Decidim::Faker::Localized.sentence(2),
-          description: Decidim::Faker::Localized.sentence(5),
-          file: File.new(File.join(__dir__, "seeds", "city.jpeg")),
-          attached_to: meeting
-        )
-        Decidim::Attachment.create!(
-          title: Decidim::Faker::Localized.sentence(2),
-          description: Decidim::Faker::Localized.sentence(5),
-          file: File.new(File.join(__dir__, "seeds", "Exampledocument.pdf")),
-          attached_to: meeting
-        )
-      end
+    3.times do
+      meeting = Decidim::Meetings::Meeting.create!(
+        feature: feature,
+        scope: process.organization.scopes.sample,
+        category: process.categories.sample,
+        title: Decidim::Faker::Localized.sentence(2),
+        description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+          Decidim::Faker::Localized.paragraph(3)
+        end,
+        location: Decidim::Faker::Localized.sentence,
+        location_hints: Decidim::Faker::Localized.sentence,
+        start_time: 3.weeks.from_now,
+        end_time: 3.weeks.from_now + 4.hours,
+        address: "#{Faker::Address.street_address} #{Faker::Address.zip} #{Faker::Address.city}",
+        latitude: Faker::Address.latitude,
+        longitude: Faker::Address.longitude
+      )
+      Decidim::Attachment.create!(
+        title: Decidim::Faker::Localized.sentence(2),
+        description: Decidim::Faker::Localized.sentence(5),
+        file: File.new(File.join(__dir__, "seeds", "city.jpeg")),
+        attached_to: meeting
+      )
+      Decidim::Attachment.create!(
+        title: Decidim::Faker::Localized.sentence(2),
+        description: Decidim::Faker::Localized.sentence(5),
+        file: File.new(File.join(__dir__, "seeds", "Exampledocument.pdf")),
+        attached_to: meeting
+      )
     end
   end
 end

--- a/decidim-meetings/lib/decidim/meetings/feature.rb
+++ b/decidim-meetings/lib/decidim/meetings/feature.rb
@@ -25,8 +25,6 @@ Decidim.register_feature(:meetings) do |feature|
 
   feature.seeds do
     Decidim::ParticipatoryProcess.find_each do |process|
-      next unless process.steps.any?
-
       feature = Decidim::Feature.create!(
         name: Decidim::Features::Namer.new(process.organization.available_locales, :meetings).i18n_name,
         published_at: Time.current,

--- a/decidim-pages/lib/decidim/pages/feature.rb
+++ b/decidim-pages/lib/decidim/pages/feature.rb
@@ -51,23 +51,21 @@ Decidim.register_feature(:pages) do |feature|
     resource.model_class_name = "Decidim::Pages::Page"
   end
 
-  feature.seeds do
-    Decidim::ParticipatoryProcess.find_each do |process|
-      feature = Decidim::Feature.create!(
-        name: Decidim::Features::Namer.new(process.organization.available_locales, :pages).i18n_name,
-        manifest_name: :pages,
-        published_at: Time.current,
-        participatory_process: process
-      )
+  feature.seeds do |process|
+    feature = Decidim::Feature.create!(
+      name: Decidim::Features::Namer.new(process.organization.available_locales, :pages).i18n_name,
+      manifest_name: :pages,
+      published_at: Time.current,
+      participatory_process: process
+    )
 
-      page = Decidim::Pages::Page.create!(
-        feature: feature,
-        body: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-          Decidim::Faker::Localized.paragraph(3)
-        end
-      )
+    page = Decidim::Pages::Page.create!(
+      feature: feature,
+      body: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+        Decidim::Faker::Localized.paragraph(3)
+      end
+    )
 
-      Decidim::Comments::Seed.comments_for(page)
-    end
+    Decidim::Comments::Seed.comments_for(page)
   end
 end

--- a/decidim-pages/lib/decidim/pages/feature.rb
+++ b/decidim-pages/lib/decidim/pages/feature.rb
@@ -53,8 +53,6 @@ Decidim.register_feature(:pages) do |feature|
 
   feature.seeds do
     Decidim::ParticipatoryProcess.find_each do |process|
-      next unless process.steps.any?
-
       feature = Decidim::Feature.create!(
         name: Decidim::Features::Namer.new(process.organization.available_locales, :pages).i18n_name,
         manifest_name: :pages,

--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -90,6 +90,15 @@ Decidim.register_feature(:proposals) do |feature|
     20.times do |n|
       author = Decidim::User.where(organization: feature.organization).all.sample
       user_group = [true, false].sample ? author.user_groups.verified.sample : nil
+      state, answer = if n > 15
+                        ["accepted", Decidim::Faker::Localized.sentence(10)]
+                      elsif n > 9
+                        ["rejected", nil]
+                      elsif n > 6
+                        ["evaluating", nil]
+                      else
+                        [nil, nil]
+                      end
 
       proposal = Decidim::Proposals::Proposal.create!(
         feature: feature,
@@ -98,23 +107,11 @@ Decidim.register_feature(:proposals) do |feature|
         title: Faker::Lorem.sentence(2),
         body: Faker::Lorem.paragraphs(2).join("\n"),
         author: author,
-        user_group: user_group
+        user_group: user_group,
+        state: state,
+        answer: answer,
+        answered_at: Time.current
       )
-
-      if n > 15
-        proposal.state = "accepted"
-        proposal.answered_at = Time.current
-        proposal.save!
-      elsif n > 9
-        proposal.state = "rejected"
-        proposal.answered_at = Time.current
-        proposal.answer = Decidim::Faker::Localized.sentence(10)
-        proposal.save!
-      elsif n > 6
-        proposal.state = "evaluating"
-        proposal.answered_at = Time.current
-        proposal.save!
-      end
 
       rand(3).times do |m|
         email = "vote-author-#{process.id}-#{n}-#{m}@example.org"

--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -73,8 +73,6 @@ Decidim.register_feature(:proposals) do |feature|
 
   feature.seeds do
     Decidim::ParticipatoryProcess.find_each do |process|
-      next unless process.steps.any?
-
       feature = Decidim::Feature.create!(
         name: Decidim::Features::Namer.new(process.organization.available_locales, :proposals).i18n_name,
         manifest_name: :proposals,

--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -87,7 +87,6 @@ Decidim.register_feature(:proposals) do |feature|
           process.active_step.id => { votes_enabled: true, votes_blocked: false, creation_enabled: true }
         }
       )
-      categories = feature.participatory_process.categories
       # So that we have some with global scope
       scopes = feature.organization.scopes + [nil]
 
@@ -97,7 +96,7 @@ Decidim.register_feature(:proposals) do |feature|
 
         proposal = Decidim::Proposals::Proposal.create!(
           feature: feature,
-          category: categories.sample,
+          category: process.categories.sample,
           scope: scopes.sample,
           title: Faker::Lorem.sentence(2),
           body: Faker::Lorem.paragraphs(2).join("\n"),

--- a/decidim-results/lib/decidim/results/feature.rb
+++ b/decidim-results/lib/decidim/results/feature.rb
@@ -33,28 +33,26 @@ Decidim.register_feature(:results) do |feature|
     settings.attribute :comments_blocked, type: :boolean, default: false
   end
 
-  feature.seeds do
-    Decidim::ParticipatoryProcess.find_each do |process|
-      feature = Decidim::Feature.create!(
-        name: Decidim::Features::Namer.new(process.organization.available_locales, :results).i18n_name,
-        manifest_name: :results,
-        published_at: Time.current,
-        participatory_process: process
+  feature.seeds do |process|
+    feature = Decidim::Feature.create!(
+      name: Decidim::Features::Namer.new(process.organization.available_locales, :results).i18n_name,
+      manifest_name: :results,
+      published_at: Time.current,
+      participatory_process: process
+    )
+
+    3.times do
+      result = Decidim::Results::Result.create!(
+        feature: feature,
+        scope: process.organization.scopes.sample,
+        category: process.categories.sample,
+        title: Decidim::Faker::Localized.sentence(2),
+        description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+          Decidim::Faker::Localized.paragraph(3)
+        end
       )
 
-      3.times do
-        result = Decidim::Results::Result.create!(
-          feature: feature,
-          scope: process.organization.scopes.sample,
-          category: process.categories.sample,
-          title: Decidim::Faker::Localized.sentence(2),
-          description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-            Decidim::Faker::Localized.paragraph(3)
-          end
-        )
-
-        Decidim::Comments::Seed.comments_for(result)
-      end
+      Decidim::Comments::Seed.comments_for(result)
     end
   end
 end

--- a/decidim-results/lib/decidim/results/feature.rb
+++ b/decidim-results/lib/decidim/results/feature.rb
@@ -35,8 +35,6 @@ Decidim.register_feature(:results) do |feature|
 
   feature.seeds do
     Decidim::ParticipatoryProcess.find_each do |process|
-      next unless process.steps.any?
-
       feature = Decidim::Feature.create!(
         name: Decidim::Features::Namer.new(process.organization.available_locales, :results).i18n_name,
         manifest_name: :results,

--- a/decidim-surveys/lib/decidim/surveys/feature.rb
+++ b/decidim-surveys/lib/decidim/surveys/feature.rb
@@ -67,33 +67,31 @@ Decidim.register_feature(:surveys) do |feature|
     exports.serializer Decidim::Surveys::SurveyUserAnswersSerializer
   end
 
-  feature.seeds do
-    Decidim::ParticipatoryProcess.find_each do |process|
-      feature = Decidim::Feature.create!(
-        name: Decidim::Features::Namer.new(process.organization.available_locales, :surveys).i18n_name,
-        manifest_name: :surveys,
-        published_at: Time.current,
-        participatory_process: process
-      )
+  feature.seeds do |process|
+    feature = Decidim::Feature.create!(
+      name: Decidim::Features::Namer.new(process.organization.available_locales, :surveys).i18n_name,
+      manifest_name: :surveys,
+      published_at: Time.current,
+      participatory_process: process
+    )
 
-      survey = Decidim::Surveys::Survey.create!(
-        feature: feature,
-        title: Decidim::Faker::Localized.paragraph,
-        description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-          Decidim::Faker::Localized.paragraph(3)
-        end,
-        tos: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-          Decidim::Faker::Localized.paragraph(2)
-        end
-      )
-
-      3.times do
-        Decidim::Surveys::SurveyQuestion.create!(
-          survey: survey,
-          body: Decidim::Faker::Localized.paragraph,
-          question_type: "short_answer"
-        )
+    survey = Decidim::Surveys::Survey.create!(
+      feature: feature,
+      title: Decidim::Faker::Localized.paragraph,
+      description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+        Decidim::Faker::Localized.paragraph(3)
+      end,
+      tos: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+        Decidim::Faker::Localized.paragraph(2)
       end
+    )
+
+    3.times do
+      Decidim::Surveys::SurveyQuestion.create!(
+        survey: survey,
+        body: Decidim::Faker::Localized.paragraph,
+        question_type: "short_answer"
+      )
     end
   end
 end

--- a/decidim-surveys/lib/decidim/surveys/feature.rb
+++ b/decidim-surveys/lib/decidim/surveys/feature.rb
@@ -69,8 +69,6 @@ Decidim.register_feature(:surveys) do |feature|
 
   feature.seeds do
     Decidim::ParticipatoryProcess.find_each do |process|
-      next unless process.steps.any?
-
       feature = Decidim::Feature.create!(
         name: Decidim::Features::Namer.new(process.organization.available_locales, :surveys).i18n_name,
         manifest_name: :surveys,

--- a/docs/how_to_create_a_plugin.md
+++ b/docs/how_to_create_a_plugin.md
@@ -125,8 +125,8 @@
         # Register some stat number to the application
       end
 
-      feature.seeds do
-        # Add some seeds for this feature
+      feature.seeds do |process|
+        # Define seeds for a specific participatory process
       end
     end
     ```

--- a/spec/decidim_spec.rb
+++ b/spec/decidim_spec.rb
@@ -6,33 +6,4 @@ describe Decidim do
   it "has a version number" do
     expect(Decidim.version).not_to be nil
   end
-
-  describe "#seed!" do
-    it "loads seeds of every engine" do
-      decidim_railties = [
-        double(load_seed: nil, class: double(name: "Decidim::EngineA")),
-        double(load_seed: nil, class: double(name: "Decidim::EngineB"))
-      ]
-
-      other_railties = [
-        double(load_seed: nil, class: double(name: "Something::EngineA")),
-        double(load_seed: nil, class: double(name: "Something::EngineB"))
-      ]
-
-      decidim_railties.each { |r| expect(r).to receive(:load_seed) }
-      other_railties.each { |r| expect(r).not_to receive(:load_seed) }
-
-      manifests = [double(name: "Feature A"), double(name: "Feature B")]
-      expect(Decidim).to receive(:feature_manifests).and_return(manifests)
-
-      manifests.each do |manifest|
-        expect(manifest).to receive(:seed!).once
-      end
-
-      application = double(railties: (decidim_railties + other_railties))
-      expect(Rails).to receive(:application).and_return application
-
-      Decidim.seed!
-    end
-  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR changes seeds to happen per participatory processes (receiving it as a block parameter), instead of making them iterate through all participatory processes.

This makes the feature plugin's code independent from the participatory process concept and thus makes it easier to add support for other participatory spaces (featurables).

It also includes some other simplifcations and refactoring to some seeds.

#### :pushpin: Related Issues
- Related to #1346.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![band](https://user-images.githubusercontent.com/2887858/28728410-dbf3c9f0-73c8-11e7-9c84-61eaab4b5bc9.gif)