### PR TITLE
Use correct path on authorizations

### DIFF
--- a/decidim-core/app/controllers/decidim/authorizations_controller.rb
+++ b/decidim-core/app/controllers/decidim/authorizations_controller.rb
@@ -53,7 +53,7 @@ module Decidim
     def stored_location
       location = stored_location_for(current_user)
       store_location_for(current_user, location)
-      location || participatory_processes_path
+      location || decidim_participatory_processes.participatory_processes_path
     end
 
     def handler_params

--- a/decidim-core/app/controllers/decidim/authorizations_controller.rb
+++ b/decidim-core/app/controllers/decidim/authorizations_controller.rb
@@ -53,7 +53,7 @@ module Decidim
     def stored_location
       location = stored_location_for(current_user)
       store_location_for(current_user, location)
-      location || decidim_participatory_processes.participatory_processes_path
+      location
     end
 
     def handler_params


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes the path name on AuthorizationsController. This caused a bug in Decidim Terrassa, and was detected via Sentry.

```
NameError: undefined local variable or method `participatory_processes_path' for #<Decidim::AuthorizationsController:0x007f07b82b8290>
  decidim/authorizations_controller.rb:56:in `stored_location'
    location || participatory_processes_path
  abstract_controller/helpers.rb:68:in `stored_location'
    controller.send(%(#{meth}), *args, &blk)             #   controller.send(:current_user, *args, &blk)
  bundle/ruby/2.4.0/gems/decidim-core-0.6.2/app/views/decidim/authorizations/new.html.erb:25:in `_vendor_bundle_ruby_______gems_decidim_core_______app_views_decidim_authorizations_new_html_erb___4434211303382298736_69835512056180'
    <p class="text-center skip"><%= t("decidim.authorizations.skip_verification", link: link_to(t("decidim.authorizations.current_participatory_processes"), stored_location).html_safe).html_safe %>.</p>
  action_view/template.rb:157:in `block in render'
    view.send(method_name, locals, buffer, &block)
  active_support/notifications.rb:166:in `block in instrument'
    instrumenter.instrument(name, payload) { yield payload if block_given? }
...
(144 additional frame(s) were not displayed)

ActionView::Template::Error: undefined local variable or method `participatory_processes_path' for #<Decidim::AuthorizationsController:0x007f07b82b8290>
```

This was very coupled to processes being there, and we had yet another default path that was not being used (authorizations index), so I dropped the redirect to processes so that we redirect to authorizations as a last resort. 

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None

