### PR TITLE
Constantize authorization handlers in migrations

### DIFF
--- a/decidim-core/db/migrate/20170313095436_add_available_authorizations_to_organization.rb
+++ b/decidim-core/db/migrate/20170313095436_add_available_authorizations_to_organization.rb
@@ -8,7 +8,7 @@ class AddAvailableAuthorizationsToOrganization < ActiveRecord::Migration[5.0]
   def change
     add_column :decidim_organizations, :available_authorizations, :string, array: true, default: []
 
-    handlers = Decidim.authorization_handlers
+    handlers = Decidim.authorization_handlers.map(&:constantize)
     Organization.find_each do |org|
       org.update_attributes!(available_authorizations: handlers)
     end


### PR DESCRIPTION
#### :tophat: What? Why?
This constantizes authentication handlers in migrations, as they will break on organizations with existing authorization handlers.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
*None*
