### PR TITLE
Codeclimate test coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.core.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.core.json"
       - store_artifacts:
@@ -136,7 +136,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.assemblies.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.assemblies.json"
       - store_artifacts:
@@ -164,7 +164,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.api.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.api.json"
       - store_artifacts:
@@ -192,7 +192,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.processes.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.processes.json"
       - store_artifacts:
@@ -220,7 +220,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.admin.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.admin.json"
       - store_artifacts:
@@ -248,7 +248,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.system.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.system.json"
       - store_artifacts:
@@ -276,7 +276,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.proposals.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.proposals.json"
       - store_artifacts:
@@ -304,7 +304,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.comments.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.comments.json"
       - store_artifacts:
@@ -332,7 +332,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.meetings.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.meetings.json"
       - store_artifacts:
@@ -360,7 +360,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.pages.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.pages.json"
       - store_artifacts:
@@ -388,7 +388,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.accountability.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.accountability.json"
       - store_artifacts:
@@ -416,7 +416,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.budgets.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.budgets.json"
       - store_artifacts:
@@ -444,7 +444,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.surveys.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.surveys.json"
       - store_artifacts:
@@ -456,43 +456,43 @@ jobs:
           at: /decidim
       - restore_cache:
           keys:
-            - cc-test-coverage-cache-{{ .Branch }}-core
+            - cc-test-coverage-{{ .Branch }}-core
       - restore_cache:
           keys:
-            - cc-test-coverage-cache-{{ .Branch }}-assemblies
+            - cc-test-coverage-{{ .Branch }}-assemblies
       - restore_cache:
           keys:
-            - cc-test-coverage-cache-{{ .Branch }}-api
+            - cc-test-coverage-{{ .Branch }}-api
       - restore_cache:
           keys:
-            - cc-test-coverage-cache-{{ .Branch }}-processes
+            - cc-test-coverage-{{ .Branch }}-processes
       - restore_cache:
           keys:
-            - cc-test-coverage-cache-{{ .Branch }}-admin
+            - cc-test-coverage-{{ .Branch }}-admin
       - restore_cache:
           keys:
-            - cc-test-coverage-cache-{{ .Branch }}-system
+            - cc-test-coverage-{{ .Branch }}-system
       - restore_cache:
           keys:
-            - cc-test-coverage-cache-{{ .Branch }}-proposals
+            - cc-test-coverage-{{ .Branch }}-proposals
       - restore_cache:
           keys:
-            - cc-test-coverage-cache-{{ .Branch }}-comments
+            - cc-test-coverage-{{ .Branch }}-comments
       - restore_cache:
           keys:
-            - cc-test-coverage-cache-{{ .Branch }}-meetings
+            - cc-test-coverage-{{ .Branch }}-meetings
       - restore_cache:
           keys:
-            - cc-test-coverage-cache-{{ .Branch }}-pages
+            - cc-test-coverage-{{ .Branch }}-pages
       - restore_cache:
           keys:
-            - cc-test-coverage-cache-{{ .Branch }}-accountability
+            - cc-test-coverage-{{ .Branch }}-accountability
       - restore_cache:
           keys:
-            - cc-test-coverage-cache-{{ .Branch }}-budgets
+            - cc-test-coverage-{{ .Branch }}-budgets
       - restore_cache:
           keys:
-            - cc-test-coverage-cache-{{ .Branch }}-surveys
+            - cc-test-coverage-{{ .Branch }}-surveys
       - run:
           name: Sum CC test coverage reports
           command: cc-test-reporter sum-coverage --output - --parts 13 coverage/codeclimate.*.json | cc-test-reporter upload-coverage --input -

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ defaults: &defaults
   docker:
     - image: decidim/decidim:latest-dev
       environment:
+        CC_TEST_REPORTER_ID: e052fe03e9f5f2874c7976bd2740d1b10477c964b9a5504f65a9a27f5a9633ca
         SIMPLECOV: true
         DATABASE_USERNAME: postgres
         FAIL_FAST: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
           name: Format test coverage
           command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.core.json"
       - save_cache:
-          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: codeclimate-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.core.json"
       - store_artifacts:
@@ -139,7 +139,7 @@ jobs:
           name: Format test coverage
           command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.assemblies.json"
       - save_cache:
