### PR TITLE
"Estats" -> "Statuses" in English

### DIFF
--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -70,7 +70,7 @@ en:
             title: Edit status
             update: Update status
           index:
-            title: Estats
+            title: Statuses
           new:
             create: Create status
             title: New status


### PR DESCRIPTION
#### :tophat: What? Why?

Catalan "Estats" is beautiful, yet it should not migrate to English-speaking countries. Why not contribute instead to making Catalonia a prosperous country?