### PR TITLE
Don't use constants for authorization handlers configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **decidim**: URLs now use the participatory space slug instead of the ID, both in the public pages and in the admin. Old routes using the space IDs now redirect to the ones using the slug. [\#1842](https://github.com/decidim/decidim/pull/1842)
 - **decidim**: `bin/rails generate decidim:demo` is no longer available in generated applications. Use the `--demo` flag when generating your application or do the change manually if you want to use the "demo" authorization handler. [\#1978](https://github.com/decidim/decidim/pull/1978)
 - **decidim-core**: Changes some texts in the homepage ("How do I take part in a process?" section) [\#1947](https://github.com/decidim/decidim/pull/1947)
+- **decidim-core**: Authorization handlers now must be specified as strings. To migrate, change `config.authorization_handlers = [MyHandler]` to `config.authorization_handlers = ["MyHandler"]`. [\#2016](https://github.com/decidim/decidim/pull/2016)
 
 **Fixed**
 

--- a/decidim-core/app/models/decidim/authorization.rb
+++ b/decidim-core/app/models/decidim/authorization.rb
@@ -13,14 +13,14 @@ module Decidim
   class Authorization < ApplicationRecord
     belongs_to :user, foreign_key: "decidim_user_id", class_name: "Decidim::User", inverse_of: :authorizations
 
-    validates :name, :handler, presence: true
     validates :name, uniqueness: { scope: :decidim_user_id }
 
-    # The handler that created this authorization.
-    #
-    # Returns an instance that inherits from Decidim::AuthorizationHandler.
-    def handler
-      @handler ||= AuthorizationHandler.handler_for(name, metadata)
+    validate :active_handler?
+
+    private
+
+    def active_handler?
+      AuthorizationHandler.active_handler?(name)
     end
   end
 end

--- a/decidim-core/app/services/decidim/authorization_handler.rb
+++ b/decidim-core/app/services/decidim/authorization_handler.rb
@@ -83,10 +83,13 @@ module Decidim
     # Returns an AuthorizationHandler descendant.
     # Returns nil when no handlers could be found.
     def self.handler_for(name, params = {})
-      return unless name
-      handler_klass = name.classify
-      return unless Decidim.authorization_handlers.include?(handler_klass)
-      handler_klass.constantize.from_params(params || {})
+      return unless active_handler?(name)
+
+      name.classify.constantize.from_params(params || {})
+    end
+
+    def self.active_handler?(name)
+      name && Decidim.authorization_handlers.include?(name.classify)
     end
   end
 end

--- a/decidim-core/app/services/decidim/authorization_handler.rb
+++ b/decidim-core/app/services/decidim/authorization_handler.rb
@@ -85,7 +85,7 @@ module Decidim
     def self.handler_for(name, params = {})
       return unless name
       handler_klass = name.classify
-      return unless Decidim.authorization_handlers.map(&:to_s).include?(handler_klass)
+      return unless Decidim.authorization_handlers.include?(handler_klass)
       handler_klass.constantize.from_params(params || {})
     end
   end

--- a/decidim-core/db/migrate/20170313095436_add_available_authorizations_to_organization.rb
+++ b/decidim-core/db/migrate/20170313095436_add_available_authorizations_to_organization.rb
@@ -8,7 +8,7 @@ class AddAvailableAuthorizationsToOrganization < ActiveRecord::Migration[5.0]
   def change
     add_column :decidim_organizations, :available_authorizations, :string, array: true, default: []
 
-    handlers = Decidim.authorization_handlers.map(&:name)
+    handlers = Decidim.authorization_handlers
     Organization.find_each do |org|
       org.update_attributes!(available_authorizations: handlers)
     end

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -21,7 +21,7 @@ if !Rails.env.production? || ENV["SEED"]
     default_locale: Decidim.default_locale,
     available_locales: Decidim.available_locales,
     reference_prefix: Faker::Name.suffix,
-    available_authorizations: Decidim.authorization_handlers.map(&:name)
+    available_authorizations: Decidim.authorization_handlers
   )
 
   province = Decidim::ScopeType.create!(

--- a/decidim-core/spec/commands/decidim/authorize_user_spec.rb
+++ b/decidim-core/spec/commands/decidim/authorize_user_spec.rb
@@ -41,14 +41,6 @@ module Decidim
       let(:user) { create(:user) }
       let(:unique_id) { "foo" }
 
-      before do
-        Decidim.authorization_handlers.push(DummyAuthorizationHandler)
-      end
-
-      after do
-        Decidim.authorization_handlers.delete(DummyAuthorizationHandler)
-      end
-
       context "when there's no other authorizations" do
         it "is valid if there's no authorization with the same id" do
           expect { subject.call }.to change { user.authorizations.count }.by(1)

--- a/decidim-core/spec/commands/decidim/authorize_user_spec.rb
+++ b/decidim-core/spec/commands/decidim/authorize_user_spec.rb
@@ -38,7 +38,6 @@ module Decidim
     end
 
     describe "uniqueness" do
-      let(:user) { create(:user) }
       let(:unique_id) { "foo" }
 
       context "when there's no other authorizations" do

--- a/decidim-core/spec/controllers/sessions_controller_spec.rb
+++ b/decidim-core/spec/controllers/sessions_controller_spec.rb
@@ -38,11 +38,7 @@ module Decidim
                 it { is_expected.to eq("/authorizations/first_login") }
               end
 
-              context "otherwise" do
-                before do
-                  Decidim.authorization_handlers = []
-                end
-
+              context "otherwise", without_authorizations: true do
                 it { is_expected.to eq("/") }
               end
             end

--- a/decidim-core/spec/features/authorizations_spec.rb
+++ b/decidim-core/spec/features/authorizations_spec.rb
@@ -123,12 +123,8 @@ describe "Authorizations", type: :feature, perform_enqueued: true do
       end
     end
 
-    context "when no authorizations are configured" do
+    context "when no authorizations are configured", without_authorizations: true do
       let(:authorizations) { [] }
-
-      before do
-        Decidim.authorization_handlers = []
-      end
 
       it "doesn't list authorizations" do
         click_link user.name

--- a/decidim-core/spec/features/authorizations_spec.rb
+++ b/decidim-core/spec/features/authorizations_spec.rb
@@ -9,13 +9,13 @@ describe "Authorizations", type: :feature, perform_enqueued: true do
 
   context "a new user" do
     let(:organization) { create :organization, available_authorizations: authorizations }
-    let(:authorizations) { ["Decidim::DummyAuthorizationHandler"] }
 
     let(:user) { create(:user, :confirmed, organization: organization) }
 
     context "when one authorization has been configured" do
+      let(:authorizations) { ["Decidim::DummyAuthorizationHandler"] }
+
       before do
-        Decidim.authorization_handlers = [Decidim::DummyAuthorizationHandler]
         visit decidim.root_path
         find(".sign-in-link").click
 

--- a/decidim-core/spec/services/decidim/authorization_handler_spec.rb
+++ b/decidim-core/spec/services/decidim/authorization_handler_spec.rb
@@ -54,11 +54,7 @@ module Decidim
         context "when the handler is valid" do
           let(:name) { "decidim/dummy_authorization_handler" }
 
-          context "when the handler is not configured" do
-            before do
-              Decidim.config.authorization_handlers = []
-            end
-
+          context "when the handler is not configured", without_authorizations: true do
             it { is_expected.to eq(nil) }
           end
 

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/authorization_handlers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/authorization_handlers.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.configure do |config|
-  config.before(:each) do
-    Decidim.config.authorization_handlers = [Decidim::DummyAuthorizationHandler]
+  config.around(:example, without_authorizations: true) do |example|
+    begin
+      previous_handlers = Decidim.authorization_handlers
+      Decidim.authorization_handlers = []
+
+      example.run
+    ensure
+      Decidim.authorization_handlers = previous_handlers
+    end
   end
 end

--- a/decidim-system/app/views/decidim/system/organizations/edit.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/edit.html.erb
@@ -14,7 +14,7 @@
 
   <div class="field">
     <%= f.label :available_authorizations %>
-    <%= f.collection_check_boxes :available_authorizations, Decidim.authorization_handlers, :name, :name %>
+    <%= f.collection_check_boxes :available_authorizations, Decidim.authorization_handlers, :itself, :itself %>
   </div>
 
   <div class="actions">

--- a/decidim-system/app/views/decidim/system/organizations/new.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/new.html.erb
@@ -55,7 +55,7 @@
 
   <div class="field">
     <%= f.label :available_authorizations %>
-    <%= f.collection_check_boxes :available_authorizations, Decidim.authorization_handlers, :name, :name %>
+    <%= f.collection_check_boxes :available_authorizations, Decidim.authorization_handlers, :itself, :itself %>
   </div>
 
   <div class="actions">

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -87,7 +87,7 @@ You'll need to reference it from the Decidim initializer:
 ```ruby
 # config/initializers/decidim.rb
 
-config.authorization_handlers = [<my authorization handler class>]
+config.authorization_handlers = ["<my authorization handler class>"]
 ```
 
 ## Deploy

--- a/lib/generators/decidim/app_generator.rb
+++ b/lib/generators/decidim/app_generator.rb
@@ -125,7 +125,7 @@ module Decidim
 
         gsub_file "config/initializers/decidim.rb",
                   /config\.mailer_sender = "change-me@domain\.org"/ do |match|
-          match << "\n  config.authorization_handlers = [#{auth_handler.classify}]"
+          match << "\n  config.authorization_handlers = [\"#{auth_handler.classify}\"]"
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Tests on `decidim-barcelona` running against current `decidim` master are failing because the authorization handler class is not yet available by the time tests are loaded.

I think it's better to not use constants directly on code that is evaluated at initialization/load time, since we need to make sure the constants are actually available at the time. That's inconvenient because you never need to care about that in other situations, and I sometimes have seen it causing problems with code (auto)loading.

This is similar to Rails deprecating specifying `class_name` as a constant in `ActiveRecord` associations.

This PR also includes some other refactorings in authorization handlers that I've extracted from another PR I'm working on (#1815 & #1871), to make reviewing that one easier.

#### :pushpin: Related Issues
- Related to #1994.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![house_of_cards](https://user-images.githubusercontent.com/2887858/31359983-956357fe-ad4c-11e7-86cc-bc3b3b72f361.gif)
