### PR TITLE
Simplify category and moderation routes

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/categories_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/categories_controller.rb
@@ -23,7 +23,7 @@ module Decidim
         CreateCategory.call(@form, current_participatory_process) do
           on(:ok) do
             flash[:notice] = I18n.t("categories.create.success", scope: "decidim.admin")
-            redirect_to participatory_process_categories_path(current_participatory_process)
+            redirect_to categories_path(current_participatory_process)
           end
 
           on(:invalid) do
@@ -47,7 +47,7 @@ module Decidim
         UpdateCategory.call(@category, @form) do
           on(:ok) do
             flash[:notice] = I18n.t("categories.update.success", scope: "decidim.admin")
-            redirect_to participatory_process_categories_path(current_participatory_process)
+            redirect_to categories_path(current_participatory_process)
           end
 
           on(:invalid) do
@@ -75,7 +75,7 @@ module Decidim
             flash[:alert] = I18n.t("categories.destroy.error", scope: "decidim.admin")
           end
 
-          redirect_back(fallback_location: participatory_process_categories_path(current_participatory_process))
+          redirect_back(fallback_location: categories_path(current_participatory_process))
         end
       end
 

--- a/decidim-admin/app/controllers/decidim/admin/moderations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/moderations_controller.rb
@@ -18,12 +18,12 @@ module Decidim
         Admin::UnreportResource.call(reportable) do
           on(:ok) do
             flash[:notice] = I18n.t("reportable.unreport.success", scope: "decidim.moderations.admin")
-            redirect_to decidim_admin.participatory_process_moderations_path
+            redirect_to decidim_admin.moderations_path
           end
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("reportable.unreport.invalid", scope: "decidim.moderations.admin")
-            redirect_to decidim_admin.participatory_process_moderations_path
+            redirect_to decidim_admin.moderations_path
           end
         end
       end
@@ -34,12 +34,12 @@ module Decidim
         Admin::HideResource.call(reportable) do
           on(:ok) do
             flash[:notice] = I18n.t("reportable.hide.success", scope: "decidim.moderations.admin")
-            redirect_to decidim_admin.participatory_process_moderations_path
+            redirect_to decidim_admin.moderations_path
           end
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("reportable.hide.invalid", scope: "decidim.moderations.admin")
-            redirect_to decidim_admin.participatory_process_moderations_path
+            redirect_to decidim_admin.moderations_path
           end
         end
       end

--- a/decidim-admin/app/controllers/decidim/admin/moderations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/moderations_controller.rb
@@ -18,12 +18,12 @@ module Decidim
         Admin::UnreportResource.call(reportable) do
           on(:ok) do
             flash[:notice] = I18n.t("reportable.unreport.success", scope: "decidim.moderations.admin")
-            redirect_to decidim_admin.moderations_path
+            redirect_to moderations_path
           end
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("reportable.unreport.invalid", scope: "decidim.moderations.admin")
-            redirect_to decidim_admin.moderations_path
+            redirect_to moderations_path
           end
         end
       end
@@ -34,12 +34,12 @@ module Decidim
         Admin::HideResource.call(reportable) do
           on(:ok) do
             flash[:notice] = I18n.t("reportable.hide.success", scope: "decidim.moderations.admin")
-            redirect_to decidim_admin.moderations_path
+            redirect_to moderations_path
           end
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("reportable.hide.invalid", scope: "decidim.moderations.admin")
-            redirect_to decidim_admin.moderations_path
+            redirect_to moderations_path
           end
         end
       end

--- a/decidim-admin/app/views/decidim/admin/categories/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/categories/edit.html.erb
@@ -1,4 +1,4 @@
-<%= decidim_form_for(@form, url: participatory_process_category_path(@category.participatory_process, @category), html: { class: "form edit_participatory_process_category" }) do |f| %>
+<%= decidim_form_for(@form, url: category_path(@category.participatory_process, @category), html: { class: "form edit_participatory_process_category" }) do |f| %>
   <%= render partial: 'form', object: f, locals: { title: t('.title') } %>
 
   <div class="button--double form-general-submit">

