### PR TITLE
Fix input fields for single locale organizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - **decidim**: Generator when run directly via decidim's executable was crashing due to bundler unavailability [\#1938](https://github.com/decidim/decidim/pull/1938)
 - **decidim-core**: Handle nil resources on static maps (errors were caused by search engine spiders) [\#1936](https://github.com/decidim/decidim/pull/1936)
 - **decidim-surveys**: When a survey is created without TOS, the survey cannot be answered by the users. We're making the TOS field rquired, please fill it for every language and every survey. [\#1980](https://github.com/decidim/decidim/pull/1980)
+- **decidim-surveys**: Fixes a bug where inputs for survey question bodies in the admin were not working properly when the organization had only one locale. [\#1983](https://github.com/decidim/decidim/pull/1983)
 
 ## [v0.6.5](https://github.com/decidim/decidim/tree/v0.6.5) (2017-09-28)
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.6.4...v0.6.5)

--- a/decidim-core/app/helpers/decidim/decidim_form_helper.rb
+++ b/decidim-core/app/helpers/decidim/decidim_form_helper.rb
@@ -64,9 +64,11 @@ module Decidim
       field_label = label_tag(name, options[:label])
 
       if locales.count == 1
+        field_name = "#{name}_#{locales.first.to_s.gsub("-", "__")}"
         field_input = send(
           type,
-          "#{name}_#{locales.first.to_s.gsub("-", "__")}"
+          "#{object_name}[#{field_name}]",
+          value[locales.first.to_s]
         )
 
         return safe_join [field_label, field_input]

--- a/decidim-core/spec/helpers/decidim/decidim_form_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/decidim_form_helper_spec.rb
@@ -38,12 +38,12 @@ module Decidim
             :text_field_tag,
             "survey[questions][]",
             "body",
-            "My dummy body",
+            { "en" => "My dummy body" },
             label: "Guacamole"
           )
 
           expected_markup = <<~HTML
-            <label for="body">Guacamole</label><input type="text" name="body_en" id="body_en" />
+            <label for="body">Guacamole</label><input type="text" name="survey[questions][][body_en]" id="survey_questions__body_en" value="My dummy body" />
           HTML
 
           expect(expected_markup.strip).to eq(actual_markup.strip)


### PR DESCRIPTION
#### :tophat: What? Why?
Surveys for single locale organizations were broken and not filling the question body input fields properly. Now they do!

#### :pushpin: Related Issues
- Fixes #1914

### :camera: Screenshots (optional)
http://g.recordit.co/kVcdRIplPL.gif
![Description](http://g.recordit.co/kVcdRIplPL.gif)

Public page:
![](https://i.imgur.com/rG7gjhZ.png)
