### PR TITLE
Scopes minor fixes

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/scopes_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/scopes_controller.rb
@@ -72,7 +72,7 @@ module Decidim
       end
 
       def parent_scope
-        @parent_scope ||= @scope ? @scope.parent : organization_scopes.find_by_id(params[:scope_id])
+        @parent_scope ||= scope ? scope.parent : organization_scopes.find_by_id(params[:scope_id])
       end
 
       def scope

--- a/decidim-admin/app/controllers/decidim/admin/scopes_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/scopes_controller.rb
@@ -14,7 +14,7 @@ module Decidim
                     parent_scope.children
                   else
                     collection.top_level
-                  end
+                  end .order "name->'#{I18n.locale}' ASC"
       end
 
       def new

--- a/decidim-admin/app/controllers/decidim/admin/scopes_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/scopes_controller.rb
@@ -10,7 +10,7 @@ module Decidim
 
       def index
         authorize! :index, Scope
-        @scopes = parent_scope_children.order("name->'#{I18n.locale}' ASC")
+        @scopes = children_scopes.order("name->'#{I18n.locale}' ASC")
       end
 
       def new
@@ -67,20 +67,20 @@ module Decidim
 
       private
 
-      def scope
-        @scope ||= collection.find(params[:id])
+      def organization_scopes
+        current_organization.scopes
       end
 
       def parent_scope
-        @parent_scope ||= @scope ? @scope.parent : collection.find_by_id(params[:scope_id])
+        @parent_scope ||= @scope ? @scope.parent : organization_scopes.find_by_id(params[:scope_id])
       end
 
-      def parent_scope_children
-        @parent_scope_children ||= parent_scope ? parent_scope.children : collection.top_level
+      def scope
+        @scope ||= organization_scopes.find(params[:id])
       end
 
-      def collection
-        current_organization.scopes
+      def children_scopes
+        @subscopes ||= parent_scope ? parent_scope.children : organization_scopes.top_level
       end
 
       def current_scopes_path

--- a/decidim-admin/app/controllers/decidim/admin/scopes_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/scopes_controller.rb
@@ -10,11 +10,7 @@ module Decidim
 
       def index
         authorize! :index, Scope
-        @scopes = if parent_scope
-                    parent_scope.children
-                  else
-                    collection.top_level
-                  end .order "name->'#{I18n.locale}' ASC"
+        @scopes = parent_scope_children.order "name->'#{I18n.locale}' ASC"
       end
 
       def new
@@ -77,6 +73,10 @@ module Decidim
 
       def parent_scope
         @parent_scope ||= @scope ? @scope.parent : collection.find_by_id(params[:scope_id])
+      end
+
+      def parent_scope_children
+        @parent_scope_children ||= parent_scope ? parent_scope.children : collection.top_level
       end
 
       def collection

--- a/decidim-admin/app/controllers/decidim/admin/scopes_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/scopes_controller.rb
@@ -72,11 +72,13 @@ module Decidim
       end
 
       def parent_scope
-        @parent_scope ||= scope ? scope.parent : organization_scopes.find_by_id(params[:scope_id])
+        return @parent_scope if defined?(@parent_scope)
+        @parent_scope = scope ? scope.parent : organization_scopes.find_by_id(params[:scope_id])
       end
 
       def scope
-        @scope ||= organization_scopes.find(params[:id])
+        return @scope if defined?(@scope)
+        @scope = organization_scopes.find_by_id(params[:id])
       end
 
       def children_scopes

--- a/decidim-admin/app/controllers/decidim/admin/scopes_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/scopes_controller.rb
@@ -10,7 +10,7 @@ module Decidim
 
       def index
         authorize! :index, Scope
-        @scopes = parent_scope_children.order "name->'#{I18n.locale}' ASC"
+        @scopes = parent_scope_children.order("name->'#{I18n.locale}' ASC")
       end
 
       def new

--- a/decidim-core/app/models/decidim/scope.rb
+++ b/decidim-core/app/models/decidim/scope.rb
@@ -60,15 +60,15 @@ module Decidim
     end
 
     def create_part_of
-      recalculate_part_of
+      build_part_of
       save if changed?
     end
 
     def update_part_of
-      recalculate_part_of
+      build_part_of
     end
 
-    def recalculate_part_of
+    def build_part_of
       if parent
         part_of.clear.append(id).concat(parent.reload.part_of)
       else

--- a/decidim-core/app/models/decidim/scope.rb
+++ b/decidim-core/app/models/decidim/scope.rb
@@ -50,8 +50,7 @@ module Decidim
     #
     # Returns an array of Scope objects
     def part_of_scopes
