### PR TITLE
Add meeting notification 48h before its start time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - **decidim-assemblies**: New optional beta plugin to manage participatory organs A.K.A. assemblies. [\#1659](https://https://github.com/decidim/decidim/pull/1659)
 - **decidim-meetings**: Let users follow meetings. Updating or closing a meeting will send a notification and an email to the users following that meeting. [\#1784](https://https://github.com/decidim/decidim/pull/1784)
 - **decidim-meetings**: When joining a meeting the user receives an email with its calendar information. [\#1803](https://https://github.com/decidim/decidim/pull/1803)
+- **decidim-meetings**: Users following a meeting receives a notification 48h before it starts. [\#1811](https://https://github.com/decidim/decidim/pull/1811)
 - **decidim-participatory_processes**: Add participatory processes filters (past, active and upcoming) to the processes home page. [\#1779](https://github.com/decidim/decidim/pull/1779)
 
 ## [v0.5.1](https://github.com/decidim/decidim/tree/v0.5.1) (2017-08-21)

--- a/decidim-meetings/app/events/decidim/meetings/upcoming_meeting_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/upcoming_meeting_event.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    class UpcomingMeetingEvent < Decidim::Events::BaseEvent
+      include Decidim::Events::EmailEvent
+      include Decidim::Events::NotificationEvent
+
+      def email_subject
+        I18n.t("decidim.meetings.events.upcoming_meeting_event.email_subject", resource_title: resource_title)
+      end
+
+      def email_intro
+        I18n.t("decidim.meetings.events.upcoming_meeting_event.email_intro", resource_title: resource_title)
+      end
+
+      def email_outro
+        I18n.t("decidim.meetings.events.upcoming_meeting_event.email_outro", resource_title: resource_title)
+      end
+
+      def notification_title
+        I18n.t(
+          "decidim.meetings.events.upcoming_meeting_event.notification_title",
+          resource_title: resource_title,
+          resource_path: resource_path
+        ).html_safe
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/jobs/decidim/meetings/upcoming_meeting_notification_job.rb
+++ b/decidim-meetings/app/jobs/decidim/meetings/upcoming_meeting_notification_job.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    class UpcomingMeetingNotificationJob < ApplicationJob
+      queue_as :decidim_events
+
+      def perform(meeting_id, checksum)
+        meeting = Decidim::Meetings::Meeting.find(meeting_id)
+        send_notification(meeting) if verify_checksum(meeting, checksum)
+      end
+
+      def self.generate_checksum(meeting)
+        Digest::MD5.hexdigest("#{meeting.id}-#{meeting.start_time}")
+      end
+
+      private
+
+      def send_notification(meeting)
+        Decidim::EventsManager.publish(
+          event: "decidim.events.meetings.upcoming_meeting",
+          event_class: Decidim::Meetings::UpcomingMeetingEvent,
+          resource: meeting,
+          recipient_ids: meeting.users_to_notify.pluck(:id)
+        )
+      end
+
+      def verify_checksum(meeting, checksum)
+        self.class.generate_checksum(meeting) == checksum
+      end
+    end
+  end
+end

--- a/decidim-meetings/config/locales/ca.yml
+++ b/decidim-meetings/config/locales/ca.yml
@@ -128,7 +128,7 @@ ca:
       read_more: "(Llegeix més)"
       registration_mailer:
         confirmation:
-          confirmed: "La teva inscripció per a la trobada presencial '%{title}' ha estat confirmada."
+          confirmed_html: "La teva inscripció per a la trobada presencial '%{title}' ha estat confirmada."
           details: "Trobaràs més detalls sobre la trobada a l'arxiu adjunt"
       registrations:
         create:

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -99,6 +99,11 @@ en:
           email_outro: You have received this notification because you are an admin of the meeting's participatory space.
           email_subject: The "%{resource_title}" meeting occupied slots are over %{percentage}%
           notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting occupied slots are over %{percentage}%.
+        upcoming_meeting_event:
+          email_intro: The "%{resource_title}" meeting will start in less than 48h.
+          email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
+          email_subject: The "%{resource_title}" meeting will start in less than 48h.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting will start in less than 48h.
         update_meeting_event:
           email_intro: 'The "%{resource_title}" meeting was updated. You can read the new version from its page:'
           email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.

--- a/decidim-meetings/spec/commands/create_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/create_meeting_spec.rb
@@ -12,6 +12,7 @@ describe Decidim::Meetings::Admin::CreateMeeting do
   let(:invalid) { false }
   let(:latitude) { 40.1234 }
   let(:longitude) { 2.1234 }
+  let(:start_time) { 1.day.from_now }
   let(:form) do
     double(
       invalid?: invalid,
@@ -19,7 +20,7 @@ describe Decidim::Meetings::Admin::CreateMeeting do
       description: { en: "description" },
       location: { en: "location" },
       location_hints: { en: "location_hints" },
-      start_time: 1.day.from_now,
+      start_time: start_time,
       end_time: 1.day.from_now + 1.hour,
       address: address,
       latitude: latitude,
@@ -67,6 +68,20 @@ describe Decidim::Meetings::Admin::CreateMeeting do
       last_meeting = Decidim::Meetings::Meeting.last
       expect(last_meeting.latitude).to eq(latitude)
       expect(last_meeting.longitude).to eq(longitude)
+    end
+
+    it "schedules a upcoming meeting notification job 48h before start time" do
+      expect_any_instance_of(Decidim::Meetings::Meeting)
+        .to receive(:id).at_least(:once).and_return "1"
+
+      expect(Decidim::Meetings::UpcomingMeetingNotificationJob)
+        .to receive(:generate_checksum).and_return "1234"
+
+      expect(Decidim::Meetings::UpcomingMeetingNotificationJob)
+        .to receive_message_chain(:set, :perform_later)
+        .with(set: start_time - 2.days).with("1", "1234")
+
+      subject.call
     end
   end
 end

--- a/decidim-meetings/spec/commands/create_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/create_meeting_spec.rb
@@ -72,14 +72,14 @@ describe Decidim::Meetings::Admin::CreateMeeting do
 
     it "schedules a upcoming meeting notification job 48h before start time" do
       expect_any_instance_of(Decidim::Meetings::Meeting)
-        .to receive(:id).at_least(:once).and_return "1"
+        .to receive(:id).at_least(:once).and_return 1
 
       expect(Decidim::Meetings::UpcomingMeetingNotificationJob)
         .to receive(:generate_checksum).and_return "1234"
 
       expect(Decidim::Meetings::UpcomingMeetingNotificationJob)
         .to receive_message_chain(:set, :perform_later)
-        .with(set: start_time - 2.days).with("1", "1234")
+        .with(set: start_time - 2.days).with(1, "1234")
 
       subject.call
     end

--- a/decidim-meetings/spec/commands/update_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/update_meeting_spec.rb
@@ -108,6 +108,13 @@ describe Decidim::Meetings::Admin::UpdateMeeting do
 
           subject.call
         end
+
+        it "doesn't schedule the upcoming meeting notification job" do
+          expect(Decidim::Meetings::UpcomingMeetingNotificationJob)
+            .not_to receive(:perform_later)
+
+          subject.call
+        end
       end
 
       context "when the start time changes" do
@@ -122,6 +129,17 @@ describe Decidim::Meetings::Admin::UpdateMeeting do
               resource: meeting,
               recipient_ids: [user.id]
             )
+
+          subject.call
+        end
+
+        it "schedules a upcoming meeting notification job 48h before start time" do
+          expect(Decidim::Meetings::UpcomingMeetingNotificationJob)
+            .to receive(:generate_checksum).and_return "1234"
+
+          expect(Decidim::Meetings::UpcomingMeetingNotificationJob)
+            .to receive_message_chain(:set, :perform_later)
+            .with(set: start_time - 2.days).with(meeting.id, "1234")
 
           subject.call
         end
@@ -144,7 +162,7 @@ describe Decidim::Meetings::Admin::UpdateMeeting do
         end
       end
 
-      context "when the start time changes" do
+      context "when the address changes" do
         let(:address) { "some address" }
 
         it "notifies the change" do

--- a/decidim-meetings/spec/events/decidim/meetings/upcoming_meeting_event_spec.rb
+++ b/decidim-meetings/spec/events/decidim/meetings/upcoming_meeting_event_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Meetings::UpcomingMeetingEvent do
+  describe "types" do
+    subject { described_class }
+
+    it "supports the notification type" do
+      expect(subject.types).to include :notification
+    end
+
+    it "supports the email type" do
+      expect(subject.types).to include :email
+    end
+  end
+end

--- a/decidim-meetings/spec/jobs/decidim/meetings/upcoming_meeting_notification_job_spec.rb
+++ b/decidim-meetings/spec/jobs/decidim/meetings/upcoming_meeting_notification_job_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Meetings::UpcomingMeetingNotificationJob do
+  let(:organization) { create :organization }
+  let(:user) { create :user, organization: organization }
+  let(:start_time) { 1.day.from_now }
+  let(:participatory_space) { create :participatory_process, organization: organization }
+  let(:feature) { create :feature, manifest_name: :meetings, participatory_space: participatory_space }
+  let(:meeting) { create :meeting, start_time: start_time }
+  let!(:checksum) { subject.generate_checksum(meeting) }
+  let!(:follow) { create :follow, followable: meeting, user: user }
+  subject { described_class }
+
+  context "when the checksum is correct" do
+    it "notifies the upcoming meeting" do
+      expect(Decidim::EventsManager)
+        .to receive(:publish)
+        .with(
+          event: "decidim.events.meetings.upcoming_meeting",
+          event_class: Decidim::Meetings::UpcomingMeetingEvent,
+          resource: meeting,
+          recipient_ids: [user.id]
+        )
+
+      subject.perform_now(meeting.id, checksum)
+    end
+  end
+
+  context "when the checksum is not correct" do
+    let(:checksum) { "1234" }
+
+    it "doesn't notify the upcoming meeting" do
+      expect(Decidim::EventsManager)
+        .not_to receive(:publish)
+
+      subject.perform_now(meeting.id, checksum)
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Users following a meeting will receive a notification 48h before its start time.

#### :pushpin: Related Issues
- Related to #1794 

#### :clipboard: Subtasks
- [x] Add job and event
- [x] Schedule job when meeting is created or updated

### :camera: Screenshots (optional)
N/A

#### :ghost: GIF
![](https://media2.giphy.com/media/xT9Igy5gejiGpYYPcc/giphy.gif)
