### PR TITLE
Factory classes as strings

### DIFF
--- a/decidim-accountability/lib/decidim/accountability/test/factories.rb
+++ b/decidim-accountability/lib/decidim/accountability/test/factories.rb
@@ -3,6 +3,9 @@
 require "decidim/faker/localized"
 require "decidim/dev"
 
+require "decidim/core/test/factories"
+require "decidim/participatory_processes/test/factories"
+
 FactoryGirl.define do
   factory :accountability_feature, parent: :feature do
     name { Decidim::Features::Namer.new(participatory_space.organization.available_locales, :accountability).i18n_name }

--- a/decidim-accountability/lib/decidim/accountability/test/factories.rb
+++ b/decidim-accountability/lib/decidim/accountability/test/factories.rb
@@ -22,7 +22,7 @@ FactoryGirl.define do
     end
   end
 
-  factory :status, class: Decidim::Accountability::Status do
+  factory :status, class: "Decidim::Accountability::Status" do
     feature { create(:accountability_feature) }
     sequence(:key) { |n| "status_#{n}" }
     name { Decidim::Faker::Localized.word }
@@ -30,7 +30,7 @@ FactoryGirl.define do
     progress { rand(1..100) }
   end
 
-  factory :result, class: Decidim::Accountability::Result do
+  factory :result, class: "Decidim::Accountability::Result" do
     feature { create(:accountability_feature) }
     title { Decidim::Faker::Localized.sentence(3) }
     description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
@@ -40,7 +40,7 @@ FactoryGirl.define do
     progress { rand(1..100) }
   end
 
-  factory :timeline_entry, class: Decidim::Accountability::TimelineEntry do
+  factory :timeline_entry, class: "Decidim::Accountability::TimelineEntry" do
     result { create(:result) }
     entry_date { "12/7/2017" }
     description { Decidim::Faker::Localized.sentence(2) }

--- a/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
     "#{Faker::Internet.slug(nil, "-")}-#{n}"
   end
 
-  factory :assembly, class: Decidim::Assembly do
+  factory :assembly, class: "Decidim::Assembly" do
     title { Decidim::Faker::Localized.sentence(3) }
     slug { generate(:assembly_slug) }
     subtitle { Decidim::Faker::Localized.sentence(1) }

--- a/decidim-budgets/lib/decidim/budgets/test/factories.rb
+++ b/decidim-budgets/lib/decidim/budgets/test/factories.rb
@@ -3,6 +3,9 @@
 require "decidim/faker/localized"
 require "decidim/dev"
 
+require "decidim/core/test/factories"
+require "decidim/participatory_processes/test/factories"
+
 FactoryGirl.define do
   factory :budget_feature, parent: :feature do
     name { Decidim::Features::Namer.new(participatory_space.organization.available_locales, :budgets).i18n_name }

--- a/decidim-budgets/lib/decidim/budgets/test/factories.rb
+++ b/decidim-budgets/lib/decidim/budgets/test/factories.rb
@@ -47,19 +47,19 @@ FactoryGirl.define do
     end
   end
 
-  factory :project, class: Decidim::Budgets::Project do
+  factory :project, class: "Decidim::Budgets::Project" do
     title { Decidim::Faker::Localized.sentence(3) }
     description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
     budget { Faker::Number.number(8) }
     feature { create(:budget_feature) }
   end
 
-  factory :order, class: Decidim::Budgets::Order do
+  factory :order, class: "Decidim::Budgets::Order" do
     feature { create(:budget_feature) }
     user { create(:user, organization: feature.organization) }
   end
 
-  factory :line_item, class: Decidim::Budgets::LineItem do
+  factory :line_item, class: "Decidim::Budgets::LineItem" do
     order
     project { create(:project, feature: order.feature) }
   end

--- a/decidim-comments/lib/decidim/comments/test/factories.rb
+++ b/decidim-comments/lib/decidim/comments/test/factories.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "decidim/core/test/factories"
+
 FactoryGirl.define do
   factory :comment, class: "Decidim::Comments::Comment" do
     author { build(:user, organization: commentable.organization) }

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -3,6 +3,9 @@
 require "decidim/faker/localized"
 require "decidim/dev"
 
+require "decidim/participatory_processes/test/factories"
+require "decidim/comments/test/factories"
+
 FactoryGirl.define do
   sequence(:name) do |n|
     "#{Faker::Name.name} #{n}"

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -27,7 +27,7 @@ FactoryGirl.define do
     "#{Faker::Lorem.characters(4).upcase}-#{n}"
   end
 
-  factory :category, class: Decidim::Category do
+  factory :category, class: "Decidim::Category" do
     name { Decidim::Faker::Localized.sentence(3) }
     description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(2) } }
 
@@ -40,7 +40,7 @@ FactoryGirl.define do
     participatory_space { parent.participatory_space }
   end
 
-  factory :organization, class: Decidim::Organization do
+  factory :organization, class: "Decidim::Organization" do
     name { Faker::Company.unique.name }
     reference_prefix { Faker::Name.suffix }
     twitter_handler { Faker::Hipster.word }
