### PR TITLE
Fix homepage block styles if stats are hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 - **decidim-admin**: Reference prefix was not being updated in the admin form [\#2041](https://github.com/decidim/decidim/pull/2041)
 - **decidim-core**: Handle nil resources on static maps (errors were caused by search engine spiders) [\#1936](https://github.com/decidim/decidim/pull/1936)
+- **decidim-core**: Homepage blocks were not distinguishable when statistics were hidden [\#2064](https://github.com/decidim/decidim/pull/2064)
 - **decidim-comments**: Fix a bug sending email notifications when a comment is created [\#2036](https://github.com/decidim/decidim/pull/2036)
 - **decidim-participatory-processes**: Invited moderators couldn't access the process admin panel [\#2020](https://github.com/decidim/decidim/pull/2020)
 - **decidim-proposals**: Do not count hidden proposals on stats [\#1988](https://github.com/decidim/decidim/pull/1988)

--- a/decidim-core/app/views/pages/home/_footer_sub_hero.html.erb
+++ b/decidim-core/app/views/pages/home/_footer_sub_hero.html.erb
@@ -1,4 +1,4 @@
-<section class="footer__subhero extended subhero home-section">
+<section class="footer__subhero extended subhero<%= " home-section" if current_organization.show_statistics? %>">
   <div class="row">
     <div class="columns small-centered large-10">
       <h2 class="heading3"><%= t(".footer_sub_hero_headline", organization: current_organization.name) %></h2>


### PR DESCRIPTION
#### :tophat: What? Why?
When statistics are hidden, blocks in the homepage are not clearly distinguishable. This PR fixes this, see screenshots below.

#### :pushpin: Related Issues
None

### :camera: Screenshots (optional)
Default (statistics are visible):
![](https://i.imgur.com/hkyGYJ6.png)

Before this PR, when statistics are hidden from the homepage:
![](https://i.imgur.com/7hhYryw.png)

After this PR:
![Description](https://i.imgur.com/iAE0UiU.png)
