### PR TITLE
Fix error when `scope_id` is a Hash

### DIFF
--- a/decidim-core/app/services/decidim/resource_search.rb
+++ b/decidim-core/app/services/decidim/resource_search.rb
@@ -39,7 +39,11 @@ module Decidim
     # `"global"` as parameter, and in the method we do the needed changes to search
     # properly.
     def search_scope_id
-      clean_scope_ids = [scope_id].flatten
+      clean_scope_ids = if scope_id.is_a?(Hash)
+                          scope_id.values
+                        else
+                          [scope_id].flatten
+                        end
 
       conditions = []
       conditions << "decidim_scope_id IS NULL" if clean_scope_ids.delete("global")

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -142,6 +142,7 @@ module Decidim
     def scopes_select(name, options = {})
       selected = object.send(name)
       if selected.present?
+        selected = selected.values if selected.is_a?(Hash)
         selected = [selected] unless selected.is_a?(Array)
         scopes = Decidim::Scope.where(id: selected.map(&:to_i)).map { |scope| [scope.name[I18n.locale.to_s], scope.id] }
       else


### PR DESCRIPTION
#### :tophat: What? Why?
We had some errors in Terrassa installation in the proposal filters. I could only reproduce this error by modifying the URL by hand. For some reason, Rails was treating a URL param that should have been an array as a Hash, and this was breaking the form.

This PR handles the case from the form builder side, as I could not reproduce the error on my development machine.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None