-          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: codeclimate-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.assemblies.json"
       - store_artifacts:
@@ -167,7 +167,7 @@ jobs:
           name: Format test coverage
           command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.api.json"
       - save_cache:
-          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: codeclimate-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.api.json"
       - store_artifacts:
@@ -195,7 +195,7 @@ jobs:
           name: Format test coverage
           command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.processes.json"
       - save_cache:
-          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: codeclimate-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.processes.json"
       - store_artifacts:
@@ -223,7 +223,7 @@ jobs:
           name: Format test coverage
           command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.admin.json"
       - save_cache:
-          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: codeclimate-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.admin.json"
       - store_artifacts:
@@ -251,7 +251,7 @@ jobs:
           name: Format test coverage
           command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.system.json"
       - save_cache:
-          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: codeclimate-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.system.json"
       - store_artifacts:
@@ -279,7 +279,7 @@ jobs:
           name: Format test coverage
           command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.proposals.json"
       - save_cache:
-          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: codeclimate-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.proposals.json"
       - store_artifacts:
@@ -307,7 +307,7 @@ jobs:
           name: Format test coverage
           command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.comments.json"
       - save_cache:
-          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: codeclimate-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.comments.json"
       - store_artifacts:
@@ -335,7 +335,7 @@ jobs:
           name: Format test coverage
           command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.meetings.json"
       - save_cache:
-          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: codeclimate-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.meetings.json"
       - store_artifacts:
@@ -363,7 +363,7 @@ jobs:
           name: Format test coverage
           command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.pages.json"
       - save_cache:
-          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: codeclimate-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.pages.json"
       - store_artifacts:
@@ -391,7 +391,7 @@ jobs:
           name: Format test coverage
           command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.accountability.json"
       - save_cache:
-          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: codeclimate-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.accountability.json"
       - store_artifacts:
@@ -419,7 +419,7 @@ jobs:
           name: Format test coverage
           command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.budgets.json"
       - save_cache:
-          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: codeclimate-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.budgets.json"
       - store_artifacts:
@@ -447,55 +447,55 @@ jobs:
           name: Format test coverage
           command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.surveys.json"
       - save_cache:
-          key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: codeclimate-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.surveys.json"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
-  cc-test-coverage:
+  codeclimate-test-coverage:
     <<: *defaults
     steps:
       - attach_workspace:
           at: /app
       - restore_cache:
           keys:
-            - cc-test-coverage-{{ .Branch }}-core
+            - codeclimate-test-coverage-{{ .Branch }}-core
       - restore_cache:
           keys:
-            - cc-test-coverage-{{ .Branch }}-assemblies
+            - codeclimate-test-coverage-{{ .Branch }}-assemblies
       - restore_cache:
           keys:
-            - cc-test-coverage-{{ .Branch }}-api
+            - codeclimate-test-coverage-{{ .Branch }}-api
       - restore_cache:
           keys:
-            - cc-test-coverage-{{ .Branch }}-processes
+            - codeclimate-test-coverage-{{ .Branch }}-processes
       - restore_cache:
           keys:
-            - cc-test-coverage-{{ .Branch }}-admin
+            - codeclimate-test-coverage-{{ .Branch }}-admin
       - restore_cache:
           keys:
-            - cc-test-coverage-{{ .Branch }}-system
+            - codeclimate-test-coverage-{{ .Branch }}-system
       - restore_cache:
           keys:
-            - cc-test-coverage-{{ .Branch }}-proposals
+            - codeclimate-test-coverage-{{ .Branch }}-proposals
       - restore_cache:
           keys:
-            - cc-test-coverage-{{ .Branch }}-comments
+            - codeclimate-test-coverage-{{ .Branch }}-comments
       - restore_cache:
           keys:
-            - cc-test-coverage-{{ .Branch }}-meetings
+            - codeclimate-test-coverage-{{ .Branch }}-meetings
       - restore_cache:
           keys:
-            - cc-test-coverage-{{ .Branch }}-pages
+            - codeclimate-test-coverage-{{ .Branch }}-pages
       - restore_cache:
           keys:
-            - cc-test-coverage-{{ .Branch }}-accountability
+            - codeclimate-test-coverage-{{ .Branch }}-accountability
       - restore_cache:
           keys:
