### PR TITLE
Open features collapsible menu on mobile by default

### DIFF
--- a/decidim-assemblies/app/views/layouts/decidim/_assembly_header.html.erb
+++ b/decidim-assemblies/app/views/layouts/decidim/_assembly_header.html.erb
@@ -36,7 +36,7 @@
             <% end %>
             </div>
         </button>
-        <div class="row column process-nav__content" id="process-nav-content" data-toggler=".is-active">
+        <div class="row column process-nav__content is-active" id="process-nav-content" data-toggler=".is-active">
           <ul>
             <li class="<%= "is-active" if is_active_link?(decidim_assemblies.assembly_path(current_assembly), :exclusive) %>">
               <%= active_link_to decidim_assemblies.assembly_path(current_assembly), active: :exact, class: "process-nav__link", class_active: "is-active" do %>

--- a/decidim-participatory_processes/app/views/layouts/decidim/_process_header.html.erb
+++ b/decidim-participatory_processes/app/views/layouts/decidim/_process_header.html.erb
@@ -37,7 +37,7 @@
             <% end %>
             </div>
         </button>
-        <div class="row column process-nav__content" id="process-nav-content" data-toggler=".is-active">
+        <div class="row column process-nav__content is-active" id="process-nav-content" data-toggler=".is-active">
           <ul>
             <li class="<%= "is-active" if is_active_link?(decidim_participatory_processes.participatory_process_path(current_participatory_process), :exclusive) %>">
               <%= active_link_to decidim_participatory_processes.participatory_process_path(current_participatory_process), active: :exact, class: "process-nav__link", class_active: "is-active" do %>


### PR DESCRIPTION
#### :tophat: What? Why?
Opens the process/assembly features collapsible menu on mobile by default.

#### :pushpin: Related Issues
- Fixes #1826.

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![Description](http://g.recordit.co/sdA64sscGM.gif)
