### PR TITLE
Update CHANGELOG after 0.7.1 is released

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased](https://github.com/decidim/decidim/tree/HEAD)
 
+## [v0.7.1](https://github.com/decidim/decidim/tree/v0.7.1) (2017-10-26)
+[Full Changelog](https://github.com/decidim/decidim/compare/v0.7.0...v0.7.1)
+
+**Fixed**:
+
+- **decidim**: Fixed app generators [\#2119](https://github.com/decidim/decidim/pull/2119)
+
 ## [v0.7.0](https://github.com/decidim/decidim/tree/v0.7.0) (2017-10-25)
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.6.8...v0.7.0)
 


### PR DESCRIPTION
#### :tophat: What? Why?
PR #2121 releases 0.7.1. This PR updates the CHANGELOG in master to reflect this new version.

#### :pushpin: Related Issues
- Related to #2121