-            - cc-test-coverage-{{ .Branch }}-budgets
+            - codeclimate-test-coverage-{{ .Branch }}-budgets
       - restore_cache:
           keys:
-            - cc-test-coverage-{{ .Branch }}-surveys
+            - codeclimate-test-coverage-{{ .Branch }}-surveys
       - run:
           name: Sum CC test coverage reports
           command: ./cc-test-reporter sum-coverage --output - --parts 13 coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage --input -
@@ -545,7 +545,7 @@ workflows:
       - surveys:
           requires:
             - build_test_app
-      - cc-test-coverage:
+      - codeclimate-test-coverage:
           requires:
             - core
             - assemblies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,12 +74,25 @@ jobs:
       - run:
           name: Wait for db
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
+      - run: cc-test-reporter before-build
       - run:
           name: Run main folder npm lint
           command: npm run lint
       - run:
           name: Run main folder RSpec
           command: bundle exec rspec
+      - save_cache:
+          key: decidim-{{ .Branch }}
+          paths:
+            - /decidim/node_modules
+            - /usr/local/bundle/gems
+      - run:
+          name: Format test coverage
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+      - save_cache:
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          paths:
+            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
   core:
     <<: *defaults
     steps:
@@ -95,9 +108,17 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+      - run: cc-test-reporter before-build
       - run:
           name: Run core RSpec
-          command: cd decidim-core && rake
+          command: cd decidim-core && bundle exec rake
+      - run:
+          name: Format test coverage
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+      - save_cache:
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          paths:
+            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
       - store_artifacts:
           path: /app/spec/decidim_dummy_app/tmp/capybara
   assemblies:
@@ -115,9 +136,17 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+      - run: cc-test-reporter before-build
       - run:
           name: Run assemblies RSpec
-          command: cd decidim-assemblies && rake
+          command: cd decidim-assemblies && bundle exec rake
+      - run:
+          name: Format test coverage
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+      - save_cache:
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          paths:
+            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
       - store_artifacts:
           path: /app/spec/decidim_dummy_app/tmp/capybara
   api:
@@ -135,9 +164,17 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+      - run: cc-test-reporter before-build
       - run:
           name: Run api RSpec
-          command: cd decidim-api && rake
+          command: cd decidim-api && bundle exec rake
+      - run:
+          name: Format test coverage
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+      - save_cache:
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          paths:
+            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
       - store_artifacts:
           path: /app/spec/decidim_dummy_app/tmp/capybara
   processes:
@@ -155,9 +192,17 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+      - run: cc-test-reporter before-build
       - run:
           name: Run participatory_processes RSpec
-          command: cd decidim-participatory_processes && rake
+          command: cd decidim-participatory_processes && bundle exec rake
+      - run:
+          name: Format test coverage
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+      - save_cache:
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          paths:
+            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
       - store_artifacts:
           path: /app/spec/decidim_dummy_app/tmp/capybara
   admin:
@@ -175,9 +220,17 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+      - run: cc-test-reporter before-build
       - run:
           name: Run admin RSpec
-          command: cd decidim-admin && rake
+          command: cd decidim-admin && bundle exec rake
+      - run:
+          name: Format test coverage
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+      - save_cache:
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          paths:
+            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
       - store_artifacts:
           path: /app/spec/decidim_dummy_app/tmp/capybara
   system:
@@ -195,9 +248,17 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+      - run: cc-test-reporter before-build
       - run:
           name: Run system RSpec
-          command: cd decidim-system && rake
+          command: cd decidim-system && bundle exec rake
+      - run:
+          name: Format test coverage
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+      - save_cache:
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          paths:
+            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
       - store_artifacts:
           path: /app/spec/decidim_dummy_app/tmp/capybara
   proposals:
@@ -215,9 +276,17 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+      - run: cc-test-reporter before-build
       - run:
           name: Run proposals RSpec
-          command: cd decidim-proposals && rake
+          command: cd decidim-proposals && bundle exec rake
+      - run:
+          name: Format test coverage
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+      - save_cache:
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          paths:
+            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
       - store_artifacts:
           path: /app/spec/decidim_dummy_app/tmp/capybara
   comments:
