### PR TITLE
Add view hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased](https://github.com/decidim/decidim/tree/HEAD)
 
+**Added**:
+
+- **decidim-core**: Add view hooks so external engines can extend the homepage and other sections with their own code [\#2114](https://github.com/decidim/decidim/pull/2114)
+
+**Changed**:
+
 - **decidim-admin**: Replace url to visit_url moderation admin [\#2129](https://github.com/decidim/decidim/pull/2129)
 
 ## [v0.7.1](https://github.com/decidim/decidim/tree/v0.7.1) (2017-10-26)

--- a/decidim-core/app/controllers/decidim/application_controller.rb
+++ b/decidim-core/app/controllers/decidim/application_controller.rb
@@ -18,6 +18,7 @@ module Decidim
     helper Decidim::AriaSelectedLinkToHelper
     helper Decidim::MenuHelper
     helper Decidim::FeaturePathHelper
+    helper Decidim::ViewHooksHelper
 
     protect_from_forgery with: :exception, prepend: true
     after_action :add_vary_header

--- a/decidim-core/app/controllers/decidim/pages_controller.rb
+++ b/decidim-core/app/controllers/decidim/pages_controller.rb
@@ -11,7 +11,7 @@ module Decidim
 
     authorize_resource :public_pages, class: false
     delegate :page, to: :page_finder
-    helper_method :page, :promoted_participatory_processes, :highlighted_participatory_processes, :stats
+    helper_method :page, :stats
     helper CtaButtonHelper
 
     def index
@@ -22,11 +22,6 @@ module Decidim
 
     def page_finder
       @page_finder ||= Decidim::PageFinder.new(params[:id], current_organization)
-    end
-
-    def promoted_participatory_processes
-      @promoted_participatory_processes ||=
-        ParticipatoryProcesses::OrganizationPrioritizedParticipatoryProcesses.new(current_organization) | ParticipatoryProcesses::PromotedParticipatoryProcesses.new
     end
 
     def highlighted_participatory_processes

--- a/decidim-core/app/controllers/decidim/pages_controller.rb
+++ b/decidim-core/app/controllers/decidim/pages_controller.rb
@@ -24,11 +24,6 @@ module Decidim
       @page_finder ||= Decidim::PageFinder.new(params[:id], current_organization)
     end
 
-    def highlighted_participatory_processes
-      @highlighted_participatory_processes ||=
-        ParticipatoryProcesses::OrganizationPublishedParticipatoryProcesses.new(current_organization) | ParticipatoryProcesses::HighlightedParticipatoryProcesses.new
-    end
-
     private
 
     def stats

--- a/decidim-core/app/helpers/decidim/view_hooks_helper.rb
+++ b/decidim-core/app/helpers/decidim/view_hooks_helper.rb
@@ -3,9 +3,9 @@
 module Decidim
   # This module includes helpers to manage view hooks in layout
   module ViewHooksHelper
-    # Public: Renders all hooks registered as `name`.
+    # Public: Renders all hooks registered as `hook_name`.
     #
-    # name - a Symbol reporesenting the name of the hook.
+    # hook_name - a Symbol representing the name of the hook.
     #
     # Returns an HTML safe String.
     def render_hook(hook_name)

--- a/decidim-core/app/helpers/decidim/view_hooks_helper.rb
+++ b/decidim-core/app/helpers/decidim/view_hooks_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This module includes helpers to manage view hooks in layout
+  module ViewHooksHelper
+    # Public: Renders all hooks registered as `name`.
+    #
+    # name - a Symbol reporesenting the name of the hook.
+    #
+    # Returns an HTML safe String.
+    def render_hook(hook_name)
+      Decidim.view_hooks.render(hook_name, self)
+    end
+  end
+end

--- a/decidim-core/app/views/pages/home/_highlighted_processes.html.erb
+++ b/decidim-core/app/views/pages/home/_highlighted_processes.html.erb
@@ -1,5 +1,3 @@
 <section class="wrapper-home">
-  <% Decidim.view_hooks.get(:highlighted_elements).each do |hook| %>
-    <%= render partial: hook[:partial] %>
-  <% end %>
+  <%= render_hook(:highlighted_elements) %>
 </section>

--- a/decidim-core/app/views/pages/home/_highlighted_processes.html.erb
+++ b/decidim-core/app/views/pages/home/_highlighted_processes.html.erb
@@ -1,5 +1,5 @@
 <section class="wrapper-home">
-  <% Decidim.view_hooks.get(:highlighted_elements).sort_by{ |h| h[:priority] }.each do |hook| %>
+  <% Decidim.view_hooks.get(:highlighted_elements).each do |hook| %>
     <%= render partial: hook[:partial] %>
   <% end %>
 </section>

--- a/decidim-core/app/views/pages/home/_highlighted_processes.html.erb
+++ b/decidim-core/app/views/pages/home/_highlighted_processes.html.erb
@@ -1,37 +1,5 @@
 <section class="wrapper-home">
-  <div class="row">
-    <h3 class="section-heading"><%= t(".active_processes") %></h3>
-    <div class="row collapse">
-      <div class="row small-up-1 smallmedium-up-2 mediumlarge-up-3
-                  large-up-4 card-grid">
-        <% highlighted_participatory_processes.each do |process| %>
-          <div class="column">
-            <article class="card card--process card--mini">
-              <%= link_to decidim_participatory_processes.participatory_process_path(process), class: "card__link" do %>
-                <div class="card__image-top"
-                     style="background-image:url(<%= process.hero_image.url %>)"></div>
-              <% end %>
-              <div class="card__content">
-                <%= link_to decidim_participatory_processes.participatory_process_path(process), class: "card__link" do %>
-                  <h4 class="card__title"><%= translated_attribute process.title %></h4>
-                <% end %>
-                <% if process.active_step %>
-                  <span class="card--process__small">
-                    <%= t(".active_step") %>
-                    <strong><%= translated_attribute process.active_step.title %></strong>
-                  </span>
-                <% end %>
-              </div>
-            </article>
-          </div>
-        <% end %>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="columns small-centered small-12
-                smallmedium-8 medium-6 large-4">
-      <%= link_to t(".see_all_processes"), decidim_participatory_processes.participatory_processes_path, class: "button expanded hollow button--sc home-section__cta" %>
-    </div>
-  </div>
+  <% Decidim.view_hooks.get(:highlighted_elements).sort_by{ |h| h[:priority] }.each do |hook| %>
+    <%= render partial: hook[:partial] %>
+  <% end %>
 </section>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -356,10 +356,6 @@ en:
       hero:
         participate: Participate
         welcome: Welcome to %{organization}!
-      highlighted_processes:
-        active_processes: Active processes
-        active_step: Active step
-        see_all_processes: See all processes
       statistics:
         answers_count: Answers
         comments_count: Comments

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -40,6 +40,7 @@ module Decidim
   autoload :Abilities, "decidim/abilities"
   autoload :EngineRouter, "decidim/engine_router"
   autoload :Events, "decidim/events"
+  autoload :ViewHooks, "decidim/view_hooks"
 
   include ActiveSupport::Configurable
 
@@ -248,5 +249,10 @@ module Decidim
   #
   def self.menu(name, &block)
     MenuRegistry.register(name.to_sym, &block)
+  end
+
+  # Public: Stores an instance of ViewHooks
+  def self.view_hooks
+    @view_hooks ||= ViewHooks.new
   end
 end

--- a/decidim-core/lib/decidim/view_hooks.rb
+++ b/decidim-core/lib/decidim/view_hooks.rb
@@ -43,9 +43,8 @@ module Decidim
     # partials for a given hook name by priority.
     #
     # name - a symbol representing the name of the view hook
-    # options - A hash of options
-    #         * priority: The priority of the partial to be rendered. Default is `LOW_PRIORITY`
-    #         * partial: The name of the partial that needs to be rendered.
+    # priority - a Number (Integer|Float) to sort the block.
+    # &block - The block that will be rendered in the view hook.
     #
     # Returns nothing.
     def register(name, priority: LOW_PRIORITY, &block)
@@ -87,7 +86,7 @@ module Decidim
 
     # Internal class to encapsulate each view registered on a view hook.
     class ViewHook
-      # priority - a Number (Integer/Float) to sort the block.
+      # priority - a Number (Integer|Float) to sort the block.
       # block - a block that will bbe rendered in a view context.
       def initialize(priority, block)
         @priority = priority

--- a/decidim-core/lib/decidim/view_hooks.rb
+++ b/decidim-core/lib/decidim/view_hooks.rb
@@ -1,20 +1,49 @@
 # frozen_string_literal: true
 
 module Decidim
+  # This class acts as a registry for view hooks. It saves paths to partials found in
+  # engines so they can be included in other engines. Each engine can have its own
+  # instance of this class, so that view hooks are namespaced instead of global.
+  #
+  # This mechanism is useful to extend the views of a given engine from other engines.
+  # For example, the homepage of Decidim is found on `decidim-core`, but it can be
+  # extended by other engine to show important info there. For example, an engine might
+  # want to extend the homepage to show highlighted participatory processes.
+  #
+  # In order to show view hooks, you can use something like this in your views:
+  #
+  #     Decidim.view_hooks # => an instance of this class
+  #     <% Decidim.view_hooks.get(:my_hook).each do |hook| %>
+  #       <%= render partial: hook[:partial]
+  #     <% end %>
+  #
+  # In order to add more partials to this view hook, you can register as in the
+  # following example. Note that you will probably use this from your engine initializer.
+  #
+  #     Decidim.view_hooks.register(
+  #       :my_hook,
+  #       priority: Decidim::ViewHooks::HIGH_PRIORITY,
+  #       partial: "path/to/my/partial"
+  #     )
   class ViewHooks
     HIGH_PRIORITY = 1
     MEDIUM_PRIORITY = 2
     LOW_PRIORITY = 3
 
+    # Initializes the class.
+    #
+    # hooks - a Hash to store the different view hooks. By default, it's a Hash with
+    #   Arrays as default values.
     def initialize(hooks = Hash.new { |h, k| h[k] = [] })
       @hooks = hooks
     end
 
-    # Public: Register a view for a given view hook
+    # Public: Register a view partial for a given view hook. It automatically sorts the
+    # partials for a given hook name by priority.
     #
-    # name - The name of the view hook
+    # name - a symbol representing the name of the view hook
     # options - A hash of options
-    #         * priority: The priority of the stat used for render issues.
+    #         * priority: The priority of the partial to be rendered. Default is `LOW_PRIORITY`
     #         * partial: The name of the partial that needs to be rendered.
     #
     # Returns nothing.
@@ -23,13 +52,14 @@ module Decidim
       options[:priority] ||= LOW_PRIORITY
 
       hooks[name].push(options)
+      hooks[name].sort_by! { |hook| hook[:priority] }
     end
 
     # Gets all the view hooks registered for a given hook name.
     #
     # name - The name of the view hook
     #
-    # Returns an array of Hashes.
+    # Returns an array of Hashes, ordered by their `:priority` key value.
     def get(name)
       hooks[name]
     end

--- a/decidim-core/lib/decidim/view_hooks.rb
+++ b/decidim-core/lib/decidim/view_hooks.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Decidim
+  class ViewHooks
+    HIGH_PRIORITY = 1
+    MEDIUM_PRIORITY = 2
+    LOW_PRIORITY = 3
+
+    def initialize(hooks = Hash.new { |h, k| h[k] = [] })
+      @hooks = hooks
+    end
+
+    # Public: Register a view for a given view hook
+    #
+    # name - The name of the view hook
+    # options - A hash of options
+    #         * priority: The priority of the stat used for render issues.
+    #         * partial: The name of the partial that needs to be rendered.
+    #
+    # Returns nothing.
+    def register(name, options = {})
+      raise StandardError, "Option `:partial` is not defined" if options[:partial].blank?
+      options[:priority] ||= LOW_PRIORITY
+
+      hooks[name].push(options)
+    end
+
+    # Gets all the view hooks registered for a given hook name.
+    #
+    # name - The name of the view hook
+    #
+    # Returns an array of Hashes.
+    def get(name)
+      hooks[name]
+    end
+
+    private
+
+    attr_reader :hooks
+  end
+end

--- a/decidim-core/spec/controllers/pages_controller_spec.rb
+++ b/decidim-core/spec/controllers/pages_controller_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "decidim/dev/test/promoted_participatory_processes_shared_examples"
 
 module Decidim
   module Devise
@@ -9,8 +8,6 @@ module Decidim
       routes { Decidim::Core::Engine.routes }
 
       let(:organization) { create :organization }
-
-      include_examples "with promoted participatory processes"
 
       context "when a template exists" do
         it "renders it" do

--- a/decidim-core/spec/controllers/pages_controller_spec.rb
+++ b/decidim-core/spec/controllers/pages_controller_spec.rb
@@ -9,6 +9,10 @@ module Decidim
 
       let(:organization) { create :organization }
 
+      before do
+        @request.env["decidim.current_organization"] = organization
+      end
+
       context "when a template exists" do
         it "renders it" do
           get :show, params: { id: "home" }

--- a/decidim-core/spec/lib/view_hooks_spec.rb
+++ b/decidim-core/spec/lib/view_hooks_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe ViewHooks do
+    subject { described_class.new }
+
+    describe "register" do
+      it "saves the hooks in priority order" do
+        subject.register(:test_hook, priority: 3) do
+          "Lower priority"
+        end
+        subject.register(:test_hook, priority: 1) do
+          "Higher priority"
+        end
+
+        priorities = subject.send(:hooks)[:test_hook].map(&:priority)
+        expect(priorities).to eq [1, 3]
+
+        subject.register(:test_hook, priority: 2) do
+          "Medium priority"
+        end
+
+        priorities = subject.send(:hooks)[:test_hook].map(&:priority)
+        expect(priorities).to eq [1, 2, 3]
+      end
+
+      it "defaults priority to 3" do
+        subject.register(:test_hook) do
+          "Medium priority"
+        end
+
+        priorities = subject.send(:hooks)[:test_hook].map(&:priority)
+        expect(priorities).to eq [3]
+      end
+    end
+
+    describe "render" do
+      it "joins the result of the blocks in an HTML string" do
+        subject.register(:test_hook, priority: 3) do
+          "b"
+        end
+        subject.register(:test_hook, priority: 1) do
+          "a"
+        end
+
+        result = subject.render(:test_hook, nil)
+        expect(result).to eq "ab"
+        expect(result).to be_html_safe
+      end
+    end
+  end
+end

--- a/decidim-core/spec/lib/view_hooks_spec.rb
+++ b/decidim-core/spec/lib/view_hooks_spec.rb
@@ -8,12 +8,8 @@ module Decidim
 
     describe "register" do
       it "saves the hooks in priority order" do
-        subject.register(:test_hook, priority: 3) do
-          "Lower priority"
-        end
-        subject.register(:test_hook, priority: 1) do
-          "Higher priority"
-        end
+        subject.register(:test_hook, priority: 3) { "Lower priority" }
+        subject.register(:test_hook, priority: 1) { "Higher priority" }
 
         priorities = subject.send(:hooks)[:test_hook].map(&:priority)
         expect(priorities).to eq [1, 3]
@@ -38,12 +34,8 @@ module Decidim
 
     describe "render" do
       it "joins the result of the blocks in an HTML string" do
-        subject.register(:test_hook, priority: 3) do
-          "b"
-        end
-        subject.register(:test_hook, priority: 1) do
-          "a"
-        end
+        subject.register(:test_hook, priority: 3) { "b" }
+        subject.register(:test_hook, priority: 1) { "a" }
 
         result = subject.render(:test_hook, nil)
         expect(result).to eq "ab"

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/pages/home/_highlighted_processes.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/pages/home/_highlighted_processes.html.erb
@@ -3,7 +3,7 @@
   <div class="row collapse">
     <div class="row small-up-1 smallmedium-up-2 mediumlarge-up-3
       large-up-4 card-grid">
-      <% highlighted_participatory_processes.each do |process| %>
+      <% highlighted_processes.each do |process| %>
         <div class="column">
           <article class="card card--process card--mini">
             <%= link_to decidim_participatory_processes.participatory_process_path(process), class: "card__link" do %>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/pages/home/_highlighted_processes.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/pages/home/_highlighted_processes.html.erb
@@ -1,0 +1,35 @@
+<div class="row">
+  <h3 class="section-heading"><%= t(".active_processes") %></h3>
+  <div class="row collapse">
+    <div class="row small-up-1 smallmedium-up-2 mediumlarge-up-3
+      large-up-4 card-grid">
+      <% highlighted_participatory_processes.each do |process| %>
+        <div class="column">
+          <article class="card card--process card--mini">
+            <%= link_to decidim_participatory_processes.participatory_process_path(process), class: "card__link" do %>
+              <div class="card__image-top"
+                style="background-image:url(<%= process.hero_image.url %>)"></div>
+            <% end %>
+            <div class="card__content">
+              <%= link_to decidim_participatory_processes.participatory_process_path(process), class: "card__link" do %>
+                <h4 class="card__title"><%= translated_attribute process.title %></h4>
+              <% end %>
+              <% if process.active_step %>
+                <span class="card--process__small">
+                  <%= t(".active_step") %>
+                  <strong><%= translated_attribute process.active_step.title %></strong>
+                </span>
+              <% end %>
+            </div>
+          </article>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="columns small-centered small-12
+    smallmedium-8 medium-6 large-4">
+    <%= link_to t(".see_all_processes"), decidim_participatory_processes.participatory_processes_path, class: "button expanded hollow button--sc home-section__cta" %>
+  </div>
+</div>

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -225,6 +225,12 @@ en:
         active: Active
         past: Past
         upcoming: Upcoming
+      pages:
+        home:
+          highlighted_processes:
+            active_processes: Active processes
+            active_step: Active step
+            see_all_processes: See all processes
       participatory_process_groups:
         none: None
       participatory_processes:

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
@@ -61,6 +61,14 @@ module Decidim
                     active: :inclusive
         end
       end
+
+      initializer "decidim_participatory_processes.view_hooks" do
+        Decidim.view_hooks.register(
+          :highlighted_elements,
+          priority: 1,
+          partial: "decidim/participatory_processes/pages/home/highlighted_processes"
+        )
+      end
     end
   end
 end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
@@ -63,11 +63,9 @@ module Decidim
       end
 
       initializer "decidim_participatory_processes.view_hooks" do
-        Decidim.view_hooks.register(
-          :highlighted_elements,
-          priority: 1,
-          partial: "decidim/participatory_processes/pages/home/highlighted_processes"
-        )
+        Decidim.view_hooks.register(:highlighted_elements, priority: Decidim::ViewHooks::HIGH_PRIORITY) do |view_context|
+          view_context.render partial: "decidim/participatory_processes/pages/home/highlighted_processes"
+        end
       end
     end
   end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
@@ -64,7 +64,15 @@ module Decidim
 
       initializer "decidim_participatory_processes.view_hooks" do
         Decidim.view_hooks.register(:highlighted_elements, priority: Decidim::ViewHooks::HIGH_PRIORITY) do |view_context|
-          view_context.render partial: "decidim/participatory_processes/pages/home/highlighted_processes"
+          highlighted_processes =
+            OrganizationPublishedParticipatoryProcesses.new(view_context.current_organization) | HighlightedParticipatoryProcesses.new
+
+          view_context.render(
+            partial: "decidim/participatory_processes/pages/home/highlighted_processes",
+            locals: {
+              highlighted_processes: highlighted_processes
+            }
+          )
         end
       end
     end

--- a/docs/view_hooks.md
+++ b/docs/view_hooks.md
@@ -1,0 +1,74 @@
+# View hooks
+
+## General description
+
+All engines can define their own view hooks, and register to other engines' ones. This allows engines to add content to views rendered by other engines. This will be clearer with an example.
+
+Take the homepage, for example. It is rendered by the `decidim-core`. We want to show there a list of highlighted participatory spaces (processes and assemblies). We cannot be sure the final app has these engines, so we need to check they exist:
+
+```
+<% if defined? Decidim::Processes %>
+  <% # iterate through the most important ones %>
+<% end %>
+<% if defined? Decidim::Assemblies %>
+  <% # iterate through the most important ones %>
+<% end %>
+```
+
+This raises two important issues:
+
+1. We are linking `decidim-core` with `decidim-assemblies` and `decidim-participatory_processes`. This is not perfect.
+1. The final app cannot extent this view to add more content in a simple way. The developers could overwrite the view, but this raises maintainability problems, as upgrades will be harder.
+
+## Rendering view hooks
+
+Instead of the previous example, we created the concept of "view hooks". Think of them as a registry of views which can be defined by a given engine and extended by others. To follow the previous example, we would register a view hook in `decidim-core`:
+
+```
+<%= Decidim.view_hooks.render(:highlighted_elements, self) %>
+```
+
+We're rendering the view hooks registered as `:highlighted_elements`. The `self` parameter is the view context, we will analyze it later.
+
+## Registering view hooks
+
+Other engines would register blocks of Ruby and Rails code from their initializers. For example, in `decidim-participatory_processes`:
+
+```ruby
+# decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
+initializer "decidim_participatory_processes.view_hooks" do
+  Decidim.view_hooks.register(:highlighted_elements) do |view_context|
+    view_context.render(partial: "my/partial")
+  end
+end
+```
+
+In order to register a view hook we need the hook name and a block of Ruby code. We're registering a view hook as `:highlighted-elements`, following our example. We're passing the view context to the block so that we can use our views helper methods there, and we're rendering a partial. We could write `ActiveRecord` queries and pass the results to the partial as `locals` if we wanted a more complex view:
+
+```ruby
+# decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
+initializer "decidim_participatory_processes.view_hooks" do
+  Decidim.view_hooks.register(:highlighted_elements) do |view_context|
+    highlighted_processes =
+      OrganizationPublishedParticipatoryProcesses.new(view_context.current_organization) | HighlightedParticipatoryProcesses.new
+
+    view_context.render(partial: "decidim/participatory_processes/my/partial", locals: { highlighted_processes: highlighted_processes })
+  end
+end
+```
+
+When registering a view hook, we can set a priority for each one. By default, all view hooks are registered with low priority, but we can change it:
+
+```ruby
+Decidim.view_hooks.register(:highlighted_elements, priority: Decidim::ViewHooks::HIGH_PRIORITY) do |view_context|
+  # ...
+end
+```
+
+## Enabling view hooks in your engine
+
+Ideally, each engine should hold their own instance of `Decidim::ViewHooks`. This means that if `decidim-participatory_processes` wants to allow part of its views to be extended by other engines, it should define `Decidim::ParticipatoryProcesses.view_hooks`, and other engines should register to this instance.
+
+## The engine I want to extend does not support view hooks, what can I do?
+
+First of all, send a PR to the engine to add the view hook you need. Expose your needs, so the developers can assess a view hook is the best solution. Sometimes a view hook can be replaced with another abstraction, or another UI. Meanwhile, you can use [`deface`](https://github.com/spree/deface) to extend a view file without replacing it. Be careful, since `deface` is *very* powerful and can be a double-edged sword. We considered adding `deface` to `decidim`, but found that it opened to a code that would be much harder to maintain.

--- a/docs/view_hooks.md
+++ b/docs/view_hooks.md
@@ -18,7 +18,7 @@ Take the homepage, for example. It is rendered by the `decidim-core`. We want to
 This raises two important issues:
 
 1. We are linking `decidim-core` with `decidim-assemblies` and `decidim-participatory_processes`. This is not perfect.
-1. The final app cannot extent this view to add more content in a simple way. The developers could overwrite the view, but this raises maintainability problems, as upgrades will be harder.
+1. The final app cannot extend this view to add more content in a simple way. The developers could overwrite the view, but this raises maintainability problems, as upgrades will be harder.
 
 ## Rendering view hooks
 


### PR DESCRIPTION
#### :tophat: What? Why?
Lets engines define view hooks and register partials to them, so they can be rendered.

#### :pushpin: Related Issues
- Related to #2062

#### :clipboard: Subtasks
- [x] Add `ViewHooks` registry class
- [x] Add tests
