### PR TITLE
#2081. Fixes active processes and adds all processes filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - **decidim-core**: Fixes to MigrateUserRolesToParticipatoryProcessRoles: avoid using relations and work with id's directly [\#2223](https://github.com/decidim/decidim/pull/2223)
 - **decidim-core**: Embedded videos were not displaying properly [\#2198](https://github.com/decidim/decidim/pull/2198)
 - **decidim-core**: Links in emails in development being generated without a port [\#2237](https://github.com/decidim/decidim/pull/2237)
+- **decidim-participatory-processes**: Fixes active processes and adds all processes filters [\#2081](https://github.com/decidim/decidim/pull/2131)
 
 ## [v0.7.4](https://github.com/decidim/decidim/tree/v0.7.4) (2017-11-23)
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.7.3...v0.7.4)

--- a/decidim-participatory_processes/app/models/decidim/participatory_process.rb
+++ b/decidim-participatory_processes/app/models/decidim/participatory_process.rb
@@ -48,6 +48,10 @@ module Decidim
     mount_uploader :hero_image, Decidim::HeroImageUploader
     mount_uploader :banner_image, Decidim::BannerImageUploader
 
+    scope :past, -> { where(arel_table[:end_date].lteq(Time.current)) }
+    scope :upcoming, -> { where(arel_table[:start_date].gt(Time.current)) }
+    scope :active, -> { where(arel_table[:start_date].lteq(Time.current).and(arel_table[:end_date].gt(Time.current).or(arel_table[:end_date].eq(nil)))) }
+
     # Scope to return only the promoted processes.
     #
     # Returns an ActiveRecord::Relation.

--- a/decidim-participatory_processes/app/queries/decidim/participatory_processes/filtered_participatory_processes.rb
+++ b/decidim-participatory_processes/app/queries/decidim/participatory_processes/filtered_participatory_processes.rb
@@ -13,12 +13,14 @@ module Decidim
         processes = Decidim::ParticipatoryProcess.all
 
         case @filter
-        when "past"
-          processes.where("decidim_participatory_processes.end_date <= ?", Time.current)
-        when "upcoming"
-          processes.where("decidim_participatory_processes.start_date > ?", Time.current)
-        else
+        when "all"
           processes
+        when "past"
+          processes.past
+        when "upcoming"
+          processes.upcoming
+        else
+          processes.active
         end
       end
     end

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/_order_by_processes.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/_order_by_processes.html.erb
@@ -3,7 +3,7 @@
     <%= t("participatory_processes.order_by_processes.processes", scope: "layouts.decidim", count: collection.count) %>
     <% if include_filter %>
       <span class="order-by__tabs">
-        <% %w(past active upcoming).each do |filter_name| %>
+        <% %w(past active upcoming all).each do |filter_name| %>
           <%= link_to t(".#{filter_name}"), { filter: filter_name }, remote: true, class: "order-by__tab #{'is-active' if filter == filter_name }" %>
         <% end %>
       </span>

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -223,6 +223,7 @@ en:
         title: Participatory processes
       order_by_processes:
         active: Active
+        all: All
         past: Past
         upcoming: Upcoming
       pages:

--- a/decidim-participatory_processes/spec/features/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/features/participatory_processes_spec.rb
@@ -68,6 +68,8 @@ describe "Participatory Processes", type: :feature do
     let!(:participatory_process) { base_process }
     let!(:promoted_process) { create(:participatory_process, :promoted, organization: organization) }
     let!(:unpublished_process) { create(:participatory_process, :unpublished, organization: organization) }
+    let!(:past_process) { create :participatory_process, :past, organization: organization }
+    let!(:upcoming_process) { create :participatory_process, :upcoming, organization: organization }
 
     before do
       visit decidim_participatory_processes.participatory_processes_path
@@ -93,7 +95,7 @@ describe "Participatory Processes", type: :feature do
       end
     end
 
-    it "lists all the processes" do
+    it "lists the active processes" do
       within "#processes-grid" do
         within "#processes-grid h2" do
           expect(page).to have_content("2")
@@ -104,6 +106,8 @@ describe "Participatory Processes", type: :feature do
         expect(page).to have_selector("article.card", count: 2)
 
         expect(page).to have_no_content(translated(unpublished_process.title, locale: :en))
+        expect(page).to have_no_content(translated(past_process.title, locale: :en))
+        expect(page).to have_no_content(translated(upcoming_process.title, locale: :en))
       end
     end
 
@@ -114,12 +118,21 @@ describe "Participatory Processes", type: :feature do
     end
 
     context "and filtering processes" do
-      let!(:past_process) { create :participatory_process, :past, organization: organization }
-      let!(:upcoming_process) { create :participatory_process, :upcoming, organization: organization }
+      context "choosing 'active' processes" do
+        before do
+          within ".order-by__tabs" do
+            click_link "Active"
+          end
+        end
 
-      it "list the active processes by default" do
-        expect(page).to have_no_content(translated(past_process.title, locale: :en))
-        expect(page).to have_no_content(translated(upcoming_process.title, locale: :en))
+        it "lists the active processes" do
+          within "#processes-grid h2" do
+            expect(page).to have_content("2")
+          end
+
+          expect(page).to have_content(translated(participatory_process.title, locale: :en))
+          expect(page).to have_content(translated(promoted_process.title, locale: :en))
+        end
       end
 
       context "and choosing 'past' processes" do
@@ -129,7 +142,7 @@ describe "Participatory Processes", type: :feature do
           end
         end
 
-        it "list the past processes" do
+        it "lists the past processes" do
           within "#processes-grid h2" do
             expect(page).to have_content("1")
           end
@@ -145,11 +158,30 @@ describe "Participatory Processes", type: :feature do
           end
         end
 
-        it "list the past processes" do
+        it "lists the upcoming processes" do
           within "#processes-grid h2" do
             expect(page).to have_content("1")
           end
 
+          expect(page).to have_content(translated(upcoming_process.title, locale: :en))
+        end
+      end
+
+      context "choosing 'all' processes" do
+        before do
+          within ".order-by__tabs" do
+            click_link "All"
+          end
+        end
+
+        it "lists all processes" do
+          within "#processes-grid h2" do
+            expect(page).to have_content("4")
+          end
+
+          expect(page).to have_content(translated(participatory_process.title, locale: :en))
+          expect(page).to have_content(translated(promoted_process.title, locale: :en))
+          expect(page).to have_content(translated(past_process.title, locale: :en))
           expect(page).to have_content(translated(upcoming_process.title, locale: :en))
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

Fix active processes filter so that it shows only the active ones (currently showing all). Add a new filter for showing all the processes.

#### :pushpin: Related Issues
- Fixes #2081 

#### :clipboard: Subtasks

_None_

### :camera: Screenshots (optional)
<img width="451" alt="processes filter" src="https://user-images.githubusercontent.com/3958/32120070-8d048ea2-bb57-11e7-9c3b-eed4043a8dab.png">

#### :ghost: GIF
![]()
