### PR TITLE
Fix email notifications for new comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 **Fixed**
 
 - **decidim-core**: Handle nil resources on static maps (errors were caused by search engine spiders) [\#1936](https://github.com/decidim/decidim/pull/1936)
+- **decidim-comments**: Fix a bug sending email notifications when a comment is created [\#2036](https://github.com/decidim/decidim/pull/2036)
 - **decidim-proposals**: Do not count hidden proposals on stats [\#1988](https://github.com/decidim/decidim/pull/1988)
 
 ## [v0.6.7](https://github.com/decidim/decidim/tree/v0.6.7) (2017-10-09)

--- a/decidim-comments/app/events/decidim/comments/comment_created_event.rb
+++ b/decidim-comments/app/events/decidim/comments/comment_created_event.rb
@@ -41,7 +41,7 @@ module Decidim
       private
 
       def comment
-        @comment ||= Decidim::Comments::Comment.find(extra["comment_id"])
+        @comment ||= Decidim::Comments::Comment.find(extra[:comment_id])
       end
 
       def comment_type

--- a/decidim-comments/config/locales/en.yml
+++ b/decidim-comments/config/locales/en.yml
@@ -5,9 +5,9 @@ en:
       events:
         comment_created:
           comment:
-            email_intro: The "%{resource_title}" has been commented
+            email_intro: '"%{resource_title}" has been commented. You can read the comment in this page:'
             email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
-            email_subject: There is a new comment from %{author_name} in <a href="%{resource_url}">%{resource_title}</a>
+            email_subject: There is a new comment from %{author_name} in %{resource_title}
             notification_title: There is a new comment from %{author_name} in <a href="%{resource_path}">%{resource_title}</a>
           reply:
             email_intro: The "%{resource_title}" has been commented

--- a/decidim-comments/spec/events/decidim/comments/comment_created_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/comment_created_event_spec.rb
@@ -3,6 +3,19 @@
 require "spec_helper"
 
 describe Decidim::Comments::CommentCreatedEvent do
+  let(:resource) { comment.commentable }
+  let(:organization) { resource.organization }
+  let(:comment) { create :comment }
+  let(:comment_author) { comment.author }
+  let(:event_name) { "decidim.events.comments.comment_created" }
+  let(:user) { create :user, organization: organization }
+  let(:extra) { { comment_id: comment.id } }
+  let(:resource_path) { resource_locator(resource).path }
+
+  subject do
+    described_class.new(resource: resource, event_name: event_name, user: user, extra: extra)
+  end
+
   describe "types" do
     subject { described_class }
 
@@ -12,6 +25,30 @@ describe Decidim::Comments::CommentCreatedEvent do
 
     it "supports emails" do
       expect(subject.types).to include :email
+    end
+  end
+
+  describe "email_subject" do
+    it "is generated correctly" do
+      expect(subject.email_subject).to eq "There is a new comment from #{comment_author.name} in #{resource.title}"
+    end
+  end
+
+  describe "email_intro" do
+    it "is generated correctly" do
+      expect(subject.email_intro).to eq "\"#{resource.title}\" has been commented. You can read the comment in this page:"
+    end
+  end
+
+  describe "email_outro" do
+    it "is generated correctly" do
+      expect(subject.email_outro).to eq "You have received this notification because you are following \"#{resource.title}\". You can unfollow it from the previous link."
+    end
+  end
+
+  describe "notification_title" do
+    it "is generated correctly" do
+      expect(subject.notification_title).to eq "There is a new comment from #{comment_author.name} in <a href=\"#{resource_path}\">#{resource.title}</a>"
     end
   end
 end

--- a/decidim-core/lib/decidim/events/base_event.rb
+++ b/decidim-core/lib/decidim/events/base_event.rb
@@ -39,7 +39,7 @@ module Decidim
         @event_name = event_name
         @resource = resource
         @user = user
-        @extra = extra
+        @extra = extra.with_indifferent_access
       end
 
       # Caches the locator for the given resource, so that


### PR DESCRIPTION
#### :tophat: What? Why?
Email notifications for new comments were not being created correctly because of a bug in the code. This is now solved. This PR also rewords the email texts for this case, as they were weird.

#### :pushpin: Related Issues
- Fixes #2032.

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/rHKW3GN.png)
