### PR TITLE
Update CHANGELOG after 0.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,15 @@
 
 **Fixed**
 
-- **Decidim**: A bug in the test app generator prevented installations to properly run the tests. [\#1994](https://github.com/decidim/decidim/pull/1994)
 - **decidim-core**: Handle nil resources on static maps (errors were caused by search engine spiders) [\#1936](https://github.com/decidim/decidim/pull/1936)
 - **decidim-proposals**: Do not count hidden proposals on stats [\#1988](https://github.com/decidim/decidim/pull/1988)
+
+## [v0.6.7](https://github.com/decidim/decidim/tree/v0.6.7) (2017-10-09)
+[Full Changelog](https://github.com/decidim/decidim/compare/v0.6.6...v0.6.7)
+
+**Fixed**
+
+- **decidim**: A bug in the test app generator prevented installations to properly run the tests. [\#1994](https://github.com/decidim/decidim/pull/1994)
 
 ## [v0.6.6](https://github.com/decidim/decidim/tree/v0.6.6) (2017-10-05)
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.6.5...v0.6.6)


### PR DESCRIPTION
#### :tophat: What? Why?
Updates the CHANNGELOG file after 0.6.7 release.

#### :pushpin: Related Issues
- Related to #2001 
