### PR TITLE
Handle blank values for datetime field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 **Fixed**
 
 - **decidim-core**: Fixed crash when running migrations & seeding DB in the same ruby process. [\#1649](https://github.com/decidim/decidim/pull/1649).
+- **decidim-core**: Fixed bug when blank values were used in a `datetime` field. [\#1661](https://github.com/decidim/decidim/pull/1661)
 
 ## [v0.4.3](https://github.com/decidim/decidim/tree/v0.4.3) (2017-07-25)
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.4.2...v0.4.3)

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -161,7 +161,7 @@ module Decidim
     # datepicker library
     def datetime_field(attribute, options = {})
       value = object.send(attribute)
-      if value
+      if value.present?
         iso_value = value.strftime("%Y-%m-%dT%H:%M:%S")
         formatted_value = I18n.localize(value, format: :timepicker)
       end


### PR DESCRIPTION
#### :tophat: What? Why?

For the `datetime_field` blank values weren't handled well. I used the `present?` value to handle both `nil` and blank values.

#### :pushpin: Related Issues
- Closes #1660 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
N/A

#### :ghost: GIF
None