### PR TITLE
Support for step-less participatory spaces

### DIFF
--- a/decidim-admin/app/forms/decidim/admin/feature_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/feature_form.rb
@@ -36,7 +36,7 @@ module Decidim
       end
 
       def step_settings?
-        return false unless participatory_space.steps.any?
+        return false unless participatory_space.has_steps?
 
         step_settings
           .values

--- a/decidim-budgets/app/commands/decidim/budgets/add_line_item.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/add_line_item.rb
@@ -47,7 +47,7 @@ module Decidim
       end
 
       def votes_disabled?
-        !feature.active_step_settings.votes_enabled?
+        !feature.current_settings.votes_enabled?
       end
     end
   end

--- a/decidim-budgets/app/models/decidim/budgets/project.rb
+++ b/decidim-budgets/app/models/decidim/budgets/project.rb
@@ -24,7 +24,7 @@ module Decidim
 
       # Public: Overrides the `accepts_new_comments?` Commentable concern method.
       def accepts_new_comments?
-        commentable? && !feature.active_step_settings.comments_blocked
+        commentable? && !feature.current_settings.comments_blocked
       end
 
       # Public: Overrides the `comments_have_votes?` Commentable concern method.

--- a/decidim-core/app/controllers/concerns/decidim/settings.rb
+++ b/decidim-core/app/controllers/concerns/decidim/settings.rb
@@ -16,7 +16,7 @@ module Decidim
       end
 
       def current_settings
-        @current_settings ||= current_feature.active_step_settings
+        @current_settings ||= current_feature.current_settings
       end
     end
   end

--- a/decidim-core/lib/decidim/has_settings.rb
+++ b/decidim-core/lib/decidim/has_settings.rb
@@ -18,6 +18,14 @@ module Decidim
       self[:settings]["global"] = serialize_settings(settings_schema(:global), data)
     end
 
+    def current_settings
+      if participatory_space.allows_steps?
+        active_step_settings
+      else
+        default_step_settings
+      end
+    end
+
     def default_step_settings
       settings_schema(:step).new(self[:settings]["default_step"])
     end
@@ -38,14 +46,14 @@ module Decidim
       end
     end
 
+    private
+
     def active_step_settings
       active_step = participatory_space.active_step
       return default_step_settings unless active_step
 
       step_settings.fetch(active_step.id.to_s)
     end
-
-    private
 
     def serialize_settings(schema, value)
       if value.respond_to?(:attributes)

--- a/decidim-core/lib/decidim/has_settings.rb
+++ b/decidim-core/lib/decidim/has_settings.rb
@@ -35,6 +35,8 @@ module Decidim
     end
 
     def step_settings
+      return {} unless participatory_space.allows_steps?
+
       participatory_space.steps.each_with_object({}) do |step, result|
         result[step.id.to_s] = settings_schema(:step).new(self[:settings].dig("steps", step.id.to_s))
       end
@@ -49,6 +51,8 @@ module Decidim
     private
 
     def active_step_settings
+      return unless participatory_space.allows_steps?
+
       active_step = participatory_space.active_step
       return default_step_settings unless active_step
 

--- a/decidim-core/lib/decidim/participable.rb
+++ b/decidim-core/lib/decidim/participable.rb
@@ -52,5 +52,13 @@ module Decidim
     def admins
       admins_query.for(self)
     end
+
+    def allows_steps?
+      respond_to?(:steps)
+    end
+
+    def has_steps?
+      allows_steps? && steps.any?
+    end
   end
 end

--- a/decidim-pages/app/models/decidim/pages/page.rb
+++ b/decidim-pages/app/models/decidim/pages/page.rb
@@ -23,7 +23,7 @@ module Decidim
 
       # Public: Overrides the `accepts_new_comments?` Commentable concern method.
       def accepts_new_comments?
-        commentable? && !feature.active_step_settings.comments_blocked
+        commentable? && !feature.current_settings.comments_blocked
       end
 
       # Public: Overrides the `comments_have_alignment?` Commentable concern method.

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -83,7 +83,7 @@ module Decidim
 
       # Public: Overrides the `accepts_new_comments?` Commentable concern method.
       def accepts_new_comments?
-        commentable? && !feature.active_step_settings.comments_blocked
+        commentable? && !feature.current_settings.comments_blocked
       end
 
       # Public: Overrides the `comments_have_alignment?` Commentable concern method.

--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -72,6 +72,12 @@ Decidim.register_feature(:proposals) do |feature|
   end
 
   feature.seeds do |participatory_space|
+    step_settings = if participatory_space.allows_steps?
+                      { participatory_space.active_step.id => { votes_enabled: true, votes_blocked: false, creation_enabled: true } }
+                    else
+                      {}
+                    end
+
     feature = Decidim::Feature.create!(
       name: Decidim::Features::Namer.new(participatory_space.organization.available_locales, :proposals).i18n_name,
       manifest_name: :proposals,
@@ -80,9 +86,7 @@ Decidim.register_feature(:proposals) do |feature|
       settings: {
         vote_limit: 0
       },
-      step_settings: {
-        participatory_space.active_step.id => { votes_enabled: true, votes_blocked: false, creation_enabled: true }
-      }
+      step_settings: step_settings
     )
 
     if participatory_space.scope
@@ -120,7 +124,7 @@ Decidim.register_feature(:proposals) do |feature|
       )
 
       rand(3).times do |m|
-        email = "vote-author-#{participatory_space.id}-#{n}-#{m}@example.org"
+        email = "vote-author-#{participatory_space.underscored_name}-#{participatory_space.id}-#{n}-#{m}@example.org"
         name = "#{Faker::Name.name} #{participatory_space.id} #{n} #{m}"
 
         author = Decidim::User.find_or_initialize_by(email: email)

--- a/decidim-results/app/models/decidim/results/result.rb
+++ b/decidim-results/app/models/decidim/results/result.rb
@@ -21,7 +21,7 @@ module Decidim
 
       # Public: Overrides the `accepts_new_comments?` Commentable concern method.
       def accepts_new_comments?
-        commentable? && !feature.active_step_settings.comments_blocked
+        commentable? && !feature.current_settings.comments_blocked
       end
 
       # Public: Overrides the `comments_have_alignment?` Commentable concern method.


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds preliminary support for step-less participatory spaces, like assemblies.

The current approach is to reuse what's already there: when the participatory space has no steps, we use the "default step settings" defined for the feature.

This works, but it feels a bit hacky. I'm open to ideas on how to make it better. Also, I'm aware this is untested. The tests in the assemblies plugin, which I mean to add next, should exercise this.

#### :pushpin: Related Issues
- Related to #1659.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![cat_dance](https://user-images.githubusercontent.com/2887858/29090758-e1f8d956-7c80-11e7-9eca-4dcfcc090596.gif)
