### PR TITLE
Don't show status indicator if no progress has been made

### DIFF
--- a/decidim-accountability/app/views/decidim/accountability/results/_home_header.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_home_header.html.erb
@@ -4,9 +4,9 @@
       <%== translated_attribute feature_settings.intro %>
     </div>
 
-    <div class="small-12 medium-5 columns">
-      <div class="progress-level">
-        <% if progress_calculator(current_scope, nil).present? %>
+    <% if progress_calculator(current_scope, nil).present? %>
+      <div class="small-12 medium-5 columns">
+        <div class="progress-level">
           <p><%= t(".global_status") %></p>
 
           <div class="progress">
@@ -16,10 +16,8 @@
           <div class="progress-figure">
             <%= display_percentage progress_calculator(current_scope, nil) %>
           </div>
-        <% end %>
-
-        <%= render partial: "decidim/accountability/shared/extra" %>
+        </div>
       </div>
-    </div>
+    <% end %>
   </div>
 </div>

--- a/decidim-accountability/app/views/decidim/accountability/results/_home_header.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_home_header.html.erb
@@ -6,9 +6,9 @@
 
     <div class="small-12 medium-5 columns">
       <div class="progress-level">
-        <p><%= t(".global_status") %></p>
-
         <% if progress_calculator(current_scope, nil).present? %>
+          <p><%= t(".global_status") %></p>
+
           <div class="progress">
             <div class="progress-meter" style="width:<%= progress_calculator(current_scope, nil) %>%"></div>
           </div>


### PR DESCRIPTION
#### :tophat: What? Why?
This hides the `Execution progress` title if there's no current progress set.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/3ofT5S2jG9fFknAmNW/giphy.gif)
