### PR TITLE
No after login redirections

### DIFF
--- a/decidim-core/app/controllers/decidim/application_controller.rb
+++ b/decidim-core/app/controllers/decidim/application_controller.rb
@@ -19,22 +19,12 @@ module Decidim
     helper Decidim::MenuHelper
     helper Decidim::FeaturePathHelper
 
-    # Saves the location before loading each page so we can return to the
-    # right page. If we're on a devise page, we don't want to store that as the
-    # place to return to (for example, we don't want to return to the sign in page
-    # after signing in), which is what the :unless prevents
-    before_action :store_current_location, unless: :devise_controller?
-
     protect_from_forgery with: :exception, prepend: true
     after_action :add_vary_header
 
     layout "layouts/decidim/application"
 
     private
-
-    def store_current_location
-      store_location_for(:user, request.url)
-    end
 
     def user_not_authorized_path
       decidim.root_path

--- a/decidim-core/app/controllers/decidim/authorizations_controller.rb
+++ b/decidim-core/app/controllers/decidim/authorizations_controller.rb
@@ -4,7 +4,7 @@ module Decidim
   # This controller allows users to create and destroy their authorizations. It
   # shouldn't be necessary to expand it to add new authorization schemes.
   class AuthorizationsController < Decidim::ApplicationController
-    helper_method :handler, :handlers, :stored_location
+    helper_method :handler, :handlers
     before_action :valid_handler, only: [:new, :create]
 
     include Decidim::UserProfile
@@ -12,7 +12,6 @@ module Decidim
     helper Decidim::AuthorizationFormHelper
 
     layout "layouts/decidim/user_profile", only: [:index]
-    skip_before_action :store_current_location
 
     def new; end
 
@@ -34,7 +33,7 @@ module Decidim
       AuthorizeUser.call(handler) do
         on(:ok) do
           flash[:notice] = t("authorizations.create.success", scope: "decidim")
-          redirect_to params[:redirect_url] || stored_location_for(current_user) || authorizations_path
+          redirect_to params[:redirect_url] || authorizations_path
         end
 
         on(:invalid) do
@@ -48,12 +47,6 @@ module Decidim
 
     def handler
       @handler ||= AuthorizationHandler.handler_for(handler_name, handler_params)
-    end
-
-    def stored_location
-      location = stored_location_for(current_user)
-      store_location_for(current_user, location)
-      location
     end
 
     def handler_params

--- a/decidim-core/app/controllers/decidim/cookie_policy_controller.rb
+++ b/decidim-core/app/controllers/decidim/cookie_policy_controller.rb
@@ -5,8 +5,6 @@ module Decidim
   class CookiePolicyController < Decidim::ApplicationController
     skip_authorization_check
 
-    skip_before_action :store_current_location
-
     def accept
       response.set_cookie "decidim-cc", value: "true",
                                         path: "/",

--- a/decidim-core/app/controllers/decidim/devise/invitations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/invitations_controller.rb
@@ -16,7 +16,7 @@ module Decidim
       # invitation. Using the param `invite_redirect` we can redirect the user
       # to a custom path after it has accepted the invitation.
       def after_accept_path_for(resource)
-        params[:invite_redirect] || after_sign_in_path_for(resource)
+        params[:invite_redirect] || super
       end
 
       # When a managed user accepts the invitation is promoted to non-managed user.

--- a/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
@@ -44,19 +44,11 @@ module Decidim
       end
 
       def after_sign_in_path_for(user)
-        if !pending_redirect?(user) && first_login_and_not_authorized?(user)
+        if first_login_and_not_authorized?(user)
           authorizations_path
         else
           super
         end
-      end
-
-      # Calling the `stored_location_for` method removes the key, so in order
-      # to check if there's any pending redirect after login I need to call
-      # this method and use the value to set a pending redirect. This is the
-      # only way to do this without checking the session directly.
-      def pending_redirect?(user)
-        store_location_for(user, stored_location_for(user))
       end
 
       def first_login_and_not_authorized?(user)

--- a/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
@@ -12,14 +12,6 @@ module Decidim
         super
       end
 
