### PR TITLE
Hide "Mark all as read" button when no notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **decidim-core**: Show a disabled "Follow" button to anonymous users (not logged in) with a prompt to sign in [\#1903](https://github.com/decidim/decidim/pull/1903)
 - **decidim-core**: Adds an option to the initializer file to enable/disable header snippets (`true` by default) [\#1923](https://github.com/decidim/decidim/pull/1923)
 - **decidim-core**: Adds an option to configure the maximum file size for avatar images [\#1969](https://github.com/decidim/decidim/pull/1969)
+- **decidim-core**: Hides the "Mark all as read" notifications button when no notifications are found [\#1948](https://github.com/decidim/decidim/pull/1948)
 - **decidim-meetings**: Participatory admins can invite users to join a meeting. [\#1879](https://github.com/decidim/decidim/pull/1879)
 
 **Changed**

--- a/decidim-core/app/views/decidim/notifications/index.html.erb
+++ b/decidim-core/app/views/decidim/notifications/index.html.erb
@@ -3,14 +3,16 @@
     <div class="columns">
       <div class="title-action" >
         <h1 class="heading1 title-action__title"><%= t("title", scope: "layouts.decidim.notifications_dashboard") %></h1>
-        <%= link_to(
-          t("mark_all_as_read", scope: "layouts.decidim.notifications_dashboard"),
-          decidim.read_all_notifications_path,
-          class: "button title-action__action hollow mark-all-as-read-button",
-          method: :delete,
-          data: { disable: true },
-          remote: true
-        ) %>
+        <% if notifications.any? %>
+          <%= link_to(
+            t("mark_all_as_read", scope: "layouts.decidim.notifications_dashboard"),
+            decidim.read_all_notifications_path,
+            class: "button title-action__action hollow mark-all-as-read-button",
+            method: :delete,
+            data: { disable: true },
+            remote: true
+          ) %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/decidim-core/app/views/decidim/notifications/index.html.erb
+++ b/decidim-core/app/views/decidim/notifications/index.html.erb
@@ -18,7 +18,9 @@
   </div>
   <div class="row">
     <div class="columns mediumlarge-12 large-12">
-      <p class="empty-notifications hide"><%= t("no_notifications", scope: "layouts.decidim.notifications_dashboard") %></p>
+      <div class="empty-notifications hide callout secondary">
+        <p><%= t("no_notifications", scope: "layouts.decidim.notifications_dashboard") %></p>
+      </div>
       <% if notifications.any? %>
         <section class="section" id="notifications-list">
           <div class="card card--list">

--- a/decidim-core/spec/features/notifications_spec.rb
+++ b/decidim-core/spec/features/notifications_spec.rb
@@ -54,6 +54,7 @@ describe "Notifications", type: :feature do
     end
 
     it "doesn't show any notification" do
+      expect(page).not_to have_content("Mark all as read")
       expect(page).to have_content("No notifications yet")
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Hides the "Mark all as read" notifications button when no notifications are found.

#### :pushpin: Related Issues
- Fixes #1863
### :camera: Screenshots (optional)
![Description](https://i.imgur.com/Pihnjvt.png)
