### PR TITLE
Notify process admins when official proposal is commented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **decidim-core**: Fixed preview permissions for unpublished features. [\#1670](https://github.com/decidim/decidim/pull/1670).
 - **decidim-meetings**: Fixed bug where current meeting's category wouldn't appear in form. [\#1666](https://github.com/decidim/decidim/pull/1666).
 - **decidim-proposals**: Fixed bug where current proposal's category wouldn't appear in form. [\#1666](https://github.com/decidim/decidim/pull/1666).
+- **decidim-proposals**: Fixed error when official proposals where commented and could not be notified. [\#1663](https://github.com/decidim/decidim/pull/1663).
 - **decidim-results**: Fixed bug where current result's category wouldn't appear in form. [\#1666](https://github.com/decidim/decidim/pull/1666).
 
 ## [v0.4.3](https://github.com/decidim/decidim/tree/v0.4.3) (2017-07-25)

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -34,7 +34,7 @@ module Decidim
 
       def author_name
         return I18n.t("decidim.proposals.models.proposal.fields.official_proposal") if official?
-        user_group&.name || author&.name
+        user_group&.name || author.name
       end
 
       def author_avatar_url

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -33,7 +33,8 @@ module Decidim
       end
 
       def author_name
-        user_group&.name || author&.name || I18n.t("decidim.proposals.models.proposal.fields.official_proposal")
+        return I18n.t("decidim.proposals.models.proposal.fields.official_proposal") if official?
+        user_group&.name || author&.name
       end
 
       def author_avatar_url
@@ -100,15 +101,22 @@ module Decidim
         ResourceLocatorPresenter.new(self).url
       end
 
+      # Public: Whether the proposal is official or not.
+      def official?
+        author.nil?
+      end
+
       # Public: Overrides the `notifiable?` Notifiable concern method.
       # When a proposal is commented the proposal's author is notified if it is not the same
       # who has commented the proposal and if the proposal's author has comment notifications enabled.
       def notifiable?(context)
+        return true if official?
         context[:author] != author && author.comments_notifications?
       end
 
       # Public: Overrides the `users_to_notify` Notifiable concern method.
       def users_to_notify
+        return Decidim::Admin::ProcessAdmins.for(feature.participatory_process) if official?
         [author]
       end
     end

--- a/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
@@ -81,6 +81,24 @@ module Decidim
             end
           end
         end
+
+        context "when the proposal is official" do
+          let!(:organization) { create :organization }
+          let!(:admin) { create :user, :admin, organization: organization }
+          let!(:participatory_process) { create :participatory_process, organization: organization }
+          let!(:process_admin) { create :user, :process_admin, organization: organization, participatory_process: participatory_process }
+          let!(:feature) { create :proposal_feature, participatory_process: participatory_process }
+          let!(:context_author) { create(:user, organization: organization) }
+          let!(:proposal) { build(:proposal, :official, feature: feature) }
+
+          it "is notifiable" do
+            expect(subject.notifiable?(author: context_author)).to be_truthy
+          end
+
+          it "notifies admins and process admins" do
+            expect(subject.users_to_notify).to match_array([admin, process_admin])
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

Comments on official proposals were causing errors because official proposals didn't have an author.

#### :pushpin: Related Issues
- Fixes #1662

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
N/A

#### :ghost: GIF
None