### PR TITLE
Fix decidim generator error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,7 @@ PATH
       db-query-matchers (~> 0.9.0)
       decidim (= 0.5.0.pre.pre)
       factory_girl_rails
-      faker (~> 1.7.3)
+      faker (~> 1.8.4)
       i18n-tasks (= 0.9.15)
       launchy
       listen (~> 3.1.0)
@@ -269,7 +269,7 @@ GEM
     factory_girl_rails (4.8.0)
       factory_girl (~> 4.8.0)
       railties (>= 3.0.0)
-    faker (1.7.3)
+    faker (1.8.4)
       i18n (~> 0.5)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
@@ -293,7 +293,7 @@ GEM
     graphiql-rails (1.4.2)
       rails
     graphql (1.6.6)
-    hashdiff (0.3.4)
+    hashdiff (0.3.5)
     hashie (3.5.6)
     high_voltage (3.0.0)
     highline (1.7.8)

--- a/decidim-core/lib/decidim/core/version.rb
+++ b/decidim-core/lib/decidim/core/version.rb
@@ -11,7 +11,7 @@ module Decidim
   end
 
   def self.faker_version
-    "~> 1.7.3"
+    "~> 1.8.4"
   end
 
   def self.add_default_gemspec_properties(spec)

--- a/decidim-core/lib/decidim/core/version.rb
+++ b/decidim-core/lib/decidim/core/version.rb
@@ -10,6 +10,10 @@ module Decidim
     ["~> 5.1.3"]
   end
 
+  def self.faker_version
+    "~> 1.7.3"
+  end
+
   def self.add_default_gemspec_properties(spec)
     spec.version = Decidim.version
     spec.authors = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva"]

--- a/decidim-dev/decidim-dev.gemspec
+++ b/decidim-dev/decidim-dev.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency "listen", "~> 3.1.0"
   s.add_dependency "launchy"
   s.add_dependency "i18n-tasks", "0.9.15"
-  s.add_dependency "faker", "~> 1.7.3"
+  s.add_dependency "faker", Decidim.faker_version
   s.add_dependency "poltergeist", "~> 1.15.0"
   s.add_dependency "rails-controller-testing", "~> 1.0.1"
   s.add_dependency "simplecov", "~> 0.13"

--- a/lib/generators/decidim/templates/Gemfile.erb
+++ b/lib/generators/decidim/templates/Gemfile.erb
@@ -12,7 +12,7 @@ gem "decidim", "<%= Gem::Specification.find_by_name("decidim").version %>"
 <% end %>
 gem 'puma', '~> 3.0'
 gem 'uglifier', '>= 1.3.0'
-gem 'faker', '~> <%= Gem::Specification.find_by_name("faker").version %>'
+gem 'faker', "<%= Decidim.faker_version %>"
 
 group :development, :test do
   gem 'byebug', platform: :mri


### PR DESCRIPTION
#### :tophat: What? Why?

I was trying to reproduce #1709, and got another error. It can be reproduced by doing

```
gem uninstall faker # the decidim-compatible version if you have it installed
gem install faker # the latest (decidim-incompatible) version
gem install decidim # which doesn't install faker (not a hard dependency)
decidim decidim_application
```

And you get

```
$ decidim decidim_application

... correct stuff ...

         run  bundle install
The dependency tzinfo-data (>= 0) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`.
Fetching gem metadata from https://rubygems.org/............
Fetching version metadata from https://rubygems.org/...
Fetching dependency metadata from https://rubygems.org/..
Resolving dependencies...
Bundler could not find compatible versions for gem "faker":
  In Gemfile:
    faker (~> 1.8.4)

    decidim-dev (= 0.4.4) was resolved to 0.4.4, which depends on
      faker (~> 1.7.3)
         run  bundle exec spring binstub --all
Bundler could not find compatible versions for gem "faker":
  In Gemfile:
    faker (~> 1.8.4)

    decidim-dev (= 0.4.4) was resolved to 0.4.4, which depends on
      faker (~> 1.7.3)
       force  config/database.yml
      create  app/controllers/decidim_controller.rb
      create  Dockerfile
      create  docker-compose.yml
       force  config/cable.yml
       force  README.md
       route  mount Decidim::Core::Engine => '/'
       rails  railties:install:migrations
Bundler could not find compatible versions for gem "faker":
  In Gemfile:
    faker (~> 1.8.4)

    decidim-dev (= 0.4.4) was resolved to 0.4.4, which depends on
      faker (~> 1.7.3)
      append  db/seeds.rb

  ... more correct stuff ...

```

And when running `bin/rails --version` inside the app

```
$ bin/rails --version
Bundler could not find compatible versions for gem "faker":
  In Gemfile:
    faker (~> 1.8.4)

    decidim-dev (= 0.4.4) was resolved to 0.4.4, which depends on
      faker (~> 1.7.3)
```

Unsure how to test this without actually releasing the gem :sweat_smile:. Any ideas?

#### :pushpin: Related Issues
- Related to #1709.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![defense](https://user-images.githubusercontent.com/2887858/29110226-4260d658-7ce6-11e7-8d3e-50e8a8296bce.gif)

