### PR TITLE
Fix `scopes_enabled` checkbox on participatory process creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 
 ## [Unreleased](https://github.com/decidim/decidim/tree/HEAD)
+
+**Fixed**
+
+- **decidim-participatory_processes**: Scopes enabled checkbox being ignored in participatory process creation. [\#1762](https://https://github.com/decidim/decidim/pull/1762)
+
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.5.1...HEAD)
 
 **Added**

--- a/decidim-admin/app/assets/javascripts/decidim/admin/participatory_processes.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/participatory_processes.js.es6
@@ -2,7 +2,7 @@ $(() => {
   const $participatoryProcessScopeEnabled = $('#participatory_process_scopes_enabled');
   const $participatoryProcessScopeId = $("#participatory_process_scope_id");
 
-  if ($('.edit_participatory_process').length > 0) {
+  if ($('.edit_participatory_process, .new_participatory_process').length > 0) {
     $participatoryProcessScopeEnabled.on('change', (event) => {
       const checked = event.target.checked;
       $participatoryProcessScopeId.attr("disabled", !checked);

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process.rb
@@ -48,6 +48,7 @@ module Decidim
             hero_image: form.hero_image,
             banner_image: form.banner_image,
             promoted: form.promoted,
+            scopes_enabled: form.scopes_enabled,
             scope: form.scope,
             developer_group: form.developer_group,
             local_area: form.local_area,

--- a/decidim-participatory_processes/spec/commands/create_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/commands/create_participatory_process_spec.rb
@@ -28,6 +28,7 @@ describe Decidim::ParticipatoryProcesses::Admin::CreateParticipatoryProcess do
       description: { en: "description" },
       short_description: { en: "short_description" },
       current_organization: organization,
+      scopes_enabled: true,
       scope: scope,
       errors: errors,
       participatory_process_group: participatory_process_group


### PR DESCRIPTION
#### :tophat: What? Why?

The `scopes_enabled` checkbox was being ignored on participatory process creation. This PR fixes that.

#### :pushpin: Related Issues
- Related to #1716.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![ping-pong-table-tennis-boss](https://user-images.githubusercontent.com/2887858/29586758-13507304-878c-11e7-9b0e-1d796fdb77c9.gif)
