### PR TITLE
Ignore hidden proposals on stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 **Fixed**
 
 - **decidim-core**: Handle nil resources on static maps (errors were caused by search engine spiders) [\#1936](https://github.com/decidim/decidim/pull/1936)
+- **decidim-proposals**: Do not count hidden proposals on stats [\#1988](https://github.com/decidim/decidim/pull/1988)
 
 ## [v0.6.6](https://github.com/decidim/decidim/tree/v0.6.6) (2017-10-05)
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.6.5...v0.6.6)

--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -42,16 +42,16 @@ Decidim.register_feature(:proposals) do |feature|
   end
 
   feature.register_stat :proposals_count, primary: true, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |features, start_at, end_at|
-    Decidim::Proposals::FilteredProposals.for(features, start_at, end_at).count
+    Decidim::Proposals::FilteredProposals.for(features, start_at, end_at).not_hidden.count
   end
 
   feature.register_stat :votes_count, priority: Decidim::StatsRegistry::MEDIUM_PRIORITY do |features, start_at, end_at|
-    proposals = Decidim::Proposals::FilteredProposals.for(features, start_at, end_at)
+    proposals = Decidim::Proposals::FilteredProposals.for(features, start_at, end_at).not_hidden
     Decidim::Proposals::ProposalVote.where(proposal: proposals).count
   end
 
   feature.register_stat :comments_count, tag: :comments do |features, start_at, end_at|
-    proposals = Decidim::Proposals::FilteredProposals.for(features, start_at, end_at)
+    proposals = Decidim::Proposals::FilteredProposals.for(features, start_at, end_at).not_hidden
     Decidim::Comments::Comment.where(root_commentable: proposals).count
   end
 

--- a/decidim-proposals/spec/lib/decidim/proposals/feature_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/feature_spec.rb
@@ -30,4 +30,61 @@ describe "Proposals feature" do
       end
     end
   end
+
+  describe "stats" do
+    let(:raw_stats) do
+      Decidim.feature_manifests.map do |feature_manifest|
+        feature_manifest.stats.filter(name: stats_name).with_context(feature).flat_map { |name, data| [feature_manifest.name, name, data] }
+      end
+    end
+
+    let(:stats) do
+      raw_stats.select { |stat| stat[0] == :proposals }
+    end
+
+    let!(:proposal) { create :proposal }
+    let(:feature) { proposal.feature }
+    let!(:hidden_proposal) { create :proposal, feature: feature }
+    let!(:moderation) { create :moderation, reportable: hidden_proposal, hidden_at: 1.day.ago }
+
+    let(:current_stat) { stats.find { |stat| stat[1] == stats_name } }
+    subject { current_stat[2] }
+
+    context "proposals_count" do
+      let(:stats_name) { :proposals_count }
+
+      it "only counts not hidden proposals" do
+        expect(Decidim::Proposals::Proposal.where(feature: feature).count).to eq 2
+        expect(subject).to eq 1
+      end
+    end
+
+    context "votes_count" do
+      let(:stats_name) { :votes_count }
+
+      before do
+        create_list :proposal_vote, 2, proposal: proposal
+        create_list :proposal_vote, 3, proposal: hidden_proposal
+      end
+
+      it "counts the votes from visible proposals" do
+        expect(Decidim::Proposals::ProposalVote.count).to eq 5
+        expect(subject).to eq 2
+      end
+    end
+
+    context "comments_count" do
+      let(:stats_name) { :comments_count }
+
+      before do
+        create_list :comment, 2, commentable: proposal
+        create_list :comment, 3, commentable: hidden_proposal
+      end
+
+      it "counts the comments from visible proposals" do
+        expect(Decidim::Comments::Comment.count).to eq 5
+        expect(subject).to eq 2
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Stats were taking into account the hidden proposals (that are hidden from Moderation), which caused proposal counts to differ.

This fixes it.

#### :pushpin: Related Issues
- Fixes #1987.
