### PR TITLE
Add comments to meetings

### DIFF
--- a/decidim-core/spec/services/decidim/email_notification_generator_spec.rb
+++ b/decidim-core/spec/services/decidim/email_notification_generator_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe Decidim::EmailNotificationGenerator do
   let(:event) { "decidim.events.dummy.dummy_resource_updated" }
   let(:resource) { create(:dummy_resource) }
-  let(:follow) { create(:follow, resource: resource, user: recipient) }
+  let(:follow) { create(:follow, followable: resource, user: recipient) }
   let(:recipient) { resource.author }
   let(:event_class) { Decidim::Events::BaseEvent }
   let(:event_class_name) { "Decidim::Events::BaseEvent" }

--- a/decidim-core/spec/services/decidim/notification_generator_for_recipient_spec.rb
+++ b/decidim-core/spec/services/decidim/notification_generator_for_recipient_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe Decidim::NotificationGeneratorForRecipient do
   let(:event) { "decidim.events.dummy.dummy_resource_updated" }
   let(:resource) { create(:dummy_resource) }
-  let(:follow) { create(:follow, resource: resource, user: recipient) }
+  let(:follow) { create(:follow, followable: resource, user: recipient) }
   let(:recipient) { resource.author }
   let(:event_class) { Decidim::Events::BaseEvent }
   subject { described_class.new(event, event_class, resource, recipient.id) }

--- a/decidim-core/spec/services/decidim/notification_generator_spec.rb
+++ b/decidim-core/spec/services/decidim/notification_generator_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe Decidim::NotificationGenerator do
   let(:event) { "decidim.events.dummy.dummy_resource_updated" }
   let(:resource) { create(:dummy_resource) }
-  let(:follow) { create(:follow, resource: resource, user: recipient) }
+  let(:follow) { create(:follow, followable: resource, user: recipient) }
   let(:recipient) { resource.author }
   let(:event_class) { Decidim::Events::BaseEvent }
   let(:event_class_name) { "Decidim::Events::BaseEvent" }

--- a/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
@@ -9,6 +9,7 @@ module Decidim
       include Decidim::MapHelper
       include Decidim::Meetings::MapHelper
       include Decidim::Meetings::MeetingsHelper
+      include Decidim::Comments::CommentsHelper
     end
   end
 end

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -12,6 +12,7 @@ module Decidim
       include Decidim::HasScope
       include Decidim::HasCategory
       include Decidim::Followable
+      include Decidim::Comments::Commentable
 
       has_many :registrations, class_name: "Decidim::Meetings::Registration", foreign_key: "decidim_meeting_id"
 
@@ -36,6 +37,36 @@ module Decidim
 
       def has_registration_for?(user)
         registrations.where(user: user).any?
+      end
+
+      # Public: Overrides the `commentable?` Commentable concern method.
+      def commentable?
+        feature.settings.comments_enabled?
+      end
+
+      # Public: Overrides the `accepts_new_comments?` Commentable concern method.
+      def accepts_new_comments?
+        commentable? && !feature.current_settings.comments_blocked
+      end
+
+      # Public: Overrides the `comments_have_alignment?` Commentable concern method.
+      def comments_have_alignment?
+        true
+      end
+
+      # Public: Overrides the `comments_have_votes?` Commentable concern method.
+      def comments_have_votes?
+        true
+      end
+
+      # Public: Overrides the `notifiable?` Notifiable concern method.
+      def notifiable?(_context)
+        true
+      end
+
+      # Public: Overrides the `users_to_notify` Notifiable concern method.
+      def users_to_notify
+        feature.participatory_space.admins
       end
     end
   end

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -63,11 +63,6 @@ module Decidim
       def notifiable?(_context)
         true
       end
-
-      # Public: Overrides the `users_to_notify` Notifiable concern method.
-      def users_to_notify
-        feature.participatory_space.admins
-      end
     end
   end
 end

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -79,6 +79,8 @@
   </div>
 </div>
 <%= attachments_for meeting %>
+<%= comments_for meeting %>
+
 <%= render partial: "registration_confirm" %>
 
 <%= javascript_include_tag "decidim/proposals/social_share" %>

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -27,8 +27,10 @@ en:
         settings:
           global:
             announcement: Announcement
+            comments_enabled: Comments enabled
           step:
             announcement: Announcement
+            comments_blocked: Comments blocked
     meetings:
       actions:
         attachments: Attachments

--- a/decidim-meetings/lib/decidim/meetings/feature.rb
+++ b/decidim-meetings/lib/decidim/meetings/feature.rb
@@ -27,10 +27,12 @@ Decidim.register_feature(:meetings) do |feature|
 
   feature.settings(:global) do |settings|
     settings.attribute :announcement, type: :text, translated: true, editor: true
+    settings.attribute :comments_enabled, type: :boolean, default: true
   end
 
   feature.settings(:step) do |settings|
     settings.attribute :announcement, type: :text, translated: true, editor: true
+    settings.attribute :comments_blocked, type: :boolean, default: false
   end
 
   feature.seeds do |participatory_space|

--- a/decidim-meetings/spec/factories.rb
+++ b/decidim-meetings/spec/factories.rb
@@ -4,5 +4,6 @@ require "decidim/core/test/factories"
 require "decidim/participatory_processes/test/factories"
 require "decidim/proposals/test/factories"
 require "decidim/results/test/factories"
+require "decidim/comments/test/factories"
 
 require "decidim/meetings/test/factories"

--- a/decidim-meetings/spec/features/comments_spec.rb
+++ b/decidim-meetings/spec/features/comments_spec.rb
@@ -15,6 +15,7 @@ describe "Comments", type: :feature, perform_enqueued: true do
     user
   end
   let!(:commentable) { create(:meeting, feature: feature) }
+  let!(:follow) { create(:follow, followable: commentable, user: participatory_process_admin) }
 
   let(:resource_path) { resource_locator(commentable).path }
   include_examples "comments"

--- a/decidim-meetings/spec/features/comments_spec.rb
+++ b/decidim-meetings/spec/features/comments_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Comments", type: :feature, perform_enqueued: true do
+  let!(:feature) { create(:feature, manifest_name: :meetings, organization: organization) }
+  let!(:participatory_space) { feature.participatory_space }
+  let!(:participatory_process_admin) do
+    user = create(:user, :confirmed, organization: organization)
+    Decidim::ParticipatoryProcessUserRole.create!(
+      role: :admin,
+      user: user,
+      participatory_process: participatory_space
+    )
+    user
+  end
+  let!(:commentable) { create(:meeting, feature: feature) }
+
+  let(:resource_path) { resource_locator(commentable).path }
+  include_examples "comments"
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Add comments to meetings so we can add notifications for users following those meetings.

#### :pushpin: Related Issues
- Related to #1794 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/106021/30205757-1776d8f0-948a-11e7-9e4a-6efcadaf239a.png)

#### :ghost: GIF
Nope
