### PR TITLE
Authorization improvements

### DIFF
--- a/decidim-assemblies/app/views/layouts/decidim/assembly.html.erb
+++ b/decidim-assemblies/app/views/layouts/decidim/assembly.html.erb
@@ -19,8 +19,8 @@
       </div>
     </div>
   <% end %>
-<% end %>
 
-<%= render "layouts/decidim/feature_authorization_modals" %>
+  <%= render "layouts/decidim/feature_authorization_modals" %>
+<% end %>
 
 <% provide :meta_image_url, current_assembly.banner_image.url %>

--- a/decidim-assemblies/app/views/layouts/decidim/assembly.html.erb
+++ b/decidim-assemblies/app/views/layouts/decidim/assembly.html.erb
@@ -21,10 +21,6 @@
   <% end %>
 <% end %>
 
-<% if try(:current_feature) %>
-  <% current_feature.manifest.actions.each do |action| %>
-    <%= action_authorization_modal(action) %>
-  <% end %>
-<% end %>
+<%= render "layouts/decidim/feature_authorization_modals" %>
 
 <% provide :meta_image_url, current_assembly.banner_image.url %>

--- a/decidim-core/app/controllers/concerns/decidim/action_authorization.rb
+++ b/decidim-core/app/controllers/concerns/decidim/action_authorization.rb
@@ -17,8 +17,7 @@ module Decidim
     # redirect_url - Url to be redirected to when the authorization is finished.
     def authorize_action!(action_name, redirect_url: nil)
       @action_authorizations ||= {}
-      @action_authorizations[action_name] = _action_authorizer(action_name).authorize
-      status = @action_authorizations[action_name]
+      status = @action_authorizations[action_name] = action_authorization(action_name)
 
       return if status.ok?
       raise Unauthorized if status.code == :invalid

--- a/decidim-core/app/controllers/decidim/authorizations_controller.rb
+++ b/decidim-core/app/controllers/decidim/authorizations_controller.rb
@@ -44,11 +44,11 @@ module Decidim
       end
     end
 
+    protected
+
     def handler
       @handler ||= AuthorizationHandler.handler_for(handler_name, handler_params)
     end
-
-    protected
 
     def stored_location
       location = stored_location_for(current_user)

--- a/decidim-core/app/controllers/decidim/authorizations_controller.rb
+++ b/decidim-core/app/controllers/decidim/authorizations_controller.rb
@@ -73,10 +73,6 @@ module Decidim
       redirect_to(authorizations_path) && (return false)
     end
 
-    def only_one_handler?
-      redirect_to(action: :new, handler: available_handlers.first.handler_name) && return if available_handlers.length == 1
-    end
-
     def handlers
       @handlers ||= available_authorization_handlers.reject do |handler|
         authorized_handlers.include?(handler.handler_name)

--- a/decidim-core/app/views/layouts/decidim/_feature_authorization_modals.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_feature_authorization_modals.html.erb
@@ -1,0 +1,5 @@
+<% if try(:current_feature) %>
+  <% current_feature.manifest.actions.each do |action| %>
+    <%= action_authorization_modal(action) %>
+  <% end %>
+<% end %>

--- a/decidim-core/lib/decidim/authorization_form_builder.rb
+++ b/decidim-core/lib/decidim/authorization_form_builder.rb
@@ -3,7 +3,7 @@
 require "decidim/form_builder"
 
 module Decidim
-  # A customf orm builder to render AuthorizationHandler forms.
+  # A custom form builder to render AuthorizationHandler forms.
   class AuthorizationFormBuilder < Decidim::FormBuilder
     # Renders all form attributes defined by the handler.
     #

--- a/decidim-core/spec/controllers/authorizations_controller_spec.rb
+++ b/decidim-core/spec/controllers/authorizations_controller_spec.rb
@@ -11,7 +11,7 @@ module Decidim
     describe "handler" do
       it "injects the current_user" do
         controller.params[:handler] = "decidim/dummy_authorization_handler"
-        expect(controller.handler.user).to eq(user)
+        expect(controller.send(:handler).user).to eq(user)
       end
     end
 

--- a/decidim-participatory_processes/app/views/layouts/decidim/participatory_process.html.erb
+++ b/decidim-participatory_processes/app/views/layouts/decidim/participatory_process.html.erb
@@ -19,8 +19,8 @@
       </div>
     </div>
   <% end %>
-<% end %>
 
-<%= render "layouts/decidim/feature_authorization_modals" %>
+  <%= render "layouts/decidim/feature_authorization_modals" %>
+<% end %>
 
 <% provide :meta_image_url, current_participatory_process.banner_image.url %>

--- a/decidim-participatory_processes/app/views/layouts/decidim/participatory_process.html.erb
+++ b/decidim-participatory_processes/app/views/layouts/decidim/participatory_process.html.erb
@@ -21,10 +21,6 @@
   <% end %>
 <% end %>
 
-<% if try(:current_feature) %>
-  <% current_feature.manifest.actions.each do |action| %>
-    <%= action_authorization_modal(action) %>
-  <% end %>
-<% end %>
+<%= render "layouts/decidim/feature_authorization_modals" %>
 
 <% provide :meta_image_url, current_participatory_process.banner_image.url %>

--- a/lib/generators/decidim/templates/authorization_handler.rb
+++ b/lib/generators/decidim/templates/authorization_handler.rb
@@ -37,7 +37,7 @@ class ExampleAuthorizationHandler < Decidim::AuthorizationHandler
   # be created or not, you should return a Boolean value.
   #
   # Note that if you set some validations and overwrite this method, then the
-  # validations will not run, so it's easier to just remove this method and reite
+  # validations will not run, so it's easier to remove this method and rewrite
   # your logic using ActiveModel validations.
   def valid?
     raise NotImplementedError


### PR DESCRIPTION
#### :tophat: What? Why?

One pass of simplifications over the current authorizations. The only real fix is an HTML issue where the authorization modals would be rendered outside of `<html></html>`.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![police](https://user-images.githubusercontent.com/2887858/30649398-73ba16c8-9e20-11e7-95fa-3921510b23f7.gif)
