### PR TITLE
Remove scroll from admin tables when not necessary

### DIFF
--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_table-list.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_table-list.scss
@@ -1,5 +1,6 @@
 //Override Foundation defaults
 .table-scroll table{
+  border-collapse: unset;
   width: 100%;
 }
 


### PR DESCRIPTION
#### :tophat: What? Why?

Currently all tables in admin show a horizontal overflow even when the content fits. This change seems to fix it.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)

#### Before
![beforecss](https://user-images.githubusercontent.com/2887858/31183165-1567a462-a926-11e7-8162-fcada759c512.png)

#### After
![aftercss](https://user-images.githubusercontent.com/2887858/31183170-1a3cb0d6-a926-11e7-8e40-c9bc80f19063.png)

#### :ghost: GIF
![white_flag](https://user-images.githubusercontent.com/2887858/31183432-e00dc908-a926-11e7-8199-736e91b1ef05.gif)

