### PR TITLE
Introduces an option to toggle the header snippets setting

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/update_organization.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization.rb
@@ -65,9 +65,12 @@ module Decidim
           official_img_footer: form.official_img_footer,
           remove_official_img_footer: form.remove_official_img_footer,
           official_url: form.official_url,
-          header_snippets: form.header_snippets,
           show_statistics: form.show_statistics
-        }
+        }.tap do |attributes|
+          if Decidim.enable_html_header_snippets
+            attributes[:header_snippets] = form.header_snippets
+          end
+        end
       end
     end
   end

--- a/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
@@ -78,7 +78,9 @@
   <%= form.check_box :show_statistics %>
 </div>
 
-<div class="row column">
-  <%= form.text_area :header_snippets %>
-  <p class="help-text"><%= t(".header_snippets_help") %></p>
-</div>
+<% if Decidim.enable_html_header_snippets %>
+  <div class="row column">
+    <%= form.text_area :header_snippets %>
+    <p class="help-text"><%= t(".header_snippets_help") %></p>
+  </div>
+<% end %>

--- a/decidim-admin/spec/commands/update_organization_spec.rb
+++ b/decidim-admin/spec/commands/update_organization_spec.rb
@@ -89,12 +89,17 @@ module Decidim
             expect(organization.header_snippets).to_not be_present
           end
 
-          it "saves header snippets if configured" do
-            expect(Decidim).to receive(:enable_html_header_snippets).and_return(true)
-            expect { command.call }.to broadcast(:ok)
-            organization.reload
+          describe 'when header snippets are configured' do
+            before do
+              allow(Decidim).to receive(:enable_html_header_snippets).and_return(true)
+            end
 
-            expect(organization.header_snippets).to be_present
+            it "saves header snippets" do
+              expect { command.call }.to broadcast(:ok)
+              organization.reload
+
+              expect(organization.header_snippets).to be_present
+            end
           end
 
           context "when no homepage image is set" do

--- a/decidim-admin/spec/commands/update_organization_spec.rb
+++ b/decidim-admin/spec/commands/update_organization_spec.rb
@@ -20,6 +20,7 @@ module Decidim
               description_es: "Mi descripción",
               description_ca: "La meva descripció",
               show_statistics: false,
+              header_snippets: '<script>alert("Hello");</script>',
               favicon: File.new(Decidim::Dev.asset("icon.png"))
             }
           }
@@ -79,6 +80,21 @@ module Decidim
             organization.reload
 
             expect(organization.name).to eq("My super organization")
+          end
+
+          it "does not save header snippets" do
+            expect { command.call }.to broadcast(:ok)
+            organization.reload
+
+            expect(organization.header_snippets).to_not be_present
+          end
+
+          it "saves header snippets if configured" do
+            expect(Decidim).to receive(:enable_html_header_snippets).and_return(true)
+            expect { command.call }.to broadcast(:ok)
+            organization.reload
+
+            expect(organization.header_snippets).to be_present
           end
 
           context "when no homepage image is set" do

--- a/decidim-admin/spec/commands/update_organization_spec.rb
+++ b/decidim-admin/spec/commands/update_organization_spec.rb
@@ -89,7 +89,7 @@ module Decidim
             expect(organization.header_snippets).to_not be_present
           end
 
-          describe 'when header snippets are configured' do
+          describe "when header snippets are configured" do
             before do
               allow(Decidim).to receive(:enable_html_header_snippets).and_return(true)
             end

--- a/decidim-core/app/views/layouts/decidim/_head.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_head.html.erb
@@ -22,4 +22,4 @@
 <%= javascript_include_tag 'application' %>
 
 <%= render partial: 'layouts/decidim/head_extra' %>
-<%== current_organization.header_snippets %>
+<%== current_organization.header_snippets if Decidim.enable_html_header_snippets %>

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -136,6 +136,11 @@ module Decidim
     3
   end
 
+  # Allow organization's administrators to inject custom HTML into the frontend
+  config_accessor :enable_html_header_snippets do
+    true
+  end
+
   # A base path for the uploads. If set, make sure it ends in a slash.
   # Uploads will be set to `<base_path>/uploads/`. This can be useful if you
   # want to use the same uploads place for both staging and production

--- a/decidim-core/spec/features/homepage_spec.rb
+++ b/decidim-core/spec/features/homepage_spec.rb
@@ -46,7 +46,6 @@ describe "Homepage", type: :feature do
           expect(page).to have_selector("meta[data-hello]", visible: false)
         end
       end
-
     end
 
     it "welcomes the user" do

--- a/decidim-core/spec/features/homepage_spec.rb
+++ b/decidim-core/spec/features/homepage_spec.rb
@@ -32,9 +32,21 @@ describe "Homepage", type: :feature do
       let(:snippet) { "<meta data-hello=\"This is the organization header_snippet field\">" }
       let(:organization) { create(:organization, official_url: official_url, header_snippets: snippet) }
 
-      it "includes the header snippets" do
-        expect(page).to have_selector("meta[data-hello]", visible: false)
+      it "does not include the header snippets" do
+        expect(page).to_not have_selector("meta[data-hello]", visible: false)
       end
+
+      context "when header snippets are enabled" do
+        before do
+          allow(Decidim).to receive(:enable_html_header_snippets).and_return(true)
+          visit decidim.root_path
+        end
+
+        it "includes the header snippets" do
+          expect(page).to have_selector("meta[data-hello]", visible: false)
+        end
+      end
+
     end
 
     it "welcomes the user" do

--- a/lib/generators/decidim/templates/initializer.rb
+++ b/lib/generators/decidim/templates/initializer.rb
@@ -27,6 +27,21 @@ Decidim.configure do |config|
 
   # The number of reports which an object can receive before hiding it
   # config.max_reports_before_hiding = 3
+
+  # Custom HTML Header snippets
+  #
+  # The most common use is to integrate third-party services that require some
+  # extra JavaScript or CSS. Also, you can use it to add extra meta tags to the
+  # HTML. Note that this will only be rendered in public pages, not in the admin
+  # section.
+  #
+  # Before enabling this you should ensure that any tracking that might be done
+  # is in accordance with the rules and regulations that apply to your
+  # environment and usage scenarios. This feature also comes with the risk
+  # that an organization's administrator injects malicious scripts to spy on or
+  # take over user accounts.
+  #
+  config.enable_html_header_snippets = false
 end
 
 Rails.application.config.i18n.available_locales = Decidim.available_locales


### PR DESCRIPTION
#### :tophat: What? Why?

As discussed in #1868 , here's a PR that introduces a setting to toggle the `header_snippets` feature.
I made it default to true (enabled) to not break existing applications, but new apps will have it disabled by default through the generated initializer.
