### PR TITLE
Hide home block while participatory processes are empty

### DIFF
--- a/decidim-core/app/views/pages/home/_highlighted_processes.html.erb
+++ b/decidim-core/app/views/pages/home/_highlighted_processes.html.erb
@@ -1,3 +1,7 @@
-<section class="wrapper-home">
-  <%= render_hook(:highlighted_elements) %>
-</section>
+<% highlighted_elements = render_hook(:highlighted_elements) %>
+
+<% if !highlighted_elements.blank? %>
+  <section class="wrapper-home">
+    <%= highlighted_elements %>
+  </section>
+<% end %>

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
@@ -67,6 +67,8 @@ module Decidim
           highlighted_processes =
             OrganizationPublishedParticipatoryProcesses.new(view_context.current_organization) | HighlightedParticipatoryProcesses.new
 
+          next unless highlighted_processes.any?
+
           view_context.render(
             partial: "decidim/participatory_processes/pages/home/highlighted_processes",
             locals: {


### PR DESCRIPTION
#### :tophat: What? Why?
This hides the participatory process home block in order to prevent them from being shown if empty.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/9WHE2bo5Na9Gg/giphy.gif)
