### PR TITLE
Specify PhantomJS should be installed from official website

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ In order to develop on decidim, you'll need:
 * **Ruby** 2.4.1
 * **NodeJS** 8.x.x
 * **ImageMagick**
-* **PhantomJS**
+* **PhantomJS**. If you're on Ubuntu, make sure you download it from the [official website](http://phantomjs.org/download.html) instead of using the version of the Ubuntu repositories
 
 The easiest way to work on decidim is to clone decidim's repository and install its dependencies
 


### PR DESCRIPTION
#### :tophat: What? Why?
#2137 emphasizes that on Ubuntu, PhantomJS should be installed from the official website instead of using th eversion from the repos. This PR reflects this on the README.

#### :pushpin: Related Issues
- Related to #2137.