### PR TITLE
Send email on event

### DIFF
--- a/decidim-core/app/jobs/decidim/email_notification_generator_job.rb
+++ b/decidim-core/app/jobs/decidim/email_notification_generator_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Decidim
+  class EmailNotificationGeneratorJob < ApplicationJob
+    queue_as :decidim_events
+
+    def perform(event, event_class_name, followable, recipient_ids)
+      event_class = event_class_name.constantize
+      EmailNotificationGenerator.new(event, event_class, followable, recipient_ids).generate
+    end
+  end
+end

--- a/decidim-core/app/jobs/decidim/notification_generator_for_recipient_job.rb
+++ b/decidim-core/app/jobs/decidim/notification_generator_for_recipient_job.rb
@@ -4,7 +4,8 @@ module Decidim
   class NotificationGeneratorForRecipientJob < ApplicationJob
     queue_as :decidim_events
 
-    def perform(event, event_class, resource, recipient_id)
+    def perform(event, event_class_name, resource, recipient_id)
+      event_class = event_class_name.constantize
       NotificationGeneratorForRecipient
         .new(event, event_class, resource, recipient_id)
         .generate

--- a/decidim-core/app/mailers/decidim/notification_mailer.rb
+++ b/decidim-core/app/mailers/decidim/notification_mailer.rb
@@ -8,13 +8,11 @@ module Decidim
 
     def event_received(event, event_class_name, resource, user)
       with_user(user) do
-        @user = user
-        @resource = resource
-        @locator = Decidim::ResourceLocatorPresenter.new(@resource)
+        @locator = Decidim::ResourceLocatorPresenter.new(resource)
         @organization = resource.organization
         event_class = event_class_name.constantize
-        @event_instance = event_class.new(resource)
-        subject = event_instance.subject
+        @event_instance = event_class.new(resource: resource, event_name: event, user: user)
+        subject = @event_instance.email_subject
 
         mail(to: user.email, subject: subject)
       end

--- a/decidim-core/app/mailers/decidim/notification_mailer.rb
+++ b/decidim-core/app/mailers/decidim/notification_mailer.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Decidim
+  # A custom mailer for sending notifications to users when
+  # a events are received.
+  class NotificationMailer < Decidim::ApplicationMailer
+    helper Decidim::ResourceHelper
+
+    def event_received(event, event_class_name, resource, user)
+      with_user(user) do
+        @user = user
+        @resource = resource
+        @locator = Decidim::ResourceLocatorPresenter.new(@resource)
+        @organization = resource.organization
+        event_class = event_class_name.constantize
+        @event_instance = event_class.new(resource)
+        subject = event_instance.subject
+
+        mail(to: user.email, subject: subject)
+      end
+    end
+  end
+end

--- a/decidim-core/app/services/decidim/email_notification_generator.rb
+++ b/decidim-core/app/services/decidim/email_notification_generator.rb
@@ -3,10 +3,10 @@
 module Decidim
   # This class handles system events affecting resources and generates a
   # notification for each recipient by scheduling a new
-  # `Decidim::NotificationGeneratorForRecipientJob` job for each of them. This way
-  # we can easily control which jobs fail and retry them, so that we don't have
+  # `Decidim::NotificationMailer` job for each of them. This way we can
+  # easily control which jobs fail and retry them, so that we don't have
   # duplicated notifications.
-  class NotificationGenerator
+  class EmailNotificationGenerator
     # Initializes the class.
     #
     # event - A String with the name of the event.
@@ -19,16 +19,16 @@ module Decidim
       @recipient_ids = recipient_ids
     end
 
-    # Schedules a job for each recipient to create the notification. Returns `nil`
+    # Schedules a job for each recipient to send the email. Returns `nil`
     # if the resource is not resource or if it is not present.
     #
     # Returns nothing.
     def generate
       return unless resource
