### PR TITLE
Conditionally pass test suites

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,10 +125,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run core JS tests
-          command: ./.circleci/run_tests.sh decidim-core "time npm test -- decidim-core"
+          command: ./.circleci/run_tests.sh decidim-core "npm test -- decidim-core"
       - run:
           name: Run core RSpec
-          command: ./.circleci/run_tests.sh decidim-core "cd decidim-core && time bundle exec rake"
+          command: ./.circleci/run_tests.sh decidim-core "cd decidim-core && bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   assemblies:
@@ -145,10 +145,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run assemblies JS tests
-          command: ./.circleci/run_tests.sh decidim-assemblies "time npm test -- decidim-assemblies"
+          command: ./.circleci/run_tests.sh decidim-assemblies "npm test -- decidim-assemblies"
       - run:
           name: Run assemblies RSpec
-          command: ./.circleci/run_tests.sh decidim-assemblies "cd decidim-assemblies && time bundle exec rake"
+          command: ./.circleci/run_tests.sh decidim-assemblies "cd decidim-assemblies && bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   api:
@@ -165,10 +165,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run api JS tests
-          command: ./.circleci/run_tests.sh decidim-api "time npm test -- decidim-api"
+          command: ./.circleci/run_tests.sh decidim-api "npm test -- decidim-api"
       - run:
           name: Run api RSpec
-          command: ./.circleci/run_tests.sh decidim-api "cd decidim-api && time bundle exec rake"
+          command: ./.circleci/run_tests.sh decidim-api "cd decidim-api && bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   processes:
@@ -185,10 +185,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run participatory_processes JS tests
-          command: ./.circleci/run_tests.sh decidim-participatory_processes "time npm test -- decidim-participatory_processes"
+          command: ./.circleci/run_tests.sh decidim-participatory_processes "npm test -- decidim-participatory_processes"
       - run:
           name: Run participatory_processes RSpec
-          command: ./.circleci/run_tests.sh decidim-participatory_processes "cd decidim-participatory_processes && time bundle exec rake"
+          command: ./.circleci/run_tests.sh decidim-participatory_processes "cd decidim-participatory_processes && bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   admin:
@@ -205,10 +205,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run admin JS tests
-          command: ./.circleci/run_tests.sh decidim-admin "time npm test -- decidim-admin"
+          command: ./.circleci/run_tests.sh decidim-admin "npm test -- decidim-admin"
       - run:
           name: Run admin RSpec
-          command: ./.circleci/run_tests.sh decidim-admin "cd decidim-admin && time bundle exec rake"
+          command: ./.circleci/run_tests.sh decidim-admin "cd decidim-admin && bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   system:
@@ -225,10 +225,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run system JS tests
-          command: ./.circleci/run_tests.sh decidim-system "time npm test -- decidim-system"
+          command: ./.circleci/run_tests.sh decidim-system "npm test -- decidim-system"
       - run:
           name: Run system RSpec
-          command: ./.circleci/run_tests.sh decidim-system "cd decidim-system && time bundle exec rake"
+          command: ./.circleci/run_tests.sh decidim-system "cd decidim-system && bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   proposals:
@@ -245,10 +245,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run proposals JS tests
-          command: ./.circleci/run_tests.sh decidim-proposals "time npm test -- decidim-proposals"
+          command: ./.circleci/run_tests.sh decidim-proposals "npm test -- decidim-proposals"
       - run:
           name: Run proposals RSpec
-          command: ./.circleci/run_tests.sh decidim-proposals "cd decidim-proposals && time bundle exec rake"
+          command: ./.circleci/run_tests.sh decidim-proposals "cd decidim-proposals && bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   comments:
@@ -265,10 +265,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run comments JS tests
-          command: ./.circleci/run_tests.sh decidim-comments "time npm test -- decidim-comments"
+          command: ./.circleci/run_tests.sh decidim-comments "npm test -- decidim-comments"
       - run:
           name: Run comments RSpec
-          command: ./.circleci/run_tests.sh decidim-comments "cd decidim-comments && time bundle exec rake"
+          command: ./.circleci/run_tests.sh decidim-comments "cd decidim-comments && bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   meetings:
@@ -285,10 +285,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run meetings JS tests
-          command: ./.circleci/run_tests.sh decidim-meetings "time npm test -- decidim-meetings"
+          command: ./.circleci/run_tests.sh decidim-meetings "npm test -- decidim-meetings"
       - run:
           name: Run meetings RSpec