@@ -235,9 +304,17 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+      - run: cc-test-reporter before-build
       - run:
           name: Run comments RSpec
-          command: cd decidim-comments && rake
+          command: cd decidim-comments && bundle exec rake
+      - run:
+          name: Format test coverage
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+      - save_cache:
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          paths:
+            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
       - store_artifacts:
           path: /app/spec/decidim_dummy_app/tmp/capybara
   meetings:
@@ -255,9 +332,17 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+      - run: cc-test-reporter before-build
       - run:
           name: Run meetings RSpec
-          command: cd decidim-meetings && rake
+          command: cd decidim-meetings && bundle exec rake
+      - run:
+          name: Format test coverage
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+      - save_cache:
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          paths:
+            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
       - store_artifacts:
           path: /app/spec/decidim_dummy_app/tmp/capybara
   pages:
@@ -275,9 +360,17 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+      - run: cc-test-reporter before-build
       - run:
           name: Run pages RSpec
-          command: cd decidim-pages && rake
+          command: cd decidim-pages && bundle exec rake
+      - run:
+          name: Format test coverage
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+      - save_cache:
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          paths:
+            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
       - store_artifacts:
           path: /app/spec/decidim_dummy_app/tmp/capybara
   accountability:
@@ -295,9 +388,17 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+      - run: cc-test-reporter before-build
       - run:
           name: Run accountability RSpec
-          command: cd decidim-accountability && rake
+          command: cd decidim-accountability && bundle exec rake
+      - run:
+          name: Format test coverage
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+      - save_cache:
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          paths:
+            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
       - store_artifacts:
           path: /app/spec/decidim_dummy_app/tmp/capybara
   budgets:
@@ -315,9 +416,17 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+      - run: cc-test-reporter before-build
       - run:
           name: Run budgets RSpec
-          command: cd decidim-budgets && rake
+          command: cd decidim-budgets && bundle exec rake
+      - run:
+          name: Format test coverage
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+      - save_cache:
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          paths:
+            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
       - store_artifacts:
           path: /app/spec/decidim_dummy_app/tmp/capybara
   surveys:
@@ -335,11 +444,43 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+      - run: cc-test-reporter before-build
       - run:
           name: Run surveys RSpec
-          command: cd decidim-surveys && rake
+          command: cd decidim-surveys && bundle exec rake
+      - run:
+          name: Format test coverage
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+      - save_cache:
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          paths:
+            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
       - store_artifacts:
-          path: /app/spec/decidim_dummy_app/tmp/capybara
+          path: /decidim/spec/decidim_dummy_app/tmp/capybara
+  cc-test-coverage:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /decidim
+      - restore_cache:
+          keys:
+            - cc-test-coverage-cache-{{ .Branch }}-main
+            - cc-test-coverage-cache-{{ .Branch }}-core
+            - cc-test-coverage-cache-{{ .Branch }}-assemblies
+            - cc-test-coverage-cache-{{ .Branch }}-api
+            - cc-test-coverage-cache-{{ .Branch }}-processes
+            - cc-test-coverage-cache-{{ .Branch }}-admin
+            - cc-test-coverage-cache-{{ .Branch }}-system
+            - cc-test-coverage-cache-{{ .Branch }}-proposals
+            - cc-test-coverage-cache-{{ .Branch }}-comments
+            - cc-test-coverage-cache-{{ .Branch }}-meetings
+            - cc-test-coverage-cache-{{ .Branch }}-pages
+            - cc-test-coverage-cache-{{ .Branch }}-accountability
+            - cc-test-coverage-cache-{{ .Branch }}-budgets
+            - cc-test-coverage-cache-{{ .Branch }}-surveys
+      - run:
+          name: Sum CC test coverage reports
+          command: cc-test-reporter sum-coverage --output --parts 14 coverage/codeclimate.*.json | cc-test-reporter upload-coverage --input -
 
 workflows:
   version: 2
@@ -386,3 +527,19 @@ workflows:
       - surveys:
           requires:
             - build_test_app
+      - cc-test-coverage:
+          requires:
+            - main
+            - core
+            - assemblies
+            - api
+            - processes
+            - admin
+            - system
+            - proposals
+            - comments
+            - meetings
+            - pages
+            - accountability
+            - budgets
+            - surveys

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,11 +106,11 @@ jobs:
           command: cd decidim-core && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.core.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
           paths:
