### PR TITLE
Add votes column on proposals admin index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - **decidim-core**: Adds an option to configure the maximum file size for avatar images [\#1969](https://github.com/decidim/decidim/pull/1969)
 - **decidim-core**: Hides the "Mark all as read" notifications button when no notifications are found [\#1948](https://github.com/decidim/decidim/pull/1948)
 - **decidim-meetings**: Participatory admins can invite users to join a meeting. [\#1879](https://github.com/decidim/decidim/pull/1879)
+- **decidim-proposals**: Show votes in the proposals table in admin when votes are enabled [\#2011](https://github.com/decidim/decidim/pull/2011)
 
 **Changed**
 

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -25,8 +25,13 @@
             <% if scopes_enabled?(current_participatory_space) %>
               <th><%= t("models.proposal.fields.scope", scope: "decidim.proposals") %></th>
             <% end %>
+
             <th><%= t("models.proposal.fields.state", scope: "decidim.proposals") %></th>
-            <th><%= t("models.proposal.fields.votes", scope: "decidim.proposals") %></th>
+
+            <% if current_settings.votes_enabled? %>
+              <th><%= t("models.proposal.fields.votes", scope: "decidim.proposals") %></th>
+            <% end %>
+
             <th class="actions"><%= t("actions.title", scope: "decidim.proposals") %></th>
           </tr>
         </thead>
@@ -58,9 +63,11 @@
                   <%= humanize_proposal_state proposal.state %>
                 </strong>
               </td>
-              <td>
-                <%= proposal.votes.count %>
-              </td>
+              <% if current_settings.votes_enabled? %>
+                <td>
+                  <%= proposal.votes.count %>
+                </td>
+              <% end %>
               <td class="table-list__actions">
                 <% if can? :update, proposal %>
                   <%= icon_link_to "chat", edit_proposal_proposal_answer_path(proposal_id: proposal.id, id: proposal.id), t("actions.answer", scope: "decidim.proposals"), class: "action-icon--edit-answer" %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -26,6 +26,7 @@
               <th><%= t("models.proposal.fields.scope", scope: "decidim.proposals") %></th>
             <% end %>
             <th><%= t("models.proposal.fields.state", scope: "decidim.proposals") %></th>
+            <th><%= t("models.proposal.fields.votes", scope: "decidim.proposals") %></th>
             <th class="actions"><%= t("actions.title", scope: "decidim.proposals") %></th>
           </tr>
         </thead>
@@ -56,6 +57,9 @@
                 <strong class="<%= proposal_state_css_class proposal.state %>">
                   <%= humanize_proposal_state proposal.state %>
                 </strong>
+              </td>
+              <td>
+                <%= proposal.votes.count %>
               </td>
               <td class="table-list__actions">
                 <% if can? :update, proposal %>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -88,6 +88,7 @@ en:
             scope: Scope
             state: State
             title: Title
+            votes: Votes
       proposal_votes:
         create:
           error: There's been errors when voting the proposal.

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -379,4 +379,44 @@ shared_examples "manage proposals" do
       end
     end
   end
+
+  context "when the votes_enabled feature setting is disabled" do
+    before do
+      current_feature.update_attributes!(
+        step_settings: {
+          feature.participatory_space.active_step.id => {
+            votes_enabled: false
+          }
+        }
+      )
+    end
+
+    it "doesn't show the votes column" do
+      visit current_path
+
+      within "thead" do
+        expect(page).not_to have_content("VOTES")
+      end
+    end
+  end
+
+  context "when the votes_enabled feature setting is enabled" do
+    before do
+      current_feature.update_attributes!(
+        step_settings: {
+          feature.participatory_space.active_step.id => {
+            votes_enabled: true
+          }
+        }
+      )
+    end
+
+    it "shows the votes column" do
+      visit current_path
+
+      within "thead" do
+        expect(page).to have_content("VOTES")
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Add votes column on proposals list in the admin. We'll need this column in order to make the column sortable.

#### :pushpin: Related Issues
- Related to #1993

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/x3ndP7M.png)
