### PR TITLE
Fix gem version update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,23 +10,51 @@ RUN gem install bundler --no-rdoc --no-ri
 
 ADD Gemfile /tmp/Gemfile
 ADD Gemfile.lock /tmp/Gemfile.lock
+
 ADD decidim.gemspec /tmp/decidim.gemspec
+ADD lib/decidim/version.rb /tmp/lib/decidim/version.rb
 
 ADD decidim-core/decidim-core.gemspec /tmp/decidim-core/decidim-core.gemspec
 ADD decidim-core/lib/decidim/core/version.rb /tmp/decidim-core/lib/decidim/core/version.rb
+
 ADD decidim-participatory_processes/decidim-participatory_processes.gemspec /tmp/decidim-participatory_processes/decidim-participatory_processes.gemspec
+ADD decidim-participatory_processes/lib/decidim/participatory_processes/version.rb /tmp/decidim-participatory_processes/lib/decidim/participatory_processes/version.rb
+
 ADD decidim-assemblies/decidim-assemblies.gemspec /tmp/decidim-assemblies/decidim-assemblies.gemspec
+ADD decidim-assemblies/lib/decidim/assemblies/version.rb /tmp/decidim-assemblies/lib/decidim/assemblies/version.rb
+
 ADD decidim-system/decidim-system.gemspec /tmp/decidim-system/decidim-system.gemspec
+ADD decidim-system/lib/decidim/system/version.rb /tmp/decidim-system/lib/decidim/system/version.rb
+
 ADD decidim-admin/decidim-admin.gemspec /tmp/decidim-admin/decidim-admin.gemspec
+ADD decidim-admin/lib/decidim/admin/version.rb /tmp/decidim-admin/lib/decidim/admin/version.rb
+
 ADD decidim-dev/decidim-dev.gemspec /tmp/decidim-dev/decidim-dev.gemspec
+ADD decidim-dev/lib/decidim/dev/version.rb /tmp/decidim-dev/lib/decidim/dev/version.rb
+
 ADD decidim-api/decidim-api.gemspec /tmp/decidim-api/decidim-api.gemspec
+ADD decidim-api/lib/decidim/api/version.rb /tmp/decidim-api/lib/decidim/api/version.rb
+
 ADD decidim-pages/decidim-pages.gemspec /tmp/decidim-pages/decidim-pages.gemspec
+ADD decidim-pages/lib/decidim/pages/version.rb /tmp/decidim-pages/lib/decidim/pages/version.rb
+
 ADD decidim-comments/decidim-comments.gemspec /tmp/decidim-comments/decidim-comments.gemspec
+ADD decidim-comments/lib/decidim/comments/version.rb /tmp/decidim-comments/lib/decidim/comments/version.rb
+
 ADD decidim-meetings/decidim-meetings.gemspec /tmp/decidim-meetings/decidim-meetings.gemspec
+ADD decidim-meetings/lib/decidim/meetings/version.rb /tmp/decidim-meetings/lib/decidim/meetings/version.rb
+
 ADD decidim-proposals/decidim-proposals.gemspec /tmp/decidim-proposals/decidim-proposals.gemspec
-ADD decidim-budgets/decidim-budgets.gemspec /tmp/decidim-proposals/decidim-budgets.gemspec
+ADD decidim-proposals/lib/decidim/proposals/version.rb /tmp/decidim-proposals/lib/decidim/proposals/version.rb
+
+ADD decidim-budgets/decidim-budgets.gemspec /tmp/decidim-budgets/decidim-budgets.gemspec
+ADD decidim-budgets/lib/decidim/budgets/version.rb /tmp/decidim-budgets/lib/decidim/budgets/version.rb
+
 ADD decidim-surveys/decidim-surveys.gemspec /tmp/decidim-surveys/decidim-surveys.gemspec
+ADD decidim-surveys/lib/decidim/surveys/version.rb /tmp/decidim-surveys/lib/decidim/surveys/version.rb
+
 ADD decidim-accountability/decidim-accountability.gemspec /tmp/decidim-accountability/decidim-accountability.gemspec
+ADD decidim-accountability/lib/decidim/accountability/version.rb /tmp/decidim-accountability/lib/decidim/accountability/version.rb
 
 ADD package.json /tmp/package.json
 ADD package-lock.json /tmp/package-lock.json

--- a/Rakefile
+++ b/Rakefile
@@ -44,7 +44,7 @@ task :update_versions do
     /^  "version": "[^"]*"/,
     "  \"version\": \"#{version}\""
   )
-  
+
   replace_file(
     "#{__dir__}/package-lock.json",
     /^  "version": "[^"]*"/,
@@ -58,7 +58,7 @@ task :update_versions do
       "def self.version\\1\"#{version}\""
     )
   end
-  
+
   replace_file(
     "#{__dir__}/lib/decidim/version.rb",
     /def self\.version(\s*)"[^"]*"/,

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ require "decidim/dev"
 
 load "decidim-dev/lib/tasks/test_app.rake"
 
-DECIDIM_GEMS = %w(core system admin api participatory_processes assemblies pages meetings proposals comments results budgets surveys dev).freeze
+DECIDIM_GEMS = %w(core system admin api participatory_processes assemblies pages meetings proposals comments accountability budgets surveys dev).freeze
 
 RSpec::Core::RakeTask.new(:spec)
 

--- a/Rakefile
+++ b/Rakefile
@@ -40,6 +40,12 @@ task :update_versions do
   version = File.read("#{__dir__}/.decidim-version").strip
 
   replace_file(
+    "#{__dir__}/package.json",
+    /^  "version": "[^"]*"/,
+    "  \"version\": \"#{version}\""
+  )
+  
+  replace_file(
     "#{__dir__}/package-lock.json",
     /^  "version": "[^"]*"/,
     "  \"version\": \"#{version}\""

--- a/Rakefile
+++ b/Rakefile
@@ -52,6 +52,12 @@ task :update_versions do
       "def self.version\\1\"#{version}\""
     )
   end
+  
+  replace_file(
+    "#{__dir__}/lib/decidim/version.rb",
+    /def self\.version(\s*)"[^"]*"/,
+    "def self.version\\1\"#{version}\""
+  )
 end
 
 desc "Pushes a new build for each gem."


### PR DESCRIPTION
#### :tophat: What? Why?
The Rakefile still pointed to results and missed accountability, so releasing new gem versions failed. This fixes it.

It also updates the version on the main `decidim` gem.

#### :pushpin: Related Issues
None