### PR TITLE
Feature: follow resources

### DIFF
--- a/decidim-assemblies/app/presenters/decidim/assemblies/assembly_stats_presenter.rb
+++ b/decidim-assemblies/app/presenters/decidim/assemblies/assembly_stats_presenter.rb
@@ -38,7 +38,7 @@ module Decidim
 
       def render_stats_data(feature_manifest, name, data, index)
         safe_join([
-                    index.zero? ? feature_manifest_icon(feature_manifest) : " /&nbsp".html_safe,
+                    index.zero? ? manifest_icon(feature_manifest) : " /&nbsp".html_safe,
                     content_tag(:span, "#{number_with_delimiter(data)} " + I18n.t(name, scope: "decidim.assemblies.statistics"),
                                 class: "#{name} process_stats-text")
                   ])

--- a/decidim-core/app/assets/config/decidim_core_manifest.js
+++ b/decidim-core/app/assets/config/decidim_core_manifest.js
@@ -5,6 +5,7 @@
 //= link decidim/orders
 //= link decidim/map.js
 //= link decidim/map.css
+//= link decidim/notifications.js
 //= link_directory ../../../vendor/assets/javascripts/datepicker-locales
 //= link decidim/widget.js
 //= link decidim/impersonation.js

--- a/decidim-core/app/assets/javascripts/decidim/notifications.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/notifications.js.es6
@@ -1,0 +1,33 @@
+$(() => {
+  const $wrapper = $('#notifications');
+  const $section = $wrapper.find('section#notifications-list');
+  const $noNotificationsText = $wrapper.find('.empty-notifications');
+  const $pagination = $wrapper.find('ul.pagination');
+  const FADEOUT_TIME = 500;
+
+  const anyNotifications = () => $wrapper.find('.card--list__item').length > 0;
+  const emptyNotifications = () => {
+    if (!anyNotifications()) {
+      $section.remove();
+      $noNotificationsText.removeClass('hide');
+    }
+  };
+
+  $section.on('click', '.mark-as-read-button', (event) => {
+    const $item = $(event.target).parents('.card--list__item');
+    $item.fadeOut(FADEOUT_TIME, () => {
+      $item.remove();
+      emptyNotifications();
+    });
+  });
+
+  $wrapper.on('click', '.mark-all-as-read-button', () => {
+    $section.fadeOut(FADEOUT_TIME, () => {
+      $pagination.remove();
+      $wrapper.find('.card--list__item').remove();
+      emptyNotifications();
+    });
+  });
+
+  emptyNotifications();
+});

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_extra.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_extra.scss
@@ -5,6 +5,10 @@
   .button:last-of-type{
     margin-bottom: 0;
   }
