### PR TITLE
Fix escaped HTML

### DIFF
--- a/decidim-system/app/views/decidim/system/organizations/show.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/show.html.erb
@@ -1,7 +1,7 @@
 <% provide :title do %>
   <h2><%= link_to @organization.name, @organization %></h2>
   <h3 class="subheader"><%= @organization.host %></h3>
-  <p><%= translated_attribute @organization.description %></p>
+  <p><%== translated_attribute @organization.description %></p>
 <% end %>
 
 <div class="actions">


### PR DESCRIPTION
#### :tophat: What? Why?

Found some incorrectly escaped HTML in the system interface. This fixes it.

#### :pushpin: Related Issues
_None_

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![ghandi](https://user-images.githubusercontent.com/2887858/31165388-35a69660-a8eb-11e7-9c7e-0c387a16c9ac.gif)
