### PR TITLE
Make moderations polymorphic

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/moderations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/moderations_controller.rb
@@ -61,7 +61,7 @@ module Decidim
       end
 
       def participatory_process_moderations
-        @participatory_process_moderations ||= Decidim::Moderation.where(participatory_process: current_participatory_process)
+        @participatory_process_moderations ||= Decidim::Moderation.where(featurable: current_participatory_process)
       end
     end
   end

--- a/decidim-admin/app/models/decidim/admin/abilities/participatory_process_admin_ability.rb
+++ b/decidim-admin/app/models/decidim/admin/abilities/participatory_process_admin_ability.rb
@@ -41,7 +41,7 @@ module Decidim
           end
 
           can :manage, Moderation do |moderation|
-            can_manage_process?(moderation.participatory_process)
+            can_manage_process?(moderation.featurable)
           end
 
           can :manage, ParticipatoryProcessStep do |step|

--- a/decidim-comments/spec/queries/sorted_comments_spec.rb
+++ b/decidim-comments/spec/queries/sorted_comments_spec.rb
@@ -34,7 +34,7 @@ describe Decidim::Comments::SortedComments do
 
   context "when the comment is hidden" do
     before do
-      moderation = create(:moderation, reportable: comment, participatory_process: comment.feature.featurable, report_count: 1, hidden_at: Time.current)
+      moderation = create(:moderation, reportable: comment, featurable: comment.feature.featurable, report_count: 1, hidden_at: Time.current)
       create(:report, moderation: moderation)
     end
 

--- a/decidim-core/app/commands/decidim/create_report.rb
+++ b/decidim-core/app/commands/decidim/create_report.rb
@@ -44,7 +44,7 @@ module Decidim
     attr_reader :form, :report
 
     def find_or_create_moderation!
-      @moderation = Moderation.find_or_create_by!(reportable: @reportable, participatory_process: participatory_process)
+      @moderation = Moderation.find_or_create_by!(reportable: @reportable, featurable: participatory_process)
     end
 
     def create_report!

--- a/decidim-core/app/mailers/decidim/reported_mailer.rb
+++ b/decidim-core/app/mailers/decidim/reported_mailer.rb
@@ -10,7 +10,7 @@ module Decidim
     def report(user, report)
       with_user(user) do
         @report = report
-        @participatory_process = @report.moderation.participatory_process
+        @featurable = @report.moderation.featurable
         @organization = user.organization
         @user = user
         subject = I18n.t("report.subject", scope: "decidim.reported_mailer")
@@ -21,7 +21,7 @@ module Decidim
     def hide(user, report)
       with_user(user) do
         @report = report
-        @participatory_process = @report.moderation.participatory_process
+        @featurable = @report.moderation.featurable
         @organization = user.organization
         @user = user
         subject = I18n.t("hide.subject", scope: "decidim.reported_mailer")
@@ -36,7 +36,7 @@ module Decidim
     end
 
     def manage_moderations_url
-      @manage_moderations_url ||= decidim_admin.participatory_process_moderations_url(@participatory_process.id, host: @organization.host)
+      @manage_moderations_url ||= decidim_admin.participatory_process_moderations_url(@featurable.id, host: @organization.host)
     end
   end
 end

--- a/decidim-core/app/models/decidim/moderation.rb
+++ b/decidim-core/app/models/decidim/moderation.rb
@@ -4,7 +4,7 @@ module Decidim
   # A moderation belongs to a reportable and includes many reports
   class Moderation < ApplicationRecord
     belongs_to :reportable, foreign_key: "decidim_reportable_id", foreign_type: "decidim_reportable_type", polymorphic: true
-    belongs_to :participatory_process, foreign_key: "decidim_participatory_process_id", class_name: "Decidim::ParticipatoryProcess"
+    belongs_to :featurable, foreign_key: "decidim_featurable_id", foreign_type: "decidim_featurable_type", polymorphic: true
     has_many :reports, foreign_key: "decidim_moderation_id", class_name: "Decidim::Report"
 
     delegate :feature, :organization, to: :reportable