-      scopes_by_id = organization.scopes.where(id: part_of).index_by(&:id)
-      part_of.reverse.collect { |id| scopes_by_id[id] }
+      organization.scopes.where(id: part_of).sort { |s1, s2| part_of.index(s2.id) <=> part_of.index(s1.id) }
     end
 
     private

--- a/decidim-core/app/models/decidim/scope.rb
+++ b/decidim-core/app/models/decidim/scope.rb
@@ -60,19 +60,19 @@ module Decidim
     end
 
     def create_part_of
-      self[:part_of] = calculate_part_of
+      recalculate_part_of
       save if changed?
     end
 
     def update_part_of
-      self[:part_of] = calculate_part_of
+      recalculate_part_of
     end
 
-    def calculate_part_of
+    def recalculate_part_of
       if parent
-        [id] + parent.part_of
+        part_of.clear.append(id).concat(parent.reload.part_of)
       else
-        [id]
+        part_of.clear.append(id)
       end
     end
   end

--- a/decidim-core/app/models/decidim/scope.rb
+++ b/decidim-core/app/models/decidim/scope.rb
@@ -46,11 +46,12 @@ module Decidim
       organization.scopes.where("? = ANY(decidim_scopes.part_of)", id)
     end
 
-    # Gets the scopes from the part_of list
+    # Gets the scopes from the part_of list in descending order (first the top level scope, last itself)
     #
-    # Returns an ActiveRecord::Relation.
+    # Returns an array of Scope objects
     def part_of_scopes
-      organization.scopes.where(id: part_of)
+      scopes_by_id = organization.scopes.where(id: part_of).index_by(&:id)
+      part_of.reverse.collect { |id| scopes_by_id[id] }
     end
 
     private

--- a/decidim-core/spec/models/decidim/scope_spec.rb
+++ b/decidim-core/spec/models/decidim/scope_spec.rb
@@ -73,14 +73,49 @@ module Decidim
         subject.save
         expect(subject.part_of).to eq([subject.id])
       end
+
+      context "with parent scope" do
+        let(:parent) { create(:scope) }
+
+        it "is updated after save" do
+          subject.save
+          expect(subject.part_of).to eq([subject.id, parent.id])
+        end
+      end
     end
 
-    context "part_of for top level scopes" do
-      let(:parent) { create(:scope) }
+    context "#part_of_scopes" do
+      let(:grandparent) { create(:scope) }
+      let(:parent) { create(:scope, parent: grandparent) }
 
-      it "is updated after save" do
+      it "returns correct path" do
         subject.save
-        expect(subject.part_of).to eq([subject.id, parent.id])
+        expect(subject.part_of_scopes).to eq([grandparent, parent, scope])
+      end
+    end
+
+    context "creating several scopes on a transaction" do
+      let(:scopes) { build_list(:scope, 9) }
+
+      before do
+        Scope.transaction do
+          scopes.each_with_index do |scope, i|
+            scope.parent_id = scopes[i / 2].id if i.positive?
+            scope.save!
+          end
+        end
+      end
+
+      it "updates part_of lists" do
+        {
+          2 => [2, 1, 0],
+          3 => [3, 1, 0],
+          4 => [4, 2, 1, 0],
+          5 => [5, 2, 1, 0],
+          8 => [8, 4, 2, 1, 0]
+        }.each do |s1, list|
+          expect(scopes[s1].part_of).to eq(list.map { |i| scopes[i].id })
+        end
       end
     end
   end

--- a/decidim-core/spec/models/decidim/scope_spec.rb
+++ b/decidim-core/spec/models/decidim/scope_spec.rb
@@ -108,11 +108,11 @@ module Decidim
 
       it "updates part_of lists" do
         {
+          0 => [0],
+          1 => [1, 0],
           2 => [2, 1, 0],
           3 => [3, 1, 0],
-          4 => [4, 2, 1, 0],
-          5 => [5, 2, 1, 0],
-          8 => [8, 4, 2, 1, 0]
+          4 => [4, 2, 1, 0]
         }.each do |s1, list|
           expect(scopes[s1].part_of).to eq(list.map { |i| scopes[i].id })
         end


### PR DESCRIPTION
#### :tophat: What? Why?
When working with a large number of scopes certain minor problems arise:
* Scopes lists at admin pages are very large, ordering by name helps better to handle them.
* Creating several scopes inside a transaction affects the order of the scopes creation. This breaks the `part_of` attribute (list of parent scopes) updating process.
* The previous problem also affects the breadcrumbs showing in the admin section. I changed the method that retrieves the full scope path to keep the right order independently the database order. 

This PR fixes all these problems.

#### :pushpin: Related Issues

#### :clipboard: Subtasks

#### :ghost: GIF
![](http://www.reactiongifs.com/wp-content/uploads/2013/08/party-wipeout.gif)
