### PR TITLE
Render avatar error messages and make maximum filesize configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **decidim-core**: Show a disabled "Follow" button to anonymous users (not logged in) with a prompt to sign in [\#1903](https://github.com/decidim/decidim/pull/1903)
 - **decidim-core**: Adds an option to the initializer file to enable/disable header snippets (`true` by default) [\#1923](https://github.com/decidim/decidim/pull/1923)
+- **decidim-core**: Adds an option to configure the maximum file size for avatar images [\#1969](https://github.com/decidim/decidim/pull/1969)
 - **decidim-meetings**: Participatory admins can invite users to join a meeting. [\#1879](https://github.com/decidim/decidim/pull/1879)
 
 **Changed**
@@ -24,6 +25,7 @@
 **Fixed**
 - **decidim-assemblies**: Embed pages were not working properly. Now we have tests to check they do [\#1929](https://github.com/decidim/decidim/pull/1929)
 - **decidim-core**: Fixes a bug with filter forms and URLs [\#1937](https://github.com/decidim/decidim/pull/1937)
+- **decidim-core**: The form builder now renders an error message in case an uploaded file failed validation [\#1969](https://github.com/decidim/decidim/pull/1969)
 - **decidim-meetings**: Embed pages were not working properly. Now we have tests to check they do [\#1929](https://github.com/decidim/decidim/pull/1929)
 - **decidim-participatory-processes**: Embed pages were not working properly. Now we have tests to check they do [\#1929](https://github.com/decidim/decidim/pull/1929)
 - **decidim-proposals**: Embed pages were not working properly. Now we have tests to check they do [\#1929](https://github.com/decidim/decidim/pull/1929)

--- a/decidim-core/app/forms/decidim/account_form.rb
+++ b/decidim-core/app/forms/decidim/account_form.rb
@@ -19,7 +19,7 @@ module Decidim
     validates :password, confirmation: true
     validates :password, length: { in: Decidim::User.password_length, allow_blank: true }
     validates :password_confirmation, presence: true, if: :password_present
-    validates :avatar, file_size: { less_than_or_equal_to: ->(_record) { Decidim::User::MAXIMUM_AVATAR_FILE_SIZE } }
+    validates :avatar, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_avatar_size } }
 
     validate :unique_email
 

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -5,7 +5,6 @@ require_dependency "devise/models/decidim_validatable"
 module Decidim
   # A User is a citizen that wants to join the platform to participate.
   class User < ApplicationRecord
-    MAXIMUM_AVATAR_FILE_SIZE = 5.megabytes
     OMNIAUTH_PROVIDERS = [:facebook, :twitter, :google_oauth2, (:developer if Rails.env.development?)].compact
     ROLES = %w(admin user_manager).freeze
 
@@ -25,7 +24,7 @@ module Decidim
     validates :name, presence: true, unless: -> { deleted? }
     validates :locale, inclusion: { in: :available_locales }, allow_blank: true
     validates :tos_agreement, acceptance: true, allow_nil: false, on: :create
-    validates :avatar, file_size: { less_than_or_equal_to: MAXIMUM_AVATAR_FILE_SIZE }
+    validates :avatar, file_size: { less_than_or_equal_to: ->(_record){ Decidim.maximum_avatar_size } }
     validates :email, uniqueness: { scope: :organization }, unless: -> { deleted? || managed? }
     validate :all_roles_are_valid
 

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -24,7 +24,7 @@ module Decidim
     validates :name, presence: true, unless: -> { deleted? }
     validates :locale, inclusion: { in: :available_locales }, allow_blank: true
     validates :tos_agreement, acceptance: true, allow_nil: false, on: :create
-    validates :avatar, file_size: { less_than_or_equal_to: ->(_record){ Decidim.maximum_avatar_size } }
+    validates :avatar, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_avatar_size } }
     validates :email, uniqueness: { scope: :organization }, unless: -> { deleted? || managed? }
     validate :all_roles_are_valid
 

--- a/decidim-core/app/models/decidim/user_group.rb
+++ b/decidim-core/app/models/decidim/user_group.rb
@@ -11,7 +11,7 @@ module Decidim
     validates :name, presence: true, uniqueness: { scope: :decidim_organization_id }
     validates :document_number, presence: true, uniqueness: { scope: :decidim_organization_id }
     validates :phone, presence: true
-    validates :avatar, file_size: { less_than_or_equal_to: ->(_record){ Decidim.maximum_avatar_size } }
+    validates :avatar, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_avatar_size } }
 
     validate :correct_state
 

--- a/decidim-core/app/models/decidim/user_group.rb
+++ b/decidim-core/app/models/decidim/user_group.rb
@@ -11,7 +11,7 @@ module Decidim
     validates :name, presence: true, uniqueness: { scope: :decidim_organization_id }
     validates :document_number, presence: true, uniqueness: { scope: :decidim_organization_id }
     validates :phone, presence: true
-    validates :avatar, file_size: { less_than_or_equal_to: 5.megabytes }
+    validates :avatar, file_size: { less_than_or_equal_to: ->(_record){ Decidim.maximum_avatar_size } }
 
     validate :correct_state
 

--- a/decidim-core/app/views/decidim/account/show.html.erb
+++ b/decidim-core/app/views/decidim/account/show.html.erb
@@ -2,6 +2,9 @@
   <%= decidim_form_for(@account, url: account_path, method: :put, class: "user-form") do |f| %>
     <div class="columns large-4">
       <%= f.upload :avatar %>
+      <% if @account.errors[:avatar].any? %>
+        <p class="is-invalid-label"><%= safe_join @account.errors[:avatar], '<br/>' %></p>
+      <% end %>
     </div>
 
     <div class="columns large-8 end">

--- a/decidim-core/app/views/decidim/account/show.html.erb
+++ b/decidim-core/app/views/decidim/account/show.html.erb
@@ -2,9 +2,6 @@
   <%= decidim_form_for(@account, url: account_path, method: :put, class: "user-form") do |f| %>
     <div class="columns large-4">
       <%= f.upload :avatar %>
-      <% if @account.errors[:avatar].any? %>
-        <p class="is-invalid-label"><%= safe_join @account.errors[:avatar], '<br/>' %></p>
-      <% end %>
     </div>
 
     <div class="columns large-8 end">

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -131,6 +131,11 @@ module Decidim
     10.megabytes
   end
 
+  # Exposes a configuration option: The maximum file size for user avatar images.
+  config_accessor :maximum_avatar_size do
+    5.megabytes
+  end
+
   # The number of reports which an object can receive before hiding it
   config_accessor :max_reports_before_hiding do
     3

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -250,6 +250,12 @@ module Decidim
         end
       end
 
+      if object.errors[attribute].any?
+        template += content_tag :p, class: "is-invalid-label" do
+          safe_join object.errors[attribute], "<br/>"
+        end
+      end
+
       template.html_safe
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

When the avatar image isn't accepted the user isn't given any hint about what is wrong with it. Since we are both checking image dimensions and file size this can lead to some trial and error.

The first commit adds printing of avatar image errors to the account form, the second makes the maximum avatar file size configurable.