--- a/decidim-admin/app/views/decidim/admin/categories/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/categories/index.html.erb
@@ -3,7 +3,7 @@
     <h2 class='card-title'>
       <%= t(".categories_title") %>
       <% if can? :create, Decidim::Category %>
-        <%= link_to t("actions.new", scope: "decidim.admin", name: t("models.category.name", scope: "decidim.admin")), new_participatory_process_category_path(current_participatory_process), class: 'button tiny button--title new' %>
+        <%= link_to t("actions.new", scope: "decidim.admin", name: t("models.category.name", scope: "decidim.admin")), new_category_path(current_participatory_process), class: 'button tiny button--title new' %>
       <% end %>
     </h2>
   </div>
@@ -22,16 +22,16 @@
             <% current_participatory_process.categories.first_class.each do |category| %>
               <tr>
                 <td>
-                  <%= link_to translated_attribute(category.name), edit_participatory_process_category_path(current_participatory_process, category) %><br />
+                  <%= link_to translated_attribute(category.name), edit_category_path(current_participatory_process, category) %><br />
                 </td>
                 <td class="table-list__actions">
                   <% if can? :update, category %>
-                    <%= icon_link_to "pencil", edit_participatory_process_category_path(current_participatory_process, category), t("actions.edit", scope: "decidim.admin"), class: "action-icon--edit" %>
+                    <%= icon_link_to "pencil", edit_category_path(current_participatory_process, category), t("actions.edit", scope: "decidim.admin"), class: "action-icon--edit" %>
                   <% end %>
 
                   <% if can? :destroy, category %>
                     <% if category.unused? %>
-                      <%= icon_link_to "circle-x", participatory_process_category_path(current_participatory_process, category), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
+                      <%= icon_link_to "circle-x", category_path(current_participatory_process, category), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
                     <% else %>
                       <span class="action-icon" title="<%= t('.category_used') %>" data-tooltip="true" data-disable-hover="false">
                         <%= icon "circle-x", class: "action-icon action-icon--disabled" %>
@@ -43,15 +43,15 @@
               <% category.subcategories.each do |subcategory| %>
                 <tr class="extra__table-list__subcategory">
                   <td>
-                    <%= link_to translated_attribute(subcategory.name), edit_participatory_process_category_path(current_participatory_process, subcategory) %><br />
+                    <%= link_to translated_attribute(subcategory.name), edit_category_path(current_participatory_process, subcategory) %><br />
                   </td>
                   <td class="table-list__actions">
                   <% if can? :update, subcategory %>
-                    <%= icon_link_to "pencil", edit_participatory_process_category_path(current_participatory_process, subcategory), t("actions.edit", scope: "decidim.admin"), class: "action-icon--edit" %>
+                    <%= icon_link_to "pencil", edit_category_path(current_participatory_process, subcategory), t("actions.edit", scope: "decidim.admin"), class: "action-icon--edit" %>
                   <% end %>
 
                   <% if can? :destroy, subcategory %>
-                    <%= icon_link_to "circle-x", participatory_process_category_path(current_participatory_process, subcategory), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
+                    <%= icon_link_to "circle-x", category_path(current_participatory_process, subcategory), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
                   <% end %>
                   </td>
                 </tr>

--- a/decidim-admin/app/views/decidim/admin/categories/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/categories/new.html.erb
@@ -1,4 +1,4 @@
-<%= decidim_form_for(@form, url: participatory_process_categories_path(current_participatory_process), html: { class: "form new_participatory_process_category" }) do |f| %>
+<%= decidim_form_for(@form, url: categories_path(current_participatory_process), html: { class: "form new_participatory_process_category" }) do |f| %>
   <%= render partial: 'form', object: f, locals: { title: t('.title') } %>
 
   <div class="button--double form-general-submit">

--- a/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
@@ -4,9 +4,9 @@
       <%= t(".title") %>
 
       <div class="card__filter">
-        <%= link_to t("actions.not_hidden", scope: "decidim.moderations"), decidim_admin.moderations_path %>
+        <%= link_to t("actions.not_hidden", scope: "decidim.moderations"), moderations_path %>
         |
