### PR TITLE
Proposal edition

### DIFF
--- a/decidim-core/lib/decidim/core/test/shared_examples/reportable.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/reportable.rb
@@ -3,43 +3,45 @@
 require "spec_helper"
 
 shared_examples_for "reportable" do
-  let(:user) { create(:user, organization: subject.organization) }
-  let(:participatory_space) { subject.feature.participatory_space }
-  let(:moderation) { create(:moderation, reportable: subject, participatory_space: participatory_space, report_count: 1) }
-  let!(:report) { create(:report, moderation: moderation, user: user) }
+  context "is reportable" do
+    let(:user) { create(:user, organization: subject.organization) }
+    let(:participatory_space) { subject.feature.participatory_space }
+    let(:moderation) { create(:moderation, reportable: subject, participatory_space: participatory_space, report_count: 1) }
+    let!(:report) { create(:report, moderation: moderation, user: user) }
 
-  describe "#reported_by?" do
-    context "when the resource has not been reported by the given user" do
-      let!(:report) { nil }
+    describe "#reported_by?" do
+      context "when the resource has not been reported by the given user" do
+        let!(:report) { nil }
 
-      it { expect(subject.reported_by?(user)).to be_falsey }
+        it { expect(subject.reported_by?(user)).to be_falsey }
+      end
+
+      context "when the resource has been reported" do
+        it { expect(subject.reported_by?(user)).to be_truthy }
+      end
     end
 
-    context "when the resource has been reported" do
-      it { expect(subject.reported_by?(user)).to be_truthy }
-    end
-  end
+    context "#hidden?" do
+      context "when the resource has not been hidden" do
+        it { expect(subject).not_to be_hidden }
+      end
 
-  context "#hidden?" do
-    context "when the resource has not been hidden" do
-      it { expect(subject).not_to be_hidden }
-    end
-
-    context "when the resource has been hidden" do
-      let(:moderation) { create(:moderation, reportable: subject, participatory_space: participatory_space, report_count: 1, hidden_at: Time.current) }
-      it { expect(subject).to be_hidden }
-    end
-  end
-
-  context "#reported?" do
-    context "when the report count is equal to 0" do
-      let(:moderation) { create(:moderation, reportable: subject, participatory_space: participatory_space, report_count: 0) }
-      let!(:report) { nil }
-      it { expect(subject).not_to be_reported }
+      context "when the resource has been hidden" do
+        let(:moderation) { create(:moderation, reportable: subject, participatory_space: participatory_space, report_count: 1, hidden_at: Time.current) }
+        it { expect(subject).to be_hidden }
+      end
     end
 
-    context "when the report count is greater than 0" do
-      it { expect(subject).to be_reported }
+    context "#reported?" do
+      context "when the report count is equal to 0" do
+        let(:moderation) { create(:moderation, reportable: subject, participatory_space: participatory_space, report_count: 0) }
+        let!(:report) { nil }
+        it { expect(subject).not_to be_reported }
+      end
+
+      context "when the report count is greater than 0" do
+        it { expect(subject).to be_reported }
+      end
     end
   end
 end

--- a/decidim-proposals/app/commands/decidim/proposals/update_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/update_proposal.rb
@@ -23,6 +23,7 @@ module Decidim
       # Returns nothing.
       def call
         return broadcast(:invalid) if form.invalid?
+        return broadcast(:invalid) unless proposal.editable_by?(current_user)
 
         if process_attachments?
           build_attachment
@@ -39,7 +40,7 @@ module Decidim
 
       private
 