-      # Calling the `stored_location_for` method removes the key, so in order
-      # to check if there's any pending redirect after login I need to call
-      # this method and use the value to set a pending redirect. This is the
-      # only way to do this without checking the session directly.
-      def pending_redirect?(user)
-        store_location_for(user, stored_location_for(user))
-      end
-
       def first_login_and_not_authorized?(user)
         user.is_a?(User) && user.sign_in_count == 1 && current_organization.available_authorizations.any?
       end

--- a/decidim-core/app/controllers/decidim/scopes_controller.rb
+++ b/decidim-core/app/controllers/decidim/scopes_controller.rb
@@ -3,8 +3,6 @@
 module Decidim
   # Exposes the scopes text search so users can choose a scope writing its name.
   class ScopesController < Decidim::ApplicationController
-    skip_before_action :store_current_location
-
     def search
       authorize! :search, Scope
       root = Scope.where(id: params[:root], organization: current_organization).first

--- a/decidim-core/app/views/decidim/authorizations/new.html.erb
+++ b/decidim-core/app/views/decidim/authorizations/new.html.erb
@@ -22,7 +22,9 @@
                 </div>
               <% end %>
             <% end %>
-            <p class="text-center skip"><%= t("decidim.authorizations.skip_verification", link: link_to(t("decidim.authorizations.current_participatory_processes"), stored_location).html_safe).html_safe %>.</p>
+            <p class="text-center skip">
+              <%= t("decidim.authorizations.skip_verification", link: link_to(t("decidim.authorizations.current_participatory_processes"), decidim_participatory_processes.participatory_processes_path).html_safe).html_safe %>.
+            </p>
           </div>
         </div>
       </div>

--- a/decidim-core/spec/controllers/scopes_controller_spec.rb
+++ b/decidim-core/spec/controllers/scopes_controller_spec.rb
@@ -45,10 +45,6 @@ module Decidim
       it "result has text" do
         expect(subject.first).to have_key("text")
       end
-
-      it "doesn't store the location for user" do
-        expect(controller.stored_location_for(user)).to be_nil
-      end
     end
 
     context "search top scopes" do

--- a/decidim-core/spec/features/authorizations_spec.rb
+++ b/decidim-core/spec/features/authorizations_spec.rb
@@ -36,8 +36,8 @@ describe "Authorizations", type: :feature, perform_enqueued: true do
       end
 
       it "allows the user to skip it" do
-        find(".skip a").click
-        expect(page).to have_content("Welcome")
+        click_link "take a look at the current processes"
+        expect(page).to have_content("No participatory processes yet!")
       end
     end
 

--- a/decidim-core/spec/views/decidim/authorizations/new.html.erb_spec.rb
+++ b/decidim-core/spec/views/decidim/authorizations/new.html.erb_spec.rb
@@ -13,7 +13,6 @@ module Decidim
       view.extend DecidimFormHelper
       allow(view).to receive(:handler).and_return(handler)
       allow(view).to receive(:authorizations_path).and_return("/authorizations")
-      allow(view).to receive(:stored_location).and_return("/processes")
     end
 
     context "when there's a partial to render the form" do


### PR DESCRIPTION
#### :tophat: What? Why?

I extracted these changes from #1897 because I don't think we need to block this.

The idea here is that we're not making use of the feature of saving the redirection url to session when redirecting to the login form and then redirecting back to it after login.

This is because our login form is served with every request as a hidden modal that opens up under certain conditions. Thus, we never hit the controller when the modal is opened and we don't save the redirect url properly.

Until we can implement a proper redirection flow I think it's better to remove this because:

* It's a globally introduced feature (`ApplicationController`) very sensible to bugs. For example, #1856. This might even be the cause of #1893 and thus fix it.

* It currently creates weird UI behavior. For example, in the verification page after the first login, there's a link that says "You can skip this step and take a look at the current processes". But that link doesn't necessarily take you to the current processes but to whatever url is saved in session as the redirect URL (this is the single test that this PR broke).

#### :pushpin: Related Issues
- Related to #1897.
- Might fix #1893.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![lion](https://user-images.githubusercontent.com/2887858/31015463-84d5656e-a520-11e7-9d1d-8311fc8f1bf7.gif)
