### PR TITLE
Admin design tweaks

### DIFF
--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_buttons.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_buttons.scss
@@ -31,12 +31,10 @@
   .button:not(:last-child){
     margin-right: 1rem;
   }
-  @include breakpoint(mediumlarge){
-    display: flex;
-    align-items: center;
-    .button{
-      margin-bottom: 0;
-    }
+  display: flex;
+  align-items: center;
+  .button{
+    margin-bottom: 0;
   }
 }
 

--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_buttons.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_buttons.scss
@@ -20,9 +20,7 @@
 
 .button--title{
   margin-bottom: 0;
-  @include breakpoint(mediumlarge){
-    float: right;
-  }
+  float: right;
   &:not(:first-child){
     margin-right: 1rem;
   }

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_buttons.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_buttons.scss
@@ -86,10 +86,6 @@
   font-weight: 600;
 }
 
-.link--no-color{
-  color: inherit;
-}
-
 .muted-link{
   font-weight: 600;
   color: $muted;


### PR DESCRIPTION
#### :tophat: What? Why?

These are some small improvements in the admin design that I added while working on the new authorization flows.

Basically, it's just removing what I think are some unnecessary differences between the mobile & desktop. Not sure if I'm missing something. 

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)

#### Always float buttons in title section to the right

##### Before
![before](https://user-images.githubusercontent.com/2887858/32186852-8fe5cb6a-bda3-11e7-9087-f7d644dfff70.gif)

##### After
![after2](https://user-images.githubusercontent.com/2887858/32187238-aeba59b0-bda4-11e7-99d5-c9e43477f893.gif)



#### Always place action buttons in a centered position

##### Before
![beforeleft](https://user-images.githubusercontent.com/2887858/32186865-9bfd4824-bda3-11e7-9021-acca336f892c.gif)

##### After
![afterleft](https://user-images.githubusercontent.com/2887858/32186877-a0213438-bda3-11e7-8d33-7775e818dc6b.gif)

#### :ghost: GIF
![glassesfall](https://user-images.githubusercontent.com/2887858/32186843-8a013a54-bda3-11e7-82c5-0f477f4cc092.gif)
