### PR TITLE
sanitize user-entered html

### DIFF
--- a/decidim-assemblies/app/views/decidim/assemblies/_assembly.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/_assembly.html.erb
@@ -8,7 +8,7 @@
       <%= link_to assembly_path(assembly), class: "card__link" do %>
         <h4 class="card__title"><%= translated_attribute assembly.title %></h4>
       <% end %>
-      <p class="card__desc"><%== html_truncate(translated_attribute(assembly.short_description), length: 630, separator: '...') %></p>
+      <p class="card__desc"><%= sanitize html_truncate(translated_attribute(assembly.short_description), length: 630, separator: '...') %></p>
     </div>
     <div class="card__footer">
       <div class="card__support">

--- a/decidim-assemblies/app/views/decidim/assemblies/assemblies/_promoted_assembly.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/assemblies/_promoted_assembly.html.erb
@@ -5,7 +5,7 @@
         <%= link_to assembly_path(promoted_assembly), class: "card__link" do %>
           <h2 class="card__title"><%= translated_attribute promoted_assembly.title %></h2>
         <% end %>
-        <%== html_truncate(translated_attribute(promoted_assembly.short_description), length: 630, separator: '...') %>
+        <%= sanitize html_truncate(translated_attribute(promoted_assembly.short_description), length: 630, separator: '...') %>
         <%= link_to assembly_path(promoted_assembly), class: "button secondary small hollow card__button" do %>
           <%= t("assemblies.promoted_assembly.more_info", scope: "layouts.decidim") %>
         <% end %>

--- a/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
@@ -11,9 +11,9 @@
     <div class="columns medium-7 mediumlarge-8">
       <div class="section">
         <div class="lead">
-          <%== translated_attribute(current_assembly.short_description) %>
+          <%= sanitize translated_attribute(current_assembly.short_description) %>
         </div>
-        <%== translated_attribute(current_assembly.description) %>
+        <%= sanitize translated_attribute(current_assembly.description) %>
       </div>
       <%= attachments_for current_assembly %>
     </div>
@@ -22,42 +22,42 @@
         <% if translated_attribute(current_assembly.meta_scope).present? %>
           <div class="definition-data__item scope">
             <span class="definition-data__title"><%= t("assemblies.show.scope", scope: "decidim") %></span>
-              <%== translated_attribute(current_assembly.meta_scope) %>
+              <%= sanitize translated_attribute(current_assembly.meta_scope) %>
           </div>
         <% end %>
 
         <% if translated_attribute(current_assembly.developer_group).present? %>
           <div class="definition-data__item developer-group">
             <span class="definition-data__title"><%= t("assemblies.show.developer_group", scope: "decidim") %></span>
-              <%== translated_attribute(current_assembly.developer_group) %>
+              <%= sanitize translated_attribute(current_assembly.developer_group) %>
           </div>
         <% end %>
 
         <% if translated_attribute(current_assembly.local_area).present? %>
           <div class="definition-data__item local_area">
             <span class="definition-data__title"><%= t("assemblies.show.local_area", scope: "decidim") %></span>
-              <%== translated_attribute(current_assembly.local_area) %>
+              <%= sanitize translated_attribute(current_assembly.local_area) %>
           </div>
         <% end %>
 
          <% if translated_attribute(current_assembly.target).present? %>
           <div class="definition-data__item target">
             <span class="definition-data__title"><%= t("assemblies.show.target", scope: "decidim") %></span>
-              <%== translated_attribute(current_assembly.target) %>
+              <%= sanitize translated_attribute(current_assembly.target) %>
           </div>
         <% end %>
 
          <% if translated_attribute(current_assembly.participatory_scope).present? %>
           <div class="definition-data__item participatory_scope">
             <span class="definition-data__title"><%= t("assemblies.show.participatory_scope", scope: "decidim") %></span>
