### PR TITLE
Show active assemblies to the homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Added**:
 
+- **decidim-assemblies**: Show promoted assemblies in the homepage [\#2162](https://github.com/decidim/decidim/pull/2162)
 - **decidim-core**: Add view hooks so external engines can extend the homepage and other sections with their own code [\#2114](https://github.com/decidim/decidim/pull/2114)
 
 **Changed**:

--- a/decidim-assemblies/app/views/decidim/assemblies/pages/home/_highlighted_assemblies.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/pages/home/_highlighted_assemblies.html.erb
@@ -1,0 +1,29 @@
+<div class="row" id="highlighted-assemblies">
+  <h3 class="section-heading"><%= t(".active_assemblies") %></h3>
+  <div class="row collapse">
+    <div class="row small-up-1 smallmedium-up-2 mediumlarge-up-3
+      large-up-4 card-grid">
+      <% highlighted_assemblies.each do |assembly| %>
+        <div class="column">
+          <article class="card card--assembly card--mini">
+            <%= link_to decidim_assemblies.assembly_path(assembly), class: "card__link" do %>
+              <div class="card__image-top"
+                style="background-image:url(<%= assembly.hero_image.url %>)"></div>
+            <% end %>
+            <div class="card__content">
+              <%= link_to decidim_assemblies.assembly_path(assembly), class: "card__link" do %>
+                <h4 class="card__title"><%= translated_attribute assembly.title %></h4>
+              <% end %>
+            </div>
+          </article>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+<div class="row" id="see-all-assemblies">
+  <div class="columns small-centered small-12
+    smallmedium-8 medium-6 large-4">
+    <%= link_to t(".see_all_assemblies"), decidim_assemblies.assemblies_path, class: "button expanded hollow button--sc home-section__cta" %>
+  </div>
+</div>

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -88,6 +88,11 @@ en:
             slug_help: 'URL slugs are used to generate the URLs that point to this assembly. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
       index:
         title: Assemblies
+      pages:
+        home:
+          highlighted_assemblies:
+            active_assemblies: Active assemblies
+            see_all_assemblies: See all assemblies
       show:
         developer_group: Developer group
         local_area: Local area

--- a/decidim-assemblies/lib/decidim/assemblies/engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/engine.rb
@@ -59,6 +59,21 @@ module Decidim
                     active: :inclusive
         end
       end
+
+      initializer "decidim_assemblies.view_hooks" do
+        Decidim.view_hooks.register(:highlighted_elements, priority: Decidim::ViewHooks::MEDIUM_PRIORITY) do |view_context|
+          highlighted_assemblies = OrganizationPrioritizedAssemblies.new(view_context.current_organization)
+
+          next unless highlighted_assemblies.any?
+
+          view_context.render(
+            partial: "decidim/assemblies/pages/home/highlighted_assemblies",
+            locals: {
+              highlighted_assemblies: highlighted_assemblies
+            }
+          )
+        end
+      end
     end
   end
 end

--- a/decidim-assemblies/spec/features/homepage_view_hooks_spec.rb
+++ b/decidim-assemblies/spec/features/homepage_view_hooks_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Highlighted Assemblies", type: :feature do
+  let(:organization) { create(:organization) }
+  let(:show_statistics) { true }
+  let!(:promoted_assembly) { create(:assembly, :promoted, organization: organization) }
+  let!(:unpromoted_assembly) { create(:assembly, organization: organization) }
+  let!(:promoted_external_assembly) { create(:assembly, :promoted) }
+
+  before do
+    switch_to_host(organization.host)
+  end
+
+  it "includes active assemblies to the homepage" do
+    visit decidim.root_path
+
+    within "#highlighted-assemblies" do
+      expect(page).to have_i18n_content(promoted_assembly.title)
+      expect(page).to have_i18n_content(unpromoted_assembly.title)
+      expect(page).to_not have_i18n_content(promoted_external_assembly.title)
+    end
+  end
+end

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/pages/home/_highlighted_processes.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/pages/home/_highlighted_processes.html.erb
@@ -1,4 +1,4 @@
-<div class="row">
+<div class="row" id="highlighted-processes">
   <h3 class="section-heading"><%= t(".active_processes") %></h3>
   <div class="row collapse">
     <div class="row small-up-1 smallmedium-up-2 mediumlarge-up-3
@@ -27,7 +27,7 @@
     </div>
   </div>
 </div>
-<div class="row">
+<div class="row" id="see-all-processes">
   <div class="columns small-centered small-12
     smallmedium-8 medium-6 large-4">
     <%= link_to t(".see_all_processes"), decidim_participatory_processes.participatory_processes_path, class: "button expanded hollow button--sc home-section__cta" %>

--- a/decidim-participatory_processes/spec/features/homepage_view_hooks_spec.rb
+++ b/decidim-participatory_processes/spec/features/homepage_view_hooks_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Highlighted Processes", type: :feature do
+  let(:organization) { create(:organization) }
+  let(:show_statistics) { true }
+  let!(:promoted_process) { create(:participatory_process, :promoted, organization: organization) }
+  let!(:unpromoted_process) { create(:participatory_process, organization: organization) }
+  let!(:promoted_external_process) { create(:participatory_process, :promoted) }
+
+  before do
+    switch_to_host(organization.host)
+  end
+
+  it "includes active processes to the homepage" do
+    visit decidim.root_path
+
+    within "#highlighted-processes" do
+      expect(page).to have_i18n_content(promoted_process.title)
+      expect(page).to have_i18n_content(unpromoted_process.title)
+      expect(page).to_not have_i18n_content(promoted_external_process.title)
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR uses #2114 to show active assemblies in the homepage.

#### :pushpin: Related Issues
- Fixes #2062

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/eu0qrYA.png)