-        <%= link_to t("actions.hidden", scope: "decidim.moderations"), decidim_admin.moderations_path(hidden: true) %>
+        <%= link_to t("actions.hidden", scope: "decidim.moderations"), moderations_path(hidden: true) %>
       </div>
     </h2>
   </div>

--- a/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
@@ -4,9 +4,9 @@
       <%= t(".title") %>
 
       <div class="card__filter">
-        <%= link_to t("actions.not_hidden", scope: "decidim.moderations"), decidim_admin.participatory_process_moderations_path %>
+        <%= link_to t("actions.not_hidden", scope: "decidim.moderations"), decidim_admin.moderations_path %>
         |
-        <%= link_to t("actions.hidden", scope: "decidim.moderations"), decidim_admin.participatory_process_moderations_path(hidden: true) %>
+        <%= link_to t("actions.hidden", scope: "decidim.moderations"), decidim_admin.moderations_path(hidden: true) %>
       </div>
     </h2>
   </div>
@@ -55,14 +55,14 @@
 
                 <% if can? :unreport, moderation %>
                   <%= icon_link_to "action-undo",
-                                   decidim_admin.unreport_participatory_process_moderation_path(id: moderation),
+                                   decidim_admin.unreport_moderation_path(id: moderation),
                                    t("actions.unreport", scope: "decidim.moderations"),
                                    class: "action-icon--unreport",
                                    method: :put %>
                 <% end %>
                 <% if !moderation.reportable.hidden? && can?(:hide, moderation) %>
                   <%= icon_link_to "eye",
-                                   decidim_admin.hide_participatory_process_moderation_path(id: moderation),
+                                   decidim_admin.hide_moderation_path(id: moderation),
                                    t("actions.hide", scope: "decidim.moderations"),
                                    class: "action-icon--hide",
                                    method: :put %>

--- a/decidim-admin/app/views/decidim/admin/participatory_processes/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_processes/index.html.erb
@@ -29,7 +29,7 @@
                 <% elsif can? :preview, process %>
                   <%= link_to translated_attribute(process.title), decidim.participatory_process_path(process) %><br />
                 <% elsif can? :read, Decidim::Moderation %>
-                  <%= link_to translated_attribute(process.title), decidim_admin.participatory_process_moderations_path(process) %><br />
+                  <%= link_to translated_attribute(process.title), decidim_admin.moderations_path(process) %><br />
                 <% else %>
                   <%= translated_attribute(process.title) %>
                 <% end %>

--- a/decidim-admin/app/views/decidim/admin/participatory_processes/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_processes/index.html.erb
@@ -29,7 +29,7 @@
                 <% elsif can? :preview, process %>
                   <%= link_to translated_attribute(process.title), decidim.participatory_process_path(process) %><br />
                 <% elsif can? :read, Decidim::Moderation %>
-                  <%= link_to translated_attribute(process.title), decidim_admin.moderations_path(process) %><br />
+                  <%= link_to translated_attribute(process.title), moderations_path(process) %><br />
                 <% else %>
                   <%= translated_attribute(process.title) %>
                 <% end %>

--- a/decidim-admin/app/views/layouts/decidim/admin/participatory_process.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/participatory_process.html.erb
@@ -31,8 +31,8 @@
         </li>
       <% end %>
       <% if can? :read, Decidim::Category %>
