### PR TITLE
Allow CSS styled failure screenshots

### DIFF
--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -60,6 +60,8 @@ module Decidim
         Decidim.feature_manifests.each do |feature|
           app.config.assets.precompile += [feature.icon]
         end
+
+        app.config.assets.debug = true if Rails.env.test?
       end
 
       initializer "decidim.high_voltage" do |_app|

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -49,6 +49,8 @@ Capybara.configure do |config|
   config.default_driver = :poltergeist
 end
 
+Capybara.asset_host = "http://localhost:3000"
+
 RSpec.configure do |config|
   config.before :each, type: :feature do
     Capybara.current_session.driver.reset!


### PR DESCRIPTION
#### :tophat: What? Why?

When getting test failures, html screenshots appear without CSS styles applying making them hardly useful. This PR fixes that as long as a development server is running on the default port.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![simpsons_smartphone](https://user-images.githubusercontent.com/2887858/32682082-729fbb18-c651-11e7-9bb5-a7a002cf86bc.gif)