-          command: ./.circleci/run_tests.sh decidim-meetings "cd decidim-meetings && time bundle exec rake"
+          command: ./.circleci/run_tests.sh decidim-meetings "cd decidim-meetings && bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   pages:
@@ -305,10 +305,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run pages JS tests
-          command: ./.circleci/run_tests.sh decidim-pages "time npm test -- decidim-pages"
+          command: ./.circleci/run_tests.sh decidim-pages "npm test -- decidim-pages"
       - run:
           name: Run pages RSpec
-          command: ./.circleci/run_tests.sh decidim-pages "cd decidim-pages && time bundle exec rake"
+          command: ./.circleci/run_tests.sh decidim-pages "cd decidim-pages && bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   accountability:
@@ -325,10 +325,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run accountability JS tests
-          command: ./.circleci/run_tests.sh decidim-accountability "time npm test -- decidim-accountability"
+          command: ./.circleci/run_tests.sh decidim-accountability "npm test -- decidim-accountability"
       - run:
           name: Run accountability RSpec
-          command: ./.circleci/run_tests.sh decidim-accountability "cd decidim-accountability && time bundle exec rake"
+          command: ./.circleci/run_tests.sh decidim-accountability "cd decidim-accountability && bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   budgets:
@@ -345,10 +345,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run budgets JS tests
-          command: ./.circleci/run_tests.sh decidim-budgets "time npm test -- decidim-budgets"
+          command: ./.circleci/run_tests.sh decidim-budgets "npm test -- decidim-budgets"
       - run:
           name: Run budgets RSpec
-          command: ./.circleci/run_tests.sh decidim-budgets "cd decidim-budgets && time bundle exec rake"
+          command: ./.circleci/run_tests.sh decidim-budgets "cd decidim-budgets && bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   surveys:
@@ -365,10 +365,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run surveys JS tests
-          command: ./.circleci/run_tests.sh decidim-surveys "time npm test -- decidim-surveys"
+          command: ./.circleci/run_tests.sh decidim-surveys "npm test -- decidim-surveys"
       - run:
           name: Run surveys RSpec
-          command: ./.circleci/run_tests.sh decidim-surveys "cd decidim-surveys && time bundle exec rake"
+          command: ./.circleci/run_tests.sh decidim-surveys "cd decidim-surveys && bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,10 +125,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run core JS tests
-          command: npm test -- decidim-core
+          command: ./.circleci/run_tests.sh decidim-core "time npm test -- decidim-core"
       - run:
           name: Run core RSpec
-          command: cd decidim-core && bundle exec rake
+          command: ./circleci/run_tests.sh decidim-core "cd decidim-core && time bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   assemblies:
@@ -145,10 +145,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run assemblies JS tests
-          command: npm test -- decidim-assemblies
+          command: ./.circleci/run_tests.sh decidim-assemblies "time npm test -- decidim-assemblies"
       - run:
           name: Run assemblies RSpec
-          command: cd decidim-assemblies && bundle exec rake
+          command: ./.circleci/run_tests.sh decidim-assemblies "cd decidim-assemblies && time bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   api:
@@ -165,10 +165,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run api JS tests
-          command: npm test -- decidim-api
+          command: ./.circleci/run_tests.sh decidim-api "time npm test -- decidim-api"
       - run:
           name: Run api RSpec
-          command: cd decidim-api && bundle exec rake
+          command: ./.circleci/run_tests.sh decidim-api "cd decidim-api && time bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   processes:
@@ -185,10 +185,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run participatory_processes JS tests
-          command: npm test -- decidim-participatory_processes
+          command: ./.circleci/run_tests.sh decidim-participatory_processes "time npm test -- decidim-participatory_processes"
       - run:
           name: Run participatory_processes RSpec
-          command: cd decidim-participatory_processes && bundle exec rake
+          command: ./.circleci/run_tests.sh decidim-participatory_processes "cd decidim-participatory_processes && time bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   admin:
@@ -205,10 +205,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run admin JS tests
-          command: npm test -- decidim-admin
+          command: ./.circleci/run_tests.sh decidim-admin "time npm test -- decidim-admin"
       - run:
           name: Run admin RSpec
-          command: cd decidim-admin && bundle exec rake
+          command: ./.circleci/run_tests.sh decidim-admin "cd decidim-admin && time bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   system:
@@ -225,10 +225,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run system JS tests
-          command: npm test -- decidim-system
+          command: ./.circleci/run_tests.sh decidim-system "time npm test -- decidim-system"
       - run:
           name: Run system RSpec
-          command: cd decidim-system && bundle exec rake
+          command: ./.circleci/run_tests.sh decidim-system "cd decidim-system && time bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   proposals:
@@ -245,10 +245,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run proposals JS tests
-          command: npm test -- decidim-proposals
+          command: ./.circleci/run_tests.sh decidim-proposals "time npm test -- decidim-proposals"
       - run:
           name: Run proposals RSpec
