### PR TITLE
Decouple global ability context

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/participatory_processes_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/participatory_processes_controller.rb
@@ -75,14 +75,18 @@ module Decidim
         authorize! :create, Decidim::ParticipatoryProcess
       end
 
+      private
+
       def current_participatory_process
         @current_participatory_process ||= collection.find(params[:id]) if params[:id]
       end
 
-      private
-
       def collection
         @collection ||= Decidim::ParticipatoryProcessesWithUserRole.for(current_user)
+      end
+
+      def ability_context
+        super.merge(current_participatory_process: current_participatory_process)
       end
 
       def participatory_process_params

--- a/decidim-core/app/controllers/concerns/decidim/needs_authorization.rb
+++ b/decidim-core/app/controllers/concerns/decidim/needs_authorization.rb
@@ -30,8 +30,7 @@ module Decidim
           current_settings: try(:current_settings),
           feature_settings: try(:feature_settings),
           current_organization: try(:current_organization),
-          current_feature: try(:current_feature),
-          current_participatory_process: try(:current_participatory_process)
+          current_feature: try(:current_feature)
         }
       end
 

--- a/decidim-core/app/controllers/decidim/features/base_controller.rb
+++ b/decidim-core/app/controllers/decidim/features/base_controller.rb
@@ -47,7 +47,6 @@ module Decidim
       def ability_context
         super.merge(
           current_manifest: current_manifest,
-          current_participatory_process: current_participatory_process,
           current_settings: current_settings,
           feature_settings: feature_settings
         )


### PR DESCRIPTION
#### :tophat: What? Why?

The global ability context shouldn't always try to look for the current
participatory process.

As a result, we can make the `current_participatory_process` method in
the participatory processes admin controller private. Public methods in
controllers should match the public controller route actions, so having
to have this method public was weird.

#### :pushpin: Related Issues
- Preparation for #1346.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![bolt](https://user-images.githubusercontent.com/2887858/28784158-d81fc030-7612-11e7-83ca-3120947daeb0.gif)

