### PR TITLE
Fix default step settings on feature creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased](https://github.com/decidim/decidim/tree/HEAD)
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.4.4...HEAD)
 
+**Fixed**
+
+- **decidim-admin**: Fixed default step settings for a feature not being properly saved when the feature doesn't have steps yet. [\#1724](https://github.com/decidim/decidim/pull/1724)
+
 **Added**
 
 - **decidim**: Added `announcement` global and step setting to all features. As an admin you can configure a visible callout in the public page of a feature. [\#1696](https://github.com/decidim/decidim/pull/1696)

--- a/decidim-admin/app/commands/decidim/admin/create_feature.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_feature.rb
@@ -39,6 +39,7 @@ module Decidim
           name: form.name,
           participatory_process: participatory_process,
           settings: @form.settings,
+          default_step_settings: form.default_step_settings,
           step_settings: form.step_settings
         )
       end

--- a/decidim-admin/app/commands/decidim/admin/create_feature.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_feature.rb
@@ -38,7 +38,7 @@ module Decidim
           manifest_name: manifest.name,
           name: form.name,
           participatory_process: participatory_process,
-          settings: @form.settings,
+          settings: form.settings,
           default_step_settings: form.default_step_settings,
           step_settings: form.step_settings
         )

--- a/decidim-admin/spec/commands/create_feature_spec.rb
+++ b/decidim-admin/spec/commands/create_feature_spec.rb
@@ -20,6 +20,12 @@ module Decidim
             dummy_global_attribute_1: true,
             dummy_global_attribute_2: false
           },
+          default_step_settings: {
+            step.id.to_s => {
+              dummy_step_attribute_1: true,
+              dummy_step_attribute_2: false
+            }
+          },
           step_settings: {
             step.id.to_s => {
               dummy_step_attribute_1: true,

--- a/decidim-admin/spec/features/admin_manages_features_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_features_spec.rb
@@ -65,6 +65,58 @@ describe "Admin manages features", type: :feature do
         expect(all("input[type=checkbox]").first).to be_checked
       end
     end
+
+    context "when the process doesn't have active steps" do
+      let!(:participatory_process) do
+        create(:participatory_process, organization: organization)
+      end
+
+      it "saves the default step settings" do
+        find("button[data-toggle=add-feature-dropdown]").click
+
+        within "#add-feature-dropdown" do
+          find(".dummy").click
+        end
+
+        within ".new_feature" do
+          fill_in_i18n(
+            :feature_name,
+            "#feature-name-tabs",
+            en: "My feature",
+            ca: "La meva funcionalitat",
+            es: "Mi funcionalitat"
+          )
+
+          within ".global-settings" do
+            all("input[type=checkbox]").last.click
+          end
+
+          within ".default-step-settings" do
+            all("input[type=checkbox]").first.click
+          end
+
+          find("*[type=submit]").click
+        end
+
+        within ".callout-wrapper" do
+          expect(page).to have_content("successfully")
+        end
+
+        expect(page).to have_content("My feature")
+
+        within find("tr", text: "My feature") do
+          page.find(".action-icon--configure").click
+        end
+
+        within ".global-settings" do
+          expect(all("input[type=checkbox]").last).to be_checked
+        end
+
+        within ".default-step-settings" do
+          expect(all("input[type=checkbox]").first).to be_checked
+        end
+      end
+    end
   end
 
   describe "edit a feature" do


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes a bug where default step settings would not be properly saved on feature creation.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![cat_dog_love](https://user-images.githubusercontent.com/2887858/29158771-8eba257e-7dac-11e7-8b05-0b6d7027312e.gif)
