### PR TITLE
Remove the button to delete organizations from system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
 - **decidim-participatory-processes**: Invited moderators couldn't access the process admin panel [\#2020](https://github.com/decidim/decidim/pull/2020)
 - **decidim-proposals**: Do not count hidden proposals on stats [\#1988](https://github.com/decidim/decidim/pull/1988)
 
+**Removed**
+
+- **decidim-system**: Removed button to delete organizations, as this is not implemented [\#2067](https://github.com/decidim/decidim/pull/2067)
+
 ## [v0.6.8](https://github.com/decidim/decidim/tree/v0.6.8) (2017-10-17)
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.6.7...v0.6.8)
 

--- a/decidim-system/app/views/decidim/system/organizations/index.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/index.html.erb
@@ -26,7 +26,6 @@
         </td>
         <td class="actions">
           <%= link_to t("actions.edit", scope: "decidim.system"), ['edit', organization] %>
-          <%= link_to t("actions.destroy", scope: "decidim.system"), organization, method: :delete, class: "small alert button", data: { confirm: t("actions.confirm_destroy", scope: "decidim.system") } %>
         </td>
       </tr>
     <% end %>

--- a/decidim-system/config/routes.rb
+++ b/decidim-system/config/routes.rb
@@ -11,7 +11,7 @@ Decidim::System::Engine.routes.draw do
              }
 
   authenticate(:admin) do
-    resources :organizations
+    resources :organizations, except: [:destroy]
     resources :admins
     root to: "dashboard#show"
   end


### PR DESCRIPTION
#### :tophat: What? Why?
In system we had the button to delete organizations, but the feature is not implemented, so this PR removes the button. Discussion on how to delete organizations can be found on #2066.

#### :pushpin: Related Issues
- Closes #1777.

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/DfEXL8G.png)
