### PR TITLE
Preparation for headless chrome

### DIFF
--- a/decidim-accountability/spec/shared/manage_child_results_examples.rb
+++ b/decidim-accountability/spec/shared/manage_child_results_examples.rb
@@ -82,7 +82,7 @@ RSpec.shared_examples "manage child results" do
 
     it "deletes a result" do
       within find("tr", text: translated(child_result.title)) do
-        find("a.action-icon--remove").click
+        accept_confirm { find("a.action-icon--remove").click }
       end
 
       within ".callout-wrapper" do

--- a/decidim-accountability/spec/shared/manage_results_examples.rb
+++ b/decidim-accountability/spec/shared/manage_results_examples.rb
@@ -87,7 +87,7 @@ shared_examples "manage results" do
 
     it "deletes a result" do
       within find("tr", text: translated(result2.title)) do
-        find("a.action-icon--remove").click
+        accept_confirm { find("a.action-icon--remove").click }
       end
 
       within ".callout-wrapper" do

--- a/decidim-accountability/spec/shared/manage_statuses_examples.rb
+++ b/decidim-accountability/spec/shared/manage_statuses_examples.rb
@@ -73,7 +73,7 @@ RSpec.shared_examples "manage statuses" do
 
     it "deletes a status" do
       within find("tr", text: status2.key) do
-        find("a.action-icon--remove").click
+        accept_confirm { find("a.action-icon--remove").click }
       end
 
       within ".callout-wrapper" do

--- a/decidim-admin/lib/decidim/admin/test/manage_attachments_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_attachments_examples.rb
@@ -60,7 +60,7 @@ shared_examples "manage attachments examples" do
 
     it "can delete an attachment from a process" do
       within find("tr", text: stripped(translated(attachment.title))) do
-        page.find("a.action-icon--remove").click
+        accept_confirm { page.find("a.action-icon--remove").click }
       end
 
       within ".callout-wrapper" do

--- a/decidim-admin/spec/features/admin_manages_newsletters_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_newsletters_spec.rb
@@ -119,7 +119,7 @@ describe "Admin manages newsletters", type: :feature do
       visit decidim_admin.newsletter_path(newsletter)
 
       within ".button--double" do
-        find("*", text: "Deliver").click
+        accept_confirm { find("*", text: "Deliver").click }
       end
 
       expect(page).to have_content("NEWSLETTERS")
@@ -138,7 +138,7 @@ describe "Admin manages newsletters", type: :feature do
       visit decidim_admin.newsletters_path
 
       within("tr[data-newsletter-id=\"#{newsletter.id}\"]") do
-        page.find(".action-icon.action-icon--remove").click
+        accept_confirm { page.find(".action-icon.action-icon--remove").click }
       end
 
       expect(page).to have_content("successfully")

--- a/decidim-admin/spec/features/admin_manages_organization_admins_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_organization_admins_spec.rb
@@ -88,7 +88,7 @@ describe "Organization admins", type: :feature do
         expect(page).to have_content(other_admin.name)
 
         within "tr[data-user-id=\"#{other_admin.id}\"]" do
-          page.find(".action-icon.action-icon--remove").click
+          accept_confirm { page.find(".action-icon.action-icon--remove").click }
         end
 
         expect(page).to have_no_content(other_admin.name)

--- a/decidim-admin/spec/features/admin_manages_organization_scopes_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_organization_scopes_spec.rb
@@ -74,7 +74,7 @@ describe "Organization scopes", type: :feature do
 
       it "can destroy them" do
         within find("tr", text: translated(scope.name)) do
-          page.find("a.action-icon.action-icon--remove").click
+          accept_confirm { page.find("a.action-icon.action-icon--remove").click }
         end
 
         within ".callout-wrapper" do

--- a/decidim-admin/spec/features/static_pages_spec.rb
+++ b/decidim-admin/spec/features/static_pages_spec.rb
@@ -109,7 +109,7 @@ describe "Content pages", type: :feature do
 
       it "can destroy them" do
         within find("tr", text: translated(decidim_page.title)) do