-      attr_reader :form, :proposal, :attachment
+      attr_reader :form, :proposal, :attachment, :current_user
 
       def update_proposal
         @proposal.update_attributes!(
@@ -47,7 +48,7 @@ module Decidim
           body: form.body,
           category: form.category,
           scope: form.scope,
-          author: @current_user,
+          author: current_user,
           decidim_user_group_id: form.user_group_id,
           address: form.address,
           latitude: form.latitude,
@@ -59,7 +60,7 @@ module Decidim
         @attachment = Attachment.new(
           title: form.attachment.title,
           file: form.attachment.file,
-          attached_to: @proposal
+          attached_to: proposal
         )
       end
 

--- a/decidim-proposals/app/commands/decidim/proposals/update_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/update_proposal.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    # A command with all the business logic when a user updates a proposal.
+    class UpdateProposal < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # form         - A form object with the params.
+      # current_user - The current user.
+      # proposal - the proposal to update.
+      def initialize(form, current_user, proposal)
+        @form = form
+        @current_user = current_user
+        @proposal = proposal
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid, together with the proposal.
+      # - :invalid if the form wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        return broadcast(:invalid) if form.invalid?
+
+        if process_attachments?
+          build_attachment
+          return broadcast(:invalid) if attachment_invalid?
+        end
+
+        transaction do
+          update_proposal
+          create_attachment if process_attachments?
+        end
+
+        broadcast(:ok, proposal)
+      end
+
+      private
+
+      attr_reader :form, :proposal, :attachment
+
+      def update_proposal
+        @proposal.update_attributes!(
+          title: form.title,
+          body: form.body,
+          category: form.category,
+          scope: form.scope,
+          author: @current_user,
+          decidim_user_group_id: form.user_group_id,
+          address: form.address,
+          latitude: form.latitude,
+          longitude: form.longitude
+        )
+      end
+
+      def build_attachment
+        @attachment = Attachment.new(
+          title: form.attachment.title,
+          file: form.attachment.file,
+          attached_to: @proposal
+        )
+      end
+
+      def attachment_invalid?
+        if attachment.invalid? && attachment.errors.has_key?(:file)
+          form.attachment.errors.add :file, attachment.errors[:file]
+          true
+        end
+      end
+
+      def attachment_present?
+        form.attachment.file.present?
+      end
+
+      def create_attachment
+        attachment.attached_to = proposal
+        attachment.save!
+      end
+
+      def attachments_allowed?
+        form.current_feature.settings.attachments_allowed?
+      end
+
+      def process_attachments?
+        attachments_allowed? && attachment_present?
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -112,11 +112,6 @@ module Decidim
           related_to: ""
         }
       end
-
-      def user_not_authorized_path
-        super unless @proposal
-        proposal_path(@proposal)
-      end
     end
   end
 end

--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -65,6 +65,32 @@ module Decidim
         end
       end
 
+      def edit
+        @proposal = Proposal.not_hidden.where(feature: current_feature).find(params[:id])
+        authorize! :edit, @proposal
+
+        @form = form(ProposalForm).from_model(@proposal)
+      end
+
+      def update
+        @proposal = Proposal.not_hidden.where(feature: current_feature).find(params[:id])
+        authorize! :edit, @proposal
+
+        @form = form(ProposalForm).from_params(params)
+
+        UpdateProposal.call(@form, current_user, @proposal) do
+          on(:ok) do |proposal|
+            flash[:notice] = I18n.t("proposals.update.success", scope: "decidim")
+            redirect_to proposal_path(proposal)
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("proposals.update.error", scope: "decidim")
+            render :new
+          end
+        end
+      end
+
       private
 
       def geocoded_proposals
@@ -85,6 +111,11 @@ module Decidim
           scope_id: nil,
           related_to: ""
         }
+      end
+
+      def user_not_authorized_path
+        super unless @proposal
+        proposal_path(@proposal)
       end
     end
   end

--- a/decidim-proposals/app/models/decidim/proposals/abilities/current_user_ability.rb
+++ b/decidim-proposals/app/models/decidim/proposals/abilities/current_user_ability.rb
@@ -26,7 +26,7 @@ module Decidim
 
           can :create, Proposal if authorized?(:create) && creation_enabled?
           can :edit, Proposal do |proposal|
-            user_is_author?(user, proposal) && !proposal.answered? && within_time_limit?(proposal)
+            proposal.editable_by?(user)
           end
 
           can :report, Proposal
@@ -61,16 +61,6 @@ module Decidim
         def voting_enabled?
           return unless current_settings
           current_settings.votes_enabled? && !current_settings.votes_blocked?
-        end
-
-        def user_is_author?(user, proposal)
-          proposal.author == user || user.user_groups.include?(proposal.user_group)
-        end
-
-        def within_time_limit?(proposal)
-          return unless feature_settings
-          limit = proposal.created_at + feature_settings.proposal_edit_before_minutes.minutes
-          Time.current < limit
         end
 
         def current_settings

--- a/decidim-proposals/app/models/decidim/proposals/abilities/current_user_ability.rb
+++ b/decidim-proposals/app/models/decidim/proposals/abilities/current_user_ability.rb
@@ -26,7 +26,7 @@ module Decidim
 
           can :create, Proposal if authorized?(:create) && creation_enabled?
           can :edit, Proposal do |proposal|
