### PR TITLE
global routes engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **decidim-assemblies**: Show promoted assemblies in the homepage [\#2162](https://github.com/decidim/decidim/pull/2162)
 - **decidim-core**: Add support for extending the user profile menu. [\#2193](https://github.com/decidim/decidim/pull/2193)
 - **decidim-core**: Add view hooks so external engines can extend the homepage and other sections with their own code [\#2114](https://github.com/decidim/decidim/pull/2114)
+- **decidim-core**: Add the ability to register Global Engines that sit at the root of the project. [\#2194](https://github.com/decidim/decidim/pull/2194)
 - **decidim-proposals**: Admins can set a minute window after the creation of a proposal in which the proposal can be edited by its author. Once the window has passed, it cannot be edited. [\#2171](https://github.com/decidim/decidim/pull/2171)
 - **decidim-verifications**: Support for deferred verification methods that require several steps in order to be granted. [\#2024](https://github.com/decidim/decidim/pull/2024)
 

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -27,6 +27,9 @@ Decidim::Core::Engine.routes.draw do
   end
 
   mount Decidim::Verifications::Engine, at: "/", as: "decidim_verifications"
+  Decidim.global_engines.each do |engine|
+    mount engine, at: "/"
+  end
 
   authenticate(:user) do
     resource :account, only: [:show, :update, :destroy], controller: "account" do

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -27,8 +27,9 @@ Decidim::Core::Engine.routes.draw do
   end
 
   mount Decidim::Verifications::Engine, at: "/", as: "decidim_verifications"
-  Decidim.global_engines.each do |engine|
-    mount engine, at: "/"
+
+  Decidim.global_engines.each do |name, engine_data|
+    mount engine_data[:engine], at: engine_data[:at], as: name
   end
 
   authenticate(:user) do

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require "decidim/core/engine"

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 require "decidim/core/engine"
@@ -150,15 +151,33 @@ module Decidim
 
   # Public: Registers a global engine. This method is intended to be used
   # by feature engines that also offer unscoped functionality
-  def self.register_global_engine(engine)
-    global_engines << engine unless global_engines.include? engine
+  #
+  # name    - The name of the engine to register. Should be unique.
+  # engine  - The engine to register.
+  # options - Options to pass to the engine.
+  #           :at - The route to mount the engine to.
+  #
+  # Returns nothing.
+  def self.register_global_engine(name, engine, options = {})
+    return if global_engines.keys.include?(name)
+
+    options[:at] ||= "/#{name}"
+
+    global_engines[name.to_sym] = {
+      at: options[:at],
+      engine: engine
+    }
+  end
+
+  def self.unregister_global_engine(name)
+    global_engines.delete(name.to_sym)
   end
 
   # Public: Finds all registered engines via the 'register_global_engine' method.
   #
   # Returns an Array[::Rails::Engine]
   def self.global_engines
-    @global_engines ||= []
+    @global_engines ||= {}
   end
 
   # Public: Registers a feature, usually held in an external library or in a

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -148,6 +148,19 @@ module Decidim
   # environments, but in different folders.
   config_accessor :base_uploads_path
 
+  # Public: Registers a global engine. This method is intended to be used
+  # by feature engines that also offer unscoped functionality
+  def self.register_global_engine(engine)
+    global_engines << engine unless global_engines.include? engine
+  end
+
+  # Public: Finds all registered engines via the 'register_global_engine' method.
+  #
+  # Returns an Array[::Rails::Engine]
+  def self.global_engines
+    @global_engines ||= []
+  end
+
   # Public: Registers a feature, usually held in an external library or in a
   # separate folder in the main repository. Exposes a DSL defined by
   # `Decidim::FeatureManifest`.

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -169,6 +169,12 @@ module Decidim
     }
   end
 
+  # Semiprivate: Removes a global engine from the registry. Mostly used on testing,
+  # no real reason to use this on production.
+  #
+  # name - The name of the global engine to remove.
+  #
+  # Returns nothing.
   def self.unregister_global_engine(name)
     global_engines.delete(name.to_sym)
   end

--- a/decidim-core/spec/lib/global_engines_spec.rb
+++ b/decidim-core/spec/lib/global_engines_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "global engines", type: :feature do
+  let(:organization) { create(:organization) }
+  let(:mount_at) { nil }
+
+  around do |example|
+    Decidim.register_global_engine(:global_engine, Decidim::DummyEngine, at: mount_at)
+    Rails.application.reload_routes!
+    switch_to_host(organization.host)
+    example.run
+    Decidim.unregister_global_engine(:global_engine)
+    Rails.application.reload_routes!
+  end
+
+  it "renders the engine" do
+    visit decidim.global_engine_path
+    expect(page).to have_content("DUMMY ENGINE")
+  end
+
+  it "mounts the engine under a route with its own name" do
+    expect(decidim.global_engine_path).to eq("/global_engine")
+  end
+
+  context "with an explicit mount route" do
+    let(:mount_at) { "/foo" }
+
+    it "mounts the engine under the right route" do
+      expect(decidim.global_engine_path).to eq("/foo")
+    end
+
+    it "renders the engine" do
+      visit decidim.global_engine_path
+      expect(page).to have_content("DUMMY ENGINE")
+    end
+  end
+end


### PR DESCRIPTION
Decidim has been extended to allow feature engines to publish routes
outside the participatory space scope.