-        <li <% if is_active_link?(decidim_admin.participatory_process_categories_path(current_participatory_process)) %> class="is-active" <% end %>>
-          <%= aria_selected_link_to t("categories", scope: "decidim.admin.menu.participatory_processes_submenu"), decidim_admin.participatory_process_categories_path(current_participatory_process) %>
+        <li <% if is_active_link?(decidim_admin.categories_path(current_participatory_process)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("categories", scope: "decidim.admin.menu.participatory_processes_submenu"), decidim_admin.categories_path(current_participatory_process) %>
         </li>
       <% end %>
       <% if can? :read, Decidim::Attachment %>
@@ -46,8 +46,8 @@
         </li>
       <% end %>
       <% if can? :read, Decidim::Moderation %>
-        <li <% if is_active_link?(decidim_admin.participatory_process_moderations_path(current_participatory_process.id)) %> class="is-active" <% end %>>
-          <%= aria_selected_link_to t("moderations", scope: "decidim.admin.menu.participatory_processes_submenu"), decidim_admin.participatory_process_moderations_path(current_participatory_process.id) %>
+        <li <% if is_active_link?(decidim_admin.moderations_path(current_participatory_process.id)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("moderations", scope: "decidim.admin.menu.participatory_processes_submenu"), decidim_admin.moderations_path(current_participatory_process.id) %>
         </li>
       <% end %>
     </ul>

--- a/decidim-admin/config/routes.rb
+++ b/decidim-admin/config/routes.rb
@@ -8,8 +8,6 @@ Decidim::Admin::Engine.routes.draw do
       resource :publish, controller: "participatory_process_publications", only: [:create, :destroy]
       resources :copies, controller: "participatory_process_copies", only: [:new, :create]
 
-      resources :categories
-
       resources :steps, controller: "participatory_process_steps" do
         resource :activate, controller: "participatory_process_step_activations", only: [:create, :destroy]
         collection do
@@ -22,16 +20,11 @@ Decidim::Admin::Engine.routes.draw do
         end
       end
       resources :attachments, controller: "participatory_process_attachments"
-
-      resources :moderations do
-        member do
-          put :unreport
-          put :hide
-        end
-      end
     end
 
     scope "/participatory_processes/:participatory_process_id" do
+      resources :categories
+
       resources :features do
         resource :permissions, controller: "feature_permissions"
         member do
@@ -39,6 +32,13 @@ Decidim::Admin::Engine.routes.draw do
           put :unpublish
         end
         resources :exports, only: :create
+      end
+
+      resources :moderations do
+        member do
+          put :unreport
+          put :hide
+        end
       end
     end
 

--- a/decidim-core/app/mailers/decidim/reported_mailer.rb
+++ b/decidim-core/app/mailers/decidim/reported_mailer.rb
@@ -36,7 +36,7 @@ module Decidim
     end
 
     def manage_moderations_url
-      @manage_moderations_url ||= decidim_admin.participatory_process_moderations_url(@participatory_process.id, host: @organization.host)
+      @manage_moderations_url ||= decidim_admin.moderations_url(@participatory_process.id, host: @organization.host)
     end
   end
 end

--- a/decidim-core/spec/controllers/static_map_controller_spec.rb
+++ b/decidim-core/spec/controllers/static_map_controller_spec.rb
@@ -12,7 +12,6 @@ module Decidim
 
     before do
       @request.env["decidim.current_organization"] = organization
-      @request.env["decidim.current_participatory_process"] = feature.participatory_process
       @request.env["decidim.current_feature"] = feature
     end
 

--- a/decidim-proposals/spec/controllers/decidim/admin/proposal_answers_controller_spec.rb
+++ b/decidim-proposals/spec/controllers/decidim/admin/proposal_answers_controller_spec.rb
@@ -14,7 +14,6 @@ module Decidim
 
         before do
           @request.env["decidim.current_organization"] = feature.organization
-          @request.env["decidim.current_participatory_process"] = feature.participatory_process
           @request.env["decidim.current_feature"] = feature
           sign_in user
         end

--- a/decidim-results/spec/controllers/results_controller_spec.rb
+++ b/decidim-results/spec/controllers/results_controller_spec.rb
@@ -9,7 +9,6 @@ module Decidim
 
       before do
         @request.env["decidim.current_organization"] = feature.organization
-        @request.env["decidim.current_participatory_process"] = feature.participatory_process
         @request.env["decidim.current_feature"] = feature
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR simplifies routing for moderations & categories, just like I did previously for feature management. It also removes some unnecessary controller test setup.

#### :pushpin: Related Issues
- Related to #1346 (getting ready for it).

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![big-gulp](https://user-images.githubusercontent.com/2887858/28890777-839b579c-77c8-11e7-8771-afdb7714f784.gif)
