### PR TITLE
Fix more model usages in migrations

### DIFF
--- a/decidim-core/db/migrate/20170215115407_add_organization_custom_reference.rb
+++ b/decidim-core/db/migrate/20170215115407_add_organization_custom_reference.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 class AddOrganizationCustomReference < ActiveRecord::Migration[5.0]
+  class Organization < ApplicationRecord
+    self.table_name = :decidim_organizations
+  end
+
   def change
     add_column :decidim_organizations, :reference_prefix, :string
 
-    Decidim::Organization.find_each do |organization|
+    Organization.find_each do |organization|
       organization.update_attributes!(reference_prefix: organization.name[0])
     end
 

--- a/decidim-core/db/migrate/20170313095436_add_available_authorizations_to_organization.rb
+++ b/decidim-core/db/migrate/20170313095436_add_available_authorizations_to_organization.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
 class AddAvailableAuthorizationsToOrganization < ActiveRecord::Migration[5.0]
+  class Organization < ApplicationRecord
+    self.table_name = :decidim_organizations
+  end
+
   def change
     add_column :decidim_organizations, :available_authorizations, :string, array: true, default: []
 
     handlers = Decidim.authorization_handlers.map(&:name)
-    Decidim::Organization.find_each do |org|
+    Organization.find_each do |org|
       org.update_attributes!(available_authorizations: handlers)
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

Some unrelated changes surfaced more bad usages of models in migrations. This change fixes it.

#### :pushpin: Related Issues
Related to: #1921, #1745, #1649, #1626.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![tianamen](https://user-images.githubusercontent.com/2887858/31165611-06cf593e-a8ec-11e7-9781-aa5a857cb0d6.gif)
