### PR TITLE
Speed up seeds

### DIFF
--- a/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
@@ -10,7 +10,7 @@ Decidim.register_participatory_space(:assemblies) do |participatory_space|
     seeds_root = File.join(__dir__, "..", "..", "..", "db", "seeds")
 
     3.times do
-      Decidim::Assembly.create!(
+      assembly = Decidim::Assembly.create!(
         title: Decidim::Faker::Localized.sentence(5),
         slug: Faker::Internet.unique.slug(nil, "-"),
         subtitle: Decidim::Faker::Localized.sentence(2),
@@ -34,9 +34,7 @@ Decidim.register_participatory_space(:assemblies) do |participatory_space|
         participatory_structure: Decidim::Faker::Localized.sentence(2),
         scope: Faker::Boolean.boolean(0.5) ? nil : Decidim::Scope.reorder("RANDOM()").first
       )
-    end
 
-    Decidim::Assembly.find_each do |assembly|
       Decidim::Attachment.create!(
         title: Decidim::Faker::Localized.sentence(2),
         description: Decidim::Faker::Localized.sentence(5),

--- a/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
@@ -9,7 +9,7 @@ Decidim.register_participatory_space(:assemblies) do |participatory_space|
     organization = Decidim::Organization.first
     seeds_root = File.join(__dir__, "..", "..", "..", "db", "seeds")
 
-    3.times do
+    2.times do
       assembly = Decidim::Assembly.create!(
         title: Decidim::Faker::Localized.sentence(5),
         slug: Faker::Internet.unique.slug(nil, "-"),

--- a/decidim-budgets/lib/decidim/budgets/feature.rb
+++ b/decidim-budgets/lib/decidim/budgets/feature.rb
@@ -57,7 +57,7 @@ Decidim.register_feature(:budgets) do |feature|
       participatory_space: participatory_space
     )
 
-    3.times do
+    2.times do
       project = Decidim::Budgets::Project.create!(
         feature: feature,
         scope: participatory_space.organization.scopes.sample,

--- a/decidim-comments/app/models/decidim/comments/seed.rb
+++ b/decidim-comments/app/models/decidim/comments/seed.rb
@@ -14,7 +14,7 @@ module Decidim
       def self.comments_for(resource)
         organization = resource.organization
 
-        rand(1..5).times do
+        2.times do
           author = Decidim::User.where(organization: organization).all.sample
           user_group = [true, false].sample ? author.user_groups.verified.sample : nil
 

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -35,7 +35,7 @@ if !Rails.env.production? || ENV["SEED"]
     organization: organization
   )
 
-  3.times.each do
+  3.times do
     parent = Decidim::Scope.create!(
       name: Decidim::Faker::Localized.literal(Faker::Address.unique.state),
       code: Faker::Address.unique.country_code,
@@ -43,7 +43,7 @@ if !Rails.env.production? || ENV["SEED"]
       organization: organization
     )
 
-    5.times.each do
+    5.times do
       Decidim::Scope.create!(
         name: Decidim::Faker::Localized.literal(Faker::Address.unique.city),
         code: parent.code + "-" + Faker::Address.unique.state_abbr,

--- a/decidim-meetings/lib/decidim/meetings/feature.rb
+++ b/decidim-meetings/lib/decidim/meetings/feature.rb
@@ -51,7 +51,7 @@ Decidim.register_feature(:meetings) do |feature|
       global = nil
     end
 
-    3.times do
+    2.times do
       meeting = Decidim::Meetings::Meeting.create!(
         feature: feature,
         scope: Faker::Boolean.boolean(0.5) ? global : scopes.sample,
@@ -74,7 +74,7 @@ Decidim.register_feature(:meetings) do |feature|
         end
       )
 
-      10.times do |n|
+      2.times do |n|
         email = "meeting-registered-user-#{meeting.id}-#{n}@example.org"
         name = "#{Faker::Name.name} #{meeting.id} #{n}"
         user = Decidim::User.find_or_initialize_by(email: email)

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
@@ -22,7 +22,7 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
     end
 
     3.times do
-      Decidim::ParticipatoryProcess.create!(
+      process = Decidim::ParticipatoryProcess.create!(
         title: Decidim::Faker::Localized.sentence(5),
         slug: Faker::Internet.unique.slug(nil, "-"),
         subtitle: Decidim::Faker::Localized.sentence(2),
@@ -49,9 +49,7 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
         participatory_process_group: process_groups.sample,
         scope: Faker::Boolean.boolean(0.5) ? nil : Decidim::Scope.reorder("RANDOM()").first
       )
-    end
 
-    Decidim::ParticipatoryProcess.find_each do |process|
       Decidim::ParticipatoryProcessStep.find_or_initialize_by(
         participatory_process: process,
         active: true

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
@@ -10,7 +10,7 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
     seeds_root = File.join(__dir__, "..", "..", "..", "db", "seeds")
 
     process_groups = []
-    3.times do
+    2.times do
       process_groups << Decidim::ParticipatoryProcessGroup.create!(
         name: Decidim::Faker::Localized.sentence(3),
         description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
@@ -21,7 +21,7 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
       )
     end
 
-    3.times do
+    2.times do
       process = Decidim::ParticipatoryProcess.create!(
         title: Decidim::Faker::Localized.sentence(5),
         slug: Faker::Internet.unique.slug(nil, "-"),

--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -101,14 +101,14 @@ Decidim.register_feature(:proposals) do |feature|
       global = nil
     end
 
-    20.times do |n|
+    5.times do |n|
       author = Decidim::User.where(organization: feature.organization).all.sample
       user_group = [true, false].sample ? author.user_groups.verified.sample : nil
-      state, answer = if n > 15
+      state, answer = if n > 3
                         ["accepted", Decidim::Faker::Localized.sentence(10)]
-                      elsif n > 9
+                      elsif n > 2
                         ["rejected", nil]
-                      elsif n > 6
+                      elsif n > 1
                         ["evaluating", nil]
                       else
                         [nil, nil]
@@ -127,7 +127,7 @@ Decidim.register_feature(:proposals) do |feature|
         answered_at: Time.current
       )
 
-      rand(3).times do |m|
+      (n % 3).times do |m|
         email = "vote-author-#{participatory_space.underscored_name}-#{participatory_space.id}-#{n}-#{m}@example.org"
         name = "#{Faker::Name.name} #{participatory_space.id} #{n} #{m}"
 

--- a/decidim-results/lib/decidim/results/feature.rb
+++ b/decidim-results/lib/decidim/results/feature.rb
@@ -43,7 +43,7 @@ Decidim.register_feature(:results) do |feature|
       participatory_space: participatory_space
     )
 
-    3.times do
+    2.times do
       result = Decidim::Results::Result.create!(
         feature: feature,
         scope: participatory_space.organization.scopes.sample,

--- a/decidim-surveys/lib/decidim/surveys/feature.rb
+++ b/decidim-surveys/lib/decidim/surveys/feature.rb
@@ -85,7 +85,7 @@ Decidim.register_feature(:surveys) do |feature|
       end
     )
 
-    3.times do
+    2.times do
       Decidim::Surveys::SurveyQuestion.create!(
         survey: survey,
         body: Decidim::Faker::Localized.paragraph,


### PR DESCRIPTION
#### :tophat: What? Why?

I added a few small changes to speed up seeds a bit. I don't think we need as many objects as we used to have. What do you think?

* Before:

```console
$ time bundle exec rails db:seed

real	1m22.813s
user	1m16.380s
sys	0m2.984s
```

* After:

```console
$ time bundle exec rails db:seed

real	0m28.093s
user	0m24.944s
sys	0m1.948s
```

What do you 
#### :pushpin: Related Issues
- Related to #1921.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![referendum_one_week](https://user-images.githubusercontent.com/2887858/30807835-d1c91870-a1fb-11e7-9cb6-a57da92f85c9.gif)
