### PR TITLE
Fix dev apps dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - **decidim-proposals**: Fix proposal vote button visibility problem when votes were disabled and the user logged in. [\#1862](https://github.com/decidim/decidim/pull/1862)
 - **decidim-core**: Incompatible `puma` dependencies on `gemspec` and development app's Gemfile preventing the development application from being properly generated. [\#1862](https://github.com/decidim/decidim/pull/1862)
+- **decidim-core**: Problem in development app's Gemfile resolution caused because the initial `bundle install` would not consider `decidim` dependency specifications. [\#1862](https://github.com/decidim/decidim/pull/1862)
 
 ## [v0.6.1](https://github.com/decidim/decidim/tree/v0.6.1) (2017-09-15)
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.6.0...v0.6.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Fixed**
 
 - **decidim-proposals**: Fix proposal vote button visibility problem when votes were disabled and the user logged in. [\#1862](https://github.com/decidim/decidim/pull/1862)
+- **decidim-core**: Incompatible `puma` dependencies on `gemspec` and development app's Gemfile preventing the development application from being properly generated. [\#1862](https://github.com/decidim/decidim/pull/1862)
 
 ## [v0.6.1](https://github.com/decidim/decidim/tree/v0.6.1) (2017-09-15)
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.6.0...v0.6.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,6 @@ PATH
       launchy
       listen (~> 3.1.0)
       poltergeist (~> 1.16.0)
-      puma (~> 3.9.1)
       rails-controller-testing (~> 1.0.1)
       rspec-html-matchers (~> 0.9.1)
       rspec-rails (~> 3.6.1)
@@ -406,7 +405,6 @@ GEM
       actionmailer (>= 3, < 6)
       premailer (~> 1.7, >= 1.7.9)
     public_suffix (3.0.0)
-    puma (3.9.1)
     rack (2.0.3)
     rack-cors (0.4.1)
     rack-test (0.7.0)

--- a/decidim-dev/decidim-dev.gemspec
+++ b/decidim-dev/decidim-dev.gemspec
@@ -37,5 +37,4 @@ Gem::Specification.new do |s|
   s.add_dependency "db-query-matchers", "~> 0.9.0"
   s.add_dependency "rspec-html-matchers", "~> 0.9.1"
   s.add_dependency "webmock", "~> 3.0.1"
-  s.add_dependency "puma", "~> 3.9.1"
 end

--- a/lib/generators/decidim/app_generator.rb
+++ b/lib/generators/decidim/app_generator.rb
@@ -42,6 +42,9 @@ module Decidim
       class_option :app_const_base, type: :string,
                                     desc: "The application constant name"
 
+      class_option :skip_bundle, type: :boolean, aliases: "-B", default: true,
+                                 desc: "Don't run bundle install"
+
       def database_yml
         template "database.yml.erb", "config/database.yml", force: true
       end


### PR DESCRIPTION
#### :tophat: What? Why?

I was getting errors when generating a development application. Not sure why they appeared only now, I think it's because new versions were released for some dependencies causing the conflicts. If we confirm they happen consistenly and it's not just something weird with my environment, I think we should release this as 0.6.2.
 
#### :pushpin: Related Issues
* #1845.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![forrest_doubts](https://user-images.githubusercontent.com/2887858/30560231-8749144c-9cb7-11e7-92b1-0eafd85bb1c0.gif)
