### PR TITLE
Fix missing add proposal button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **decidim**: `decidim:check_locales` task not working properly. [\#1740]((https://https://github.com/decidim/decidim/pull/1740)
 - **decidim-core**: Disable HTML validations which sometimes caused unexpected form behavior. [\#1772](https://https://github.com/decidim/decidim/pull/1772)
 - **decidim-participatory_processes**: Scopes enabled checkbox being ignored in participatory process creation. [\#1762](https://https://github.com/decidim/decidim/pull/1762)
+- **decidim-proposals**: Fix incorrect button displayed when proposal creation not enabled. [\#1847](https://https://github.com/decidim/decidim/pull/1847)
 - **decidim-surveys**: Drag & drop icon incorrectly rendered in form. [\#1761](https://https://github.com/decidim/decidim/pull/1761)
 
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.5.1...HEAD)

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -5,7 +5,7 @@
 
       <div class="button--title">
 
-        <% if feature_settings.official_proposals_enabled %>
+        <% if can? :create, Decidim::Proposals::Proposal %>
           <%= link_to t("actions.new", scope: "decidim.proposals", name: t("models.proposal.name", scope: "decidim.proposals.admin")), new_proposal_path, class: 'button tiny button--simple' if can? :manage, current_feature %>
         <% end %>
 

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -40,6 +40,8 @@ shared_examples "manage proposals" do
               }
             }
           )
+
+          visit_feature_admin
         end
 
         context "when process is not related to any scope" do
@@ -181,6 +183,28 @@ shared_examples "manage proposals" do
           end
         end
       end
+
+      context "when creation is not enabled" do
+        before do
+          current_feature.update_attributes!(
+            step_settings: {
+              current_feature.participatory_space.active_step.id => {
+                creation_enabled: false
+              }
+            }
+          )
+        end
+
+        it "cannot create a new proposal from the main site" do
+          visit_feature
+          expect(page).to have_no_button("New Proposal")
+        end
+
+        it "cannot create a new proposal from the admin site" do
+          visit_feature_admin
+          expect(page).to have_no_link(/New/)
+        end
+      end
     end
 
     context "when official_proposals setting is disabled" do
@@ -188,9 +212,14 @@ shared_examples "manage proposals" do
         current_feature.update_attributes!(settings: { official_proposals_enabled: false })
       end
 
-      it "cannot create a new proposal" do
+      it "cannot create a new proposal from the main site" do
         visit_feature
         expect(page).to have_no_button("New Proposal")
+      end
+
+      it "cannot create a new proposal from the admin site" do
+        visit_feature_admin
+        expect(page).to have_no_link(/New/)
       end
     end
   end

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -290,7 +290,7 @@ shared_examples "manage proposals" do
           answered_at: Time.current
         )
 
-        visit manage_feature_path(current_feature)
+        visit_feature_admin
 
         within find("tr", text: proposal.title) do
           within find("td:nth-child(5)") do

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -190,7 +190,7 @@ shared_examples "manage proposals" do
 
       it "cannot create a new proposal" do
         visit_feature
-        expect(page).to have_no_content("New Proposal")
+        expect(page).to have_no_button("New Proposal")
       end
     end
   end
@@ -331,7 +331,7 @@ shared_examples "manage proposals" do
         visit current_path
 
         within find("tr", text: proposal.title) do
-          expect(page).to have_no_css("a", text: "Answer")
+          expect(page).to have_no_link("Answer")
         end
       end
     end
@@ -346,7 +346,7 @@ shared_examples "manage proposals" do
       visit current_path
 
       within find("tr", text: proposal.title) do
-        expect(page).to have_no_css("a", text: "Answer")
+        expect(page).to have_no_link("Answer")
       end
     end
   end

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -86,7 +86,7 @@ shared_examples "manage proposals" do
           end
 
           it "cannot be related to a scope" do
-            find(".card-title a.button").click
+            click_link "New"
 
             within "form" do
               expect(page).to have_no_content(/Scope/i)
@@ -94,7 +94,7 @@ shared_examples "manage proposals" do
           end
 
           it "creates a new proposal related to the process scope" do
-            find(".card-title a.button").click
+            click_link "New"
 
             within ".new_proposal" do
               fill_in :proposal_title, with: "Make decidim great again"
@@ -123,7 +123,7 @@ shared_examples "manage proposals" do
             end
 
             it "creates a new proposal related to the process scope" do
-              find(".card-title a.button").click
+              click_link "New"
 
               within ".new_proposal" do
                 fill_in :proposal_title, with: "Make decidim great again"


### PR DESCRIPTION
#### :tophat: What? Why?

While trying to reproduce #1833, I was very confused at first because after creating a test proposal feature and clicking on "New", I would get an authorization error. Turns out I was creating the proposals with the "creation enabled" setting turned off. In this case, the "New" button should not be displayed since it leads to an error.

#### :pushpin: Related Issues
- Fixes #1846.
- Related to #1833.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
![not_crash](https://user-images.githubusercontent.com/2887858/30444671-0321ac6e-9984-11e7-8a14-6ba87ebeaa87.gif)


#### :ghost: GIF
![guardiola](https://user-images.githubusercontent.com/2887858/30444328-de5ef914-9982-11e7-8ef0-5925e2678e21.gif)

