### PR TITLE
Wysiwyg editor for proposal body

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
@@ -9,7 +9,7 @@
     </div>
 
     <div class="row column">
-      <%= form.text_area :body, rows: 10 %>
+      <%= form.editor :body, lines: 10 %>
     </div>
 
     <% if feature_settings.geocoding_enabled? %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_proposal.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_proposal.html.erb
@@ -11,7 +11,7 @@
         <%= feature_reference(proposal, class: "reference--text-left") %>
       </div>
       <%= render partial: "proposal_badge", locals: { proposal: proposal } %>
-      <p><%= truncate(proposal.body, length: 100) %></p>
+      <p><%= sanitize html_truncate proposal.body, length: 100 %></p>
       <%= render partial: "decidim/shared/tags", locals: { resource: proposal, tags_class_extra: "tags--proposal" } %>
     </div>
     <div class="card__footer">

--- a/decidim-proposals/app/views/decidim/proposals/proposals/new.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/new.html.erb
@@ -20,7 +20,7 @@
           </div>
 
           <div class="field">
-            <%= form.text_area :body, rows: 10 %>
+            <%= form.editor :body, lines: 10 %>
           </div>
 
           <% if feature_settings.geocoding_enabled? %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -38,7 +38,7 @@
   <div class="columns mediumlarge-8 mediumlarge-pull-4">
     <div class="section">
       <%= render partial: "proposal_badge", locals: { proposal: @proposal } %>
-      <%= simple_format @proposal.body %>
+      <%= sanitize @proposal.body %>
       <% if feature_settings.geocoding_enabled? %>
         <%= render partial: "decidim/shared/static_map", locals: { icon_name: "proposals", geolocalizable: @proposal } %>
       <% end %>

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -72,7 +72,7 @@ describe "Proposals", type: :feature do
 
           within ".new_proposal" do
             fill_in :proposal_title, with: "Oriol for president"
-            fill_in :proposal_body, with: "He will solve everything"
+            fill_in_editor :proposal_body, with: "He will solve everything"
             select translated(category.name), from: :proposal_category_id
             select2 translated(scope.name), xpath: '//select[@id="proposal_scope_id"]/..', search: true
 
@@ -102,7 +102,7 @@ describe "Proposals", type: :feature do
 
             within ".new_proposal" do
               fill_in :proposal_title, with: "Oriol for president"
-              fill_in :proposal_body, with: "He will solve everything"
+              fill_in_editor :proposal_body, with: "He will solve everything"
 
               check :proposal_has_address
 
@@ -136,7 +136,7 @@ describe "Proposals", type: :feature do
 
             within ".new_proposal" do
               fill_in :proposal_title, with: "Oriol for president"
-              fill_in :proposal_body, with: "He will solve everything"
+              fill_in_editor :proposal_body, with: "He will solve everything"
               select translated(category.name), from: :proposal_category_id
               select2 translated(scope.name), xpath: '//select[@id="proposal_scope_id"]/..', search: true
               select user_group.name, from: :proposal_user_group_id
@@ -167,7 +167,7 @@ describe "Proposals", type: :feature do
 
               within ".new_proposal" do
                 fill_in :proposal_title, with: "Oriol for president"
-                fill_in :proposal_body, with: "He will solve everything"
+                fill_in_editor :proposal_body, with: "He will solve everything"
 
                 check :proposal_has_address
 
@@ -218,7 +218,7 @@ describe "Proposals", type: :feature do
 
             within ".new_proposal" do
               fill_in :proposal_title, with: "Proposal with attachments"
-              fill_in :proposal_body, with: "This is my proposal and I want to upload attachments."
+              fill_in_editor :proposal_body, with: "This is my proposal and I want to upload attachments."
               fill_in :proposal_attachment_title, with: "My attachment"
               attach_file :proposal_attachment_file, Decidim::Dev.asset("city.jpeg")
               find("*[type=submit]").click

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -60,7 +60,7 @@ shared_examples "manage proposals" do
           it "creates a new proposal" do
             within ".new_proposal" do
               fill_in :proposal_title, with: "Make decidim great again"
-              fill_in :proposal_body, with: "Decidim is great but it can be better"
+              fill_in_editor :proposal_body, with: "Decidim is great but it can be better"
               select translated(category.name), from: :proposal_category_id
               select2 translated(scope.name), xpath: '//select[@id="proposal_scope_id"]/..', search: true
 
@@ -100,7 +100,7 @@ shared_examples "manage proposals" do
 
             within ".new_proposal" do
               fill_in :proposal_title, with: "Make decidim great again"
-              fill_in :proposal_body, with: "Decidim is great but it can be better"
+              fill_in_editor :proposal_body, with: "Decidim is great but it can be better"
               select category.name["en"], from: :proposal_category_id
               find("*[type=submit]").click
             end
@@ -129,7 +129,7 @@ shared_examples "manage proposals" do
 
               within ".new_proposal" do
                 fill_in :proposal_title, with: "Make decidim great again"
-                fill_in :proposal_body, with: "Decidim is great but it can be better"
+                fill_in_editor :proposal_body, with: "Decidim is great but it can be better"
                 fill_in :proposal_address, with: address
                 select category.name["en"], from: :proposal_category_id
                 find("*[type=submit]").click
@@ -161,7 +161,7 @@ shared_examples "manage proposals" do
 
             within ".new_proposal" do
               fill_in :proposal_title, with: "Proposal with attachments"
-              fill_in :proposal_body, with: "This is my proposal and I want to upload attachments."
+              fill_in_editor :proposal_body, with: "This is my proposal and I want to upload attachments."
               fill_in :proposal_attachment_title, with: "My attachment"
               attach_file :proposal_attachment_file, Decidim::Dev.asset("city.jpeg")
               find("*[type=submit]").click


### PR DESCRIPTION
#### :tophat: What? Why?

This extends the _New Proposal_ form to use the simple version of the Quill JS editor.

#### :pushpin: Related Issues
- Fixes #1568 