-              <%== translated_attribute(current_assembly.participatory_scope) %>
+              <%= sanitize translated_attribute(current_assembly.participatory_scope) %>
           </div>
         <% end %>
 
         <% if translated_attribute(current_assembly.participatory_structure).present? %>
           <div class="definition-data__item participatory_structure">
             <span class="definition-data__title"><%= t("assemblies.show.participatory_structure", scope: "decidim") %></span>
-              <%== translated_attribute(current_assembly.participatory_structure) %>
+              <%= sanitize translated_attribute(current_assembly.participatory_structure) %>
           </div>
         <% end %>
       </div>

--- a/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
@@ -11,7 +11,7 @@
     <div class="columns medium-7 mediumlarge-8">
       <div class="section">
         <div class="lead">
-          <%= sanitize translated_attribute(current_assembly.short_description) %>
+          <%= translated_attribute(current_assembly.short_description) %>
         </div>
         <%= sanitize translated_attribute(current_assembly.description) %>
       </div>
@@ -22,42 +22,42 @@
         <% if translated_attribute(current_assembly.meta_scope).present? %>
           <div class="definition-data__item scope">
             <span class="definition-data__title"><%= t("assemblies.show.scope", scope: "decidim") %></span>
-              <%= sanitize translated_attribute(current_assembly.meta_scope) %>
+              <%= translated_attribute(current_assembly.meta_scope) %>
           </div>
         <% end %>
 
         <% if translated_attribute(current_assembly.developer_group).present? %>
           <div class="definition-data__item developer-group">
             <span class="definition-data__title"><%= t("assemblies.show.developer_group", scope: "decidim") %></span>
-              <%= sanitize translated_attribute(current_assembly.developer_group) %>
+              <%= translated_attribute(current_assembly.developer_group) %>
           </div>
         <% end %>
 
         <% if translated_attribute(current_assembly.local_area).present? %>
           <div class="definition-data__item local_area">
             <span class="definition-data__title"><%= t("assemblies.show.local_area", scope: "decidim") %></span>
-              <%= sanitize translated_attribute(current_assembly.local_area) %>
+              <%= translated_attribute(current_assembly.local_area) %>
           </div>
         <% end %>
 
          <% if translated_attribute(current_assembly.target).present? %>
           <div class="definition-data__item target">
             <span class="definition-data__title"><%= t("assemblies.show.target", scope: "decidim") %></span>
-              <%= sanitize translated_attribute(current_assembly.target) %>
+              <%= translated_attribute(current_assembly.target) %>
           </div>
         <% end %>
 
          <% if translated_attribute(current_assembly.participatory_scope).present? %>
           <div class="definition-data__item participatory_scope">
             <span class="definition-data__title"><%= t("assemblies.show.participatory_scope", scope: "decidim") %></span>
-              <%= sanitize translated_attribute(current_assembly.participatory_scope) %>
+              <%= translated_attribute(current_assembly.participatory_scope) %>
           </div>
         <% end %>
 
         <% if translated_attribute(current_assembly.participatory_structure).present? %>
           <div class="definition-data__item participatory_structure">
             <span class="definition-data__title"><%= t("assemblies.show.participatory_structure", scope: "decidim") %></span>
-              <%= sanitize translated_attribute(current_assembly.participatory_structure) %>
+              <%= translated_attribute(current_assembly.participatory_structure) %>
           </div>
         <% end %>
       </div>

--- a/decidim-assemblies/app/views/decidim/assemblies/assembly_widgets/show.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/assembly_widgets/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:header, "false") %>
 <% content_for(:title, translated_attribute(model.title)) %>
-<p class="card__desc"><%== html_truncate(translated_attribute(model.short_description), length: 630, separator: '...') %></p>
+<p class="card__desc"><%= sanitize html_truncate(translated_attribute(model.short_description), length: 630, separator: '...') %></p>
 <% content_for(:footer) do %>
   <div class="card__support">
     <span class="card--process__small"></span>

--- a/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
@@ -37,7 +37,7 @@
   </div>
   <div class="columns mediumlarge-8 mediumlarge-pull-4">
     <div class="section">
