### PR TITLE
Add proposal answer callout when evaluating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - **decidim**: `bin/rails generate decidim:demo` is no longer available in generated applications. Use the `--demo` flag when generating your application or do the change manually if you want to use the "demo" authorization handler. [\#1978](https://github.com/decidim/decidim/pull/1978)
 - **decidim-core**: Changes some texts in the homepage ("How do I take part in a process?" section) [\#1947](https://github.com/decidim/decidim/pull/1947)
 - **decidim-core**: Authorization handlers now must be specified as strings. To migrate, change `config.authorization_handlers = [MyHandler]` to `config.authorization_handlers = ["MyHandler"]`. [\#2016](https://github.com/decidim/decidim/pull/2016)
+- **decidim-proposals**: Change proposal answer callouts so they match their real state [\#2025](https://github.com/decidim/decidim/pull/2025)
 - **decidim-results**: Results description is truncated to 100 chars on the public list view [\#2008](https://github.com/decidim/decidim/pull/2008)
 
 **Fixed**

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -52,10 +52,17 @@
             <p><%= sanitize translated_attribute @proposal.answer %></p>
           </div>
         </div>
-      <% else %>
+      <% elsif @proposal.rejected? %>
         <div class="section">
           <div class="callout warning">
             <h5><%= t(".proposal_rejected_reason") %></h5>
+            <p><%= sanitize translated_attribute @proposal.answer %></p>
+          </div>
+        </div>
+      <% else %>
+        <div class="section">
+          <div class="callout secondary">
+            <h5><%= t(".proposal_in_evaluation_reason") %></h5>
             <p><%= sanitize translated_attribute @proposal.answer %></p>
           </div>
         </div>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -144,6 +144,7 @@ en:
           view_proposal: View proposal
         show:
           proposal_accepted_reason: 'This proposal has been accepted because:'
+          proposal_in_evaluation_reason: This proposal is being evaluated
           proposal_rejected_reason: 'This proposal has been rejected because:'
           report: Report
         vote_button:

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -82,6 +82,11 @@ FactoryGirl.define do
       author nil
     end
 
+    trait :evaluating do
+      state "evaluating"
+      answered_at { Time.current }
+    end
+
     trait :accepted do
       state "accepted"
       answered_at { Time.current }
@@ -89,8 +94,11 @@ FactoryGirl.define do
 
     trait :rejected do
       state "rejected"
-      answer { Decidim::Faker::Localized.sentence }
       answered_at { Time.current }
+    end
+
+    trait :with_answer do
+      answer { Decidim::Faker::Localized.sentence }
     end
   end
 

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -361,39 +361,51 @@ describe "Proposals", type: :feature do
       end
     end
 
-    context "when a proposal has been accepted" do
-      let!(:proposal) { create(:proposal, :accepted, feature: feature) }
+    context "when a proposal is in evaluation" do
+      let!(:proposal) { create(:proposal, :evaluating, :with_answer, feature: feature) }
 
-      it "shows a badge" do
+      it "shows a badge and an answer" do
         visit_feature
         click_link proposal.title
 
-        expect(page).to have_content("Accepted")
-        expect(page).to have_i18n_content(proposal.answer)
+        expect(page).to have_content("Evaluating")
+
+        within ".callout.secondary" do
+          expect(page).to have_content("This proposal is being evaluated")
+          expect(page).to have_i18n_content(proposal.answer)
+        end
       end
     end
 
     context "when a proposal has been rejected" do
-      let!(:proposal) { create(:proposal, :rejected, feature: feature) }
+      let!(:proposal) { create(:proposal, :rejected, :with_answer, feature: feature) }
 
       it "shows the rejection reason" do
         visit_feature
         click_link proposal.title
 
         expect(page).to have_content("Rejected")
-        expect(page).to have_i18n_content(proposal.answer)
+
+        within ".callout.warning" do
+          expect(page).to have_content("This proposal has been rejected")
+          expect(page).to have_i18n_content(proposal.answer)
+        end
       end
     end
 
     context "when a proposal has been accepted" do
-      let!(:proposal) { create(:proposal, :accepted, feature: feature) }
+      let!(:proposal) { create(:proposal, :accepted, :with_answer, feature: feature) }
 
       it "shows the acceptance reason" do
         visit_feature
         click_link proposal.title
 
         expect(page).to have_content("Accepted")
-        expect(page).to have_i18n_content(proposal.answer)
+
+        within ".callout.success" do
+          expect(page).to have_content("This proposal has been accepted")
+          expect(page).to have_i18n_content(proposal.answer)
+        end
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Proposals in evaluation showed answers in a `rejected` callout, which looks weird. This makes the proposal look like it's both rejected and in evaluation, which is wrong. This PR adds another style for callouts for proposals in evaluation, so that in matches the style of the badge. See screenshots below.

Found in https://www.decidimmataro.cat/processes/4/f/21/proposals/201

Fixes #1999

### :camera: Screenshots (optional)
Before (badge is "Evaluating", callout is "rejected"):
![Description](https://i.imgur.com/tWIxVZj.png)

Before (badge is "Evaluating", callout is "evaluating"):
![Description](https://i.imgur.com/exBEnmb.png)

