### PR TITLE
Fix menu home highlight when using different locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - **decidim-admin**: Reference prefix was not being updated in the admin form [\#2041](https://github.com/decidim/decidim/pull/2041)
 - **decidim-core**: Handle nil resources on static maps (errors were caused by search engine spiders) [\#1936](https://github.com/decidim/decidim/pull/1936)
 - **decidim-core**: Homepage blocks were not distinguishable when statistics were hidden [\#2064](https://github.com/decidim/decidim/pull/2064)
+- **decidim-core**: Menu was not being properly highlighted when users were logged in with non-default locales [\#2095](https://github.com/decidim/decidim/pull/2095)
 - **decidim-comments**: Fix a bug sending email notifications when a comment is created [\#2036](https://github.com/decidim/decidim/pull/2036)
 - **decidim-participatory-processes**: Invited moderators couldn't access the process admin panel [\#2020](https://github.com/decidim/decidim/pull/2020)
 - **decidim-proposals**: Do not count hidden proposals on stats [\#1988](https://github.com/decidim/decidim/pull/1988)

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -142,7 +142,7 @@ module Decidim
           menu.item I18n.t("menu.home", scope: "decidim"),
                     decidim.root_path,
                     position: 1,
-                    active: :exact
+                    active: :exclusive
 
           menu.item I18n.t("menu.more_information", scope: "decidim"),
                     decidim.pages_path,

--- a/decidim-core/spec/features/menu_spec.rb
+++ b/decidim-core/spec/features/menu_spec.rb
@@ -55,4 +55,26 @@ describe "Menu", type: :feature do
       end
     end
   end
+
+  context "with a user logged in and multiple languages" do
+    let!(:user) { create :user, :confirmed, organization: organization }
+
+    before do
+      login_as user, scope: :user
+
+      visit decidim.root_path
+
+      within_language_menu do
+        click_link "Català"
+      end
+    end
+
+    it "works with multiple languages" do
+      visit decidim.root_path
+
+      within ".main-nav" do
+        expect(page).to have_selected_option("Inici")
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes the menu Home element highlight when the user is logged in.

#### :pushpin: Related Issues
None

### :camera: Screenshots (optional)
Before this PR:

http://recordit.co/3KFDe2Vwz4
![Description](http://g.recordit.co/3KFDe2Vwz4.gif)

After this PR:

http://recordit.co/VaaInJckOy
![](http://g.recordit.co/VaaInJckOy.gif)
