### PR TITLE
Add Appearance settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - **decidim**: URLs now use the participatory space slug instead of the ID, both in the public pages and in the admin. Old routes using the space IDs now redirect to the ones using the slug. [\#1842](https://github.com/decidim/decidim/pull/1842)
 - **decidim**: `bin/rails generate decidim:demo` is no longer available in generated applications. Use the `--demo` flag when generating your application or do the change manually if you want to use the "demo" authorization handler. [\#1978](https://github.com/decidim/decidim/pull/1978)
+- **decidim-admin**: Organization settings form is now split in two: connfiguration and appearance [\#2041](https://github.com/decidim/decidim/pull/2041)
 - **decidim-core**: Changes some texts in the homepage ("How do I take part in a process?" section) [\#1947](https://github.com/decidim/decidim/pull/1947)
 - **decidim-core**: Authorization handlers now must be specified as strings. To migrate, change `config.authorization_handlers = [MyHandler]` to `config.authorization_handlers = ["MyHandler"]`. [\#2016](https://github.com/decidim/decidim/pull/2016)
 - **decidim-proposals**: Change proposal answer callouts so they match their real state [\#2025](https://github.com/decidim/decidim/pull/2025)
@@ -23,6 +24,7 @@
 
 **Fixed**
 
+- **decidim-admin**: Reference prefix was not being updated in the admin form [\#2041](https://github.com/decidim/decidim/pull/2041)
 - **decidim-core**: Handle nil resources on static maps (errors were caused by search engine spiders) [\#1936](https://github.com/decidim/decidim/pull/1936)
 - **decidim-comments**: Fix a bug sending email notifications when a comment is created [\#2036](https://github.com/decidim/decidim/pull/2036)
 - **decidim-participatory-processes**: Invited moderators couldn't access the process admin panel [\#2020](https://github.com/decidim/decidim/pull/2020)

--- a/decidim-admin/app/commands/decidim/admin/update_organization.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization.rb
@@ -23,15 +23,8 @@ module Decidim
       def call
         return broadcast(:invalid) if form.invalid?
 
-        update_organization
-
-        if @organization.valid?
-          broadcast(:ok, @organization)
-        else
-          form.errors.add(:official_img_header, @organization.errors[:official_img_header]) if @organization.errors.include? :official_img_header
-          form.errors.add(:official_img_footer, @organization.errors[:official_img_footer]) if @organization.errors.include? :official_img_footer
-          broadcast(:invalid)
-        end
+        return broadcast(:ok, @organization) if update_organization
+        broadcast(:invalid)
       end
 
       private
@@ -46,31 +39,14 @@ module Decidim
       def attributes
         {
           name: form.name,
+          default_locale: form.default_locale,
+          reference_prefix: form.reference_prefix,
           twitter_handler: form.twitter_handler,
           facebook_handler: form.facebook_handler,
           instagram_handler: form.instagram_handler,
           youtube_handler: form.youtube_handler,
-          github_handler: form.github_handler,
-          description: form.description,
-          welcome_text: form.welcome_text,
-          homepage_image: form.homepage_image,
-          remove_homepage_image: form.remove_homepage_image,
-          logo: form.logo,
-          remove_logo: form.remove_logo,
-          favicon: form.favicon,
-          remove_favicon: form.remove_favicon,
-          default_locale: form.default_locale,
-          official_img_header: form.official_img_header,
-          remove_official_img_header: form.remove_official_img_header,
-          official_img_footer: form.official_img_footer,
-          remove_official_img_footer: form.remove_official_img_footer,
-          official_url: form.official_url,
-          show_statistics: form.show_statistics
-        }.tap do |attributes|
-          if Decidim.enable_html_header_snippets
-            attributes[:header_snippets] = form.header_snippets
-          end
-        end
+          github_handler: form.github_handler
+        }
       end
     end
   end

--- a/decidim-admin/app/commands/decidim/admin/update_organization_appearance.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization_appearance.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # A command with all the business logic for updating the current
+    # organization appearance.
+    class UpdateOrganizationAppearance < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # organization - The Organization that will be updated.
+      # form - A form object with the params.
+      def initialize(organization, form)
+        @organization = organization
+        @form = form
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid.
+      # - :invalid if the form wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        return broadcast(:invalid) if form.invalid?
+
+        update_organization
+
+        if @organization.valid?
+          broadcast(:ok, @organization)
+        else
+          form.errors.add(:official_img_header, @organization.errors[:official_img_header]) if @organization.errors.include? :official_img_header
+          form.errors.add(:official_img_footer, @organization.errors[:official_img_footer]) if @organization.errors.include? :official_img_footer
+          broadcast(:invalid)
+        end
+      end
+
+      private
+
+      attr_reader :form, :organization
+
+      def update_organization
+        @organization.assign_attributes(attributes)
+        @organization.save! if @organization.valid?
+      end
+
+      def attributes
+        {
+          description: form.description,
+          welcome_text: form.welcome_text,
+          homepage_image: form.homepage_image,
+          remove_homepage_image: form.remove_homepage_image,
+          logo: form.logo,
+          remove_logo: form.remove_logo,
+          favicon: form.favicon,
+          remove_favicon: form.remove_favicon,
+          official_img_header: form.official_img_header,
+          remove_official_img_header: form.remove_official_img_header,
+          official_img_footer: form.official_img_footer,
+          remove_official_img_footer: form.remove_official_img_footer,
+          official_url: form.official_url,
+          show_statistics: form.show_statistics
+        }.tap do |attributes|
+          if Decidim.enable_html_header_snippets
+            attributes[:header_snippets] = form.header_snippets
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/app/controllers/decidim/admin/organization_appearance_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/organization_appearance_controller.rb
@@ -2,24 +2,23 @@
 
 module Decidim
   module Admin
-    # Controller that allows managing the user organization.
-    #
-    class OrganizationController < Decidim::Admin::ApplicationController
+    # Controller that allows managing the appearance of the organization.
+    class OrganizationAppearanceController < Decidim::Admin::ApplicationController
       layout "decidim/admin/settings"
 
       def edit
         authorize! :update, current_organization
-        @form = form(OrganizationForm).from_model(current_organization)
+        @form = form(OrganizationAppearanceForm).from_model(current_organization)
       end
 
       def update
         authorize! :update, current_organization
-        @form = form(OrganizationForm).from_params(params)
+        @form = form(OrganizationAppearanceForm).from_params(params)
 
-        UpdateOrganization.call(current_organization, @form) do
+        UpdateOrganizationAppearance.call(current_organization, @form) do
           on(:ok) do
             flash[:notice] = I18n.t("organization.update.success", scope: "decidim.admin")
-            redirect_to edit_organization_path
+            redirect_to edit_organization_appearance_path
           end
 
           on(:invalid) do

--- a/decidim-admin/app/forms/decidim/admin/organization_appearance_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_appearance_form.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # A form object used to update the current organization appearance from the admin
+    # dashboard.
+    #
+    class OrganizationAppearanceForm < Form
+      include TranslatableAttributes
+
+      mimic :organization_appearance
+
+      attribute :homepage_image
+      attribute :remove_homepage_image
+      attribute :logo
+      attribute :remove_logo
+      attribute :favicon
+      attribute :remove_favicon
+      attribute :official_img_header
+      attribute :remove_official_img_header
+      attribute :official_img_footer
+      attribute :remove_official_img_footer
+      attribute :official_url
+      attribute :show_statistics, Boolean
+      attribute :header_snippets, String
+
+      translatable_attribute :description, String
+      translatable_attribute :welcome_text, String
+
+      validates :official_img_header,
+                :official_img_footer,
+                :logo,
+                file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } },
+                file_content_type: { allow: ["image/jpeg", "image/png"] }
+    end
+  end
+end

--- a/decidim-admin/app/forms/decidim/admin/organization_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_form.rb
@@ -18,33 +18,10 @@ module Decidim
       attribute :youtube_handler, String
       attribute :github_handler, String
       attribute :default_locale, String
-      attribute :homepage_image
-      attribute :remove_homepage_image
-      attribute :logo
-      attribute :remove_logo
-      attribute :favicon
-      attribute :remove_favicon
-      attribute :official_url
-      attribute :official_img_header
-      attribute :remove_official_img_header
-      attribute :official_img_footer
-      attribute :remove_official_img_footer
-      attribute :show_statistics
-      attribute :header_snippets, String
-
-      translatable_attribute :description, String
-      translatable_attribute :welcome_text, String
 
       validates :name, presence: true
       validates :default_locale, presence: true
       validates :default_locale, inclusion: { in: :available_locales }
-
-      validates :official_img_header,
-                file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } },
-                file_content_type: { allow: ["image/jpeg", "image/png"] }
-      validates :official_img_footer,
-                file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } },
-                file_content_type: { allow: ["image/jpeg", "image/png"] }
 
       private
 

--- a/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
@@ -29,58 +29,11 @@
 </div>
 
 <div class="row column">
-  <%= form.translated :editor, :description %>
-</div>
-
-<div class="row column">
-  <%= form.translated :text_area, :welcome_text %>
-</div>
-
-<div class="row column">
   <%= form.collection_select :default_locale, localized_locales(current_organization.available_locales), :id, :name %>
-</div>
-
-<div class="row">
-  <div class="columns xlarge-4">
-    <%= form.upload :homepage_image %>
-  </div>
-
-  <div class="columns xlarge-4">
-    <%= form.upload :logo %>
-  </div>
-
-  <div class="columns xlarge-4">
-    <%= form.upload :favicon %>
-  </div>
-</div>
-
-<div class="row">
-  <div class="columns xlarge-6">
-    <%= form.upload :official_img_header %>
-  </div>
-
-  <div class="columns xlarge-6">
-    <%= form.upload :official_img_footer %>
-  </div>
 </div>
 
 <div class="row">
   <div class="columns xlarge-6">
     <%= form.text_field :reference_prefix %>
   </div>
-
-  <div class="columns xlarge-6">
-    <%= form.text_field :official_url %>
-  </div>
 </div>
-
-<div class="row column">
-  <%= form.check_box :show_statistics %>
-</div>
-
-<% if Decidim.enable_html_header_snippets %>
-  <div class="row column">
-    <%= form.text_area :header_snippets %>
-    <p class="help-text"><%= t(".header_snippets_help") %></p>
-  </div>
-<% end %>

--- a/decidim-admin/app/views/decidim/admin/organization/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/edit.html.erb
@@ -1,4 +1,4 @@
-<%= decidim_form_for(@form, html: { class: "form eidt_organitzation" }, url: organization_path) do |f| %>
+<%= decidim_form_for(@form, html: { class: "form edit_organization" }, url: organization_path) do |f| %>
   <div class="card">
     <div class="card-divider">
       <h2 class="card-title"><%= t ".title" %></h2>

--- a/decidim-admin/app/views/decidim/admin/organization_appearance/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization_appearance/_form.html.erb
@@ -1,0 +1,64 @@
+<div class="card">
+  <div class="card-divider">
+    <h2 class="card-title"><%= t ".homepage_appearance_title" %></h2>
+  </div>
+  <div class="card-section">
+    <div class="row column">
+      <%= form.translated :editor, :description %>
+    </div>
+
+    <div class="row column">
+      <%= form.translated :text_area, :welcome_text %>
+    </div>
+
+    <div class="row">
+      <div class="columns xlarge-6">
+        <%= form.upload :homepage_image %>
+      </div>
+    </div>
+
+    <div class="row column">
+      <%= form.check_box :show_statistics %>
+    </div>
+  </div>
+</div>
+
+<div class="card">
+  <div class="card-divider">
+    <h2 class="card-title"><%= t ".layout_appearance_title" %></h2>
+  </div>
+  <div class="card-section">
+    <div class="row">
+      <div class="columns xlarge-6">
+        <%= form.upload :logo %>
+      </div>
+
+      <div class="columns xlarge-6">
+        <%= form.upload :favicon %>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="columns xlarge-6">
+        <%= form.upload :official_img_header %>
+      </div>
+
+      <div class="columns xlarge-6">
+        <%= form.upload :official_img_footer %>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="columns xlarge-6">
+        <%= form.text_field :official_url %>
+      </div>
+    </div>
+
+    <% if Decidim.enable_html_header_snippets %>
+      <div class="row column">
+        <%= form.text_area :header_snippets %>
+        <p class="help-text"><%= t(".header_snippets_help") %></p>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/decidim-admin/app/views/decidim/admin/organization_appearance/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization_appearance/edit.html.erb
@@ -1,0 +1,7 @@
+<%= decidim_form_for(@form, html: { class: "form edit_organization_appearance" }, url: organization_appearance_path) do |f| %>
+  <%= render partial: 'form', object: f %>
+  <div class="button--double form-general-submit">
+    <%= f.submit t(".update") %>
+  </div>
+<% end %>
+

--- a/decidim-admin/app/views/layouts/decidim/admin/settings.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/settings.html.erb
@@ -5,7 +5,10 @@
     </div>
     <ul>
       <li <% if is_active_link?(decidim_admin.edit_organization_path) %> class="is-active" <% end %>>
-        <%= link_to t("menu.settings", scope: "decidim.admin"), decidim_admin.edit_organization_path %>
+        <%= link_to t("menu.configuration", scope: "decidim.admin"), decidim_admin.edit_organization_path %>
+      </li>
+      <li <% if is_active_link?(decidim_admin.edit_organization_appearance_path) %> class="is-active" <% end %>>
+        <%= link_to t("menu.appearance", scope: "decidim.admin"), decidim_admin.edit_organization_appearance_path %>
       </li>
       <li <% if is_active_link?(decidim_admin.scopes_path) %> class="is-active" <% end %>>
         <%= link_to t("menu.scopes", scope: "decidim.admin"), decidim_admin.scopes_path %>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -18,16 +18,17 @@ en:
         subject: Subject
       organization:
         default_locale: Default locale
+        name: Name
+        reference_prefix: Reference prefix
+      organization_appearance:
         description: Description
         favicon: Icon
         header_snippets: Header snippets
         homepage_image: Homepage image
         logo: Logo
-        name: Name
         official_img_footer: Official logo footer
         official_img_header: Official logo header
-        official_url: Official organization url
-        reference_prefix: Reference prefix
+        official_url: Official organization URL
         show_statistics: Show statistics
         welcome_text: Welcome text
       scope:
@@ -206,6 +207,8 @@ en:
             promote: Promote
       menu:
         admins: Admins
+        appearance: Appearance
+        configuration: Configuration
         dashboard: Dashboard
         managed_users: Managed users
         newsletters: Newsletters
@@ -313,10 +316,8 @@ en:
           title: Edit organization
           update: Update
         form:
-          current_image: Current image
           facebook: Facebook
           github: GitHub
-          header_snippets_help: Use this field to add things to the HTML head. The most common use is to integrate third-party services that require some extra JavaScript or CSS. Also, you can use it to add extra meta tags to the HTML. Note that this will only be rendered in public pages, not in the admin section.
           instagram: Instagram
           social_handlers: Social
           twitter: Twitter
@@ -325,6 +326,13 @@ en:
         update:
           error: There was an error when updating this organization.
           success: Organization updated successfully.
+      organization_appearance:
+        edit:
+          update: Update
+        form:
+          header_snippets_help: Use this field to add things to the HTML head. The most common use is to integrate third-party services that require some extra JavaScript or CSS. Also, you can use it to add extra meta tags to the HTML. Note that this will only be rendered in public pages, not in the admin section.
+          homepage_appearance_title: Edit homepage appearance
+          layout_appearance_title: Edit layout appearance
       scope_types:
         create:
           error: There was an error creating a new scope type.

--- a/decidim-admin/config/routes.rb
+++ b/decidim-admin/config/routes.rb
@@ -2,7 +2,9 @@
 
 Decidim::Admin::Engine.routes.draw do
   constraints(->(request) { Decidim::Admin::OrganizationDashboardConstraint.new(request).matches? }) do
-    resource :organization, only: [:edit, :update], controller: "organization"
+    resource :organization, only: [:edit, :update], controller: "organization" do
+      resource :appearance, only: [:edit, :update], controller: "organization_appearance"
+    end
 
     Decidim.participatory_space_manifests.each do |manifest|
       mount manifest.admin_engine, at: "/", as: "decidim_admin_#{manifest.name}"

--- a/decidim-admin/spec/commands/update_organization_appearance_spec.rb
+++ b/decidim-admin/spec/commands/update_organization_appearance_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Admin
+    describe UpdateOrganizationAppearance do
+      describe "call" do
+        let(:organization) { create(:organization, show_statistics: true) }
+        let(:params) do
+          {
+            organization_appearance: {
+              welcome_text_en: "Welcome",
+              welcome_text_es: "Hola",
+              welcome_text_ca: "Hola",
+              description_en: "My description",
+              description_es: "Mi descripción",
+              description_ca: "La meva descripció",
+              show_statistics: false,
+              header_snippets: '<script>alert("Hello");</script>',
+              favicon: File.new(Decidim::Dev.asset("icon.png"))
+            }
+          }
+        end
+        let(:context) do
+          { current_organization: organization }
+        end
+        let(:form) do
+          OrganizationAppearanceForm.from_params(params).with_context(context)
+        end
+        let(:command) { described_class.new(organization, form) }
+
+        describe "when the form is not valid" do
+          before do
+            expect(form).to receive(:invalid?).and_return(true)
+          end
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+
+          it "doesn't update the organization" do
+            command.call
+            organization.reload
+
+            expect(organization.show_statistics).to be_truthy
+          end
+        end
+
+        describe "when the organization is not valid" do
+          before do
+            expect(form).to receive(:invalid?).and_return(false)
+            expect(organization).to receive(:valid?).at_least(:once).and_return(false)
+            organization.errors.add(:official_img_header, "Image too big")
+            organization.errors.add(:official_img_footer, "Image too big")
+          end
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+
+          it "adds errors to the form" do
+            command.call
+
+            expect(form.errors[:official_img_header]).not_to be_empty
+            expect(form.errors[:official_img_footer]).not_to be_empty
+          end
+        end
+
+        describe "when the form is valid" do
+          it "broadcasts ok" do
+            expect { command.call }.to broadcast(:ok)
+          end
+
+          it "updates the organization in the organization" do
+            expect { command.call }.to broadcast(:ok)
+            organization.reload
+
+            expect(organization.show_statistics).to be_falsey
+          end
+
+          it "does not save header snippets" do
+            expect { command.call }.to broadcast(:ok)
+            organization.reload
+
+            expect(organization.header_snippets).to_not be_present
+          end
+
+          describe "when header snippets are configured" do
+            before do
+              allow(Decidim).to receive(:enable_html_header_snippets).and_return(true)
+            end
+
+            it "saves header snippets" do
+              expect { command.call }.to broadcast(:ok)
+              organization.reload
+
+              expect(organization.header_snippets).to be_present
+            end
+          end
+
+          context "when no homepage image is set" do
+            it "does not replace the homepage image" do
+              command.call
+              organization.reload
+
+              expect(organization.homepage_image).to be_present
+            end
+          end
+
+          context "when there's a favicon in the params" do
+            it "does set a favicon for the organization" do
+              command.call
+              organization.reload
+
+              expect(organization.favicon.small).to be_present
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/commands/update_organization_spec.rb
+++ b/decidim-admin/spec/commands/update_organization_spec.rb
@@ -12,16 +12,7 @@ module Decidim
             organization: {
               name: "My super organization",
               reference_prefix: "MSO",
-              default_locale: "en",
-              welcome_text_en: "Welcome",
-              welcome_text_es: "Hola",
-              welcome_text_ca: "Hola",
-              description_en: "My description",
-              description_es: "Mi descripción",
-              description_ca: "La meva descripció",
-              show_statistics: false,
-              header_snippets: '<script>alert("Hello");</script>',
-              favicon: File.new(Decidim::Dev.asset("icon.png"))
+              default_locale: "en"
             }
           }
         end
@@ -50,26 +41,6 @@ module Decidim
           end
         end
 
-        describe "when the organization is not valid" do
-          before do
-            expect(form).to receive(:invalid?).and_return(false)
-            expect(organization).to receive(:valid?).at_least(:once).and_return(false)
-            organization.errors.add(:official_img_header, "Image too big")
-            organization.errors.add(:official_img_footer, "Image too big")
-          end
-
-          it "broadcasts invalid" do
-            expect { command.call }.to broadcast(:invalid)
-          end
-
-          it "adds errors to the form" do
-            command.call
-
-            expect(form.errors[:official_img_header]).not_to be_empty
-            expect(form.errors[:official_img_footer]).not_to be_empty
-          end
-        end
-
         describe "when the form is valid" do
           it "broadcasts ok" do
             expect { command.call }.to broadcast(:ok)
@@ -80,44 +51,6 @@ module Decidim
             organization.reload
 
             expect(organization.name).to eq("My super organization")
-          end
-
-          it "does not save header snippets" do
-            expect { command.call }.to broadcast(:ok)
-            organization.reload
-
-            expect(organization.header_snippets).to_not be_present
-          end
-
-          describe "when header snippets are configured" do
-            before do
-              allow(Decidim).to receive(:enable_html_header_snippets).and_return(true)
-            end
-
-            it "saves header snippets" do
-              expect { command.call }.to broadcast(:ok)
-              organization.reload
-
-              expect(organization.header_snippets).to be_present
-            end
-          end
-
-          context "when no homepage image is set" do
-            it "does not replace the homepage image" do
-              command.call
-              organization.reload
-
-              expect(organization.homepage_image).to be_present
-            end
-          end
-
-          context "when there's a favicon in the params" do
-            it "does set a favicon for the organization" do
-              command.call
-              organization.reload
-
-              expect(organization.favicon.small).to be_present
-            end
           end
         end
       end

--- a/decidim-admin/spec/features/admin_manages_organization_appearance_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_organization_appearance_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin manages ogranization", type: :feature do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+  end
+
+  describe "edit" do
+    it "updates the values from the form" do
+      visit decidim_admin.edit_organization_appearance_path
+
+      fill_in_i18n_editor :organization_appearance_description,
+                          "#organization_appearance-description-tabs",
+                          en: "My own super description",
+                          es: "Mi gran descripción",
+                          ca: "La meva gran descripció"
+
+      fill_in_i18n :organization_appearance_welcome_text,
+                   "#organization_appearance-welcome_text-tabs",
+                   en: "My super welcome text",
+                   es: "Mi super texto de bienvenida",
+                   ca: "El meu súper text de benvinguda"
+
+      fill_in "Official organization URL", with: "http://www.example.com"
+
+      attach_file "Homepage image", Decidim::Dev.asset("city.jpeg")
+      attach_file "Logo", Decidim::Dev.asset("city2.jpeg")
+      attach_file "Icon", Decidim::Dev.asset("city3.jpeg")
+      attach_file "Official logo header", Decidim::Dev.asset("city2.jpeg")
+      attach_file "Official logo footer", Decidim::Dev.asset("city3.jpeg")
+
+      click_button "Update"
+
+      expect(page).to have_content("updated successfully")
+    end
+  end
+end

--- a/decidim-admin/spec/features/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_organization_spec.rb
@@ -17,30 +17,15 @@ describe "Admin manages ogranization", type: :feature do
 
       fill_in "Name", with: "My super-uber organization"
 
-      fill_in_i18n_editor :organization_description, "#organization-description-tabs", en: "My own super description",
-                                                                                       es: "Mi gran descripción",
-                                                                                       ca: "La meva gran descripció"
-
-      fill_in_i18n :organization_welcome_text, "#organization-welcome_text-tabs", en: "My super welcome text",
-                                                                                  es: "Mi super texto de bienvenida",
-                                                                                  ca: "El meu súper text de benvinguda"
-
       %w(Twitter Facebook Instagram YouTube GitHub).each do |network|
         click_link network
         fill_in "organization_#{network.downcase}_handler", with: "decidim"
       end
 
-      click_button "Update"
       select "Castellano", from: "Default locale"
       fill_in "Reference prefix", with: "ABC"
-      fill_in "Official organization url", with: "http://www.example.com"
 
-      attach_file "Homepage image", Decidim::Dev.asset("city.jpeg")
-      attach_file "Logo", Decidim::Dev.asset("city2.jpeg")
-      attach_file "Icon", Decidim::Dev.asset("city3.jpeg")
-      attach_file "Official logo header", Decidim::Dev.asset("city2.jpeg")
-      attach_file "Official logo footer", Decidim::Dev.asset("city3.jpeg")
-
+      click_button "Update"
       expect(page).to have_content("updated successfully")
     end
   end

--- a/decidim-admin/spec/forms/organization_appearance_form_spec.rb
+++ b/decidim-admin/spec/forms/organization_appearance_form_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Admin
+    describe OrganizationAppearanceForm do
+      let(:header_snippets) { "<my-html />" }
+      let(:welcome_text) do
+        {
+          en: "Welcome",
+          es: "Hola",
+          ca: "Hola"
+        }
+      end
+      let(:description) do
+        {
+          en: "Description, awesome description",
+          es: "Descripción",
+          ca: "Descripció"
+        }
+      end
+      let(:organization) { create(:organization) }
+      let(:homepage_image_path) { Decidim::Dev.asset("city.jpeg") }
+      let(:attributes) do
+        {
+          "organization_appearance" => {
+            "welcome_text_en" => welcome_text[:en],
+            "welcome_text_es" => welcome_text[:es],
+            "welcome_text_ca" => welcome_text[:ca],
+            "description_en" => description[:en],
+            "description_es" => description[:es],
+            "description_ca" => description[:ca],
+            "homepage_image" => Rack::Test::UploadedFile.new(homepage_image_path, "image/jpeg"),
+            "show_statics" => false,
+            "header_snippets" => header_snippets
+          }
+        }
+      end
+      let(:context) do
+        {
+          current_organization: organization,
+          current_user: instance_double(Decidim::User).as_null_object
+        }
+      end
+
+      subject do
+        described_class.from_params(attributes).with_context(
+          context
+        )
+      end
+
+      context "when everything is OK" do
+        it { is_expected.to be_valid }
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/forms/organization_form_spec.rb
+++ b/decidim-admin/spec/forms/organization_form_spec.rb
@@ -12,40 +12,14 @@ module Decidim
       let(:instagram_handler) { "My instagram awesome handler" }
       let(:youtube_handler) { "My youtube awesome handler" }
       let(:github_handler) { "My github awesome handler" }
-      let(:header_snippets) { "<my-html />" }
       let(:default_locale) { :en }
-      let(:welcome_text) do
-        {
-          en: "Welcome",
-          es: "Hola",
-          ca: "Hola"
-        }
-      end
-      let(:description) do
-        {
-          en: "Description, awesome description",
-          es: "Descripción",
-          ca: "Descripció"
-        }
-      end
       let(:organization) { create(:organization) }
-      let(:homepage_image_path) { Decidim::Dev.asset("city.jpeg") }
       let(:attributes) do
         {
           "organization" => {
             "name" => name,
             "reference_prefix" => reference_prefix,
             "default_locale" => default_locale,
-            "available_locales" => %w(en ca es),
-            "welcome_text_en" => welcome_text[:en],
-            "welcome_text_es" => welcome_text[:es],
-            "welcome_text_ca" => welcome_text[:ca],
-            "description_en" => description[:en],
-            "description_es" => description[:es],
-            "description_ca" => description[:ca],
-            "homepage_image" => Rack::Test::UploadedFile.new(homepage_image_path, "image/jpeg"),
-            "show_statics" => false,
-            "header_snippets" => header_snippets,
             "twitter_handler" => twitter_handler,
             "facebook_handler" => facebook_handler,
             "instagram_handler" => instagram_handler,
@@ -85,6 +59,7 @@ module Decidim
 
       context "when default_locale is not an available locale" do
         let(:default_locale) { :de }
+
         before do
           allow(organization).to receive(:available_locales).and_return([:en, :es, :ca])
         end

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -229,9 +229,9 @@ module Decidim
 
       if file_is_image?(file)
         template += if file.present?
-                      @template.label_tag I18n.t("current_image", scope: "decidim.forms")
+                      @template.content_tag :label, I18n.t("current_image", scope: "decidim.forms")
                     else
-                      @template.label_tag I18n.t("default_image", scope: "decidim.forms")
+                      @template.content_tag :label, I18n.t("default_image", scope: "decidim.forms")
                     end
         template += @template.link_to @template.image_tag(file.url), file.url, target: "_blank"
       elsif file_is_present?(file)


### PR DESCRIPTION
#### :tophat: What? Why?
This PR refactors the org settings page and splits it in two: Settings and Appearance.

### :camera: Screenshots (optional)
Configuration page:
![localhost-3000-admin-organization-edit](https://user-images.githubusercontent.com/491891/31608881-53c3e504-b272-11e7-973e-679ed1dd7b7c.png)

Appearance page:
![localhost-3000-admin-organization-appearance-edit](https://user-images.githubusercontent.com/491891/31608908-694c4060-b272-11e7-938d-f4b5c2c5b707.png)
