### PR TITLE
Use latest bundler version on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV APP_HOME /decidim
 RUN apt-get update
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash && \
     apt-get install -y nodejs
+RUN gem install bundler --no-rdoc --no-ri
 
 ADD Gemfile /tmp/Gemfile
 ADD Gemfile.lock /tmp/Gemfile.lock


### PR DESCRIPTION
#### :tophat: What? Why?
CircleCI builds raise warnings about using an older Bundler version. This PR updates it on the Dockerfile, so tests can use the latest one.

#### :pushpin: Related Issues
None