### PR TITLE
Show a disabled follow button to anonymous users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/decidim/decidim/tree/HEAD)
 
+**Added**
+
+- **decidim-core**: Show a disabled "Follow" button to anonymous users (not logged in) with a prompt to sign in [\#1903](https://github.com/decidim/decidim/pull/1903)
+
 **Changed**
 
 - **decidim**: URLs now use the participatory space slug instead of the ID, both in the public pages and in the admin. Old routes using the space IDs now redirect to the ones using the slug. [\#1842](https://github.com/decidim/decidim/pull/1842)

--- a/decidim-core/app/assets/javascripts/decidim/foundation.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/foundation.js.es6
@@ -8,6 +8,7 @@
 // = require foundation.sticky.js
 // = require foundation.tabs.js
 // = require foundation.toggler.js
+// = require foundation.tooltip.js
 // = require foundation.util.box.js
 // = require foundation.util.keyboard.js
 // = require foundation.util.mediaQuery.js

--- a/decidim-core/app/views/decidim/shared/_follow_button.html.erb
+++ b/decidim-core/app/views/decidim/shared/_follow_button.html.erb
@@ -1,5 +1,5 @@
-<% if current_user %>
-  <div id="follow-resource">
+<div id="follow-resource">
+  <% if current_user %>
     <% if current_user.follows?(followable) %>
       <%= button_to decidim.follow_path, class: "button secondary hollow expanded small button--icon follow-button", params: { follow: { followable_gid: followable.to_sgid.to_s }}, data: { disable: true }, method: :delete, remote: true do %>
         <%= icon "bell" %>
@@ -15,5 +15,20 @@
         </span>
       <% end %>
     <% end %>
-  </div>
-<% end %>
+  <% else %>
+    <%= button_to(
+      decidim.follow_path,
+      class: "button secondary hollow expanded small button--icon follow-button",
+      params: { follow: { followable_gid: followable.to_sgid.to_s }},
+      data: { tooltip: true, disable_hover: false },
+      :'aria-haspopup' => true,
+      title: t(".sign_in_before_follow"),
+      disabled: true,
+      remote: true) do %>
+      <%= icon "bell" %>
+      <span>
+        <%= t("follows.create.button", scope: "decidim") %>
+      </span>
+    <% end %>
+  <% end %>
+</div>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -243,6 +243,8 @@ en:
         report: Report
         spam: Contains clickbait, advertising, scams or script bots.
         title: Report a problem
+      follow_button:
+        sign_in_before_follow: Please sign in before performing this action
       login_modal:
         please_sign_in: Please sign in
         sign_up: Sign up


### PR DESCRIPTION
#### :tophat: What? Why?
When an anonymous user (lot logged in) visits a followable resource, we didn't show any "Follow" button. This PR adds a disabled "Follow" button so the user cannot click it, but knows that the action can be performed. It also shows a tooltip prompting the user to sign in before following.

#### :pushpin: Related Issues
- Fixes #1894

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![Description](http://g.recordit.co/G0qdC0WSab.gif)
