### PR TITLE
Add missing i18n for "Remove file" checkbox

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -174,6 +174,7 @@ en:
       default_image: Default image
       errors:
         error: There's an error in this field.
+      remove_this_file: Remove this file
     managed_users:
       expired_session: The current impersonation session has expired.
     menu:

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -243,7 +243,7 @@ module Decidim
           template += content_tag :div, class: "field" do
             safe_join([
                         @template.check_box(@object_name, "remove_#{attribute}"),
-                        label("remove_#{attribute}", label_for("remove_#{attribute}"))
+                        label("remove_#{attribute}", I18n.t("remove_this_file", scope: "decidim.forms"))
                       ])
           end
         end


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes a problem with the forms that did not show any i18n option for the checkboxes to remove the attachment. The `label_for` method does not use the i18n system for random strings.

#### :pushpin: Related Issues
- Fixes #1600.