### PR TITLE
Fix CI on external PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,9 @@ jobs:
   build_test_app:
     <<: *defaults
     steps:
+      - run:
+          name: "Remove image's decidim folder"
+          command: rm -fR /decidim
       - attach_workspace:
           at: /decidim
       - checkout
@@ -66,6 +69,9 @@ jobs:
   main:
     <<: *defaults
     steps:
+      - run:
+          name: "Remove image's decidim folder"
+          command: rm -fR /decidim
       - attach_workspace:
           at: /decidim
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,9 @@ jobs:
           at: /decidim
       - checkout
       - run:
+          name: Install dependencies
+          command: bundle install
+      - run:
           name: Wait for db
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run:
@@ -75,6 +78,12 @@ jobs:
       - attach_workspace:
           at: /decidim
       - checkout
+      - run:
+          name: Install ruby dependencies
+          command: bundle install
+      - run:
+          name: Install node dependencies
+          command: bundle install
       - run:
           name: Wait for db
           command: dockerize -wait tcp://localhost:5432 -timeout 1m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,8 +95,8 @@ jobs:
           name: Install ruby dependencies
           command: bundle install
       - run:
-          name: Install node dependencies
-          command: bundle install
+          name: Install npm dependencies
+          command: npm install
       - run:
           name: Wait for db
           command: dockerize -wait tcp://localhost:5432 -timeout 1m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 defaults: &defaults
   docker:
-    - image: codegram/decidim:test-$CIRCLE_SHA1
+    - image: codegram/decidim:test-latest
       environment:
         SIMPLECOV: true
         DATABASE_USERNAME: postgres
@@ -44,7 +44,6 @@ jobs:
             else
               docker build -f Dockerfile.ci --build-arg BASE_IMAGE_TAG=prod-$CIRCLE_SHA1 --tag codegram/decidim:test-$CIRCLE_SHA1 --cache-from codegram/decidim:test-latest .
             fi
-            docker push codegram/decidim:test-$CIRCLE_SHA1
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,10 @@ jobs:
       - attach_workspace:
           at: /decidim
       - checkout
+      - restore_cache:
+         keys:
+          - decidim-{{ .Branch }}
+          - decidim-master
       - run:
           name: Install dependencies
           command: bundle install
@@ -65,6 +69,11 @@ jobs:
       - run:
           name: Precompile test app assets
           command: cd spec/decidim_dummy_app && bundle exec rails assets:precompile
+      - save_cache:
+          key: decidim-{{ .Branch }}
+          paths:
+            - /decidim/node_modules
+            - /usr/local/bundle/gems
       - persist_to_workspace:
           root: .
           paths:
@@ -78,6 +87,10 @@ jobs:
       - attach_workspace:
           at: /decidim
       - checkout
+      - restore_cache:
+         keys:
+          - decidim-{{ .Branch }}
+          - decidim-master
       - run:
           name: Install ruby dependencies
           command: bundle install
@@ -93,6 +106,11 @@ jobs:
       - run:
           name: Run main folder RSpec
           command: bundle exec rspec
+      - save_cache:
+          key: decidim-{{ .Branch }}
+          paths:
+            - /decidim/node_modules
+            - /usr/local/bundle/gems
   core:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,12 +346,8 @@ workflows:
   build_and_test:
     jobs:
       - build_docker_images
-      - build_test_app:
-          requires:
-            - build_docker_images
-      - main:
-          requires:
-            - build_docker_images
+      - build_test_app
+      - main
       - core:
           requires:
             - build_test_app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,8 @@ jobs:
   build_test_app:
     <<: *defaults
     steps:
+      - attach_workspace:
+          at: /decidim
       - checkout
       - run:
           name: Wait for db
@@ -64,6 +66,8 @@ jobs:
   main:
     <<: *defaults
     steps:
+      - attach_workspace:
+          at: /decidim
       - checkout
       - run:
           name: Wait for db

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,15 +44,10 @@ jobs:
             else
               docker build -f Dockerfile.ci --build-arg BASE_IMAGE_TAG=prod-$CIRCLE_SHA1 --tag codegram/decidim:test-$CIRCLE_SHA1 --cache-from codegram/decidim:test-latest .
             fi
-      - persist_to_workspace:
-          root: .
-          paths:
-            - "*"
   build_test_app:
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: /decidim
+      - checkout
       - run:
           name: Wait for db
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
@@ -69,8 +64,7 @@ jobs:
   main:
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: /decidim
+      - checkout
       - run:
           name: Wait for db
           command: dockerize -wait tcp://localhost:5432 -timeout 1m


### PR DESCRIPTION
#### :tophat: What? Why?
Building images every time run breaks when external PRs are issued, as we don't want environment variables to leak to these PRs (security) but they need it to be able to push images.

Unfortunately, we can't seem to be able to load images from a file when specifying them on a test run, so we can only use the `decidim:test-latest` image. This is not ideal & doesn't make builds idempotent, but I can't come up with another solution.

#### :pushpin: Related Issues
- Related to #2194

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/FaKV1cVKlVRxC/giphy.gif)
