### PR TITLE
Install decidim as a gem for main job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,6 @@ jobs:
       - run:
           name: Install app dependencies
           command: |
-            gem install decidim
             bundle install
             npm i
       - run:
@@ -50,6 +49,9 @@ jobs:
             mv phantomjs-2.1.1-linux-x86_64 /usr/local/share
             ln -sf /usr/local/share/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin
             rm phantomjs-2.1.1-linux-x86_64.tar.bz2
+      - run:
+          name: Install dependencies
+          command: gem install decidim
       - run:
           name: Create test DB
           command: |


### PR DESCRIPTION
#### :tophat: What? Why?
PR #1938 modified dependencies for tests on CircleCI, but on #1939 I didn't realize that change so when both PRs were merged the result was inconsistent.

This PR fixes this error, reported on #1950. 

#### :pushpin: Related Issues
- Fixes #1950
