### PR TITLE
Fix html not properly interpreted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 
 ## [Unreleased](https://github.com/decidim/decidim/tree/HEAD)
+
+**Fixed**
+
+- **decidim-surveys**: Drag & drop icon incorrectly rendered in form. [\#1761](https://https://github.com/decidim/decidim/pull/1761)
+
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.5.1...HEAD)
 
 **Added**

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
@@ -3,7 +3,7 @@
     <h2 class="card-title">
     <span>
       <% if survey.questions_editable? %>
-        <%= "#{icon("move")} #{t(".question")}" %>
+        <%== "#{icon("move")} #{t(".question")}" %>
       <% else %>
         <%= t(".question") %>
       <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

In #1741 I introduced a visual bug where drag & drop icon on survey edition would not be properly rendered. This tiny change should fix it.

#### :pushpin: Related Issues
- Related to #1741.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_Before_
![before](https://user-images.githubusercontent.com/2887858/29586498-29fc9cf0-878b-11e7-9132-7c72c928e889.png)

_After_
![after](https://user-images.githubusercontent.com/2887858/29586504-2d946500-878b-11e7-8812-9cb203832101.png)



#### :ghost: GIF
![ping-pong-retro](https://user-images.githubusercontent.com/2887858/29586337-a0e6d548-878a-11e7-8fbb-0ffd2ce257c4.gif)