### PR TITLE
Use Decidim available_locales and default_locale

### DIFF
--- a/decidim-core/app/helpers/decidim/translations_helper.rb
+++ b/decidim-core/app/helpers/decidim/translations_helper.rb
@@ -22,7 +22,7 @@ module Decidim
     #           available locales by default.
     #
     # Returns a Hash with the locales as keys and the translations as values.
-    def multi_translation(key, locales = I18n.available_locales)
+    def multi_translation(key, locales = Decidim.available_locales)
       locales.each_with_object({}) do |locale, result|
         I18n.with_locale(locale) do
           result[locale.to_sym] = I18n.t(key)

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -19,7 +19,7 @@ module Decidim
     has_many :user_groups, through: :memberships, class_name: "Decidim::UserGroup", foreign_key: :decidim_user_group_id
 
     validates :name, presence: true, unless: -> { deleted? }
-    validates :locale, inclusion: { in: I18n.available_locales.map(&:to_s) }, allow_blank: true
+    validates :locale, inclusion: { in: Decidim.available_locales.map(&:to_s) }, allow_blank: true
     validates :tos_agreement, acceptance: true, allow_nil: false, on: :create
     validates :avatar, file_size: { less_than_or_equal_to: MAXIMUM_AVATAR_FILE_SIZE }
     validates :email, uniqueness: { scope: :organization }, unless: -> { deleted? }

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -16,8 +16,8 @@ if !Rails.env.production? || ENV["SEED"]
       Decidim::Faker::Localized.sentence(15)
     end,
     homepage_image: File.new(File.join(__dir__, "seeds", "homepage_image.jpg")),
-    default_locale: I18n.default_locale,
-    available_locales: [:en, :ca, :es],
+    default_locale: Decidim.default_locale,
+    available_locales: Decidim.available_locales,
     reference_prefix: Faker::Name.suffix
   )
 

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -43,7 +43,7 @@ FactoryGirl.define do
     welcome_text { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(2) } }
     homepage_image { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
     favicon { Decidim::Dev.test_file("icon.png", "image/png") }
-    default_locale { I18n.default_locale }
+    default_locale { Decidim.default_locale }
     available_locales { Decidim.available_locales }
     official_img_header { Decidim::Dev.test_file("avatar.jpg", "image/jpeg") }
     official_img_footer { Decidim::Dev.test_file("avatar.jpg", "image/jpeg") }

--- a/decidim-core/lib/decidim/faker/localized.rb
+++ b/decidim-core/lib/decidim/faker/localized.rb
@@ -123,7 +123,7 @@ module Decidim
       def self.literal(text)
         Decidim.available_locales.inject({}) do |result, locale|
           result.update(locale => text)
-        end
+        end.with_indifferent_access
       end
 
       # Wrapps a text build by the block with some other text.o
@@ -154,7 +154,7 @@ module Decidim
           end
 
           result.update(locale => text)
-        end
+        end.with_indifferent_access
       end
 
       private_class_method :localized

--- a/decidim-core/lib/decidim/faker/localized.rb
+++ b/decidim-core/lib/decidim/faker/localized.rb
@@ -121,7 +121,7 @@ module Decidim
       #
       # Returns a Hash with a value for each locale.
       def self.literal(text)
-        I18n.available_locales.inject({}) do |result, locale|
+        Decidim.available_locales.inject({}) do |result, locale|
           result.update(locale => text)
         end
       end
@@ -148,7 +148,7 @@ module Decidim
 
       # nodoc
       def self.localized
-        I18n.available_locales.inject({}) do |result, locale|
+        Decidim.available_locales.inject({}) do |result, locale|
           text = ::Faker::Base.with_locale(locale) do
             yield
           end

--- a/decidim-core/spec/helpers/decidim/translations_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/translations_helper_spec.rb
@@ -5,6 +5,10 @@ require "spec_helper"
 module Decidim
   describe TranslationsHelper do
     describe "#translated_attribute" do
+      before do
+        allow(I18n.config).to receive(:enforce_available_locales).and_return(false)
+      end
+
       it "translates the attribute against the current locale" do
         attribute = { "ca" => "Hola", "zh-CN" => "你好" }
 
@@ -35,7 +39,6 @@ module Decidim
 
       context "when given only a key" do
         it "returns a hash scoped to the available list of locales" do
-          allow(I18n).to receive(:available_locales).and_return [:en, :ca, :es]
           result = TranslationsHelper.multi_translation("booleans.true")
           expect(result.keys.length).to eq(3)
           expect(result).to include(en: "Yes", ca: "Sí", es: "Sí")

--- a/decidim-core/spec/lib/faker_localized_spec.rb
+++ b/decidim-core/spec/lib/faker_localized_spec.rb
@@ -24,7 +24,7 @@ module Decidim
       let(:available_locales) { [:en, :ca] }
 
       before do
-        allow(I18n).to receive(:available_locales).and_return available_locales
+        allow(Decidim).to receive(:available_locales).and_return available_locales
       end
 
       it_behaves_like "a localized Faker method", :name

--- a/decidim-core/spec/lib/form_builder_spec.rb
+++ b/decidim-core/spec/lib/form_builder_spec.rb
@@ -44,6 +44,7 @@ module Decidim
 
     before do
       allow(Decidim).to receive(:available_locales).and_return available_locales
+      allow(I18n.config).to receive(:enforce_available_locales).and_return(false)
     end
 
     let(:builder) { FormBuilder.new(:resource, resource, helper, {}) }

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/i18n.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/i18n.rb
@@ -3,7 +3,7 @@
 RSpec.configure do |config|
   config.before(:suite) do
     I18n.config.enforce_available_locales = false
-    I18n.available_locales = %w(en ca es)
     Decidim.available_locales = %w(en ca es)
+    I18n.available_locales = Decidim.available_locales
   end
 end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/i18n.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/i18n.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.configure do |config|
-  config.before(:suite) do
-    I18n.config.enforce_available_locales = false
-    Decidim.available_locales = %w(en ca es)
-    I18n.available_locales = Decidim.available_locales
-  end
-end

--- a/decidim-system/app/commands/decidim/system/create_default_pages.rb
+++ b/decidim-system/app/commands/decidim/system/create_default_pages.rb
@@ -31,7 +31,7 @@ module Decidim
       attr_reader :organization
 
       def localized_attribute(slug, attribute)
-        I18n.available_locales.inject({}) do |result, locale|
+        Decidim.available_locales.inject({}) do |result, locale|
           text = I18n.with_locale(locale) do
             I18n.t(attribute, scope: "decidim.system.default_pages.placeholders", page: slug)
           end

--- a/lib/generators/decidim/templates/initializer.rb
+++ b/lib/generators/decidim/templates/initializer.rb
@@ -6,8 +6,8 @@ Decidim.configure do |config|
   config.mailer_sender = "change-me@domain.org"
   config.authorization_handlers = [ExampleAuthorizationHandler]
 
-  # Uncomment this lines to set your preferred locales
-  # config.available_locales = [:en, :ca, :es]
+  # Change this line to set your preferred locales
+  config.available_locales = [:en, :ca, :es]
 
   # Geocoder configuration
   # config.geocoder = {


### PR DESCRIPTION
#### :tophat: What? Why?

When creating some review apps for some of our Decidim installations I detected an error in our seeds. The organization created while seeding had some locales that were not available in the installation itself so it causes an error.

I modified some `I18n.available_locales` and `I18n.default_locale` calls to use the `Decidim` ones. I also modified our app generator to set the locales hard-coded so we just deal with them in our local apps.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
N/A

#### :ghost: GIF
None