### PR TITLE
Unify i18n: use "votes" instead of "orders" on budgets

### DIFF
--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -101,7 +101,7 @@ en:
         comments_count: Comments
         headline: Activity
         meetings_count: Meetings
-        orders_count: Orders
+        orders_count: Votes
         pages_count: Pages
         projects_count: Projects
         proposals_count: Proposals

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -33,8 +33,8 @@ en:
             title: Edit project
             update: Update
           index:
-            finished_orders: Finished orders
-            pending_orders: Pending orders
+            finished_orders: Finished votes
+            pending_orders: Pending votes
             title: Projects
           new:
             create: Create
@@ -129,5 +129,5 @@ en:
       included_proposals:
         project_proposals: 'Proposals included in this project:'
   index:
-    confirmed_orders_count: Orders count
+    confirmed_orders_count: Votes count
   total_budget: Total budget

--- a/decidim-budgets/spec/shared/manage_projects_examples.rb
+++ b/decidim-budgets/spec/shared/manage_projects_examples.rb
@@ -40,7 +40,7 @@ shared_examples "manage projects" do
     end
   end
 
-  context "seeing finished and pending orders" do
+  context "seeing finished and pending votes" do
     let!(:project) { create(:project, budget: 70_000_000, feature: current_feature) }
 
     let!(:finished_orders) do
@@ -58,8 +58,8 @@ shared_examples "manage projects" do
 
     it "shows the order count" do
       visit current_path
-      expect(page).to have_content("Finished orders: 10")
-      expect(page).to have_content("Pending orders: 5")
+      expect(page).to have_content("Finished votes: 10")
+      expect(page).to have_content("Pending votes: 5")
     end
   end
 

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -364,7 +364,7 @@ en:
         comments_count: Comments
         headline: Current state of %{organization}
         meetings_count: Meetings
-        orders_count: Orders
+        orders_count: Votes
         pages_count: Pages
         processes_count: Processes
         projects_count: Projects

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -244,7 +244,7 @@ en:
         comments_count: Comments
         headline: Activity
         meetings_count: Meetings
-        orders_count: Orders
+        orders_count: Votes
         pages_count: Pages
         processes_count: Processes
         projects_count: Projects


### PR DESCRIPTION
#### :tophat: What? Why?
Changes "orders" to "votes" in `budgets` so the texts are clearer for the end user.

#### :pushpin: Related Issues
- Fixes #1944.