-            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+            - "coverage/codeclimate.core.json"
       - store_artifacts:
           path: /app/spec/decidim_dummy_app/tmp/capybara
   assemblies:
@@ -134,11 +134,11 @@ jobs:
           command: cd decidim-assemblies && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.assemblies.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
           paths:
-            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+            - "coverage/codeclimate.assemblies.json"
       - store_artifacts:
           path: /app/spec/decidim_dummy_app/tmp/capybara
   api:
@@ -162,11 +162,11 @@ jobs:
           command: cd decidim-api && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.api.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
           paths:
-            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+            - "coverage/codeclimate.api.json"
       - store_artifacts:
           path: /app/spec/decidim_dummy_app/tmp/capybara
   processes:
@@ -190,11 +190,11 @@ jobs:
           command: cd decidim-participatory_processes && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.processes.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
           paths:
-            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+            - "coverage/codeclimate.processes.json"
       - store_artifacts:
           path: /app/spec/decidim_dummy_app/tmp/capybara
   admin:
@@ -218,11 +218,11 @@ jobs:
           command: cd decidim-admin && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.admin.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
           paths:
-            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+            - "coverage/codeclimate.admin.json"
       - store_artifacts:
           path: /app/spec/decidim_dummy_app/tmp/capybara
   system:
@@ -246,11 +246,11 @@ jobs:
           command: cd decidim-system && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.system.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
           paths:
-            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+            - "coverage/codeclimate.system.json"
       - store_artifacts:
           path: /app/spec/decidim_dummy_app/tmp/capybara
   proposals:
@@ -274,11 +274,11 @@ jobs:
           command: cd decidim-proposals && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.proposals.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
           paths:
-            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+            - "coverage/codeclimate.proposals.json"
       - store_artifacts:
           path: /app/spec/decidim_dummy_app/tmp/capybara
   comments:
@@ -302,11 +302,11 @@ jobs:
           command: cd decidim-comments && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.comments.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
           paths:
-            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+            - "coverage/codeclimate.comments.json"
       - store_artifacts:
           path: /app/spec/decidim_dummy_app/tmp/capybara
   meetings:
@@ -330,11 +330,11 @@ jobs:
           command: cd decidim-meetings && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.meetings.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
           paths:
-            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+            - "coverage/codeclimate.meetings.json"
       - store_artifacts:
           path: /app/spec/decidim_dummy_app/tmp/capybara
   pages:
@@ -358,11 +358,11 @@ jobs:
           command: cd decidim-pages && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.pages.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
           paths:
-            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+            - "coverage/codeclimate.pages.json"
       - store_artifacts:
           path: /app/spec/decidim_dummy_app/tmp/capybara
   accountability:
@@ -386,11 +386,11 @@ jobs:
           command: cd decidim-accountability && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.accountability.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
           paths:
-            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+            - "coverage/codeclimate.accountability.json"
       - store_artifacts:
           path: /app/spec/decidim_dummy_app/tmp/capybara
   budgets:
@@ -414,11 +414,11 @@ jobs:
           command: cd decidim-budgets && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.budgets.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
           paths:
-            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+            - "coverage/codeclimate.budgets.json"
       - store_artifacts:
           path: /app/spec/decidim_dummy_app/tmp/capybara
   surveys:
@@ -442,11 +442,11 @@ jobs:
           command: cd decidim-surveys && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+          command: cc-test-reporter format-coverage --output "coverage/codeclimate.surveys.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
           paths:
-            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
+            - "coverage/codeclimate.surveys.json"
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   cc-test-coverage:
@@ -456,19 +456,19 @@ jobs:
           at: /decidim
       - restore_cache:
           keys:
