### PR TITLE
Search scopes by ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - **decidim-assemblies**: When visiting the assembly page on a multiple language organization and the URL had the deafult locale as a param, link to the resource itself was not being properly highlighted [\#1892](https://github.com/decidim/decidim/pull/1892)
 - **decidim-core**: On certain cases, authorizations controller was trying to redirect to an unexisting path. Fixed now. [\#1882](https://github.com/decidim/decidim/pull/1882)
 - **decidim-participatory-processes**: When visiting the process page on a multiple language organization and the URL had the deafult locale as a param, link to the resource itself was not being properly highlighted [\#1892](https://github.com/decidim/decidim/pull/1892)
+- **decidim-proposals**: Fixes proposals filter when filtering by scopes [\#1907](https://github.com/decidim/decidim/pull/1907)
 
 ## [v0.6.2](https://github.com/decidim/decidim/tree/v0.6.2) (2017-09-19)
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.6.1...v0.6.2)

--- a/decidim-core/app/services/decidim/resource_search.rb
+++ b/decidim-core/app/services/decidim/resource_search.rb
@@ -43,9 +43,15 @@ module Decidim
 
       conditions = []
       conditions << "decidim_scope_id IS NULL" if clean_scope_ids.delete("global")
-      conditions.concat(["? = ANY(decidim_scopes.part_of)"] * clean_scope_ids.count) if clean_scope_ids.any?
 
-      query.includes(:scope).references(:decidim_scopes).where(conditions.join(" OR "), *clean_scope_ids.map(&:to_i))
+      clean_scope_ids.map!(&:to_i)
+
+      if clean_scope_ids.any?
+        conditions.concat(["? = ANY(decidim_scopes.part_of)"] * clean_scope_ids.count)
+        conditions << "decidim_scopes.id IN (?)"
+      end
+
+      query.includes(:scope).references(:decidim_scopes).where(conditions.join(" OR "), *clean_scope_ids, clean_scope_ids)
     end
 
     private


### PR DESCRIPTION
#### :tophat: What? Why?
Proposal filter by scope is not searching by scope ID, it's only searching by the scope `part_of` field. 

For example, see this link:

https://www.decidim.barcelona/processes/1/f/1/proposals?filter%5Bscope_id%5D%5B%5D=2

We're asking for all proposals belonging to the scope with ID = 2 ("Eixample"), but no proposal is found right now. But in the proposals homepage, without any active filter, we see some of them belonging to that scope:

http://recordit.co/z28urPj11t
![](http://g.recordit.co/z28urPj11t.gif)

With this PR active, we see this working as expected:

http://recordit.co/Ghca8p7yDB
![](http://g.recordit.co/Ghca8p7yDB.gif)

#### :pushpin: Related Issues
- Related to #1500

#### :clipboard: Subtasks
None