-          command: cd decidim-proposals && bundle exec rake
+          command: ./.circleci/run_tests.sh decidim-proposals "cd decidim-proposals && time bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   comments:
@@ -265,10 +265,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run comments JS tests
-          command: npm test -- decidim-comments
+          command: ./.circleci/run_tests.sh decidim-comments "time npm test -- decidim-comments"
       - run:
           name: Run comments RSpec
-          command: cd decidim-comments && bundle exec rake
+          command: ./.circleci/run_tests.sh decidim-comments "cd decidim-comments && time bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   meetings:
@@ -285,10 +285,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run meetings JS tests
-          command: npm test -- decidim-meetings
+          command: ./.circleci/run_tests.sh decidim-meetings "time npm test -- decidim-meetings"
       - run:
           name: Run meetings RSpec
-          command: cd decidim-meetings && bundle exec rake
+          command: ./.circleci/run_tests.sh decidim-meetings "cd decidim-meetings && time bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   pages:
@@ -305,10 +305,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run pages JS tests
-          command: npm test -- decidim-pages
+          command: ./.circleci/run_tests.sh decidim-pages "time npm test -- decidim-pages"
       - run:
           name: Run pages RSpec
-          command: cd decidim-pages && bundle exec rake
+          command: ./.circleci/run_tests.sh decidim-pages "cd decidim-pages && time bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   accountability:
@@ -325,10 +325,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run accountability JS tests
-          command: npm test -- decidim-accountability
+          command: ./.circleci/run_tests.sh decidim-accountability "time npm test -- decidim-accountability"
       - run:
           name: Run accountability RSpec
-          command: cd decidim-accountability && bundle exec rake
+          command: ./.circleci/run_tests.sh decidim-accountability "cd decidim-accountability && time bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   budgets:
@@ -345,10 +345,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run budgets JS tests
-          command: npm test -- decidim-budgets
+          command: ./.circleci/run_tests.sh decidim-budgets "time npm test -- decidim-budgets"
       - run:
           name: Run budgets RSpec
-          command: cd decidim-budgets && bundle exec rake
+          command: ./.circleci/run_tests.sh decidim-budgets "cd decidim-budgets && time bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   surveys:
@@ -365,10 +365,10 @@ jobs:
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
       - run:
           name: Run surveys JS tests
-          command: npm test -- decidim-surveys
+          command: ./.circleci/run_tests.sh decidim-surveys "time npm test -- decidim-surveys"
       - run:
           name: Run surveys RSpec
-          command: cd decidim-surveys && bundle exec rake
+          command: ./.circleci/run_tests.sh decidim-surveys "cd decidim-surveys && time bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
           command: ./.circleci/run_tests.sh decidim-core "time npm test -- decidim-core"
       - run:
           name: Run core RSpec
-          command: ./circleci/run_tests.sh decidim-core "cd decidim-core && time bundle exec rake"
+          command: ./.circleci/run_tests.sh decidim-core "cd decidim-core && time bundle exec rake"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   assemblies:

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -3,7 +3,12 @@
 engine=$1
 testCommand=$2
 branch=`git rev-parse --abbrev-ref HEAD`
+echo $branch
 modifiedFiles="git diff --name-only $branch master"
+
+git checkout master
+git reset --hard origin/master
+git checkout -
 
 if git diff --name-only $branch master | grep "^decidim-core" ; then
   echo "YES"

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -5,7 +5,10 @@ testCommand=$2
 branch=`git rev-parse --abbrev-ref HEAD`
 modifiedFiles="git diff --name-only $branch master"
 
-if git diff --name-only $branch master | grep "^${engine}" ; then
+if git diff --name-only $branch master | grep "^decidim-core" ; then
+  echo "YES"
+  eval $testCommand
+elif git diff --name-only $branch master | grep "^${engine}" ; then
   echo "YES"
   eval $testCommand
 else

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -6,11 +6,14 @@ branch=`git rev-parse --abbrev-ref HEAD`
 echo $branch
 modifiedFiles="git diff --name-only $branch master"
 
-git checkout master
-git reset --hard origin/master
-git checkout -
+# git checkout master
+# git reset --hard origin/master
+# git checkout -
 
-if git diff --name-only $branch master | grep "^decidim-core" ; then
+if [ "$branch" = "master" ]; then
+   echo "YES, IT'S MASTER!!"
+   eval $testCommand
+elif git diff --name-only $branch master | grep "^decidim-core" ; then
   echo "YES"
   eval $testCommand
 elif git diff --name-only $branch master | grep "^${engine}" ; then

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+engine=$1
+testCommand=$2
+branch=`git rev-parse --abbrev-ref HEAD`
+
+if git diff --name-only $branch master | grep "^${engine}" ; then
+  echo "YES"
+  echo $testCommand
+else
+  echo "NO"
+fi

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -3,21 +3,19 @@
 engine=$1
 testCommand=$2
 branch=`git rev-parse --abbrev-ref HEAD`