-            - cc-test-coverage-cache-{{ .Branch }}-core
-            - cc-test-coverage-cache-{{ .Branch }}-assemblies
-            - cc-test-coverage-cache-{{ .Branch }}-api
-            - cc-test-coverage-cache-{{ .Branch }}-processes
-            - cc-test-coverage-cache-{{ .Branch }}-admin
-            - cc-test-coverage-cache-{{ .Branch }}-system
-            - cc-test-coverage-cache-{{ .Branch }}-proposals
-            - cc-test-coverage-cache-{{ .Branch }}-comments
-            - cc-test-coverage-cache-{{ .Branch }}-meetings
-            - cc-test-coverage-cache-{{ .Branch }}-pages
-            - cc-test-coverage-cache-{{ .Branch }}-accountability
-            - cc-test-coverage-cache-{{ .Branch }}-budgets
-            - cc-test-coverage-cache-{{ .Branch }}-surveys
+            - cc-test-coverage-cache-{{ .Revision }}-core
+            - cc-test-coverage-cache-{{ .Revision }}-assemblies
+            - cc-test-coverage-cache-{{ .Revision }}-api
+            - cc-test-coverage-cache-{{ .Revision }}-processes
+            - cc-test-coverage-cache-{{ .Revision }}-admin
+            - cc-test-coverage-cache-{{ .Revision }}-system
+            - cc-test-coverage-cache-{{ .Revision }}-proposals
+            - cc-test-coverage-cache-{{ .Revision }}-comments
+            - cc-test-coverage-cache-{{ .Revision }}-meetings
+            - cc-test-coverage-cache-{{ .Revision }}-pages
+            - cc-test-coverage-cache-{{ .Revision }}-accountability
+            - cc-test-coverage-cache-{{ .Revision }}-budgets
+            - cc-test-coverage-cache-{{ .Revision }}-surveys
       - run:
           name: Sum CC test coverage reports
           command: cc-test-reporter sum-coverage --output --parts 14 coverage/codeclimate.*.json | cc-test-reporter upload-coverage --input -

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.core.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.core.json"
       - store_artifacts:
@@ -136,7 +136,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.assemblies.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.assemblies.json"
       - store_artifacts:
@@ -164,7 +164,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.api.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.api.json"
       - store_artifacts:
@@ -192,7 +192,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.processes.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.processes.json"
       - store_artifacts:
@@ -220,7 +220,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.admin.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.admin.json"
       - store_artifacts:
@@ -248,7 +248,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.system.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.system.json"
       - store_artifacts:
@@ -276,7 +276,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.proposals.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.proposals.json"
       - store_artifacts:
@@ -304,7 +304,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.comments.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.comments.json"
       - store_artifacts:
@@ -332,7 +332,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.meetings.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.meetings.json"
       - store_artifacts:
@@ -360,7 +360,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.pages.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.pages.json"
       - store_artifacts:
@@ -388,7 +388,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.accountability.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.accountability.json"
       - store_artifacts:
@@ -416,7 +416,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.budgets.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.budgets.json"
       - store_artifacts:
@@ -444,7 +444,7 @@ jobs:
           name: Format test coverage
           command: cc-test-reporter format-coverage --output "coverage/codeclimate.surveys.json"
       - save_cache:
-          key: cc-test-coverage-cache-{{ .Revision }}-{{ .Environment.CIRCLE_JOB }}
+          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - "coverage/codeclimate.surveys.json"
       - store_artifacts:
@@ -456,22 +456,46 @@ jobs:
           at: /decidim
       - restore_cache:
           keys:
