### PR TITLE
Lint markdown

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -37,6 +37,12 @@ engines:
           annotation: "Don't leave trailing whitespace"
           severity: minor
           categories: Style
+  markdownlint:
+    enabled: true
+    exclude_paths:
+      - docs/*
+      - .github/*
+      - CHANGELOG.md
   rubocop:
     enabled: true
     channel: rubocop-0-50

--- a/.mdl_style.rb
+++ b/.mdl_style.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+all
+
+exclude_rule "first-line-h1"
+
+exclude_rule "line-length"
+
+exclude_rule "no-bare-urls"
+
+exclude_rule "no-inline-html"
+
+rule "no-trailing-punctuation", punctuation: ".,;:!"

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,1 @@
+style ".mdl_style.rb"

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ All members of the Decidim community agree with [Decidim Social Contract or Code
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](http://rubydoc.info/github/decidim/decidim/master)
 [![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/decidim/decidim)
 
+Code quality
 
-### Code quality
 [![Build Status](https://img.shields.io/circleci/project/github/decidim/decidim/master.svg)](https://circleci.com/gh/decidim/decidim)
 [![Code Climate](https://img.shields.io/codeclimate/github/decidim/decidim.svg)](https://codeclimate.com/github/decidim/decidim/trends)
 [![codecov](https://img.shields.io/codecov/c/github/decidim/decidim.svg)](https://codecov.io/gh/decidim/decidim)
@@ -27,7 +27,8 @@ All members of the Decidim community agree with [Decidim Social Contract or Code
 [![Accessibility issues](https://rocketvalidator.com/badges/a11y_issues.svg?url=http://staging.decidim.codegram.com/)](https://rocketvalidator.com/badges/link?url=http://staging.decidim.codegram.com/&report=a11y)
 [![HTML issues](https://rocketvalidator.com/badges/html_issues.svg?url=http://staging.decidim.codegram.com/)](https://rocketvalidator.com/badges/link?url=http://staging.decidim.codegram.com/&report=html)
 
-### Project management [[See on Waffle.io]](https://waffle.io/decidim/decidim)
+Project management [[See on Waffle.io]](https://waffle.io/decidim/decidim)
+
 [![Stories in Discussion](https://img.shields.io/waffle/label/decidim/decidim/discussion.svg)](https://github.com/decidim/decidim/issues?q=is%3Aopen+is%3Aissue+label%3Adiscussion)
 [![Stories in Planned](https://img.shields.io/waffle/label/decidim/decidim/planned.svg)](https://github.com/decidim/decidim/issues?q=is%3Aopen+is%3Aissue+label%3Aplanned)
 [![Bugs](https://img.shields.io/waffle/label/decidim/decidim/bug.svg)](https://github.com/decidim/decidim/issues?q=is%3Aopen+is%3Aissue+label%3Abug)
@@ -36,14 +37,14 @@ All members of the Decidim community agree with [Decidim Social Contract or Code
 
 ---
 
-## What do you need to do?
+# What do you need to do?
 
-- [Get started with Decidim](#getting-started-with-decidim)
-- [Contribute to the project](#how-to-contribute)
-- [Decidim components](#officially-supported-libraries)
-- [How to test Decidim engines](docs/testing.md)
-- [Create & browse development app](#browse-decidim)
-- [Technical tradeoffs](#technical-tradeoffs)
+* [Get started with Decidim](#getting-started-with-decidim)
+* [Contribute to the project](#how-to-contribute)
+* [Decidim components](#officially-supported-libraries)
+* [How to test Decidim engines](docs/testing.md)
+* [Create & browse development app](#browse-decidim)
+* [Technical tradeoffs](#technical-tradeoffs)
 
 ---
 
@@ -70,10 +71,10 @@ In order to develop on decidim, you'll need:
 The easiest way to work on decidim is to clone decidim's repository and install its dependencies
 
 ```bash
-$ git clone git@github.com:decidim/decidim.git
-$ cd decidim
-$ bundle install
-$ npm install
+git clone git@github.com:decidim/decidim.git
+cd decidim
+bundle install
+npm install
 ```
 
 You have several rake tasks available:
@@ -87,26 +88,25 @@ You have several rake tasks available:
 #### Browse Decidim
 
 After you create a development app (`bundle exec rake development_app`):
-- `cd development_app`
-- `bundle exec rails s`
-- Go to 'http://localhost:3000'
+
+* `cd development_app`
+* `bundle exec rails s`
+* Go to 'http://localhost:3000'
 
 Optionally, you can log in as: user@example.org | decidim123456
 
 Also, if you want to verify yourself against the default authorization handler use a document number ended with "X".
 
-
 #### Browse Admin Interface
 
 After you create a development app (`bundle exec rake development_app`):
-- `cd development_app`
-- `bundle exec rails s`
-- Go to 'http://localhost:3000/admin'
-- Login data: admin@example.org | decidim123456
 
+* `cd development_app`
+* `bundle exec rails s`
+* Go to 'http://localhost:3000/admin'
+* Login data: admin@example.org | decidim123456
 
 ## Officially supported libraries
-
 
 | Library        | Description           |
 | ------------- |-------------|
@@ -142,7 +142,6 @@ The support of Turbolinks was dropped in [d8c7d9f](https://github.com/decidim/de
 ## Following our license
 
 If you plan to release your application you'll need to publish it using the same license: GPL Affero 3. We recommend doing that on GitHub before publishing, you can read more on "[Being Open Source From Day One is Especially Important for Government Projects](http://producingoss.com/en/governments-and-open-source.html#starting-open-for-govs)". If you have any trouble you can contact us on [Gitter](https://gitter.im/decidim/decidim).
-
 
 ## Example applications
 

--- a/decidim-accountability/README.md
+++ b/decidim-accountability/README.md
@@ -2,12 +2,12 @@
 
 The Accountability module adds results to any participatory process. It adds a CRUD engine to the admin and public views scoped inside the participatory process. Accountability will link to related meetings and proposals and will be used to show the progress on the related proposals.
 
-
 ## Usage
 
 Accountability will be available as a Feature for a Participatory Process.
 
 ## Installation
+
 Add this line to your application's Gemfile:
 
 ```ruby
@@ -15,12 +15,15 @@ gem 'decidim-accountability'
 ```
 
 And then execute:
+
 ```bash
-$ bundle
+bundle
 ```
 
 ## Contributing
+
 See [Decidim](https://github.com/AjuntamentdeBarcelona/decidim).
 
 ## License
+
 See [Decidim](https://github.com/AjuntamentdeBarcelona/decidim).

--- a/decidim-admin/README.md
+++ b/decidim-admin/README.md
@@ -4,10 +4,12 @@ This library adds an administration dashboard so users can manage their
 organization, participatory processes and all other entities.
 
 ## Usage
+
 This will add an admin dashboard to manage an organization an all its entities.
 It's included by default with Decidim.
 
 ## Installation
+
 Add this line to your application's Gemfile:
 
 ```ruby
@@ -15,8 +17,9 @@ gem 'decidim-admin'
 ```
 
 And then execute:
+
 ```bash
-$ bundle
+bundle
 ```
 
 ## Features
@@ -26,10 +29,10 @@ $ bundle
 This feature allows an admin to create pages to serve static content. Some
 example of this kind of pages could be:
 
-  * Terms and Conditions
-  * FAQ
-  * Accessibility guidelines
-  * About the project
+* Terms and Conditions
+* FAQ
+* Accessibility guidelines
+* About the project
 
 All the pages can be created with I18n support and will be accessible as
 `/pages/:page-slug`. You can link them at your website the same way you link
@@ -40,7 +43,9 @@ are links to them inside the Decidim framework, see `Decidim::StaticPage` for
 the default list.
 
 ## Contributing
+
 See [Decidim](https://github.com/decidim/decidim).
 
 ## License
+
 See [Decidim](https://github.com/decidim/decidim).

--- a/decidim-api/README.md
+++ b/decidim-api/README.md
@@ -3,14 +3,15 @@
 This library exposes a [GraphQL](https://facebook.github.io/graphql/) API to programatically interact with the Decidim platform via HTTP.
 
 ## Usage
+
 Including `decidim-api` will get expose two nice endpoints:
 
 * `/api`: The main GraphQL endpoint that holds the actual API.
 * `/api/docs`: Nicely-written docs of the entities of the API.
 * `/api/grapiql`: A neat sandbox to interactively play with the API and its capabilities.
 
-
 ## Installation
+
 Add this line to your application's Gemfile:
 
 ```ruby
@@ -18,12 +19,15 @@ gem 'decidim-api'
 ```
 
 And then execute:
+
 ```bash
-$ bundle
+bundle
 ```
 
 ## Contributing
+
 See [Decidim](https://github.com/decidim/decidim).
 
 ## License
+
 See [Decidim](https://github.com/decidim/decidim).

--- a/decidim-assemblies/README.md
+++ b/decidim-assemblies/README.md
@@ -16,6 +16,7 @@ This plugin provides:
 * Public views for assembly via a high level section in the main menu.
 
 ## Installation
+
 Add this line to your application's Gemfile:
 
 ```ruby
@@ -23,12 +24,15 @@ gem 'decidim-assemblies'
 ```
 
 And then execute:
+
 ```bash
-$ bundle
+bundle
 ```
 
 ## Contributing
+
 See [Decidim](https://github.com/decidim/decidim).
 
 ## License
+
 See [Decidim](https://github.com/decidim/decidim).

--- a/decidim-budgets/README.md
+++ b/decidim-budgets/README.md
@@ -1,10 +1,13 @@
 # Decidim::Budgets
+
 The Budgets module adds projects to any participatory process. It adds a CRUD engine to the admin and public views scoped inside the participatory process. Projects will link to related proposals and have a budget. The users should be able to distribute a budget between these projects.
 
 ## Usage
+
 Budgets will be available as a Feature for a Participatory Process.
 
 ## Installation
+
 Add this line to your application's Gemfile:
 
 ```ruby
@@ -12,12 +15,15 @@ gem 'decidim-budgets
 ```
 
 And then execute:
+
 ```bash
-$ bundle
+bundle
 ```
 
 ## Contributing
+
 See [Decidim](https://github.com/decidim/decidim).
 
 ## License
+
 See [Decidim](https://github.com/decidim/decidim).

--- a/decidim-comments/README.md
+++ b/decidim-comments/README.md
@@ -31,8 +31,9 @@ gem 'decidim-comments'
 ```
 
 And then execute:
+
 ```bash
-$ bundle
+bundle
 ```
 
 ## How to contribute
@@ -40,17 +41,19 @@ $ bundle
 The technology stack used in this module is the following:
 
 For the backend side:
-  - Ruby on Rails
-  - GraphQL
+
+- Ruby on Rails
+- GraphQL
 
 For the frontend side:
-  - Typescript (introduced in #1001)
-  - React
-  - Apollo
+
+- Typescript (introduced in #1001)
+- React
+- Apollo
 
 The frontend code can be found in the folder `app/frontend` instead of `app/assets`. We are using Webpack to build the React application so we are keeping the React files in a separate folder and then including the `bundle.js` file using sprockets as usual.
 
-#### Developing React components
+### Developing React components
 
 You need to execute `npm start` in a separate terminal, in the `decidim` root folder while you are developing this module. When you are finished you can build the project for production like this: `npm run build:prod`. We are checking in the bundle into the repository.
 
@@ -69,7 +72,9 @@ Since we are using Typescript we can generate interfaces and types from our sche
 This command will create a file called `app/frontend/support/schema.ts` that can be used to strict type checking in our components.
 
 ## Contributing
+
 See [Decidim](https://github.com/decidim/decidim).
 
 ## License
+
 See [Decidim](https://github.com/decidim/decidim).

--- a/decidim-core/README.md
+++ b/decidim-core/README.md
@@ -1,10 +1,13 @@
 # Decidim
+
 Short description and motivation.
 
 ## Usage
+
 How to use my plugin.
 
 ## Installation
+
 Add this line to your application's Gemfile:
 
 ```ruby
@@ -12,17 +15,21 @@ gem 'decidim'
 ```
 
 And then execute:
+
 ```bash
-$ bundle
+bundle
 ```
 
 Or install it yourself as:
+
 ```bash
-$ gem install decidim
+gem install decidim
 ```
 
 ## Contributing
+
 Contribution directions go here.
 
 ## License
+
 The gem is available as open source under the terms of the [AGPLv3 License](https://opensource.org/licenses/AGPL-3.0).

--- a/decidim-dev/README.md
+++ b/decidim-dev/README.md
@@ -3,9 +3,11 @@
 This gem allows local development of decidim's features and other features.
 
 ## Usage
+
 TODO: Write docs.
 
 ## Installation
+
 Add this line to your application's Gemfile:
 
 ```ruby
@@ -13,12 +15,15 @@ gem 'decidim-dev'
 ```
 
 And then execute:
+
 ```bash
-$ bundle
+bundle
 ```
 
 ## Contributing
+
 See [Decidim](https://github.com/decidim/decidim).
 
 ## License
+
 See [Decidim](https://github.com/decidim/decidim).

--- a/decidim-meetings/README.md
+++ b/decidim-meetings/README.md
@@ -1,10 +1,13 @@
 # Decidim::Meetings
+
 The Meetings module adds meeting to any participatory process. It adds a CRUD engine to the admin and public view scoped inside the participatory process.
 
 ## Usage
+
 Meetings will be available as a Feature for a Participatory Process.
 
 ## Installation
+
 Add this line to your application's Gemfile:
 
 ```ruby
@@ -12,12 +15,15 @@ gem 'decidim-meetings'
 ```
 
 And then execute:
+
 ```bash
-$ bundle
+bundle
 ```
 
 ## Contributing
+
 See [Decidim](https://github.com/decidim/decidim).
 
 ## License
+
 See [Decidim](https://github.com/decidim/decidim).

--- a/decidim-pages/README.md
+++ b/decidim-pages/README.md
@@ -3,9 +3,11 @@
 The Pages module adds static page capabilities to any participatory process. It basically provides an interface to include arbitrary HTML content to any step.
 
 ## Usage
+
 Pages will be available as a Feature for a Participatory Process.
 
 ## Installation
+
 Add this line to your application's Gemfile:
 
 ```ruby
@@ -13,12 +15,15 @@ gem 'decidim-pages'
 ```
 
 And then execute:
+
 ```bash
-$ bundle
+bundle
 ```
 
 ## Contributing
+
 See [Decidim](https://github.com/decidim/decidim).
 
 ## License
+
 See [Decidim](https://github.com/decidim/decidim).

--- a/decidim-participatory_processes/README.md
+++ b/decidim-participatory_processes/README.md
@@ -18,6 +18,7 @@ This plugin provides:
   menu.
 
 ## Installation
+
 Add this line to your application's Gemfile:
 
 ```ruby
@@ -25,12 +26,15 @@ gem 'decidim-participatory_processes'
 ```
 
 And then execute:
+
 ```bash
-$ bundle
+bundle
 ```
 
 ## Contributing
+
 See [Decidim](https://github.com/decidim/decidim).
 
 ## License
+
 See [Decidim](https://github.com/decidim/decidim).

--- a/decidim-proposals/README.md
+++ b/decidim-proposals/README.md
@@ -3,9 +3,11 @@
 The Proposals module adds one of the main features of Decidim: allows users to contribute to a particiaptory process by creating proposals.
 
 ## Usage
+
 Proposals will be available as a Feature for a Participatory Process.
 
 ## Installation
+
 Add this line to your application's Gemfile:
 
 ```ruby
@@ -13,12 +15,15 @@ gem 'decidim-proposals
 ```
 
 And then execute:
+
 ```bash
-$ bundle
+bundle
 ```
 
 ## Contributing
+
 See [Decidim](https://github.com/decidim/decidim).
 
 ## License
+
 See [Decidim](https://github.com/decidim/decidim).

--- a/decidim-surveys/README.md
+++ b/decidim-surveys/README.md
@@ -3,9 +3,11 @@
 The Surveys module adds one of the main features of Decidim: allows admins to contribute to a participatory process by creating surveys. Users can participate in the surveys answering their questions from the public page.
 
 ## Usage
+
 Surveys will be available as a Feature for a Participatory Process.
 
 ## Installation
+
 Add this line to your application's Gemfile:
 
 ```ruby
@@ -13,12 +15,15 @@ gem 'decidim-surveys'
 ```
 
 And then execute:
+
 ```bash
-$ bundle
+bundle
 ```
 
 ## Contributing
+
 See [Decidim](https://github.com/decidim/decidim).
 
 ## License
+
 See [Decidim](https://github.com/decidim/decidim).

--- a/decidim-system/README.md
+++ b/decidim-system/README.md
@@ -14,8 +14,9 @@ gem 'decidim-system'
 ```
 
 And then execute:
+
 ```bash
-$ bundle
+bundle
 ```
 
 ## Multi-tenancy in Decidim
@@ -62,4 +63,5 @@ Remember that System admins and regular Admins are completely different users (t
 system user to login in as an organization admin.
 
 ## License
+
 The gem is available as open source under the terms of the [AGPLv3 License](https://opensource.org/licenses/AGPL-3.0).


### PR DESCRIPTION
#### :tophat: What? Why?

Follow up #2148. It enforces in general what @xabier fixed in that PR for `CONTRIBUTING.md`, but also enforces other stuff like:

* Consistent symbols (- or *) for lists.
* Blank lines around code blocks, lists and headers (helps editors do their highlighting job).
* No `$` signs on terminal commands (helps with copy-pasting them).
* ...

I've just started with the easiest rules, and with `README.md` and `CONTRIBUTING.md` for now. But we can tweak further later.

@decidim/developers What do you think about this? Some people arg that it's overkill to lint markdown. I think it's another part of software where linting can be useful...

#### :pushpin: Related Issues
- Related to #2148.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![tiger small](https://user-images.githubusercontent.com/2887858/32392677-4fb65c5c-c0b5-11e7-8352-75f44fe704aa.gif)

