### PR TITLE
Downgrade `graphiql-rails` version as it raises errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ PATH
       sassc-rails (~> 1.3.0)
       select2-rails (~> 4.0.3)
     decidim-api (0.7.0.pre.pre)
-      graphiql-rails (~> 1.4.2)
+      graphiql-rails (~> 1.4.2, < 1.4.5)
       graphql (~> 1.6.0)
       rack-cors (~> 1.0.1)
       sprockets-es6 (~> 0.9.2)

--- a/decidim-api/decidim-api.gemspec
+++ b/decidim-api/decidim-api.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,vendor}/**/*", "Rakefile", "README.md"]
 
   s.add_dependency "graphql", "~> 1.6.0"
-  s.add_dependency "graphiql-rails", "~> 1.4.2"
+  s.add_dependency "graphiql-rails", "~> 1.4.2", "< 1.4.5"
   s.add_dependency "rack-cors", "~> 1.0.1"
   s.add_dependency "sprockets-es6", "~> 0.9.2"
 


### PR DESCRIPTION
#### :tophat: What? Why?
Force `graphiql-rails` version to be lower than `1.4.5`, as it raises errors as per https://github.com/rmosolgo/graphiql-rails/issues/28 and causes our builds to fail.

#### :pushpin: Related Issues
- Related to #2092 