### PR TITLE
Sanitize some extra user-input strings

### DIFF
--- a/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
@@ -11,7 +11,7 @@
     <div class="columns medium-7 mediumlarge-8">
       <div class="section">
         <div class="lead">
-          <%= translated_attribute(current_assembly.short_description) %>
+          <%= sanitize translated_attribute(current_assembly.short_description) %>
         </div>
         <%= sanitize translated_attribute(current_assembly.description) %>
       </div>

--- a/decidim-core/app/views/pages/home/_sub_hero.html.erb
+++ b/decidim-core/app/views/pages/home/_sub_hero.html.erb
@@ -1,7 +1,7 @@
   <section class="extended subhero home-section">
     <div class="row">
       <div class="columns small-centered large-10">
-        <h2 class="heading3"><%= translated_attribute current_organization.description %></h2>
+        <h2 class="heading3"><%= sanitize translated_attribute current_organization.description %></h2>
         <%= link_to new_user_registration_path, class: "button--sc link subhero-cta" do %>
           <%= t(".register") %>
           <%= icon "chevron-right", aria_hidden: true %>


### PR DESCRIPTION
#### :tophat: What? Why?
Coming from #1868, and fixing #1878. Some strings were showing raw HTML, this fixes it.

#### :pushpin: Related Issues
- Related to #1868 
- Fixes #1878

### :camera: Screenshots (optional)
Assembly show:
![Description](https://i.imgur.com/6z3jVHT.png)

Homepage description:
![](https://i.imgur.com/0EsJoUR.jpg)
