### PR TITLE
Add Excel format exporter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ PATH
       rubyzip (= 1.2.1)
       sassc-rails (~> 1.3.0)
       select2-rails (~> 4.0.3)
+      spreadsheet (~> 1.1)
       sprockets-es6 (~> 0.9.2)
       truncato (~> 0.7.10)
       wisper (~> 2.0.0)
@@ -174,7 +175,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     ast (2.3.0)
-    autoprefixer-rails (7.1.5)
+    autoprefixer-rails (7.1.6)
       execjs
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -484,6 +485,7 @@ GEM
       rainbow (>= 2.2.2, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-ole (1.2.12.1)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
     rubyzip (1.2.1)
@@ -510,6 +512,8 @@ GEM
     simplecov-html (0.10.2)
     social-share-button (1.0.0)
       coffee-rails
+    spreadsheet (1.1.4)
+      ruby-ole (>= 1.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)

--- a/decidim-admin/app/views/decidim/admin/exports/_dropdown.html.erb
+++ b/decidim-admin/app/views/decidim/admin/exports/_dropdown.html.erb
@@ -2,8 +2,8 @@
 <div class="dropdown-pane" id="export-dropdown" data-dropdown data-auto-focus="true" data-close-on-click="true">
   <ul class="vertical menu add-features">
     <% feature.manifest.export_manifests.each do |manifest| %>
-      <% %w{csv json}.each do |format| %>
-        <li class="exports--format--<%= format %> exports--<%= manifest.name %>"><%= link_to t("decidim.admin.exports.export_as", name: t("decidim.#{feature.manifest.name}.admin.exports.#{manifest.name}"), export_format: format.upcase), exports_path(feature, id: manifest.name, format: format), method: :post %></li>
+      <% %w{CSV JSON Excel}.each do |format| %>
+        <li class="exports--format--<%= format.downcase %> exports--<%= manifest.name %>"><%= link_to t("decidim.admin.exports.export_as", name: t("decidim.#{feature.manifest.name}.admin.exports.#{manifest.name}"), export_format: format.upcase), exports_path(feature, id: manifest.name, format: format), method: :post %></li>
       <% end %>
     <% end %>
   </ul>

--- a/decidim-admin/spec/helpers/exports_helper_spec.rb
+++ b/decidim-admin/spec/helpers/exports_helper_spec.rb
@@ -12,14 +12,14 @@ module Decidim
       let!(:feature) { create(:feature, manifest_name: "dummy") }
 
       it "creates a dropdown an export for each format and artifact" do
-        expect(subject.css("li.exports--dummies").length).to eq(2)
+        expect(subject.css("li.exports--dummies").length).to eq(3)
         expect(subject.css("li.exports--format--csv").length).to eq(1)
-        expect(subject.css("li.exports--format--json").length).to eq(1)
+        expect(subject.css("li.exports--format--excel").length).to eq(1)
       end
 
       it "creates links for each format" do
         link = subject.css("li.exports--format--csv.exports--dummies a")[0]
-        expect(link["href"]).to eq("/admin/participatory_processes/#{feature.participatory_space.slug}/features/#{feature.id}/exports.csv?id=dummies")
+        expect(link["href"]).to eq("/admin/participatory_processes/#{feature.participatory_space.slug}/features/#{feature.id}/exports.CSV?id=dummies")
         expect(link["data-method"]).to eq("post")
       end
     end

--- a/decidim-admin/spec/jobs/export_job_spec.rb
+++ b/decidim-admin/spec/jobs/export_job_spec.rb
@@ -10,7 +10,7 @@ module Decidim
       let!(:user) { create(:user, organization: organization) }
 
       it "sends an email with the result of the export" do
-        ExportJob.perform_now(user, feature, "dummies", "csv")
+        ExportJob.perform_now(user, feature, "dummies", "CSV")
 
         email = last_email
         expect(email.subject).to include("dummies")
@@ -33,7 +33,7 @@ module Decidim
             .to(receive(:export).with(user, anything, export_data))
             .and_return(double(deliver_now: true))
 
-          ExportJob.perform_now(user, feature, "dummies", "csv")
+          ExportJob.perform_now(user, feature, "dummies", "CSV")
         end
       end
 
@@ -49,7 +49,7 @@ module Decidim
             .to(receive(:export).with(user, anything, export_data))
             .and_return(double(deliver_now: true))
 
-          ExportJob.perform_now(user, feature, "dummies", "json")
+          ExportJob.perform_now(user, feature, "dummies", "JSON")
         end
       end
     end

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -49,6 +49,7 @@ Gem::Specification.new do |s|
   s.add_dependency "geocoder", "~> 1.4.2"
   s.add_dependency "rubyzip", "1.2.1"
   s.add_dependency "select2-rails", "~> 4.0.3"
+  s.add_dependency "spreadsheet", "~> 1.1"
 
   s.add_dependency "decidim-api", Decidim::Core.version
 

--- a/decidim-core/lib/decidim/exporters.rb
+++ b/decidim-core/lib/decidim/exporters.rb
@@ -11,7 +11,7 @@ module Decidim
 
     # Get the exporter class constant from the format as a string.
     #
-    # format - The exporter format as a string. i.e "csv"
+    # format - The exporter format as a string. i.e "CSV"
     def self.find_exporter(format)
       const_get(format)
     end

--- a/decidim-core/lib/decidim/exporters.rb
+++ b/decidim-core/lib/decidim/exporters.rb
@@ -5,6 +5,7 @@ module Decidim
     autoload :Exporter, "decidim/exporters/exporter"
     autoload :JSON, "decidim/exporters/json"
     autoload :CSV, "decidim/exporters/csv"
+    autoload :Excel, "decidim/exporters/excel"
     autoload :ExportData, "decidim/exporters/export_data"
     autoload :Serializer, "decidim/exporters/serializer"
 
@@ -12,7 +13,7 @@ module Decidim
     #
     # format - The exporter format as a string. i.e "csv"
     def self.find_exporter(format)
-      const_get(format.upcase)
+      const_get(format)
     end
   end
 end

--- a/decidim-core/lib/decidim/exporters/excel.rb
+++ b/decidim-core/lib/decidim/exporters/excel.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spreadsheet"
+
+module Decidim
+  module Exporters
+    # Exports any serialized object (Hash) into a readable Excel file. It transforms
+    # the columns using slashes in a way that can be afterwards reconstructed
+    # into the original nested hash.
+    #
+    # For example, `{ name: { ca: "Hola", en: "Hello" } }` would result into
+    # the columns: `name/ca` and `name/es`.
+    class Excel < CSV
+      # Public: Exports a file in an Excel readable format.
+      #
+      # Returns an ExportData instance.
+      def export
+        book = Spreadsheet::Workbook.new
+        sheet = book.create_worksheet
+        sheet.name = "Export"
+
+        sheet.row(0).default_format = Spreadsheet::Format.new(
+          weight: :bold,
+          pattern: 1,
+          pattern_fg_color: :xls_color_14,
+          horizontal_align: :center,
+        )
+        sheet.row(0).replace headers
+
+        headers.length.times.each do |index|
+          sheet.column(index).width = 20
+        end
+
+        processed_collection.each_with_index do |resource, index|
+          sheet.row(index + 1).replace headers.map { |header| resource[header] }
+        end
+
+        output = StringIO.new
+        book.write output
+
+        ExportData.new(output.string, "xls")
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/exporters/excel.rb
+++ b/decidim-core/lib/decidim/exporters/excel.rb
@@ -10,6 +10,9 @@ module Decidim
     #
     # For example, `{ name: { ca: "Hola", en: "Hello" } }` would result into
     # the columns: `name/ca` and `name/es`.
+    #
+    # It will maintain types like Integers, Floats & Dates so Excel can deal with
+    # them.
     class Excel < CSV
       # Public: Exports a file in an Excel readable format.
       #
@@ -23,8 +26,9 @@ module Decidim
           weight: :bold,
           pattern: 1,
           pattern_fg_color: :xls_color_14,
-          horizontal_align: :center,
+          horizontal_align: :center
         )