-          page.find(".action-icon.action-icon--remove").click
+          accept_confirm { page.find(".action-icon.action-icon--remove").click }
         end
 
         within ".callout-wrapper" do

--- a/decidim-assemblies/spec/features/admin/admin_manages_assemblies_spec.rb
+++ b/decidim-assemblies/spec/features/admin/admin_manages_assemblies_spec.rb
@@ -129,7 +129,7 @@ describe "Admin manages assemblies", type: :feature do
 
     it "deletes an assembly" do
       click_link translated(assembly2.title)
-      click_link "Destroy"
+      accept_confirm { click_link "Destroy" }
 
       within ".callout-wrapper" do
         expect(page).to have_content("successfully")

--- a/decidim-assemblies/spec/features/admin/admin_manages_assembly_categories_spec.rb
+++ b/decidim-assemblies/spec/features/admin/admin_manages_assembly_categories_spec.rb
@@ -89,7 +89,7 @@ describe "Admin manages assembly categories", type: :feature do
 
         it "deletes a category" do
           within find("tr", text: translated(category2.name)) do
-            page.find("a.action-icon--remove").click
+            accept_confirm { page.find("a.action-icon--remove").click }
           end
 
           within ".callout-wrapper" do
@@ -111,7 +111,7 @@ describe "Admin manages assembly categories", type: :feature do
 
         it "deletes a category" do
           within find("tr", text: translated(category2.name)) do
-            page.find("a.action-icon--remove").click
+            accept_confirm { page.find("a.action-icon--remove").click }
           end
 
           within ".callout-wrapper" do

--- a/decidim-assemblies/spec/features/assemblies_spec.rb
+++ b/decidim-assemblies/spec/features/assemblies_spec.rb
@@ -21,9 +21,8 @@ describe "Assemblies", type: :feature do
 
   context "when there are no assemblies" do
     context "direct access from URL" do
-      it "renders an error page" do
-        visit decidim_assemblies.assemblies_path
-        expect(page).to have_http_status(:not_found)
+      it_behaves_like "a 404 page" do
+        let(:target_path) { decidim_assemblies.assemblies_path }
       end
     end
 
@@ -51,9 +50,8 @@ describe "Assemblies", type: :feature do
     end
 
     context "direct access from URL" do
-      it "renders an error page" do
-        visit decidim_assemblies.assemblies_path
-        expect(page).to have_http_status(:not_found)
+      it_behaves_like "a 404 page" do
+        let(:target_path) { decidim_assemblies.assemblies_path }
       end
     end
 

--- a/decidim-budgets/spec/features/orders_spec.rb
+++ b/decidim-budgets/spec/features/orders_spec.rb
@@ -162,7 +162,7 @@ describe "Orders", type: :feature do
         visit_feature
 
         within ".budget-summary" do
-          page.find(".cancel-order").click
+          accept_confirm { page.find(".cancel-order").click }
         end
 
         expect(page).to have_content("successfully")

--- a/decidim-budgets/spec/shared/manage_projects_examples.rb
+++ b/decidim-budgets/spec/shared/manage_projects_examples.rb
@@ -107,7 +107,7 @@ shared_examples "manage projects" do
 
     it "deletes a project" do
       within find("tr", text: translated(project2.title)) do
-        find("a.action-icon--remove").click
+        accept_confirm { find("a.action-icon--remove").click }
       end
 
       within ".callout-wrapper" do

--- a/decidim-core/lib/decidim/core/test/shared_examples/errors.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/errors.rb
@@ -1,21 +1,23 @@
 # frozen_string_literal: true
 
 shared_examples_for "a 404 page" do
-  before do
-    allow(Rails.application).to \
-      receive(:env_config).with(no_args).and_wrap_original do |m, *|
-        m.call.merge(
-          "action_dispatch.show_exceptions" => true,
-          "action_dispatch.show_detailed_exceptions" => false
-        )
-      end
+  describe "visiting the page", driver: :rack_test do
+    before do
+      allow(Rails.application).to \
+        receive(:env_config).with(no_args).and_wrap_original do |m, *|
+          m.call.merge(
+            "action_dispatch.show_exceptions" => true,
+            "action_dispatch.show_detailed_exceptions" => false
+          )
+        end
 