-            user_is_author?(user, proposal) && !proposal.answered?
+            user_is_author?(user, proposal) && !proposal.answered? && within_time_limit?(proposal)
           end
 
           can :report, Proposal
@@ -65,6 +65,12 @@ module Decidim
 
         def user_is_author?(user, proposal)
           proposal.author == user || user.user_groups.include?(proposal.user_group)
+        end
+
+        def within_time_limit?(proposal)
+          return unless feature_settings
+          limit = proposal.created_at + feature_settings.proposal_edit_before_minutes.minutes
+          Time.current < limit
         end
 
         def current_settings

--- a/decidim-proposals/app/models/decidim/proposals/abilities/current_user_ability.rb
+++ b/decidim-proposals/app/models/decidim/proposals/abilities/current_user_ability.rb
@@ -26,7 +26,7 @@ module Decidim
 
           can :create, Proposal if authorized?(:create) && creation_enabled?
           can :edit, Proposal do |proposal|
-            proposal.author == user && !proposal.answered?
+            user_is_author?(user, proposal) && !proposal.answered?
           end
 
           can :report, Proposal
@@ -61,6 +61,10 @@ module Decidim
         def voting_enabled?
           return unless current_settings
           current_settings.votes_enabled? && !current_settings.votes_blocked?
+        end
+
+        def user_is_author?(user, proposal)
+          proposal.author == user || user.user_groups.include?(proposal.user_group)
         end
 
         def current_settings

--- a/decidim-proposals/app/models/decidim/proposals/abilities/current_user_ability.rb
+++ b/decidim-proposals/app/models/decidim/proposals/abilities/current_user_ability.rb
@@ -25,6 +25,9 @@ module Decidim
           end
 
           can :create, Proposal if authorized?(:create) && creation_enabled?
+          can :edit, Proposal do |proposal|
+            proposal.author == user && !proposal.answered?
+          end
 
           can :report, Proposal
         end

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -132,6 +132,29 @@ module Decidim
 
         votes.count >= maximum_votes
       end
+
+      # Checks whether the user is author of the given proposal, either directly
+      # authoring it or via a user group.
+      #
+      # user - the user to check for authorship
+      def authored_by?(user)
+        author == user || user.user_groups.include?(user_group)
+      end
+
+      # Checks whether the user can edit the given proposal.
+      #
+      # user - the user to check for authorship
+      def editable_by?(user)
+        authored_by?(user) && !answered? && within_edit_time_limit?
+      end
+
+      private
+
+      # Checks whether the proposal is inside the time window to be editable or not.
+      def within_edit_time_limit?
+        limit = created_at + feature.settings.proposal_edit_before_minutes.minutes
+        Time.current < limit
+      end
     end
   end
 end

--- a/decidim-proposals/app/views/decidim/proposals/proposals/edit.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/edit.html.erb
@@ -1,0 +1,77 @@
+<div class="row columns">
+  <%= link_to :back, class: "muted-link" do %>
+    <%= icon "chevron-left", class: "icon--small" %>
+    <%= t(".back") %>
+  <% end %>
+  <h2 class="section-heading"><%= t(".title") %></h2>
+</div>
+
+<div class="row">
+  <div class="columns large-6 medium-centered">
+    <div class="card">
+      <% if translated_attribute(feature_settings.new_proposal_help_text).present? %>
+        <%= render partial: "decidim/shared/announcement", locals: { announcement: feature_settings.new_proposal_help_text } %>
+      <% end %>
+
+      <div class="card__content">
+        <%= decidim_form_for(@form) do |form| %>
+          <div class="field">
+            <%= form.text_field :title %>
+          </div>
+
+          <div class="field">
+            <%= form.text_area :body, rows: 10 %>
+          </div>
+
+          <% if feature_settings.geocoding_enabled? %>
+            <div class="field">
+              <%= form.check_box :has_address %>
+            </div>
+            <div class="field" id="address_input">
+              <%= form.text_field :address %>
+            </div>
+          <% end %>
+
+          <% if @form.categories&.any? %>
+            <div class="field">
+              <%= form.categories_select :category_id, @form.categories, prompt: t(".select_a_category") %>
+            </div>
+          <% end %>
+
+          <% if current_participatory_space.has_subscopes? %>
+            <div class="field">
+              <%= form.scopes_select :scope_id, prompt: I18n.t("decidim.scopes.global"), remote_path: decidim.scopes_search_path(root: current_participatory_space.scope) %>
+            </div>
+          <% end %>
+
+          <% if current_user.user_groups.verified.any? %>
+            <div class="field">
+              <%= form.select :user_group_id, current_user.user_groups.verified.map{|g| [g.name, g.id]}, prompt: current_user.name %>
+            </div>
+          <% end %>
+
+          <% if feature_settings.attachments_allowed? %>
+            <fieldset>
+              <legend><%= t('.attachment_legend') %></legend>
+              <%= form.fields_for :attachment, @form.attachment do |form| %>
+                <div class="field">
+                  <%= form.text_field :title %>
+                </div>
+
+                <div class="field">
+                  <%= form.upload :file, optional: false %>
+                </div>
+              <% end %>
+            </fieldset>
+          <% end %>
+
+          <div class="actions">
+            <%= form.submit t(".send"), class: "button expanded", "data-disable-with" => "#{t('.send')}..." %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>
+
+<%= javascript_include_tag "decidim/proposals/add_proposal" %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/new.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/new.html.erb
@@ -13,6 +13,12 @@
         <%= render partial: "decidim/shared/announcement", locals: { announcement: feature_settings.new_proposal_help_text } %>
       <% end %>
 
