### PR TITLE
Enable Russian translation

### DIFF
--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -90,7 +90,7 @@ module Decidim
 
   # Exposes a configuration option: The application available locales.
   config_accessor :available_locales do
-    %w(en ca es eu it fi fr nl uk)
+    %w(en ca es eu it fi fr nl uk ru)
   end
 
   # Exposes a configuration option: The application default locale.


### PR DESCRIPTION
#### :tophat: What? Why?
Adds Russian as one of the available locales for Decidim.

#### :pushpin: Related Issues
None
