### PR TITLE
Handle nil resource on StaticMapGenerator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 **Fixed**
 - **decidim-assemblies**: Embed pages were not working properly. Now we have tests to check they do [\#1929](https://github.com/decidim/decidim/pull/1929)
+- **decidim-core**: Handle nil resources on static maps (errors were caused by search engine spiders) [\#1936](https://github.com/decidim/decidim/pull/1936)
 - **decidim-meetings**: Embed pages were not working properly. Now we have tests to check they do [\#1929](https://github.com/decidim/decidim/pull/1929)
 - **decidim-participatory-processes**: Embed pages were not working properly. Now we have tests to check they do [\#1929](https://github.com/decidim/decidim/pull/1929)
 - **decidim-proposals**: Embed pages were not working properly. Now we have tests to check they do [\#1929](https://github.com/decidim/decidim/pull/1929)

--- a/decidim-core/app/services/decidim/static_map_generator.rb
+++ b/decidim-core/app/services/decidim/static_map_generator.rb
@@ -15,7 +15,7 @@ module Decidim
     end
 
     def data
-      return if Decidim.geocoder.nil?
+      return if Decidim.geocoder.nil? || @resource.blank?
 
       Rails.cache.fetch(@resource.cache_key) do
         request = HTTParty.get(uri, headers: { "Referer" => organization.host })

--- a/decidim-core/spec/services/decidim/static_map_generator_spec.rb
+++ b/decidim-core/spec/services/decidim/static_map_generator_spec.rb
@@ -23,6 +23,24 @@ module Decidim
       it "returns the request body" do
         expect(subject.data).to eq(body)
       end
+
+      context "when no resource is given" do
+        let(:dummy_resource) { nil }
+
+        it "returns nil" do
+          expect(subject.data).to be_nil
+        end
+      end
+
+      context "when no geocoder is configured" do
+        before do
+          allow(Decidim).to receive(:geocoder).and_return(nil)
+        end
+
+        it "returns nil" do
+          expect(subject.data).to be_nil
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
We have some Sentry issues reporting errors here. They are caused by search engine spiders, but it'd be good if we can avoid errors.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None
