### PR TITLE
Show page slug on default static page text

### DIFF
--- a/decidim-system/config/locales/en.yml
+++ b/decidim-system/config/locales/en.yml
@@ -28,7 +28,7 @@ en:
           success: Admin updated successfully
       default_pages:
         placeholders:
-          content: Please add meaningful content to this page on the admin dashboard.
+          content: Please add meaningful content to the %{page} static page on the admin dashboard.
           title: Default title for %{page}
       menu:
         admins: Admins


### PR DESCRIPTION
#### :tophat: What? Why?
Adds the slug to the default StaticPage text, so the users know what they have to modify. We were already passing the page slug to the locale string, but we were not using it:

https://github.com/decidim/decidim/blob/5a42a08c8118084422aa3eb9e287942c384a3470/decidim-system/app/commands/decidim/system/create_default_pages.rb#L35-L37

#### :pushpin: Related Issues
- Fixes #1798

### :camera: Screenshots (optional)
See the (manually) highlighted text for the new text:

![Description](https://i.imgur.com/JRPDBtD.png)