--- a/decidim-core/db/migrate/20170720120231_make_moderations_polymorphic.rb
+++ b/decidim-core/db/migrate/20170720120231_make_moderations_polymorphic.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class MakeModerationsPolymorphic < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :decidim_moderations,
+                 name: "decidim_moderations_participatory_process"
+
+    add_column :decidim_moderations, :decidim_featurable_type, :string
+
+    reversible do |direction|
+      direction.up do
+        execute <<~SQL.squish
+          UPDATE decidim_moderations
+          SET decidim_featurable_type = 'Decidim::ParticipatoryProcess'
+        SQL
+      end
+    end
+
+    rename_column :decidim_moderations,
+                  :decidim_participatory_process_id,
+                  :decidim_featurable_id
+
+    add_index :decidim_moderations,
+              [:decidim_featurable_id, :decidim_featurable_type],
+              name: "decidim_moderations_featurable"
+
+    change_column_null :decidim_moderations, :decidim_featurable_type, false
+  end
+end

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -297,7 +297,7 @@ FactoryGirl.define do
 
   factory :moderation, class: Decidim::Moderation do
     reportable { build(:dummy_resource) }
-    participatory_process { reportable.feature.featurable }
+    featurable { reportable.feature.featurable }
   end
 
   factory :report, class: Decidim::Report do

--- a/decidim-core/lib/decidim/core/test/shared_examples/reportable.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/reportable.rb
@@ -4,8 +4,8 @@ require "spec_helper"
 
 shared_examples_for "reportable" do
   let(:user) { create(:user, organization: subject.organization) }
-  let(:participatory_process) { subject.feature.featurable }
-  let(:moderation) { create(:moderation, reportable: subject, participatory_process: participatory_process, report_count: 1) }
+  let(:featurable) { subject.feature.featurable }
+  let(:moderation) { create(:moderation, reportable: subject, featurable: featurable, report_count: 1) }
   let!(:report) { create(:report, moderation: moderation, user: user) }
 
   describe "#reported_by?" do
@@ -26,14 +26,14 @@ shared_examples_for "reportable" do
     end
 
     context "when the resource has been hidden" do
-      let(:moderation) { create(:moderation, reportable: subject, participatory_process: participatory_process, report_count: 1, hidden_at: Time.current) }
+      let(:moderation) { create(:moderation, reportable: subject, featurable: featurable, report_count: 1, hidden_at: Time.current) }
       it { expect(subject).to be_hidden }
     end
   end
 
   context "#reported?" do
     context "when the report count is equal to 0" do
-      let(:moderation) { create(:moderation, reportable: subject, participatory_process: participatory_process, report_count: 0) }
+      let(:moderation) { create(:moderation, reportable: subject, featurable: featurable, report_count: 0) }
       let!(:report) { nil }
       it { expect(subject).not_to be_reported }
     end

--- a/decidim-core/lib/decidim/core/test/shared_examples/reports_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/reports_examples.rb
@@ -43,7 +43,7 @@ RSpec.shared_examples "reports" do
 
     context "and the user has reported the resource previously" do
       before do
-        moderation = create(:moderation, reportable: reportable, participatory_process: participatory_process)
+        moderation = create(:moderation, reportable: reportable, featurable: participatory_process)
         create(:report, moderation: moderation, user: user, reason: "spam")
       end
 

--- a/decidim-core/spec/mailers/reported_mailer_spec.rb
+++ b/decidim-core/spec/mailers/reported_mailer_spec.rb
@@ -9,7 +9,7 @@ module Decidim
     let(:user) { create(:user, :admin, organization: organization) }
     let(:feature) { create(:feature, organization: organization) }
     let(:reportable) { create(:dummy_resource, feature: feature) }
-    let(:moderation) { create(:moderation, reportable: reportable, participatory_process: feature.featurable, report_count: 1) }
+    let(:moderation) { create(:moderation, reportable: reportable, featurable: feature.featurable, report_count: 1) }
     let!(:report) { create(:report, moderation: moderation) }
 
     describe "#report" do


### PR DESCRIPTION
#### :tophat: What? Why?

An admin should be able to manage moderations on featurable objects other than participatory process. To achieve that, I make moderations polymorphic.

By the way, I'm wondering whether I should use a more generic name than "featurables" for the new abstraction I'm adding, such as "participable". In this case, features are not directly involved so "featurable" seems a bit off.

#### :pushpin: Related Issues
- Related to #1659.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![djokovic_lol](https://user-images.githubusercontent.com/2887858/28796452-dcaaf914-763d-11e7-9436-cbe6a6da294b.gif)