### PR TITLE
Remove model dependencies from migrations

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -58,7 +58,6 @@ task :development_app do
 
   Dir.chdir("#{__dir__}/development_app") do
     Bundler.with_clean_env do
-      sh "bundle exec spring stop"
       sh "bundle exec rails db:seed"
       sh "bundle exec rails generate decidim:demo"
     end

--- a/decidim-core/db/migrate/20170605162500_add_hierarchy_to_scopes.rb
+++ b/decidim-core/db/migrate/20170605162500_add_hierarchy_to_scopes.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 class AddHierarchyToScopes < ActiveRecord::Migration[5.0]
+  class Scope < ApplicationRecord
+    self.table_name = :decidim_scopes
+  end
+
+  class Organization < ApplicationRecord
+    self.table_name = :decidim_organizations
+  end
+
   def self.up
     # schema migration
     create_table :decidim_scope_types do |t|
@@ -10,7 +18,7 @@ class AddHierarchyToScopes < ActiveRecord::Migration[5.0]
     end
 
     # retrieve current data
-    current_data = Decidim::Scope.select(:id, :name, :decidim_organization_id).as_json
+    current_data = Scope.select(:id, :name, :decidim_organization_id).as_json
 
     change_table :decidim_scopes do |t|
       t.remove_index :name
@@ -24,7 +32,7 @@ class AddHierarchyToScopes < ActiveRecord::Migration[5.0]
     end
 
     current_data.each do |s|
-      locales = Decidim::Organization.find(s["decidim_organization_id"]).available_locales
+      locales = Organization.find(s["decidim_organization_id"]).available_locales
       name = s["name"].gsub(/'/, "''")
       execute("
         UPDATE decidim_scopes
@@ -50,7 +58,7 @@ class AddHierarchyToScopes < ActiveRecord::Migration[5.0]
     drop_table :decidim_scope_types
 
     # post migration data fixes
-    Decidim::Scope.select(:id, :name).as_json.each do |s|
+    Scope.select(:id, :name).as_json.each do |s|
       name = quote(JSON.parse(s["name"]).values.first)
       execute("
         UPDATE decidim_scopes

--- a/decidim-core/db/migrate/20170713131206_add_admin_to_users.rb
+++ b/decidim-core/db/migrate/20170713131206_add_admin_to_users.rb
@@ -3,6 +3,11 @@
 class AddAdminToUsers < ActiveRecord::Migration[5.1]
   def up
     add_column :decidim_users, :admin, :boolean, null: false, default: false
-    Decidim::User.where("roles @> ?", "{admin}").update_all(admin: true)
+
+    execute <<~SQL
+      UPDATE decidim_users
+      SET admin = true
+      WHERE roles @> '{admin}'
+    SQL
   end
 end

--- a/decidim-core/db/migrate/20170713131308_migrate_user_roles_to_participatory_process_roles.rb
+++ b/decidim-core/db/migrate/20170713131308_migrate_user_roles_to_participatory_process_roles.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 class MigrateUserRolesToParticipatoryProcessRoles < ActiveRecord::Migration[5.1]
+  class User < ApplicationRecord
+    self.table_name = :decidim_users
+  end
+
   def up
     participatory_processes = Decidim::ParticipatoryProcess.includes(:organization).all
-    Decidim::User.find_each do |user|
+    User.find_each do |user|
       next if user.roles.empty? || user.roles.include?("admin")
 
       processes = participatory_processes.select { |process| process.organization == user.organization }


### PR DESCRIPTION
#### :tophat: What? Why?

This is the same as #1649, fixing the same problem that crept in again. I also "exercised" this during the development application generation (by removing the `spring stop` workaround in https://github.com/decidim/decidim/commit/3aa240827dcf272a802cfd6c695e343c42f28d7a), so we can find about it earlier and don't break it again.

#### :pushpin: Related Issues
- Related to #1649.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![funny-facepalm-gif](https://user-images.githubusercontent.com/2887858/29251617-31a761b8-8058-11e7-9d7f-9540a2ce846b.gif)
