### PR TITLE
Fix version in package.json file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,6 @@
 {
   "name": "decidim",
+  "version": "0.5.0-pre",
   "lockfileVersion": 1,
   "dependencies": {
     "@types/async": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decidim",
-  "version": "0.4.3",
+  "version": "0.5.0-pre",
   "repository": {
     "url": "git@github.com:decidim/decidim.git",
     "type": "git"


### PR DESCRIPTION
#### :tophat: What? Why?
The `package.json` file has the old version, I guess we forgot it during the last gem release. We should add some docs on how to release the gem @josepjaume @beagleknight 

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None