+      <div class="row column">
+        <div class="callout warning">
+          <%= t(".proposal_edit_before_minutes", count: feature_settings.proposal_edit_before_minutes) %>
+        </div>
+      </div>
+
       <div class="card__content">
         <%= decidim_form_for(@form) do |form| %>
           <div class="field">

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -18,7 +18,7 @@
 </div>
 <div class="row">
   <div class="columns section view-side mediumlarge-4 mediumlarge-push-8 large-3 large-push-9">
-    <% if current_user && can?(:edit, @proposal) %>
+    <% if can?(:edit, @proposal) %>
       <%= link_to t(".edit_proposal"), edit_proposal_path(@proposal), class: "button secondary hollow expanded button-sc button--icon follow-button" %>
     <% end %>
     <% if current_settings.votes_enabled? || current_user %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -18,6 +18,9 @@
 </div>
 <div class="row">
   <div class="columns section view-side mediumlarge-4 mediumlarge-push-8 large-3 large-push-9">
+    <% if current_user && can?(:edit, @proposal) %>
+      <%= link_to t(".edit_proposal"), edit_proposal_path(@proposal), class: "button secondary hollow expanded button-sc button--icon follow-button" %>
+    <% end %>
     <% if current_settings.votes_enabled? || current_user %>
       <div class="card extra">
         <div class="card__content">

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -27,6 +27,7 @@ en:
             new_proposal_help_text: New proposal help text
             official_proposals_enabled: Official proposals enabled
             proposal_answering_enabled: Proposal answering enabled
+            proposal_edit_before_minutes: Proposals can be edited by authors before this meny minutes passes
             proposal_limit: Proposal limit per user
             vote_limit: Vote limit per user
           step:

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -153,6 +153,7 @@ en:
         proposal:
           view_proposal: View proposal
         show:
+          edit_proposal: Edit proposal
           proposal_accepted_reason: 'This proposal has been accepted because:'
           proposal_in_evaluation_reason: This proposal is being evaluated
           proposal_rejected_reason: 'This proposal has been rejected because:'

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -143,6 +143,9 @@ en:
         new:
           attachment_legend: "(Optional) Add an attachment"
           back: Back
+          proposal_edit_before_minutes:
+            one: You will be able to edit this proposal during the first minute after the proposal was created. Once this time window passes, you will not be able to edit the proposal.
+            other: You will be able to edit this proposal during the first %{count} minutes after the proposal was created. Once this time window passes, you will not be able to edit the proposal.
           select_a_category: Please select a category
           send: Send
           title: New proposal

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -104,6 +104,12 @@ en:
           proposals_count:
             one: 1 proposal
             other: "%{count} proposals"
+        edit:
+          attachment_legend: "(Optional) Add an attachment"
+          back: Back
+          select_a_category: Please select a category
+          send: Send
+          title: Edit proposal
         filters:
           accepted: Accepted
           activity: Activity
@@ -172,6 +178,9 @@ en:
             description: You can vote up to %{limit} proposals.
             left: Remaining
             votes: Votes
