### PR TITLE
Fix a couple of regexp warnings

### DIFF
--- a/decidim-admin/app/forms/decidim/admin/organization_appearance_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_appearance_form.rb
@@ -29,7 +29,7 @@ module Decidim
       translatable_attribute :description, String
       translatable_attribute :welcome_text, String
 
-      validates :cta_button_path, format: { with: %r{\A[a-zA-Z]+[a-zA-Z0-9-/]+\z} }, allow_blank: true
+      validates :cta_button_path, format: { with: %r{\A[a-zA-Z]+[a-zA-Z0-9\-/]+\z} }, allow_blank: true
       validates :official_img_header,
                 :official_img_footer,
                 :homepage_image,

--- a/decidim-core/lib/decidim/participable.rb
+++ b/decidim-core/lib/decidim/participable.rb
@@ -74,7 +74,7 @@ module Decidim
 
     class_methods do
       def slug_format
-        /\A[a-zA-Z]+[a-zA-Z0-9-]+\z/
+        /\A[a-zA-Z]+[a-zA-Z0-9\-]+\z/
       end
 
       def participatory_space_manifest


### PR DESCRIPTION
#### :tophat: What? Why?

Fixes some warnings like the following

```
character class has '-' without escape: /\A[a-zA-Z]+[a-zA-Z0-9-\/]+
```

that have recently appeared while running the test suite.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![tail](https://user-images.githubusercontent.com/2887858/32262471-1feb7ffc-bed5-11e7-95cf-3c5941b22511.gif)
