### PR TITLE
Processes: fix user invites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 - **decidim-core**: Handle nil resources on static maps (errors were caused by search engine spiders) [\#1936](https://github.com/decidim/decidim/pull/1936)
 - **decidim-comments**: Fix a bug sending email notifications when a comment is created [\#2036](https://github.com/decidim/decidim/pull/2036)
+- **decidim-participatory-processes**: Invited moderators couldn't access the process admin panel [\#2020](https://github.com/decidim/decidim/pull/2020)
 - **decidim-proposals**: Do not count hidden proposals on stats [\#1988](https://github.com/decidim/decidim/pull/1988)
 
 ## [v0.6.7](https://github.com/decidim/decidim/tree/v0.6.7) (2017-10-09)

--- a/decidim-admin/spec/features/admin_invite_spec.rb
+++ b/decidim-admin/spec/features/admin_invite_spec.rb
@@ -45,6 +45,7 @@ describe "Admin invite", type: :feature do
       end
 
       expect(page).to have_content("DASHBOARD")
+      expect(current_path).to eq "/admin/"
     end
   end
 end

--- a/decidim-core/app/commands/decidim/invite_user.rb
+++ b/decidim-core/app/commands/decidim/invite_user.rb
@@ -33,7 +33,7 @@ module Decidim
     def update_user
       user.admin = form.role == "admin"
       user.roles << form.role if form.role != "admin"
-      user.roles = user.roles.uniq
+      user.roles = user.roles.uniq.compact
       user.save!
     end
 
@@ -43,7 +43,7 @@ module Decidim
         email: form.email.downcase,
         organization: form.organization,
         admin: form.role == "admin",
-        roles: form.role == "admin" ? [] : [form.role]
+        roles: form.role == "admin" ? [] : [form.role].compact
       )
       @user.invite!(
         form.invited_by,

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -106,7 +106,7 @@ module Decidim
     end
 
     def all_roles_are_valid
-      errors.add(:roles, :invalid) unless roles.all? { |role| ROLES.include?(role) }
+      errors.add(:roles, :invalid) unless roles.compact.all? { |role| ROLES.include?(role) }
     end
 
     def available_locales

--- a/decidim-core/spec/features/authentication_spec.rb
+++ b/decidim-core/spec/features/authentication_spec.rb
@@ -286,6 +286,7 @@ describe "Authentication", type: :feature, perform_enqueued: true do
         end
 
         expect(page).to have_content("password has been changed successfully")
+        expect(current_path).to eq "/"
       end
     end
 

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
@@ -83,7 +83,7 @@ module Decidim
                     icon_name: "target",
                     position: 2,
                     active: :inclusive,
-                    if: can?(:manage, Decidim::ParticipatoryProcess)
+                    if: can?(:read, Decidim::ParticipatoryProcess)
 
           menu.item I18n.t("menu.participatory_process_groups", scope: "decidim.admin"),
                     decidim_admin_participatory_processes.participatory_process_groups_path,

--- a/decidim-participatory_processes/spec/features/admin/invite_process_admin_spec.rb
+++ b/decidim-participatory_processes/spec/features/admin/invite_process_admin_spec.rb
@@ -2,8 +2,9 @@
 
 require "spec_helper"
 
-describe "Invite process moderator", type: :feature do
+describe "Invite process administrator", type: :feature do
   include_context "invite process users"
+  let(:role) { "Administrator" }
 
   before do
     switch_to_host organization.host
@@ -35,7 +36,7 @@ describe "Invite process moderator", type: :feature do
         end
 
         within ".secondary-nav" do
-          expect(page.text).to eq "Moderations"
+          expect(page.text).to eq "Info Steps Features Categories Attachments Process users Moderations"
         end
       end
     end
@@ -43,16 +44,16 @@ describe "Invite process moderator", type: :feature do
 
   context "when the user already exists" do
     describe "Accept an invitation", perform_enqueued: true do
-      let(:email) { "moderator@example.org" }
-      let(:moderator) { @moderator }
+      let(:email) { "administrator@example.org" }
+      let(:administrator) { @administrator }
 
       before do
-        @moderator = create :user, :confirmed, email: email, organization: organization
+        @administrator = create :user, :confirmed, email: email, organization: organization
         invite_user
       end
 
-      it "redirects the moderator to the admin dashboard" do
-        login_as moderator, scope: :user
+      it "redirects the administrator to the admin dashboard" do
+        login_as administrator, scope: :user
 
         visit decidim_admin.root_path
         expect(page).to have_content("DASHBOARD")
@@ -65,7 +66,7 @@ describe "Invite process moderator", type: :feature do
         end
 
         within ".secondary-nav" do
-          expect(page.text).to eq "Moderations"
+          expect(page.text).to eq "Info Steps Features Categories Attachments Process users Moderations"
         end
       end
     end

--- a/decidim-participatory_processes/spec/features/admin/invite_process_collaborator_spec.rb
+++ b/decidim-participatory_processes/spec/features/admin/invite_process_collaborator_spec.rb
@@ -2,8 +2,9 @@
 
 require "spec_helper"
 
-describe "Invite process moderator", type: :feature do
+describe "Invite process collaborator", type: :feature do
   include_context "invite process users"
+  let(:role) { "Collaborator" }
 
   before do
     switch_to_host organization.host
@@ -31,11 +32,6 @@ describe "Invite process moderator", type: :feature do
 
         within "#processes" do
           expect(page).to have_i18n_content(participatory_process.title)
-          click_link translated(participatory_process.title)
-        end
-
-        within ".secondary-nav" do
-          expect(page.text).to eq "Moderations"
         end
       end
     end
@@ -43,16 +39,16 @@ describe "Invite process moderator", type: :feature do
 
   context "when the user already exists" do
     describe "Accept an invitation", perform_enqueued: true do
-      let(:email) { "moderator@example.org" }
-      let(:moderator) { @moderator }
+      let(:email) { "collaborator@example.org" }
+      let(:collaborator) { @collaborator }
 
       before do
-        @moderator = create :user, :confirmed, email: email, organization: organization
+        @collaborator = create :user, :confirmed, email: email, organization: organization
         invite_user
       end
 
-      it "redirects the moderator to the admin dashboard" do
-        login_as moderator, scope: :user
+      it "redirects the collaborator to the admin dashboard" do
+        login_as collaborator, scope: :user
 
         visit decidim_admin.root_path
         expect(page).to have_content("DASHBOARD")
@@ -61,11 +57,6 @@ describe "Invite process moderator", type: :feature do
 
         within "#processes" do
           expect(page).to have_i18n_content(participatory_process.title)
-          click_link translated(participatory_process.title)
-        end
-
-        within ".secondary-nav" do
-          expect(page.text).to eq "Moderations"
         end
       end
     end

--- a/decidim-participatory_processes/spec/features/admin/invite_process_moderator_spec.rb
+++ b/decidim-participatory_processes/spec/features/admin/invite_process_moderator_spec.rb
@@ -21,6 +21,71 @@ describe "Invite process moderator", type: :feature do
 
   before do
     switch_to_host organization.host
+  end
+
+  context "when the user does not exist" do
+    describe "Accept an invitation", perform_enqueued: true do
+      before do
+        invite_user
+      end
+
+      it "asks for a password and redirects to the admin dashboard" do
+        visit last_email_link
+
+        within "form.new_user" do
+          fill_in :user_password, with: "123456"
+          fill_in :user_password_confirmation, with: "123456"
+          find("*[type=submit]").click
+        end
+
+        expect(current_path).to eq "/admin/"
+        expect(page).to have_content("DASHBOARD")
+
+        click_link "Processes"
+
+        within "#processes" do
+          expect(page).to have_i18n_content(participatory_process.title)
+          click_link translated(participatory_process.title)
+        end
+
+        within ".secondary-nav" do
+          expect(page.text).to eq "Moderations"
+        end
+      end
+    end
+  end
+
+  context "when the user already exists" do
+    describe "Accept an invitation", perform_enqueued: true do
+      let(:email) { "moderator@example.org" }
+      let(:moderator) { @moderator }
+
+      before do
+        @moderator = create :user, :confirmed, email: email, organization: organization
+        invite_user
+      end
+
+      it "redirects the moderator to the admin dashboard" do
+        login_as moderator, scope: :user
+
+        visit decidim_admin.root_path
+        expect(page).to have_content("DASHBOARD")
+
+        click_link "Processes"
+
+        within "#processes" do
+          expect(page).to have_i18n_content(participatory_process.title)
+          click_link translated(participatory_process.title)
+        end
+
+        within ".secondary-nav" do
+          expect(page.text).to eq "Moderations"
+        end
+      end
+    end
+  end
+
+  def invite_user
     login_as user, scope: :user
 
     visit decidim_admin_participatory_processes.participatory_process_user_roles_path(participatory_process)
@@ -33,22 +98,5 @@ describe "Invite process moderator", type: :feature do
     select role, from: "Role"
     click_button "Create"
     logout :user
-  end
-
-  context "when the user does not exist" do
-    describe "Accept an invitation", perform_enqueued: true do
-      it "asks for a password and redirects to the admin dashboard" do
-        visit last_email_link
-
-        within "form.new_user" do
-          fill_in :user_password, with: "123456"
-          fill_in :user_password_confirmation, with: "123456"
-          find("*[type=submit]").click
-        end
-
-        expect(current_path).to eq "/admin/"
-        expect(page).to have_content("DASHBOARD")
-      end
-    end
   end
 end

--- a/decidim-participatory_processes/spec/features/admin/invite_process_moderator_spec.rb
+++ b/decidim-participatory_processes/spec/features/admin/invite_process_moderator_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Invite process moderator", type: :feature do
+  let(:form) do
+    Decidim::ParticipatoryProcesses::Admin::ParticipatoryProcessUserRoleForm.from_params(params)
+  end
+  let(:participatory_process) { create :participatory_process }
+  let(:organization) { participatory_process.organization }
+  let(:user) { create :user, :admin, :confirmed, organization: participatory_process.organization }
+  let(:email) { "this_email_does_not_exist@example.org" }
+  let(:role) { "Moderator" }
+  let(:params) do
+    {
+      name: "Alice Liddel",
+      email: email,
+      role: role
+    }
+  end
+
+  before do
+    switch_to_host organization.host
+    login_as user, scope: :user
+
+    visit decidim_admin_participatory_processes.participatory_process_user_roles_path(participatory_process)
+    within ".container" do
+      click_link "New"
+    end
+
+    fill_in "Name", with: "Alice Liddel"
+    fill_in "Email", with: email
+    select role, from: "Role"
+    click_button "Create"
+    logout :user
+  end
+
+  context "when the user does not exist" do
+    describe "Accept an invitation", perform_enqueued: true do
+      it "asks for a password and redirects to the admin dashboard" do
+        visit last_email_link
+
+        within "form.new_user" do
+          fill_in :user_password, with: "123456"
+          fill_in :user_password_confirmation, with: "123456"
+          find("*[type=submit]").click
+        end
+
+        within ".callout-wrapper" do
+          page.find(".close-button").click
+        end
+
+        expect(page).to have_content("DASHBOARD")
+        expect(current_path).to eq "/admin/"
+      end
+    end
+  end
+end

--- a/decidim-participatory_processes/spec/features/admin/invite_process_moderator_spec.rb
+++ b/decidim-participatory_processes/spec/features/admin/invite_process_moderator_spec.rb
@@ -46,12 +46,8 @@ describe "Invite process moderator", type: :feature do
           find("*[type=submit]").click
         end
 
-        within ".callout-wrapper" do
-          page.find(".close-button").click
-        end
-
-        expect(page).to have_content("DASHBOARD")
         expect(current_path).to eq "/admin/"
+        expect(page).to have_content("DASHBOARD")
       end
     end
   end

--- a/decidim-participatory_processes/spec/shared/invite_process_users_shared_context.rb
+++ b/decidim-participatory_processes/spec/shared/invite_process_users_shared_context.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+shared_context "invite process users" do
+  let(:participatory_process) { create :participatory_process }
+  let(:organization) { participatory_process.organization }
+  let(:user) { create :user, :admin, :confirmed, organization: participatory_process.organization }
+  let(:email) { "this_email_does_not_exist@example.org" }
+  let(:role) { "Moderator" }
+
+  def invite_user
+    login_as user, scope: :user
+
+    visit decidim_admin_participatory_processes.participatory_process_user_roles_path(participatory_process)
+    within ".container" do
+      click_link "New"
+    end
+
+    fill_in "Name", with: "Alice Liddel"
+    fill_in "Email", with: email
+    select role, from: "Role"
+    click_button "Create"
+    logout :user
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Moderator invites are broken. This PR tries to fix them.

#### :pushpin: Related Issues
- Fixes #1995.

#### :clipboard: Subtasks
- [x] Fix moderator invites for new users
- [x] Fix moderator invites for existing users