-      <%== translated_attribute project.description %>
+      <%= sanitize translated_attribute project.description %>
       <%= render partial: "decidim/shared/tags", locals: { resource: project, tags_class_extra: "tags--project" } %>
     </div>
     <%= linked_resources_for project, :proposals, "included_proposals" %>

--- a/decidim-core/app/views/decidim/newsletter_mailer/newsletter.html.erb
+++ b/decidim-core/app/views/decidim/newsletter_mailer/newsletter.html.erb
@@ -1,5 +1,5 @@
-<%== @body %>
+<%= sanitize @body %>
 
 <% content_for :note do %>
-  <%== t ".note", organization_name: @organization.name, link: decidim.notifications_settings_url(host: @organization.host) %>
+  <%== t ".note", organization_name: h(@organization.name), link: decidim.notifications_settings_url(host: @organization.host) %>
 <% end %>

--- a/decidim-core/app/views/decidim/shared/_address_details.html.erb
+++ b/decidim-core/app/views/decidim/shared/_address_details.html.erb
@@ -1,9 +1,9 @@
 <div class="address__details">
   <% if geolocalizable.respond_to? :location %>
-    <strong><%= sanitize translated_attribute geolocalizable.location %></strong><br />
+    <strong><%= translated_attribute geolocalizable.location %></strong><br />
   <% end %>
   <span><%= geolocalizable.address %></span><br />
   <% if geolocalizable.respond_to? :location_hints %>
-    <span><%= sanitize translated_attribute geolocalizable.location_hints %></span>
+    <span><%= translated_attribute geolocalizable.location_hints %></span>
   <% end %>
 </div>

--- a/decidim-core/app/views/decidim/shared/_address_details.html.erb
+++ b/decidim-core/app/views/decidim/shared/_address_details.html.erb
@@ -1,9 +1,9 @@
 <div class="address__details">
   <% if geolocalizable.respond_to? :location %>
-    <strong><%== translated_attribute geolocalizable.location %></strong><br />
+    <strong><%= sanitize translated_attribute geolocalizable.location %></strong><br />
   <% end %>
   <span><%= geolocalizable.address %></span><br />
   <% if geolocalizable.respond_to? :location_hints %>
-    <span><%== translated_attribute geolocalizable.location_hints %></span>
+    <span><%= sanitize translated_attribute geolocalizable.location_hints %></span>
   <% end %>
 </div>

--- a/decidim-core/app/views/decidim/shared/_announcement.html.erb
+++ b/decidim-core/app/views/decidim/shared/_announcement.html.erb
@@ -1,5 +1,5 @@
 <div class="row column">
   <div class="callout secondary announcement">
-    <%== translated_attribute announcement %>
+    <%= sanitize translated_attribute announcement %>
   </div>
 </div>

--- a/decidim-core/app/views/pages/decidim_page.html.erb
+++ b/decidim-core/app/views/pages/decidim_page.html.erb
@@ -10,7 +10,7 @@
   <div class="row">
     <div class="columns large-8">
       <div class="static__content">
-        <%== translated_attribute page.content %>
+        <%= sanitize translated_attribute page.content %>
       </div>
     </div>
   </div>

--- a/decidim-core/app/views/pages/home/_hero.html.erb
+++ b/decidim-core/app/views/pages/home/_hero.html.erb
@@ -6,7 +6,7 @@
           <% if translated_attribute(current_organization.welcome_text).blank? %>
             <%= t('.welcome', organization: current_organization.name) %>
           <% else %>
-            <%== translated_attribute current_organization.welcome_text %>
+            <%= sanitize translated_attribute current_organization.welcome_text %>
           <% end %>
         </h1>
       </div>

--- a/decidim-core/app/views/pages/home/_sub_hero.html.erb
+++ b/decidim-core/app/views/pages/home/_sub_hero.html.erb
@@ -1,7 +1,7 @@
   <section class="extended subhero home-section">
     <div class="row">
       <div class="columns small-centered large-10">
