### PR TITLE
Correctly highlight active spaces links on default language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@
 
 **Fixed**
 
+- **decidim-assemblies**: When visiting the assembly page on a multiple language organization and the URL had the deafult locale as a param, link to the resource itself was not being properly highlighted [\#1892](https://github.com/decidim/decidim/pull/1892)
 - **decidim-core**: On certain cases, authorizations controller was trying to redirect to an unexisting path. Fixed now. [\#1882](https://github.com/decidim/decidim/pull/1882)
+- **decidim-participatory-processes**: When visiting the process page on a multiple language organization and the URL had the deafult locale as a param, link to the resource itself was not being properly highlighted [\#1892](https://github.com/decidim/decidim/pull/1892)
 
 ## [v0.6.2](https://github.com/decidim/decidim/tree/v0.6.2) (2017-09-19)
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.6.1...v0.6.2)

--- a/decidim-assemblies/app/views/layouts/decidim/_assembly_header.html.erb
+++ b/decidim-assemblies/app/views/layouts/decidim/_assembly_header.html.erb
@@ -39,7 +39,7 @@
         <div class="row column process-nav__content is-active" id="process-nav-content" data-toggler=".is-active">
           <ul>
             <li class="<%= "is-active" if is_active_link?(decidim_assemblies.assembly_path(current_assembly), :exclusive) %>">
-              <%= active_link_to decidim_assemblies.assembly_path(current_assembly), active: :exact, class: "process-nav__link", class_active: "is-active" do %>
+              <%= active_link_to decidim_assemblies.assembly_path(current_assembly), active: :exclusive, class: "process-nav__link", class_active: "is-active" do %>
                 <%= external_icon "decidim/assemblies/assembly.svg" %>
                 <%= t ".assembly_menu_item" %>
               <% end %>

--- a/decidim-participatory_processes/app/views/layouts/decidim/_process_header.html.erb
+++ b/decidim-participatory_processes/app/views/layouts/decidim/_process_header.html.erb
@@ -40,7 +40,7 @@
         <div class="row column process-nav__content is-active" id="process-nav-content" data-toggler=".is-active">
           <ul>
             <li class="<%= "is-active" if is_active_link?(decidim_participatory_processes.participatory_process_path(current_participatory_process), :exclusive) %>">
-              <%= active_link_to decidim_participatory_processes.participatory_process_path(current_participatory_process), active: :exact, class: "process-nav__link", class_active: "is-active" do %>
+              <%= active_link_to decidim_participatory_processes.participatory_process_path(current_participatory_process), active: :exclusive, class: "process-nav__link", class_active: "is-active" do %>
                 <%= external_icon "decidim/participatory_processes/process.svg" %>
                 <%= t ".process_menu_item" %>
               <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
When visiting a process/assembly page, link to itself was not being properly highlighted when params included the default language.

Steps to reproduce:
1. Have an organization with multiple languages (the development app works ok, or http://decidim.barcelona)
1. Visit a process/assembly page
1. See the header link to the resource itself properly highlighted
1. Change language. Link is properly highlighted
1. Change language to the default one. Link is not highlighted

#### :pushpin: Related Issues
None

### :camera: Screenshots (optional)
Before:
![Description](https://i.imgur.com/nVS0W7G.png)

After:
![](https://i.imgur.com/UrpjOqc.png)
