### PR TITLE
Fix feature edition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Fixed**
 
 - **decidim**: `decidim:check_locales` task not working properly. [\#1740]((https://https://github.com/decidim/decidim/pull/1740)
+- **decidim-admin**: Crash in feature edition when using Rails 5.1.4 [\#1848](https://https://github.com/decidim/decidim/pull/1848)
 - **decidim-core**: Disable HTML validations which sometimes caused unexpected form behavior. [\#1772](https://https://github.com/decidim/decidim/pull/1772)
 - **decidim-participatory_processes**: Scopes enabled checkbox being ignored in participatory process creation. [\#1762](https://https://github.com/decidim/decidim/pull/1762)
 - **decidim-surveys**: Drag & drop icon incorrectly rendered in form. [\#1761](https://https://github.com/decidim/decidim/pull/1761)

--- a/decidim-admin/app/forms/decidim/admin/feature_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/feature_form.rb
@@ -21,12 +21,6 @@ module Decidim
       attribute :step_settings, Hash[String => Object]
       attribute :participatory_space
 
-      def map_model(model)
-        self.attributes = model.attributes
-        self.settings = model.settings
-        self.default_step_settings = model.default_step_settings
-      end
-
       def settings?
         settings.manifest.attributes.any?
       end

--- a/decidim-admin/app/forms/decidim/admin/feature_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/feature_form.rb
@@ -34,17 +34,6 @@ module Decidim
       def default_step_settings?
         default_step_settings.manifest.attributes.any?
       end
-
-      def step_settings?
-        return false unless participatory_space.has_steps?
-
-        step_settings
-          .values
-          .map(&:manifest)
-          .flat_map(&:attributes)
-          .flat_map(&:keys)
-          .any?
-      end
     end
   end
 end

--- a/decidim-admin/app/views/decidim/admin/features/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/features/_form.html.erb
@@ -44,12 +44,12 @@
                   <%= form.fields_for "step_settings", nil do |settings_fields| %>
                     <%= settings_fields.fields_for step.id.to_s, step_settings do |settings_fields| %>
                       <%= render partial: "decidim/admin/features/settings_fields",
-                      locals: {
-                        form: settings_fields,
-                        feature: feature,
-                        settings_name: "step",
-                        tabs_prefix: "step-#{step.id}-settings"
-                      } %>
+                                 locals: {
+                                   form: settings_fields,
+                                   feature: feature,
+                                   settings_name: "step",
+                                   tabs_prefix: "step-#{step.id}-settings"
+                                 } %>
                     <% end %>
                   <% end %>
                 </fieldset>
@@ -66,12 +66,12 @@
             <div class="card-section">
               <%= form.fields_for :default_step_settings, form.object.default_step_settings do |settings_fields| %>
                 <%= render partial: "decidim/admin/features/settings_fields",
-                          locals: {
-                            form: settings_fields,
-                            feature: @feature,
-                            settings_name: "step",
-                            tabs_prefix: "default-step-settings"
-                          } %>
+                           locals: {
+                             form: settings_fields,
+                             feature: @feature,
+                             settings_name: "step",
+                             tabs_prefix: "default-step-settings"
+                           } %>
               <% end %>
             </div>
           </div>

--- a/decidim-admin/app/views/decidim/admin/features/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/features/_form.html.erb
@@ -29,7 +29,7 @@
         </fieldset>
       <% end %>
 
-      <% if form.object.step_settings? %>
+      <% if current_participatory_space.has_steps? %>
         <fieldset class="step-settings">
           <div class="card">
             <div class="card-divider">

--- a/decidim-admin/app/views/decidim/admin/features/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/features/_form.html.erb
@@ -41,7 +41,7 @@
                   <legend><%= step.position + 1 %>. <%= translated_attribute step.title %></legend>
                   <% step_settings = form.object.step_settings[step.id.to_s] %>
 
-                  <%= form.fields_for "step_settings", nil do |settings_fields| %>
+                  <%= form.fields_for :step_settings, nil do |settings_fields| %>
                     <%= settings_fields.fields_for step.id.to_s, step_settings do |settings_fields| %>
                       <%= render partial: "decidim/admin/features/settings_fields",
                                  locals: {

--- a/decidim-assemblies/spec/commands/copy_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/copy_assembly_spec.rb
@@ -98,7 +98,7 @@ describe Decidim::Assemblies::Admin::CopyAssembly do
 
       expect(last_feature.participatory_space).to eq(last_assembly)
       expect(last_feature.name).to eq(feature.name)
-      expect(last_feature.settings).to eq(feature.settings)
+      expect(last_feature.settings.attributes).to eq(feature.settings.attributes)
       expect(last_feature.step_settings.keys).to eq(feature.step_settings.keys)
       expect(last_feature.step_settings.values).to eq(feature.step_settings.values)
     end

--- a/decidim-assemblies/spec/features/admin/admin_manages_assembly_features_spec.rb
+++ b/decidim-assemblies/spec/features/admin/admin_manages_assembly_features_spec.rb
@@ -42,7 +42,7 @@ describe "Admin manages assembly features", type: :feature do
           all("input[type=checkbox]").first.click
         end
 
-        find("*[type=submit]").click
+        click_button "Add feature"
       end
 
       within ".callout-wrapper" do
@@ -104,7 +104,7 @@ describe "Admin manages assembly features", type: :feature do
           all("input[type=checkbox]").first.click
         end
 
-        find("*[type=submit]").click
+        click_button "Update"
       end
 
       within ".callout-wrapper" do

--- a/decidim-assemblies/spec/features/admin/admin_manages_assembly_features_spec.rb
+++ b/decidim-assemblies/spec/features/admin/admin_manages_assembly_features_spec.rb
@@ -16,9 +16,7 @@ describe "Admin manages assembly features", type: :feature do
   describe "add a feature" do
     before do
       visit decidim_admin_assemblies.features_path(assembly)
-    end
 
-    it "adds a feature" do
       find("button[data-toggle=add-feature-dropdown]").click
 
       within "#add-feature-dropdown" do
@@ -44,23 +42,39 @@ describe "Admin manages assembly features", type: :feature do
 
         click_button "Add feature"
       end
+    end
 
+    it "is successfully created" do
       within ".callout-wrapper" do
         expect(page).to have_content("successfully")
       end
 
       expect(page).to have_content("My feature")
+    end
 
-      within find("tr", text: "My feature") do
-        page.find(".action-icon--configure").click
+    context "and then edit it" do
+      before do
+        within find("tr", text: "My feature") do
+          page.find(".action-icon--configure").click
+        end
       end
 
-      within ".global-settings" do
-        expect(all("input[type=checkbox]").last).to be_checked
+      it "sucessfully displays initial values in the form" do
+        within ".global-settings" do
+          expect(all("input[type=checkbox]").last).to be_checked
+        end
+
+        within ".default-step-settings" do
+          expect(all("input[type=checkbox]").first).to be_checked
+        end
       end
 
-      within ".default-step-settings" do
-        expect(all("input[type=checkbox]").first).to be_checked
+      it "successfully edits it" do
+        click_button "Update"
+
+        within ".callout-wrapper" do
+          expect(page).to have_content("successfully")
+        end
       end
     end
   end

--- a/decidim-core/lib/decidim/has_settings.rb
+++ b/decidim-core/lib/decidim/has_settings.rb
@@ -15,7 +15,7 @@ module Decidim
     end
 
     def settings=(data)
-      self[:settings]["global"] = serialize_settings(settings_schema(:global), data)
+      self[:settings]["global"] = settings_schema(:global).new(data)
     end
 
     def current_settings
@@ -31,7 +31,7 @@ module Decidim
     end
 
     def default_step_settings=(data)
-      self[:settings]["default_step"] = serialize_settings(settings_schema(:step), data)
+      self[:settings]["default_step"] = settings_schema(:step).new(data)
     end
 
     def step_settings
@@ -44,7 +44,7 @@ module Decidim
 
     def step_settings=(data)
       self[:settings]["steps"] = data.each_with_object({}) do |(key, value), result|
-        result[key.to_s] = serialize_settings(settings_schema(:step), value)
+        result[key.to_s] = settings_schema(:step).new(value)
       end
     end
 
@@ -57,14 +57,6 @@ module Decidim
       return default_step_settings unless active_step
 
       step_settings.fetch(active_step.id.to_s)
-    end
-
-    def serialize_settings(schema, value)
-      if value.respond_to?(:attributes)
-        value.attributes
-      else
-        schema.new(value)
-      end
     end
 
     def settings_schema(name)

--- a/decidim-core/lib/decidim/settings_manifest.rb
+++ b/decidim-core/lib/decidim/settings_manifest.rb
@@ -52,10 +52,6 @@ module Decidim
           self.class.manifest
         end
 
-        def ==(other)
-          other.attributes == attributes
-        end
-
         manifest.attributes.each do |name, attribute|
           if attribute.translated?
             translatable_attribute name, attribute.type_class, default: attribute.default_value

--- a/decidim-core/spec/controllers/concerns/settings_spec.rb
+++ b/decidim-core/spec/controllers/concerns/settings_spec.rb
@@ -15,16 +15,24 @@ module Decidim
       include Decidim::Settings
     end
 
+    matcher :be_equivalent_to do |expected|
+      match do |actual|
+        actual.attributes == expected.attributes
+      end
+    end
+
     describe "#feature_settings" do
       it "returns the current feature's configuration" do
-        expect(controller.feature_settings).to eq(feature.settings)
+        expect(controller.feature_settings)
+          .to be_equivalent_to(feature.settings)
       end
     end
 
     describe "current_settings" do
       context "when no step is active" do
         it "returns the default step settings" do
-          expect(controller.current_settings).to eq(feature.default_step_settings)
+          expect(controller.current_settings)
+            .to be_equivalent_to(feature.default_step_settings)
         end
       end
 
@@ -37,7 +45,7 @@ module Decidim
 
         it "returns the settings for the active step" do
           expect(controller.current_settings)
-            .to eq(feature.step_settings[step.id.to_s])
+            .to be_equivalent_to(feature.step_settings[step.id.to_s])
         end
       end
     end

--- a/decidim-participatory_processes/spec/commands/copy_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/commands/copy_participatory_process_spec.rb
@@ -120,7 +120,7 @@ describe Decidim::ParticipatoryProcesses::Admin::CopyParticipatoryProcess do
 
       expect(last_feature.participatory_space).to eq(last_participatory_process)
       expect(last_feature.name).to eq(feature.name)
-      expect(last_feature.settings).to eq(feature.settings)
+      expect(last_feature.settings.attributes).to eq(feature.settings.attributes)
       expect(last_feature.step_settings.keys).to_not eq(feature.step_settings.keys)
       expect(last_feature.step_settings.values).to_not eq(feature.step_settings.values)
     end

--- a/decidim-participatory_processes/spec/features/admin/admin_manages_participatory_process_features_spec.rb
+++ b/decidim-participatory_processes/spec/features/admin/admin_manages_participatory_process_features_spec.rb
@@ -20,49 +20,51 @@ describe "Admin manages participatory process features", type: :feature do
       visit decidim_admin_participatory_processes.features_path(participatory_process)
     end
 
-    it "adds a feature" do
-      find("button[data-toggle=add-feature-dropdown]").click
+    context "when the process has active steps" do
+      it "adds a feature" do
+        find("button[data-toggle=add-feature-dropdown]").click
 
-      within "#add-feature-dropdown" do
-        find(".dummy").click
-      end
+        within "#add-feature-dropdown" do
+          find(".dummy").click
+        end
 
-      within ".new_feature" do
-        fill_in_i18n(
-          :feature_name,
-          "#feature-name-tabs",
-          en: "My feature",
-          ca: "La meva funcionalitat",
-          es: "Mi funcionalitat"
-        )
+        within ".new_feature" do
+          fill_in_i18n(
+            :feature_name,
+            "#feature-name-tabs",
+            en: "My feature",
+            ca: "La meva funcionalitat",
+            es: "Mi funcionalitat"
+          )
+
+          within ".global-settings" do
+            all("input[type=checkbox]").last.click
+          end
+
+          within ".step-settings" do
+            all("input[type=checkbox]").first.click
+          end
+
+          find("*[type=submit]").click
+        end
+
+        within ".callout-wrapper" do
+          expect(page).to have_content("successfully")
+        end
+
+        expect(page).to have_content("My feature")
+
+        within find("tr", text: "My feature") do
+          page.find(".action-icon--configure").click
+        end
 
         within ".global-settings" do
-          all("input[type=checkbox]").last.click
+          expect(all("input[type=checkbox]").last).to be_checked
         end
 
         within ".step-settings" do
-          all("input[type=checkbox]").first.click
+          expect(all("input[type=checkbox]").first).to be_checked
         end
-
-        find("*[type=submit]").click
-      end
-
-      within ".callout-wrapper" do
-        expect(page).to have_content("successfully")
-      end
-
-      expect(page).to have_content("My feature")
-
-      within find("tr", text: "My feature") do
-        page.find(".action-icon--configure").click
-      end
-
-      within ".global-settings" do
-        expect(all("input[type=checkbox]").last).to be_checked
-      end
-
-      within ".step-settings" do
-        expect(all("input[type=checkbox]").first).to be_checked
       end
     end
 

--- a/decidim-participatory_processes/spec/features/admin/admin_manages_participatory_process_features_spec.rb
+++ b/decidim-participatory_processes/spec/features/admin/admin_manages_participatory_process_features_spec.rb
@@ -21,7 +21,7 @@ describe "Admin manages participatory process features", type: :feature do
     end
 
     context "when the process has active steps" do
-      it "adds a feature" do
+      before do
         find("button[data-toggle=add-feature-dropdown]").click
 
         within "#add-feature-dropdown" do
@@ -47,23 +47,39 @@ describe "Admin manages participatory process features", type: :feature do
 
           click_button "Add feature"
         end
+      end
 
+      it "is successfully created" do
         within ".callout-wrapper" do
           expect(page).to have_content("successfully")
         end
 
         expect(page).to have_content("My feature")
+      end
 
-        within find("tr", text: "My feature") do
-          page.find(".action-icon--configure").click
+      context "and then edit it" do
+        before do
+          within find("tr", text: "My feature") do
+            page.find(".action-icon--configure").click
+          end
         end
 
-        within ".global-settings" do
-          expect(all("input[type=checkbox]").last).to be_checked
+        it "sucessfully displays initial values in the form" do
+          within ".global-settings" do
+            expect(all("input[type=checkbox]").last).to be_checked
+          end
+
+          within ".step-settings" do
+            expect(all("input[type=checkbox]").first).to be_checked
+          end
         end
 
-        within ".step-settings" do
-          expect(all("input[type=checkbox]").first).to be_checked
+        it "successfully edits it" do
+          click_button "Update"
+
+          within ".callout-wrapper" do
+            expect(page).to have_content("successfully")
+          end
         end
       end
     end
@@ -73,7 +89,7 @@ describe "Admin manages participatory process features", type: :feature do
         create(:participatory_process, organization: organization)
       end
 
-      it "saves the default step settings" do
+      before do
         find("button[data-toggle=add-feature-dropdown]").click
 
         within "#add-feature-dropdown" do
@@ -99,23 +115,39 @@ describe "Admin manages participatory process features", type: :feature do
 
           click_button "Add feature"
         end
+      end
 
+      it "is successfully created" do
         within ".callout-wrapper" do
           expect(page).to have_content("successfully")
         end
 
         expect(page).to have_content("My feature")
+      end
 
-        within find("tr", text: "My feature") do
-          page.find(".action-icon--configure").click
+      context "and then edit it" do
+        before do
+          within find("tr", text: "My feature") do
+            page.find(".action-icon--configure").click
+          end
         end
 
-        within ".global-settings" do
-          expect(all("input[type=checkbox]").last).to be_checked
+        it "sucessfully displays initial values in the form" do
+          within ".global-settings" do
+            expect(all("input[type=checkbox]").last).to be_checked
+          end
+
+          within ".default-step-settings" do
+            expect(all("input[type=checkbox]").first).to be_checked
+          end
         end
 
-        within ".default-step-settings" do
-          expect(all("input[type=checkbox]").first).to be_checked
+        it "successfully edits it" do
+          click_button "Update"
+
+          within ".callout-wrapper" do
+            expect(page).to have_content("successfully")
+          end
         end
       end
     end

--- a/decidim-participatory_processes/spec/features/admin/admin_manages_participatory_process_features_spec.rb
+++ b/decidim-participatory_processes/spec/features/admin/admin_manages_participatory_process_features_spec.rb
@@ -45,7 +45,7 @@ describe "Admin manages participatory process features", type: :feature do
             all("input[type=checkbox]").first.click
           end
 
-          find("*[type=submit]").click
+          click_button "Add feature"
         end
 
         within ".callout-wrapper" do
@@ -97,7 +97,7 @@ describe "Admin manages participatory process features", type: :feature do
             all("input[type=checkbox]").first.click
           end
 
-          find("*[type=submit]").click
+          click_button "Add feature"
         end
 
         within ".callout-wrapper" do
@@ -160,7 +160,7 @@ describe "Admin manages participatory process features", type: :feature do
           all("input[type=checkbox]").first.click
         end
 
-        find("*[type=submit]").click
+        click_button "Update"
       end
 
       within ".callout-wrapper" do
@@ -195,7 +195,7 @@ describe "Admin manages participatory process features", type: :feature do
             all("input[type=checkbox]").first.click
           end
 
-          find("*[type=submit]").click
+          click_button "Update"
         end
 
         within ".callout-wrapper" do


### PR DESCRIPTION
#### :tophat: What? Why?

This fixes the feature edition crashes reported in #1833. It's been a bit of a nightmare to figure this out :laughing:.

I wanted to fix this since I feel responsible for the introduction of assemblies and I was pretty sure I introduced this bug when adding them. Well, it turns out I didn't.

The fix happens because of some change in behavior in Rails 5.1.4. :disappointed:. I'm not going to dig in further into that since I can't justify the time.

My strategy to solve this was remove code until no longer hitting the bug. Turns out I was able to remove the custom `==` method in the dynamic class that defines the "settings schema", which is where the crash happens. The crash didn't show up earlier (Rails 5.1.3) because this method was dead code before Rails 5.1.4 (only 4 test used it in their assertions, but the test application itself didn't hit it).

@virgile-dev Can you give this a try and confirm it fixes things?

#### :pushpin: Related Issues
- Fixes #1833.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![guardiola2](https://user-images.githubusercontent.com/2887858/30446229-cd3956f6-9988-11e7-973b-2605f146b8c3.gif)