-    visit target_path
-  end
+      visit target_path
+    end
 
-  it "leads to a 404" do
-    expect(page).to have_content("The page you're looking for can't be found")
+    it "leads to a 404" do
+      expect(page).to have_content("The page you're looking for can't be found")
 
-    expect(page).to have_http_status(:not_found)
+      expect(page).to have_http_status(:not_found)
+    end
   end
 end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/phantomjs_polyfills/phantomjs-shim.js
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/phantomjs_polyfills/phantomjs-shim.js
@@ -87,23 +87,6 @@
 }());
 
 /**
- * Polyfill for CustomEvent
- * Until PhantomJS v2.0 is out (see https://github.com/ariya/phantomjs/issues/11289)
- */
-(function() {
-  function CustomEvent(event, params) {
-    params = params || { bubbles: false, cancelable: false, detail: undefined };
-    var evt = document.createEvent('CustomEvent');
-    evt.initCustomEvent(event, params.bubbles, params.cancelable, params.detail);
-    return evt;
-  };
-
-  CustomEvent.prototype = window.Event.prototype;
-
-  window.CustomEvent = CustomEvent;
-})();
-
-/**
  * Polyfill for String.startsWith
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
  */

--- a/decidim-meetings/spec/shared/manage_meetings_examples.rb
+++ b/decidim-meetings/spec/shared/manage_meetings_examples.rb
@@ -121,7 +121,7 @@ shared_examples "manage meetings" do
 
     it "deletes a meeting" do
       within find("tr", text: translated(meeting2.title)) do
-        page.find("a.action-icon--remove").click
+        accept_confirm { page.find("a.action-icon--remove").click }
       end
 
       within ".callout-wrapper" do

--- a/decidim-meetings/spec/shared/manage_registrations_examples.rb
+++ b/decidim-meetings/spec/shared/manage_registrations_examples.rb
@@ -104,7 +104,7 @@ shared_examples "manage registrations" do
     end
   end
 
-  context "export registrations" do
+  context "export registrations", driver: :rack_test do
     let!(:registrations) { create_list :registration, 10, meeting: meeting }
 
     it "exports a CSV" do

--- a/decidim-participatory_processes/spec/features/admin/admin_manages_participatory_process_groups_spec.rb
+++ b/decidim-participatory_processes/spec/features/admin/admin_manages_participatory_process_groups_spec.rb
@@ -102,7 +102,7 @@ describe "Admin manages participatory process groups", type: :feature do
 
     it "can destroy them" do
       within find("tr", text: participatory_process_group.name["en"]) do
-        page.find(".action-icon.action-icon--remove").click
+        accept_confirm { page.find(".action-icon.action-icon--remove").click }
       end
 
       within ".callout-wrapper" do

--- a/decidim-participatory_processes/spec/features/admin/admin_manages_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/features/admin/admin_manages_participatory_processes_spec.rb
@@ -105,7 +105,7 @@ describe "Admin manages participatory processes", type: :feature do
 
     it "deletes a participatory_process" do
       click_link translated(participatory_process2.title)
-      click_link "Destroy"
+      accept_confirm { click_link "Destroy" }
 
       within ".callout-wrapper" do
         expect(page).to have_content("successfully")

--- a/decidim-participatory_processes/spec/features/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/features/participatory_processes_spec.rb
@@ -21,9 +21,8 @@ describe "Participatory Processes", type: :feature do
 
   context "when there are no processes" do
     context "direct access form URL" do
-      it "renders an error page" do
-        visit decidim_participatory_processes.participatory_processes_path
-        expect(page).to have_http_status(:not_found)
+      it_behaves_like "a 404 page" do
+        let(:target_path) { decidim_participatory_processes.participatory_processes_path }
       end
     end
 
@@ -51,9 +50,8 @@ describe "Participatory Processes", type: :feature do
     end
 
     context "direct access from URL" do
-      it "renders an error page" do
-        visit decidim_participatory_processes.participatory_processes_path
-        expect(page).to have_http_status(:not_found)
+      it_behaves_like "a 404 page" do
+        let(:target_path) { decidim_participatory_processes.participatory_processes_path }
       end
     end
 

