### PR TITLE
Add header snippets for organizations

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/update_organization.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization.rb
@@ -65,6 +65,7 @@ module Decidim
           official_img_footer: form.official_img_footer,
           remove_official_img_footer: form.remove_official_img_footer,
           official_url: form.official_url,
+          header_snippets: form.header_snippets,
           show_statistics: form.show_statistics
         }
       end

--- a/decidim-admin/app/forms/decidim/admin/organization_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_form.rb
@@ -30,6 +30,7 @@ module Decidim
       attribute :official_img_footer
       attribute :remove_official_img_footer
       attribute :show_statistics
+      attribute :header_snippets, String
 
       translatable_attribute :description, String
       translatable_attribute :welcome_text, String

--- a/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
@@ -77,3 +77,8 @@
 <div class="row column">
   <%= form.check_box :show_statistics %>
 </div>
+
+<div class="row column">
+  <%= form.text_area :header_snippets %>
+  <p class="help-text"><%= t(".header_snippets_help") %></p>
+</div>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -20,6 +20,7 @@ en:
         default_locale: Default locale
         description: Description
         favicon: Icon
+        header_snippets: Header snippets
         homepage_image: Homepage image
         logo: Logo
         name: Name
@@ -310,6 +311,7 @@ en:
           current_image: Current image
           facebook: Facebook
           github: GitHub
+          header_snippets_help: Use this field to add things to the HTML head. The most common use is to integrate third-party services that require some extra JavaScript or CSS. Also, you can use it to add extra meta tags to the HTML. Note that this will only be rendered in public pages, not in the admin section.
           instagram: Instagram
           social_handlers: Social
           twitter: Twitter

--- a/decidim-admin/spec/forms/organization_form_spec.rb
+++ b/decidim-admin/spec/forms/organization_form_spec.rb
@@ -12,6 +12,8 @@ module Decidim
       let(:instagram_handler) { "My instagram awesome handler" }
       let(:youtube_handler) { "My youtube awesome handler" }
       let(:github_handler) { "My github awesome handler" }
+      let(:header_snippets) { "<my-html />" }
+      let(:default_locale) { :en }
       let(:welcome_text) do
         {
           en: "Welcome",
@@ -33,7 +35,7 @@ module Decidim
           "organization" => {
             "name" => name,
             "reference_prefix" => reference_prefix,
-            "default_locale" => :en,
+            "default_locale" => default_locale,
             "available_locales" => %w(en ca es),
             "welcome_text_en" => welcome_text[:en],
             "welcome_text_es" => welcome_text[:es],
@@ -43,6 +45,7 @@ module Decidim
             "description_ca" => description[:ca],
             "homepage_image" => Rack::Test::UploadedFile.new(homepage_image_path, "image/jpeg"),
             "show_statics" => false,
+            "header_snippets" => header_snippets,
             "twitter_handler" => twitter_handler,
             "facebook_handler" => facebook_handler,
             "instagram_handler" => instagram_handler,
@@ -70,6 +73,21 @@ module Decidim
 
       context "when name is missing" do
         let(:name) { nil }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "when default_locale is missing" do
+        let(:default_locale) { nil }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "when default_locale is not an available locale" do
+        let(:default_locale) { :de }
+        before do
+          allow(organization).to receive(:available_locales).and_return([:en, :es, :ca])
+        end
 
         it { is_expected.to be_invalid }
       end

--- a/decidim-core/app/views/layouts/decidim/_head.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_head.html.erb
@@ -22,3 +22,4 @@
 <%= javascript_include_tag 'application' %>
 
 <%= render partial: 'layouts/decidim/head_extra' %>
+<%== current_organization.header_snippets %>

--- a/decidim-core/app/views/layouts/decidim/_head_extra.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_head_extra.html.erb
@@ -2,6 +2,13 @@
 This file is meant to be overriden by the app developers in order to
 include extra headers like tracking, error handling and such.
 
+Note that thie code you add here will be run for all organizations in
+your instance of Decidim. If you want to add code for a specific
+organization, add it to the organization's `header_snippets` field,
+which can be modified at the organization admin section.
+
+The `header_snippets` organization field will render *after* this file.
+
 Just copy your own version of the file under:
 `app/views/layouts/decidim/_head_extra.html.erb`
 %>

--- a/decidim-core/db/migrate/20170913092351_add_header_snippets_to_organizations.rb
+++ b/decidim-core/db/migrate/20170913092351_add_header_snippets_to_organizations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddHeaderSnippetsToOrganizations < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_organizations, :header_snippets, :text
+  end
+end

--- a/decidim-core/spec/features/homepage_spec.rb
+++ b/decidim-core/spec/features/homepage_spec.rb
@@ -28,6 +28,15 @@ describe "Homepage", type: :feature do
       expect(page).to have_selector("a.main-footer__badge[href='#{official_url}']")
     end
 
+    context "with header snippets" do
+      let(:snippet) { "<meta data-hello=\"This is the organization header_snippet field\">" }
+      let(:organization) { create(:organization, official_url: official_url, header_snippets: snippet) }
+
+      it "includes the header snippets" do
+        expect(page).to have_selector("meta[data-hello]", visible: false)
+      end
+    end
+
     it "welcomes the user" do
       expect(page).to have_content(organization.name)
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Adds a `header_snippets` field to organization, which can render any tag inside the `<head>` HTML tag. This is useful for 3rd-party JS and CSS code, and it can even be used to solve #1759.

#### :pushpin: Related Issues
- Fixes #1818.

### :camera: Screenshots (optional)
Screenshot from the Chrome dev tools:

![Description](https://i.imgur.com/rxB5Job.png)
