### PR TITLE
Ignore markdown files on codecov code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -61,6 +61,7 @@ comment:
 
 ignore:
   - package-lock.json
+  - *.md
 
 flags:
   core:


### PR DESCRIPTION
#### :tophat: What? Why?

Ignore markdown files on codecov. Making a change on the README or any markdown files for that matter should not lower code coverage.


#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/pull/2132

#### :ghost: GIF
![](https://media.giphy.com/media/zOvBKUUEERdNm/giphy.gif)
