### PR TITLE
Make seeds quasi-idempotent

### DIFF
--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -117,15 +117,17 @@ Decidim.register_feature(:proposals) do |feature|
         email = "vote-author-#{process.id}-#{n}-#{m}@example.org"
         name = "#{Faker::Name.name} #{process.id} #{n} #{m}"
 
-        author = Decidim::User.create!(email: email,
-                                       password: "password1234",
-                                       password_confirmation: "password1234",
-                                       name: name,
-                                       organization: feature.organization,
-                                       tos_agreement: "1",
-                                       confirmed_at: Time.current,
-                                       comments_notifications: true,
-                                       replies_notifications: true)
+        author = Decidim::User.find_or_initialize_by(email: email)
+        author.update!(
+          password: "password1234",
+          password_confirmation: "password1234",
+          name: name,
+          organization: feature.organization,
+          tos_agreement: "1",
+          confirmed_at: Time.current,
+          comments_notifications: true,
+          replies_notifications: true
+        )
 
         Decidim::Proposals::ProposalVote.create!(proposal: proposal,
                                                  author: author)

--- a/decidim-system/db/seeds.rb
+++ b/decidim-system/db/seeds.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 if !Rails.env.production? || ENV["SEED"]
-  Decidim::System::Admin.create!(
-    email: "system@example.org",
+  Decidim::System::Admin.find_or_initialize_by(email: "system@example.org").update!(
     password: "decidim123456",
     password_confirmation: "decidim123456"
   )


### PR DESCRIPTION

#### :tophat: What? Why?

**What**. This allows re-seeding the DB without having to drop it first. That crashes at the moment. Doing this is not fully idempotent, some objects like votes or comments are created randomly, so re-seeding will create other different objects. But the main objects (users, organizations) will be the same and will be created only if not already there.

**Why**. I think this can be handy sometimes:

* For example, I'm not fully familiarized with the environment where we've setup the assemblies demo, and dropping the DB is not straightforward since I have to stop the app and some other processes that seem to be laying around and are locking the DB. This would allow me to seed the DB without having to wear the sysadmin hat. 

* Another example would be when you've deleted a lot of default objects as part of some test and want to restore them without having to `db:drop db:create db:migrate db:seed`.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![i-totally-got-this](https://user-images.githubusercontent.com/2887858/28867740-52d96f82-7777-11e7-90ee-aaee743fba6a.gif)

