### PR TITLE
Show "View steps" button on mobile

### DIFF
--- a/decidim-participatory_processes/app/views/layouts/decidim/_process_header_steps.html.erb
+++ b/decidim-participatory_processes/app/views/layouts/decidim/_process_header_steps.html.erb
@@ -1,6 +1,6 @@
 <% if participatory_process.steps.any? %>
   <div class="columns mediumlarge-3">
-    <div class="process-header__phase process-header__phase--simple">
+    <div class="process-header__phase">
       <div class="process-header__progress show-for-medium">
         <ol>
           <% past_step = true %>
@@ -21,7 +21,7 @@
           <%= participatory_process_step_dates participatory_process.active_step %>
         </span>
       </div>
-      <%= link_to t('.view_steps'), decidim_participatory_processes.participatory_process_participatory_process_steps_path(current_participatory_process), class: "button tiny hollow show-for-medium" %>
+      <%= link_to t('.view_steps'), decidim_participatory_processes.participatory_process_participatory_process_steps_path(current_participatory_process), class: "button tiny hollow" %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes the process header layout to use the one in https://decidim-design.herokuapp.com/info/ so that the "View steps" button appears correctly on mobile devices.

#### :pushpin: Related Issues
- Fixes #1824.

#### :clipboard: Subtasks
None
### :camera: Screenshots (optional)
![Description](https://i.imgur.com/nxOuMve.png)
