### PR TITLE
Add missing space

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/proposals/_linked_proposals.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_linked_proposals.html.erb
@@ -20,7 +20,9 @@
         </div>
       </div>
       <div class="card--list__data">
-        <%==t(".proposal_votes", count: proposal.votes.size) %>
+        <span class="card--list__data__number">
+          <%= proposal.votes.size %>
+        </span> <%== t(".proposal_votes", count: proposal.votes.size) %>
       </div>
     </div>
   <% end %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_linked_proposals.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_linked_proposals.html.erb
@@ -22,7 +22,7 @@
       <div class="card--list__data">
         <span class="card--list__data__number">
           <%= proposal.votes.size %>
-        </span> <%== t(".proposal_votes", count: proposal.votes.size) %>
+        </span> <%= t(".proposal_votes", count: proposal.votes.size) %>
       </div>
     </div>
   <% end %>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -132,8 +132,8 @@ en:
           view_proposal: View proposal
         linked_proposals:
           proposal_votes:
-            one: <span class="card--list__data__number">1</span>vote
-            other: <span class="card--list__data__number">%{count}</span>votes
+            one: vote
+            other: votes
         new:
           attachment_legend: "(Optional) Add an attachment"
           back: Back


### PR DESCRIPTION
#### :tophat: What? Why?
A locale key had a missing space which caused doubts to translators. I've checked and the space does not affect the final design, so I thought we'd better add it to remove uncertainty.

Noticed by @Digharatta on Crowdin 😄 

As you can see, design is not affected:

![](https://i.imgur.com/MZH3hYZ.png)

#### :pushpin: Related Issues
None