-            - cc-test-coverage-cache-{{ .Revision }}-core
-            - cc-test-coverage-cache-{{ .Revision }}-assemblies
-            - cc-test-coverage-cache-{{ .Revision }}-api
-            - cc-test-coverage-cache-{{ .Revision }}-processes
-            - cc-test-coverage-cache-{{ .Revision }}-admin
-            - cc-test-coverage-cache-{{ .Revision }}-system
-            - cc-test-coverage-cache-{{ .Revision }}-proposals
-            - cc-test-coverage-cache-{{ .Revision }}-comments
-            - cc-test-coverage-cache-{{ .Revision }}-meetings
-            - cc-test-coverage-cache-{{ .Revision }}-pages
-            - cc-test-coverage-cache-{{ .Revision }}-accountability
-            - cc-test-coverage-cache-{{ .Revision }}-budgets
-            - cc-test-coverage-cache-{{ .Revision }}-surveys
+            - cc-test-coverage-cache-{{ .Branch }}-core
+      - restore_cache:
+          keys:
+            - cc-test-coverage-cache-{{ .Branch }}-assemblies
+      - restore_cache:
+          keys:
+            - cc-test-coverage-cache-{{ .Branch }}-api
+      - restore_cache:
+          keys:
+            - cc-test-coverage-cache-{{ .Branch }}-processes
+      - restore_cache:
+          keys:
+            - cc-test-coverage-cache-{{ .Branch }}-admin
+      - restore_cache:
+          keys:
+            - cc-test-coverage-cache-{{ .Branch }}-system
+      - restore_cache:
+          keys:
+            - cc-test-coverage-cache-{{ .Branch }}-proposals
+      - restore_cache:
+          keys:
+            - cc-test-coverage-cache-{{ .Branch }}-comments
+      - restore_cache:
+          keys:
+            - cc-test-coverage-cache-{{ .Branch }}-meetings
+      - restore_cache:
+          keys:
+            - cc-test-coverage-cache-{{ .Branch }}-pages
+      - restore_cache:
+          keys:
+            - cc-test-coverage-cache-{{ .Branch }}-accountability
+      - restore_cache:
+          keys:
+            - cc-test-coverage-cache-{{ .Branch }}-budgets
+      - restore_cache:
+          keys:
+            - cc-test-coverage-cache-{{ .Branch }}-surveys
       - run:
           name: Sum CC test coverage reports
-          command: cc-test-reporter sum-coverage --output --parts 14 coverage/codeclimate.*.json | cc-test-reporter upload-coverage --input -
+          command: cc-test-reporter sum-coverage --output --parts 13 coverage/codeclimate.*.json | cc-test-reporter upload-coverage --input -
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,9 @@ jobs:
           key: assets-{{ .Branch }}
           paths:
             - spec/decidim_dummy_app/public/assets
+      - run:
+          name: Install CodeClimate test reporter
+          command: /app/.circleci/install_cc_test_reporter.sh
       - persist_to_workspace:
           root: /app
           paths:
@@ -100,13 +103,13 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
-      - run: cc-test-reporter before-build
+      - run: ./cc-test-reporter before-build
       - run:
           name: Run core RSpec
           command: cd decidim-core && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.core.json"
+          command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.core.json"
       - save_cache:
           key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
@@ -128,13 +131,13 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
-      - run: cc-test-reporter before-build
+      - run: ./cc-test-reporter before-build
       - run:
           name: Run assemblies RSpec
           command: cd decidim-assemblies && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.assemblies.json"
+          command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.assemblies.json"
       - save_cache:
           key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
@@ -156,13 +159,13 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
-      - run: cc-test-reporter before-build
+      - run: ./cc-test-reporter before-build
       - run:
           name: Run api RSpec
           command: cd decidim-api && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.api.json"
+          command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.api.json"
       - save_cache:
           key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
@@ -184,13 +187,13 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
-      - run: cc-test-reporter before-build
+      - run: ./cc-test-reporter before-build
       - run:
           name: Run participatory_processes RSpec
           command: cd decidim-participatory_processes && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.processes.json"
+          command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.processes.json"
       - save_cache:
           key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
@@ -212,13 +215,13 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
-      - run: cc-test-reporter before-build
+      - run: ./cc-test-reporter before-build
       - run:
           name: Run admin RSpec
           command: cd decidim-admin && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.admin.json"
+          command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.admin.json"
       - save_cache:
           key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
@@ -240,13 +243,13 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
-      - run: cc-test-reporter before-build
+      - run: ./cc-test-reporter before-build
       - run:
           name: Run system RSpec
           command: cd decidim-system && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.system.json"
+          command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.system.json"
       - save_cache:
           key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
@@ -268,13 +271,13 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
-      - run: cc-test-reporter before-build
+      - run: ./cc-test-reporter before-build
       - run:
           name: Run proposals RSpec
           command: cd decidim-proposals && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.proposals.json"
+          command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.proposals.json"
       - save_cache:
           key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
@@ -296,13 +299,13 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
-      - run: cc-test-reporter before-build
+      - run: ./cc-test-reporter before-build
       - run:
           name: Run comments RSpec
           command: cd decidim-comments && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.comments.json"
+          command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.comments.json"
       - save_cache:
           key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
