### PR TITLE
Fix small visual regression

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_signup.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_signup.scss
@@ -19,12 +19,6 @@
 
 .register__separator__text{
   display: inline-block;
-  background: $white;
-  padding: 0 1rem;
-}
-
-.register__separator-mini__text{
-  display: inline-block;
   background: $light-gray;
   padding: 0 1rem;
 }

--- a/decidim-core/app/views/decidim/devise/shared/_omniauth_buttons_mini.html.erb
+++ b/decidim-core/app/views/decidim/devise/shared/_omniauth_buttons_mini.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="columns medium-8 medium-centered">
       <span class="register__separator">
-        <span class="register__separator-mini__text"><%= t('or', scope: "decidim.devise.shared.omniauth_buttons") %></span>
+        <span class="register__separator__text"><%= t('or', scope: "decidim.devise.shared.omniauth_buttons") %></span>
       </span>
       <div class="text-center">
         <%- Decidim::User.omniauth_providers.each do |provider| %>


### PR DESCRIPTION
#### :tophat: What? Why?

Background under the - or - separator should be always gray. Now it shows a rectangle with white background around it.

I accidentally introduced this in #1940 when not properly undoing all of my design "improvements" 

#### :pushpin: Related Issues
- Related to #1940.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![cat](https://user-images.githubusercontent.com/2887858/31007498-0d93aca0-a501-11e7-95e9-685a79fd3fc3.gif)
