### PR TITLE
Disable autocomplete on password fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - **decidim-core**: Handle nil resources on static maps (errors were caused by search engine spiders) [\#1936](https://github.com/decidim/decidim/pull/1936)
 - **decidim-core**: Homepage blocks were not distinguishable when statistics were hidden [\#2064](https://github.com/decidim/decidim/pull/2064)
 - **decidim-core**: Menu was not being properly highlighted when users were logged in with non-default locales [\#2095](https://github.com/decidim/decidim/pull/2095)
+- **decidim-core**: Don't autocomplete the profile's password fields so uptating it doesn't break. [\#2108](https://github.com/decidim/decidim/pull/2108)
 - **decidim-comments**: Fix a bug sending email notifications when a comment is created [\#2036](https://github.com/decidim/decidim/pull/2036)
 - **decidim-participatory-processes**: Invited moderators couldn't access the process admin panel [\#2020](https://github.com/decidim/decidim/pull/2020)
 - **decidim-proposals**: Do not count hidden proposals on stats [\#1988](https://github.com/decidim/decidim/pull/1988)

--- a/decidim-core/app/views/decidim/account/_password_fields.html.erb
+++ b/decidim-core/app/views/decidim/account/_password_fields.html.erb
@@ -1,2 +1,2 @@
-<%= form.password_field :password, value: form.object.password %>
-<%= form.password_field :password_confirmation, value: form.object.password_confirmation %>
+<%= form.password_field :password, value: form.object.password, autocomplete: "off" %>
+<%= form.password_field :password_confirmation, value: form.object.password_confirmation, autocomplete: "off" %>


### PR DESCRIPTION
#### :tophat: What? Why?
This disables autocomplete on password fields to prevent a weird behavior on `Firefox` and potentially any other browsers that store passwords.

#### :pushpin: Related Issues
* Fixes #2105

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/GfkNhj7XLQi2c/giphy.gif)
