### PR TITLE
Cleanup bundler env before `bundle install`

### DIFF
--- a/lib/generators/decidim/install_generator.rb
+++ b/lib/generators/decidim/install_generator.rb
@@ -20,7 +20,7 @@ module Decidim
                                  desc: "Recreate db after installing decidim"
 
       def bundle_install
-        run "bundle install"
+        Bundler.with_clean_env { run "bundle install" }
       end
 
       def install


### PR DESCRIPTION
#### :tophat: What? Why?
During app generation, we want to force usage of the generated
application's Gemfile, not the root folder Gemfile, since they may have
different dependencies. For example, `puma` is only necessary in the
generated application. However, since we are running "bundler inside
bundler", we were inheriting the previous (root folder) environment.

This commit fixes that.

#### :pushpin: Related Issues
- Introduced by #1866, in particular https://github.com/decidim/decidim/commit/242e930898a238bffd366f3373a67b2a6055d0bf.
- Fixes https://github.com/decidim/decidim/pull/1866#issuecomment-330486995, and https://github.com/decidim/decidim/pull/1866#issuecomment-330485756, and https://github.com/decidim/decidim/pull/1866#issuecomment-330489722.

@beagleknight Not introducing a change log entry since #1866 is still unreleased, right?

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![forrest_ice_cream](https://user-images.githubusercontent.com/2887858/30587310-fc7e33e8-9d32-11e7-9a30-75fc05740f39.gif)