@@ -60,7 +60,7 @@ FactoryGirl.define do
     official_url { Faker::Internet.url }
   end
 
-  factory :user, class: Decidim::User do
+  factory :user, class: "Decidim::User" do
     email { generate(:email) }
     password "password1234"
     password_confirmation "password1234"
@@ -140,13 +140,13 @@ FactoryGirl.define do
     end
   end
 
-  factory :participatory_process_user_role, class: Decidim::ParticipatoryProcessUserRole do
+  factory :participatory_process_user_role, class: "Decidim::ParticipatoryProcessUserRole" do
     user
     participatory_process { create :participatory_process, organization: user.organization }
     role "admin"
   end
 
-  factory :user_group, class: Decidim::UserGroup do
+  factory :user_group, class: "Decidim::UserGroup" do
     name { Faker::Educator.course }
     document_number { Faker::Number.number(8) + "X" }
     phone { Faker::PhoneNumber.phone_number }
@@ -175,25 +175,25 @@ FactoryGirl.define do
     end
   end
 
-  factory :user_group_membership, class: Decidim::UserGroupMembership do
+  factory :user_group_membership, class: "Decidim::UserGroupMembership" do
     user
     user_group
   end
 
-  factory :identity, class: Decidim::Identity do
+  factory :identity, class: "Decidim::Identity" do
     provider "facebook"
     sequence(:uid)
     user
     organization { user.organization }
   end
 
-  factory :authorization, class: Decidim::Authorization do
+  factory :authorization, class: "Decidim::Authorization" do
     name "decidim/dummy_authorization_handler"
     user
     metadata { {} }
   end
 