+      update:
+        error: There's been errors when saving the proposal.
+        success: Proposal updated successfully.
     resource_links:
       included_proposals:
         proposal_projects: 'Proposal appearing in these projects:'

--- a/decidim-proposals/lib/decidim/proposals/engine.rb
+++ b/decidim-proposals/lib/decidim/proposals/engine.rb
@@ -12,7 +12,7 @@ module Decidim
       isolate_namespace Decidim::Proposals
 
       routes do
-        resources :proposals, only: [:create, :new, :index, :show] do
+        resources :proposals, except: [:destroy] do
           resource :proposal_vote, only: [:create, :destroy]
           resource :proposal_widget, only: :show, path: "embed"
         end

--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -18,6 +18,7 @@ Decidim.register_feature(:proposals) do |feature|
   feature.settings(:global) do |settings|
     settings.attribute :vote_limit, type: :integer, default: 0
     settings.attribute :proposal_limit, type: :integer, default: 0
+    settings.attribute :proposal_edit_before_minutes, type: :integer, default: 5
     settings.attribute :maximum_votes_per_proposal, type: :integer, default: 0
     settings.attribute :proposal_answering_enabled, type: :boolean, default: true
     settings.attribute :official_proposals_enabled, type: :boolean, default: true

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -119,6 +119,7 @@ FactoryGirl.define do
 
     trait :with_answer do
       answer { Decidim::Faker::Localized.sentence }
+      answered_at { Time.current }
     end
   end
 

--- a/decidim-proposals/spec/commands/decidim/proposals/update_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/update_proposal_spec.rb
@@ -63,6 +63,22 @@ module Decidim
           end
         end
 
+        describe "when the proposal is not editable by the user" do
+          before do
+            expect(proposal).to receive(:editable_by?).and_return(false)
+          end
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+
+          it "doesn't update the proposal" do
+            expect do
+              command.call
+            end.not_to change { proposal.title }
+          end
+        end
+
         describe "when the form is valid" do
           it "broadcasts ok" do
             expect { command.call }.to broadcast(:ok)

--- a/decidim-proposals/spec/commands/decidim/proposals/update_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/update_proposal_spec.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Proposals
+    describe UpdateProposal do
+      let(:form_klass) { ProposalForm }
+
+      let(:feature) { create(:proposal_feature) }
+      let(:organization) { feature.organization }
+      let(:form) do
+        form_klass.from_params(
+          form_params
+        ).with_context(
+          current_organization: organization,
+          current_feature: feature
+        )
+      end
+
+      let!(:proposal) { create :proposal, feature: feature, author: author }
+      let(:author) { create(:user, organization: organization) }
+
+      let(:user_group) do
+        create(:user_group, :verified, organization: organization, users: [author])
+      end
+
+      let(:has_address) { false }
+      let(:address) { nil }
+      let(:latitude) { 40.1234 }
+      let(:longitude) { 2.1234 }
+      let(:attachment_params) { nil }
+
+      describe "call" do
+        let(:form_params) do
+          {
+            title: "A reasonable proposal title",
+            body: "A reasonable proposal body",
+            address: address,
+            has_address: has_address,
+            attachment: attachment_params,
+            user_group_id: user_group.try(:id)
+          }
+        end
+
+        let(:command) do
+          described_class.new(form, author, proposal)
+        end
+
+        describe "when the form is not valid" do
+          before do
+            expect(form).to receive(:invalid?).and_return(true)
+          end
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+
+          it "doesn't update the proposal" do
+            expect do
+              command.call
+            end.not_to change { proposal.title }
+          end
+        end
+
+        describe "when the form is valid" do
+          it "broadcasts ok" do
+            expect { command.call }.to broadcast(:ok)
+          end
+
+          it "updates the proposal" do
+            expect do
+              command.call
+            end.to change { proposal.title }
+          end
+
+          context "with an author" do
+            let(:user_group) { nil }
+
+            it "sets the author" do
+              command.call
+              proposal = Decidim::Proposals::Proposal.last
+
+              expect(proposal.author).to eq(author)
+              expect(proposal.user_group).to eq(nil)
+            end
+          end
+
+          context "with a user group" do
+            it "sets the user group" do
+              command.call
+              proposal = Decidim::Proposals::Proposal.last
+
+              expect(proposal.author).to eq(author)
+              expect(proposal.user_group).to eq(user_group)
+            end
+          end
+
+          context "when geocoding is enabled" do
+            let(:feature) { create(:proposal_feature, :with_geocoding_enabled) }
+
+            context "when the has address checkbox is checked" do
+              let(:has_address) { true }
+
+              context "when the address is present" do
+                let(:address) { "Carrer Pare Llaurador 113, baixos, 08224 Terrassa" }
+
+                before do
+                  Geocoder::Lookup::Test.add_stub(
+                    address,
+                    [{ "latitude" => latitude, "longitude" => longitude }]
+                  )
+                end
+
+                it "sets the latitude and longitude" do
+                  command.call
+                  proposal = Decidim::Proposals::Proposal.last
+
+                  expect(proposal.latitude).to eq(latitude)
+                  expect(proposal.longitude).to eq(longitude)
+                end
+              end
+            end
+          end
+
+          context "when attachments are allowed", processing_uploads_for: Decidim::AttachmentUploader do
+            let(:feature) { create(:proposal_feature, :with_attachments_allowed) }
+            let(:attachment_params) do
+              {
+                title: "My attachment",
+                file: Decidim::Dev.test_file("city.jpeg", "image/jpeg")
+              }
+            end
+
+            it "creates an atachment for the proposal" do
+              expect do
+                command.call
+              end.to change { Decidim::Attachment.count }.by(1)
+              last_proposal = Decidim::Proposals::Proposal.last
+              last_attachment = Decidim::Attachment.last
+              expect(last_attachment.attached_to).to eq(last_proposal)
+            end
+
+            context "when attachment is left blank" do
+              let(:attachment_params) do
+                {
+                  title: ""
+                }
+              end
+
+              it "broadcasts ok" do
+                expect { command.call }.to broadcast(:ok)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/commands/decidim/proposals/update_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/update_proposal_spec.rb
@@ -79,6 +79,15 @@ module Decidim
           end
         end
 