@@ -324,13 +327,13 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
-      - run: cc-test-reporter before-build
+      - run: ./cc-test-reporter before-build
       - run:
           name: Run meetings RSpec
           command: cd decidim-meetings && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.meetings.json"
+          command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.meetings.json"
       - save_cache:
           key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
@@ -352,13 +355,13 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
-      - run: cc-test-reporter before-build
+      - run: ./cc-test-reporter before-build
       - run:
           name: Run pages RSpec
           command: cd decidim-pages && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.pages.json"
+          command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.pages.json"
       - save_cache:
           key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
@@ -380,13 +383,13 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
-      - run: cc-test-reporter before-build
+      - run: ./cc-test-reporter before-build
       - run:
           name: Run accountability RSpec
           command: cd decidim-accountability && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.accountability.json"
+          command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.accountability.json"
       - save_cache:
           key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
@@ -408,13 +411,13 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
-      - run: cc-test-reporter before-build
+      - run: ./cc-test-reporter before-build
       - run:
           name: Run budgets RSpec
           command: cd decidim-budgets && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.budgets.json"
+          command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.budgets.json"
       - save_cache:
           key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
@@ -436,13 +439,13 @@ jobs:
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
-      - run: cc-test-reporter before-build
+      - run: ./cc-test-reporter before-build
       - run:
           name: Run surveys RSpec
           command: cd decidim-surveys && bundle exec rake
       - run:
           name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.surveys.json"
+          command: ./cc-test-reporter format-coverage --output "coverage/codeclimate.surveys.json"
       - save_cache:
           key: cc-test-coverage-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
@@ -453,7 +456,7 @@ jobs:
     <<: *defaults
     steps:
       - attach_workspace:
-          at: /decidim
+          at: /app
       - restore_cache:
           keys:
             - cc-test-coverage-{{ .Branch }}-core
@@ -495,7 +498,7 @@ jobs:
             - cc-test-coverage-{{ .Branch }}-surveys
       - run:
           name: Sum CC test coverage reports
-          command: cc-test-reporter sum-coverage --output - --parts 13 coverage/codeclimate.*.json | cc-test-reporter upload-coverage --input -
+          command: ./cc-test-reporter sum-coverage --output - --parts 13 coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage --input -
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -495,7 +495,7 @@ jobs:
             - cc-test-coverage-cache-{{ .Branch }}-surveys
       - run:
           name: Sum CC test coverage reports
-          command: cc-test-reporter sum-coverage --output --parts 13 coverage/codeclimate.*.json | cc-test-reporter upload-coverage --input -
+          command: cc-test-reporter sum-coverage --output - --parts 13 coverage/codeclimate.*.json | cc-test-reporter upload-coverage --input -
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,6 @@ jobs:
       - run:
           name: Wait for db
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
-      - run: cc-test-reporter before-build
       - run:
           name: Run main folder npm lint
           command: npm run lint
@@ -86,13 +85,6 @@ jobs:
           paths:
             - /decidim/node_modules
             - /usr/local/bundle/gems
-      - run:
-          name: Format test coverage
-          command: cc-test-reporter format-coverage --output "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
-      - save_cache:
-          key: cc-test-coverage-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
-          paths:
-            - "coverage/codeclimate.${CIRCLE_JOB}.${CIRCLE_BRANCH}.json"
   core:
     <<: *defaults
     steps:
@@ -464,7 +456,6 @@ jobs:
           at: /decidim
       - restore_cache:
           keys:
-            - cc-test-coverage-cache-{{ .Branch }}-main
             - cc-test-coverage-cache-{{ .Branch }}-core
             - cc-test-coverage-cache-{{ .Branch }}-assemblies
             - cc-test-coverage-cache-{{ .Branch }}-api
@@ -529,7 +520,6 @@ workflows:
             - build_test_app
       - cc-test-coverage:
           requires:
-            - main
             - core
             - assemblies
             - api

--- a/.circleci/install_cc_test_reporter.sh
+++ b/.circleci/install_cc_test_reporter.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /app/cc-test-reporter
+chmod +x /app/cc-test-reporter


### PR DESCRIPTION
#### :tophat: What? Why?
Use CodeClimate to calculate the test coverage reports. If this works properly it would unblock #2028 (we'd need to retrieve the cached reports from master).

#### :pushpin: Related Issues
- Related to #2028.
