### PR TITLE
Ensure CTA button path is a path

### DIFF
--- a/decidim-admin/app/forms/decidim/admin/organization_appearance_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_appearance_form.rb
@@ -29,8 +29,10 @@ module Decidim
       translatable_attribute :description, String
       translatable_attribute :welcome_text, String
 
+      validates :cta_button_path, format: { with: %r{\A[a-zA-Z]+[a-zA-Z0-9-/]+\z} }, allow_blank: true
       validates :official_img_header,
                 :official_img_footer,
+                :homepage_image,
                 :logo,
                 file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } },
                 file_content_type: { allow: ["image/jpeg", "image/png"] }

--- a/decidim-admin/app/views/decidim/admin/organization_appearance/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization_appearance/edit.html.erb
@@ -1,4 +1,4 @@
-<%= decidim_form_for(@form, html: { class: "form edit_organization_appearance" }, url: organization_appearance_path) do |f| %>
+<%= decidim_form_for(@form, html: { class: "form edit_organization_appearance" }, url: organization_appearance_path, method: :put) do |f| %>
   <%= render partial: 'form', object: f %>
   <div class="button--double form-general-submit">
     <%= f.submit t(".update") %>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -332,7 +332,7 @@ en:
         edit:
           update: Update
         form:
-          cta_button_path_help: 'You can override where the Call To Action button in the homepage links to. Use partial paths, not full URLs here. The Call To Action button is shown in the homepage between the welcome text and the description. Example: %{url}'
+          cta_button_path_help: 'You can override where the Call To Action button in the homepage links to. Use partial paths, not full URLs here. Accepts letters, numbers, dashes and slashes, and must start with a letter. The Call To Action button is shown in the homepage between the welcome text and the description. Example: %{url}'
           cta_button_text_help: You can override the Call To Action button text in the homepage for each available language in your organization. If not set, the default value will be used. The Call To Action button is shown in the homepage between the welcome text and the description.
           header_snippets_help: Use this field to add things to the HTML head. The most common use is to integrate third-party services that require some extra JavaScript or CSS. Also, you can use it to add extra meta tags to the HTML. Note that this will only be rendered in public pages, not in the admin section.
           homepage_appearance_title: Edit homepage appearance

--- a/decidim-admin/spec/forms/organization_appearance_form_spec.rb
+++ b/decidim-admin/spec/forms/organization_appearance_form_spec.rb
@@ -21,6 +21,7 @@ module Decidim
         }
       end
       let(:organization) { create(:organization) }
+      let(:cta_button_path) { nil }
       let(:homepage_image_path) { Decidim::Dev.asset("city.jpeg") }
       let(:attributes) do
         {
@@ -33,6 +34,7 @@ module Decidim
             "description_ca" => description[:ca],
             "homepage_image" => Rack::Test::UploadedFile.new(homepage_image_path, "image/jpeg"),
             "show_statics" => false,
+            "cta_button_path" => cta_button_path,
             "header_snippets" => header_snippets
           }
         }
@@ -51,6 +53,18 @@ module Decidim
       end
 
       context "when everything is OK" do
+        it { is_expected.to be_valid }
+      end
+
+      context "when cta_button_path is a full URL" do
+        let(:cta_button_path) { "http://example.org" }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when cta_button_path is a valid path" do
+        let(:cta_button_path) { "processes/my-process/" }
+
         it { is_expected.to be_valid }
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
On #2053 I forgot to validate the format of the CTA path. This PR ensure it is a valid path (only accepts letters, numbers, dashes and slashes, and must start with a letter).

#### :pushpin: Related Issues
- Related to #2053

