### PR TITLE
Fix HTML validations conflicting with abide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Fixed**
 
 - **decidim**: `decidim:check_locales` task not working properly. [\#1740]((https://https://github.com/decidim/decidim/pull/1740)
+- **decidim-core**: Disable HTML validations which sometimes caused unexpected form behavior. [\#1772](https://https://github.com/decidim/decidim/pull/1772)
 - **decidim-participatory_processes**: Scopes enabled checkbox being ignored in participatory process creation. [\#1762](https://https://github.com/decidim/decidim/pull/1762)
 - **decidim-surveys**: Drag & drop icon incorrectly rendered in form. [\#1761](https://https://github.com/decidim/decidim/pull/1761)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ PATH
       devise (~> 4.2)
       devise-i18n (~> 1.1.0)
       devise_invitable (~> 1.7.1)
-      foundation_rails_helper (~> 3.0.0.rc)
+      foundation_rails_helper (~> 3.0.0)
       jquery-rails (~> 4.3.1)
       rails (~> 5.1.3)
       rectify (~> 0.9.1)

--- a/decidim-core/app/helpers/decidim/decidim_form_helper.rb
+++ b/decidim-core/app/helpers/decidim/decidim_form_helper.rb
@@ -13,6 +13,10 @@ module Decidim
     def decidim_form_for(record, options = {}, &block)
       options[:data] ||= {}
       options[:data].update(abide: true, "live-validate" => true, "validate-on-blur" => true)
+
+      options[:html] ||= {}
+      options[:html].update(novalidate: true)
+
       form_for(record, options, &block)
     end
 

--- a/decidim-core/spec/helpers/decidim/decidim_form_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/decidim_form_helper_spec.rb
@@ -13,6 +13,9 @@ module Decidim
             abide: true,
             "live-validate" => true,
             "validate-on-blur" => true
+          },
+          html: {
+            novalidate: true
           }
         }
 

--- a/decidim-system/decidim-system.gemspec
+++ b/decidim-system/decidim-system.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "devise_invitable", "~> 1.7.1"
   s.add_dependency "sassc-rails", "~> 1.3.0"
   s.add_dependency "jquery-rails", "~> 4.3.1"
-  s.add_dependency "foundation_rails_helper", "~> 3.0.0.rc"
+  s.add_dependency "foundation_rails_helper", "~> 3.0.0"
   s.add_dependency "active_link_to", "~> 1.0.0"
 
   s.add_development_dependency "decidim-dev", Decidim.version


### PR DESCRIPTION
#### :tophat: What? Why?

We are not intentionally using HTML validations, and sometimes they get in the middle and cause strange behavior. For example, in the screenshots, I would get a single error after submitting an empty form and that got me into thinking that was the only field required.
  
#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)

#### Before
![before](https://user-images.githubusercontent.com/2887858/29664438-e0107486-88cf-11e7-90e3-3dc3b7906fff.gif)

#### After
![after](https://user-images.githubusercontent.com/2887858/29664453-e731268e-88cf-11e7-930c-8b29dca57d4a.gif)

#### :ghost: GIF
![tenor2](https://user-images.githubusercontent.com/2887858/29664336-83d58a62-88cf-11e7-9952-e0a80714de4b.gif)