### PR TITLE
Customize Call To Action button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@
 **Added**
 
 - **decidim**: Available authorization handlers are added to the sample organization automatically when seeding. [\#1978](https://github.com/decidim/decidim/pull/1978)
+- **decidim-admin**: Let admins customize the Call To Action homepage button text and URL [\#2053](https://github.com/decidim/decidim/pull/2053)
 - **decidim-core**: Show a disabled "Follow" button to anonymous users (not logged in) with a prompt to sign in [\#1903](https://github.com/decidim/decidim/pull/1903)
 - **decidim-core**: Adds an option to the initializer file to enable/disable header snippets (`true` by default) [\#1923](https://github.com/decidim/decidim/pull/1923)
 - **decidim-core**: Adds an option to configure the maximum file size for avatar images [\#1969](https://github.com/decidim/decidim/pull/1969)
 - **decidim-core**: Hides the "Mark all as read" notifications button when no notifications are found [\#1948](https://github.com/decidim/decidim/pull/1948)
+- **decidim-core**: Add fields to customize the Call To Action homepage button text and URL [\#2053](https://github.com/decidim/decidim/pull/2053)
 - **decidim-meetings**: Participatory admins can invite users to join a meeting. [\#1879](https://github.com/decidim/decidim/pull/1879)
 - **decidim-proposals**: Show votes in the proposals table in admin when votes are enabled [\#2011](https://github.com/decidim/decidim/pull/2011)
 

--- a/decidim-admin/app/commands/decidim/admin/update_organization_appearance.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization_appearance.rb
@@ -45,6 +45,8 @@ module Decidim
 
       def attributes
         {
+          cta_button_path: form.cta_button_path,
+          cta_button_text: form.cta_button_text,
           description: form.description,
           welcome_text: form.welcome_text,
           homepage_image: form.homepage_image,

--- a/decidim-admin/app/forms/decidim/admin/organization_appearance_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_appearance_form.rb
@@ -23,7 +23,9 @@ module Decidim
       attribute :official_url
       attribute :show_statistics, Boolean
       attribute :header_snippets, String
+      attribute :cta_button_path, String
 
+      translatable_attribute :cta_button_text, String
       translatable_attribute :description, String
       translatable_attribute :welcome_text, String
 

--- a/decidim-admin/app/views/decidim/admin/organization_appearance/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization_appearance/_form.html.erb
@@ -1,3 +1,5 @@
+<%= javascript_include_tag "decidim/slug_form" %>
+
 <div class="card">
   <div class="card-divider">
     <h2 class="card-title"><%= t ".homepage_appearance_title" %></h2>
@@ -29,6 +31,7 @@
 
       <div class="columns xlarge-6">
         <%= form.translated :text_field, :cta_button_text %>
+        <p class="help-text"><%= t(".cta_button_text_help") %></p>
       </div>
     </div>
   </div>

--- a/decidim-admin/app/views/decidim/admin/organization_appearance/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization_appearance/_form.html.erb
@@ -4,6 +4,10 @@
   </div>
   <div class="card-section">
     <div class="row column">
+      <%= form.check_box :show_statistics %>
+    </div>
+
+    <div class="row column">
       <%= form.translated :editor, :description %>
     </div>
 
@@ -17,8 +21,15 @@
       </div>
     </div>
 
-    <div class="row column">
-      <%= form.check_box :show_statistics %>
+    <div class="row">
+      <div class="columns xlarge-6 slug">
+        <%= form.text_field :cta_button_path %>
+        <p class="help-text"><%== t(".cta_button_path_help", url: decidim_form_slug_url("", form.object.cta_button_path)) %></p>
+      </div>
+
+      <div class="columns xlarge-6">
+        <%= form.translated :text_field, :cta_button_text %>
+      </div>
     </div>
   </div>
 </div>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -21,6 +21,8 @@ en:
         name: Name
         reference_prefix: Reference prefix
       organization_appearance:
+        cta_button_path: Call To Action button path
+        cta_button_text: Call To Action button text
         description: Description
         favicon: Icon
         header_snippets: Header snippets
@@ -330,7 +332,8 @@ en:
         edit:
           update: Update
         form:
-          cta_button_path_help: 'URL slugs are used to generate the URLs that point to this process. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
+          cta_button_path_help: 'You can override where the Call To Action button in the homepage links to. Use partial paths, not full URLs here. The Call To Action button is shown in the homepage between the welcome text and the description. Example: %{url}'
+          cta_button_text_help: 'You can override the Call To Action button text in the homepage for each available language in your organization. If not set, the default value will be used. The Call To Action button is shown in the homepage between the welcome text and the description.'
           header_snippets_help: Use this field to add things to the HTML head. The most common use is to integrate third-party services that require some extra JavaScript or CSS. Also, you can use it to add extra meta tags to the HTML. Note that this will only be rendered in public pages, not in the admin section.
           homepage_appearance_title: Edit homepage appearance
           layout_appearance_title: Edit layout appearance

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -330,6 +330,7 @@ en:
         edit:
           update: Update
         form:
+          cta_button_path_help: 'URL slugs are used to generate the URLs that point to this process. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
           header_snippets_help: Use this field to add things to the HTML head. The most common use is to integrate third-party services that require some extra JavaScript or CSS. Also, you can use it to add extra meta tags to the HTML. Note that this will only be rendered in public pages, not in the admin section.
           homepage_appearance_title: Edit homepage appearance
           layout_appearance_title: Edit layout appearance

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -333,7 +333,7 @@ en:
           update: Update
         form:
           cta_button_path_help: 'You can override where the Call To Action button in the homepage links to. Use partial paths, not full URLs here. The Call To Action button is shown in the homepage between the welcome text and the description. Example: %{url}'
-          cta_button_text_help: 'You can override the Call To Action button text in the homepage for each available language in your organization. If not set, the default value will be used. The Call To Action button is shown in the homepage between the welcome text and the description.'
+          cta_button_text_help: You can override the Call To Action button text in the homepage for each available language in your organization. If not set, the default value will be used. The Call To Action button is shown in the homepage between the welcome text and the description.
           header_snippets_help: Use this field to add things to the HTML head. The most common use is to integrate third-party services that require some extra JavaScript or CSS. Also, you can use it to add extra meta tags to the HTML. Note that this will only be rendered in public pages, not in the admin section.
           homepage_appearance_title: Edit homepage appearance
           layout_appearance_title: Edit layout appearance

--- a/decidim-core/app/controllers/decidim/pages_controller.rb
+++ b/decidim-core/app/controllers/decidim/pages_controller.rb
@@ -12,6 +12,7 @@ module Decidim
     authorize_resource :public_pages, class: false
     delegate :page, to: :page_finder
     helper_method :page, :promoted_participatory_processes, :highlighted_participatory_processes, :stats
+    helper HomepageHelper
 
     def index
       @pages = current_organization.static_pages.all.to_a.sort do |a, b|

--- a/decidim-core/app/helpers/decidim/decidim_form_helper.rb
+++ b/decidim-core/app/helpers/decidim/decidim_form_helper.rb
@@ -125,23 +125,26 @@ module Decidim
       object.respond_to?(:errors) && object.errors[attribute].present?
     end
 
-    # Helper method that generates the URL of a participatory space with a
-    # span surrounding the space slug. This is only intended to be used in
-    # help text for the slug input, so that we can update the span contents
-    # via JS with the input value.
+    # Helper method to show how slugs will look like. Intended to be used in forms
+    # together with some JavaScript code. More precisely, this will most probably
+    # show in help texts in forms. The space slug is surrounded with a `span` so
+    # the slug can be updated via JavaScript with the input value.
     #
-    # space_name - the name, in plural, of the space (eg. "processes" or "assemblies")
-    # value - the initial value of the slug field, so  that edit forms have a value
+    # prepend_path - a path to prepend to the slug, without final slash
+    # value - the initial value of the slug field, so that edit forms have a value
     #
     # Returns an HTML-safe String.
-    def decidim_form_slug_url(space_name, value = "")
+    def decidim_form_slug_url(prepend_path = "", value = "")
+      prepend_slug_path = if prepend_path.present?
+                            "/#{prepend_path}/"
+                          else
+                            "/"
+                          end
       content_tag(:span, class: "slug-url") do
         [
           request.protocol,
           request.host_with_port,
-          "/",
-          space_name,
-          "/"
+          prepend_slug_path
         ].join("").html_safe +
           content_tag(:span, value, class: "slug-url-value")
       end

--- a/decidim-core/app/helpers/decidim/homepage_helper.rb
+++ b/decidim-core/app/helpers/decidim/homepage_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Decidim
+  # A Helper to render homepage elements.
+  module HomepageHelper
+    # Renders the Call To Action button. Link and text can be configured
+    # per organizationn.
+    def cta_button
+      button_text = translated_attribute(current_organization.cta_button_text).presence || t(".participate")
+      button_path =
+        current_organization.cta_button_path.presence || decidim_participatory_processes.participatory_processes_path
+
+      link_to button_text, button_path, class: "hero-cta button expanded large button--sc"
+    end
+  end
+end

--- a/decidim-core/app/helpers/decidim/homepage_helper.rb
+++ b/decidim-core/app/helpers/decidim/homepage_helper.rb
@@ -6,7 +6,7 @@ module Decidim
     # Renders the Call To Action button. Link and text can be configured
     # per organizationn.
     def cta_button
-      button_text = translated_attribute(current_organization.cta_button_text).presence || t(".participate")
+      button_text = translated_attribute(current_organization.cta_button_text).presence || t("pages.home.hero.participate")
       button_path =
         current_organization.cta_button_path.presence || decidim_participatory_processes.participatory_processes_path
 

--- a/decidim-core/app/views/pages/home/_hero.html.erb
+++ b/decidim-core/app/views/pages/home/_hero.html.erb
@@ -13,7 +13,7 @@
     </div>
     <div class="row">
       <div class="columns small-centered small-6 medium-4 mediumlarge-3">
-        <%= link_to t('.participate'), decidim_participatory_processes.participatory_processes_path, class: "hero-cta button expanded large button--sc" %>
+        <%= cta_button %>
       </div>
     </div>
   </div>

--- a/decidim-core/db/migrate/20171017084546_add_cta_button_url_and_text_to_organization.rb
+++ b/decidim-core/db/migrate/20171017084546_add_cta_button_url_and_text_to_organization.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddCtaButtonUrlAndTextToOrganization < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_organizations, :cta_button_text, :jsonb
+    add_column :decidim_organizations, :cta_button_path, :string
+  end
+end

--- a/decidim-core/spec/features/homepage_spec.rb
+++ b/decidim-core/spec/features/homepage_spec.rb
@@ -28,6 +28,48 @@ describe "Homepage", type: :feature do
       expect(page).to have_selector("a.main-footer__badge[href='#{official_url}']")
     end
 
+    context "call to action" do
+      context "when the organization has the CTA button text customized" do
+        let(:cta_button_text) { { en: "Log in", es: "Conéctate", ca: "Connecta't" } }
+        let(:organization) { create(:organization, cta_button_text: cta_button_text) }
+
+        it "uses the custom values for the CTA button text" do
+          within ".hero" do
+            expect(page).to have_selector("a.hero-cta", text: "LOG IN")
+            click_link "Log in"
+          end
+
+          expect(current_path).to eq decidim_participatory_processes.participatory_processes_path
+        end
+      end
+
+      context "when the organization has the CTA button link customized" do
+        let(:organization) { create(:organization, cta_button_path: "users/sign_in") }
+
+        it "uses the custom values for the CTA button" do
+          within ".hero" do
+            expect(page).to have_selector("a.hero-cta", text: "PARTICIPATE")
+            click_link "Participate"
+          end
+
+          expect(current_path).to eq decidim.new_user_session_path
+          expect(page).to have_content("Sign in")
+          expect(page).to have_content("New to the platform?")
+        end
+      end
+
+      context "when the organization does not have it customized" do
+        it "uses the default values for the CTA button" do
+          within ".hero" do
+            expect(page).to have_selector("a.hero-cta", text: "PARTICIPATE")
+            click_link "Participate"
+          end
+
+          expect(current_path).to eq decidim_participatory_processes.participatory_processes_path
+        end
+      end
+    end
+
     context "with header snippets" do
       let(:snippet) { "<meta data-hello=\"This is the organization header_snippet field\">" }
       let(:organization) { create(:organization, official_url: official_url, header_snippets: snippet) }


### PR DESCRIPTION
#### :tophat: What? Why?
This PR lets admins customize the text and path of the Call To Action button in the homepage.

#### :pushpin: Related Issues
- Fixes #1819.

### :camera: Screenshots (optional)
With default values (no custom values set):

http://recordit.co/yBjZJZMMv4
![](http://g.recordit.co/yBjZJZMMv4.gif)

Setting custom values:

http://recordit.co/zXgX5PqUNo
![](http://g.recordit.co/zXgX5PqUNo.gif)