--- a/decidim-participatory_processes/spec/shared/manage_process_admins_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_process_admins_examples.rb
@@ -75,7 +75,7 @@ shared_examples "manage process admins examples" do
 
     it "deletes a participatory_process_user_role" do
       within find("#process_admins tr", text: other_user.email) do
-        page.find("a.action-icon--remove").click
+        accept_confirm { page.find("a.action-icon--remove").click }
       end
 
       within ".callout-wrapper" do

--- a/decidim-participatory_processes/spec/shared/manage_process_categories_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_process_categories_examples.rb
@@ -78,7 +78,7 @@ shared_examples "manage process categories examples" do
 
         it "deletes a category" do
           within find("tr", text: translated(category2.name)) do
-            page.find("a.action-icon--remove").click
+            accept_confirm { page.find("a.action-icon--remove").click }
           end
 
           within ".callout-wrapper" do
@@ -100,7 +100,7 @@ shared_examples "manage process categories examples" do
 
         it "deletes a category" do
           within find("tr", text: translated(category2.name)) do
-            page.find("a.action-icon--remove").click
+            accept_confirm { page.find("a.action-icon--remove").click }
           end
 
           within ".callout-wrapper" do

--- a/decidim-participatory_processes/spec/shared/manage_process_steps_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_process_steps_examples.rb
@@ -93,7 +93,7 @@ shared_examples "manage process steps examples" do
 
     it "deletes a participatory_process_step" do
       within find("tr", text: translated(process_step2.title)) do
-        page.find(".action-icon--remove").click
+        accept_confirm { page.find(".action-icon--remove").click }
       end
 
       within ".callout-wrapper" do

--- a/decidim-surveys/spec/features/survey_spec.rb
+++ b/decidim-surveys/spec/features/survey_spec.rb
@@ -81,7 +81,7 @@ describe "Answer a survey", type: :feature do
 
         check "survey_tos_agreement"
 
-        click_button "Submit"
+        accept_confirm { click_button "Submit" }
 
         within ".success.flash" do
           expect(page).to have_content("successfully")
@@ -109,7 +109,7 @@ describe "Answer a survey", type: :feature do
 
           check "survey_tos_agreement"
 
-          click_button "Submit"
+          accept_confirm { click_button "Submit" }
 
           within ".alert.flash" do
             expect(page).to have_content("error")
@@ -151,7 +151,7 @@ describe "Answer a survey", type: :feature do
 
           check "survey_tos_agreement"
 
-          click_button "Submit"
+          accept_confirm { click_button "Submit" }
 
           within ".success.flash" do
             expect(page).to have_content("successfully")
@@ -185,7 +185,7 @@ describe "Answer a survey", type: :feature do
 
           check "survey_tos_agreement"
 
-          click_button "Submit"
+          accept_confirm { click_button "Submit" }
 
           within ".success.flash" do
             expect(page).to have_content("successfully")
@@ -219,7 +219,7 @@ describe "Answer a survey", type: :feature do
 
           check "survey_tos_agreement"
 
-          click_button "Submit"
+          accept_confirm { click_button "Submit" }
 
           within ".success.flash" do
             expect(page).to have_content("successfully")

--- a/decidim-system/spec/features/manage_admins_spec.rb
+++ b/decidim-system/spec/features/manage_admins_spec.rb
@@ -53,7 +53,7 @@ describe "Manage admins", type: :feature do
 
   it "deletes an admin" do
     within find("tr", text: admin2.email) do
-      click_link "Destroy"
+      accept_confirm { click_link "Destroy" }
     end
 
     within ".success.flash" do


### PR DESCRIPTION
#### :tophat: What? Why?

These are some tweaks in our specs to make them capybara driver independent, so it'll be easier to migrate to headless chrome.

#### :pushpin: Related Issues
- Related to #2098.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![cat-gifs-sleepy](https://user-images.githubusercontent.com/2887858/32263803-b0e5ee6a-bedb-11e7-9be0-c92a521f7e12.gif)
