### PR TITLE
Move user locale validation to a method

### DIFF
--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -20,7 +20,7 @@ module Decidim
     has_many :user_groups, through: :memberships, class_name: "Decidim::UserGroup", foreign_key: :decidim_user_group_id
 
     validates :name, presence: true, unless: -> { deleted? }
-    validates :locale, inclusion: { in: Decidim.available_locales.map(&:to_s) }, allow_blank: true
+    validates :locale, inclusion: { in: :available_locales }, allow_blank: true
     validates :tos_agreement, acceptance: true, allow_nil: false, on: :create
     validates :avatar, file_size: { less_than_or_equal_to: MAXIMUM_AVATAR_FILE_SIZE }
     validates :email, uniqueness: { scope: :organization }, unless: -> { deleted? || managed? }
@@ -101,6 +101,10 @@ module Decidim
 
     def all_roles_are_valid
       errors.add(:roles, :invalid) unless roles.all? { |role| ROLES.include?(role) }
+    end
+
+    def available_locales
+      Decidim.available_locales.map(&:to_s)
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

User `locale` validation was causing problems while testing because the inclusion was evaluated at load time so we can't override the `Decidim.available_locales`.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
N/A

#### :ghost: GIF
![](https://media2.giphy.com/media/Fc32CJcqXzOXm/giphy.gif)
