### PR TITLE
Add Follow & Notification models

### DIFF
--- a/decidim-core/app/models/decidim/follow.rb
+++ b/decidim-core/app/models/decidim/follow.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Decidim
+  class Follow < ApplicationRecord
+    belongs_to :followable, foreign_key: "decidim_followable_id", foreign_type: "decidim_followable_type", polymorphic: true
+    belongs_to :user, foreign_key: "decidim_user_id", class_name: "Decidim::User"
+
+    validates :user, uniqueness: { scope: [:followable] }
+    validates :user, :followable, presence: true
+  end
+end

--- a/decidim-core/app/models/decidim/follow.rb
+++ b/decidim-core/app/models/decidim/follow.rb
@@ -6,6 +6,5 @@ module Decidim
     belongs_to :user, foreign_key: "decidim_user_id", class_name: "Decidim::User"
 
     validates :user, uniqueness: { scope: [:followable] }
-    validates :user, :followable, presence: true
   end
 end

--- a/decidim-core/app/models/decidim/notification.rb
+++ b/decidim-core/app/models/decidim/notification.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Decidim
+  class Notification < ApplicationRecord
+    belongs_to :followable, foreign_key: "decidim_followable_id", foreign_type: "decidim_followable_type", polymorphic: true
+    belongs_to :user, foreign_key: "decidim_user_id", class_name: "Decidim::User"
+  end
+end

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -18,7 +18,8 @@ module Decidim
     has_many :identities, foreign_key: "decidim_user_id", class_name: "Decidim::Identity"
     has_many :memberships, class_name: "Decidim::UserGroupMembership", foreign_key: :decidim_user_id
     has_many :user_groups, through: :memberships, class_name: "Decidim::UserGroup", foreign_key: :decidim_user_group_id
-    has_many :follows, foreign_key: "decidim_user_id", class_name: "Decidim::Follow"
+    has_many :follows, foreign_key: "decidim_user_id", class_name: "Decidim::Follow", dependent: :destroy
+    has_many :notifications, foreign_key: "decidim_user_id", class_name: "Decidim::Notification", dependent: :destroy
 
     validates :name, presence: true, unless: -> { deleted? }
     validates :locale, inclusion: { in: :available_locales }, allow_blank: true

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -18,6 +18,7 @@ module Decidim
     has_many :identities, foreign_key: "decidim_user_id", class_name: "Decidim::Identity"
     has_many :memberships, class_name: "Decidim::UserGroupMembership", foreign_key: :decidim_user_id
     has_many :user_groups, through: :memberships, class_name: "Decidim::UserGroup", foreign_key: :decidim_user_group_id
+    has_many :follows, foreign_key: "decidim_user_id", class_name: "Decidim::Follow"
 
     validates :name, presence: true, unless: -> { deleted? }
     validates :locale, inclusion: { in: :available_locales }, allow_blank: true

--- a/decidim-core/db/migrate/20170807123535_create_decidim_follows.rb
+++ b/decidim-core/db/migrate/20170807123535_create_decidim_follows.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateDecidimFollows < ActiveRecord::Migration[5.1]
+  def change
+    create_table :decidim_follows do |t|
+      t.references :decidim_user, null: false
+      t.references :decidim_followable, polymorphic: true, index: false
+      t.timestamps
+    end
+
+    add_index :decidim_follows,
+              [:decidim_user_id, :decidim_followable_id, :decidim_followable_type],
+              unique: true,
+              name: "index_uniq_on_follows_user_and_followable"
+    add_index :decidim_follows,
+              [:decidim_followable_id, :decidim_followable_type],
+              unique: true,
+              name: "index_uniq_on_followable"
+  end
+end

--- a/decidim-core/db/migrate/20170808071019_create_decidim_notifications.rb
+++ b/decidim-core/db/migrate/20170808071019_create_decidim_notifications.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateDecidimNotifications < ActiveRecord::Migration[5.1]
+  def change
+    create_table :decidim_notifications do |t|
+      t.references :decidim_user, null: false
+      t.references :decidim_followable, polymorphic: true, index: false, null: false
+      t.string :notification_type, null: false
+      t.timestamps
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -28,6 +28,7 @@ module Decidim
   autoload :HasFeature, "decidim/has_feature"
   autoload :HasScope, "decidim/has_scope"
   autoload :HasCategory, "decidim/has_category"