-      return unless event_class.types.include?(:notification)
+      return unless event_class.types.include?(:email)
 
       recipient_ids.each do |recipient_id|
-        generate_notification_for(recipient_id)
+        send_email_to(recipient_id)
       end
     end
 
@@ -36,13 +36,18 @@ module Decidim
 
     attr_reader :event, :event_class, :resource, :recipient_ids
 
-    def generate_notification_for(recipient_id)
-      NotificationGeneratorForRecipientJob.perform_later(
-        event,
-        event_class,
-        resource,
-        recipient_id
-      )
+    def send_email_to(recipient_id)
+      recipient = Decidim::User.where(id: recipient_id).first
+      return unless recipient
+
+      NotificationMailer
+        .event_received(
+          event,
+          event_class.name,
+          resource,
+          recipient
+        )
+        .deliver_later
     end
   end
 end

--- a/decidim-core/app/services/decidim/notification_generator.rb
+++ b/decidim-core/app/services/decidim/notification_generator.rb
@@ -39,7 +39,7 @@ module Decidim
     def generate_notification_for(recipient_id)
       NotificationGeneratorForRecipientJob.perform_later(
         event,
-        event_class,
+        event_class.name,
         resource,
         recipient_id
       )

--- a/decidim-core/app/views/decidim/notification_mailer/event_received.html.erb
+++ b/decidim-core/app/views/decidim/notification_mailer/event_received.html.erb
@@ -1,0 +1,9 @@
+<p><%= @event_instance.email_greeting %></p>
+
+<p><%= @event_instance.email_intro %></p>
+
+<p>
+  <%= link_to @locator.url, @locator.url %>
+</p>
+
+<p><%= @event_instance.email_outro %></p>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -129,10 +129,10 @@ en:
         title: The page you're looking for can't be found
     events:
       email_event:
-        email_greeting: "Hello %{user_name},"
-        email_intro: "There has been an update to \"%{resource_title}\". You can see it from this page:"
-        email_outro: "You have received this notification because you are following \"%{resource_title}\". You can unfollow it from the previous link."
-        email_subject: "An update to %{resource_title}"
+        email_greeting: Hello %{user_name},
+        email_intro: 'There has been an update to "%{resource_title}". You can see it from this page:'
+        email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
+        email_subject: An update to %{resource_title}
     export_mailer:
       export:
         ready: Please find attached a zipped version of your export.

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -127,6 +127,12 @@ en:
         back_home: Back home
         content_doesnt_exist: This address is incorrect or has been removed.
         title: The page you're looking for can't be found
+    events:
+      email_event:
+        email_greeting: "Hello %{user_name},"
+        email_intro: "There has been an update to \"%{resource_title}\". You can see it from this page:"
+        email_outro: "You have received this notification because you are following \"%{resource_title}\". You can unfollow it from the previous link."
+        email_subject: "An update to %{resource_title}"
     export_mailer:
       export:
         ready: Please find attached a zipped version of your export.

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "decidim/core/engine"

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -154,6 +154,12 @@ module Decidim
 
       initializer "decidim.notifications" do
         Decidim::EventsManager.subscribe(/^decidim\.events\./) do |event, data|
