### PR TITLE
Require survey TOS field on admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - **decidim**: Generator when run directly via decidim's executable was crashing due to bundler unavailability [\#1938](https://github.com/decidim/decidim/pull/1938)
 - **decidim-core**: Handle nil resources on static maps (errors were caused by search engine spiders) [\#1936](https://github.com/decidim/decidim/pull/1936)
+- **decidim-surveys**: When a survey is created without TOS, the survey cannot be answered by the users. We're making the TOS field rquired, please fill it for every language and every survey. [\#1980](https://github.com/decidim/decidim/pull/1980)
 
 ## [v0.6.5](https://github.com/decidim/decidim/tree/v0.6.5) (2017-09-28)
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.6.4...v0.6.5)

--- a/decidim-surveys/app/forms/decidim/surveys/admin/survey_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/admin/survey_form.rb
@@ -14,7 +14,7 @@ module Decidim
 
         attribute :questions, Array[SurveyQuestionForm]
 
-        validates :title, translatable_presence: true
+        validates :title, :tos, translatable_presence: true
       end
     end
   end

--- a/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
@@ -68,14 +68,12 @@
                     </div>
                   <% end %>
 
-                  <% if translated_attribute(survey.tos).present? %>
-                    <div class="row column">
-                      <%= form.check_box :tos_agreement, label: t(".tos_agreement"), id: "survey_tos_agreement" %>
-                      <div class="tos-agreement-help-text help-text">
-                        <%= sanitize translated_attribute survey.tos %>
-                      </div>
+                  <div class="row column">
+                    <%= form.check_box :tos_agreement, label: t(".tos_agreement"), id: "survey_tos_agreement" %>
+                    <div class="tos-agreement-help-text help-text">
+                      <%= sanitize translated_attribute survey.tos %>
                     </div>
-                  <% end %>
+                  </div>
 
                   <div class="button--double form-general-submit">
                     <%= form.submit t(".submit"), class: "button", data: { confirm: t('.are_you_sure') } %>

--- a/decidim-surveys/spec/commands/decidim/surveys/admin/update_survey_spec.rb
+++ b/decidim-surveys/spec/commands/decidim/surveys/admin/update_survey_spec.rb
@@ -18,6 +18,11 @@ module Decidim
               "ca" => "Title",
               "es" => "Title"
             },
+            "tos" => {
+              "en" => "<p>TOS</p>",
+              "ca" => "<p>TOS</p>",
+              "es" => "<p>TOS</p>"
+            },
             "description" => {
               "en" => "<p>Content</p>",
               "ca" => "<p>Contingut</p>",
@@ -135,6 +140,11 @@ module Decidim
                   "en" => "<p>Content</p>",
                   "ca" => "<p>Contingut</p>",
                   "es" => "<p>Contenido</p>"
+                },
+                "tos" => {
+                  "en" => "<p>TOS</p>",
+                  "ca" => "<p>TOS</p>",
+                  "es" => "<p>TOS</p>"
                 },
                 "questions" => [
                   {

--- a/decidim-surveys/spec/forms/decidim/surveys/admin/survey_form_spec.rb
+++ b/decidim-surveys/spec/forms/decidim/surveys/admin/survey_form_spec.rb
@@ -16,6 +16,14 @@ module Decidim
           }
         end
 
+        let(:tos) do
+          {
+            "en" => tos_english,
+            "ca" => "<p>TOS: contingut</p>",
+            "es" => "<p>TOS: contenido</p>"
+          }
+        end
+
         let(:description) do
           {
             "en" => "<p>Content</p>",
@@ -25,6 +33,7 @@ module Decidim
         end
 
         let(:body_english) { "First question" }
+        let(:tos_english) { "<p>TOS: content</p>" }
 
         let(:questions) do
           [
@@ -53,6 +62,7 @@ module Decidim
         let(:attributes) do
           {
             "survey" => {
+              "tos" => tos,
               "title" => title,
               "description" => description,
               "questions" => questions
@@ -72,6 +82,12 @@ module Decidim
 
         context "when a question is not valid" do
           let(:body_english) { "" }
+
+          it { is_expected.not_to be_valid }
+        end
+
+        context "when tos is not valid" do
+          let(:tos_english) { "" }
 
           it { is_expected.not_to be_valid }
         end


### PR DESCRIPTION
#### :tophat: What? Why?
Reported on #1976, see the discussion there. In the public form we are only showing the TOS checkbox if the text for that locale is present, but we are requiring the presence of it when submitting the form. This causes errors every time a user tries to submit a survey without TOS in that language. 

To avoid this, I made the TOS field required and always show the TOS checkbox.

#### :pushpin: Related Issues
- Fixes #1976.
