### PR TITLE
Add ID column on proposals table

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -19,6 +19,7 @@
       <table class="table-list">
         <thead>
           <tr>
+            <th><%= t("models.proposal.fields.id", scope: "decidim.proposals") %></th>
             <th><%= t("models.proposal.fields.title", scope: "decidim.proposals") %></th>
             <th><%= t("models.proposal.fields.category", scope: "decidim.proposals") %></th>
             <% if scopes_enabled?(current_participatory_space) %>
@@ -31,6 +32,9 @@
         <tbody>
           <% proposals.each do |proposal| %>
             <tr data-id="<%= proposal.id %>">
+              <td>
+                <%= proposal.id %><br />
+              </td>
               <td>
                 <%= proposal.title %><br />
               </td>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -83,6 +83,7 @@ en:
         proposal:
           fields:
             category: Category
+            id: ID
             official_proposal: Official proposal
             scope: Scope
             state: State

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -233,7 +233,7 @@ shared_examples "manage proposals" do
         end
 
         within find("tr", text: proposal.title) do
-          within find("td:nth-child(4)") do
+          within find("td:nth-child(5)") do
             expect(page).to have_content("Rejected")
           end
         end
@@ -254,7 +254,7 @@ shared_examples "manage proposals" do
         end
 
         within find("tr", text: proposal.title) do
-          within find("td:nth-child(4)") do
+          within find("td:nth-child(5)") do
             expect(page).to have_content("Accepted")
           end
         end
@@ -275,7 +275,7 @@ shared_examples "manage proposals" do
         end
 
         within find("tr", text: proposal.title) do
-          within find("td:nth-child(4)") do
+          within find("td:nth-child(5)") do
             expect(page).to have_content("Evaluating")
           end
         end
@@ -293,7 +293,7 @@ shared_examples "manage proposals" do
         visit manage_feature_path(current_feature)
 
         within find("tr", text: proposal.title) do
-          within find("td:nth-child(4)") do
+          within find("td:nth-child(5)") do
             expect(page).to have_content("Rejected")
           end
           find("a.action-icon--edit-answer").click
@@ -309,7 +309,7 @@ shared_examples "manage proposals" do
         end
 
         within find("tr", text: proposal.title) do
-          within find("td:nth-child(4)") do
+          within find("td:nth-child(5)") do
             expect(page).to have_content("Accepted")
           end
         end


### PR DESCRIPTION
#### :tophat: What? Why?
Adds the ID column on the admin proposals table.

#### :pushpin: Related Issues
- Fixes #1828.

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/myWcvQP.png)