### PR TITLE
Bundle less generator failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
       - run:
           name: Install app dependencies
           command: |
+            gem install decidim
             bundle install
             npm i
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - **decidim**: URLs now use the participatory space slug instead of the ID, both in the public pages and in the admin. Old routes using the space IDs now redirect to the ones using the slug. [\#1842](https://github.com/decidim/decidim/pull/1842)
 
 **Fixed**
+
+- **decidim**: Generator when run directly via decidim's executable was crashing due to bundler unavailability [\#1938](https://github.com/decidim/decidim/pull/1938)
 - **decidim-assemblies**: Embed pages were not working properly. Now we have tests to check they do [\#1929](https://github.com/decidim/decidim/pull/1929)
 - **decidim-core**: Handle nil resources on static maps (errors were caused by search engine spiders) [\#1936](https://github.com/decidim/decidim/pull/1936)
 - **decidim-meetings**: Embed pages were not working properly. Now we have tests to check they do [\#1929](https://github.com/decidim/decidim/pull/1929)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The easiest way to work on decidim is to clone decidim's repository and install 
 ```bash
 $ git clone git@github.com:decidim/decidim.git
 $ cd decidim
+$ gem install decidim
 $ bundle install
 $ npm install
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -50,12 +50,12 @@ task :development_app do
     sh "rm -fR development_app", verbose: false
   end
 
-  Decidim::Generators::AppGenerator.start(
-    ["development_app", "--path", "..", "--recreate_db", "--seed_db"]
-  )
+  Bundler.with_clean_env do
+    Decidim::Generators::AppGenerator.start(
+      ["development_app", "--path", "..", "--recreate_db", "--seed_db"]
+    )
 
-  Dir.chdir("#{__dir__}/development_app") do
-    Bundler.with_clean_env do
+    Dir.chdir("#{__dir__}/development_app") do
       sh "bundle exec spring stop", verbose: false
       sh "bundle exec rails generate decidim:demo", verbose: false
     end
@@ -70,9 +70,11 @@ task :docker_development_app do
 
   path = __dir__ + "/docker_development_app"
 
-  Decidim::Generators::DockerGenerator.start(
-    ["docker_development_app", "--path", path]
-  )
+  Bundler.with_clean_env do
+    Decidim::Generators::DockerGenerator.start(
+      ["docker_development_app", "--path", path]
+    )
+  end
 end
 
 desc "Build webpack bundle files"

--- a/decidim-dev/lib/tasks/test_app.rake
+++ b/decidim-dev/lib/tasks/test_app.rake
@@ -7,10 +7,12 @@ namespace :decidim do
   task :generate_test_app do
     dummy_app_path = File.expand_path(File.join(Dir.pwd, "spec", "decidim_dummy_app"))
 
-    Decidim::Generators::DummyGenerator.start(
-      [
-        "--dummy_app_path=#{dummy_app_path}"
-      ]
-    )
+    Bundler.with_clean_env do
+      Decidim::Generators::DummyGenerator.start(
+        [
+          "--dummy_app_path=#{dummy_app_path}"
+        ]
+      )
+    end
   end
 end

--- a/lib/generators/decidim/install_generator.rb
+++ b/lib/generators/decidim/install_generator.rb
@@ -22,7 +22,7 @@ module Decidim
                              desc: "Seed db after installing decidim"
 
       def bundle_install
-        Bundler.with_clean_env { run "bundle install" }
+        run "bundle install"
       end
 
       def install

--- a/lib/generators/decidim/install_generator.rb
+++ b/lib/generators/decidim/install_generator.rb
@@ -118,7 +118,7 @@ module Decidim
       private
 
       def recreate_db
-        rails "db:environment:set", "db:drop" unless ENV["CI"]
+        soft_rails "db:environment:set", "db:drop"
         rails "db:create"
 
         if options[:seed_db]
@@ -130,8 +130,14 @@ module Decidim
         rails "db:test:prepare"
       end
 
+      # Runs rails commands in a subprocess, and aborts if it doesn't suceeed
       def rails(*args)
         abort unless system("bin/rails", *args)
+      end
+
+      # Runs rails commands in a subprocess silencing errors, and ignores status
+      def soft_rails(*args)
+        system("bin/rails", *args, err: File::NULL)
       end
 
       def scss_variables

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe "Application generation" do
-  let(:status) { system(command, out: File::NULL) }
+  let(:status) { Bundler.clean_system(command, out: File::NULL) }
 
   let(:test_app) { "spec/generator_test_app" }
 
@@ -32,7 +32,7 @@ describe "Application generation" do
   end
 
   context "development application" do
-    let(:command) { "rake development_app" }
+    let(:command) { "bundle exec rake development_app" }
 
     it_behaves_like "a sane generator"
   end

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -11,19 +11,19 @@ describe "Application generation" do
     end
   end
 
-  context "with edge argument" do
+  context "with --edge flag" do
     let(:command) { "bin/decidim --edge tmp/test_app" }
 
     it_behaves_like "a sane generator"
   end
 
-  context "with branch argument" do
+  context "with --branch flag" do
     let(:command) { "bin/decidim --branch master tmp/test_app" }
 
     it_behaves_like "a sane generator"
   end
 
-  context "with path argument" do
+  context "with --path flag" do
     let(:command) { "bin/decidim --path #{File.expand_path("..", __dir__)} tmp/test_app" }
 
     it_behaves_like "a sane generator"

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -5,35 +5,33 @@ describe "Application generation" do
 
   after { FileUtils.rm_rf("tmp/test_app") }
 
-  context "with edge argument" do
-    let(:command) { "bin/decidim --edge tmp/test_app" }
-
+  shared_examples_for "a sane generator" do
     it "successfully generates application" do
       expect(status).to eq(true)
     end
+  end
+
+  context "with edge argument" do
+    let(:command) { "bin/decidim --edge tmp/test_app" }
+
+    it_behaves_like "a sane generator"
   end
 
   context "with branch argument" do
     let(:command) { "bin/decidim --branch master tmp/test_app" }
 
-    it "successfully generates application" do
-      expect(status).to eq(true)
-    end
+    it_behaves_like "a sane generator"
   end
 
   context "with path argument" do
     let(:command) { "bin/decidim --path #{File.expand_path("..", __dir__)} tmp/test_app" }
 
-    it "successfully generates application" do
-      expect(status).to eq(true)
-    end
+    it_behaves_like "a sane generator"
   end
 
   context "development application" do
     let(:command) { "rake development_app" }
 
-    it "successfully generates application" do
-      expect(status).to eq(true)
-    end
+    it_behaves_like "a sane generator"
   end
 end

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -38,7 +38,9 @@ describe "Application generation" do
   end
 
   context "development application" do
-    let(:command) { "bundle exec rake development_app" }
+    let(:command) do
+      "bin/decidim --path #{File.expand_path("..", __dir__)} #{test_app} --recreate_db --seed_db"
+    end
 
     it_behaves_like "a sane generator"
   end

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -3,7 +3,9 @@
 describe "Application generation" do
   let(:status) { system(command, out: File::NULL) }
 
-  after { FileUtils.rm_rf("tmp/test_app") }
+  let(:test_app) { "spec/generator_test_app" }
+
+  after { FileUtils.rm_rf(test_app) }
 
   shared_examples_for "a sane generator" do
     it "successfully generates application" do
@@ -12,19 +14,19 @@ describe "Application generation" do
   end
 
   context "with --edge flag" do
-    let(:command) { "bin/decidim --edge tmp/test_app" }
+    let(:command) { "bin/decidim --edge #{test_app}" }
 
     it_behaves_like "a sane generator"
   end
 
   context "with --branch flag" do
-    let(:command) { "bin/decidim --branch master tmp/test_app" }
+    let(:command) { "bin/decidim --branch master #{test_app}" }
 
     it_behaves_like "a sane generator"
   end
 
   context "with --path flag" do
-    let(:command) { "bin/decidim --path #{File.expand_path("..", __dir__)} tmp/test_app" }
+    let(:command) { "bin/decidim --path #{File.expand_path("..", __dir__)} #{test_app}" }
 
     it_behaves_like "a sane generator"
   end

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -13,6 +13,12 @@ describe "Application generation" do
     end
   end
 
+  context "without flags" do
+    let(:command) { "bin/decidim #{test_app}" }
+
+    it_behaves_like "a sane generator"
+  end
+
   context "with --edge flag" do
     let(:command) { "bin/decidim --edge #{test_app}" }
 


### PR DESCRIPTION
#### :tophat: What? Why?

Our generator was crashing when run directly via `decidim`'s executable (`gem install decidim; decidim my_awesome_app`). This is because `bundler` is not available in that case.

This PR fixes that, changes our tests so they catch this thing, and improves some extra related stuff.
  
#### :pushpin: Related Issues
- Related to #1873 (where I introduced this while fixing other issues).

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![todo_lo_que_ves](https://user-images.githubusercontent.com/2887858/30916110-d8d4b3d8-a398-11e7-86c8-bee1501027b8.gif)
