### PR TITLE
do not store /cookies/accept as a potential redirect location

### DIFF
--- a/decidim-core/app/controllers/decidim/cookie_policy_controller.rb
+++ b/decidim-core/app/controllers/decidim/cookie_policy_controller.rb
@@ -5,6 +5,8 @@ module Decidim
   class CookiePolicyController < Decidim::ApplicationController
     skip_authorization_check
 
+    skip_before_action :store_current_location
+
     def accept
       response.set_cookie "decidim-cc", value: "true",
                                         path: "/",


### PR DESCRIPTION
I ran into a redirect loop when I clicked 'accept cookies' when looking at the login
form and loggin in afterwards.