### PR TITLE
More style normalization

### DIFF
--- a/decidim-admin/app/views/decidim/admin/features/_feature.html.erb
+++ b/decidim-admin/app/views/decidim/admin/features/_feature.html.erb
@@ -28,7 +28,7 @@
       <% if feature.manifest.actions.empty? %>
         <%= icon "key", class: "action-icon action-icon--disabled" %>
       <% else %>
-        <%= icon_link_to "key", edit_feature_permissions_path(feature_id: feature), t("actions.permissions", scope: "decidim.admin"), class: "action-icon--permissions" %>
+        <%= icon_link_to "key", url_for(action: :edit, feature_id: feature, controller: "feature_permissions"), t("actions.permissions", scope: "decidim.admin"), class: "action-icon--permissions" %>
       <% end %>
     <% end %>
 

--- a/decidim-core/app/queries/decidim/highlighted_participatory_processes.rb
+++ b/decidim-core/app/queries/decidim/highlighted_participatory_processes.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 module Decidim
-  # This query adds some scopes so the processes are ready to be showed in a
-  # public view.
+  # This query selects some prioritized processes.
   class HighlightedParticipatoryProcesses < Rectify::Query
     def query
       PrioritizedParticipatoryProcesses.new.query.limit(8)

--- a/decidim-core/app/queries/decidim/organization_participatory_process_groups.rb
+++ b/decidim-core/app/queries/decidim/organization_participatory_process_groups.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 module Decidim
-  # This query class returns the participatory process groups given an
-  # Organization.
+  # This query class filters participatory process groups given an organization.
   class OrganizationParticipatoryProcessGroups < Rectify::Query
     def initialize(organization)
       @organization = organization

--- a/decidim-core/app/queries/decidim/organization_participatory_processes.rb
+++ b/decidim-core/app/queries/decidim/organization_participatory_processes.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 module Decidim
-  # This query class returns the visible Participatory Processes given an
-  # Organization.
+  # This query class filters all processes given an organization.
   class OrganizationParticipatoryProcesses < Rectify::Query
     def initialize(organization)
       @organization = organization

--- a/decidim-core/app/queries/decidim/organization_prioritized_participatory_processes.rb
+++ b/decidim-core/app/queries/decidim/organization_prioritized_participatory_processes.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module Decidim
-  # This query class returns the public Participatory Processes given an
-  # Organization in a meaningful order.
+  # This query class filters public processes given an organization in a
+  # meaningful prioritized order.
   class OrganizationPrioritizedParticipatoryProcesses < Rectify::Query
     def initialize(organization)
       @organization = organization

--- a/decidim-core/app/queries/decidim/organization_published_participatory_processes.rb
+++ b/decidim-core/app/queries/decidim/organization_published_participatory_processes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Decidim
-  # This query class returns the Participatory Processes given an Organization.
+  # This query class filters published processes given an organization.
   class OrganizationPublishedParticipatoryProcesses < Rectify::Query
     def initialize(organization)
       @organization = organization

--- a/decidim-core/app/queries/decidim/published_participatory_processes.rb
+++ b/decidim-core/app/queries/decidim/published_participatory_processes.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 module Decidim
-  # This query orders processes by importance, prioritizing promoted processes
-  # first, and closest to finalization date second.
+  # This query filters published processes only.
   class PublishedParticipatoryProcesses < Rectify::Query
     def query
       ParticipatoryProcess.published

--- a/decidim-core/spec/queries/decidim/organization_participatory_process_groups_spec.rb
+++ b/decidim-core/spec/queries/decidim/organization_participatory_process_groups_spec.rb
@@ -2,28 +2,26 @@
 
 require "spec_helper"
 
-module Decidim
-  describe OrganizationParticipatoryProcessGroups do
-    subject { described_class.new(organization) }
+describe Decidim::OrganizationParticipatoryProcessGroups do
+  subject { described_class.new(organization) }
 
-    let!(:organization) { create(:organization) }
+  let!(:organization) { create(:organization) }
 
-    let!(:local_participatory_process_groups) do
-      create_list(:participatory_process_group, 3, organization: organization)
+  let!(:local_participatory_process_groups) do
+    create_list(:participatory_process_group, 3, organization: organization)
+  end
+
+  let!(:foreign_participatory_process_groups) do
+    create_list(:participatory_process_group, 3)
+  end
+
+  describe "query" do
+    it "includes the organization's processes" do
+      expect(subject).to include(*local_participatory_process_groups)
     end
 
-    let!(:foreign_participatory_process_groups) do
-      create_list(:participatory_process_group, 3)
-    end
-
-    describe "query" do
-      it "includes the organization's processes" do
-        expect(subject).to include(*local_participatory_process_groups)
-      end
-
-      it "excludes the external processes" do
-        expect(subject).not_to include(*foreign_participatory_process_groups)
-      end
+    it "excludes the external processes" do
+      expect(subject).not_to include(*foreign_participatory_process_groups)
     end
   end
 end