+          EmailNotificationGeneratorJob.perform_later(
+            event,
+            data[:event_class],
+            data[:resource],
+            data[:recipient_ids]
+          )
           NotificationGeneratorJob.perform_later(
             event,
             data[:event_class],

--- a/decidim-core/lib/decidim/events.rb
+++ b/decidim-core/lib/decidim/events.rb
@@ -3,6 +3,7 @@
 module Decidim
   module Events
     autoload :BaseEvent, "decidim/events/base_event"
+    autoload :EmailEvent, "decidim/events/email_event"
     autoload :NotificationEvent, "decidim/events/notification_event"
   end
 end

--- a/decidim-core/lib/decidim/events/base_event.rb
+++ b/decidim-core/lib/decidim/events/base_event.rb
@@ -32,8 +32,8 @@ module Decidim
       # Initializes the class.
       #
       # event_name - a String with the name of the event.
-      # payload - a Hash with extra data from the event.
-      def initialize(event_name, payload)
+      # payload - an optional Hash with extra data from the event.
+      def initialize(event_name, payload = {})
         @event_name = event_name
         @payload = payload
       end

--- a/decidim-core/lib/decidim/events/base_event.rb
+++ b/decidim-core/lib/decidim/events/base_event.rb
@@ -32,15 +32,17 @@ module Decidim
       # Initializes the class.
       #
       # event_name - a String with the name of the event.
-      # payload - an optional Hash with extra data from the event.
-      def initialize(event_name, payload = {})
+      # resource - the resource that received the event
+      # user - the User that receives the event
+      def initialize(resource:, event_name:, user:)
         @event_name = event_name
-        @payload = payload
+        @resource = resource
+        @user = user
       end
 
       private
 
-      attr_reader :event_name, :payload
+      attr_reader :event_name, :resource, :user
     end
   end
 end

--- a/decidim-core/lib/decidim/events/email_event.rb
+++ b/decidim-core/lib/decidim/events/email_event.rb
@@ -1,0 +1,21 @@
+module Decidim
+  module Events
+    # This module is used to be included in event classes (those inheriting from
+    # `Decidim::Events::BaseEvent`) that need to send emails with the notification.
+    #
+    # This modules adds the needed logic to deliver emails to a given user.
+    #
+    # Example:
+    #
+    #   class MyEvent < Decidim::Events::BaseEvent
+    #     include Decidim::Events::EmailEvent
+    #   end
+    module EmailEvent
+      extend ActiveSupport::Concern
+
+      included do
+        types << :email
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/events/email_event.rb
+++ b/decidim-core/lib/decidim/events/email_event.rb
@@ -1,3 +1,5 @@
+# frozen-string_literal: true
+
 module Decidim
   module Events
     # This module is used to be included in event classes (those inheriting from
@@ -15,6 +17,28 @@ module Decidim
 
       included do
         types << :email
+
+        def email_subject
+          I18n.t("decidim.events.email_event.email_subject", resource_title: resource_title)
+        end
+
+        def email_greeting
+          I18n.t("decidim.events.email_event.email_greeting", user_name: user.name)
+        end
+
+        def email_intro
+          I18n.t("decidim.events.email_event.email_intro", resource_title: resource_title)
+        end
+
+        def email_outro
+          I18n.t("decidim.events.email_event.email_outro", resource_title: resource_title)
+        end
+
+        private
+
+        def resource_title
+          resource.title.is_a?(Hash) ? resource.title[I18n.locale.to_s] : resource.title
+        end
       end
     end
   end

--- a/decidim-core/lib/decidim/events/notification_event.rb
+++ b/decidim-core/lib/decidim/events/notification_event.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Decidim
   module Events
     # This module is used to be included in event classes (those inheriting from

--- a/decidim-core/spec/jobs/decidim/email_notification_generator_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/email_notification_generator_job_spec.rb
@@ -22,8 +22,8 @@ describe Decidim::EmailNotificationGeneratorJob do
     it "delegates the work to the class" do
       expect(Decidim::EmailNotificationGenerator)
         .to receive(:new)
-              .with(event, event_class, followable, recipient_ids)
-              .and_return(generator)
+        .with(event, event_class, followable, recipient_ids)
+        .and_return(generator)
       expect(generator)
         .to receive(:generate)
 

--- a/decidim-core/spec/jobs/decidim/email_notification_generator_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/email_notification_generator_job_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::EmailNotificationGeneratorJob do
+  subject { described_class }
+
+  describe "queue" do
+    it "is queued to events" do
+      expect(subject.queue_name).to eq "decidim_events"
+    end
+  end
+
+  describe "perform" do
+    let(:event) { double :event }
+    let(:event_class) { Decidim::Events::BaseEvent }
+    let(:event_class_name) { "Decidim::Events::BaseEvent" }
+    let(:followable) { double :followable }
+    let(:generator) { double :generator }
+    let(:recipient_ids) { [1, 2, 3] }
+
+    it "delegates the work to the class" do
+      expect(Decidim::EmailNotificationGenerator)
+        .to receive(:new)
+              .with(event, event_class, followable, recipient_ids)
+              .and_return(generator)
+      expect(generator)
+        .to receive(:generate)
+
+      subject.perform_now(event, event_class_name, followable, recipient_ids)
+    end
+  end
+end

--- a/decidim-core/spec/jobs/decidim/notification_generator_for_recipient_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/notification_generator_for_recipient_job_spec.rb
@@ -14,6 +14,7 @@ describe Decidim::NotificationGeneratorForRecipientJob do
   describe "perform" do
     let(:event) { double :event }
     let(:event_class) { Decidim::Events::BaseEvent }
+    let(:event_class_name) { "Decidim::Events::BaseEvent" }
     let(:resource) { double :resource }
     let(:recipient) { double :recipient }
     let(:generator) { double :generator }
@@ -26,7 +27,7 @@ describe Decidim::NotificationGeneratorForRecipientJob do
       expect(generator)
         .to receive(:generate)
 
-      subject.perform_now(event, event_class, resource, recipient)
+      subject.perform_now(event, event_class_name, resource, recipient)
     end
   end
 end

--- a/decidim-core/spec/lib/events/base_event_spec.rb
+++ b/decidim-core/spec/lib/events/base_event_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Decidim::Events::BaseEvent do

--- a/decidim-core/spec/lib/events/email_event_spec.rb
+++ b/decidim-core/spec/lib/events/email_event_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+describe Decidim::Events::EmailEvent do
+  class TestEvent < Decidim::Events::BaseEvent
+    include Decidim::Events::EmailEvent
+  end
+
+  describe ".types" do
+    subject { TestEvent }
+
+    it "adds `:email` to the types array" do
+      expect(subject.types).to include :email
+    end
+  end
+end

--- a/decidim-core/spec/lib/events/email_event_spec.rb
+++ b/decidim-core/spec/lib/events/email_event_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Decidim::Events::EmailEvent do

--- a/decidim-core/spec/lib/events/notification_event_spec.rb
+++ b/decidim-core/spec/lib/events/notification_event_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Decidim::Events::NotificationEvent do

--- a/decidim-core/spec/services/decidim/email_notification_generator_spec.rb
+++ b/decidim-core/spec/services/decidim/email_notification_generator_spec.rb
@@ -8,6 +8,7 @@ describe Decidim::EmailNotificationGenerator do
   let(:follow) { create(:follow, resource: resource, user: recipient) }
   let(:recipient) { resource.author }
   let(:event_class) { Decidim::Events::BaseEvent }
+  let(:event_class_name) { "Decidim::Events::BaseEvent" }
   let(:recipient_ids) { [recipient.id] }
   subject { described_class.new(event, event_class, resource, recipient_ids) }
 
@@ -22,7 +23,7 @@ describe Decidim::EmailNotificationGenerator do
       it "schedules a job for each recipient" do
         expect(Decidim::NotificationMailer)
           .to receive(:event_received)
-          .with(event, event_class, resource, recipient)
+          .with(event, event_class_name, resource, recipient)
           .and_return(mailer)
         expect(mailer).to receive(:deliver_later)
 

--- a/decidim-core/spec/services/decidim/email_notification_generator_spec.rb
+++ b/decidim-core/spec/services/decidim/email_notification_generator_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::EmailNotificationGenerator do
+  let(:event) { "decidim.events.dummy.dummy_resource_updated" }
+  let(:resource) { create(:dummy_resource) }
+  let(:follow) { create(:follow, resource: resource, user: recipient) }
+  let(:recipient) { resource.author }
+  let(:event_class) { Decidim::Events::BaseEvent }
+  let(:recipient_ids) { [recipient.id] }
+  subject { described_class.new(event, event_class, resource, recipient_ids) }
+
+  describe "generate" do
+    context "when the event_class supports emails" do
+      let(:mailer) { double(deliver_later: true) }
+
+      before do
+        allow(event_class).to receive(:types).and_return([:email])
+      end
+
+      it "schedules a job for each recipient" do
+        expect(Decidim::NotificationMailer)
+          .to receive(:event_received)
+          .with(event, event_class, resource, recipient)
+          .and_return(mailer)
+        expect(mailer).to receive(:deliver_later)
+
+        subject.generate
+      end
+    end
+
+    context "when the event_class supports emails" do
+      before do
+        allow(event_class).to receive(:types).and_return([])
+      end
+
+      it "schedules a job for each recipient" do
+        expect(Decidim::NotificationMailer)
+          .not_to receive(:event_received)
+
+        subject.generate
+      end
+    end
+  end
+end

--- a/decidim-core/spec/services/decidim/notification_generator_spec.rb
+++ b/decidim-core/spec/services/decidim/notification_generator_spec.rb
@@ -7,6 +7,7 @@ describe Decidim::NotificationGenerator do
   let(:resource) { create(:dummy_resource) }
   let(:follow) { create(:follow, resource: resource, user: recipient) }
   let(:recipient) { resource.author }
+  let(:event_class) { Decidim::Events::BaseEvent }
   let(:event_class_name) { "Decidim::Events::BaseEvent" }
   let(:recipient_ids) { [recipient.id] }
   subject { described_class.new(event, event_class, resource, recipient_ids) }

--- a/decidim-core/spec/services/decidim/notification_generator_spec.rb
+++ b/decidim-core/spec/services/decidim/notification_generator_spec.rb
@@ -7,7 +7,7 @@ describe Decidim::NotificationGenerator do
   let(:resource) { create(:dummy_resource) }
   let(:follow) { create(:follow, resource: resource, user: recipient) }
   let(:recipient) { resource.author }
-  let(:event_class) { Decidim::Events::BaseEvent }
+  let(:event_class_name) { "Decidim::Events::BaseEvent" }
   let(:recipient_ids) { [recipient.id] }
   subject { described_class.new(event, event_class, resource, recipient_ids) }
 
@@ -20,7 +20,7 @@ describe Decidim::NotificationGenerator do
       it "schedules a job for each recipient" do
         expect(Decidim::NotificationGeneratorForRecipientJob)
           .to receive(:perform_later)
-          .with(event, event_class, resource, recipient.id)
+          .with(event, event_class_name, resource, recipient.id)
 
         subject.generate
       end

--- a/decidim-meetings/app/events/decidim/meetings/close_meeting_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/close_meeting_event.rb
@@ -1,6 +1,7 @@
 module Decidim
   module Meetings
     class CloseMeetingEvent < Decidim::Events::BaseEvent
+      include Decidim::Events::EmailEvent
       include Decidim::Events::NotificationEvent
     end
   end

--- a/decidim-meetings/app/events/decidim/meetings/close_meeting_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/close_meeting_event.rb
@@ -5,6 +5,18 @@ module Decidim
     class CloseMeetingEvent < Decidim::Events::BaseEvent
       include Decidim::Events::EmailEvent
       include Decidim::Events::NotificationEvent
+
+      def email_subject
+        I18n.t("decidim.meetings.events.close_meeting_event.email_subject", resource_title: resource_title)
+      end
+
+      def email_intro
+        I18n.t("decidim.meetings.events.close_meeting_event.email_intro", resource_title: resource_title)
+      end
+
+      def email_outro
+        I18n.t("decidim.meetings.events.close_meeting_event.email_outro", resource_title: resource_title)
+      end
     end
   end
 end

--- a/decidim-meetings/app/events/decidim/meetings/close_meeting_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/close_meeting_event.rb
@@ -1,3 +1,5 @@
+# frozen-string_literal: true
+
 module Decidim
   module Meetings
     class CloseMeetingEvent < Decidim::Events::BaseEvent

--- a/decidim-meetings/app/events/decidim/meetings/update_meeting_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/update_meeting_event.rb
@@ -1,6 +1,7 @@
 module Decidim
   module Meetings
     class UpdateMeetingEvent < Decidim::Events::BaseEvent
+      include Decidim::Events::EmailEvent
       include Decidim::Events::NotificationEvent
     end
   end

--- a/decidim-meetings/app/events/decidim/meetings/update_meeting_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/update_meeting_event.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Decidim
   module Meetings
     class UpdateMeetingEvent < Decidim::Events::BaseEvent

--- a/decidim-meetings/app/events/decidim/meetings/update_meeting_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/update_meeting_event.rb
@@ -5,6 +5,18 @@ module Decidim
     class UpdateMeetingEvent < Decidim::Events::BaseEvent
       include Decidim::Events::EmailEvent
       include Decidim::Events::NotificationEvent
+
+      def email_subject
+        I18n.t("decidim.meetings.events.update_meeting_event.email_subject", resource_title: resource_title)
+      end
+
+      def email_intro
+        I18n.t("decidim.meetings.events.update_meeting_event.email_intro", resource_title: resource_title)
+      end
+
+      def email_outro
+        I18n.t("decidim.meetings.events.update_meeting_event.email_outro", resource_title: resource_title)
+      end
     end
   end
 end

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -81,6 +81,15 @@ en:
           update:
             invalid: There's been a problem saving the registration settings.
             success: Meeting registrations settings successfully saved.
+      events:
+        close_meeting_event:
+          email_intro: 'The "%{resource_title}" meeting was closed. You can read the conclusions from its page:'
+          email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
+          email_subject: The "%{resource_title}" meeting was closed
+        update_meeting_event:
+          email_intro: 'The "%{resource_title}" meeting was updated. You can read the new version from its page:'
+          email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
+          email_subject: The "%{resource_title}" meeting was updated
       meetings:
         filters:
           category: Category

--- a/decidim-meetings/spec/events/decidim/meetings/close_meeting_event_spec.rb
+++ b/decidim-meetings/spec/events/decidim/meetings/close_meeting_event_spec.rb
@@ -7,5 +7,9 @@ describe Decidim::Meetings::CloseMeetingEvent do
     it "supports notifications" do
       expect(subject.types).to include :notification
     end
+
+    it "supports emails" do
+      expect(subject.types).to include :email
+    end
   end
 end

--- a/decidim-meetings/spec/events/decidim/meetings/close_meeting_event_spec.rb
+++ b/decidim-meetings/spec/events/decidim/meetings/close_meeting_event_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Decidim::Meetings::CloseMeetingEvent do

--- a/decidim-meetings/spec/events/decidim/meetings/update_meeting_event_spec.rb
+++ b/decidim-meetings/spec/events/decidim/meetings/update_meeting_event_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Decidim::Meetings::UpdateMeetingEvent do

--- a/decidim-meetings/spec/events/decidim/meetings/update_meeting_event_spec.rb
+++ b/decidim-meetings/spec/events/decidim/meetings/update_meeting_event_spec.rb
@@ -7,5 +7,9 @@ describe Decidim::Meetings::UpdateMeetingEvent do
     it "supports notifications" do
       expect(subject.types).to include :notification
     end
+
+    it "supports notifications" do
+      expect(subject.types).to include :email
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR builds on top of #1785 and adds a way for events to send emails to users. The email has a default general text that can be overwritten in the event class level.

#### :pushpin: Related Issues
- Related to #1785, #1695
