### PR TITLE
[#1960] hide new_user_registration_path links when user is logged in

### DIFF
--- a/decidim-core/app/views/pages/home/_footer_sub_hero.html.erb
+++ b/decidim-core/app/views/pages/home/_footer_sub_hero.html.erb
@@ -3,9 +3,11 @@
     <div class="columns small-centered large-10">
       <h2 class="heading3"><%= t(".footer_sub_hero_headline", organization: current_organization.name) %></h2>
       <h5 class="heading4"><%== t(".footer_sub_hero_body") %></h5>
-      <%= link_to new_user_registration_path, class: "button--sc link subhero-cta" do %>
-        <%= t(".register") %>
-        <%= icon "chevron-right", aria_hidden: true %>
+      <% unless current_user %>
+        <%= link_to new_user_registration_path, class: "button--sc link subhero-cta" do %>
+          <%= t(".register") %>
+          <%= icon "chevron-right", aria_hidden: true %>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/decidim-core/app/views/pages/home/_sub_hero.html.erb
+++ b/decidim-core/app/views/pages/home/_sub_hero.html.erb
@@ -2,9 +2,11 @@
     <div class="row">
       <div class="columns small-centered large-10">
         <h2 class="heading3"><%= sanitize translated_attribute current_organization.description %></h2>
-        <%= link_to new_user_registration_path, class: "button--sc link subhero-cta" do %>
-          <%= t(".register") %>
-          <%= icon "chevron-right", aria_hidden: true %>
+        <% unless current_user %>
+          <%= link_to new_user_registration_path, class: "button--sc link subhero-cta" do %>
+            <%= t(".register") %>
+            <%= icon "chevron-right", aria_hidden: true %>
+          <% end %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
#### :tophat: What? Why?

It hides "Register" links on the home page when the user is already logged in.

#### :pushpin: Related Issues
- Fixes: #1960

### :camera: Screenshots (optional)
![](https://user-images.githubusercontent.com/34633/31834587-b9d8a2f8-b5ce-11e7-868c-a08c227043ef.png)

#### :ghost: GIF
![](https://media.giphy.com/media/pxwlYSM8PfY5y/giphy.gif)