+        context "when the author changinng the author to one that has reached the proposal limit" do
+          let!(:other_proposal) { create :proposal, feature: feature, author: author, user_group: user_group }
+          let(:feature) { create(:proposal_feature, :with_proposal_limit) }
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+        end
+
         describe "when the form is valid" do
           it "broadcasts ok" do
             expect { command.call }.to broadcast(:ok)

--- a/decidim-proposals/spec/features/edit_proposal_spec.rb
+++ b/decidim-proposals/spec/features/edit_proposal_spec.rb
@@ -54,4 +54,22 @@ describe "Edit proposals", type: :feature do
       expect(page).to have_content("not authorized")
     end
   end
+
+  describe "editing my proposal outside the time limit" do
+    let!(:proposal) { create :proposal, author: user, feature: feature, created_at: 1.hour.ago }
+
+    before do
+      login_as another_user, scope: :user
+    end
+
+    it "renders an error" do
+      visit_feature
+
+      click_link proposal.title
+      expect(page).to have_no_content("Edit proposal")
+      visit current_path + "/edit"
+
+      expect(page).to have_content("not authorized")
+    end
+  end
 end

--- a/decidim-proposals/spec/features/edit_proposal_spec.rb
+++ b/decidim-proposals/spec/features/edit_proposal_spec.rb
@@ -26,7 +26,7 @@ describe "Edit proposals", type: :feature do
       visit_feature
 
       click_link proposal.title
-      visit current_path + "/edit"
+      click_link "Edit proposal"
 
       expect(page).to have_content "EDIT PROPOSAL"
 
@@ -48,11 +48,10 @@ describe "Edit proposals", type: :feature do
       visit_feature
 
       click_link proposal.title
-      proposal_path = current_path
+      expect(page).to have_no_content("Edit proposal")
       visit current_path + "/edit"
 
       expect(page).to have_content("not authorized")
-      expect(current_path).to eq proposal_path
     end
   end
 end

--- a/decidim-proposals/spec/models/decidim/proposals/abilities/current_user_ability_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/abilities/current_user_ability_spec.rb
@@ -108,6 +108,13 @@ describe Decidim::Proposals::Abilities::CurrentUserAbility do
       it { is_expected.to be_able_to(:edit, proposal) }
     end
 