-echo $branch
-modifiedFiles="git diff --name-only $branch master"
 
-git checkout master
-git reset --hard origin/master
-git checkout -
+# git checkout master
+# git reset --hard origin/master
+# git checkout -
 
 if [ "$branch" = "master" ]; then
-   echo "YES, IT'S MASTER!!"
-   eval $testCommand
-elif git diff --name-only $branch master | grep "^decidim-core" ; then
-  echo "YES"
+  echo "YES, IT'S MASTER!!"
   eval $testCommand
-elif git diff --name-only $branch master | grep "^${engine}" ; then
-  echo "YES"
+elif git diff --name-only $branch origin/master | grep "^decidim-core" ; then
+  echo "YES, CORE IS BEING MODIFIED"
+  eval $testCommand
+elif git diff --name-only $branch origin/master | grep "^${engine}" ; then
+  echo "YES, THIS ENGINE IS BEING MODIFIED"
   eval $testCommand
 else
   echo "NO"

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -6,9 +6,9 @@ branch=`git rev-parse --abbrev-ref HEAD`
 echo $branch
 modifiedFiles="git diff --name-only $branch master"
 
-# git checkout master
-# git reset --hard origin/master
-# git checkout -
+git checkout master
+git reset --hard origin/master
+git checkout -
 
 if [ "$branch" = "master" ]; then
    echo "YES, IT'S MASTER!!"

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -3,10 +3,11 @@
 engine=$1
 testCommand=$2
 branch=`git rev-parse --abbrev-ref HEAD`
+modifiedFiles="git diff --name-only $branch master"
 
 if git diff --name-only $branch master | grep "^${engine}" ; then
   echo "YES"
-  echo $testCommand
+  eval $testCommand
 else
   echo "NO"
 fi

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -4,17 +4,13 @@ engine=$1
 testCommand=$2
 branch=`git rev-parse --abbrev-ref HEAD`
 
-# git checkout master
-# git reset --hard origin/master
-# git checkout -
-
 if [ "$branch" = "master" ]; then
   echo "YES, IT'S MASTER!!"
   eval $testCommand
-elif git diff --name-only $branch origin/master | grep "^decidim-core" ; then
+elif git diff --name-only origin/master...$branch  | grep "^decidim-core" ; then
   echo "YES, CORE IS BEING MODIFIED"
   eval $testCommand
-elif git diff --name-only $branch origin/master | grep "^${engine}" ; then
+elif git diff --name-only origin/master...$branch  | grep "^${engine}" ; then
   echo "YES, THIS ENGINE IS BEING MODIFIED"
   eval $testCommand
 else

--- a/codecov.yml
+++ b/codecov.yml
@@ -65,41 +65,54 @@ ignore:
 
 flags:
   core:
+    assume: true
     paths:
       - decidim-core/
   assemblies:
+    assume: true
     paths:
       - decidim-assemblies/
   api:
+    assume: true
     paths:
       - decidim-api/
   processes:
+    assume: true
     paths:
       - decidim-participatory_processes/
   admin:
+    assume: true
     paths:
       - decidim-admin/
   system:
+    assume: true
     paths:
       - decidim-system/
   proposals:
+    assume: true
     paths:
       - decidim-proposals/
   comments:
+    assume: true
     paths:
       - decidim-comments/
   meetings:
+    assume: true
     paths:
       - decidim-meetings/
   pages:
+    assume: true
     paths:
       - decidim-pages/
   accountability:
+    assume: true
     paths:
       - decidim-accountability/
   budgets:
+    assume: true
     paths:
       - decidim-budgets/
   surveys:
+    assume: true
     paths:
       - decidim-surveys/


### PR DESCRIPTION
#### :tophat: What? Why?
Let's try to conditionally run tests on CircleCI:

- [x] If we're on `master` git branch, run all jobs
- [x] If a file from `decidim-core` is modified, run all jobs
- [x] Else, only run tests from the modified folder.

The `main` tests are always run, because that's where we have the i18n specs and similar. This means that if we only modify files from `proposals`, then only `main` and `proposals` jobs would really run.

To discuss:

- If a file from the main folder (Gemfile(.lock), Rakefile, Dockerfile, `config/`, `lib/`, `spec/`) is changed, run all jobs? Note that `main` is always run right now.

#### :pushpin: Related Issues
- Related to #1939 
