### PR TITLE
Add bootsnap to the generated application

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ gem "decidim", path: "."
 # Uncomment the following line if you want to use decidim-assemblies plugin
 # gem "decidim-assemblies", path: "."
 
+gem "bootsnap", require: false
+
 gem "puma", "~> 3.0"
 gem "uglifier", ">= 1.3.0"
 

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,3 @@ group :development do
   gem "spring-watcher-listen", "~> 2.0.0"
   gem "web-console"
 end
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,8 @@ GEM
       execjs (~> 2.0)
     bcrypt (3.1.11)
     bindex (0.5.0)
+    bootsnap (1.1.3)
+      msgpack (~> 1.0)
     builder (3.2.3)
     byebug (9.1.0)
     cancancan (2.0.0)
@@ -354,6 +356,7 @@ GEM
     mini_mime (0.1.4)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
+    msgpack (1.1.0)
     multi_json (1.12.2)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -573,6 +576,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bootsnap
   byebug
   decidim!
   decidim-dev!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -586,7 +586,6 @@ DEPENDENCIES
   puma (~> 3.0)
   spring
   spring-watcher-listen (~> 2.0.0)
-  tzinfo-data
   uglifier (>= 1.3.0)
   web-console
 

--- a/lib/generators/decidim/app_generator.rb
+++ b/lib/generators/decidim/app_generator.rb
@@ -87,6 +87,10 @@ module Decidim
         gsub_file "Gemfile", /gem "decidim([^"]*)".*/, "gem \"decidim\\1\", #{gem_modifier}"
       end
 
+      def bootsnap
+        append_file "config/boot.rb", "require 'bootsnap/setup'\n"
+      end
+
       def add_ignore_uploads
         unless options["skip_git"]
           append_file ".gitignore", "\n# Ignore public uploads\npublic/uploads"


### PR DESCRIPTION
#### :tophat: What? Why?

In my case, this speeds up loading Rails by almost ~50%!

*  `time rails db:migrate:status` with bootsnap

```
real	0m2.357s
user	0m2.180s
sys	0m0.152s
```

*  `time rails db:migrate:status` on master

```
real	0m4.418s
user	0m3.692s
sys	0m0.664s
```

Build might fail because of #1938.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![einstein](https://user-images.githubusercontent.com/2887858/30924205-5fb5ef7e-a3ae-11e7-9fb8-460609610910.gif)