+    context "when proposal is from user group and user is admin" do
+      let(:user_group) { create :user_group, users: [user], organization: user.organization }
+      let(:proposal) { build :proposal, feature: proposal_feature, user_group: user_group }
+
+      it { is_expected.to be_able_to(:edit, proposal) }
+    end
+
     context "when user is not the author" do
       let(:proposal) { build :proposal, feature: proposal_feature }
 

--- a/decidim-proposals/spec/models/decidim/proposals/abilities/current_user_ability_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/abilities/current_user_ability_spec.rb
@@ -7,7 +7,8 @@ describe Decidim::Proposals::Abilities::CurrentUserAbility do
   let(:proposal_feature) { create :proposal_feature }
   let(:extra_context) do
     {
-      current_settings: current_settings
+      current_settings: current_settings,
+      feature_settings: feature_settings
     }
   end
   let(:context) do
@@ -24,6 +25,7 @@ describe Decidim::Proposals::Abilities::CurrentUserAbility do
   end
   let(:extra_settings) { {} }
   let(:current_settings) { double(settings.merge(extra_settings)) }
+  let(:feature_settings) { double(proposal_edit_before_minutes: 5) }
 
   subject { described_class.new(user, context) }
 
@@ -103,26 +105,32 @@ describe Decidim::Proposals::Abilities::CurrentUserAbility do
 
   context "edit proposal" do
     context "when user is author" do
-      let(:proposal) { build :proposal, author: user, feature: proposal_feature }
+      let(:proposal) { build :proposal, author: user, created_at: Time.current, feature: proposal_feature }
 
       it { is_expected.to be_able_to(:edit, proposal) }
     end
 
     context "when proposal is from user group and user is admin" do
       let(:user_group) { create :user_group, users: [user], organization: user.organization }
-      let(:proposal) { build :proposal, feature: proposal_feature, user_group: user_group }
+      let(:proposal) { build :proposal, created_at: Time.current, feature: proposal_feature, user_group: user_group }
 
       it { is_expected.to be_able_to(:edit, proposal) }
     end
 
     context "when user is not the author" do
-      let(:proposal) { build :proposal, feature: proposal_feature }
+      let(:proposal) { build :proposal, created_at: Time.current, feature: proposal_feature }
 
       it { is_expected.not_to be_able_to(:edit, proposal) }
     end
 
     context "when proposal is answered" do
-      let(:proposal) { build :proposal, :with_answer, feature: proposal_feature }
+      let(:proposal) { build :proposal, :with_answer, created_at: Time.current, author: user, feature: proposal_feature }
+
+      it { is_expected.not_to be_able_to(:edit, proposal) }
+    end
+
+    context "when proposal editing time has run out" do
+      let(:proposal) { build :proposal, created_at: 10.minutes.ago, author: user, feature: proposal_feature }
 
       it { is_expected.not_to be_able_to(:edit, proposal) }
     end

--- a/decidim-proposals/spec/models/decidim/proposals/abilities/current_user_ability_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/abilities/current_user_ability_spec.rb
@@ -104,33 +104,20 @@ describe Decidim::Proposals::Abilities::CurrentUserAbility do
   end
 
   context "edit proposal" do
-    context "when user is author" do
-      let(:proposal) { build :proposal, author: user, created_at: Time.current, feature: proposal_feature }
+    let(:proposal) { build :proposal, author: user, created_at: Time.current, feature: proposal_feature }
+
+    context "when proposal is editable" do
+      before do
+        allow(proposal).to receive(:editable_by?).and_return(true)
+      end
 
       it { is_expected.to be_able_to(:edit, proposal) }
     end
 
-    context "when proposal is from user group and user is admin" do
-      let(:user_group) { create :user_group, users: [user], organization: user.organization }
-      let(:proposal) { build :proposal, created_at: Time.current, feature: proposal_feature, user_group: user_group }
-
-      it { is_expected.to be_able_to(:edit, proposal) }
-    end
-
-    context "when user is not the author" do
-      let(:proposal) { build :proposal, created_at: Time.current, feature: proposal_feature }
-
-      it { is_expected.not_to be_able_to(:edit, proposal) }
-    end
-
-    context "when proposal is answered" do
-      let(:proposal) { build :proposal, :with_answer, created_at: Time.current, author: user, feature: proposal_feature }
-
-      it { is_expected.not_to be_able_to(:edit, proposal) }
-    end
-
-    context "when proposal editing time has run out" do
-      let(:proposal) { build :proposal, created_at: 10.minutes.ago, author: user, feature: proposal_feature }
+    context "when proposal is not editable" do
+      before do
+        allow(proposal).to receive(:editable_by?).and_return(false)
+      end
 
       it { is_expected.not_to be_able_to(:edit, proposal) }
     end

