### PR TITLE
Let admins remove process groups image

### DIFF
--- a/decidim-core/app/helpers/decidim/decidim_form_helper.rb
+++ b/decidim-core/app/helpers/decidim/decidim_form_helper.rb
@@ -117,6 +117,15 @@ module Decidim
       "#{name}_#{locale.to_s.gsub("-", "__")}"
     end
 
+    # Helper method that generates the URL of a participatory space with a
+    # span surrounding the space slug. This is only intended to be used in
+    # help text for the slug input, so that we can update the span contents
+    # via JS with the input value.
+    #
+    # space_name - the name, in plural, of the space (eg. "processes" or "assemblies")
+    # value - the initial value of the slug field, so  that edit forms have a value
+    #
+    # Returns an HTML-safe String.
     def decidim_form_slug_url(space_name, value = "")
       content_tag(:span, class: "slug-url") do
         [

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/update_participatory_process_group.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/update_participatory_process_group.rb
@@ -46,6 +46,7 @@ module Decidim
           {
             name: form.name,
             hero_image: form.hero_image,
+            remove_hero_image: form.remove_hero_image,
             description: form.description,
             participatory_processes: participatory_processes
           }

--- a/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_group_form.rb
+++ b/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_group_form.rb
@@ -16,6 +16,7 @@ module Decidim
         mimic :participatory_process_group
 
         attribute :hero_image
+        attribute :remove_hero_image
 
         validates :name, :description, translatable_presence: true
 

--- a/decidim-participatory_processes/spec/features/admin/admin_manages_participatory_process_groups_spec.rb
+++ b/decidim-participatory_processes/spec/features/admin/admin_manages_participatory_process_groups_spec.rb
@@ -45,7 +45,7 @@ describe "Admin manages participatory process groups", type: :feature do
     expect(page).to have_css("img[src*='#{image1_filename}']")
   end
 
-  context "with exsiting groups" do
+  context "with existing groups" do
     let!(:participatory_processes) { create_list(:participatory_process, 3, organization: organization) }
     let!(:participatory_process_group) { create(:participatory_process_group, organization: organization) }
 
@@ -87,6 +87,17 @@ describe "Admin manages participatory process groups", type: :feature do
       expect(page).to have_content("New description")
       expect(page).to have_content(@participatory_processes.last.title["en"])
       expect(page).to have_css("img[src*='#{image2_filename}']")
+    end
+
+    it "can remove its image" do
+      within find("tr", text: participatory_process_group.name["en"]) do
+        page.find(".action-icon.action-icon--edit").click
+      end
+
+      check "Remove this file"
+      click_button "Update"
+
+      expect(page).to have_no_css("img")
     end
 
     it "can destroy them" do


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes a bug that didn't let admins remove the hero image from a process group.

#### :pushpin: Related Issues
- Fixes #1875

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![Description](http://g.recordit.co/Pp5DNsdQyA.gif)