-        <h2 class="heading3"><%== translated_attribute current_organization.description %></h2>
+        <h2 class="heading3"><%= sanitize translated_attribute current_organization.description %></h2>
         <%= link_to new_user_registration_path, class: "button--sc link subhero-cta" do %>
           <%= t(".register") %>
           <%= icon "chevron-right", aria_hidden: true %>

--- a/decidim-core/app/views/pages/home/_sub_hero.html.erb
+++ b/decidim-core/app/views/pages/home/_sub_hero.html.erb
@@ -1,7 +1,7 @@
   <section class="extended subhero home-section">
     <div class="row">
       <div class="columns small-centered large-10">
-        <h2 class="heading3"><%= sanitize translated_attribute current_organization.description %></h2>
+        <h2 class="heading3"><%= translated_attribute current_organization.description %></h2>
         <%= link_to new_user_registration_path, class: "button--sc link subhero-cta" do %>
           <%= t(".register") %>
           <%= icon "chevron-right", aria_hidden: true %>

--- a/decidim-meetings/app/views/decidim/meetings/meeting_widgets/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meeting_widgets/show.html.erb
@@ -1,6 +1,6 @@
 <%= content_for(:title, translated_attribute(model.title)) %>
 <%= render partial: "decidim/meetings/meetings/datetime", locals: { meeting: model } %>
-<%== meeting_description(model) %>
+<%= sanitize meeting_description(model) %>
 <div class="address card__extra">
   <div class="address__icon">
     <%= icon "meetings", remove_icon_class: true, width: 40, height: 70 %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_linked_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_linked_meetings.html.erb
@@ -14,7 +14,7 @@
               <%= meeting.start_time.strftime("%H:%M") %> - <%= meeting.end_time.strftime("%H:%M") %>
             </div>
           </div>
-          <%== translated_attribute meeting.description %>
+          <%= sanitize translated_attribute meeting.description %>
         </div>
       </article>
     </div>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
@@ -19,7 +19,7 @@
             <h5 class="card__title"><%= translated_attribute meeting.title %></h5>
           <% end %>
           <%= render partial: "datetime", locals: { meeting: meeting } %>
-          <%== meeting_description(meeting) %>
+          <%= sanitize meeting_description(meeting) %>
           <%= render partial: "decidim/shared/tags", locals: { resource: meeting, tags_class_extra: "tags--meeting" } %>
           <div class="address card__extra">
             <div class="address__icon">

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_registration_confirm.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_registration_confirm.html.erb
@@ -1,7 +1,7 @@
 <div class="reveal" data-reveal id="meeting-registration-confirm">
   <div class="row">
     <div class="columns medium-10 medium-offset-1 help-text">
-      <%== translated_attribute(meeting.registration_terms) %>
+      <%= sanitize translated_attribute(meeting.registration_terms) %>
     </div>
   </div>
   <div class="row">

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -74,7 +74,7 @@
     <% end %>
     <%= linked_resources_for meeting, :proposals, "proposals_from_meeting" %>
     <%= linked_resources_for meeting, :results, "meetings_through_proposals" %>
-  e/div>
+  </div>
 </div>
 <%= attachments_for meeting %>
 <%= comments_for meeting %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -62,19 +62,19 @@
   </div>
   <div class="columns mediumlarge-8 mediumlarge-pull-4">
     <div class="section">
-      <p><%== translated_attribute meeting.description %></p>
+      <p><%= sanitize translated_attribute meeting.description %></p>
       <%= render partial: "decidim/shared/static_map", locals: { icon_name: "meetings", geolocalizable: meeting } %>
       <%= render partial: "decidim/shared/tags", locals: { resource: meeting, tags_class_extra: "tags--meeting" } %>
     </div>
     <% if meeting.closed? %>
       <div class="section">
         <h3 class="section-heading"><%= t(".meeting_report") %></h3>
-        <%== translated_attribute meeting.closing_report %>
+        <%= sanitize translated_attribute meeting.closing_report %>
       </div>
     <% end %>
     <%= linked_resources_for meeting, :proposals, "proposals_from_meeting" %>
     <%= linked_resources_for meeting, :results, "meetings_through_proposals" %>