+
         sheet.row(0).replace headers
 
         headers.length.times.each do |index|

--- a/decidim-core/lib/decidim/exporters/exporter.rb
+++ b/decidim-core/lib/decidim/exporters/exporter.rb
@@ -10,7 +10,7 @@ module Decidim
       #
       # collection - An Array with the collection to be exported.
       # serializer - A Serializer to be used during the export.
-      def initialize(collection, serializer)
+      def initialize(collection, serializer = Serializer)
         @collection = collection
         @serializer = serializer
       end

--- a/decidim-core/spec/lib/exporters/excel_spec.rb
+++ b/decidim-core/spec/lib/exporters/excel_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "spreadsheet"
+
+describe Decidim::Exporters::Excel do
+  let(:serializer) do
+    Class.new do
+      def initialize(resource)
+        @resource = resource
+      end
+
+      def serialize
+        {
+          id: @resource.id,
+          serialized_name: @resource.name,
+          other_ids: @resource.ids,
+          float: @resource.float,
+          date: @resource.date
+        }
+      end
+    end
+  end
+
+  let(:collection) do
+    [
+      OpenStruct.new(id: 1, name: { ca: "foocat", es: "fooes" }, ids: [1, 2, 3], float: 1.66, date: DateTime.civil(2017, 10, 1, 5, 0)),
+      OpenStruct.new(id: 2, name: { ca: "barcat", es: "bares" }, ids: [2, 3, 4], float: 0.55, date: DateTime.civil(2017, 9, 20))
+    ]
+  end
+
+  subject { described_class.new(collection, serializer) }
+
+  describe "export" do
+    it "exports the collection using the right serializer" do
+      exported = StringIO.new(subject.export.read)
+      book = Spreadsheet.open(exported)
+      worksheet = book.worksheet(0)
+      expect(worksheet.rows.length).to eq(3)
+
+      headers = worksheet.rows[0]
+      expect(headers).to eq(["id", "serialized_name/ca", "serialized_name/es", "other_ids", "float", "date"])
+      expect(worksheet.rows[1][0..4]).to eq([1, "foocat", "fooes", "1, 2, 3", 1.66])
+      expect(worksheet.rows[1].datetime(5)).to eq(DateTime.civil(2017, 10, 1, 5, 0))
+
+      expect(worksheet.rows[2][0..4]).to eq([2, "barcat", "bares", "2, 3, 4", 0.55])
+      expect(worksheet.rows[2].datetime(5)).to eq(DateTime.civil(2017, 9, 20))
+    end
+  end
+end

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/registrations_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/registrations_controller.rb
@@ -29,7 +29,7 @@ module Decidim
           format = params[:format]
           export_data = Decidim::Exporters.find_exporter(format).new(meeting.registrations, Decidim::Meetings::RegistrationSerializer).export
 
