### PR TITLE
Add email_on_notification flag to users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **decidim**: Support for multiple participatory spaces via custom plugins. [\#1659](https://https://github.com/decidim/decidim/pull/1659)
 - **decidim**: Let users follow resources. [\#1784](https://https://github.com/decidim/decidim/pull/1784)
 - **decidim**: Add a notification dashboard with a list of events on resources the user is following. [\#1784](https://https://github.com/decidim/decidim/pull/1784)
+- **decidim**: Add a flag for users so they can enable/disable emails on notifications. [\#1812](https://https://github.com/decidim/decidim/pull/1812)
 - **decidim-assemblies**: New optional beta plugin to manage participatory organs A.K.A. assemblies. [\#1659](https://https://github.com/decidim/decidim/pull/1659)
 - **decidim-meetings**: Let users follow meetings. Updating or closing a meeting will send a notification and an email to the users following that meeting. [\#1784](https://https://github.com/decidim/decidim/pull/1784)
 - **decidim-meetings**: When joining a meeting the user receives an email with its calendar information. [\#1803](https://https://github.com/decidim/decidim/pull/1803)

--- a/decidim-core/app/commands/decidim/update_notifications_settings.rb
+++ b/decidim-core/app/commands/decidim/update_notifications_settings.rb
@@ -26,6 +26,7 @@ module Decidim
     def update_notifications_settings
       @user.comments_notifications = @form.comments_notifications
       @user.replies_notifications = @form.replies_notifications
+      @user.email_on_notification = @form.email_on_notification
       @user.newsletter_notifications = @form.newsletter_notifications
     end
   end

--- a/decidim-core/app/forms/decidim/notifications_settings_form.rb
+++ b/decidim-core/app/forms/decidim/notifications_settings_form.rb
@@ -8,10 +8,12 @@ module Decidim
 
     attribute :comments_notifications
     attribute :replies_notifications
+    attribute :email_on_notification
     attribute :newsletter_notifications
 
     validates :comments_notifications, presence: true
     validates :replies_notifications, presence: true
+    validates :email_on_notification, presence: true
     validates :newsletter_notifications, presence: true
   end
 end

--- a/decidim-core/app/services/decidim/email_notification_generator.rb
+++ b/decidim-core/app/services/decidim/email_notification_generator.rb
@@ -38,9 +38,16 @@ module Decidim
 
     attr_reader :event, :event_class, :resource, :recipient_ids, :extra
 
+    # Private: sends the notification email to the user if they have the
+    # `email_on_notification` flag active.
+    #
+    # recipient_id - The ID of the user that will receive the email.
+    #
+    # Returns nothing.
     def send_email_to(recipient_id)
       recipient = Decidim::User.where(id: recipient_id).first
       return unless recipient
+      return unless recipient.email_on_notification?
 
       NotificationMailer
         .event_received(

--- a/decidim-core/app/views/decidim/notifications_settings/show.html.erb
+++ b/decidim-core/app/views/decidim/notifications_settings/show.html.erb
@@ -14,6 +14,13 @@
         <span class="switch-label"><%= t('.replies_notifications') %></span>
       </label>
     </div>
+    <div class="switch tiny switch-with-label email_on_notification">
+      <label>
+        <%= f.check_box :email_on_notification, label: false, class: "switch-input" %>
+        <span class="switch-paddle"></span>
+        <span class="switch-label"><%= t('.email_on_notification') %></span>
+      </label>
+    </div>
     <div class="switch tiny switch-with-label newsletter_notifications">
       <label>
         <%= f.check_box :newsletter_notifications, label: false, class: "switch-input" %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -185,6 +185,7 @@ en:
     notifications_settings:
       show:
         comments_notifications: I want to receive email notifications when someone comments in my publications.
+        email_on_notification: I want to receive an email every time I receive a notification.
         newsletter_notifications: I want to receive information about relevant activity
         replies_notifications: I want to receive email notifications when someone replies my comments.
         update_notifications_settings: Save changes

--- a/decidim-core/db/migrate/20170912082054_add_emails_on_notifications_flag_to_user.rb
+++ b/decidim-core/db/migrate/20170912082054_add_emails_on_notifications_flag_to_user.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddEmailsOnNotificationsFlagToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_users, :email_on_notification, :boolean, default: false, null: false
+  end
+end

--- a/decidim-core/spec/commands/decidim/update_notifications_settings_spec.rb
+++ b/decidim-core/spec/commands/decidim/update_notifications_settings_spec.rb
@@ -11,6 +11,7 @@ module Decidim
       {
         comments_notifications: "1",
         replies_notifications: "0",
+        email_on_notification: "1",
         newsletter_notifications: "1"
       }
     end
@@ -19,6 +20,7 @@ module Decidim
       form = double(
         comments_notifications: data[:comments_notifications],
         replies_notifications: data[:replies_notifications],
+        email_on_notification: data[:email_on_notification],
         newsletter_notifications: data[:newsletter_notifications],
         valid?: valid
       )
@@ -42,6 +44,7 @@ module Decidim
         expect { command.call }.to broadcast(:ok)
         expect(user.reload.comments_notifications).to be_truthy
         expect(user.reload.replies_notifications).to be_falsy
+        expect(user.reload.email_on_notification).to be_truthy
         expect(user.reload.newsletter_notifications).to be_truthy
       end
     end

--- a/decidim-core/spec/forms/notifications_settings_form_spec.rb
+++ b/decidim-core/spec/forms/notifications_settings_form_spec.rb
@@ -8,12 +8,14 @@ module Decidim
 
     let(:comments_notifications) { "1" }
     let(:replies_notifications) { "1" }
+    let(:email_on_notification) { "1" }
     let(:newsletter_notifications) { "1" }
 
     subject do
       described_class.new(
         comments_notifications: comments_notifications,
         replies_notifications: replies_notifications,
+        email_on_notification: email_on_notification,
         newsletter_notifications: newsletter_notifications
       ).with_context(
         current_user: user
@@ -36,6 +38,14 @@ module Decidim
 
     context "with an empty replies notifications" do
       let(:replies_notifications) { "" }
+
+      it "is invalid" do
+        expect(subject).not_to be_valid
+      end
+    end
+
+    context "with an empty email on notification" do
+      let(:email_on_notification) { "" }
 
       it "is invalid" do
         expect(subject).not_to be_valid

--- a/decidim-core/spec/services/decidim/email_notification_generator_spec.rb
+++ b/decidim-core/spec/services/decidim/email_notification_generator_spec.rb
@@ -21,14 +21,29 @@ describe Decidim::EmailNotificationGenerator do
         allow(event_class).to receive(:types).and_return([:email])
       end
 
-      it "schedules a job for each recipient" do
-        expect(Decidim::NotificationMailer)
-          .to receive(:event_received)
-          .with(event, event_class_name, resource, recipient, extra)
-          .and_return(mailer)
-        expect(mailer).to receive(:deliver_later)
+      context "when the user does not want emails for notifications" do
+        it "does not schedule a job for that recipient" do
+          expect(Decidim::NotificationMailer)
+            .not_to receive(:event_received)
 
-        subject.generate
+          subject.generate
+        end
+      end
+
+      context "when the user wants emails for notifications" do
+        before do
+          recipient.update_attributes(email_on_notification: true)
+        end
+
+        it "schedules a job for each recipient" do
+          expect(Decidim::NotificationMailer)
+            .to receive(:event_received)
+            .with(event, event_class_name, resource, recipient, extra)
+            .and_return(mailer)
+          expect(mailer).to receive(:deliver_later)
+
+          subject.generate
+        end
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Adds a flag to users so they can control whether they want to receive emails for notifications or not. This builds on #1784.

#### :pushpin: Related Issues
- Related to #1784.

### :camera: Screenshots (optional)
The new flag is the third one:

![Description](https://i.imgur.com/e7Uh3uF.png)

#### :ghost: GIF
![]()
