### PR TITLE
Add 'many' key to Ukrainian translation

### DIFF
--- a/decidim-participatory_processes/config/locales/uk.yml
+++ b/decidim-participatory_processes/config/locales/uk.yml
@@ -265,6 +265,7 @@ uk:
           processes:
             one: "%{count} процес"
             few: "%{count} процеси"
+            many: "%{count} процесів"           
             other: "%{count} процесів"
         participatory_process:
           active_step: 'Поточний крок:'

--- a/decidim-participatory_processes/config/locales/uk.yml
+++ b/decidim-participatory_processes/config/locales/uk.yml
@@ -265,7 +265,7 @@ uk:
           processes:
             one: "%{count} процес"
             few: "%{count} процеси"
-            many: "%{count} процесів"           
+            many: "%{count} процесів"
             other: "%{count} процесів"
         participatory_process:
           active_step: 'Поточний крок:'


### PR DESCRIPTION
#### :tophat: What? Why?

On every webpage in Ukrainian translation which uses keys `one, few, other`, I got error mesagges, namely:

```
I18n::InvalidPluralizationData in Decidim::ParticipatoryProcesses::ParticipatoryProcesses#index

Showing /home/timon/decidim/decidim-participatory_processes/app/views/decidim/participatory_processes/_order_by_processes.html.erb where line #3 raised:

translation data {:one=>"%{count} процес", :few=>"%{count} процеси", :other=>"%{count} процесів"} can not be used with :count => 5. key 'many' is missing.
--------------------------------------------------------------------------------------------------------------------
I18n::InvalidPluralizationData in Decidim::Proposals::Proposals#index

Showing /home/timon/decidim/decidim-proposals/app/views/decidim/proposals/proposals/_count.html.erb where line #1 raised:

translation data {:one=>"1 пропозиція", :few=>"%{count} пропозиції", :other=>"%{count} пропозицій"} can not be used with :count => 20. key 'many' is missing.
---------------------------------------------------------------------------------------------------------------------
I18n::InvalidPluralizationData in Decidim::Proposals::Proposals#index

Showing /home/timon/decidim/decidim-proposals/app/views/decidim/proposals/proposals/_votes_count.html.erb where line #7 raised:

translation data {:one=>"ГОЛОС", :few=>"ГОЛОСИ", :other=>"ГОЛОСІВ"} can not be used with :count => 0. key 'many' is missing.
```
So, as recommended in the messages, I added `many` key, and the problem disappeared.

#### :pushpin: Related Issues

I don't know whether this is the appropriate solution, and whether it would integrate properly with Crowdin.

I noticed that in other languages there's no `few` key. Seems like it is generated by Crowdin for Ukrainian, where `few` key is indeed necessary.

#### :clipboard: Subtasks

If this will turn out to be the appropriate solution, I am going to add `many` key in all other places of Ukrainian translation where `one, few, other` keys are used.