-          send_data export_data.read, type: "text/#{format}", filename: export_data.filename("registrations")
+          send_data export_data.read, type: "text/#{export_data.extension}", filename: export_data.filename("registrations")
         end
 
         private

--- a/decidim-meetings/app/views/decidim/meetings/admin/registrations/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/registrations/_form.html.erb
@@ -6,8 +6,8 @@
       <span class="exports dropdown tiny button button--simple button--title" data-toggle="export-dropdown"><%= t "actions.export", scope: "decidim.admin" %></span>
       <div class="dropdown-pane" id="export-dropdown" data-dropdown data-auto-focus="true" data-close-on-click="true">
         <ul class="vertical menu add-features">
-          <% %w{csv json}.each do |format| %>
-            <li class="exports--format--<%= format %> exports--registrations"><%= link_to t("decidim.admin.exports.export_as", name: t("decidim.#{current_feature.manifest.name}.admin.exports.registrations"), export_format: format.upcase), export_meeting_registrations_path(meeting_id: meeting, format: format) %></li>
+          <% %w{CSV JSON Excel}.each do |format| %>
+            <li class="exports--format--<%= format.downcase %> exports--registrations"><%= link_to t("decidim.admin.exports.export_as", name: t("decidim.#{current_feature.manifest.name}.admin.exports.registrations"), export_format: format), export_meeting_registrations_path(meeting_id: meeting, format: format) %></li>
           <% end %>
         </ul>
       </div>


### PR DESCRIPTION
#### :tophat: What? Why?
This adds an explicit `Excel` exporter that exports to a Spreadsheet instead of a CSV, which is causing lots of issues (mainly due to the undocumented nature of CSV itself).

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
*None*