--- a/decidim-core/spec/queries/decidim/organization_participatory_processes_spec.rb
+++ b/decidim-core/spec/queries/decidim/organization_participatory_processes_spec.rb
@@ -2,27 +2,25 @@
 
 require "spec_helper"
 
-module Decidim
-  describe OrganizationParticipatoryProcesses do
-    subject { described_class.new(organization) }
+describe Decidim::OrganizationParticipatoryProcesses do
+  subject { described_class.new(organization) }
 
-    let!(:organization) { create(:organization) }
-    let!(:local_participatory_processes) do
-      create_list(:participatory_process, 3, organization: organization)
+  let!(:organization) { create(:organization) }
+  let!(:local_participatory_processes) do
+    create_list(:participatory_process, 3, organization: organization)
+  end
+
+  let!(:foreign_participatory_processes) do
+    create_list(:participatory_process, 3)
+  end
+
+  describe "query" do
+    it "includes the organization's processes" do
+      expect(subject).to include(*local_participatory_processes)
     end
 
-    let!(:foreign_participatory_processes) do
-      create_list(:participatory_process, 3)
-    end
-
-    describe "query" do
-      it "includes the organization's processes" do
-        expect(subject).to include(*local_participatory_processes)
-      end
-
-      it "excludes the external processes" do
-        expect(subject).not_to include(*foreign_participatory_processes)
-      end
+    it "excludes the external processes" do
+      expect(subject).not_to include(*foreign_participatory_processes)
     end
   end
 end

--- a/decidim-core/spec/queries/decidim/organization_prioritized_participatory_processes_spec.rb
+++ b/decidim-core/spec/queries/decidim/organization_prioritized_participatory_processes_spec.rb
@@ -2,51 +2,47 @@
 
 require "spec_helper"
 
-module Decidim
-  describe OrganizationPrioritizedParticipatoryProcesses do
-    subject { described_class.new(organization) }
+describe Decidim::OrganizationPrioritizedParticipatoryProcesses do
+  subject { described_class.new(organization) }
 
-    let!(:organization) { create(:organization) }
-    let!(:local_promoted_process_ending_first) do
-      create(:participatory_process,
-             :promoted,
-             :with_steps,
-             organization: organization,
-             current_step_ends: 1.month.from_now)
-    end
+  let!(:organization) { create(:organization) }
+  let!(:local_promoted_process_ending_first) do
+    create(:participatory_process,
+           :promoted,
+           :with_steps,
+           organization: organization,
+           current_step_ends: 1.month.from_now)
+  end
 
-    let!(:local_promoted_process_ending_last) do
-      create(:participatory_process,
-             :promoted,
-             :with_steps,
-             organization: organization,
-             current_step_ends: 2.months.from_now)
-    end
+  let!(:local_promoted_process_ending_last) do
+    create(:participatory_process,
+           :promoted,
+           :with_steps,
+           organization: organization,
+           current_step_ends: 2.months.from_now)
+  end
 
-    let!(:local_non_promoted_process_with_steps) do
-      create(:participatory_process,
-             :published,
-             :with_steps,
-             organization: organization)
-    end
+  let!(:local_non_promoted_process_with_steps) do
+    create(:participatory_process,
+           :published,
+           :with_steps,
+           organization: organization)
+  end
 
-    let!(:local_non_promoted_process_without_steps) do
-      create(:participatory_process,
-             :published,
-             organization: organization)
-    end
+  let!(:local_non_promoted_process_without_steps) do
+    create(:participatory_process, :published, organization: organization)
+  end
 
-    before { create(:participatory_process) }
+  before { create(:participatory_process) }
 
-    describe "query" do
-      it "orders by promoted status first, and then by closest end date" do
-        expect(subject.to_a).to eq [
-          local_promoted_process_ending_first,
-          local_promoted_process_ending_last,
-          local_non_promoted_process_with_steps,
-          local_non_promoted_process_without_steps
-        ]
-      end
+  describe "query" do
+    it "orders by promoted status first, and then by closest end date" do
+      expect(subject.to_a).to eq [
+        local_promoted_process_ending_first,
+        local_promoted_process_ending_last,
+        local_non_promoted_process_with_steps,
+        local_non_promoted_process_without_steps
+      ]
     end
   end
 end

--- a/decidim-core/spec/queries/decidim/organization_published_participatory_processes_spec.rb
+++ b/decidim-core/spec/queries/decidim/organization_published_participatory_processes_spec.rb
@@ -2,41 +2,39 @@
 
 require "spec_helper"
 
-module Decidim
-  describe OrganizationPublishedParticipatoryProcesses do
-    subject { described_class.new(organization) }
+describe Decidim::OrganizationPublishedParticipatoryProcesses do
+  subject { described_class.new(organization) }
 
