### PR TITLE
Fix writing rules in i18n-tasks config

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -19,10 +19,10 @@ data:
   # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
   # `i18n-tasks normalize -p` will force move the keys according to these rules
   write:
-    ## For example, write devise and simple form keys to their respective files:
-    # - ['{devise, simple_form}.*', 'config/locales/\1.%{locale}.yml']
-    ## Catch-all default:
-    # - config/locales/%{locale}.yml
+    <% Dir.glob("decidim-*").each do |path| -%>
+      <%= "- ['#{path.sub('-', '.')}.*', '#{path}/config/locales/%{locale}.yml']" %>
+    <% end -%>
+      - 'decidim-core/config/locales/%{locale}.yml'
 
   ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, or a custom class.
   # router: convervative_router


### PR DESCRIPTION
#### :tophat: What? Why?

Smarter writing rules for `i18n-tasks`. @mrcasals @beagleknight Can you check this out and see if it fixes the problem?

#### :pushpin: Related Issues
- Fixes #1810.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![gasolface](https://user-images.githubusercontent.com/2887858/30322001-514bd554-97b8-11e7-88da-4e0e79426bea.gif)

