### PR TITLE
Add notification dashboard

### DIFF
--- a/decidim-assemblies/app/presenters/decidim/assemblies/assembly_stats_presenter.rb
+++ b/decidim-assemblies/app/presenters/decidim/assemblies/assembly_stats_presenter.rb
@@ -38,7 +38,7 @@ module Decidim
 
       def render_stats_data(feature_manifest, name, data, index)
         safe_join([
-                    index.zero? ? feature_manifest_icon(feature_manifest) : " /&nbsp".html_safe,
+                    index.zero? ? manifest_icon(feature_manifest) : " /&nbsp".html_safe,
                     content_tag(:span, "#{number_with_delimiter(data)} " + I18n.t(name, scope: "decidim.assemblies.statistics"),
                                 class: "#{name} process_stats-text")
                   ])

--- a/decidim-core/app/assets/config/decidim_core_manifest.js
+++ b/decidim-core/app/assets/config/decidim_core_manifest.js
@@ -5,6 +5,7 @@
 //= link decidim/orders
 //= link decidim/map.js
 //= link decidim/map.css
+//= link decidim/notifications.js
 //= link_directory ../../../vendor/assets/javascripts/datepicker-locales
 //= link decidim/widget.js
 //= link decidim/impersonation.js

--- a/decidim-core/app/assets/javascripts/decidim/notifications.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/notifications.js.es6
@@ -24,6 +24,7 @@ $(() => {
   $wrapper.on('click', '.mark-all-as-read-button', () => {
     $section.fadeOut(FADEOUT_TIME, () => {
       $pagination.remove();
+      $wrapper.find('.card--list__item').remove();
       emptyNotifications();
     });
   });

--- a/decidim-core/app/assets/javascripts/decidim/notifications.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/notifications.js.es6
@@ -1,6 +1,6 @@
 $(() => {
   const $section = $('section#unread-notifications');
   $section.on('click', '.mark-as-read-button', (event) => {
-    $(event.target).parents('.card--list__data').hide();
+    $(event.target).parents('.card--list__item').fadeOut(1000);
   })
 });

--- a/decidim-core/app/assets/javascripts/decidim/notifications.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/notifications.js.es6
@@ -1,12 +1,32 @@
 $(() => {
-  const $section = $('section#unread-notifications');
   const $wrapper = $('#notifications');
+  const $section = $wrapper.find('section#notifications-list');
+  const $noNotificationsText = $wrapper.find('.empty-notifications');
+  const $pagination = $wrapper.find('ul.pagination');
+  const FADEOUT_TIME = 500;
+
+  const anyNotifications = () => $wrapper.find('.card--list__item').length > 0;
+  const emptyNotifications = () => {
+    if (!anyNotifications()) {
+      $section.remove();
+      $noNotificationsText.removeClass('hide');
+    }
+  };
 
   $section.on('click', '.mark-as-read-button', (event) => {
-    $(event.target).parents('.card--list__item').fadeOut(1000);
+    const $item = $(event.target).parents('.card--list__item');
+    $item.fadeOut(FADEOUT_TIME, () => {
+      $item.remove();
+      emptyNotifications();
+    });
   });
 
-  $wrapper.on('click', '.mark-all-as-read-button', (_event) => {
-    $section.fadeOut(1000);
+  $wrapper.on('click', '.mark-all-as-read-button', () => {
+    $section.fadeOut(FADEOUT_TIME, () => {
+      $pagination.remove();
+      emptyNotifications();
+    });
   });
+
+  emptyNotifications();
 });

--- a/decidim-core/app/assets/javascripts/decidim/notifications.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/notifications.js.es6
@@ -1,6 +1,12 @@
 $(() => {
   const $section = $('section#unread-notifications');
+  const $wrapper = $('#notifications');
+
   $section.on('click', '.mark-as-read-button', (event) => {
     $(event.target).parents('.card--list__item').fadeOut(1000);
-  })
+  });
+
+  $wrapper.on('click', '.mark-all-as-read-button', (_event) => {
+    $section.fadeOut(1000);
+  });
 });

--- a/decidim-core/app/assets/javascripts/decidim/notifications.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/notifications.js.es6
@@ -1,0 +1,6 @@
+$(() => {
+  const $section = $('section#unread-notifications');
+  $section.on('click', '.mark-as-read-button', (event) => {
+    $(event.target).parents('.card--list__data').hide();
+  })
+});

--- a/decidim-core/app/controllers/decidim/notifications_controller.rb
+++ b/decidim-core/app/controllers/decidim/notifications_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Decidim
+  # The controller to handle the user's notifications dashboard.
+  class NotificationsController < Decidim::ApplicationController
+    helper Decidim::IconHelper
+
+    helper_method :collection, :read_notifications, :unread_notifications
+
+    def index
+      authorize! :read, Notification
+    end
+
+    private
+
+    def collection
+      @collection ||= current_user.notifications.order(created_at: :desc)
+    end
+
+    def unread_notifications
+      @unread_notifications ||= collection.limit(3)
+    end
+
+    def read_notifications
+      @read_notifications ||= collection.offset(3)
+    end
+  end
+end

--- a/decidim-core/app/controllers/decidim/notifications_controller.rb
+++ b/decidim-core/app/controllers/decidim/notifications_controller.rb
@@ -18,11 +18,11 @@ module Decidim
     end
 
     def unread_notifications
-      @unread_notifications ||= collection.limit(3)
+      @unread_notifications ||= collection.unread
     end
 
     def read_notifications
-      @read_notifications ||= collection.offset(3)
+      @read_notifications ||= collection.read
     end
   end
 end

--- a/decidim-core/app/controllers/decidim/notifications_controller.rb
+++ b/decidim-core/app/controllers/decidim/notifications_controller.rb
@@ -20,6 +20,11 @@ module Decidim
       notification.destroy
     end
 
+    def read_all
+      authorize! :destroy, notifications.first
+      notifications.destroy_all
+    end
+
     private
 
     def notifications

--- a/decidim-core/app/controllers/decidim/notifications_controller.rb
+++ b/decidim-core/app/controllers/decidim/notifications_controller.rb
@@ -5,30 +5,22 @@ module Decidim
   class NotificationsController < Decidim::ApplicationController
     helper Decidim::IconHelper
 
-    helper_method :collection, :read_notifications, :unread_notifications
+    helper_method :notifications
 
     def index
       authorize! :read, Notification
     end
 
-    def read
-      authorize! :update, Notification
-      notification = collection.find(params[:id])
-      notification.update_attributes(read_at: Time.current)
+    def destroy
+      notification = notifications.find(params[:id])
+      authorize! :destroy, notification
+      notification.destroy
     end
 
     private
 
-    def collection
-      @collection ||= current_user.notifications.order(created_at: :desc)
-    end
-
-    def unread_notifications
-      @unread_notifications ||= collection.unread
-    end
-
-    def read_notifications
-      @read_notifications ||= collection.read
+    def notifications
+      @notifications ||= current_user.notifications.order(created_at: :desc)
     end
   end
 end

--- a/decidim-core/app/controllers/decidim/notifications_controller.rb
+++ b/decidim-core/app/controllers/decidim/notifications_controller.rb
@@ -11,6 +11,12 @@ module Decidim
       authorize! :read, Notification
     end
 
+    def read
+      authorize! :update, Notification
+      notification = collection.find(params[:id])
+      notification.update_attributes(read_at: Time.current)
+    end
+
     private
 
     def collection

--- a/decidim-core/app/controllers/decidim/notifications_controller.rb
+++ b/decidim-core/app/controllers/decidim/notifications_controller.rb
@@ -4,11 +4,14 @@ module Decidim
   # The controller to handle the user's notifications dashboard.
   class NotificationsController < Decidim::ApplicationController
     helper Decidim::IconHelper
+    helper Decidim::PaginateHelper
+    include Paginable
 
     helper_method :notifications
 
     def index
       authorize! :read, Notification
+      @notifications = paginate(notifications)
     end
 
     def destroy
@@ -21,6 +24,11 @@ module Decidim
 
     def notifications
       @notifications ||= current_user.notifications.order(created_at: :desc)
+    end
+
+    # Private: overwrites the amount of elements per page.
+    def per_page
+      50
     end
   end
 end

--- a/decidim-core/app/helpers/decidim/icon_helper.rb
+++ b/decidim-core/app/helpers/decidim/icon_helper.rb
@@ -7,23 +7,41 @@ module Decidim
     # a question mark when no icon is found.
     #
     # feature - The feature to generate the icon for.
+    # options - a Hash with options
     #
     # Returns an HTML tag with the icon.
-    def feature_icon(feature)
-      feature_manifest_icon(feature.manifest)
+    def feature_icon(feature, options = {})
+      feature_manifest_icon(feature.manifest, options)
     end
 
     # Public: Returns an icon given an instance of a Feature Manifest. It defaults to
     # a question mark when no icon is found.
     #
     # feature_manifest - The feature manifest to generate the icon for.
+    # options - a Hash with options
     #
     # Returns an HTML tag with the icon.
-    def feature_manifest_icon(feature_manifest)
+    def feature_manifest_icon(feature_manifest, options = {})
       if feature_manifest.icon
-        external_icon feature_manifest.icon
+        external_icon feature_manifest.icon, options
       else
-        icon "question-mark"
+        icon "question-mark", options
+      end
+    end
+
+    # Public: Finds the correct icon for the given resource. If the resource has a
+    # Feature then it uses it to find the icon, otherwise checks for the resource
+    # type to find the icon.
+    #
+    # resource - The resource to generate the icon for.
+    # options - a Hash with options
+    #
+    # Returns an HTML tag with the icon.
+    def resource_icon(resource, options = {})
+      if resource.respond_to?(:feature)
+        feature_icon(resource.feature, options)
+      else
+        external_icon "decidim/participatory_processes/process.svg", options
       end
     end
   end

--- a/decidim-core/app/helpers/decidim/icon_helper.rb
+++ b/decidim-core/app/helpers/decidim/icon_helper.rb
@@ -11,19 +11,19 @@ module Decidim
     #
     # Returns an HTML tag with the icon.
     def feature_icon(feature, options = {})
-      feature_manifest_icon(feature.manifest, options)
+      manifest_icon(feature.manifest, options)
     end
 
-    # Public: Returns an icon given an instance of a Feature Manifest. It defaults to
+    # Public: Returns an icon given an instance of a Manifest. It defaults to
     # a question mark when no icon is found.
     #
-    # feature_manifest - The feature manifest to generate the icon for.
+    # manifest - The manifest to generate the icon for.
     # options - a Hash with options
     #
     # Returns an HTML tag with the icon.
-    def feature_manifest_icon(feature_manifest, options = {})
-      if feature_manifest.icon
-        external_icon feature_manifest.icon, options
+    def manifest_icon(manifest, options = {})
+      if manifest.icon
+        external_icon manifest.icon, options
       else
         icon "question-mark", options
       end
@@ -31,7 +31,7 @@ module Decidim
 
     # Public: Finds the correct icon for the given resource. If the resource has a
     # Feature then it uses it to find the icon, otherwise checks for the resource
-    # type to find the icon.
+    # manifest to find the icon.
     #
     # resource - The resource to generate the icon for.
     # options - a Hash with options
@@ -41,7 +41,7 @@ module Decidim
       if resource.respond_to?(:feature)
         feature_icon(resource.feature, options)
       else
-        external_icon "decidim/participatory_processes/process.svg", options
+        manifest_icon(resource.manifest, options)
       end
     end
   end

--- a/decidim-core/app/helpers/decidim/paginate_helper.rb
+++ b/decidim-core/app/helpers/decidim/paginate_helper.rb
@@ -8,7 +8,7 @@ module Decidim
     #
     # collection - a collection of elements that need to be paginated
     # paginate_params - a Hash with options to delegate to the pagination helper.
-    def decidim_paginate(collection, paginate_params)
+    def decidim_paginate(collection, paginate_params = {})
       # Kaminari uses url_for to generate the url, but this doesn't play nice with our engine system
       # and unless we remove these params they are added again as query string :(
       default_params = {

--- a/decidim-core/app/jobs/decidim/email_notification_generator_job.rb
+++ b/decidim-core/app/jobs/decidim/email_notification_generator_job.rb
@@ -4,9 +4,9 @@ module Decidim
   class EmailNotificationGeneratorJob < ApplicationJob
     queue_as :decidim_events
 
-    def perform(event, event_class_name, followable, recipient_ids)
+    def perform(event, event_class_name, resource, recipient_ids)
       event_class = event_class_name.constantize
-      EmailNotificationGenerator.new(event, event_class, followable, recipient_ids).generate
+      EmailNotificationGenerator.new(event, event_class, resource, recipient_ids).generate
     end
   end
 end

--- a/decidim-core/app/jobs/decidim/notification_generator_job.rb
+++ b/decidim-core/app/jobs/decidim/notification_generator_job.rb
@@ -4,9 +4,9 @@ module Decidim
   class NotificationGeneratorJob < ApplicationJob
     queue_as :decidim_events
 
-    def perform(event, event_class_name, followable, recipient_ids)
+    def perform(event, event_class_name, resource, recipient_ids)
       event_class = event_class_name.constantize
-      NotificationGenerator.new(event, event_class, followable, recipient_ids).generate
+      NotificationGenerator.new(event, event_class, resource, recipient_ids).generate
     end
   end
 end

--- a/decidim-core/app/mailers/decidim/notification_mailer.rb
+++ b/decidim-core/app/mailers/decidim/notification_mailer.rb
@@ -8,7 +8,6 @@ module Decidim
 
     def event_received(event, event_class_name, resource, user)
       with_user(user) do
-        @locator = Decidim::ResourceLocatorPresenter.new(resource)
         @organization = resource.organization
         event_class = event_class_name.constantize
         @event_instance = event_class.new(resource: resource, event_name: event, user: user)

--- a/decidim-core/app/models/decidim/abilities/base_ability.rb
+++ b/decidim-core/app/models/decidim/abilities/base_ability.rb
@@ -28,6 +28,10 @@ module Decidim
         can :manage, Authorization do |authorization|
           authorization.user == user
         end
+
+        can :manage, Notification do |notification|
+          notification.user == user
+        end
       end
     end
   end

--- a/decidim-core/app/models/decidim/notification.rb
+++ b/decidim-core/app/models/decidim/notification.rb
@@ -4,5 +4,9 @@ module Decidim
   class Notification < ApplicationRecord
     belongs_to :followable, foreign_key: "decidim_followable_id", foreign_type: "decidim_followable_type", polymorphic: true
     belongs_to :user, foreign_key: "decidim_user_id", class_name: "Decidim::User"
+
+    def event_class_instance
+      @event_class_instance ||= event_class.constantize.new(resource: followable, event_name: notification_type, user: user)
+    end
   end
 end

--- a/decidim-core/app/models/decidim/notification.rb
+++ b/decidim-core/app/models/decidim/notification.rb
@@ -5,6 +5,14 @@ module Decidim
     belongs_to :resource, foreign_key: "decidim_resource_id", foreign_type: "decidim_resource_type", polymorphic: true
     belongs_to :user, foreign_key: "decidim_user_id", class_name: "Decidim::User"
 
+    def self.unread
+      where(read_at: nil)
+    end
+
+    def self.read
+      where.not(read_at: nil)
+    end
+
     def event_class_instance
       @event_class_instance ||= event_class.constantize.new(resource: resource, event_name: event_name, user: user)
     end

--- a/decidim-core/app/models/decidim/notification.rb
+++ b/decidim-core/app/models/decidim/notification.rb
@@ -13,6 +13,14 @@ module Decidim
       where.not(read_at: nil)
     end
 
+    def unread?
+      !read?
+    end
+
+    def read?
+      read_at.present?
+    end
+
     def event_class_instance
       @event_class_instance ||= event_class.constantize.new(resource: resource, event_name: event_name, user: user)
     end

--- a/decidim-core/app/models/decidim/notification.rb
+++ b/decidim-core/app/models/decidim/notification.rb
@@ -5,22 +5,6 @@ module Decidim
     belongs_to :resource, foreign_key: "decidim_resource_id", foreign_type: "decidim_resource_type", polymorphic: true
     belongs_to :user, foreign_key: "decidim_user_id", class_name: "Decidim::User"
 
-    def self.unread
-      where(read_at: nil)
-    end
-
-    def self.read
-      where.not(read_at: nil)
-    end
-
-    def unread?
-      !read?
-    end
-
-    def read?
-      read_at.present?
-    end
-
     def event_class_instance
       @event_class_instance ||= event_class.constantize.new(resource: resource, event_name: event_name, user: user)
     end

--- a/decidim-core/app/models/decidim/notification.rb
+++ b/decidim-core/app/models/decidim/notification.rb
@@ -2,11 +2,11 @@
 
 module Decidim
   class Notification < ApplicationRecord
-    belongs_to :followable, foreign_key: "decidim_followable_id", foreign_type: "decidim_followable_type", polymorphic: true
+    belongs_to :resource, foreign_key: "decidim_resource_id", foreign_type: "decidim_resource_type", polymorphic: true
     belongs_to :user, foreign_key: "decidim_user_id", class_name: "Decidim::User"
 
     def event_class_instance
-      @event_class_instance ||= event_class.constantize.new(resource: followable, event_name: notification_type, user: user)
+      @event_class_instance ||= event_class.constantize.new(resource: resource, event_name: event_name, user: user)
     end
   end
 end

--- a/decidim-core/app/services/decidim/notification_generator_for_recipient.rb
+++ b/decidim-core/app/services/decidim/notification_generator_for_recipient.rb
@@ -35,8 +35,8 @@ module Decidim
       Notification.create!(
         user: recipient,
         event_class: event_class,
-        followable: resource,
-        notification_type: event
+        resource: resource,
+        event_name: event
       )
     end
 

--- a/decidim-core/app/views/decidim/notification_mailer/event_received.html.erb
+++ b/decidim-core/app/views/decidim/notification_mailer/event_received.html.erb
@@ -3,7 +3,7 @@
 <p><%= @event_instance.email_intro %></p>
 
 <p>
-  <%= link_to @locator.url, @locator.url %>
+  <%= link_to @event_instance.resource_url, @event_instance.resource_url %>
 </p>
 
 <p><%= @event_instance.email_outro %></p>

--- a/decidim-core/app/views/decidim/notifications/_notification.html.erb
+++ b/decidim-core/app/views/decidim/notifications/_notification.html.erb
@@ -1,0 +1,18 @@
+<div class="card--list__item">
+  <div class="card--list__text">
+    <%= link_to notification.event_class_instance.resource_path do %>
+      <%= resource_icon notification.followable, class: "icon--chat card--list__icon" %>
+    <% end %>
+    <div>
+      <h5 class="card--list__heading">
+        <%= notification.event_class_instance.notification_title %>
+      </h5>
+      <span class="text-small"><%= l notification.created_at.to_date, format: :long %></span>
+    </div>
+  </div>
+  <div class="card--list__data">
+    <a href="" class="card--list__data__icon">
+      <svg class="icon icon--chevron-right "> <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/images/icons.svg#icon-chevron-right"></use> </svg>
+    </a>
+  </div>
+</div>

--- a/decidim-core/app/views/decidim/notifications/_notification.html.erb
+++ b/decidim-core/app/views/decidim/notifications/_notification.html.erb
@@ -10,9 +10,11 @@
       <span class="text-small"><%= l notification.created_at.to_date, format: :long %></span>
     </div>
   </div>
-  <div class="card--list__data">
-    <a href="" class="card--list__data__icon">
-      <svg class="icon icon--chevron-right "> <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/images/icons.svg#icon-chevron-right"></use> </svg>
-    </a>
-  </div>
+  <% if notification.unread? %>
+    <div class="card--list__data">
+      <a href="" class="card--list__data__icon">
+        <%= icon "check", class: "icon icon--chevron-right" %>
+      </a>
+    </div>
+  <% end %>
 </div>

--- a/decidim-core/app/views/decidim/notifications/_notification.html.erb
+++ b/decidim-core/app/views/decidim/notifications/_notification.html.erb
@@ -12,9 +12,9 @@
   </div>
   <% if notification.unread? %>
     <div class="card--list__data">
-      <a href="" class="card--list__data__icon">
+      <%= link_to [:read, notification], class: "mark-as-read-button card--list__data__icon", remote: true, method: :put do %>
         <%= icon "check", class: "icon icon--chevron-right" %>
-      </a>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/decidim-core/app/views/decidim/notifications/_notification.html.erb
+++ b/decidim-core/app/views/decidim/notifications/_notification.html.erb
@@ -1,7 +1,7 @@
 <div class="card--list__item">
   <div class="card--list__text">
     <%= link_to notification.event_class_instance.resource_path do %>
-      <%= resource_icon notification.followable, class: "icon--chat card--list__icon" %>
+      <%= resource_icon notification.resource, class: "icon--chat card--list__icon" %>
     <% end %>
     <div>
       <h5 class="card--list__heading">

--- a/decidim-core/app/views/decidim/notifications/_notification.html.erb
+++ b/decidim-core/app/views/decidim/notifications/_notification.html.erb
@@ -10,11 +10,9 @@
       <span class="text-small"><%= l notification.created_at.to_date, format: :long %></span>
     </div>
   </div>
-  <% if notification.unread? %>
-    <div class="card--list__data">
-      <%= link_to [:read, notification], class: "mark-as-read-button card--list__data__icon", remote: true, method: :put do %>
-        <%= icon "check", class: "icon icon--chevron-right" %>
-      <% end %>
-    </div>
-  <% end %>
+  <div class="card--list__data">
+    <%= link_to notification, class: "mark-as-read-button card--list__data__icon", remote: true, method: :delete do %>
+      <%= icon "check", class: "icon icon--chevron-right" %>
+    <% end %>
+  </div>
 </div>

--- a/decidim-core/app/views/decidim/notifications/index.html.erb
+++ b/decidim-core/app/views/decidim/notifications/index.html.erb
@@ -15,6 +15,7 @@
       <% else %>
         <p><%= t("no_notifications", scope: "layouts.decidim.notifications_dashboard") %></p>
       <% end %>
+      <%= decidim_paginate notifications %>
     </div>
   </div>
 </main>

--- a/decidim-core/app/views/decidim/notifications/index.html.erb
+++ b/decidim-core/app/views/decidim/notifications/index.html.erb
@@ -16,15 +16,14 @@
   </div>
   <div class="row">
     <div class="columns mediumlarge-12 large-12">
+      <p class="empty-notifications hide"><%= t("no_notifications", scope: "layouts.decidim.notifications_dashboard") %></p>
       <% if notifications.any? %>
-        <section class="section" id="unread-notifications">
+        <section class="section" id="notifications-list">
           <div class="card card--list">
             <%= render notifications %>
           </div>
         </section>
         <%= decidim_paginate notifications %>
-      <% else %>
-        <p><%= t("no_notifications", scope: "layouts.decidim.notifications_dashboard") %></p>
       <% end %>
     </div>
   </div>

--- a/decidim-core/app/views/decidim/notifications/index.html.erb
+++ b/decidim-core/app/views/decidim/notifications/index.html.erb
@@ -1,0 +1,66 @@
+<main class="wrapper">
+  <div class="row collapse">
+    <div class="columns">
+      <h1 class="heading1 user-header"><%= t("title", scope: "layouts.decidim.user_profile") %></h1>
+    </div>
+  </div>
+  <div class="row">
+    <div class="columns mediumlarge-4 large-3">
+      <div class="filters-controls hide-for-mediumlarge">
+        <button data-open="filter-box" class="filters-controls__trigger" aria-controls="filter-box" aria-haspopup="true" tabindex="0">
+          Filtrar
+          <svg class="icon icon--caret-bottom icon--small float-right" role="img" aria-label="Desplegar"> <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/images/icons.svg#icon-caret-bottom"></use> </svg>
+        </button>
+      </div>
+
+
+      <div class="card card--secondary show-for-mediumlarge">
+        <div class="filters">
+          <div class="filters__section">
+            <form>
+              <fieldset>
+                <legend>
+                  <h6 class="heading6">
+                    Veure
+                  </h6>
+                </legend>
+                <label><input id="" type="radio" name="author" checked="">Tots</label>
+                <label><input id="" type="radio" name="author">Comentaris</label>
+                <label><input id="" type="radio" name="author">Propostes</label>
+                <label><input id="" type="radio" name="author">Trobades</label>
+                <label><input id="" type="radio" name="author">Altres</label>
+              </fieldset>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="columns mediumlarge-8 large-9">
+      <% if unread_notifications.any? %>
+        <section class="section">
+          <h2 class="section-heading">Notificacions per revisar</h2>
+          <div class="card card--list">
+            <%= render unread_notifications %>
+          </div>
+        </section>
+      <% end %>
+      <section class="section">
+        <h2 class="section-heading">Notificacions antigues</h2>
+        <div class="card card--list">
+          <%= render read_notifications %>
+        </div>
+      </section>
+      <ul class="pagination text-center" role="navigation" aria-label="Pagination">
+        <li class="pagination-previous disabled">Anterior</li>
+        <li class="current"><span class="show-for-sr">You're on page</span> 1</li>
+        <li><a href="#" aria-label="Page 2">2</a></li>
+        <li><a href="#" aria-label="Page 3">3</a></li>
+        <li><a href="#" aria-label="Page 4">4</a></li>
+        <li class="ellipsis"></li>
+        <li><a href="#" aria-label="Page 12">12</a></li>
+        <li><a href="#" aria-label="Page 13">13</a></li>
+        <li class="pagination-next"><a href="#" aria-label="Next page">Siguiente</a></li>
+      </ul>
+    </div>
+  </div>
+</main>

--- a/decidim-core/app/views/decidim/notifications/index.html.erb
+++ b/decidim-core/app/views/decidim/notifications/index.html.erb
@@ -6,24 +6,15 @@
   </div>
   <div class="row">
     <div class="columns mediumlarge-12 large-12">
-      <% if unread_notifications.any? %>
+      <% if notifications.any? %>
         <section class="section" id="unread-notifications">
-          <h2 class="section-heading"><%= t("unread_notifications", scope: "layouts.decidim.notifications_dashboard") %></h2>
           <div class="card card--list">
-            <%= render unread_notifications %>
+            <%= render notifications %>
           </div>
         </section>
+      <% else %>
+        <p><%= t("no_notifications", scope: "layouts.decidim.notifications_dashboard") %></p>
       <% end %>
-      <section class="section" id="read-notifications">
-        <h2 class="section-heading"><%= t("old_notifications", scope: "layouts.decidim.notifications_dashboard") %></h2>
-        <% if read_notifications.any? %>
-          <div class="card card--list">
-            <%= render read_notifications %>
-          </div>
-        <% else %>
-          <p><%= t("no_notifications", scope: "layouts.decidim.notifications_dashboard") %></p>
-        <% end %>
-      </section>
     </div>
   </div>
 </main>

--- a/decidim-core/app/views/decidim/notifications/index.html.erb
+++ b/decidim-core/app/views/decidim/notifications/index.html.erb
@@ -7,14 +7,14 @@
   <div class="row">
     <div class="columns mediumlarge-12 large-12">
       <% if unread_notifications.any? %>
-        <section class="section">
+        <section class="section" id="unread-notifications">
           <h2 class="section-heading"><%= t("unread_notifications", scope: "layouts.decidim.notifications_dashboard") %></h2>
           <div class="card card--list">
             <%= render unread_notifications %>
           </div>
         </section>
       <% end %>
-      <section class="section">
+      <section class="section" id="read-notifications">
         <h2 class="section-heading"><%= t("old_notifications", scope: "layouts.decidim.notifications_dashboard") %></h2>
         <% if read_notifications.any? %>
           <div class="card card--list">
@@ -27,3 +27,5 @@
     </div>
   </div>
 </main>
+
+<%= javascript_include_tag "decidim/notifications" %>

--- a/decidim-core/app/views/decidim/notifications/index.html.erb
+++ b/decidim-core/app/views/decidim/notifications/index.html.erb
@@ -1,66 +1,29 @@
 <main class="wrapper">
   <div class="row collapse">
     <div class="columns">
-      <h1 class="heading1 user-header"><%= t("title", scope: "layouts.decidim.user_profile") %></h1>
+      <h1 class="heading1 user-header"><%= t("title", scope: "layouts.decidim.notifications_dashboard") %></h1>
     </div>
   </div>
   <div class="row">
-    <div class="columns mediumlarge-4 large-3">
-      <div class="filters-controls hide-for-mediumlarge">
-        <button data-open="filter-box" class="filters-controls__trigger" aria-controls="filter-box" aria-haspopup="true" tabindex="0">
-          Filtrar
-          <svg class="icon icon--caret-bottom icon--small float-right" role="img" aria-label="Desplegar"> <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/images/icons.svg#icon-caret-bottom"></use> </svg>
-        </button>
-      </div>
-
-
-      <div class="card card--secondary show-for-mediumlarge">
-        <div class="filters">
-          <div class="filters__section">
-            <form>
-              <fieldset>
-                <legend>
-                  <h6 class="heading6">
-                    Veure
-                  </h6>
-                </legend>
-                <label><input id="" type="radio" name="author" checked="">Tots</label>
-                <label><input id="" type="radio" name="author">Comentaris</label>
-                <label><input id="" type="radio" name="author">Propostes</label>
-                <label><input id="" type="radio" name="author">Trobades</label>
-                <label><input id="" type="radio" name="author">Altres</label>
-              </fieldset>
-            </form>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="columns mediumlarge-8 large-9">
+    <div class="columns mediumlarge-12 large-12">
       <% if unread_notifications.any? %>
         <section class="section">
-          <h2 class="section-heading">Notificacions per revisar</h2>
+          <h2 class="section-heading"><%= t("unread_notifications", scope: "layouts.decidim.notifications_dashboard") %></h2>
           <div class="card card--list">
             <%= render unread_notifications %>
           </div>
         </section>
       <% end %>
       <section class="section">
-        <h2 class="section-heading">Notificacions antigues</h2>
-        <div class="card card--list">
-          <%= render read_notifications %>
-        </div>
+        <h2 class="section-heading"><%= t("old_notifications", scope: "layouts.decidim.notifications_dashboard") %></h2>
+        <% if read_notifications.any? %>
+          <div class="card card--list">
+            <%= render read_notifications %>
+          </div>
+        <% else %>
+          <p><%= t("no_notifications", scope: "layouts.decidim.notifications_dashboard") %></p>
+        <% end %>
       </section>
-      <ul class="pagination text-center" role="navigation" aria-label="Pagination">
-        <li class="pagination-previous disabled">Anterior</li>
-        <li class="current"><span class="show-for-sr">You're on page</span> 1</li>
-        <li><a href="#" aria-label="Page 2">2</a></li>
-        <li><a href="#" aria-label="Page 3">3</a></li>
-        <li><a href="#" aria-label="Page 4">4</a></li>
-        <li class="ellipsis"></li>
-        <li><a href="#" aria-label="Page 12">12</a></li>
-        <li><a href="#" aria-label="Page 13">13</a></li>
-        <li class="pagination-next"><a href="#" aria-label="Next page">Siguiente</a></li>
-      </ul>
     </div>
   </div>
 </main>

--- a/decidim-core/app/views/decidim/notifications/index.html.erb
+++ b/decidim-core/app/views/decidim/notifications/index.html.erb
@@ -1,7 +1,17 @@
-<main class="wrapper">
+<main class="wrapper" id="notifications">
   <div class="row collapse">
     <div class="columns">
-      <h1 class="heading1 user-header"><%= t("title", scope: "layouts.decidim.notifications_dashboard") %></h1>
+      <div class="title-action" >
+        <h1 class="heading1 title-action__title"><%= t("title", scope: "layouts.decidim.notifications_dashboard") %></h1>
+        <%= link_to(
+          t("mark_all_as_read", scope: "layouts.decidim.notifications_dashboard"),
+          decidim.read_all_notifications_path,
+          class: "button title-action__action hollow mark-all-as-read-button",
+          method: :delete,
+          data: { disable: true },
+          remote: true
+        ) %>
+      </div>
     </div>
   </div>
   <div class="row">
@@ -12,10 +22,10 @@
             <%= render notifications %>
           </div>
         </section>
+        <%= decidim_paginate notifications %>
       <% else %>
         <p><%= t("no_notifications", scope: "layouts.decidim.notifications_dashboard") %></p>
       <% end %>
-      <%= decidim_paginate notifications %>
     </div>
   </div>
 </main>

--- a/decidim-core/app/views/layouts/decidim/_user_menu.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_user_menu.html.erb
@@ -1,4 +1,5 @@
 <li><%= link_to t(".profile"), decidim.account_path %></li>
+<li><%= link_to t(".notifications"), decidim.notifications_path %></li>
 <% if can? :read, :admin_dashboard %>
   <li><%= link_to t(".admin_dashboard"), decidim_admin.root_path %></li>
 <% end %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -133,6 +133,8 @@ en:
         email_intro: 'There has been an update to "%{resource_title}". You can see it from this page:'
         email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
         email_subject: An update to %{resource_title}
+      notification_event:
+        notification_title: An event occured to <a href="%{resource_path}">%{resource_title}</a>.
     export_mailer:
       export:
         ready: Please find attached a zipped version of your export.

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -311,6 +311,7 @@ en:
         description_html: You are impersonating the user <b>%{user_name}</b>.
         expire_time_html: Your session will expire in <b><span class="minutes">%{minutes}</span> minutes</b>.
       notifications_dashboard:
+        mark_all_as_read: Mark all as read
         no_notifications: No notifications yet.
         title: Notifications
       user_menu:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -310,6 +310,11 @@ en:
         close_session: Close session
         description_html: You are impersonating the user <b>%{user_name}</b>.
         expire_time_html: Your session will expire in <b><span class="minutes">%{minutes}</span> minutes</b>.
+      notifications_dashboard:
+        no_notifications: No notifications yet.
+        old_notifications: Old notifications
+        title: Notifications
+        unread_notifications: Unread notifications
       user_menu:
         admin_dashboard: Admin dashboard
         profile: My account

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -312,9 +312,7 @@ en:
         expire_time_html: Your session will expire in <b><span class="minutes">%{minutes}</span> minutes</b>.
       notifications_dashboard:
         no_notifications: No notifications yet.
-        old_notifications: Old notifications
         title: Notifications
-        unread_notifications: Unread notifications
       user_menu:
         admin_dashboard: Admin dashboard
         notifications: Notifications

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -317,6 +317,7 @@ en:
         unread_notifications: Unread notifications
       user_menu:
         admin_dashboard: Admin dashboard
+        notifications: Notifications
         profile: My account
         sign_out: Sign out
       user_profile:

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -37,7 +37,11 @@ Decidim::Core::Engine.routes.draw do
         get :delete
       end
     end
-    resources :notifications, only: [:index]
+    resources :notifications, only: [:index] do
+      member do
+        put :read
+      end
+    end
     resource :notifications_settings, only: [:show, :update], controller: "notifications_settings"
     resources :own_user_groups, only: [:index]
   end

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -37,7 +37,11 @@ Decidim::Core::Engine.routes.draw do
         get :delete
       end
     end
-    resources :notifications, only: [:index, :destroy]
+    resources :notifications, only: [:index, :destroy] do
+      collection do
+        delete :read_all
+      end
+    end
     resource :notifications_settings, only: [:show, :update], controller: "notifications_settings"
     resources :own_user_groups, only: [:index]
   end

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -37,6 +37,7 @@ Decidim::Core::Engine.routes.draw do
         get :delete
       end
     end
+    resources :notifications, only: [:index]
     resource :notifications_settings, only: [:show, :update], controller: "notifications_settings"
     resources :own_user_groups, only: [:index]
   end

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -37,11 +37,7 @@ Decidim::Core::Engine.routes.draw do
         get :delete
       end
     end
-    resources :notifications, only: [:index] do
-      member do
-        put :read
-      end
-    end
+    resources :notifications, only: [:index, :destroy]
     resource :notifications_settings, only: [:show, :update], controller: "notifications_settings"
     resources :own_user_groups, only: [:index]
   end

--- a/decidim-core/db/migrate/20170808071019_create_decidim_notifications.rb
+++ b/decidim-core/db/migrate/20170808071019_create_decidim_notifications.rb
@@ -4,8 +4,8 @@ class CreateDecidimNotifications < ActiveRecord::Migration[5.1]
   def change
     create_table :decidim_notifications do |t|
       t.references :decidim_user, null: false
-      t.references :decidim_followable, polymorphic: true, index: false, null: false
-      t.string :notification_type, null: false
+      t.references :decidim_resource, polymorphic: true, index: false, null: false
+      t.string :event_name, null: false
       t.string :event_class, null: false
       t.timestamps
     end

--- a/decidim-core/db/migrate/20170808071019_create_decidim_notifications.rb
+++ b/decidim-core/db/migrate/20170808071019_create_decidim_notifications.rb
@@ -7,6 +7,7 @@ class CreateDecidimNotifications < ActiveRecord::Migration[5.1]
       t.references :decidim_resource, polymorphic: true, index: false, null: false
       t.string :event_name, null: false
       t.string :event_class, null: false
+      t.datetime :read_at
       t.timestamps
     end
   end

--- a/decidim-core/db/migrate/20170808071019_create_decidim_notifications.rb
+++ b/decidim-core/db/migrate/20170808071019_create_decidim_notifications.rb
@@ -7,7 +7,6 @@ class CreateDecidimNotifications < ActiveRecord::Migration[5.1]
       t.references :decidim_resource, polymorphic: true, index: false, null: false
       t.string :event_name, null: false
       t.string :event_class, null: false
-      t.datetime :read_at
       t.timestamps
     end
   end

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -314,6 +314,6 @@ FactoryGirl.define do
     end
     resource { build(:dummy_resource) }
     event_name { resource.class.name.underscore.tr("/", ".") }
-    event_class { "Decidim::Events::BaseEvent" }
+    event_class { "Decidim::DummyResourceEvent" }
   end
 end

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -309,11 +309,11 @@ FactoryGirl.define do
     user do
       build(
         :user,
-        organization: followable.try(:organization) || build(:organization)
+        organization: resource.try(:organization) || build(:organization)
       )
     end
-    followable { build(:dummy_resource) }
-    notification_type { followable.class.name.underscore.tr("/", ".") }
+    resource { build(:dummy_resource) }
+    event_name { resource.class.name.underscore.tr("/", ".") }
     event_class { "Decidim::Events::BaseEvent" }
   end
 end

--- a/decidim-core/lib/decidim/events/base_event.rb
+++ b/decidim-core/lib/decidim/events/base_event.rb
@@ -40,9 +40,29 @@ module Decidim
         @user = user
       end
 
+      # Caches the locator for the given resource, so that
+      # we can find the resource URL.
+      def resource_locator
+        @resource_locator ||= Decidim::ResourceLocatorPresenter.new(resource)
+      end
+
+      # Caches the path for the given resource.
+      def resource_path
+        @resource_url ||= resource_locator.path
+      end
+
+      # Caches the URL for the given resource.
+      def resource_url
+        @resource_url ||= resource_locator.url
+      end
+
       private
 
       attr_reader :event_name, :resource, :user
+
+      def resource_title
+        resource.title.is_a?(Hash) ? resource.title[I18n.locale.to_s] : resource.title
+      end
     end
   end
 end

--- a/decidim-core/lib/decidim/events/base_event.rb
+++ b/decidim-core/lib/decidim/events/base_event.rb
@@ -48,7 +48,7 @@ module Decidim
 
       # Caches the path for the given resource.
       def resource_path
-        @resource_url ||= resource_locator.path
+        @resource_path ||= resource_locator.path
       end
 
       # Caches the URL for the given resource.

--- a/decidim-core/lib/decidim/events/email_event.rb
+++ b/decidim-core/lib/decidim/events/email_event.rb
@@ -33,12 +33,6 @@ module Decidim
         def email_outro
           I18n.t("decidim.events.email_event.email_outro", resource_title: resource_title)
         end
-
-        private
-
-        def resource_title
-          resource.title.is_a?(Hash) ? resource.title[I18n.locale.to_s] : resource.title
-        end
       end
     end
   end

--- a/decidim-core/lib/decidim/events/notification_event.rb
+++ b/decidim-core/lib/decidim/events/notification_event.rb
@@ -20,7 +20,11 @@ module Decidim
         types << :notification
 
         def notification_title
-          "S'ha tancat la proposta <a href=\"#{resource_path}\">#{resource_title}</a>.".html_safe
+          I18n.t(
+            "decidim.events.notification_event.notification_title",
+            resource_title: resource_title,
+            resource_path: resource_path,
+          ).html_safe
         end
       end
     end

--- a/decidim-core/lib/decidim/events/notification_event.rb
+++ b/decidim-core/lib/decidim/events/notification_event.rb
@@ -18,6 +18,10 @@ module Decidim
 
       included do
         types << :notification
+
+        def notification_title
+          "S'ha tancat la proposta <a href=\"#{resource_path}\">#{resource_title}</a>.".html_safe
+        end
       end
     end
   end

--- a/decidim-core/lib/decidim/events/notification_event.rb
+++ b/decidim-core/lib/decidim/events/notification_event.rb
@@ -23,7 +23,7 @@ module Decidim
           I18n.t(
             "decidim.events.notification_event.notification_title",
             resource_title: resource_title,
-            resource_path: resource_path,
+            resource_path: resource_path
           ).html_safe
         end
       end

--- a/decidim-core/lib/decidim/participable.rb
+++ b/decidim-core/lib/decidim/participable.rb
@@ -5,60 +5,74 @@ module Decidim
   # Utilities for models that can act as participatory spaces
   #
   module Participable
-    def demodulized_name
-      self.class.name.demodulize
+    extend ActiveSupport::Concern
+
+    included do
+      def demodulized_name
+        self.class.name.demodulize
+      end
+
+      def foreign_key
+        demodulized_name.foreign_key
+      end
+
+      def module_name
+        "Decidim::#{demodulized_name.pluralize}"
+      end
+
+      def admin_module_name
+        "#{module_name}::Admin"
+      end
+
+      def underscored_name
+        demodulized_name.underscore
+      end
+
+      def mounted_engine
+        "decidim_#{underscored_name.pluralize}"
+      end
+
+      def mounted_admin_engine
+        "decidim_admin_#{underscored_name.pluralize}"
+      end
+
+      def mounted_params
+        { host: organization.host, foreign_key.to_sym => id }
+      end
+
+      def extension_module
+        "#{module_name}::#{demodulized_name}Context".constantize
+      end
+
+      def admin_extension_module
+        "#{admin_module_name}::#{demodulized_name}Context".constantize
+      end
+
+      def admins_query
+        "#{admin_module_name}::AdminUsers".constantize
+      end
+
+      def admins
+        admins_query.for(self)
+      end
+
+      def allows_steps?
+        respond_to?(:steps)
+      end
+
+      def has_steps?
+        allows_steps? && steps.any?
+      end
+
+      def manifest
+        self.class.participatory_space_manifest
+      end
     end
 
-    def foreign_key
-      demodulized_name.foreign_key
-    end
-
-    def module_name
-      "Decidim::#{demodulized_name.pluralize}"
-    end
-
-    def admin_module_name
-      "#{module_name}::Admin"
-    end
-
-    def underscored_name
-      demodulized_name.underscore
-    end
-
-    def mounted_engine
-      "decidim_#{underscored_name.pluralize}"
-    end
-
-    def mounted_admin_engine
-      "decidim_admin_#{underscored_name.pluralize}"
-    end
-
-    def mounted_params
-      { host: organization.host, foreign_key.to_sym => id }
-    end
-
-    def extension_module
-      "#{module_name}::#{demodulized_name}Context".constantize
-    end
-
-    def admin_extension_module
-      "#{admin_module_name}::#{demodulized_name}Context".constantize
-    end
-
-    def admins_query
-      "#{admin_module_name}::AdminUsers".constantize
-    end
-
-    def admins
-      admins_query.for(self)
-    end
-
-    def allows_steps?
-      respond_to?(:steps)
-    end
-
-    def has_steps?
-      allows_steps? && steps.any?
+    class_methods do
+      def participatory_space_manifest
+        Decidim.find_participatory_space_manifest(name.demodulize.underscore.pluralize)
+      end
     end
   end
 end

--- a/decidim-core/spec/features/notifications_spec.rb
+++ b/decidim-core/spec/features/notifications_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Notifications", type: :feature do
+  let(:resource) { create :dummy_resource }
+  let(:participatory_space) { resource.feature.participatory_space }
+  let(:organization) { participatory_space.organization }
+  let!(:user) { create :user, :confirmed, organization: organization }
+  let!(:notification) { create :notification, user: user, resource: resource }
+
+  before do
+    switch_to_host organization.host
+    login_as user, scope: :user
+    page.visit decidim.notifications_path
+  end
+
+  context "when no notification is found" do
+    let!(:notification) { nil }
+
+    it "doesn't show any notification" do
+      expect(page).to have_content("No notifications yet")
+    end
+  end
+
+  context "with notifications" do
+    it "shows the notifications" do
+      expect(page).to have_selector("section#notifications-list .card--list__item")
+    end
+
+    context "when setting a single notification as read" do
+      let(:notification_title) { "An event occured to #{resource.title}" }
+
+      it "hides the notification from the page" do
+        expect(page).to have_content(notification_title)
+        find(".mark-as-read-button").click
+        expect(page).to have_no_content(notification_title)
+        expect(page).to have_content("No notifications yet")
+      end
+    end
+
+    context "when setting all notifications as read" do
+      it "hides all notifications from the page" do
+        click_link "Mark all as read"
+        expect(page).to have_content("No notifications yet")
+      end
+    end
+  end
+end

--- a/decidim-core/spec/jobs/decidim/email_notification_generator_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/email_notification_generator_job_spec.rb
@@ -15,19 +15,19 @@ describe Decidim::EmailNotificationGeneratorJob do
     let(:event) { double :event }
     let(:event_class) { Decidim::Events::BaseEvent }
     let(:event_class_name) { "Decidim::Events::BaseEvent" }
-    let(:followable) { double :followable }
+    let(:resource) { double :resource }
     let(:generator) { double :generator }
     let(:recipient_ids) { [1, 2, 3] }
 
     it "delegates the work to the class" do
       expect(Decidim::EmailNotificationGenerator)
         .to receive(:new)
-        .with(event, event_class, followable, recipient_ids)
+        .with(event, event_class, resource, recipient_ids)
         .and_return(generator)
       expect(generator)
         .to receive(:generate)
 
-      subject.perform_now(event, event_class_name, followable, recipient_ids)
+      subject.perform_now(event, event_class_name, resource, recipient_ids)
     end
   end
 end

--- a/decidim-core/spec/jobs/decidim/notification_generator_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/notification_generator_job_spec.rb
@@ -15,19 +15,19 @@ describe Decidim::NotificationGeneratorJob do
     let(:event) { double :event }
     let(:event_class) { Decidim::Events::BaseEvent }
     let(:event_class_name) { "Decidim::Events::BaseEvent" }
-    let(:followable) { double :followable }
+    let(:resource) { double :resource }
     let(:generator) { double :generator }
     let(:recipient_ids) { [1, 2, 3] }
 
     it "delegates the work to the class" do
       expect(Decidim::NotificationGenerator)
         .to receive(:new)
-        .with(event, event_class, followable, recipient_ids)
+        .with(event, event_class, resource, recipient_ids)
         .and_return(generator)
       expect(generator)
         .to receive(:generate)
 
-      subject.perform_now(event, event_class_name, followable, recipient_ids)
+      subject.perform_now(event, event_class_name, resource, recipient_ids)
     end
   end
 end

--- a/decidim-core/spec/models/notification_spec.rb
+++ b/decidim-core/spec/models/notification_spec.rb
@@ -15,8 +15,8 @@ describe Decidim::Notification, :db do
       it { is_expected.not_to be_valid }
     end
 
-    context "without followable" do
-      let(:notification) { build(:notification, followable: nil) }
+    context "without resource" do
+      let(:notification) { build(:notification, resource: nil) }
 
       it { is_expected.not_to be_valid }
     end

--- a/decidim-core/spec/services/decidim/notification_generator_for_recipient_spec.rb
+++ b/decidim-core/spec/services/decidim/notification_generator_for_recipient_spec.rb
@@ -18,8 +18,8 @@ describe Decidim::NotificationGeneratorForRecipient do
       notification = Decidim::Notification.last
 
       expect(notification.user).to eq recipient
-      expect(notification.notification_type).to eq event
-      expect(notification.followable).to eq resource
+      expect(notification.event_name).to eq event
+      expect(notification.resource).to eq resource
     end
 
     context "when it is not notifiable for the given user" do

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
@@ -23,6 +23,8 @@ module Decidim
   end
 
   class DummyResourceEvent < Events::BaseEvent
+    include Decidim::Events::EmailEvent
+    include Decidim::Events::NotificationEvent
   end
 
   class DummyResource < ActiveRecord::Base

--- a/decidim-meetings/app/events/decidim/meetings/close_meeting_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/close_meeting_event.rb
@@ -17,6 +17,14 @@ module Decidim
       def email_outro
         I18n.t("decidim.meetings.events.close_meeting_event.email_outro", resource_title: resource_title)
       end
+
+      def notification_title
+        I18n.t(
+          "decidim.meetings.events.close_meeting_event.notification_title",
+          resource_title: resource_title,
+          resource_path: resource_path
+        ).html_safe
+      end
     end
   end
 end

--- a/decidim-meetings/app/events/decidim/meetings/update_meeting_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/update_meeting_event.rb
@@ -17,6 +17,14 @@ module Decidim
       def email_outro
         I18n.t("decidim.meetings.events.update_meeting_event.email_outro", resource_title: resource_title)
       end
+
+      def notification_title
+        I18n.t(
+          "decidim.meetings.events.update_meeting_event.notification_title",
+          resource_title: resource_title,
+          resource_path: resource_path
+        ).html_safe
+      end
     end
   end
 end

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -86,10 +86,12 @@ en:
           email_intro: 'The "%{resource_title}" meeting was closed. You can read the conclusions from its page:'
           email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
           email_subject: The "%{resource_title}" meeting was closed
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting was closed.
         update_meeting_event:
           email_intro: 'The "%{resource_title}" meeting was updated. You can read the new version from its page:'
           email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
           email_subject: The "%{resource_title}" meeting was updated
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting was updated.
       meetings:
         filters:
           category: Category

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_stats_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_stats_presenter.rb
@@ -38,7 +38,7 @@ module Decidim
 
       def render_stats_data(feature_manifest, name, data, index)
         safe_join([
-                    index.zero? ? feature_manifest_icon(feature_manifest) : " /&nbsp".html_safe,
+                    index.zero? ? manifest_icon(feature_manifest) : " /&nbsp".html_safe,
                     content_tag(:span, "#{number_with_delimiter(data)} " + I18n.t(name, scope: "decidim.participatory_processes.statistics"),
                                 class: "#{name} process_stats-text")
                   ])


### PR DESCRIPTION
#### :tophat: What? Why?
This PR builds on top of #1786 and adds a notification dashboard for the user. Once the notification is set as read, the notification is destroyed, as discussed in #1692.

#### :pushpin: Related Issues
- Related to #1692, #1695

#### :clipboard: Subtasks
- [x] Add the dashboard
- [x] Destroy notifications on read
- [x] Add a "Mark all as read" button
- [x] Paginate notifications (around 50)
- [x] Improve JS when marking notifications as read
- [x] Add tests for setting notifications as read (single/all)