--- a/decidim-proposals/spec/models/decidim/proposals/abilities/current_user_ability_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/abilities/current_user_ability_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Proposals::Abilities::CurrentUserAbility do
+  let(:user) { build(:user) }
+  let(:proposal_feature) { create :proposal_feature }
+  let(:extra_context) do
+    {
+      current_settings: current_settings
+    }
+  end
+  let(:context) do
+    {
+      current_feature: proposal_feature
+    }.merge(extra_context)
+  end
+  let(:settings) do
+    {
+      creation_enabled?: false,
+      votes_enabled?: false,
+      votes_blocked?: true
+    }
+  end
+  let(:extra_settings) { {} }
+  let(:current_settings) { double(settings.merge(extra_settings)) }
+
+  subject { described_class.new(user, context) }
+
+  it { is_expected.to be_able_to(:report, Decidim::Proposals::Proposal) }
+
+  context "voting" do
+    context "when voting is disabled" do
+      let(:proposal) { build :proposal, feature: proposal_feature }
+      let(:extra_settings) do
+        {
+          votes_enabled?: false,
+          votes_blocked?: true
+        }
+      end
+
+      it { is_expected.not_to be_able_to(:unvote, proposal) }
+    end
+
+    context "when user is authorized" do
+      let(:extra_settings) do
+        {
+          votes_enabled?: true,
+          votes_blocked?: false
+        }
+      end
+
+      it { is_expected.to be_able_to(:unvote, Decidim::Proposals::Proposal) }
+    end
+  end
+
+  context "unvoting" do
+    context "when voting is disabled" do
+      let(:proposal) { build :proposal, feature: proposal_feature }
+      let(:extra_settings) do
+        {
+          votes_enabled?: false,
+          votes_blocked?: true
+        }
+      end
+
+      it { is_expected.not_to be_able_to(:unvote, proposal) }
+    end
+
+    context "when user is authorized" do
+      let(:extra_settings) do
+        {
+          votes_enabled?: true,
+          votes_blocked?: false
+        }
+      end
+
+      it { is_expected.to be_able_to(:unvote, Decidim::Proposals::Proposal) }
+    end
+  end
+
+  context "creation" do
+    context "when creation is disabled" do
+      let(:extra_settings) do
+        {
+          creation_enabled?: false
+        }
+      end
+
+      it { is_expected.not_to be_able_to(:create, Decidim::Proposals::Proposal) }
+    end
+
+    context "when user is authorized" do
+      let(:extra_settings) do
+        {
+          creation_enabled?: true
+        }
+      end
+
+      it { is_expected.to be_able_to(:create, Decidim::Proposals::Proposal) }
+    end
+  end
+
+  context "edit proposal" do
+    context "when user is author" do
+      let(:proposal) { build :proposal, author: user, feature: proposal_feature }
+
+      it { is_expected.to be_able_to(:edit, proposal) }
+    end
+
+    context "when user is not the author" do
+      let(:proposal) { build :proposal, feature: proposal_feature }
+
+      it { is_expected.not_to be_able_to(:edit, proposal) }
+    end
+
+    context "when proposal is answered" do
+      let(:proposal) { build :proposal, :with_answer, feature: proposal_feature }
+
+      it { is_expected.not_to be_able_to(:edit, proposal) }
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR deals with proposal edition, as per #1957. With it, proposal authors will be able to edit their own proposals within X minutes after proposal creation. This value will be configurable by admins, with a sane default of 5 minutes.

#### :pushpin: Related Issues
- Related to #1957.

#### :clipboard: Subtasks
- [x] Add ability option for users
- [x] Add edit views
- [x] Deal with user group proposals
- [x] Add editing restrictions (5 minutes by default, configurable)
- [x] Tell users they will be able to edit the proposal within 5 minutes after creation

### :camera: Screenshots (optional)
Warning about time window to edit the proposal (number of minutes is configurable from the admin): 
![](https://i.imgur.com/EBggcAr.png)

Proposal page while it can be edited (button disappears when the time window passes):
![](https://i.imgur.com/Sgxhgjp.png)

Proposal edit form (it's the same form as in the creation page):
![](https://i.imgur.com/o8BbSxi.png)