### PR TITLE
Fix bad HTML in footer

### DIFF
--- a/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
@@ -85,7 +85,7 @@
             <% if current_organization.static_pages.any? %>
               <ul class="footer-nav">
                 <% current_organization.static_pages.each do |page| %>
-                  <li><%= link_to translated_attribute(page.title), decidim.page_path(page) %></a></li>
+                  <li><%= link_to translated_attribute(page.title), decidim.page_path(page) %></li>
                 <% end %>
               </ul>
             <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

Fixes a double link closing tag in our footer.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![thank_you_my_love](https://user-images.githubusercontent.com/2887858/29158956-411d025e-7dad-11e7-8704-3ce718599a96.gif)

