### PR TITLE
Fix app generators

### DIFF
--- a/lib/generators/decidim/app_generator.rb
+++ b/lib/generators/decidim/app_generator.rb
@@ -73,14 +73,6 @@ module Decidim
         template "Gemfile.erb", "Gemfile", force: true
       end
 
-      def install
-        Decidim::Generators::InstallGenerator.start [
-          "--recreate_db=#{options[:recreate_db]}",
-          "--seed_db=#{options[:seed_db]}",
-          "--app_name=#{app_name}"
-        ]
-      end
-
       def add_ignore_uploads
         unless options["skip_git"]
           append_file ".gitignore", "\n# Ignore public uploads\npublic/uploads"
@@ -94,6 +86,16 @@ module Decidim
 
       def authorization_handler
         template "authorization_handler.rb", "app/services/example_authorization_handler.rb", force: true
+      end
+
+      def install
+        Decidim::Generators::InstallGenerator.start(
+          [
+            "--recreate_db=#{options[:recreate_db]}",
+            "--seed_db=#{options[:seed_db]}",
+            "--app_name=#{app_name}"
+          ]
+        )
       end
 
       private

--- a/lib/generators/decidim/install_generator.rb
+++ b/lib/generators/decidim/install_generator.rb
@@ -36,11 +36,6 @@ module Decidim
         RUBY
       end
 
-      def copy_migrations
-        rails "railties:install:migrations"
-        recreate_db if options[:recreate_db]
-      end
-
       def copy_initializer
         template "initializer.rb", "config/initializers/decidim.rb"
         template "carrierwave.rb", "config/initializers/carrierwave.rb"
@@ -96,6 +91,11 @@ module Decidim
             |  end
           RUBY
         end
+      end
+
+      def copy_migrations
+        rails "railties:install:migrations"
+        recreate_db if options[:recreate_db]
       end
 
       def letter_opener_web


### PR DESCRIPTION
#### :tophat: What? Why?
Following from #1921, the app generator was broken for demo values because we were creating the seeds before adding the initializers. This caused the seed organization to have all Decidim available languages set (instead of just English, Catalan and Spanish), but the initializer set the app's available languages to those three.

The result of this is that running the server and visiting the homepage caused an error because Decidim couldn't find the valid languages.

This PR fixes this. Thanks to @beagleknight for the help.

#### :pushpin: Related Issues
- Related to #1921

#### :clipboard: Subtasks
None