### PR TITLE
Change "citizenship" to "citizens"

### DIFF
--- a/decidim-proposals/app/services/decidim/proposals/proposal_search.rb
+++ b/decidim-proposals/app/services/decidim/proposals/proposal_search.rb
@@ -25,7 +25,7 @@ module Decidim
       def search_origin
         if origin == "official"
           query.where(decidim_author_id: nil)
-        elsif origin == "citizenship"
+        elsif origin == "citizens"
           query.where.not(decidim_author_id: nil)
         else # Assume 'all'
           query

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
@@ -13,7 +13,7 @@
   </div>
 
   <% if feature_settings.official_proposals_enabled %>
-    <%= form.collection_radio_buttons :origin, [["all", t('.all')], ["official", t('.official')], ["citizenship", t('.citizenship')]], :first, :last, legend_title: t('.origin') %>
+    <%= form.collection_radio_buttons :origin, [["all", t('.all')], ["official", t('.official')], ["citizens", t('.citizens')]], :first, :last, legend_title: t('.origin') %>
   <% end %>
 
   <% if feature_settings.proposal_answering_enabled && current_settings.proposal_answering_enabled %>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -105,7 +105,7 @@ en:
           all: All
           category: Category
           category_prompt: Select a category
-          citizenship: Citizenship
+          citizens: Citizens
           evaluating: Evaluating
           official: Official
           origin: Origin

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -568,14 +568,14 @@ describe "Proposals", type: :feature do
           end
         end
 
-        context "by origin 'citizenship'" do
+        context "by origin 'citizens'" do
           it "lists the filtered proposals" do
             create_list(:proposal, 2, feature: feature, scope: scope)
             create(:proposal, :official, feature: feature, scope: scope)
             visit_feature
 
             within ".filters" do
-              choose "Citizenship"
+              choose "Citizens"
             end
 
             expect(page).to have_css(".card--proposal", count: 2)

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_search_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_search_spec.rb
@@ -78,7 +78,7 @@ module Decidim
           end
 
           context "when filtering citizen proposals" do
-            let(:origin) { "citizenship" }
+            let(:origin) { "citizens" }
 
             it "returns only citizen proposals" do
               create_list(:proposal, 3, :official, feature: feature)


### PR DESCRIPTION
#### :tophat: What? Why?
This PR changes all appearences of "Citizenship" to "Citizens", as its clearer in English.

#### :pushpin: Related Issues
- Fixes #1943.

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/pL6jio6.png)
