### PR TITLE
Fix impersonation

### DIFF
--- a/decidim-admin/app/models/decidim/admin/abilities/user_manager_ability.rb
+++ b/decidim-admin/app/models/decidim/admin/abilities/user_manager_ability.rb
@@ -10,20 +10,22 @@ module Decidim
           super
 
           can :manage, :managed_users
+
           cannot [:new, :create], :managed_users if empty_available_authorizations?
+
           can :impersonate, Decidim::User do |user_to_impersonate|
-            user_to_impersonate.managed? && Decidim::ImpersonationLog.active.empty?
+            user_to_impersonate.managed? && Decidim::ImpersonationLog.active.where(admin: user).empty?
           end
+
           can :promote, Decidim::User do |user_to_promote|
-            user_to_promote.managed? && Decidim::ImpersonationLog.active.empty?
+            user_to_promote.managed? && Decidim::ImpersonationLog.active.where(admin: user).empty?
           end
         end
 
         private
 
         def empty_available_authorizations?
-          return unless @context[:current_organization]
-          @context[:current_organization].available_authorizations.empty?
+          user.organization.available_authorizations.empty?
         end
       end
     end

--- a/decidim-admin/spec/models/abilities/user_manager_ability_spec.rb
+++ b/decidim-admin/spec/models/abilities/user_manager_ability_spec.rb
@@ -3,17 +3,64 @@
 require "spec_helper"
 
 describe Decidim::Admin::Abilities::UserManagerAbility do
-  let(:user) { build(:user, :user_manager) }
+  let(:organization) { create(:organization, available_authorizations: ["dummy"]) }
+  let(:user) { create(:user, :user_manager, organization: organization) }
 
   subject { described_class.new(user, {}) }
 
+  context "when the organization has authorizations" do
+    it "can create new managed users" do
+      expect(subject).to be_able_to(:new, :managed_users)
+      expect(subject).to be_able_to(:create, :managed_users)
+    end
+  end
+
+  context "when the organization doesn't have authorizations" do
+    let(:organization) { create(:organization, available_authorizations: []) }
+
+    it "can't create new managed users" do
+      expect(subject).to_not be_able_to(:new, :managed_users)
+      expect(subject).to_not be_able_to(:create, :managed_users)
+    end
+  end
+
   context "when the user is not a user manager" do
-    let(:user) { build(:user) }
+    let(:user) { create(:user, organization: organization) }
 
     it "doesn't have any permission" do
       expect(subject.permissions[:can]).to be_empty
       expect(subject.permissions[:cannot]).to be_empty
     end
+  end
+
+  context "when the user doesn't have an impersonation log" do
+    let(:managed) { create(:user, :managed, organization: organization) }
+
+    before do
+      create(:impersonation_log, admin: create(:user, organization: organization))
+    end
+
+    it { is_expected.to be_able_to(:impersonate, managed) }
+  end
+
+  context "when the user doesn't have an active impersonation log" do
+    let(:managed) { create(:user, :managed, organization: organization) }
+
+    before do
+      create(:impersonation_log, admin: user, started_at: 2.days.ago, ended_at: 1.day.ago)
+    end
+
+    it { is_expected.to be_able_to(:impersonate, managed) }
+  end
+
+  context "when the user has an active impersonation log" do
+    let(:managed) { create(:user, :managed, organization: organization) }
+
+    before do
+      create(:impersonation_log, admin: user, started_at: 10.minutes.ago)
+    end
+
+    it { is_expected.to_not be_able_to(:impersonate, managed) }
   end
 
   it { is_expected.to be_able_to(:manage, :managed_users) }

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -290,7 +290,7 @@ FactoryGirl.define do
   factory :impersonation_log, class: Decidim::ImpersonationLog do
     admin { build(:user, :admin) }
     user { build(:user, :managed, organization: admin.organization) }
-    started_at Time.current
+    started_at { 10.minutes.ago }
   end
 
   factory :follow, class: "Decidim::Follow" do


### PR DESCRIPTION
#### :tophat: What? Why?
This fixes impersonation, as it was globally sharing the impersonation trail thus disallowing any user to impersonate anyone while another user was impersonating.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/zSuBxqWH0w3jW/giphy.gif)
