### PR TITLE
Fix default locale problems

### DIFF
--- a/decidim-core/app/models/decidim/organization.rb
+++ b/decidim-core/app/models/decidim/organization.rb
@@ -16,6 +16,7 @@ module Decidim
 
     validates :name, :host, uniqueness: true
     validates :reference_prefix, presence: true
+    validates :default_locale, inclusion: { in: :available_locales }
 
     mount_uploader :homepage_image, Decidim::HomepageImageUploader
     mount_uploader :official_img_header, Decidim::OfficialImageHeaderUploader

--- a/decidim-core/spec/models/decidim/organization_spec.rb
+++ b/decidim-core/spec/models/decidim/organization_spec.rb
@@ -34,6 +34,12 @@ module Decidim
 
         it { is_expected.not_to be_valid }
       end
+
+      it "default locale should be included in available locales" do
+        subject.available_locales = [:ca, :es]
+        subject.default_locale = :en
+        expect(subject).not_to be_valid
+      end
     end
   end
 end

--- a/lib/generators/decidim/templates/initializer.rb
+++ b/lib/generators/decidim/templates/initializer.rb
@@ -5,7 +5,8 @@ Decidim.configure do |config|
   config.mailer_sender = "change-me@domain.org"
   config.authorization_handlers = [ExampleAuthorizationHandler]
 
-  # Change this line to set your preferred locales
+  # Change these lines to set your preferred locales
+  config.default_locale = :en
   config.available_locales = [:en, :ca, :es]
 
   # Geocoder configuration


### PR DESCRIPTION
#### :tophat: What? Why?

Our generator wasn't including the `Decidim.default_locale` so the `Organization` created by default in some organization had the wrong value.
We also had a missing validation in the `Organization` model.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
N/A

#### :ghost: GIF
None