-    let!(:organization) { create(:organization) }
-    let!(:published_participatory_processes) do
-      create_list(:participatory_process,
-                  3,
-                  :published,
-                  organization: organization)
+  let!(:organization) { create(:organization) }
+  let!(:published_participatory_processes) do
+    create_list(:participatory_process,
+                3,
+                :published,
+                organization: organization)
+  end
+
+  let!(:unpublished_participatory_processes) do
+    create_list(:participatory_process,
+                3,
+                :unpublished,
+                organization: organization)
+  end
+
+  let!(:foreign_participatory_processes) do
+    create_list(:participatory_process, 3, :published)
+  end
+
+  describe "query" do
+    it "includes the organization's published processes" do
+      expect(subject).to include(*published_participatory_processes)
     end
 
-    let!(:unpublished_participatory_processes) do
-      create_list(:participatory_process,
-                  3,
-                  :unpublished,
-                  organization: organization)
+    it "excludes the organization's unpublished processes" do
+      expect(subject).not_to include(*unpublished_participatory_processes)
     end
 
-    let!(:foreign_participatory_processes) do
-      create_list(:participatory_process, 3, :published)
-    end
-
-    describe "query" do
-      it "includes the organization's published processes" do
-        expect(subject).to include(*published_participatory_processes)
-      end
-
-      it "excludes the organization's unpublished processes" do
-        expect(subject).not_to include(*unpublished_participatory_processes)
-      end
-
-      it "excludes other organization's published processes" do
-        expect(subject).not_to include(*foreign_participatory_processes)
-      end
+    it "excludes other organization's published processes" do
+      expect(subject).not_to include(*foreign_participatory_processes)
     end
   end
 end

--- a/decidim-core/spec/queries/decidim/stats_users_count_spec.rb
+++ b/decidim-core/spec/queries/decidim/stats_users_count_spec.rb
@@ -2,43 +2,41 @@
 
 require "spec_helper"
 
-module Decidim
-  describe StatsUsersCount do
-    let(:organization) { create(:organization) }
-    let(:start_at) { nil }
-    let(:end_at) { nil }
-    subject { described_class.new(organization, start_at, end_at) }
+describe Decidim::StatsUsersCount do
+  let(:organization) { create(:organization) }
+  let(:start_at) { nil }
+  let(:end_at) { nil }
+  subject { described_class.new(organization, start_at, end_at) }
 
-    context "without start and end date" do
-      it "returns the number of confirmed users" do
-        create(:user, :confirmed)
-        create(:user, :confirmed, organization: organization)
-        create(:user, organization: organization)
+  context "without start and end date" do
+    it "returns the number of confirmed users" do
+      create(:user, :confirmed)
+      create(:user, :confirmed, organization: organization)
+      create(:user, organization: organization)
 
-        expect(subject.query).to eq(1)
-      end
+      expect(subject.query).to eq(1)
     end
+  end
 
-    context "with start date" do
-      let(:start_at) { 1.week.ago }
+  context "with start date" do
+    let(:start_at) { 1.week.ago }
 
-      it "returns the number of confirmed user created equal or after this date" do
-        create(:user, :confirmed, organization: organization, created_at: 2.weeks.ago)
-        create(:user, :confirmed, organization: organization)
+    it "returns the number of confirmed user created equal or after this date" do
+      create(:user, :confirmed, organization: organization, created_at: 2.weeks.ago)
+      create(:user, :confirmed, organization: organization)
 
-        expect(subject.query).to eq(1)
-      end
+      expect(subject.query).to eq(1)
     end
+  end
 
-    context "with end date" do
-      let(:end_at) { 1.week.from_now }
+  context "with end date" do
+    let(:end_at) { 1.week.from_now }
 
-      it "returns the number of confirmed user created equal or after this date" do
-        create(:user, :confirmed, organization: organization, created_at: 2.weeks.from_now)
-        create(:user, :confirmed, organization: organization)
+    it "returns the number of confirmed user created equal or after this date" do
+      create(:user, :confirmed, organization: organization, created_at: 2.weeks.from_now)
+      create(:user, :confirmed, organization: organization)
 
-        expect(subject.query).to eq(1)
-      end
+      expect(subject.query).to eq(1)
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

The main point of this PR is to normalize query specs to always use fully qualified classes after `describe` instead of module nesting. The main point of doing that is not only to be consistent, but also to make diffs in following PR's simpler, since they won't pollute the indentation of the whole file.

I also added a couple of extra changes:

* Reviews comments on top of query classes.
* Normalize route generation in the feature admin template.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![small_cat_big_fail](https://user-images.githubusercontent.com/2887858/28873149-b75f2dec-778c-11e7-8295-140c5fe6ca38.gif)

