### PR TITLE
Copy Gemfile.lock to generated test apps

### DIFF
--- a/lib/generators/decidim/app_generator.rb
+++ b/lib/generators/decidim/app_generator.rb
@@ -87,8 +87,19 @@ module Decidim
         gsub_file "Gemfile", /gem "decidim([^"]*)".*/, "gem \"decidim\\1\", #{gem_modifier}"
       end
 
+      def gemfile_lock
+        path = File.expand_path(File.join("..", "..", "..", "Gemfile.lock"), __dir__)
+
+        template path, "Gemfile.lock", force: true
+      end
+
       def bootsnap
         append_file "config/boot.rb", "require 'bootsnap/setup'\n"
+      end
+
+      def secret_token
+        require "securerandom"
+        SecureRandom.hex(64)
       end
 
       def add_ignore_uploads


### PR DESCRIPTION
#### :tophat: What? Why?
Following from https://github.com/decidim/decidim/pull/1967#issuecomment-333510330, we'll lock the `Gemfile.lock` file for test apps so we don't have version issues. Builds on top of #1958.

#### :pushpin: Related Issues
- Related to #https://github.com/decidim/decidim/pull/1967#issuecomment-333510330, #1958.