-  </div>
+  e/div>
 </div>
 <%= attachments_for meeting %>
 <%= comments_for meeting %>

--- a/decidim-pages/app/views/decidim/pages/application/show.html.erb
+++ b/decidim-pages/app/views/decidim/pages/application/show.html.erb
@@ -8,7 +8,7 @@
   <div class="row">
     <div class="columns medium-7 mediumlarge-8">
       <div class="section">
-        <%== translated_attribute @page.body %>
+        <%= sanitize translated_attribute @page.body %>
       </div>
     </div>
   </div>

--- a/decidim-participatory_processes/app/views/decidim/participatory_process_groups/_participatory_process_group.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_process_groups/_participatory_process_group.html.erb
@@ -8,7 +8,7 @@
       <%= link_to participatory_process_group_path(participatory_process_group), class: "card__link" do %>
         <h4 class="card__title"><%= translated_attribute participatory_process_group.name %></h4>
       <% end %>
-      <p class="card__desc"><%== html_truncate(translated_attribute(participatory_process_group.description), length: 630, separator: '...') %></p>
+      <p class="card__desc"><%= sanitize html_truncate(translated_attribute(participatory_process_group.description), length: 630, separator: '...') %></p>
     </div>
     <div class="card__footer">
       <div class="card__support">

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/_participatory_process.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/_participatory_process.html.erb
@@ -8,7 +8,7 @@
       <%= link_to participatory_process_path(participatory_process), class: "card__link" do %>
         <h4 class="card__title"><%= translated_attribute participatory_process.title %></h4>
       <% end %>
-      <p class="card__desc"><%== html_truncate(translated_attribute(participatory_process.short_description), length: 630, separator: '...') %></p>
+      <p class="card__desc"><%= sanitize html_truncate(translated_attribute(participatory_process.short_description), length: 630, separator: '...') %></p>
     </div>
     <div class="card__footer">
       <div class="card__support">

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_process_widgets/show.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_process_widgets/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:header, "false") %>
 <% content_for(:title, translated_attribute(model.title)) %>
-<p class="card__desc"><%== html_truncate(translated_attribute(model.short_description), length: 630, separator: '...') %></p>
+<p class="card__desc"><%= sanitize html_truncate(translated_attribute(model.short_description), length: 630, separator: '...') %></p>
 <% content_for(:footer) do %>
   <div class="card__support">
     <% if model.active_step %>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/_promoted_process.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/_promoted_process.html.erb
@@ -5,7 +5,7 @@
         <%= link_to participatory_process_path(promoted_process), class: "card__link" do %>
           <h2 class="card__title"><%= translated_attribute promoted_process.title %></h2>
         <% end %>
-        <%== html_truncate(translated_attribute(promoted_process.short_description), length: 630, separator: '...') %>
+        <%= sanitize html_truncate(translated_attribute(promoted_process.short_description), length: 630, separator: '...') %>
         <%= link_to participatory_process_path(promoted_process), class: "button secondary small hollow card__button" do %>
           <%= t("participatory_processes.promoted_process.more_info", scope: "layouts.decidim") %>
         <% end %>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
@@ -15,9 +15,9 @@
     <div class="columns medium-7 mediumlarge-8">
       <div class="section">
         <div class="lead">
-          <%== translated_attribute(current_participatory_process.short_description) %>
+          <%= sanitize translated_attribute(current_participatory_process.short_description) %>
         </div>
-        <%== translated_attribute(current_participatory_process.description) %>
+        <%= sanitize translated_attribute(current_participatory_process.description) %>
       </div>
       <%= attachments_for current_participatory_process %>
     </div>
@@ -26,7 +26,7 @@
         <% if translated_attribute(current_participatory_process.meta_scope).present? %>
           <div class="definition-data__item scope">
             <span class="definition-data__title"><%= t("participatory_processes.show.scope", scope: "decidim") %></span>
