### PR TITLE
Fix tab incorrectly not highlighted

### DIFF
--- a/decidim-admin/lib/decidim/admin/engine.rb
+++ b/decidim-admin/lib/decidim/admin/engine.rb
@@ -61,7 +61,7 @@ module Decidim
                     can?(:read, :admin_users) ? decidim_admin.users_path : decidim_admin.managed_users_path,
                     icon_name: "person",
                     position: 5,
-                    active: [%w(decidim/admin/user_groups decidim/admin/users), []],
+                    active: [%w(decidim/admin/user_groups decidim/admin/users decidim/admin/managed_users), []],
                     if: can?(:read, :admin_users) || can?(:read, :managed_users)
 
           menu.item I18n.t("menu.newsletters", scope: "decidim.admin"),


### PR DESCRIPTION
#### :tophat: What? Why?

A tiny visual fix. When in the "managed users" tab, the main users tab in the admin wouldn't be highlighted.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![turing](https://user-images.githubusercontent.com/2887858/31182104-4809d94c-a923-11e7-8771-e172a6c01191.gif)
