### PR TITLE
Truncate result description on index page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - **decidim**: `bin/rails generate decidim:demo` is no longer available in generated applications. Use the `--demo` flag when generating your application or do the change manually if you want to use the "demo" authorization handler. [\#1978](https://github.com/decidim/decidim/pull/1978)
 - **decidim-core**: Changes some texts in the homepage ("How do I take part in a process?" section) [\#1947](https://github.com/decidim/decidim/pull/1947)
 - **decidim-core**: Authorization handlers now must be specified as strings. To migrate, change `config.authorization_handlers = [MyHandler]` to `config.authorization_handlers = ["MyHandler"]`. [\#2016](https://github.com/decidim/decidim/pull/2016)
+- **decidim-results**: Results description is truncated to 100 chars on the public list view [\#2008](https://github.com/decidim/decidim/pull/2008)
 
 **Fixed**
 

--- a/decidim-results/app/views/decidim/results/results/_results.html.erb
+++ b/decidim-results/app/views/decidim/results/results/_results.html.erb
@@ -8,7 +8,7 @@
           <%= link_to result, class: "card__link" do %>
             <h5 class="card__title"><%= translated_attribute result.title %></h5>
           <% end %>
-          <%= sanitize translated_attribute result.description %>
+          <%= sanitize(html_truncate(translated_attribute(result.description), length: 100)) %>
           <%= render partial: "decidim/shared/tags", locals: { resource: result, tags_class_extra: "tags--result" } %>
         </div>
       </article>


### PR DESCRIPTION
#### :tophat: What? Why?
Proposal's description is truncated on the index page so that we don't get a lot of texts. This PR applies this to results, as per #2006. Text is truncated at 100 chars, same as proposals:

![](https://i.imgur.com/gi0Cder.png)

(notice the description is truncated)

#### :pushpin: Related Issues
- Fixes #2006.