-              <%== translated_attribute(current_participatory_process.meta_scope) %>
+              <%= sanitize translated_attribute(current_participatory_process.meta_scope) %>
           </div>
         <% end %>
 
@@ -47,35 +47,35 @@
         <% if translated_attribute(current_participatory_process.developer_group).present? %>
           <div class="definition-data__item developer-group">
             <span class="definition-data__title"><%= t("participatory_processes.show.developer_group", scope: "decidim") %></span>
-              <%== translated_attribute(current_participatory_process.developer_group) %>
+              <%= sanitize translated_attribute(current_participatory_process.developer_group) %>
           </div>
         <% end %>
 
         <% if translated_attribute(current_participatory_process.local_area).present? %>
           <div class="definition-data__item local_area">
             <span class="definition-data__title"><%= t("participatory_processes.show.local_area", scope: "decidim") %></span>
-              <%== translated_attribute(current_participatory_process.local_area) %>
+              <%= sanitize translated_attribute(current_participatory_process.local_area) %>
           </div>
         <% end %>
 
          <% if translated_attribute(current_participatory_process.target).present? %>
           <div class="definition-data__item target">
             <span class="definition-data__title"><%= t("participatory_processes.show.target", scope: "decidim") %></span>
-              <%== translated_attribute(current_participatory_process.target) %>
+              <%= sanitize translated_attribute(current_participatory_process.target) %>
           </div>
         <% end %>
 
          <% if translated_attribute(current_participatory_process.participatory_scope).present? %>
           <div class="definition-data__item participatory_scope">
             <span class="definition-data__title"><%= t("participatory_processes.show.participatory_scope", scope: "decidim") %></span>
-              <%== translated_attribute(current_participatory_process.participatory_scope) %>
+              <%= sanitize translated_attribute(current_participatory_process.participatory_scope) %>
           </div>
         <% end %>
 
         <% if translated_attribute(current_participatory_process.participatory_structure).present? %>
           <div class="definition-data__item participatory_structure">
             <span class="definition-data__title"><%= t("participatory_processes.show.participatory_structure", scope: "decidim") %></span>
-              <%== translated_attribute(current_participatory_process.participatory_structure) %>
+              <%= sanitize translated_attribute(current_participatory_process.participatory_structure) %>
           </div>
         <% end %>
       </div>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
@@ -26,7 +26,7 @@
         <% if translated_attribute(current_participatory_process.meta_scope).present? %>
           <div class="definition-data__item scope">
             <span class="definition-data__title"><%= t("participatory_processes.show.scope", scope: "decidim") %></span>
-              <%= sanitize translated_attribute(current_participatory_process.meta_scope) %>
+              <%= translated_attribute(current_participatory_process.meta_scope) %>
           </div>
         <% end %>
 
@@ -47,35 +47,35 @@
         <% if translated_attribute(current_participatory_process.developer_group).present? %>
           <div class="definition-data__item developer-group">
             <span class="definition-data__title"><%= t("participatory_processes.show.developer_group", scope: "decidim") %></span>
-              <%= sanitize translated_attribute(current_participatory_process.developer_group) %>
+              <%= translated_attribute(current_participatory_process.developer_group) %>
           </div>
         <% end %>
 
         <% if translated_attribute(current_participatory_process.local_area).present? %>
           <div class="definition-data__item local_area">
             <span class="definition-data__title"><%= t("participatory_processes.show.local_area", scope: "decidim") %></span>
-              <%= sanitize translated_attribute(current_participatory_process.local_area) %>
+              <%= translated_attribute(current_participatory_process.local_area) %>
           </div>
         <% end %>
 
          <% if translated_attribute(current_participatory_process.target).present? %>
           <div class="definition-data__item target">
             <span class="definition-data__title"><%= t("participatory_processes.show.target", scope: "decidim") %></span>
-              <%= sanitize translated_attribute(current_participatory_process.target) %>
+              <%= translated_attribute(current_participatory_process.target) %>
           </div>
         <% end %>
 
          <% if translated_attribute(current_participatory_process.participatory_scope).present? %>
           <div class="definition-data__item participatory_scope">
             <span class="definition-data__title"><%= t("participatory_processes.show.participatory_scope", scope: "decidim") %></span>
