### PR TITLE
Add missing assembly i18n keys

### DIFF
--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -1,5 +1,27 @@
 ---
 en:
+  activemodel:
+    attributes:
+      assembly:
+        banner_image: Banner image
+        copy_categories: Copy categories
+        copy_features: Copy features
+        description: Description
+        developer_group: Developer group
+        domain: Domain
+        hashtag: Hashtag
+        hero_image: Home image
+        local_area: Local area
+        meta_scope: Scope metadata
+        participatory_scope: Participatory scope
+        participatory_structure: Participatory structure
+        promoted: Promoted
+        scope_id: Scope
+        short_description: Short description
+        slug: URL slug
+        subtitle: Subtitle
+        target: Target
+        title: Title
   decidim:
     admin:
       assemblies:


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds missing i18n keys for the `Assembly` model fields.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![chinese_rules](https://user-images.githubusercontent.com/2887858/29587024-e95799be-878c-11e7-9107-f90638efdf73.gif)

