### PR TITLE
Add attachments to proposals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@
 - **decidim-admin**: Scope selection in participatory process creation/edition using AJAX select (based on Select2) instead of a standard select. [\#1500](https://github.com/decidim/decidim/pull/1500)
 - **decidim-budgets**: Resources filter by scope using AJAX multi-select (based on Select2) instead of a list of checkboxes. [\#1500](https://github.com/decidim/decidim/pull/1500)
 - **decidim-meetings**: Resources filter by scope using AJAX multi-select (based on Select2) instead of a list of checkboxes. [\#1500](https://github.com/decidim/decidim/pull/1500)
-- **decidim-results**: Resources filter by scope using AJAX multi-select (based on Select2) instead of a list of checkboxes. [\#1500](https://github.com/decidim/decidim/pull/1500)
 - **decidim-proposals**: Resources filter by scope using AJAX multi-select (based on Select2) instead of a list of checkboxes. [\#1500](https://github.com/decidim/decidim/pull/1500)
+- **decidim-proposals**: Added feature setting `attachments_allowed`. When it is enabled users can upload an attachment when creating a new proposal. The attachment should be an image or a pdf file and users must fill in a title. [\#1688](https://github.com/decidim/decidim/pull/1688)
+- **decidim-results**: Resources filter by scope using AJAX multi-select (based on Select2) instead of a list of checkboxes. [\#1500](https://github.com/decidim/decidim/pull/1500)
 
 
 ## [v0.4.4](https://github.com/decidim/decidim/tree/v0.4.4) (2017-08-02)

--- a/decidim-core/app/assets/stylesheets/decidim/extras/_proposal_form.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/extras/_proposal_form.scss
@@ -1,0 +1,7 @@
+form.new_proposal {
+  fieldset {
+    border: 1px solid #e8e8e8;
+    padding: 0.5em;
+    margin-bottom: 1em;
+  }
+}

--- a/decidim-core/app/forms/decidim/attachment_form.rb
+++ b/decidim-core/app/forms/decidim/attachment_form.rb
@@ -8,5 +8,7 @@ module Decidim
     attribute :file
 
     mimic :attachment
+
+    validates :title, presence: true, if: ->(form) { form.file.present? }
   end
 end

--- a/decidim-core/app/forms/decidim/attachment_form.rb
+++ b/decidim-core/app/forms/decidim/attachment_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Decidim
+  # A form object used to create attachments.
+  #
+  class AttachmentForm < Form
+    attribute :title, String
+    attribute :file
+
+    mimic :attachment
+  end
+end

--- a/decidim-core/app/helpers/decidim/attachments_helper.rb
+++ b/decidim-core/app/helpers/decidim/attachments_helper.rb
@@ -12,5 +12,16 @@ module Decidim
     def attachments_for(attached_to)
       render partial: "attachments", locals: { attached_to: attached_to }
     end
+
+    # Renders the attachment's title.
+    # Checks if the attachment's title is translated or not and use
+    # the correct render method.
+    #
+    # attachment - An Attachment object
+    #
+    # Returns String.
+    def attachment_title(attachment)
+      attachment.title.is_a?(Hash) ? translated_attribute(attachment.title) : attachment.title
+    end
   end
 end

--- a/decidim-core/app/views/decidim/application/_documents.html.erb
+++ b/decidim-core/app/views/decidim/application/_documents.html.erb
@@ -8,9 +8,11 @@
             <div>
               <a href="<%= document.url %>" class="card__link">
                 <h6 class="card--list__heading heading6">
-                  <%= translated_attribute(document.title) %> <small><%= document.file_type %> <%= number_to_human_size(document.file_size) %></small>
+                  <%= attachment_title(document) %> <small><%= document.file_type %> <%= number_to_human_size(document.file_size) %></small>
                 </h6>
-                <span class="text-small"><%= translated_attribute(document.description) %></span>
+                <% if document.description.present? %>
+                  <span class="text-small"><%= translated_attribute(document.description) %></span>
+                <% end %>
               </a>
             </div>
           </div>

--- a/decidim-core/db/migrate/20170804125402_attachment_description_nullable.rb
+++ b/decidim-core/db/migrate/20170804125402_attachment_description_nullable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AttachmentDescriptionNullable < ActiveRecord::Migration[5.1]
   def change
     change_column :decidim_attachments, :description, :jsonb, null: true

--- a/decidim-core/db/migrate/20170804125402_attachment_description_nullable.rb
+++ b/decidim-core/db/migrate/20170804125402_attachment_description_nullable.rb
@@ -1,0 +1,5 @@
+class AttachmentDescriptionNullable < ActiveRecord::Migration[5.1]
+  def change
+    change_column :decidim_attachments, :description, :jsonb, null: true
+  end
+end

--- a/decidim-core/spec/forms/attachment_form_spec.rb
+++ b/decidim-core/spec/forms/attachment_form_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::AttachmentForm do
+  let(:title) { "My attachment" }
+  let(:file) { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
+
+  subject do
+    described_class.new(
+      title: title,
+      file: file
+    )
+  end
+
+  context "with correct data" do
+    it "is valid" do
+      expect(subject).to be_valid
+    end
+  end
+
+  context "when the file is present" do
+    context "and the title is not present" do
+      let(:title) { "" }
+
+      it "is not valid" do
+        expect(subject).not_to be_valid
+      end
+    end
+  end
+
+  context "when the file is not present" do
+    let(:file) { nil }
+
+    context "and the title is not present" do
+      let(:title) { "" }
+
+      it "is not valid" do
+        expect(subject).to be_valid
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/commands/decidim/proposals/admin/create_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/create_proposal.rb
@@ -21,13 +21,22 @@ module Decidim
         def call
           return broadcast(:invalid) if form.invalid?
 
-          create_proposal
-          broadcast(:ok)
+          if process_attachments?
+            build_attachment
+            return broadcast(:invalid) if attachment_invalid?
+          end
+
+          transaction do
+            create_proposal
+            create_attachment if process_attachments?
+          end
+
+          broadcast(:ok, proposal)
         end
 
         private
 
-        attr_reader :form, :proposal
+        attr_reader :form, :proposal, :attachment
 
         def create_proposal
           @proposal = Proposal.create!(
@@ -40,6 +49,38 @@ module Decidim
             latitude: form.latitude,
             longitude: form.longitude
           )
+        end
+
+        def build_attachment
+          @attachment = Attachment.new(
+            title: form.attachment.title,
+            file: form.attachment.file,
+            attached_to: @proposal
+          )
+        end
+
+        def attachment_invalid?
+          if attachment.invalid? && attachment.errors.has_key?(:file)
+            form.attachment.errors.add :file, attachment.errors[:file]
+            true
+          end
+        end
+
+        def attachment_present?
+          form.attachment.file.present?
+        end
+
+        def create_attachment
+          attachment.attached_to = proposal
+          attachment.save!
+        end
+
+        def attachments_allowed?
+          form.current_feature.settings.attachments_allowed?
+        end
+
+        def process_attachments?
+          attachments_allowed? && attachment_present?
         end
       end
     end

--- a/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
@@ -22,7 +22,10 @@ module Decidim
       def call
         return broadcast(:invalid) if form.invalid?
 
-        create_proposal
+        transaction do
+          create_proposal
+          create_attachment if attachments_allowed?
+        end
         broadcast(:ok, proposal)
       end
 
@@ -43,6 +46,18 @@ module Decidim
           latitude: form.latitude,
           longitude: form.longitude
         )
+      end
+
+      def create_attachment
+        Attachment.create!(
+          title: form.attachment.title,
+          file: form.attachment.file,
+          attached_to: @proposal
+        )
+      end
+
+      def attachments_allowed?
+        current_feature.settings.attachments_allowed?
       end
     end
   end

--- a/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
@@ -22,14 +22,14 @@ module Decidim
       def call
         return broadcast(:invalid) if form.invalid?
 
-        if attachments_allowed? && attachment_present?
+        if process_attachments?
           build_attachment
           return broadcast(:invalid) if attachment_invalid?
         end
 
         transaction do
           create_proposal
-          create_attachment if attachments_allowed? && attachment_present?
+          create_attachment if process_attachments?
         end
 
         broadcast(:ok, proposal)
@@ -80,6 +80,10 @@ module Decidim
 
       def attachments_allowed?
         form.current_feature.settings.attachments_allowed?
+      end
+
+      def process_attachments?
+        attachments_allowed? && attachment_present?
       end
     end
   end

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
@@ -10,7 +10,9 @@ module Decidim
 
         def new
           authorize! :create, Proposal
-          @form = form(Admin::ProposalForm).from_params({})
+          @form = form(Admin::ProposalForm).from_params(
+            attachment: form(AttachmentForm).from_params({})
+          )
         end
 
         def create

--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -43,7 +43,9 @@ module Decidim
       def new
         authorize! :create, Proposal
 
-        @form = form(ProposalForm).from_params({})
+        @form = form(ProposalForm).from_params(
+          attachment: form(AttachmentForm).from_params({})
+        )
       end
 
       def create

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
@@ -15,13 +15,11 @@ module Decidim
         attribute :category_id, Integer
         attribute :scope_id, Integer
         attribute :attachment, AttachmentForm
-        attribute :attachment_terms, Boolean, default: true
 
         validates :title, :body, presence: true
         validates :address, geocoding: true, if: -> { current_feature.settings.geocoding_enabled? }
         validates :category, presence: true, if: ->(form) { form.category_id.present? }
         validates :scope, presence: true, if: ->(form) { form.scope_id.present? }
-        validates :attachment_terms, acceptance: true, if: ->(form) { form.attachment && form.attachment.file.present? }
 
         delegate :categories, to: :current_feature, prefix: false
 

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
@@ -15,11 +15,13 @@ module Decidim
         attribute :category_id, Integer
         attribute :scope_id, Integer
         attribute :attachment, AttachmentForm
+        attribute :attachment_terms, Boolean, default: true
 
         validates :title, :body, presence: true
         validates :address, geocoding: true, if: -> { current_feature.settings.geocoding_enabled? }
         validates :category, presence: true, if: ->(form) { form.category_id.present? }
         validates :scope, presence: true, if: ->(form) { form.scope_id.present? }
+        validates :attachment_terms, acceptance: true, if: ->(form) { form.attachment && form.attachment.file.present? }
 
         delegate :categories, to: :current_feature, prefix: false
 

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
@@ -14,6 +14,7 @@ module Decidim
         attribute :longitude, Float
         attribute :category_id, Integer
         attribute :scope_id, Integer
+        attribute :attachment, AttachmentForm
 
         validates :title, :body, presence: true
         validates :address, geocoding: true, if: -> { current_feature.settings.geocoding_enabled? }

--- a/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
@@ -16,7 +16,6 @@ module Decidim
       attribute :user_group_id, Integer
       attribute :has_address, Boolean
       attribute :attachment, AttachmentForm
-      attribute :attachment_terms, Boolean
 
       validates :title, :body, presence: true, etiquette: true
       validates :title, length: { maximum: 150 }
@@ -25,7 +24,6 @@ module Decidim
       validates :address, presence: true, if: ->(form) { form.has_address? }
       validates :category, presence: true, if: ->(form) { form.category_id.present? }
       validates :scope, presence: true, if: ->(form) { form.scope_id.present? }
-      validates :attachment_terms, acceptance: true, if: ->(form) { form.attachment && form.attachment.file.present? }
 
       delegate :categories, to: :current_feature
 

--- a/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
@@ -15,6 +15,8 @@ module Decidim
       attribute :scope_id, Integer
       attribute :user_group_id, Integer
       attribute :has_address, Boolean
+      attribute :attachment, AttachmentForm
+      attribute :attachment_terms, Boolean
 
       validates :title, :body, presence: true, etiquette: true
       validates :title, length: { maximum: 150 }

--- a/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
@@ -25,6 +25,7 @@ module Decidim
       validates :address, presence: true, if: ->(form) { form.has_address? }
       validates :category, presence: true, if: ->(form) { form.category_id.present? }
       validates :scope, presence: true, if: ->(form) { form.scope_id.present? }
+      validates :attachment_terms, acceptance: true, if: ->(form) { form.attachment && form.attachment.file.present? }
 
       delegate :categories, to: :current_feature
 

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -11,6 +11,7 @@ module Decidim
       include Decidim::HasReference
       include Decidim::HasCategory
       include Decidim::Reportable
+      include Decidim::HasAttachments
       include Decidim::Comments::Commentable
 
       feature_manifest_name "proposals"

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
@@ -29,5 +29,20 @@
         <%= form.collection_select :scope_id, subscopes_for(current_participatory_process), :id, :name %>
       </div>
     <% end %>
+
+    <% if feature_settings.attachments_allowed? %>
+      <fieldset>
+        <legend><%= t('.attachment_legend') %></legend>
+        <%= form.fields_for :attachment, @form.attachment do |form| %>
+          <div class="field">
+            <%= form.text_field :title %>
+          </div>
+
+          <div class="field">
+            <%= form.upload :file, optional: false %>
+          </div>
+        <% end %>
+      </fieldset>
+    <% end %>
   </div>
 </div>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
@@ -31,18 +31,20 @@
     <% end %>
 
     <% if feature_settings.attachments_allowed? %>
-      <fieldset>
-        <legend><%= t('.attachment_legend') %></legend>
-        <%= form.fields_for :attachment, @form.attachment do |form| %>
-          <div class="field">
-            <%= form.text_field :title %>
-          </div>
+      <div class="row column">
+        <fieldset>
+          <legend><%= t('.attachment_legend') %></legend>
+          <%= form.fields_for :attachment, @form.attachment do |form| %>
+            <div class="row column">
+              <%= form.text_field :title %>
+            </div>
 
-          <div class="field">
-            <%= form.upload :file, optional: false %>
-          </div>
-        <% end %>
-      </fieldset>
+            <div class="row column">
+              <%= form.upload :file, optional: false %>
+            </div>
+          <% end %>
+        </fieldset>
+      </div>
     <% end %>
   </div>
 </div>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/new.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/new.html.erb
@@ -51,19 +51,22 @@
           <% end %>
 
           <% if feature_settings.attachments_allowed? %>
-            <%= form.fields_for :attachment, @form.attachment do |form| %>
-              <div class="field">
-                <%= form.text_field :title %>
-              </div>
+            <fieldset>
+              <legend><%= t('.attachment_legend') %></legend>
+              <%= form.fields_for :attachment, @form.attachment do |form| %>
+                <div class="field">
+                  <%= form.text_field :title %>
+                </div>
+
+                <div class="field">
+                  <%= form.upload :file, optional: false %>
+                </div>
+              <% end %>
 
               <div class="field">
-                <%= form.upload :file, optional: false %>
+                <%= form.check_box :attachment_terms %>
               </div>
-            <% end %>
-
-            <div class="field">
-              <%= form.check_box :attachment_terms %>
-            </div>
+            </fieldset>
           <% end %>
 
           <div class="actions">

--- a/decidim-proposals/app/views/decidim/proposals/proposals/new.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/new.html.erb
@@ -50,6 +50,22 @@
             </div>
           <% end %>
 
+          <% if feature_settings.attachments_allowed? %>
+            <%= form.fields_for :attachment, @form.attachment do |form| %>
+              <div class="field">
+                <%= form.text_field :title %>
+              </div>
+
+              <div class="field">
+                <%= form.upload :file, optional: false %>
+              </div>
+            <% end %>
+
+            <div class="field">
+              <%= form.check_box :attachment_terms %>
+            </div>
+          <% end %>
+
           <div class="actions">
             <%= form.submit t(".send"), class: "button expanded", "data-disable-with" => "#{t('.send')}..." %>
           </div>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/new.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/new.html.erb
@@ -62,10 +62,6 @@
                   <%= form.upload :file, optional: false %>
                 </div>
               <% end %>
-
-              <div class="field">
-                <%= form.check_box :attachment_terms %>
-              </div>
             </fieldset>
           <% end %>
 

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -61,6 +61,7 @@
     <%= linked_resources_for @proposal, :meetings, "proposals_from_meeting" %>
   </div>
 </div>
+<%= attachments_for @proposal %>
 
 <%= comments_for @proposal %>
 

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -20,6 +20,7 @@ en:
         settings:
           global:
             announcement: Announcement
+            attachments_allowed: Allow attachments
             comments_enabled: Comments enabled
             geocoding_enabled: Geocoding enabled
             new_proposal_help_text: New proposal help text

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -8,6 +8,7 @@ en:
         scope_id: Scope
         title: Title
         user_group_id: Create proposal as
+        attachment_terms: 
       proposal_answer:
         answer: Answer
   decidim:
@@ -128,6 +129,7 @@ en:
             one: <span class="card--list__data__number">1</span>vote
             other: <span class="card--list__data__number">%{count}</span>votes
         new:
+          attachment_legend: (Optional) Add an attachment
           back: Back
           select_a_category: Please select a category
           send: Send

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -8,7 +8,6 @@ en:
         scope_id: Scope
         title: Title
         user_group_id: Create proposal as
-        attachment_terms: 
       proposal_answer:
         answer: Answer
   decidim:
@@ -66,6 +65,7 @@ en:
             invalid: There's been a problem creating this proposal
             success: Proposal successfully created
           form:
+            attachment_legend: "(Optional) Add an attachment"
             select_a_category: Select a category
           index:
             title: Proposals
@@ -129,7 +129,7 @@ en:
             one: <span class="card--list__data__number">1</span>vote
             other: <span class="card--list__data__number">%{count}</span>votes
         new:
-          attachment_legend: (Optional) Add an attachment
+          attachment_legend: "(Optional) Add an attachment"
           back: Back
           select_a_category: Please select a category
           send: Send

--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -21,6 +21,7 @@ Decidim.register_feature(:proposals) do |feature|
     settings.attribute :official_proposals_enabled, type: :boolean, default: true
     settings.attribute :comments_enabled, type: :boolean, default: true
     settings.attribute :geocoding_enabled, type: :boolean, default: false
+    settings.attribute :attachments_allowed, type: :boolean, default: false
     settings.attribute :announcement, type: :text, translated: true, editor: true
     settings.attribute :new_proposal_help_text, type: :text, translated: true, editor: true
   end

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -60,6 +60,14 @@ FactoryGirl.define do
         }
       end
     end
+
+    trait :with_attachments_allowed do
+      settings do
+        {
+          attachments_allowed: true
+        }
+      end
+    end
   end
 
   factory :proposal, class: Decidim::Proposals::Proposal do

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -223,19 +223,15 @@ describe "Proposals", type: :feature do
             within ".new_proposal" do
               fill_in :proposal_title, with: "Proposal with attachments"
               fill_in :proposal_body, with: "This is my proposal and I want to upload attachments."
-              attach_file "proposal_attachment_0_file", Decidim::Dev.asset("city.jpeg")
-              attach_file "proposal_attachment_1_file", Decidim::Dev.asset("Exampledocument.pdf")
+              fill_in :proposal_attachment_title, with: "My attachment"
+              attach_file :proposal_attachment_file, Decidim::Dev.asset("city.jpeg")
               check :proposal_attachment_terms
               find("*[type=submit]").click
             end
 
             expect(page).to have_content("successfully")
 
-            within "section.documents" do
-              expect(page).to have_content("ExampleDocument.pdf")
-            end
-
-            within "section.images" do
+            within ".section.images" do
               expect(page).to have_selector("img[src*=\"city.jpeg\"]", count: 1)
             end
           end

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -225,7 +225,6 @@ describe "Proposals", type: :feature do
               fill_in :proposal_body, with: "This is my proposal and I want to upload attachments."
               fill_in :proposal_attachment_title, with: "My attachment"
               attach_file :proposal_attachment_file, Decidim::Dev.asset("city.jpeg")
-              check :proposal_attachment_terms
               find("*[type=submit]").click
             end
 

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -201,6 +201,45 @@ describe "Proposals", type: :feature do
             expect(page).to have_content("Authorization required")
           end
         end
+
+        context "when attachments are allowed" do
+          let!(:feature) do
+            create(:proposal_feature,
+                   :with_creation_enabled,
+                   :with_attachments_allowed,
+                   manifest: manifest,
+                   participatory_process: participatory_process)
+          end
+
+          before do
+            Decidim::AttachmentUploader.enable_processing = true
+          end
+
+          it "creates a new proposal with attachments" do
+            visit_feature
+
+            click_link "New proposal"
+
+            within ".new_proposal" do
+              fill_in :proposal_title, with: "Proposal with attachments"
+              fill_in :proposal_body, with: "This is my proposal and I want to upload attachments."
+              attach_file "proposal_attachment_0_file", Decidim::Dev.asset("city.jpeg")
+              attach_file "proposal_attachment_1_file", Decidim::Dev.asset("Exampledocument.pdf")
+              check :proposal_attachment_terms
+              find("*[type=submit]").click
+            end
+
+            expect(page).to have_content("successfully")
+
+            within "section.documents" do
+              expect(page).to have_content("ExampleDocument.pdf")
+            end
+
+            within "section.images" do
+              expect(page).to have_selector("img[src*=\"city.jpeg\"]", count: 1)
+            end
+          end
+        end
       end
 
       context "when creation is not enabled" do

--- a/decidim-proposals/spec/shared/create_proposal_examples.rb
+++ b/decidim-proposals/spec/shared/create_proposal_examples.rb
@@ -17,6 +17,8 @@ shared_examples "create a proposal" do |with_author|
   let(:address) { nil }
   let(:latitude) { 40.1234 }
   let(:longitude) { 2.1234 }
+  let(:attachment_params) { nil }
+  let(:attachment_terms) { true }
 
   describe "call" do
     let(:form_params) do
@@ -24,7 +26,9 @@ shared_examples "create a proposal" do |with_author|
         title: "A reasonable proposal title",
         body: "A reasonable proposal body",
         address: address,
-        has_address: has_address
+        has_address: has_address,
+        attachment: attachment_params,
+        attachment_terms: attachment_terms
       }
     end
 
@@ -95,6 +99,41 @@ shared_examples "create a proposal" do |with_author|
               expect(proposal.latitude).to eq(latitude)
               expect(proposal.longitude).to eq(longitude)
             end
+          end
+        end
+      end
+
+      context "when attachments are allowed" do
+        let(:feature) { create(:proposal_feature, :with_attachments_allowed) }
+        let(:attachment_params) do
+          {
+            title: "My attachment",
+            file: Decidim::Dev.test_file("city.jpeg", "image/jpeg")
+          }
+        end
+
+        before do
+          Decidim::AttachmentUploader.enable_processing = true
+        end
+
+        it "creates an atachment for the proposal" do
+          expect do
+            command.call
+          end.to change { Decidim::Attachment.count }.by(1)
+          last_proposal = Decidim::Proposals::Proposal.last
+          last_attachment = Decidim::Attachment.last
+          expect(last_attachment.attached_to).to eq(last_proposal)
+        end
+
+        context "when attachment is left blank" do
+          let(:attachment_params) do
+            {
+              title: ""
+            }
+          end
+
+          it "broadcasts ok" do
+            expect { command.call }.to broadcast(:ok)
           end
         end
       end

--- a/decidim-proposals/spec/shared/create_proposal_examples.rb
+++ b/decidim-proposals/spec/shared/create_proposal_examples.rb
@@ -18,7 +18,6 @@ shared_examples "create a proposal" do |with_author|
   let(:latitude) { 40.1234 }
   let(:longitude) { 2.1234 }
   let(:attachment_params) { nil }
-  let(:attachment_terms) { true }
 
   describe "call" do
     let(:form_params) do
@@ -27,8 +26,7 @@ shared_examples "create a proposal" do |with_author|
         body: "A reasonable proposal body",
         address: address,
         has_address: has_address,
-        attachment: attachment_params,
-        attachment_terms: attachment_terms
+        attachment: attachment_params
       }
     end
 

--- a/decidim-proposals/spec/shared/proposal_form_examples.rb
+++ b/decidim-proposals/spec/shared/proposal_form_examples.rb
@@ -14,7 +14,6 @@ shared_examples "a proposal form" do
   let(:has_address) { false }
   let(:address) { nil }
   let(:attachment_params) { nil }
-  let(:attachment_terms) { nil }
   let(:params) do
     {
       title: title,
@@ -24,8 +23,7 @@ shared_examples "a proposal form" do
       scope_id: scope_id,
       address: address,
       has_address: has_address,
-      attachment: attachment_params,
-      attachment_terms: attachment_terms
+      attachment: attachment_params
     }
   end
 
@@ -149,12 +147,6 @@ shared_examples "a proposal form" do
         title: "My attachment",
         file: Decidim::Dev.test_file("city.jpeg", "image/jpeg")
       }
-    end
-
-    context "and the attachment_terms are not accepted" do
-      let(:attachment_terms) { false }
-
-      it { is_expected.not_to be_valid }
     end
   end
 end

--- a/decidim-proposals/spec/shared/proposal_form_examples.rb
+++ b/decidim-proposals/spec/shared/proposal_form_examples.rb
@@ -13,6 +13,8 @@ shared_examples "a proposal form" do
   let(:longitude) { 2.1234 }
   let(:has_address) { false }
   let(:address) { nil }
+  let(:attachment_params) { nil }
+  let(:attachment_terms) { nil }
   let(:params) do
     {
       title: title,
@@ -21,7 +23,9 @@ shared_examples "a proposal form" do
       category_id: category_id,
       scope_id: scope_id,
       address: address,
-      has_address: has_address
+      has_address: has_address,
+      attachment: attachment_params,
+      attachment_terms: attachment_terms
     }
   end
 
@@ -137,5 +141,20 @@ shared_examples "a proposal form" do
     proposal = create(:proposal, feature: feature, category: category)
 
     expect(described_class.from_model(proposal).category_id).to eq(category_id)
+  end
+
+  context "when the attachment is present" do
+    let(:attachment_params) do
+      {
+        title: "My attachment",
+        file: Decidim::Dev.test_file("city.jpeg", "image/jpeg")
+      }
+    end
+
+    context "and the attachment_terms are not accepted" do
+      let(:attachment_terms) { false }
+
+      it { is_expected.not_to be_valid }
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

This adds attachments to proposals both for official and not official ones. As a user I will be able to upload a single attachment to a proposal. Uploads can be images or pdfs.

#### :pushpin: Related Issues
- Closes #1029
- Related to #1252

#### :clipboard: Subtasks
- [x] Feature spec
- [x] User can upload attachments when creating a proposal
- [x] Admin can upload attachments when creating a proposal
- [x] Update CHANGELOG
- [x] Remove checkbox and add text instead

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/106021/29017713-58f90898-7b58-11e7-9217-e2df59c963fa.png)
![image](https://user-images.githubusercontent.com/106021/29019370-769db8ac-7b5e-11e7-9db1-322bfc1dd775.png)

#### :ghost: GIF
![](https://media1.giphy.com/media/Fd5qf8YY3em5O/giphy.gif)