+  autoload :Followable, "decidim/followable"
   autoload :HasReference, "decidim/has_reference"
   autoload :Attributes, "decidim/attributes"
   autoload :StatsRegistry, "decidim/stats_registry"

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -294,4 +294,14 @@ FactoryGirl.define do
     user { build(:user, :managed, organization: admin.organization) }
     started_at Time.current
   end
+
+  factory :follow, class: "Decidim::Follow" do
+    user do
+      build(
+        :user,
+        organization: followable.try(:organization) || build(:organization)
+      )
+    end
+    followable { build(:dummy_resource) }
+  end
 end

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -304,4 +304,15 @@ FactoryGirl.define do
     end
     followable { build(:dummy_resource) }
   end
+
+  factory :notification, class: "Decidim::Notification" do
+    user do
+      build(
+        :user,
+        organization: followable.try(:organization) || build(:organization)
+      )
+    end
+    followable { build(:dummy_resource) }
+    notification_type { followable.class.name.underscore.tr("/", ".") }
+  end
 end

--- a/decidim-core/lib/decidim/followable.rb
+++ b/decidim-core/lib/decidim/followable.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This concern contains the logic related to followable resources. Events happening todo
+  # these resources will generate notifications to the followers.
+  module Followable
+    extend ActiveSupport::Concern
+
+    included do
+      include Decidim::Notifiable
+
+      has_many :follows, as: :followable, foreign_key: "decidim_followable_id", foreign_type: "decidim_followable_type", class_name: "Decidim::Follow"
+      has_many :followers, through: :follows, source: :user
+
+      # Defines when a Followable resource is notifiable. We set this to `true` by default
+      # as it's the basic behaviour, but it can be overridden at each resource model.
+      # Overriding this method can be useful to avoid notifications when, for example,
+      # a proposal author updates the proposal (we don't want them to receive that
+      # notification). This will depend on what events trigger notifications for each
+      # resource, though.
+      #
+      # _context - unused param. Should be a Hash.
+      #
+      # Returns a boolean.
+      def notifiable?(_context)
+        true
+      end
+
+      # Defines which users will receive the notification. This method can be overridden
+      # at each resource model to include or exclude other users, eg. admins.
+      #
+      # Returns an Array.
+      def users_to_notify
+        followers
+      end
+    end
+  end
+end

--- a/decidim-core/spec/models/decidim/follow_spec.rb
+++ b/decidim-core/spec/models/decidim/follow_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Follow, :db do
+  let(:follow) { build(:follow) }
+  subject { follow }
+
+  it { is_expected.to be_valid }
+
+  describe "uniqueness" do
+    let!(:another_follow) { create :follow }
+    let!(:follow) { build :follow, user: another_follow.user, followable: another_follow.followable }
+
+    it "cannot be repeated for user/followable combo" do
+      expect(subject).not_to be_valid
+    end
+  end
+
+  describe "presence" do
+    context "without user" do
+      let(:follow) { build(:follow, user: nil) }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context "without followable" do
+      let(:follow) { build(:follow, followable: nil) }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+end

--- a/decidim-core/spec/models/notification_spec.rb
+++ b/decidim-core/spec/models/notification_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Notification, :db do
+  let(:notification) { build(:notification) }
+  subject { notification }
+
+  it { is_expected.to be_valid }
+
+  context "validations" do
+    context "without user" do
+      let(:notification) { build(:notification, user: nil) }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context "without followable" do
+      let(:notification) { build(:notification, followable: nil) }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
@@ -30,6 +30,7 @@ module Decidim
     include HasCategory
     include HasScope
     include Decidim::Comments::Commentable
+    include Followable
 
     feature_manifest_name "dummy"
 

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -11,6 +11,7 @@ module Decidim
       include Decidim::HasReference
       include Decidim::HasScope
       include Decidim::HasCategory
+      include Decidim::Followable
 
       has_many :registrations, class_name: "Decidim::Meetings::Registration", foreign_key: "decidim_meeting_id"
 


### PR DESCRIPTION
#### :tophat: What? Why?
This is part of a bigger PR, separated so it's easier to review. This PR adds two new models to `core`:

- `Follow` represents the relation between a user and a resource, and means the user is following that resource
- `Notification` is related to a user and a resource and is used to warn the user about changes.

Also, adds a `Followable` module that can be used in different resources (for example, meetings) to identify the users that follow that resource.

This PR does not hold any logic on how to create these resources, it will come in later PRs.

#### :pushpin: Related Issues
- Related to #1692
