### PR TITLE
Don't store scopes search location for Devise.

### DIFF
--- a/decidim-core/app/controllers/decidim/scopes_controller.rb
+++ b/decidim-core/app/controllers/decidim/scopes_controller.rb
@@ -3,6 +3,8 @@
 module Decidim
   # Exposes the scopes text search so users can choose a scope writing its name.
   class ScopesController < Decidim::ApplicationController
+    skip_before_action :store_current_location
+
     def search
       authorize! :search, Scope
       root = Scope.where(id: params[:root], organization: current_organization).first

--- a/decidim-core/spec/controllers/scopes_controller_spec.rb
+++ b/decidim-core/spec/controllers/scopes_controller_spec.rb
@@ -45,6 +45,10 @@ module Decidim
       it "result has text" do
         expect(subject.first).to have_key("text")
       end
+
+      it "don't store location for user" do
+        expect(controller.stored_location_for(user)).to be_nil
+      end
     end
 
     context "search top scopes" do

--- a/decidim-core/spec/controllers/scopes_controller_spec.rb
+++ b/decidim-core/spec/controllers/scopes_controller_spec.rb
@@ -46,7 +46,7 @@ module Decidim
         expect(subject.first).to have_key("text")
       end
 
-      it "don't store location for user" do
+      it "doesn't store the location for user" do
         expect(controller.stored_location_for(user)).to be_nil
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
By default, the base ApplicationController stores every visited URL as last location, to allow return to it when the user logs in or is verified. This shouldn't happen with AJAX API calls as Scopes search.

#### :pushpin: Related Issues

#### :clipboard: Subtasks

#### :ghost: GIF
![](http://25.media.tumblr.com/ac0219734cfc2fd5ea87b4a76dee3be1/tumblr_mlex8hkqSM1qa1gn7o1_400.gif)
