### PR TITLE
[WIP] Balance test builds timings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,40 +34,40 @@ jobs:
           command: |
             case $CIRCLE_NODE_INDEX in
               0)
-                (cd /code && npm run lint) &&
-                (cd /code && npm test -- decidim-api) &&
-                (cd /code/decidim-api && bundle exec rake) &&
-                (cd /code && npm test -- decidim-core) &&
-                (cd /code/decidim-core && bundle exec rake) &&
-                (cd /code && npm test -- decidim-participatory_processes) &&
-                (cd /code/decidim-participatory_processes && bundle exec rake) &&
-                (cd /code && npm test -- decidim-assemblies) &&
-                (cd /code/decidim-assemblies && bundle exec rake)
+                (cd /code && time npm run lint) &&
+                (cd /code && time npm test -- decidim-api) &&
+                (cd /code/decidim-api && time bundle exec rake) &&
+                (cd /code && time npm test -- decidim-core) &&
+                (cd /code/decidim-core && time bundle exec rake) &&
+                (cd /code && time npm test -- decidim-participatory_processes) &&
+                (cd /code/decidim-participatory_processes && time bundle exec rake) &&
+                (cd /code && time npm test -- decidim-assemblies) &&
+                (cd /code/decidim-assemblies && time bundle exec rake)
                 ;;
               1)
-                (cd /code && bundle exec rspec) &&
-                (cd /code && npm test -- decidim-admin) &&
-                (cd /code/decidim-admin && bundle exec rake) &&
-                (cd /code && npm test -- decidim-meetings) &&
-                (cd /code/decidim-meetings && bundle exec rake)
+                (cd /code && time bundle exec rspec) &&
+                (cd /code && time npm test -- decidim-admin) &&
+                (cd /code/decidim-admin && time bundle exec rake) &&
+                (cd /code && time npm test -- decidim-meetings) &&
+                (cd /code/decidim-meetings && time bundle exec rake)
                 ;;
               2)
-                (cd /code && npm test -- decidim-proposals) &&
-                (cd /code/decidim-proposals && bundle exec rake) &&
-                (cd /code && npm test -- decidim-comments) &&
-                (cd /code/decidim-comments && bundle exec rake)
+                (cd /code && time npm test -- decidim-proposals) &&
+                (cd /code/decidim-proposals && time bundle exec rake) &&
+                (cd /code && time npm test -- decidim-comments) &&
+                (cd /code/decidim-comments && time bundle exec rake)
                 ;;
               3)
-                (cd /code && npm test -- decidim-pages) &&
-                (cd /code/decidim-pages && bundle exec rake) &&
-                (cd /code && npm test -- decidim-system) &&
-                (cd /code/decidim-system && bundle exec rake) &&
-                (cd /code && npm test -- decidim-results) &&
-                (cd /code/decidim-results && bundle exec rake) &&
-                (cd /code && npm test -- decidim-budgets) &&
-                (cd /code/decidim-budgets && bundle exec rake) &&
-                (cd /code && npm test -- decidim-surveys) &&
-                (cd /code/decidim-surveys && bundle exec rake)
+                (cd /code && time npm test -- decidim-pages) &&
+                (cd /code/decidim-pages && time bundle exec rake) &&
+                (cd /code && time npm test -- decidim-system) &&
+                (cd /code/decidim-system && time bundle exec rake) &&
+                (cd /code && time npm test -- decidim-results) &&
+                (cd /code/decidim-results && time bundle exec rake) &&
+                (cd /code && time npm test -- decidim-budgets) &&
+                (cd /code/decidim-budgets && time bundle exec rake) &&
+                (cd /code && time npm test -- decidim-surveys) &&
+                (cd /code/decidim-surveys && time bundle exec rake)
                 ;;
             esac
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,21 +35,21 @@ jobs:
             case $CIRCLE_NODE_INDEX in
               0)
                 (cd /code && time npm run lint) &&
-                (cd /code && time npm test -- decidim-api) &&
-                (cd /code/decidim-api && time bundle exec rake) &&
+                (cd /code && time bundle exec rspec) &&
                 (cd /code && time npm test -- decidim-core) &&
                 (cd /code/decidim-core && time bundle exec rake) &&
-                (cd /code && time npm test -- decidim-participatory_processes) &&
-                (cd /code/decidim-participatory_processes && time bundle exec rake) &&
                 (cd /code && time npm test -- decidim-assemblies) &&
                 (cd /code/decidim-assemblies && time bundle exec rake)
                 ;;
               1)
-                (cd /code && time bundle exec rspec) &&
+                (cd /code && time npm test -- decidim-api) &&
+                (cd /code/decidim-api && time bundle exec rake) &&
+                (cd /code && time npm test -- decidim-participatory_processes) &&
+                (cd /code/decidim-participatory_processes && time bundle exec rake) &&
                 (cd /code && time npm test -- decidim-admin) &&
                 (cd /code/decidim-admin && time bundle exec rake) &&
-                (cd /code && time npm test -- decidim-meetings) &&
-                (cd /code/decidim-meetings && time bundle exec rake)
+                (cd /code && time npm test -- decidim-system) &&
+                (cd /code/decidim-system && time bundle exec rake)
                 ;;
               2)
                 (cd /code && time npm test -- decidim-proposals) &&
@@ -58,10 +58,10 @@ jobs:
                 (cd /code/decidim-comments && time bundle exec rake)
                 ;;
               3)
+                (cd /code && time npm test -- decidim-meetings) &&
+                (cd /code/decidim-meetings && time bundle exec rake)
                 (cd /code && time npm test -- decidim-pages) &&
                 (cd /code/decidim-pages && time bundle exec rake) &&
-                (cd /code && time npm test -- decidim-system) &&
-                (cd /code/decidim-system && time bundle exec rake) &&
                 (cd /code && time npm test -- decidim-results) &&
                 (cd /code/decidim-results && time bundle exec rake) &&
                 (cd /code && time npm test -- decidim-budgets) &&


### PR DESCRIPTION
#### :tophat: What? Why?
On CircleCI we have 4 containers. Currently, [on `master`](https://circleci.com/gh/decidim/decidim/3165), timings are:

1. 23min
1. 11min
1. 14min
1. 13min

Values are approximate, but close to that. As you can see, the first containers takes twice the time from the second container, so we can try to balance those timings and improve the overall build time.

In order to do so, I start timing how long a test suite takes using UNIX's `time`. I only count the test suites times, and consider irrelevant the time it takes to `cd` into other directories.

Next step will be balancing those containers so they take a similar amount of time. This might be a long PR, since I need the builds to pass each time I change things, and this work might be needed again in the future if we keep adding new plugins/engines to Decidim.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
- [x] Time each test suite
- [ ] Balance containers

### :camera: Screenshots (optional)
[Before](https://circleci.com/gh/decidim/decidim/3165):
![Description](https://i.imgur.com/Bo9tjGj.png)