+
+  .follow-button {
+    margin-top: 1rem;
+  }
 }
 
 .extra__suport-number{

--- a/decidim-core/app/commands/decidim/create_follow.rb
+++ b/decidim-core/app/commands/decidim/create_follow.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Decidim
+  # A command with all the business logic for when a user starts following a resource.
+  class CreateFollow < Rectify::Command
+    # Public: Initializes the command.
+    #
+    # form         - A form object with the params.
+    # current_user - The current user.
+    def initialize(form, current_user)
+      @form = form
+      @current_user = current_user
+    end
+
+    # Executes the command. Broadcasts these events:
+    #
+    # - :ok when everything is valid, together with the follow.
+    # - :invalid if the form wasn't valid and we couldn't proceed.
+    #
+    # Returns nothing.
+    def call
+      return broadcast(:invalid) if form.invalid?
+
+      create_follow!
+
+      broadcast(:ok, follow)
+    end
+
+    private
+
+    attr_reader :follow, :form, :current_user
+
+    def create_follow!
+      @follow = Follow.create!(
+        followable: form.followable,
+        user: current_user,
+      )
+    end
+  end
+end

--- a/decidim-core/app/commands/decidim/create_follow.rb
+++ b/decidim-core/app/commands/decidim/create_follow.rb
@@ -33,7 +33,7 @@ module Decidim
     def create_follow!
       @follow = Follow.create!(
         followable: form.followable,
-        user: current_user,
+        user: current_user
       )
     end
   end

--- a/decidim-core/app/commands/decidim/delete_follow.rb
+++ b/decidim-core/app/commands/decidim/delete_follow.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Decidim
+  # A command with all the business logic for when a user stops following a resource.
+  class DeleteFollow < Rectify::Command
+    # Public: Initializes the command.
+    #
+    # form         - A form object with the params.
+    # current_user - The current user.
+    def initialize(form, current_user)
+      @form = form
+      @current_user = current_user
+    end
+
+    # Executes the command. Broadcasts these events:
+    #
+    # - :ok when everything is valid, together with the follow.
+    # - :invalid if the form wasn't valid and we couldn't proceed.
+    #
+    # Returns nothing.
+    def call
+      return broadcast(:invalid) if form.invalid?
+
+      delete_follow!
+
+      broadcast(:ok)
+    end
+
+    private
+
+    attr_reader :form, :current_user
+
+    def delete_follow!
+      form.follow.destroy!
+    end
+  end
+end

--- a/decidim-core/app/controllers/decidim/follows_controller.rb
+++ b/decidim-core/app/controllers/decidim/follows_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Decidim
+  class FollowsController < Decidim::ApplicationController
+    include FormFactory
+    before_action :authenticate_user!
+    helper_method :resource
+
+    def destroy
+      @form = form(Decidim::FollowForm).from_params(params)
+      authorize! :delete, @form.follow
+
+      DeleteFollow.call(@form, current_user) do
+        on(:ok) do
+          render :update_button
+        end
+
+        on(:invalid) do
+          render json: { error: I18n.t("follows.destroy.error", scope: "decidim") }, status: 422
+        end
+      end
+    end
+
+    def create
+      @form = form(Decidim::FollowForm).from_params(params)
+      authorize! :create, Follow
+
+      CreateFollow.call(@form, current_user) do
+        on(:ok) do
+          render :update_button
+        end
+
+        on(:invalid) do
+          render json: { error: I18n.t("follows.create.error", scope: "decidim") }, status: 422
+        end
+      end
+    end
+
+    def resource
+      @resource ||= GlobalID::Locator.locate_signed(
+        params[:follow][:followable_gid]
+      )
+    end
+  end
+end

--- a/decidim-core/app/controllers/decidim/notifications_controller.rb
+++ b/decidim-core/app/controllers/decidim/notifications_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Decidim
+  # The controller to handle the user's notifications dashboard.
+  class NotificationsController < Decidim::ApplicationController
+    helper Decidim::IconHelper
+    helper Decidim::PaginateHelper
+    include Paginable
+
+    helper_method :notifications
+
+    def index
+      authorize! :read, Notification
+      @notifications = paginate(notifications)
+    end
+
+    def destroy
+      notification = notifications.find(params[:id])
+      authorize! :destroy, notification
+      notification.destroy
+    end
+
+    def read_all
+      authorize! :destroy, notifications.first
+      notifications.destroy_all
+    end
+
+    private
+
+    def notifications
+      @notifications ||= current_user.notifications.order(created_at: :desc)
+    end
+
+    # Private: overwrites the amount of elements per page.
+    def per_page
+      50
+    end
+  end
+end

--- a/decidim-core/app/forms/decidim/follow_form.rb
+++ b/decidim-core/app/forms/decidim/follow_form.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Decidim
+  # A form object to be used when users want to follow a followable resource.
+  class FollowForm < Decidim::Form
+    mimic :follow
+
+    attribute :followable_gid, String
+
+    validates :followable_gid, :followable, presence: true
+
+    def followable
+      @followable ||= GlobalID::Locator.locate_signed followable_gid
+    end
+
+    def follow
+      @follow ||= Decidim::Follow.where(user: current_user, followable: followable).first
+    end
+  end
+end

--- a/decidim-core/app/helpers/decidim/icon_helper.rb
+++ b/decidim-core/app/helpers/decidim/icon_helper.rb
@@ -7,23 +7,41 @@ module Decidim
     # a question mark when no icon is found.
     #
     # feature - The feature to generate the icon for.
+    # options - a Hash with options
     #
     # Returns an HTML tag with the icon.
-    def feature_icon(feature)
-      feature_manifest_icon(feature.manifest)
+    def feature_icon(feature, options = {})
+      manifest_icon(feature.manifest, options)
     end
 
-    # Public: Returns an icon given an instance of a Feature Manifest. It defaults to
+    # Public: Returns an icon given an instance of a Manifest. It defaults to
     # a question mark when no icon is found.
     #
-    # feature_manifest - The feature manifest to generate the icon for.
+    # manifest - The manifest to generate the icon for.
+    # options - a Hash with options
     #
     # Returns an HTML tag with the icon.
-    def feature_manifest_icon(feature_manifest)
-      if feature_manifest.icon
-        external_icon feature_manifest.icon
+    def manifest_icon(manifest, options = {})
+      if manifest.icon
+        external_icon manifest.icon, options
       else
-        icon "question-mark"
+        icon "question-mark", options
+      end
+    end
+
+    # Public: Finds the correct icon for the given resource. If the resource has a
+    # Feature then it uses it to find the icon, otherwise checks for the resource
+    # manifest to find the icon.
+    #
+    # resource - The resource to generate the icon for.
+    # options - a Hash with options
+    #
+    # Returns an HTML tag with the icon.
+    def resource_icon(resource, options = {})
+      if resource.respond_to?(:feature)
+        feature_icon(resource.feature, options)
+      else
+        manifest_icon(resource.manifest, options)
       end
     end
   end

--- a/decidim-core/app/helpers/decidim/paginate_helper.rb
+++ b/decidim-core/app/helpers/decidim/paginate_helper.rb
@@ -8,7 +8,7 @@ module Decidim
     #
     # collection - a collection of elements that need to be paginated
     # paginate_params - a Hash with options to delegate to the pagination helper.
-    def decidim_paginate(collection, paginate_params)
+    def decidim_paginate(collection, paginate_params = {})
       # Kaminari uses url_for to generate the url, but this doesn't play nice with our engine system
       # and unless we remove these params they are added again as query string :(
       default_params = {

--- a/decidim-core/app/jobs/decidim/email_notification_generator_job.rb
+++ b/decidim-core/app/jobs/decidim/email_notification_generator_job.rb
@@ -4,9 +4,9 @@ module Decidim
   class EmailNotificationGeneratorJob < ApplicationJob
     queue_as :decidim_events
 
-    def perform(event, event_class_name, followable, recipient_ids)
+    def perform(event, event_class_name, resource, recipient_ids)
       event_class = event_class_name.constantize
-      EmailNotificationGenerator.new(event, event_class, followable, recipient_ids).generate
+      EmailNotificationGenerator.new(event, event_class, resource, recipient_ids).generate
     end
   end
 end

--- a/decidim-core/app/jobs/decidim/email_notification_generator_job.rb
+++ b/decidim-core/app/jobs/decidim/email_notification_generator_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Decidim
+  class EmailNotificationGeneratorJob < ApplicationJob
+    queue_as :decidim_events
+
+    def perform(event, event_class_name, followable, recipient_ids)
+      event_class = event_class_name.constantize
+      EmailNotificationGenerator.new(event, event_class, followable, recipient_ids).generate
+    end
+  end
+end

--- a/decidim-core/app/jobs/decidim/notification_generator_for_recipient_job.rb
+++ b/decidim-core/app/jobs/decidim/notification_generator_for_recipient_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Decidim
+  class NotificationGeneratorForRecipientJob < ApplicationJob
+    queue_as :decidim_events
+
+    def perform(event, event_class, resource, recipient_id)
+      NotificationGeneratorForRecipient
+        .new(event, event_class, resource, recipient_id)
+        .generate
+    end
+  end
+end

--- a/decidim-core/app/jobs/decidim/notification_generator_for_recipient_job.rb
+++ b/decidim-core/app/jobs/decidim/notification_generator_for_recipient_job.rb
@@ -4,7 +4,8 @@ module Decidim
   class NotificationGeneratorForRecipientJob < ApplicationJob
     queue_as :decidim_events
 
-    def perform(event, event_class, resource, recipient_id)
+    def perform(event, event_class_name, resource, recipient_id)
+      event_class = event_class_name.constantize
       NotificationGeneratorForRecipient
         .new(event, event_class, resource, recipient_id)
         .generate

--- a/decidim-core/app/jobs/decidim/notification_generator_job.rb
+++ b/decidim-core/app/jobs/decidim/notification_generator_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Decidim
+  class NotificationGeneratorJob < ApplicationJob
+    queue_as :decidim_events
+
+    def perform(event, event_class_name, followable, recipient_ids)
+      event_class = event_class_name.constantize
+      NotificationGenerator.new(event, event_class, followable, recipient_ids).generate
+    end
+  end
+end

--- a/decidim-core/app/jobs/decidim/notification_generator_job.rb
+++ b/decidim-core/app/jobs/decidim/notification_generator_job.rb
@@ -4,9 +4,9 @@ module Decidim
   class NotificationGeneratorJob < ApplicationJob
     queue_as :decidim_events
 
-    def perform(event, event_class_name, followable, recipient_ids)
+    def perform(event, event_class_name, resource, recipient_ids)
       event_class = event_class_name.constantize
-      NotificationGenerator.new(event, event_class, followable, recipient_ids).generate
+      NotificationGenerator.new(event, event_class, resource, recipient_ids).generate
     end
   end
 end

--- a/decidim-core/app/mailers/decidim/notification_mailer.rb
+++ b/decidim-core/app/mailers/decidim/notification_mailer.rb
@@ -8,7 +8,6 @@ module Decidim
 
     def event_received(event, event_class_name, resource, user)
       with_user(user) do
-        @locator = Decidim::ResourceLocatorPresenter.new(resource)
         @organization = resource.organization
         event_class = event_class_name.constantize
         @event_instance = event_class.new(resource: resource, event_name: event, user: user)

--- a/decidim-core/app/mailers/decidim/notification_mailer.rb
+++ b/decidim-core/app/mailers/decidim/notification_mailer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Decidim
+  # A custom mailer for sending notifications to users when
+  # a events are received.
+  class NotificationMailer < Decidim::ApplicationMailer
+    helper Decidim::ResourceHelper
+
+    def event_received(event, event_class_name, resource, user)
+      with_user(user) do
+        @locator = Decidim::ResourceLocatorPresenter.new(resource)
+        @organization = resource.organization
+        event_class = event_class_name.constantize
+        @event_instance = event_class.new(resource: resource, event_name: event, user: user)
+        subject = @event_instance.email_subject
+
+        mail(to: user.email, subject: subject)
+      end
+    end
+  end
+end

--- a/decidim-core/app/models/decidim/abilities/base_ability.rb
+++ b/decidim-core/app/models/decidim/abilities/base_ability.rb
@@ -29,6 +29,10 @@ module Decidim
           authorization.user == user
         end
 
+        can :manage, Follow do |follow|
+          follow.user == user
+        end
+
         can :manage, Notification do |notification|
           notification.user == user
         end

--- a/decidim-core/app/models/decidim/abilities/base_ability.rb
+++ b/decidim-core/app/models/decidim/abilities/base_ability.rb
@@ -28,6 +28,10 @@ module Decidim
         can :manage, Authorization do |authorization|
           authorization.user == user
         end
+
+        can :manage, Notification do |notification|
+          notification.user == user
+        end
       end
     end
   end

--- a/decidim-core/app/models/decidim/follow.rb
+++ b/decidim-core/app/models/decidim/follow.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Decidim
+  class Follow < ApplicationRecord
+    belongs_to :followable, foreign_key: "decidim_followable_id", foreign_type: "decidim_followable_type", polymorphic: true
+    belongs_to :user, foreign_key: "decidim_user_id", class_name: "Decidim::User"
+
+    validates :user, uniqueness: { scope: [:followable] }
+  end
+end

--- a/decidim-core/app/models/decidim/notification.rb
+++ b/decidim-core/app/models/decidim/notification.rb
@@ -2,7 +2,11 @@
 
 module Decidim
   class Notification < ApplicationRecord
-    belongs_to :followable, foreign_key: "decidim_followable_id", foreign_type: "decidim_followable_type", polymorphic: true
+    belongs_to :resource, foreign_key: "decidim_resource_id", foreign_type: "decidim_resource_type", polymorphic: true
     belongs_to :user, foreign_key: "decidim_user_id", class_name: "Decidim::User"
+
+    def event_class_instance
+      @event_class_instance ||= event_class.constantize.new(resource: resource, event_name: event_name, user: user)
+    end
   end
 end

--- a/decidim-core/app/models/decidim/notification.rb
+++ b/decidim-core/app/models/decidim/notification.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Decidim
+  class Notification < ApplicationRecord
+    belongs_to :followable, foreign_key: "decidim_followable_id", foreign_type: "decidim_followable_type", polymorphic: true
+    belongs_to :user, foreign_key: "decidim_user_id", class_name: "Decidim::User"
+  end
+end

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -64,6 +64,10 @@ module Decidim
       deleted_at.present?
     end
 
+    def follows?(followable)
+      Decidim::Follow.where(user: self, followable: followable).any?
+    end
+
     # Check if the user exists with the given email and the current organization
     #
     # warden_conditions - A hash with the authentication conditions

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -18,6 +18,8 @@ module Decidim
     has_many :identities, foreign_key: "decidim_user_id", class_name: "Decidim::Identity"
     has_many :memberships, class_name: "Decidim::UserGroupMembership", foreign_key: :decidim_user_id
     has_many :user_groups, through: :memberships, class_name: "Decidim::UserGroup", foreign_key: :decidim_user_group_id
+    has_many :follows, foreign_key: "decidim_user_id", class_name: "Decidim::Follow", dependent: :destroy
+    has_many :notifications, foreign_key: "decidim_user_id", class_name: "Decidim::Notification", dependent: :destroy
 
     validates :name, presence: true, unless: -> { deleted? }
     validates :locale, inclusion: { in: :available_locales }, allow_blank: true

--- a/decidim-core/app/services/decidim/email_notification_generator.rb
+++ b/decidim-core/app/services/decidim/email_notification_generator.rb
@@ -3,10 +3,10 @@
 module Decidim
   # This class handles system events affecting resources and generates a
   # notification for each recipient by scheduling a new
-  # `Decidim::NotificationGeneratorForRecipientJob` job for each of them. This way
-  # we can easily control which jobs fail and retry them, so that we don't have
+  # `Decidim::NotificationMailer` job for each of them. This way we can
+  # easily control which jobs fail and retry them, so that we don't have
   # duplicated notifications.
-  class NotificationGenerator
+  class EmailNotificationGenerator
     # Initializes the class.
     #
     # event - A String with the name of the event.
@@ -19,16 +19,16 @@ module Decidim
       @recipient_ids = recipient_ids
     end
 
-    # Schedules a job for each recipient to create the notification. Returns `nil`
+    # Schedules a job for each recipient to send the email. Returns `nil`
     # if the resource is not resource or if it is not present.
     #
     # Returns nothing.
     def generate
       return unless resource
-      return unless event_class.types.include?(:notification)
+      return unless event_class.types.include?(:email)
 
       recipient_ids.each do |recipient_id|
-        generate_notification_for(recipient_id)
+        send_email_to(recipient_id)
       end
     end
 
@@ -36,13 +36,18 @@ module Decidim
 
     attr_reader :event, :event_class, :resource, :recipient_ids
 
-    def generate_notification_for(recipient_id)
-      NotificationGeneratorForRecipientJob.perform_later(
-        event,
-        event_class.name,
-        resource,
-        recipient_id
-      )
+    def send_email_to(recipient_id)
+      recipient = Decidim::User.where(id: recipient_id).first
+      return unless recipient
+
+      NotificationMailer
+        .event_received(
+          event,
+          event_class.name,
+          resource,
+          recipient
+        )
+        .deliver_later
     end
   end
 end

--- a/decidim-core/app/services/decidim/events_manager.rb
+++ b/decidim-core/app/services/decidim/events_manager.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This class acts as a wrapper of `ActiveSupport::Notifications`, so that if
+  # we ever need to change the API we just have to change it in a single point.
+  class EventsManager
+    # Publishes a event through the events channel. It requires  the name of an
+    # event, a class that handles the event and the resource that received the action.
+    #
+    # event - a String representing the event that has happened. Ideally, it should
+    #   start with `decidim.events` and include the name of the engine that publishes
+    #   it.
+    # event_class - The event class must be a class that wraps the event name and
+    #   the resource and builds the needed information to publish the event to
+    #   the different subscribers in the system.
+    # resource - an instance of a class that received the event.
+    # user - the User that performed the event.
+    #
+    # Returns nothing.
+    def self.publish(event:, event_class: Decidim::Events::BaseEvent, resource:, user:)
+      ActiveSupport::Notifications.publish(
+        event,
+        event_class: event_class.name,
+        resource: resource,
+        user: user
+      )
+    end
+  end
+end

--- a/decidim-core/app/services/decidim/events_manager.rb
+++ b/decidim-core/app/services/decidim/events_manager.rb
@@ -15,15 +15,27 @@ module Decidim
     #   the different subscribers in the system.
     # resource - an instance of a class that received the event.
     # user - the User that performed the event.
+    # recipient_ids - an Array of IDs of the users that will receive the event
     #
     # Returns nothing.
-    def self.publish(event:, event_class: Decidim::Events::BaseEvent, resource:, user:)
+    def self.publish(event:, event_class: Decidim::Events::BaseEvent, resource:, user:, recipient_ids:)
       ActiveSupport::Notifications.publish(
         event,
         event_class: event_class.name,
         resource: resource,
-        user: user
+        user: user,
+        recipient_ids: recipient_ids
       )
+    end
+
+    # Subscribes to the given event, and runs the block every time that event
+    # is received.
+    #
+    # event_name - a String or a RegExp to match against event names.
+    #
+    # Returns nothing.
+    def self.subscribe(event_name, &block)
+      ActiveSupport::Notifications.subscribe(event_name, &block)
     end
   end
 end

--- a/decidim-core/app/services/decidim/notification_generator.rb
+++ b/decidim-core/app/services/decidim/notification_generator.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This class handles system events affecting `Decidim::Resource` resources and
+  # generates a notification for each recipient by scheduling a new
+  # `Decidim::NotificationGeneratorForRecipientJob` job for each of them. This way
+  # we can easily control which jobs fail and retry them, so that we don't have
+  # duplicated notifications.
+  class NotificationGenerator
+    # Initializes the class.
+    #
+    # event - A String with the name of the event.
+    # event_class - A class that wraps the event.
+    # resource - an instance of a class implementing the `Decidim::Resource` concern.
+    def initialize(event, event_class, resource, recipient_ids)
+      @event = event
+      @event_class = event_class
+      @resource = resource
+      @recipient_ids = recipient_ids
+    end
+
+    # Schedules a job for each recipient to create the notification. Returns `nil`
+    # if the resource is not resource or if it is not present.
+    #
+    # Returns a Decidim::Notification.
+    def generate
+      return unless resource
+      return unless event_class.types.include?(:notification)
+
+      recipient_ids.each do |recipient_id|
+        generate_notification_for(recipient_id)
+      end
+    end
+
+    private
+
+    attr_reader :event, :event_class, :resource, :recipient_ids
+
+    def generate_notification_for(recipient_id)
+      NotificationGeneratorForRecipientJob.perform_later(
+        event,
+        event_class,
+        resource,
+        recipient_id
+      )
+    end
+  end
+end

--- a/decidim-core/app/services/decidim/notification_generator_for_recipient.rb
+++ b/decidim-core/app/services/decidim/notification_generator_for_recipient.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This class generates a notification based on the given event, for the given
+  # resource/recipient couple. It is intended to be used by the
+  # `Decidim::NotificationGenerator` class, which schedules a job for each recipient
+  # of the event, so that we can easily control which jobs fail.
+  class NotificationGeneratorForRecipient
+    # Initializes the class.
+    #
+    # event - A String with the name of the event.
+    # event_class - The class that wraps the event, in order to decorate it.
+    # resource - an instance of a class implementing the `Decidim::Resource` concern.
+    # recipient - the ID of the User that will receive the notification.
+    def initialize(event, event_class, resource, recipient_id)
+      @event = event
+      @event_class = event_class
+      @resource = resource
+      @recipient_id = recipient_id
+    end
+
+    # Generates the notification. Returns `nil` if the resource is not resource
+    # or if the resource or the user are not present. It also checks if the resource
+    # resource is notifiable for the given recipient, as sometimes we might not want to
+    # generate a notification for a given user (a commenter replying to their own comment,
+    # or a proposal author updating their own proposal for example).
+    #
+    # Returns a Decidim::Notification.
+    def generate
+      return unless event_class
+      return unless resource
+      return unless recipient
+      return unless resource.notifiable?(recipient: recipient, event: event)
+
+      Notification.create!(
+        user: recipient,
+        event_class: event_class,
+        followable: resource,
+        notification_type: event
+      )
+    end
+
+    private
+
+    attr_reader :event, :event_class, :resource, :recipient_id
+
+    def recipient
+      @recipient ||= User.where(id: recipient_id).first
+    end
+  end
+end

--- a/decidim-core/app/services/decidim/notification_generator_for_recipient.rb
+++ b/decidim-core/app/services/decidim/notification_generator_for_recipient.rb
@@ -35,8 +35,8 @@ module Decidim
       Notification.create!(
         user: recipient,
         event_class: event_class,
-        followable: resource,
-        notification_type: event
+        resource: resource,
+        event_name: event
       )
     end
 

--- a/decidim-core/app/views/decidim/follows/update_button.js.erb
+++ b/decidim-core/app/views/decidim/follows/update_button.js.erb
@@ -1,0 +1,1 @@
+$("#follow-resource").html("<%= j(render partial: "decidim/shared/follow_button", locals: { followable: resource } ) %>");

--- a/decidim-core/app/views/decidim/notification_mailer/event_received.html.erb
+++ b/decidim-core/app/views/decidim/notification_mailer/event_received.html.erb
@@ -1,0 +1,9 @@
+<p><%= @event_instance.email_greeting %></p>
+
+<p><%= @event_instance.email_intro %></p>
+
+<p>
+  <%= link_to @locator.url, @locator.url %>
+</p>
+
+<p><%= @event_instance.email_outro %></p>

--- a/decidim-core/app/views/decidim/notification_mailer/event_received.html.erb
+++ b/decidim-core/app/views/decidim/notification_mailer/event_received.html.erb
@@ -3,7 +3,7 @@
 <p><%= @event_instance.email_intro %></p>
 
 <p>
-  <%= link_to @locator.url, @locator.url %>
+  <%= link_to @event_instance.resource_url, @event_instance.resource_url %>
 </p>
 
 <p><%= @event_instance.email_outro %></p>

--- a/decidim-core/app/views/decidim/notifications/_notification.html.erb
+++ b/decidim-core/app/views/decidim/notifications/_notification.html.erb
@@ -1,0 +1,18 @@
+<div class="card--list__item">
+  <div class="card--list__text">
+    <%= link_to notification.event_class_instance.resource_path do %>
+      <%= resource_icon notification.resource, class: "icon--chat card--list__icon" %>
+    <% end %>
+    <div>
+      <h5 class="card--list__heading">
+        <%= notification.event_class_instance.notification_title %>
+      </h5>
+      <span class="text-small"><%= l notification.created_at.to_date, format: :long %></span>
+    </div>
+  </div>
+  <div class="card--list__data">
+    <%= link_to notification, class: "mark-as-read-button card--list__data__icon", remote: true, method: :delete do %>
+      <%= icon "check", class: "icon icon--chevron-right" %>
+    <% end %>
+  </div>
+</div>

--- a/decidim-core/app/views/decidim/notifications/index.html.erb
+++ b/decidim-core/app/views/decidim/notifications/index.html.erb
@@ -1,0 +1,32 @@
+<main class="wrapper" id="notifications">
+  <div class="row collapse">
+    <div class="columns">
+      <div class="title-action" >
+        <h1 class="heading1 title-action__title"><%= t("title", scope: "layouts.decidim.notifications_dashboard") %></h1>
+        <%= link_to(
+          t("mark_all_as_read", scope: "layouts.decidim.notifications_dashboard"),
+          decidim.read_all_notifications_path,
+          class: "button title-action__action hollow mark-all-as-read-button",
+          method: :delete,
+          data: { disable: true },
+          remote: true
+        ) %>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="columns mediumlarge-12 large-12">
+      <p class="empty-notifications hide"><%= t("no_notifications", scope: "layouts.decidim.notifications_dashboard") %></p>
+      <% if notifications.any? %>
+        <section class="section" id="notifications-list">
+          <div class="card card--list">
+            <%= render notifications %>
+          </div>
+        </section>
+        <%= decidim_paginate notifications %>
+      <% end %>
+    </div>
+  </div>
+</main>
+
+<%= javascript_include_tag "decidim/notifications" %>

--- a/decidim-core/app/views/decidim/shared/_follow_button.html.erb
+++ b/decidim-core/app/views/decidim/shared/_follow_button.html.erb
@@ -1,0 +1,17 @@
+<% if current_user %>
+  <% if current_user.follows?(followable) %>
+    <%= button_to decidim.follow_path, class: "button secondary hollow expanded small button--icon follow-button", params: { follow: { followable_gid: followable.to_sgid.to_s }}, data: { disable: true }, method: :delete, remote: true do %>
+      <%= icon "bell" %>
+      <span>
+        <%= t("follows.destroy.button", scope: "decidim") %>
+      </span>
+    <% end %>
+  <% else %>
+    <%= button_to decidim.follow_path, class: "button secondary hollow expanded small button--icon follow-button", params: { follow: { followable_gid: followable.to_sgid.to_s }}, data: { disable: true }, remote: true do %>
+      <%= icon "bell" %>
+      <span>
+        <%= t("follows.create.button", scope: "decidim") %>
+      </span>
+    <% end %>
+  <% end %>
+<% end %>

--- a/decidim-core/app/views/layouts/decidim/_user_menu.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_user_menu.html.erb
@@ -1,4 +1,5 @@
 <li><%= link_to t(".profile"), decidim.account_path %></li>
+<li><%= link_to t(".notifications"), decidim.notifications_path %></li>
 <% if can? :read, :admin_dashboard %>
   <li><%= link_to t(".admin_dashboard"), decidim_admin.root_path %></li>
 <% end %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -133,6 +133,8 @@ en:
         email_intro: 'There has been an update to "%{resource_title}". You can see it from this page:'
         email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
         email_subject: An update to %{resource_title}
+      notification_event:
+        notification_title: An event occured to <a href="%{resource_path}">%{resource_title}</a>.
     export_mailer:
       export:
         ready: Please find attached a zipped version of your export.
@@ -306,8 +308,13 @@ en:
         close_session: Close session
         description_html: You are impersonating the user <b>%{user_name}</b>.
         expire_time_html: Your session will expire in <b><span class="minutes">%{minutes}</span> minutes</b>.
+      notifications_dashboard:
+        mark_all_as_read: Mark all as read
+        no_notifications: No notifications yet.
+        title: Notifications
       user_menu:
         admin_dashboard: Admin dashboard
+        notifications: Notifications
         profile: My account
         sign_out: Sign out
       user_profile:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -127,6 +127,12 @@ en:
         back_home: Back home
         content_doesnt_exist: This address is incorrect or has been removed.
         title: The page you're looking for can't be found
+    events:
+      email_event:
+        email_greeting: Hello %{user_name},
+        email_intro: 'There has been an update to "%{resource_title}". You can see it from this page:'
+        email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
+        email_subject: An update to %{resource_title}
     export_mailer:
       export:
         ready: Please find attached a zipped version of your export.

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -161,6 +161,13 @@ en:
         project: Projects
         proposal: Proposals
         result: Results
+    follows:
+      create:
+        button: Follow
+        error: There has been an error following this resource.
+      destroy:
+        button: Stop following
+        error: There has been an error unfollowing this resource.
     forms:
       current_file: Current file
       current_image: Current image

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -56,6 +56,7 @@ Decidim::Core::Engine.routes.draw do
   match "/404", to: "errors#not_found", via: :all
   match "/500", to: "errors#internal_server_error", via: :all
 
+  resource :follow, only: [:create, :destroy]
   resource :report, only: [:create]
 
   root to: "pages#show", id: "home"

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -37,6 +37,11 @@ Decidim::Core::Engine.routes.draw do
         get :delete
       end
     end
+    resources :notifications, only: [:index, :destroy] do
+      collection do
+        delete :read_all
+      end
+    end
     resource :notifications_settings, only: [:show, :update], controller: "notifications_settings"
     resources :own_user_groups, only: [:index]
   end

--- a/decidim-core/db/migrate/20170807123535_create_decidim_follows.rb
+++ b/decidim-core/db/migrate/20170807123535_create_decidim_follows.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateDecidimFollows < ActiveRecord::Migration[5.1]
+  def change
+    create_table :decidim_follows do |t|
+      t.references :decidim_user, null: false
+      t.references :decidim_followable, polymorphic: true, index: false
+      t.timestamps
+    end
+
+    add_index :decidim_follows,
+              [:decidim_user_id, :decidim_followable_id, :decidim_followable_type],
+              unique: true,
+              name: "index_uniq_on_follows_user_and_followable"
+    add_index :decidim_follows,
+              [:decidim_followable_id, :decidim_followable_type],
+              unique: true,
+              name: "index_uniq_on_followable"
+  end
+end

--- a/decidim-core/db/migrate/20170808071019_create_decidim_notifications.rb
+++ b/decidim-core/db/migrate/20170808071019_create_decidim_notifications.rb
@@ -4,8 +4,8 @@ class CreateDecidimNotifications < ActiveRecord::Migration[5.1]
   def change
     create_table :decidim_notifications do |t|
       t.references :decidim_user, null: false
-      t.references :decidim_followable, polymorphic: true, index: false, null: false
-      t.string :notification_type, null: false
+      t.references :decidim_resource, polymorphic: true, index: false, null: false
+      t.string :event_name, null: false
       t.string :event_class, null: false
       t.timestamps
     end

--- a/decidim-core/db/migrate/20170808071019_create_decidim_notifications.rb
+++ b/decidim-core/db/migrate/20170808071019_create_decidim_notifications.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateDecidimNotifications < ActiveRecord::Migration[5.1]
+  def change
+    create_table :decidim_notifications do |t|
+      t.references :decidim_user, null: false
+      t.references :decidim_followable, polymorphic: true, index: false, null: false
+      t.string :notification_type, null: false
+      t.timestamps
+    end
+  end
+end

--- a/decidim-core/db/migrate/20170808071019_create_decidim_notifications.rb
+++ b/decidim-core/db/migrate/20170808071019_create_decidim_notifications.rb
@@ -6,6 +6,7 @@ class CreateDecidimNotifications < ActiveRecord::Migration[5.1]
       t.references :decidim_user, null: false
       t.references :decidim_followable, polymorphic: true, index: false, null: false
       t.string :notification_type, null: false
+      t.string :event_class, null: false
       t.timestamps
     end
   end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "decidim/core/engine"

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 require "decidim/core/engine"
@@ -40,6 +41,7 @@ module Decidim
   autoload :ManifestRegistry, "decidim/manifest_registry"
   autoload :Abilities, "decidim/abilities"
   autoload :EngineRouter, "decidim/engine_router"
+  autoload :Events, "decidim/events"
 
   include ActiveSupport::Configurable
 

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -28,6 +28,7 @@ module Decidim
   autoload :HasFeature, "decidim/has_feature"
   autoload :HasScope, "decidim/has_scope"
   autoload :HasCategory, "decidim/has_category"
+  autoload :Followable, "decidim/followable"
   autoload :HasReference, "decidim/has_reference"
   autoload :Attributes, "decidim/attributes"
   autoload :StatsRegistry, "decidim/stats_registry"

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -151,6 +151,17 @@ module Decidim
                     active: :inclusive
         end
       end
+
+      initializer "decidim.notifications" do
+        Decidim::EventsManager.subscribe(/^decidim\.events\./) do |event, data|
+          NotificationGeneratorJob.perform_later(
+            event,
+            data[:event_class],
+            data[:resource],
+            data[:recipient_ids]
+          )
+        end
+      end
     end
   end
 end

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -154,6 +154,12 @@ module Decidim
 
       initializer "decidim.notifications" do
         Decidim::EventsManager.subscribe(/^decidim\.events\./) do |event, data|
+          EmailNotificationGeneratorJob.perform_later(
+            event,
+            data[:event_class],
+            data[:resource],
+            data[:recipient_ids]
+          )
           NotificationGeneratorJob.perform_later(
             event,
             data[:event_class],

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -314,5 +314,6 @@ FactoryGirl.define do
     end
     followable { build(:dummy_resource) }
     notification_type { followable.class.name.underscore.tr("/", ".") }
+    event_class { "Decidim::Events::BaseEvent" }
   end
 end

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -309,11 +309,11 @@ FactoryGirl.define do
     user do
       build(
         :user,
-        organization: followable.try(:organization) || build(:organization)
+        organization: resource.try(:organization) || build(:organization)
       )
     end
-    followable { build(:dummy_resource) }
-    notification_type { followable.class.name.underscore.tr("/", ".") }
-    event_class { "Decidim::Events::BaseEvent" }
+    resource { build(:dummy_resource) }
+    event_name { resource.class.name.underscore.tr("/", ".") }
+    event_class { "Decidim::DummyResourceEvent" }
   end
 end

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -294,4 +294,25 @@ FactoryGirl.define do
     user { build(:user, :managed, organization: admin.organization) }
     started_at Time.current
   end
+
+  factory :follow, class: "Decidim::Follow" do
+    user do
+      build(
+        :user,
+        organization: followable.try(:organization) || build(:organization)
+      )
+    end
+    followable { build(:dummy_resource) }
+  end
+
+  factory :notification, class: "Decidim::Notification" do
+    user do
+      build(
+        :user,
+        organization: followable.try(:organization) || build(:organization)
+      )
+    end
+    followable { build(:dummy_resource) }
+    notification_type { followable.class.name.underscore.tr("/", ".") }
+  end
 end

--- a/decidim-core/lib/decidim/events.rb
+++ b/decidim-core/lib/decidim/events.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Events
+    autoload :BaseEvent, "decidim/events/base_event"
+  end
+end

--- a/decidim-core/lib/decidim/events.rb
+++ b/decidim-core/lib/decidim/events.rb
@@ -3,6 +3,7 @@
 module Decidim
   module Events
     autoload :BaseEvent, "decidim/events/base_event"
+    autoload :EmailEvent, "decidim/events/email_event"
     autoload :NotificationEvent, "decidim/events/notification_event"
   end
 end

--- a/decidim-core/lib/decidim/events.rb
+++ b/decidim-core/lib/decidim/events.rb
@@ -3,5 +3,6 @@
 module Decidim
   module Events
     autoload :BaseEvent, "decidim/events/base_event"
+    autoload :NotificationEvent, "decidim/events/notification_event"
   end
 end

--- a/decidim-core/lib/decidim/events/base_event.rb
+++ b/decidim-core/lib/decidim/events/base_event.rb
@@ -40,9 +40,29 @@ module Decidim
         @user = user
       end
 
+      # Caches the locator for the given resource, so that
+      # we can find the resource URL.
+      def resource_locator
+        @resource_locator ||= Decidim::ResourceLocatorPresenter.new(resource)
+      end
+
+      # Caches the path for the given resource.
+      def resource_path
+        @resource_path ||= resource_locator.path
+      end
+
+      # Caches the URL for the given resource.
+      def resource_url
+        @resource_url ||= resource_locator.url
+      end
+
       private
 
       attr_reader :event_name, :resource, :user
+
+      def resource_title
+        resource.title.is_a?(Hash) ? resource.title[I18n.locale.to_s] : resource.title
+      end
     end
   end
 end

--- a/decidim-core/lib/decidim/events/base_event.rb
+++ b/decidim-core/lib/decidim/events/base_event.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Events
+    # This class serves as a base for all event classes. Event classes are intended to
+    # add more logic to a `Decidim::Notification` and are used to render them in the
+    # notifications dashboard and to generate other notifications (emails, for example).
+    class BaseEvent
+      # Initializes the class.
+      #
+      # event_name - a String with the name of the event.
+      # payload - a Hash with extra data from the event.
+      def initialize(event_name, payload)
+        @event_name = event_name
+        @payload = payload
+      end
+
+      private
+
+      attr_reader :event_name, :payload
+    end
+  end
+end

--- a/decidim-core/lib/decidim/events/base_event.rb
+++ b/decidim-core/lib/decidim/events/base_event.rb
@@ -32,15 +32,17 @@ module Decidim
       # Initializes the class.
       #
       # event_name - a String with the name of the event.
-      # payload - a Hash with extra data from the event.
-      def initialize(event_name, payload)
+      # resource - the resource that received the event
+      # user - the User that receives the event
+      def initialize(resource:, event_name:, user:)
         @event_name = event_name
-        @payload = payload
+        @resource = resource
+        @user = user
       end
 
       private
 
-      attr_reader :event_name, :payload
+      attr_reader :event_name, :resource, :user
     end
   end
 end

--- a/decidim-core/lib/decidim/events/base_event.rb
+++ b/decidim-core/lib/decidim/events/base_event.rb
@@ -6,6 +6,29 @@ module Decidim
     # add more logic to a `Decidim::Notification` and are used to render them in the
     # notifications dashboard and to generate other notifications (emails, for example).
     class BaseEvent
+      # Public: Stores all the notification types this event can create. Please, do not
+      # overwrite this method, consider it final. Instead, add values to the array via
+      # modules, take the `NotificationEvent` module as an example:
+      #
+      # Example:
+      #
+      #   module WebPushNotificationEvent
+      #     extend ActiveSupport::Concern
+      #
+      #     included do
+      #       types << :web_push_notifications
+      #     end
+      #   end
+      #
+      #   class MyEvent < Decidim::Events::BaseEvent
+      #     include WebPushNotificationEvent
+      #   end
+      #
+      #   MyEvent.types # => [:web_push_notifications]
+      def self.types
+        @types ||= []
+      end
+
       # Initializes the class.
       #
       # event_name - a String with the name of the event.

--- a/decidim-core/lib/decidim/events/email_event.rb
+++ b/decidim-core/lib/decidim/events/email_event.rb
@@ -33,12 +33,6 @@ module Decidim
         def email_outro
           I18n.t("decidim.events.email_event.email_outro", resource_title: resource_title)
         end
-
-        private
-
-        def resource_title
-          resource.title.is_a?(Hash) ? resource.title[I18n.locale.to_s] : resource.title
-        end
       end
     end
   end

--- a/decidim-core/lib/decidim/events/email_event.rb
+++ b/decidim-core/lib/decidim/events/email_event.rb
@@ -1,0 +1,45 @@
+# frozen-string_literal: true
+
+module Decidim
+  module Events
+    # This module is used to be included in event classes (those inheriting from
+    # `Decidim::Events::BaseEvent`) that need to send emails with the notification.
+    #
+    # This modules adds the needed logic to deliver emails to a given user.
+    #
+    # Example:
+    #
+    #   class MyEvent < Decidim::Events::BaseEvent
+    #     include Decidim::Events::EmailEvent
+    #   end
+    module EmailEvent
+      extend ActiveSupport::Concern
+
+      included do
+        types << :email
+
+        def email_subject
+          I18n.t("decidim.events.email_event.email_subject", resource_title: resource_title)
+        end
+
+        def email_greeting
+          I18n.t("decidim.events.email_event.email_greeting", user_name: user.name)
+        end
+
+        def email_intro
+          I18n.t("decidim.events.email_event.email_intro", resource_title: resource_title)
+        end
+
+        def email_outro
+          I18n.t("decidim.events.email_event.email_outro", resource_title: resource_title)
+        end
+
+        private
+
+        def resource_title
+          resource.title.is_a?(Hash) ? resource.title[I18n.locale.to_s] : resource.title
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/events/notification_event.rb
+++ b/decidim-core/lib/decidim/events/notification_event.rb
@@ -18,6 +18,14 @@ module Decidim
 
       included do
         types << :notification
+
+        def notification_title
+          I18n.t(
+            "decidim.events.notification_event.notification_title",
+            resource_title: resource_title,
+            resource_path: resource_path
+          ).html_safe
+        end
       end
     end
   end

--- a/decidim-core/lib/decidim/events/notification_event.rb
+++ b/decidim-core/lib/decidim/events/notification_event.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Decidim
   module Events
     # This module is used to be included in event classes (those inheriting from

--- a/decidim-core/lib/decidim/events/notification_event.rb
+++ b/decidim-core/lib/decidim/events/notification_event.rb
@@ -1,0 +1,22 @@
+module Decidim
+  module Events
+    # This module is used to be included in event classes (those inheriting from
+    # `Decidim::Events::BaseEvent`) that need to create system notifications, which
+    # will be later listed to the user in their Notifications Dashboard.
+    #
+    # This modules adds the needed logic to display these notifications.
+    #
+    # Example:
+    #
+    #   class MyEvent < Decidim::Events::BaseEvent
+    #     include Decidim::Events::NotificationEvent
+    #   end
+    module NotificationEvent
+      extend ActiveSupport::Concern
+
+      included do
+        types << :notification
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/followable.rb
+++ b/decidim-core/lib/decidim/followable.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This concern contains the logic related to followable resources. Events happening todo
+  # these resources will generate notifications to the followers.
+  module Followable
+    extend ActiveSupport::Concern
+
+    included do
+      include Decidim::Notifiable
+
+      has_many :follows, as: :followable, foreign_key: "decidim_followable_id", foreign_type: "decidim_followable_type", class_name: "Decidim::Follow"
+      has_many :followers, through: :follows, source: :user
+
+      # Defines when a Followable resource is notifiable. We set this to `true` by default
+      # as it's the basic behaviour, but it can be overridden at each resource model.
+      # Overriding this method can be useful to avoid notifications when, for example,
+      # a proposal author updates the proposal (we don't want them to receive that
+      # notification). This will depend on what events trigger notifications for each
+      # resource, though.
+      #
+      # _context - unused param. Should be a Hash.
+      #
+      # Returns a boolean.
+      def notifiable?(_context)
+        true
+      end
+
+      # Defines which users will receive the notification. This method can be overridden
+      # at each resource model to include or exclude other users, eg. admins.
+      #
+      # Returns an Array.
+      def users_to_notify
+        followers
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/participable.rb
+++ b/decidim-core/lib/decidim/participable.rb
@@ -5,60 +5,74 @@ module Decidim
   # Utilities for models that can act as participatory spaces
   #
   module Participable
-    def demodulized_name
-      self.class.name.demodulize
+    extend ActiveSupport::Concern
+
+    included do
+      def demodulized_name
+        self.class.name.demodulize
+      end
+
+      def foreign_key
+        demodulized_name.foreign_key
+      end
+
+      def module_name
+        "Decidim::#{demodulized_name.pluralize}"
+      end
+
+      def admin_module_name
+        "#{module_name}::Admin"
+      end
+
+      def underscored_name
+        demodulized_name.underscore
+      end
+
+      def mounted_engine
+        "decidim_#{underscored_name.pluralize}"
+      end
+
+      def mounted_admin_engine
+        "decidim_admin_#{underscored_name.pluralize}"
+      end
+
+      def mounted_params
+        { host: organization.host, foreign_key.to_sym => id }
+      end
+
+      def extension_module
+        "#{module_name}::#{demodulized_name}Context".constantize
+      end
+
+      def admin_extension_module
+        "#{admin_module_name}::#{demodulized_name}Context".constantize
+      end
+
+      def admins_query
+        "#{admin_module_name}::AdminUsers".constantize
+      end
+
+      def admins
+        admins_query.for(self)
+      end
+
+      def allows_steps?
+        respond_to?(:steps)
+      end
+
+      def has_steps?
+        allows_steps? && steps.any?
+      end
+
+      def manifest
+        self.class.participatory_space_manifest
+      end
     end
 
-    def foreign_key
-      demodulized_name.foreign_key
-    end
-
-    def module_name
-      "Decidim::#{demodulized_name.pluralize}"
-    end
-
-    def admin_module_name
-      "#{module_name}::Admin"
-    end
-
-    def underscored_name
-      demodulized_name.underscore
-    end
-
-    def mounted_engine
-      "decidim_#{underscored_name.pluralize}"
-    end
-
-    def mounted_admin_engine
-      "decidim_admin_#{underscored_name.pluralize}"
-    end
-
-    def mounted_params
-      { host: organization.host, foreign_key.to_sym => id }
-    end
-
-    def extension_module
-      "#{module_name}::#{demodulized_name}Context".constantize
-    end
-
-    def admin_extension_module
-      "#{admin_module_name}::#{demodulized_name}Context".constantize
-    end
-
-    def admins_query
-      "#{admin_module_name}::AdminUsers".constantize
-    end
-
-    def admins
-      admins_query.for(self)
-    end
-
-    def allows_steps?
-      respond_to?(:steps)
-    end
-
-    def has_steps?
-      allows_steps? && steps.any?
+    class_methods do
+      def participatory_space_manifest
+        Decidim.find_participatory_space_manifest(name.demodulize.underscore.pluralize)
+      end
     end
   end
 end

--- a/decidim-core/lib/decidim/participable.rb
+++ b/decidim-core/lib/decidim/participable.rb
@@ -7,6 +7,7 @@ module Decidim
   module Participable
     extend ActiveSupport::Concern
 
+    # rubocop:disable Metrics/BlockLength
     included do
       def demodulized_name
         self.class.name.demodulize
@@ -68,6 +69,7 @@ module Decidim
         self.class.participatory_space_manifest
       end
     end
+    # rubocop:enable Metrics/BlockLength
 
     class_methods do
       def participatory_space_manifest

--- a/decidim-core/spec/features/notifications_spec.rb
+++ b/decidim-core/spec/features/notifications_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Notifications", type: :feature do
+  let(:resource) { create :dummy_resource }
+  let(:participatory_space) { resource.feature.participatory_space }
+  let(:organization) { participatory_space.organization }
+  let!(:user) { create :user, :confirmed, organization: organization }
+  let!(:notification) { create :notification, user: user, resource: resource }
+
+  before do
+    switch_to_host organization.host
+    login_as user, scope: :user
+    page.visit decidim.notifications_path
+  end
+
+  context "when no notification is found" do
+    let!(:notification) { nil }
+
+    it "doesn't show any notification" do
+      expect(page).to have_content("No notifications yet")
+    end
+  end
+
+  context "with notifications" do
+    it "shows the notifications" do
+      expect(page).to have_selector("section#notifications-list .card--list__item")
+    end
+
+    context "when setting a single notification as read" do
+      let(:notification_title) { "An event occured to #{resource.title}" }
+
+      it "hides the notification from the page" do
+        expect(page).to have_content(notification_title)
+        find(".mark-as-read-button").click
+        expect(page).to have_no_content(notification_title)
+        expect(page).to have_content("No notifications yet")
+      end
+    end
+
+    context "when setting all notifications as read" do
+      it "hides all notifications from the page" do
+        click_link "Mark all as read"
+        expect(page).to have_content("No notifications yet")
+      end
+    end
+  end
+end

--- a/decidim-core/spec/jobs/decidim/email_notification_generator_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/email_notification_generator_job_spec.rb
@@ -15,19 +15,19 @@ describe Decidim::EmailNotificationGeneratorJob do
     let(:event) { double :event }
     let(:event_class) { Decidim::Events::BaseEvent }
     let(:event_class_name) { "Decidim::Events::BaseEvent" }
-    let(:followable) { double :followable }
+    let(:resource) { double :resource }
     let(:generator) { double :generator }
     let(:recipient_ids) { [1, 2, 3] }
 
     it "delegates the work to the class" do
       expect(Decidim::EmailNotificationGenerator)
         .to receive(:new)
-        .with(event, event_class, followable, recipient_ids)
+        .with(event, event_class, resource, recipient_ids)
         .and_return(generator)
       expect(generator)
         .to receive(:generate)
 
-      subject.perform_now(event, event_class_name, followable, recipient_ids)
+      subject.perform_now(event, event_class_name, resource, recipient_ids)
     end
   end
 end

--- a/decidim-core/spec/jobs/decidim/email_notification_generator_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/email_notification_generator_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Decidim::NotificationGeneratorForRecipientJob do
+describe Decidim::EmailNotificationGeneratorJob do
   subject { described_class }
 
   describe "queue" do
@@ -15,19 +15,19 @@ describe Decidim::NotificationGeneratorForRecipientJob do
     let(:event) { double :event }
     let(:event_class) { Decidim::Events::BaseEvent }
     let(:event_class_name) { "Decidim::Events::BaseEvent" }
-    let(:resource) { double :resource }
-    let(:recipient) { double :recipient }
+    let(:followable) { double :followable }
     let(:generator) { double :generator }
+    let(:recipient_ids) { [1, 2, 3] }
 
     it "delegates the work to the class" do
-      expect(Decidim::NotificationGeneratorForRecipient)
+      expect(Decidim::EmailNotificationGenerator)
         .to receive(:new)
-        .with(event, event_class, resource, recipient)
+        .with(event, event_class, followable, recipient_ids)
         .and_return(generator)
       expect(generator)
         .to receive(:generate)
 
-      subject.perform_now(event, event_class_name, resource, recipient)
+      subject.perform_now(event, event_class_name, followable, recipient_ids)
     end
   end
 end

--- a/decidim-core/spec/jobs/decidim/notification_generator_for_recipient_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/notification_generator_for_recipient_job_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::NotificationGeneratorForRecipientJob do
+  subject { described_class }
+
+  describe "queue" do
+    it "is queued to events" do
+      expect(subject.queue_name).to eq "decidim_events"
+    end
+  end
+
+  describe "perform" do
+    let(:event) { double :event }
+    let(:event_class) { Decidim::Events::BaseEvent }
+    let(:resource) { double :resource }
+    let(:recipient) { double :recipient }
+    let(:generator) { double :generator }
+
+    it "delegates the work to the class" do
+      expect(Decidim::NotificationGeneratorForRecipient)
+        .to receive(:new)
+        .with(event, event_class, resource, recipient)
+        .and_return(generator)
+      expect(generator)
+        .to receive(:generate)
+
+      subject.perform_now(event, event_class, resource, recipient)
+    end
+  end
+end

--- a/decidim-core/spec/jobs/decidim/notification_generator_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/notification_generator_job_spec.rb
@@ -15,19 +15,19 @@ describe Decidim::NotificationGeneratorJob do
     let(:event) { double :event }
     let(:event_class) { Decidim::Events::BaseEvent }
     let(:event_class_name) { "Decidim::Events::BaseEvent" }
-    let(:followable) { double :followable }
+    let(:resource) { double :resource }
     let(:generator) { double :generator }
     let(:recipient_ids) { [1, 2, 3] }
 
     it "delegates the work to the class" do
       expect(Decidim::NotificationGenerator)
         .to receive(:new)
-        .with(event, event_class, followable, recipient_ids)
+        .with(event, event_class, resource, recipient_ids)
         .and_return(generator)
       expect(generator)
         .to receive(:generate)
 
-      subject.perform_now(event, event_class_name, followable, recipient_ids)
+      subject.perform_now(event, event_class_name, resource, recipient_ids)
     end
   end
 end

--- a/decidim-core/spec/jobs/decidim/notification_generator_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/notification_generator_job_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::NotificationGeneratorJob do
+  subject { described_class }
+
+  describe "queue" do
+    it "is queued to events" do
+      expect(subject.queue_name).to eq "decidim_events"
+    end
+  end
+
+  describe "perform" do
+    let(:event) { double :event }
+    let(:event_class) { Decidim::Events::BaseEvent }
+    let(:event_class_name) { "Decidim::Events::BaseEvent" }
+    let(:followable) { double :followable }
+    let(:generator) { double :generator }
+    let(:recipient_ids) { [1, 2, 3] }
+
+    it "delegates the work to the class" do
+      expect(Decidim::NotificationGenerator)
+        .to receive(:new)
+        .with(event, event_class, followable, recipient_ids)
+        .and_return(generator)
+      expect(generator)
+        .to receive(:generate)
+
+      subject.perform_now(event, event_class_name, followable, recipient_ids)
+    end
+  end
+end

--- a/decidim-core/spec/lib/events/base_event_spec.rb
+++ b/decidim-core/spec/lib/events/base_event_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Decidim::Events::BaseEvent do

--- a/decidim-core/spec/lib/events/base_event_spec.rb
+++ b/decidim-core/spec/lib/events/base_event_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+describe Decidim::Events::BaseEvent do
+  describe ".types" do
+    subject { described_class }
+
+    it "returns an empty array" do
+      expect(subject.types).to eq []
+    end
+  end
+end

--- a/decidim-core/spec/lib/events/email_event_spec.rb
+++ b/decidim-core/spec/lib/events/email_event_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Events::EmailEvent do
+  class TestEvent < Decidim::Events::BaseEvent
+    include Decidim::Events::EmailEvent
+  end
+
+  describe ".types" do
+    subject { TestEvent }
+
+    it "adds `:email` to the types array" do
+      expect(subject.types).to include :email
+    end
+  end
+end

--- a/decidim-core/spec/lib/events/notification_event_spec.rb
+++ b/decidim-core/spec/lib/events/notification_event_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+describe Decidim::Events::NotificationEvent do
+  class TestEvent < Decidim::Events::BaseEvent
+    include Decidim::Events::NotificationEvent
+  end
+
+  describe ".types" do
+    subject { TestEvent }
+
+    it "adds `:notification` to the types array" do
+      expect(subject.types).to include :notification
+    end
+  end
+end

--- a/decidim-core/spec/lib/events/notification_event_spec.rb
+++ b/decidim-core/spec/lib/events/notification_event_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Decidim::Events::NotificationEvent do

--- a/decidim-core/spec/models/decidim/follow_spec.rb
+++ b/decidim-core/spec/models/decidim/follow_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Follow, :db do
+  let(:follow) { build(:follow) }
+  subject { follow }
+
+  it { is_expected.to be_valid }
+
+  describe "uniqueness" do
+    let!(:another_follow) { create :follow }
+    let!(:follow) { build :follow, user: another_follow.user, followable: another_follow.followable }
+
+    it "cannot be repeated for user/followable combo" do
+      expect(subject).not_to be_valid
+    end
+  end
+
+  describe "presence" do
+    context "without user" do
+      let(:follow) { build(:follow, user: nil) }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context "without followable" do
+      let(:follow) { build(:follow, followable: nil) }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+end

--- a/decidim-core/spec/models/notification_spec.rb
+++ b/decidim-core/spec/models/notification_spec.rb
@@ -15,8 +15,8 @@ describe Decidim::Notification, :db do
       it { is_expected.not_to be_valid }
     end
 
-    context "without followable" do
-      let(:notification) { build(:notification, followable: nil) }
+    context "without resource" do
+      let(:notification) { build(:notification, resource: nil) }
 
       it { is_expected.not_to be_valid }
     end

--- a/decidim-core/spec/models/notification_spec.rb
+++ b/decidim-core/spec/models/notification_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Notification, :db do
+  let(:notification) { build(:notification) }
+  subject { notification }
+
+  it { is_expected.to be_valid }
+
+  context "validations" do
+    context "without user" do
+      let(:notification) { build(:notification, user: nil) }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context "without followable" do
+      let(:notification) { build(:notification, followable: nil) }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+end

--- a/decidim-core/spec/services/decidim/events_manager_spec.rb
+++ b/decidim-core/spec/services/decidim/events_manager_spec.rb
@@ -8,13 +8,33 @@ describe Decidim::EventsManager do
     let(:event_class) { Decidim::Events::BaseEvent }
     let(:resource) { double }
     let(:user) { double }
+    let(:recipient_ids) { [1, 2, 3] }
 
     it "delegates the params to ActiveSupport::Notifications" do
       expect(ActiveSupport::Notifications)
         .to receive(:publish)
-        .with(event, event_class: "Decidim::Events::BaseEvent", resource: resource, user: user)
+        .with(event, event_class: "Decidim::Events::BaseEvent", resource: resource, user: user, recipient_ids: recipient_ids)
 
-      described_class.publish(event: event, event_class: event_class, resource: resource, user: user)
+      described_class.publish(
+        event: event,
+        event_class: event_class,
+        resource: resource,
+        user: user,
+        recipient_ids: recipient_ids
+      )
+    end
+  end
+
+  describe "#subscribe" do
+    let(:event) { "my.event" }
+    let(:block) { proc { "Hello world" } }
+
+    it "delegates the params to ActiveSupport::Notifications" do
+      expect(ActiveSupport::Notifications)
+        .to receive(:subscribe)
+        .with(event, &block)
+
+      described_class.subscribe(event, &block)
     end
   end
 end

--- a/decidim-core/spec/services/decidim/events_manager_spec.rb
+++ b/decidim-core/spec/services/decidim/events_manager_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::EventsManager do
+  describe "#publish" do
+    let(:event) { "my.event" }
+    let(:event_class) { Decidim::Events::BaseEvent }
+    let(:resource) { double }
+    let(:user) { double }
+
+    it "delegates the params to ActiveSupport::Notifications" do
+      expect(ActiveSupport::Notifications)
+        .to receive(:publish)
+        .with(event, event_class: "Decidim::Events::BaseEvent", resource: resource, user: user)
+
+      described_class.publish(event: event, event_class: event_class, resource: resource, user: user)
+    end
+  end
+end

--- a/decidim-core/spec/services/decidim/notification_generator_for_recipient_spec.rb
+++ b/decidim-core/spec/services/decidim/notification_generator_for_recipient_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::NotificationGeneratorForRecipient do
+  let(:event) { "decidim.events.dummy.dummy_resource_updated" }
+  let(:resource) { create(:dummy_resource) }
+  let(:follow) { create(:follow, resource: resource, user: recipient) }
+  let(:recipient) { resource.author }
+  let(:event_class) { Decidim::Events::BaseEvent }
+  subject { described_class.new(event, event_class, resource, recipient.id) }
+
+  describe "generate" do
+    it "creates a notification for the recipient" do
+      expect do
+        subject.generate
+      end.to change(Decidim::Notification, :count).by(1)
+      notification = Decidim::Notification.last
+
+      expect(notification.user).to eq recipient
+      expect(notification.notification_type).to eq event
+      expect(notification.followable).to eq resource
+    end
+
+    context "when it is not notifiable for the given user" do
+      it "returns nil" do
+        allow(resource).to receive(:notifiable?).and_return(false)
+        expect(subject.generate).to be_nil
+      end
+    end
+  end
+end

--- a/decidim-core/spec/services/decidim/notification_generator_for_recipient_spec.rb
+++ b/decidim-core/spec/services/decidim/notification_generator_for_recipient_spec.rb
@@ -18,8 +18,8 @@ describe Decidim::NotificationGeneratorForRecipient do
       notification = Decidim::Notification.last
 
       expect(notification.user).to eq recipient
-      expect(notification.notification_type).to eq event
-      expect(notification.followable).to eq resource
+      expect(notification.event_name).to eq event
+      expect(notification.resource).to eq resource
     end
 
     context "when it is not notifiable for the given user" do

--- a/decidim-core/spec/services/decidim/notification_generator_spec.rb
+++ b/decidim-core/spec/services/decidim/notification_generator_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::NotificationGenerator do
+  let(:event) { "decidim.events.dummy.dummy_resource_updated" }
+  let(:resource) { create(:dummy_resource) }
+  let(:follow) { create(:follow, resource: resource, user: recipient) }
+  let(:recipient) { resource.author }
+  let(:event_class) { Decidim::Events::BaseEvent }
+  let(:recipient_ids) { [recipient.id] }
+  subject { described_class.new(event, event_class, resource, recipient_ids) }
+
+  describe "generate" do
+    context "when the event_class supports notifications" do
+      before do
+        allow(event_class).to receive(:types).and_return([:notification])
+      end
+
+      it "schedules a job for each recipient" do
+        expect(Decidim::NotificationGeneratorForRecipientJob)
+          .to receive(:perform_later)
+          .with(event, event_class, resource, recipient.id)
+
+        subject.generate
+      end
+    end
+
+    context "when the event_class supports notifications" do
+      before do
+        allow(event_class).to receive(:types).and_return([])
+      end
+
+      it "schedules a job for each recipient" do
+        expect(Decidim::NotificationGeneratorForRecipientJob)
+          .not_to receive(:perform_later)
+
+        subject.generate
+      end
+    end
+  end
+end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
@@ -22,6 +22,9 @@ module Decidim
     end
   end
 
+  class DummyResourceEvent < Events::BaseEvent
+  end
+
   class DummyResource < ActiveRecord::Base
     include HasFeature
     include Resourceable

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
@@ -23,6 +23,8 @@ module Decidim
   end
 
   class DummyResourceEvent < Events::BaseEvent
+    include Decidim::Events::EmailEvent
+    include Decidim::Events::NotificationEvent
   end
 
   class DummyResource < ActiveRecord::Base

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
@@ -30,6 +30,7 @@ module Decidim
     include HasCategory
     include HasScope
     include Decidim::Comments::Commentable
+    include Followable
 
     feature_manifest_name "dummy"
 

--- a/decidim-meetings/app/commands/decidim/meetings/admin/close_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/close_meeting.rb
@@ -19,7 +19,7 @@ module Decidim
         #
         # Broadcasts :ok if successful, :invalid otherwise.
         def call
-          return broadcast(:invalid) if @form.invalid?
+          return broadcast(:invalid) if form.invalid?
 
           transaction do
             close_meeting
@@ -31,22 +31,29 @@ module Decidim
 
         private
 
+        attr_reader :form, :meeting
+
         def close_meeting
-          @meeting.update_attributes!(
-            closing_report: @form.closing_report,
-            attendees_count: @form.attendees_count,
-            contributions_count: @form.contributions_count,
-            attending_organizations: @form.attending_organizations,
-            closed_at: @form.closed_at
+          meeting.update_attributes!(
+            closing_report: form.closing_report,
+            attendees_count: form.attendees_count,
+            contributions_count: form.contributions_count,
+            attending_organizations: form.attending_organizations,
+            closed_at: form.closed_at
+          )
+          Decidim::EventsManager.publish(
+            event: "decidim.events.meetings.meeting_closed",
+            resource: meeting,
+            user: form.current_user
           )
         end
 
         def proposals
-          @meeting.sibling_scope(:proposals).where(id: @form.proposal_ids)
+          meeting.sibling_scope(:proposals).where(id: @form.proposal_ids)
         end
 
         def link_proposals
-          @meeting.link_resources(proposals, "proposals_from_meeting")
+          meeting.link_resources(proposals, "proposals_from_meeting")
         end
       end
     end

--- a/decidim-meetings/app/commands/decidim/meetings/admin/close_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/close_meeting.rb
@@ -43,7 +43,9 @@ module Decidim
           )
           Decidim::EventsManager.publish(
             event: "decidim.events.meetings.meeting_closed",
+            event_class: Decidim::Meetings::CloseMeetingEvent,
             resource: meeting,
+            recipient_ids: meeting.users_to_notify.pluck(:id),
             user: form.current_user
           )
         end

--- a/decidim-meetings/app/commands/decidim/meetings/admin/update_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/update_meeting.rb
@@ -45,7 +45,9 @@ module Decidim
           )
           Decidim::EventsManager.publish(
             event: "decidim.events.meetings.meeting_updated",
+            event_class: Decidim::Meetings::UpdateMeetingEvent,
             resource: meeting,
+            recipient_ids: meeting.users_to_notify.pluck(:id),
             user: form.current_user
           )
         end

--- a/decidim-meetings/app/commands/decidim/meetings/admin/update_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/update_meeting.rb
@@ -19,38 +19,45 @@ module Decidim
         #
         # Broadcasts :ok if successful, :invalid otherwise.
         def call
-          return broadcast(:invalid) if @form.invalid?
+          return broadcast(:invalid) if form.invalid?
 
           update_meeting!
-          broadcast(:ok, @meeting)
+          broadcast(:ok, meeting)
         end
 
         private
 
+        attr_reader :form, :meeting
+
         def update_meeting!
-          @meeting.update_attributes!(
-            scope: @form.scope,
-            category: @form.category,
-            title: @form.title,
-            description: @form.description,
-            end_time: @form.end_time,
-            start_time: @form.start_time,
-            address: @form.address,
-            latitude: @form.latitude,
-            longitude: @form.longitude,
-            location: @form.location,
-            location_hints: @form.location_hints
+          meeting.update_attributes!(
+            scope: form.scope,
+            category: form.category,
+            title: form.title,
+            description: form.description,
+            end_time: form.end_time,
+            start_time: form.start_time,
+            address: form.address,
+            latitude: form.latitude,
+            longitude: form.longitude,
+            location: form.location,
+            location_hints: form.location_hints
+          )
+          Decidim::EventsManager.publish(
+            event: "decidim.events.meetings.meeting_updated",
+            resource: meeting,
+            user: form.current_user
           )
         end
 
         def geocode_meeting
-          result = @meeting.geocode
-          @form.errors.add :address, :invalid unless result
+          result = meeting.geocode
+          form.errors.add :address, :invalid unless result
           result
         end
 
         def update_meeting
-          @meeting.save!
+          meeting.save!
         end
       end
     end

--- a/decidim-meetings/app/events/decidim/meetings/close_meeting_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/close_meeting_event.rb
@@ -1,0 +1,7 @@
+module Decidim
+  module Meetings
+    class CloseMeetingEvent < Decidim::Events::BaseEvent
+      include Decidim::Events::NotificationEvent
+    end
+  end
+end

--- a/decidim-meetings/app/events/decidim/meetings/close_meeting_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/close_meeting_event.rb
@@ -17,6 +17,14 @@ module Decidim
       def email_outro
         I18n.t("decidim.meetings.events.close_meeting_event.email_outro", resource_title: resource_title)
       end
+
+      def notification_title
+        I18n.t(
+          "decidim.meetings.events.close_meeting_event.notification_title",
+          resource_title: resource_title,
+          resource_path: resource_path
+        ).html_safe
+      end
     end
   end
 end

--- a/decidim-meetings/app/events/decidim/meetings/close_meeting_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/close_meeting_event.rb
@@ -1,7 +1,22 @@
+# frozen-string_literal: true
+
 module Decidim
   module Meetings
     class CloseMeetingEvent < Decidim::Events::BaseEvent
+      include Decidim::Events::EmailEvent
       include Decidim::Events::NotificationEvent
+
+      def email_subject
+        I18n.t("decidim.meetings.events.close_meeting_event.email_subject", resource_title: resource_title)
+      end
+
+      def email_intro
+        I18n.t("decidim.meetings.events.close_meeting_event.email_intro", resource_title: resource_title)
+      end
+
+      def email_outro
+        I18n.t("decidim.meetings.events.close_meeting_event.email_outro", resource_title: resource_title)
+      end
     end
   end
 end

--- a/decidim-meetings/app/events/decidim/meetings/update_meeting_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/update_meeting_event.rb
@@ -1,0 +1,7 @@
+module Decidim
+  module Meetings
+    class UpdateMeetingEvent < Decidim::Events::BaseEvent
+      include Decidim::Events::NotificationEvent
+    end
+  end
+end

--- a/decidim-meetings/app/events/decidim/meetings/update_meeting_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/update_meeting_event.rb
@@ -17,6 +17,14 @@ module Decidim
       def email_outro
         I18n.t("decidim.meetings.events.update_meeting_event.email_outro", resource_title: resource_title)
       end
+
+      def notification_title
+        I18n.t(
+          "decidim.meetings.events.update_meeting_event.notification_title",
+          resource_title: resource_title,
+          resource_path: resource_path
+        ).html_safe
+      end
     end
   end
 end

--- a/decidim-meetings/app/events/decidim/meetings/update_meeting_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/update_meeting_event.rb
@@ -1,7 +1,22 @@
+# frozen_string_literal: true
+
 module Decidim
   module Meetings
     class UpdateMeetingEvent < Decidim::Events::BaseEvent
+      include Decidim::Events::EmailEvent
       include Decidim::Events::NotificationEvent
+
+      def email_subject
+        I18n.t("decidim.meetings.events.update_meeting_event.email_subject", resource_title: resource_title)
+      end
+
+      def email_intro
+        I18n.t("decidim.meetings.events.update_meeting_event.email_intro", resource_title: resource_title)
+      end
+
+      def email_outro
+        I18n.t("decidim.meetings.events.update_meeting_event.email_outro", resource_title: resource_title)
+      end
     end
   end
 end

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -11,6 +11,7 @@ module Decidim
       include Decidim::HasReference
       include Decidim::HasScope
       include Decidim::HasCategory
+      include Decidim::Followable
 
       has_many :registrations, class_name: "Decidim::Meetings::Registration", foreign_key: "decidim_meeting_id"
 

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -30,6 +30,9 @@
             <span><%= t(".remaining_slots", count: meeting.remaining_slots) %></span>
           <% end %>
         <% end %>
+        <div id="follow-resource">
+          <%= render partial: "decidim/shared/follow_button", locals: { followable: meeting } %>
+        </div>
       </div>
       <% if meeting.closed? %>
         <div class="card card--secondary extra definition-data">

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -81,6 +81,15 @@ en:
           update:
             invalid: There's been a problem saving the registration settings.
             success: Meeting registrations settings successfully saved.
+      events:
+        close_meeting_event:
+          email_intro: 'The "%{resource_title}" meeting was closed. You can read the conclusions from its page:'
+          email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
+          email_subject: The "%{resource_title}" meeting was closed
+        update_meeting_event:
+          email_intro: 'The "%{resource_title}" meeting was updated. You can read the new version from its page:'
+          email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
+          email_subject: The "%{resource_title}" meeting was updated
       meetings:
         filters:
           category: Category

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -86,10 +86,12 @@ en:
           email_intro: 'The "%{resource_title}" meeting was closed. You can read the conclusions from its page:'
           email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
           email_subject: The "%{resource_title}" meeting was closed
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting was closed.
         update_meeting_event:
           email_intro: 'The "%{resource_title}" meeting was updated. You can read the new version from its page:'
           email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
           email_subject: The "%{resource_title}" meeting was updated
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting was updated.
       meetings:
         filters:
           category: Category

--- a/decidim-meetings/spec/commands/close_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/close_meeting_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 describe Decidim::Meetings::Admin::CloseMeeting do
   let(:meeting) { create :meeting }
+  let(:user) { create :user, :admin }
   let(:form) do
     double(
       invalid?: invalid,
@@ -12,7 +13,8 @@ describe Decidim::Meetings::Admin::CloseMeeting do
       contributions_count: 15,
       attending_organizations: "Some organization",
       closed_at: Time.current,
-      proposal_ids: proposal_ids
+      proposal_ids: proposal_ids,
+      current_user: user
     )
   end
   let(:proposal_feature) do
@@ -75,6 +77,14 @@ describe Decidim::Meetings::Admin::CloseMeeting do
 
       expect(meeting.linked_resources(:proposals, "proposals_from_meeting").length).to eq(3)
       expect(meeting.linked_resources(:proposals, "proposals_from_meeting")).to match_array(proposals)
+    end
+
+    it "notifies the change" do
+      expect(Decidim::EventsManager)
+        .to receive(:publish)
+        .with(event: "decidim.events.meetings.meeting_closed", resource: meeting, user: user)
+
+      subject.call
     end
   end
 end

--- a/decidim-meetings/spec/commands/close_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/close_meeting_spec.rb
@@ -79,12 +79,22 @@ describe Decidim::Meetings::Admin::CloseMeeting do
       expect(meeting.linked_resources(:proposals, "proposals_from_meeting")).to match_array(proposals)
     end
 
-    it "notifies the change" do
-      expect(Decidim::EventsManager)
-        .to receive(:publish)
-        .with(event: "decidim.events.meetings.meeting_closed", resource: meeting, user: user)
+    context "events" do
+      let!(:follow) { create :follow, followable: meeting, user: user }
 
-      subject.call
+      it "notifies the change" do
+        expect(Decidim::EventsManager)
+          .to receive(:publish)
+          .with(
+            event: "decidim.events.meetings.meeting_closed",
+            event_class: Decidim::Meetings::CloseMeetingEvent,
+            resource: meeting,
+            user: user,
+            recipient_ids: [user.id]
+          )
+
+        subject.call
+      end
     end
   end
 end

--- a/decidim-meetings/spec/commands/update_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/update_meeting_spec.rb
@@ -11,6 +11,7 @@ describe Decidim::Meetings::Admin::UpdateMeeting do
   let(:invalid) { false }
   let(:latitude) { 40.1234 }
   let(:longitude) { 2.1234 }
+  let(:user) { create :user, :admin }
   let(:form) do
     double(
       invalid?: invalid,
@@ -24,7 +25,8 @@ describe Decidim::Meetings::Admin::UpdateMeeting do
       category: category,
       address: address,
       latitude: latitude,
-      longitude: longitude
+      longitude: longitude,
+      current_user: user
     )
   end
 
@@ -58,6 +60,14 @@ describe Decidim::Meetings::Admin::UpdateMeeting do
       subject.call
       expect(meeting.latitude).to eq(latitude)
       expect(meeting.longitude).to eq(longitude)
+    end
+
+    it "notifies the change" do
+      expect(Decidim::EventsManager)
+        .to receive(:publish)
+        .with(event: "decidim.events.meetings.meeting_updated", resource: meeting, user: user)
+
+      subject.call
     end
   end
 end

--- a/decidim-meetings/spec/commands/update_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/update_meeting_spec.rb
@@ -62,12 +62,22 @@ describe Decidim::Meetings::Admin::UpdateMeeting do
       expect(meeting.longitude).to eq(longitude)
     end
 
-    it "notifies the change" do
-      expect(Decidim::EventsManager)
-        .to receive(:publish)
-        .with(event: "decidim.events.meetings.meeting_updated", resource: meeting, user: user)
+    context "events" do
+      let!(:follow) { create :follow, followable: meeting, user: user }
 
-      subject.call
+      it "notifies the change" do
+        expect(Decidim::EventsManager)
+          .to receive(:publish)
+          .with(
+            event: "decidim.events.meetings.meeting_updated",
+            event_class: Decidim::Meetings::UpdateMeetingEvent,
+            resource: meeting,
+            user: user,
+            recipient_ids: [user.id]
+          )
+
+        subject.call
+      end
     end
   end
 end

--- a/decidim-meetings/spec/events/decidim/meetings/close_meeting_event_spec.rb
+++ b/decidim-meetings/spec/events/decidim/meetings/close_meeting_event_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+describe Decidim::Meetings::CloseMeetingEvent do
+  describe "types" do
+    subject { described_class }
+
+    it "supports notifications" do
+      expect(subject.types).to include :notification
+    end
+  end
+end

--- a/decidim-meetings/spec/events/decidim/meetings/close_meeting_event_spec.rb
+++ b/decidim-meetings/spec/events/decidim/meetings/close_meeting_event_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Decidim::Meetings::CloseMeetingEvent do
@@ -6,6 +8,10 @@ describe Decidim::Meetings::CloseMeetingEvent do
 
     it "supports notifications" do
       expect(subject.types).to include :notification
+    end
+
+    it "supports emails" do
+      expect(subject.types).to include :email
     end
   end
 end

--- a/decidim-meetings/spec/events/decidim/meetings/update_meeting_event_spec.rb
+++ b/decidim-meetings/spec/events/decidim/meetings/update_meeting_event_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Decidim::Meetings::UpdateMeetingEvent do
@@ -6,6 +8,10 @@ describe Decidim::Meetings::UpdateMeetingEvent do
 
     it "supports notifications" do
       expect(subject.types).to include :notification
+    end
+
+    it "supports notifications" do
+      expect(subject.types).to include :email
     end
   end
 end

--- a/decidim-meetings/spec/events/decidim/meetings/update_meeting_event_spec.rb
+++ b/decidim-meetings/spec/events/decidim/meetings/update_meeting_event_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+describe Decidim::Meetings::UpdateMeetingEvent do
+  describe "types" do
+    subject { described_class }
+
+    it "supports notifications" do
+      expect(subject.types).to include :notification
+    end
+  end
+end

--- a/decidim-meetings/spec/features/follow_meetings_spec.rb
+++ b/decidim-meetings/spec/features/follow_meetings_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Follow meetings", type: :feature do
+  include_context "feature"
+  let(:manifest_name) { "meetings" }
+
+  let!(:meeting) do
+    create(:meeting, feature: feature)
+  end
+
+  before do
+    login_as user, scope: :user
+  end
+
+  context "when not following the meeting" do
+    context "when user clicks the Follow button" do
+      it "makes the user follow the meeting" do
+        visit resource_locator(meeting).path
+        expect do
+          click_button "Follow"
+          expect(page).to have_content "Stop following"
+        end.to change(Decidim::Follow, :count).by(1)
+      end
+    end
+  end
+
+  context "when the user is following the meeting" do
+    before do
+      create(:follow, followable: meeting, user: user)
+    end
+
+    context "when user clicks the Follow button" do
+      it "makes the user follow the meeting" do
+        visit resource_locator(meeting).path
+        expect do
+          click_button "Stop following"
+          expect(page).to have_content "Follow"
+        end.to change(Decidim::Follow, :count).by(-1)
+      end
+    end
+  end
+end

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_stats_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_stats_presenter.rb
@@ -38,7 +38,7 @@ module Decidim
 
       def render_stats_data(feature_manifest, name, data, index)
         safe_join([
-                    index.zero? ? feature_manifest_icon(feature_manifest) : " /&nbsp".html_safe,
+                    index.zero? ? manifest_icon(feature_manifest) : " /&nbsp".html_safe,
                     content_tag(:span, "#{number_with_delimiter(data)} " + I18n.t(name, scope: "decidim.participatory_processes.statistics"),
                                 class: "#{name} process_stats-text")
                   ])


### PR DESCRIPTION
#### :tophat: What? Why?
This PR lets users follow resources on Decidim and get notifications when an event occurs on these resources. To start, the only events published are:

- Meeting update
- Meeting is closed

So the users can only follow Meetings as of this PR. 

This PR will receive other smaller PRs so the work is easier to review.

#### :pushpin: Related Issues
- Fixes #1692
- Improves the work done on #1695, reusing the commits