-              <%= sanitize translated_attribute(current_participatory_process.participatory_scope) %>
+              <%= translated_attribute(current_participatory_process.participatory_scope) %>
           </div>
         <% end %>
 
         <% if translated_attribute(current_participatory_process.participatory_structure).present? %>
           <div class="definition-data__item participatory_structure">
             <span class="definition-data__title"><%= t("participatory_processes.show.participatory_structure", scope: "decidim") %></span>
-              <%= sanitize translated_attribute(current_participatory_process.participatory_structure) %>
+              <%= translated_attribute(current_participatory_process.participatory_structure) %>
           </div>
         <% end %>
       </div>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -49,14 +49,14 @@
         <div class="section">
           <div class="callout success">
             <h5><%= t(".proposal_accepted_reason") %></h5>
-            <p><%== translated_attribute @proposal.answer %></p>
+            <p><%= sanitize translated_attribute @proposal.answer %></p>
           </div>
         </div>
       <% else %>
         <div class="section">
           <div class="callout warning">
             <h5><%= t(".proposal_rejected_reason") %></h5>
-            <p><%== translated_attribute @proposal.answer %></p>
+            <p><%= sanitize translated_attribute @proposal.answer %></p>
           </div>
         </div>
       <% end %>

--- a/decidim-results/app/views/decidim/results/result_widgets/show.html.erb
+++ b/decidim-results/app/views/decidim/results/result_widgets/show.html.erb
@@ -1,2 +1,2 @@
 <% content_for(:title, translated_attribute(model.title)) %>
-<%== translated_attribute model.description %>
+<%= sanitize translated_attribute model.description %>

--- a/decidim-results/app/views/decidim/results/results/_results.html.erb
+++ b/decidim-results/app/views/decidim/results/results/_results.html.erb
@@ -8,7 +8,7 @@
           <%= link_to result, class: "card__link" do %>
             <h5 class="card__title"><%= translated_attribute result.title %></h5>
           <% end %>
-          <%== translated_attribute result.description %>
+          <%= sanitize translated_attribute result.description %>
           <%= render partial: "decidim/shared/tags", locals: { resource: result, tags_class_extra: "tags--result" } %>
         </div>
       </article>

--- a/decidim-results/app/views/decidim/results/results/show.html.erb
+++ b/decidim-results/app/views/decidim/results/results/show.html.erb
@@ -45,7 +45,7 @@
   </div>
   <div class="columns mediumlarge-8 mediumlarge-pull-4">
     <div class="section">
-      <%== translated_attribute result.description %>
+      <%= sanitize translated_attribute result.description %>
       <%= render partial: "decidim/shared/tags", locals: { resource: result, tags_class_extra: "tags--result" } %>
     </div>
     <%= linked_resources_for result, :proposals, "included_proposals" %>

--- a/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
@@ -9,7 +9,7 @@
   <h2 class="section-heading"><%= translated_attribute survey.title %></h2>
   <div class="row">
     <div class="columns large-6 medium-centered lead">
-      <%== translated_attribute survey.description %>
+      <%= sanitize translated_attribute survey.description %>
     </div>
   </div>
 </div>
@@ -72,7 +72,7 @@
                     <div class="row column">
                       <%= form.check_box :tos_agreement, label: t(".tos_agreement"), id: "survey_tos_agreement" %>
                       <div class="tos-agreement-help-text help-text">
-                        <%== translated_attribute survey.tos %>
+                        <%= sanitize translated_attribute survey.tos %>
                       </div>
                     </div>
                   <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

User-generated HTML content should be sanitized.

This PR replaces `<%==` with `<%= sanitize` wherever untrusted content is rendered. The only exception is the Organization's `header_snippets` because sanitizing this would break it's intended use case (which is script injection). I would suggest to move this piece of configuration somewhere below the `/system` namespace to ensure only 'real' admins can tamper with that.