-  factory :static_page, class: Decidim::StaticPage do
+  factory :static_page, class: "Decidim::StaticPage" do
     slug { generate(:slug) }
     title { Decidim::Faker::Localized.sentence(3) }
     content { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
@@ -204,7 +204,7 @@ FactoryGirl.define do
     end
   end
 
-  factory :attachment, class: Decidim::Attachment do
+  factory :attachment, class: "Decidim::Attachment" do
     title { Decidim::Faker::Localized.sentence(3) }
     description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
     file { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
@@ -219,7 +219,7 @@ FactoryGirl.define do
     end
   end
 
-  factory :feature, class: Decidim::Feature do
+  factory :feature, class: "Decidim::Feature" do
     transient do
       organization { create(:organization) }
     end
@@ -238,13 +238,13 @@ FactoryGirl.define do
     end
   end
 
-  factory :scope_type, class: Decidim::ScopeType do
+  factory :scope_type, class: "Decidim::ScopeType" do
     name { Decidim::Faker::Localized.word }
     plural { Decidim::Faker::Localized.literal(name.values.first.pluralize) }
     organization
   end
 
-  factory :scope, class: Decidim::Scope do
+  factory :scope, class: "Decidim::Scope" do
     name { Decidim::Faker::Localized.literal(generate(:scope_name)) }
     code { generate(:scope_code) }
     scope_type
@@ -259,19 +259,19 @@ FactoryGirl.define do
     end
   end
 
-  factory :dummy_resource, class: Decidim::DummyResources::DummyResource do
+  factory :dummy_resource, class: "Decidim::DummyResources::DummyResource" do
     title { generate(:name) }
     feature { create(:feature, manifest_name: "dummy") }
     author { create(:user, :confirmed, organization: feature.organization) }
   end
 
-  factory :resource_link, class: Decidim::ResourceLink do
+  factory :resource_link, class: "Decidim::ResourceLink" do
     name { generate(:slug) }
     to { build(:dummy_resource) }
     from { build(:dummy_resource, feature: to.feature) }
   end
 
-  factory :newsletter, class: Decidim::Newsletter do
+  factory :newsletter, class: "Decidim::Newsletter" do
     author { build(:user, :confirmed, organization: organization) }
     organization
 
@@ -279,18 +279,18 @@ FactoryGirl.define do
     body { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
   end
 
-  factory :moderation, class: Decidim::Moderation do
+  factory :moderation, class: "Decidim::Moderation" do
     reportable { build(:dummy_resource) }
     participatory_space { reportable.feature.participatory_space }
   end
 
-  factory :report, class: Decidim::Report do
+  factory :report, class: "Decidim::Report" do
     moderation
     user { build(:user, organization: moderation.reportable.organization) }
     reason "spam"
   end
 
-  factory :impersonation_log, class: Decidim::ImpersonationLog do
+  factory :impersonation_log, class: "Decidim::ImpersonationLog" do
     admin { build(:user, :admin) }
     user { build(:user, :managed, organization: admin.organization) }
     started_at { 10.minutes.ago }

--- a/decidim-meetings/lib/decidim/meetings/test/factories.rb
+++ b/decidim-meetings/lib/decidim/meetings/test/factories.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "decidim/core/test/factories"
+require "decidim/participatory_processes/test/factories"
+
 FactoryGirl.define do
   factory :meeting_feature, parent: :feature do
     name { Decidim::Features::Namer.new(participatory_space.organization.available_locales, :meetings).i18n_name }

--- a/decidim-meetings/lib/decidim/meetings/test/factories.rb
+++ b/decidim-meetings/lib/decidim/meetings/test/factories.rb
@@ -10,7 +10,7 @@ FactoryGirl.define do
     participatory_space { create(:participatory_process, :with_steps, organization: organization) }
   end
 
-  factory :meeting, class: Decidim::Meetings::Meeting do
+  factory :meeting, class: "Decidim::Meetings::Meeting" do
     title { Decidim::Faker::Localized.sentence(3) }
     description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
     location { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
@@ -37,7 +37,7 @@ FactoryGirl.define do
     end
   end
 
-  factory :registration, class: Decidim::Meetings::Registration do
+  factory :registration, class: "Decidim::Meetings::Registration" do
     meeting
     user
   end

--- a/decidim-pages/spec/factories.rb
+++ b/decidim-pages/spec/factories.rb
@@ -10,7 +10,7 @@ FactoryGirl.define do
     participatory_space { create(:participatory_process, :with_steps, organization: organization) }
   end
 
-  factory :page, class: Decidim::Pages::Page do
+  factory :page, class: "Decidim::Pages::Page" do
     body { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
     feature { build(:feature, manifest_name: "pages") }
   end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
@@ -3,6 +3,8 @@
 require "decidim/faker/localized"
 require "decidim/dev"
 
+require "decidim/core/test/factories"
+
 FactoryGirl.define do
   sequence(:participatory_process_slug) do |n|
     "#{Faker::Internet.slug(nil, "-")}-#{n}"

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
@@ -10,7 +10,7 @@ FactoryGirl.define do
     "#{Faker::Internet.slug(nil, "-")}-#{n}"
   end
 
-  factory :participatory_process, class: Decidim::ParticipatoryProcess do
+  factory :participatory_process, class: "Decidim::ParticipatoryProcess" do
     title { Decidim::Faker::Localized.sentence(3) }
     slug { generate(:participatory_process_slug) }
     subtitle { Decidim::Faker::Localized.sentence(1) }
@@ -66,7 +66,7 @@ FactoryGirl.define do
     end
   end
 
-  factory :participatory_process_group, class: Decidim::ParticipatoryProcessGroup do
+  factory :participatory_process_group, class: "Decidim::ParticipatoryProcessGroup" do
     name { Decidim::Faker::Localized.sentence(3) }
     description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
     hero_image { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
@@ -79,7 +79,7 @@ FactoryGirl.define do
     end
   end
 
-  factory :participatory_process_step, class: Decidim::ParticipatoryProcessStep do
+  factory :participatory_process_step, class: "Decidim::ParticipatoryProcessStep" do
     title { Decidim::Faker::Localized.sentence(3) }
     description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
     start_date 1.month.ago.at_midnight

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "decidim/core/test/factories"
+require "decidim/participatory_processes/test/factories"
+
 FactoryGirl.define do
   factory :proposal_feature, parent: :feature do
     name { Decidim::Features::Namer.new(participatory_space.organization.available_locales, :proposals).i18n_name }

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -93,7 +93,7 @@ FactoryGirl.define do
     end
   end
 
-  factory :proposal, class: Decidim::Proposals::Proposal do
+  factory :proposal, class: "Decidim::Proposals::Proposal" do
     title { Faker::Lorem.sentence }
     body { Faker::Lorem.sentences(3).join("\n") }
     feature { create(:proposal_feature) }
@@ -126,7 +126,7 @@ FactoryGirl.define do
     end
   end
 
-  factory :proposal_vote, class: Decidim::Proposals::ProposalVote do
+  factory :proposal_vote, class: "Decidim::Proposals::ProposalVote" do
     proposal { build(:proposal) }
     author { build(:user, organization: proposal.organization) }
   end

--- a/decidim-surveys/lib/decidim/surveys/test/factories.rb
+++ b/decidim-surveys/lib/decidim/surveys/test/factories.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "decidim/core/test/factories"
+require "decidim/participatory_processes/test/factories"
+
 FactoryGirl.define do
   factory :surveys_feature, parent: :feature do
     name { Decidim::Features::Namer.new(participatory_space.organization.available_locales, :surveys).i18n_name }

--- a/decidim-system/spec/factories.rb
+++ b/decidim-system/spec/factories.rb
@@ -3,7 +3,7 @@
 require "decidim/core/test/factories"
 
 FactoryGirl.define do
-  factory :admin, class: Decidim::System::Admin do
+  factory :admin, class: "Decidim::System::Admin" do
     sequence(:email) { |n| "admin#{n}@citizen.corp" }
     password "password1234"
     password_confirmation "password1234"


### PR DESCRIPTION
#### :tophat: What? Why?

While working on direct messages I've been creating some dummy objects from the Rails console. These changes allowed me to use factories independently from the rest of the code.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![keep_scrolling](https://user-images.githubusercontent.com/2887858/32676883-ffc27d1c-c63a-11e7-931a-8ced1f89acc2.gif)
