### PR TITLE
Mark reference prefix as required when creating a new organization

### DIFF
--- a/decidim-system/app/forms/decidim/system/register_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/register_organization_form.rb
@@ -15,7 +15,7 @@ module Decidim
       attribute :default_locale, String
       attribute :reference_prefix
 
-      validates :organization_admin_email, :organization_admin_name, :name, :host, presence: true
+      validates :organization_admin_email, :organization_admin_name, :name, :host, :reference_prefix, presence: true
       validates :available_locales, presence: true
       validates :default_locale, presence: true
       validates :default_locale, inclusion: { in: :available_locales }

--- a/decidim-system/app/views/decidim/system/organizations/new.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/new.html.erb
@@ -9,6 +9,7 @@
 
   <div class="field">
     <%= f.text_field :reference_prefix %>
+    <p class="help-text"><%= t(".reference_prefix_hint") %></p>
   </div>
 
   <div class="field">

--- a/decidim-system/config/locales/en.yml
+++ b/decidim-system/config/locales/en.yml
@@ -60,6 +60,7 @@ en:
         index:
           title: Organizations
         new:
+          reference_prefix_hint: The reference prefix is used to uniquely identify resources across all organizations
           secondary_hosts_hint: Enter each one of them in a new line
           title: New organization
         update:


### PR DESCRIPTION
#### :tophat: What? Why?

Creating a new Organization by filling out just the required fields failed ("Could not create a new organization") without any further information on what went wrong.

Manually reproducing what RegisterOrganization does in the console revealed that there is a validation on presence of the `reference_prefix` field in the `Organization` model, which is missing from the form class `RegisterOrganizationForm`. This leads to the field not being marked as required in the view.

On a side note, being new to Decidim I have no idea what a reference prefix is or should be. Some hint in the form would be nice :)

