### PR TITLE
Add video tag to sanitize calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,10 @@
 
 - **decidim-admin**: Replace url to visit_url moderation admin [\#2129](https://github.com/decidim/decidim/pull/2129)
 - **decidim-core**: Hide link to register when user is already logged in [\#2088](https://github.com/decidim/decidim/pull/2088)
-- **decidim-proposals**: Change "Already voted" to "Unvote" on button hover [\#2096](https://github.com/decidim/decidim/pull/2096**
+- **decidim-proposals**: Change "Already voted" to "Unvote" on button hover [\#2096](https://github.com/decidim/decidim/pull/2096)
 
 **Fixed**:
 - **decidim-core**: Embedded videos were not displaying properly [\#2198](https://github.com/decidim/decidim/pull/2198)
-
-**Fixed**:
-
 - **decidim-meetings**: Admins could not submit form after getting a validation error in the meeting registrations form [\2202](https://github.com/decidim/decidim/pull/2202)
 
 ## [v0.7.2](https://github.com/decidim/decidim/tree/v0.7.2) (2017-11-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@
 
 - **decidim-admin**: Replace url to visit_url moderation admin [\#2129](https://github.com/decidim/decidim/pull/2129)
 - **decidim-core**: Hide link to register when user is already logged in [\#2088](https://github.com/decidim/decidim/pull/2088)
-- **decidim-proposals**: Change "Already voted" to "Unvote" on button hover [\#2096](https://github.com/decidim/decidim/pull/2096)
+- **decidim-proposals**: Change "Already voted" to "Unvote" on button hover [\#2096](https://github.com/decidim/decidim/pull/2096**
+
+**Fixed**:
+- **decidim-core**: Embedded videos were not displaying properly [\#2198](https://github.com/decidim/decidim/pull/2198)
 
 **Fixed**:
 

--- a/decidim-admin/spec/features/admin_manages_organization_admins_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_organization_admins_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "Organization admins", type: :feature do
-  include ActionView::Helpers::SanitizeHelper
+  include Decidim::SanitizeHelper
 
   let(:admin) { create :user, :admin, :confirmed }
   let(:organization) { admin.organization }

--- a/decidim-admin/spec/features/admin_manages_organization_scopes_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_organization_scopes_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "Organization scopes", type: :feature do
-  include ActionView::Helpers::SanitizeHelper
+  include Decidim::SanitizeHelper
 
   let(:admin) { create :user, :admin, :confirmed }
   let(:organization) { admin.organization }

--- a/decidim-admin/spec/features/static_pages_spec.rb
+++ b/decidim-admin/spec/features/static_pages_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "Content pages", type: :feature do
-  include ActionView::Helpers::SanitizeHelper
+  include Decidim::SanitizeHelper
 
   let(:admin) { create :user, :admin, :confirmed }
   let(:organization) { admin.organization }

--- a/decidim-admin/spec/features/static_pages_spec.rb
+++ b/decidim-admin/spec/features/static_pages_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "Content pages", type: :feature do
-  include Decidim::SanitizeHelper
+  include ActionView::Helpers::SanitizeHelper
 
   let(:admin) { create :user, :admin, :confirmed }
   let(:organization) { admin.organization }

--- a/decidim-assemblies/app/controllers/decidim/assemblies/assemblies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/assemblies_controller.rb
@@ -12,6 +12,7 @@ module Decidim
       helper Decidim::AttachmentsHelper
       helper Decidim::IconHelper
       helper Decidim::WidgetUrlsHelper
+      helper Decidim::SanitizeHelper
 
       helper_method :collection, :promoted_assemblies, :assemblies, :stats
 

--- a/decidim-assemblies/app/controllers/decidim/assemblies/assembly_widgets_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/assembly_widgets_controller.rb
@@ -3,6 +3,8 @@
 module Decidim
   module Assemblies
     class AssemblyWidgetsController < Decidim::WidgetsController
+      helper Decidim::SanitizeHelper
+
       private
 
       def model

--- a/decidim-assemblies/app/views/decidim/assemblies/_assembly.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/_assembly.html.erb
@@ -8,7 +8,7 @@
       <%= link_to assembly_path(assembly), class: "card__link" do %>
         <h4 class="card__title"><%= translated_attribute assembly.title %></h4>
       <% end %>
-      <p class="card__desc"><%= sanitize html_truncate(translated_attribute(assembly.short_description), length: 630, separator: '...') %></p>
+      <p class="card__desc"><%= decidim_sanitize html_truncate(translated_attribute(assembly.short_description), length: 630, separator: '...') %></p>
     </div>
     <div class="card__footer">
       <div class="card__support">

--- a/decidim-assemblies/app/views/decidim/assemblies/assemblies/_promoted_assembly.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/assemblies/_promoted_assembly.html.erb
@@ -5,7 +5,7 @@
         <%= link_to assembly_path(promoted_assembly), class: "card__link" do %>
           <h2 class="card__title"><%= translated_attribute promoted_assembly.title %></h2>
         <% end %>
-        <%= sanitize html_truncate(translated_attribute(promoted_assembly.short_description), length: 630, separator: '...') %>
+        <%= decidim_sanitize html_truncate(translated_attribute(promoted_assembly.short_description), length: 630, separator: '...') %>
         <%= link_to assembly_path(promoted_assembly), class: "button secondary small hollow card__button" do %>
           <%= t("assemblies.promoted_assembly.more_info", scope: "layouts.decidim") %>
         <% end %>

--- a/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
@@ -11,9 +11,9 @@
     <div class="columns medium-7 mediumlarge-8">
       <div class="section">
         <div class="lead">
-          <%= sanitize translated_attribute(current_assembly.short_description) %>
+          <%= decidim_sanitize translated_attribute(current_assembly.short_description) %>
         </div>
-        <%= sanitize translated_attribute(current_assembly.description) %>
+        <%= decidim_sanitize translated_attribute(current_assembly.description) %>
       </div>
       <%= attachments_for current_assembly %>
     </div>

--- a/decidim-assemblies/app/views/decidim/assemblies/assembly_widgets/show.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/assembly_widgets/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:header, "false") %>
 <% content_for(:title, translated_attribute(model.title)) %>
-<p class="card__desc"><%= sanitize html_truncate(translated_attribute(model.short_description), length: 630, separator: '...') %></p>
+<p class="card__desc"><%= decidim_sanitize html_truncate(translated_attribute(model.short_description), length: 630, separator: '...') %></p>
 <% content_for(:footer) do %>
   <div class="card__support">
     <span class="card--process__small"></span>

--- a/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
@@ -37,7 +37,7 @@
   </div>
   <div class="columns mediumlarge-8 mediumlarge-pull-4">
     <div class="section">
-      <%= sanitize translated_attribute project.description %>
+      <%= decidim_sanitize translated_attribute project.description %>
       <%= render partial: "decidim/shared/tags", locals: { resource: project, tags_class_extra: "tags--project" } %>
     </div>
     <%= linked_resources_for project, :proposals, "included_proposals" %>

--- a/decidim-core/app/controllers/decidim/features/base_controller.rb
+++ b/decidim-core/app/controllers/decidim/features/base_controller.rb
@@ -18,6 +18,7 @@ module Decidim
       helper Decidim::ScopesHelper
       helper Decidim::ActionAuthorizationHelper
       helper Decidim::AttachmentsHelper
+      helper Decidim::SanitizeHelper
 
       helper_method :current_feature,
                     :current_participatory_space,

--- a/decidim-core/app/controllers/decidim/pages_controller.rb
+++ b/decidim-core/app/controllers/decidim/pages_controller.rb
@@ -13,6 +13,7 @@ module Decidim
     delegate :page, to: :page_finder
     helper_method :page, :stats
     helper CtaButtonHelper
+    helper Decidim::SanitizeHelper
 
     def index
       @pages = current_organization.static_pages.all.to_a.sort do |a, b|

--- a/decidim-core/app/helpers/decidim/sanitize_helper.rb
+++ b/decidim-core/app/helpers/decidim/sanitize_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Decidim
+  # Helper that provides methods to render order selector and links
+  module SanitizeHelper
+    include ActionView::Helpers::SanitizeHelper
+
+    # Public: It sanitizes a user-inputted string with the
+    # `Decidim::UserInputScrubber` scrubber, so that video embeds work
+    # as expected. Uses Rails' `sanitize` internally.
+    #
+    # html - A string representing user-inputted HTML.
+    #
+    # Returns an HTML-safe String.
+    def decidim_sanitize(html)
+      sanitize(html, scrubber: Decidim::UserInputScrubber.new)
+    end
+  end
+end

--- a/decidim-core/app/mailers/decidim/newsletter_mailer.rb
+++ b/decidim-core/app/mailers/decidim/newsletter_mailer.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   class NewsletterMailer < ApplicationMailer
-    include Decidim::SanitizeHelper
+    helper Decidim::SanitizeHelper
     add_template_helper Decidim::TranslationsHelper
 
     def newsletter(user, newsletter)

--- a/decidim-core/app/mailers/decidim/newsletter_mailer.rb
+++ b/decidim-core/app/mailers/decidim/newsletter_mailer.rb
@@ -2,6 +2,7 @@
 
 module Decidim
   class NewsletterMailer < ApplicationMailer
+    include Decidim::SanitizeHelper
     add_template_helper Decidim::TranslationsHelper
 
     def newsletter(user, newsletter)

--- a/decidim-core/app/scrubbers/decidim/user_input_scrubber.rb
+++ b/decidim-core/app/scrubbers/decidim/user_input_scrubber.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Decidim
+  # Use this class as a scrubber to sanitize user input.
+  #
+  # Example:
+  #
+  #    sanitize(@page.body, scrubber: Decidim::UserInputScrubber.new)
+  #
+  # Lists of default tags and attributes are extracted from
+  # https://stackoverflow.com/a/35073814/2110884.
+  class UserInputScrubber < Rails::Html::PermitScrubber
+    def initialize
+      super
+      self.tags = custom_allowed_tags
+      self.attributes = custom_allowed_attributes
+    end
+
+    private
+
+    def custom_allowed_attributes
+      Loofah::HTML5::WhiteList::ALLOWED_ATTRIBUTES + %w(frameborder allowfullscreen)
+    end
+
+    def custom_allowed_tags
+      Loofah::HTML5::WhiteList::ALLOWED_ELEMENTS_WITH_LIBXML2 + %w(iframe)
+    end
+  end
+end

--- a/decidim-core/app/scrubbers/decidim/user_input_scrubber.rb
+++ b/decidim-core/app/scrubbers/decidim/user_input_scrubber.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 module Decidim
-  # Use this class as a scrubber to sanitize user input.
+  # Use this class as a scrubber to sanitize user input. The default
+  # scrubbed provided by Rails does not allow `iframe`s, and we're using
+  # them to embed videos, so we need to provide a whole new scrubber.
   #
   # Example:
   #

--- a/decidim-core/app/views/decidim/newsletter_mailer/newsletter.html.erb
+++ b/decidim-core/app/views/decidim/newsletter_mailer/newsletter.html.erb
@@ -1,4 +1,4 @@
-<%= sanitize @body %>
+<%= decidim_sanitize @body %>
 
 <% content_for :note do %>
   <%== t ".note", organization_name: h(@organization.name), link: decidim.notifications_settings_url(host: @organization.host) %>

--- a/decidim-core/app/views/decidim/shared/_announcement.html.erb
+++ b/decidim-core/app/views/decidim/shared/_announcement.html.erb
@@ -1,5 +1,5 @@
 <div class="row column">
   <div class="callout secondary announcement">
-    <%= sanitize translated_attribute announcement %>
+    <%= decidim_sanitize translated_attribute announcement %>
   </div>
 </div>

--- a/decidim-core/app/views/pages/decidim_page.html.erb
+++ b/decidim-core/app/views/pages/decidim_page.html.erb
@@ -10,7 +10,7 @@
   <div class="row">
     <div class="columns large-8">
       <div class="static__content">
-        <%= sanitize translated_attribute page.content %>
+        <%= decidim_sanitize translated_attribute page.content %>
       </div>
     </div>
   </div>

--- a/decidim-core/app/views/pages/home/_hero.html.erb
+++ b/decidim-core/app/views/pages/home/_hero.html.erb
@@ -6,7 +6,7 @@
           <% if translated_attribute(current_organization.welcome_text).blank? %>
             <%= t('.welcome', organization: current_organization.name) %>
           <% else %>
-            <%= sanitize translated_attribute current_organization.welcome_text %>
+            <%= decidim_sanitize translated_attribute current_organization.welcome_text %>
           <% end %>
         </h1>
       </div>

--- a/decidim-core/app/views/pages/home/_sub_hero.html.erb
+++ b/decidim-core/app/views/pages/home/_sub_hero.html.erb
@@ -1,7 +1,7 @@
   <section class="extended subhero home-section">
     <div class="row">
       <div class="columns small-centered large-10">
-        <h2 class="heading3"><%= sanitize translated_attribute current_organization.description %></h2>
+        <h2 class="heading3"><%= decidim_sanitize translated_attribute current_organization.description %></h2>
         <% unless current_user %>
           <%= link_to new_user_registration_path, class: "button--sc link subhero-cta" do %>
             <%= t(".register") %>

--- a/decidim-core/spec/scrubbers/decidim/user_input_scrubber_spec.rb
+++ b/decidim-core/spec/scrubbers/decidim/user_input_scrubber_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::UserInputScrubber do
+  subject { described_class.new }
+
+  def scrub(html)
+    Loofah.scrub_fragment(html, subject).to_s
+  end
+
+  RSpec::Matchers.define :be_scrubbed do
+    match do |actual|
+      expect(scrub(actual)).to eq actual
+    end
+
+    failure_message do |actual|
+      "expected \"#{actual}\" to eq \"#{scrub(actual)}\" after scrubbing"
+    end
+  end
+
+  RSpec::Matchers.define :be_scrubbed_as do |expected|
+    match do |actual|
+      expect(scrub(actual)).to eq expected
+    end
+
+    failure_message do |actual|
+      "expected \"#{actual}\" to eq \"#{expected}\" after scrubbing, scrubbed as \"#{scrub(actual)}\" instead"
+    end
+  end
+
+  it "allows iframes to embed videos" do
+    html = "<iframe frameborder=\"0\" allowfullscreen=\"true\" src=\"url\"></iframe>"
+    expect(html).to be_scrubbed
+  end
+
+  it "allows most basic tags" do
+    html = "<a></a><b></b><strong></strong><em></em><i></i><p></p><br>"
+    expect(html).to be_scrubbed
+  end
+
+  it "does not allow scripts" do
+    html = "<script></script>"
+    expect(html).to be_scrubbed_as("")
+  end
+end

--- a/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
@@ -40,7 +40,7 @@ module Decidim
       end
 
       def send_email_confirmation
-        RegistrationMailer.confirmation(user, meeting).deliver_later
+        Decidim::Meetings::RegistrationMailer.confirmation(user, meeting).deliver_later
       end
 
       def participatory_space_admins

--- a/decidim-meetings/app/controllers/decidim/meetings/meeting_widgets_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meeting_widgets_controller.rb
@@ -4,6 +4,7 @@ module Decidim
   module Meetings
     class MeetingWidgetsController < Decidim::WidgetsController
       helper MeetingsHelper
+      helper Decidim::SanitizeHelper
 
       private
 

--- a/decidim-meetings/app/mailers/decidim/meetings/admin/invite_join_meeting_mailer.rb
+++ b/decidim-meetings/app/mailers/decidim/meetings/admin/invite_join_meeting_mailer.rb
@@ -7,7 +7,7 @@ module Decidim
       # an existing user.
       class InviteJoinMeetingMailer < Decidim::ApplicationMailer
         include Decidim::TranslationsHelper
-        include ActionView::Helpers::SanitizeHelper
+        include Decidim::SanitizeHelper
 
         helper Decidim::ResourceHelper
         helper Decidim::TranslationsHelper

--- a/decidim-meetings/app/mailers/decidim/meetings/registration_mailer.rb
+++ b/decidim-meetings/app/mailers/decidim/meetings/registration_mailer.rb
@@ -6,7 +6,7 @@ module Decidim
     # they join a meeting.
     class RegistrationMailer < Decidim::ApplicationMailer
       include Decidim::TranslationsHelper
-      include ActionView::Helpers::SanitizeHelper
+      include Decidim::SanitizeHelper
 
       helper Decidim::ResourceHelper
       helper Decidim::TranslationsHelper

--- a/decidim-meetings/app/mailers/decidim/meetings/registration_mailer.rb
+++ b/decidim-meetings/app/mailers/decidim/meetings/registration_mailer.rb
@@ -6,7 +6,7 @@ module Decidim
     # they join a meeting.
     class RegistrationMailer < Decidim::ApplicationMailer
       include Decidim::TranslationsHelper
-      include Decidim::SanitizeHelper
+      include ActionView::Helpers::SanitizeHelper
 
       helper Decidim::ResourceHelper
       helper Decidim::TranslationsHelper

--- a/decidim-meetings/app/views/decidim/meetings/meeting_widgets/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meeting_widgets/show.html.erb
@@ -1,6 +1,6 @@
 <%= content_for(:title, translated_attribute(model.title)) %>
 <%= render partial: "decidim/meetings/meetings/datetime", locals: { meeting: model } %>
-<%= sanitize meeting_description(model) %>
+<%= decidim_sanitize meeting_description(model) %>
 <div class="address card__extra">
   <div class="address__icon">
     <%= icon "meetings", remove_icon_class: true, width: 40, height: 70 %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_linked_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_linked_meetings.html.erb
@@ -14,7 +14,7 @@
               <%= meeting.start_time.strftime("%H:%M") %> - <%= meeting.end_time.strftime("%H:%M") %>
             </div>
           </div>
-          <%= sanitize translated_attribute meeting.description %>
+          <%= decidim_sanitize translated_attribute meeting.description %>
         </div>
       </article>
     </div>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
@@ -19,7 +19,7 @@
             <h5 class="card__title"><%= translated_attribute meeting.title %></h5>
           <% end %>
           <%= render partial: "datetime", locals: { meeting: meeting } %>
-          <%= sanitize meeting_description(meeting) %>
+          <%= decidim_sanitize meeting_description(meeting) %>
           <%= render partial: "decidim/shared/tags", locals: { resource: meeting, tags_class_extra: "tags--meeting" } %>
           <div class="address card__extra">
             <div class="address__icon">

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_registration_confirm.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_registration_confirm.html.erb
@@ -1,7 +1,7 @@
 <div class="reveal" data-reveal id="meeting-registration-confirm">
   <div class="row">
     <div class="columns medium-10 medium-offset-1 help-text">
-      <%= sanitize translated_attribute(meeting.registration_terms) %>
+      <%= decidim_sanitize translated_attribute(meeting.registration_terms) %>
     </div>
   </div>
   <div class="row">

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -62,14 +62,14 @@
   </div>
   <div class="columns mediumlarge-8 mediumlarge-pull-4">
     <div class="section">
-      <p><%= sanitize translated_attribute meeting.description %></p>
+      <p><%= decidim_sanitize translated_attribute meeting.description %></p>
       <%= render partial: "decidim/shared/static_map", locals: { icon_name: "meetings", geolocalizable: meeting } %>
       <%= render partial: "decidim/shared/tags", locals: { resource: meeting, tags_class_extra: "tags--meeting" } %>
     </div>
     <% if meeting.closed? %>
       <div class="section">
         <h3 class="section-heading"><%= t(".meeting_report") %></h3>
-        <%= sanitize translated_attribute meeting.closing_report %>
+        <%= decidim_sanitize translated_attribute meeting.closing_report %>
       </div>
     <% end %>
     <%= linked_resources_for meeting, :proposals, "proposals_from_meeting" %>

--- a/decidim-meetings/spec/mailers/registration_mailer_spec.rb
+++ b/decidim-meetings/spec/mailers/registration_mailer_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe Decidim::Meetings::RegistrationMailer, type: :mailer do
-  include ActionView::Helpers::SanitizeHelper
+  include Decidim::SanitizeHelper
 
   let(:organization) { create(:organization) }
   let(:participatory_process) { create(:participatory_process, organization: organization) }

--- a/decidim-meetings/spec/mailers/registration_mailer_spec.rb
+++ b/decidim-meetings/spec/mailers/registration_mailer_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe Decidim::Meetings::RegistrationMailer, type: :mailer do
-  include Decidim::SanitizeHelper
+  include ActionView::Helpers::SanitizeHelper
 
   let(:organization) { create(:organization) }
   let(:participatory_process) { create(:participatory_process, organization: organization) }

--- a/decidim-pages/app/views/decidim/pages/application/show.html.erb
+++ b/decidim-pages/app/views/decidim/pages/application/show.html.erb
@@ -8,7 +8,7 @@
   <div class="row">
     <div class="columns medium-7 mediumlarge-8">
       <div class="section">
-        <%= sanitize translated_attribute @page.body %>
+        <%= sanitize translated_attribute(@page.body), scrubber: Decidim::UserInputScrubber.new %>
       </div>
     </div>
   </div>

--- a/decidim-pages/app/views/decidim/pages/application/show.html.erb
+++ b/decidim-pages/app/views/decidim/pages/application/show.html.erb
@@ -8,7 +8,7 @@
   <div class="row">
     <div class="columns medium-7 mediumlarge-8">
       <div class="section">
-        <%= sanitize translated_attribute(@page.body), scrubber: Decidim::UserInputScrubber.new %>
+        <%= decidim_sanitize translated_attribute(@page.body), scrubber: Decidim::UserInputScrubber.new %>
       </div>
     </div>
   </div>

--- a/decidim-pages/app/views/decidim/pages/application/show.html.erb
+++ b/decidim-pages/app/views/decidim/pages/application/show.html.erb
@@ -8,7 +8,7 @@
   <div class="row">
     <div class="columns medium-7 mediumlarge-8">
       <div class="section">
-        <%= decidim_sanitize translated_attribute(@page.body), scrubber: Decidim::UserInputScrubber.new %>
+        <%= decidim_sanitize translated_attribute(@page.body) %>
       </div>
     </div>
   </div>

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_process_groups_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_process_groups_controller.rb
@@ -3,6 +3,7 @@
 module Decidim
   module ParticipatoryProcesses
     class ParticipatoryProcessGroupsController < Decidim::ApplicationController
+      helper Decidim::SanitizeHelper
       helper_method :participatory_processes, :group, :collection
 
       before_action :set_group

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_process_widgets_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_process_widgets_controller.rb
@@ -3,6 +3,8 @@
 module Decidim
   module ParticipatoryProcesses
     class ParticipatoryProcessWidgetsController < Decidim::WidgetsController
+      helper Decidim::SanitizeHelper
+
       private
 
       def model

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
@@ -12,6 +12,7 @@ module Decidim
       helper Decidim::AttachmentsHelper
       helper Decidim::IconHelper
       helper Decidim::WidgetUrlsHelper
+      helper Decidim::SanitizeHelper
 
       helper ParticipatoryProcessHelper
 

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/_participatory_process.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/_participatory_process.html.erb
@@ -8,7 +8,7 @@
       <%= link_to participatory_process_path(participatory_process), class: "card__link" do %>
         <h4 class="card__title"><%= translated_attribute participatory_process.title %></h4>
       <% end %>
-      <p class="card__desc"><%= sanitize html_truncate(translated_attribute(participatory_process.short_description), length: 630, separator: '...') %></p>
+      <p class="card__desc"><%= decidim_sanitize html_truncate(translated_attribute(participatory_process.short_description), length: 630, separator: '...') %></p>
     </div>
     <div class="card__footer">
       <div class="card__support">

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_process_widgets/show.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_process_widgets/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:header, "false") %>
 <% content_for(:title, translated_attribute(model.title)) %>
-<p class="card__desc"><%= sanitize html_truncate(translated_attribute(model.short_description), length: 630, separator: '...') %></p>
+<p class="card__desc"><%= decidim_sanitize html_truncate(translated_attribute(model.short_description), length: 630, separator: '...') %></p>
 <% content_for(:footer) do %>
   <div class="card__support">
     <% if model.active_step %>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/_promoted_process.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/_promoted_process.html.erb
@@ -5,7 +5,7 @@
         <%= link_to participatory_process_path(promoted_process), class: "card__link" do %>
           <h2 class="card__title"><%= translated_attribute promoted_process.title %></h2>
         <% end %>
-        <%= sanitize html_truncate(translated_attribute(promoted_process.short_description), length: 630, separator: '...') %>
+        <%= decidim_sanitize html_truncate(translated_attribute(promoted_process.short_description), length: 630, separator: '...') %>
         <%= link_to participatory_process_path(promoted_process), class: "button secondary small hollow card__button" do %>
           <%= t("participatory_processes.promoted_process.more_info", scope: "layouts.decidim") %>
         <% end %>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
@@ -15,9 +15,9 @@
     <div class="columns medium-7 mediumlarge-8">
       <div class="section">
         <div class="lead">
-          <%= sanitize translated_attribute(current_participatory_process.short_description) %>
+          <%= decidim_sanitize translated_attribute(current_participatory_process.short_description) %>
         </div>
-        <%= sanitize translated_attribute(current_participatory_process.description) %>
+        <%= decidim_sanitize translated_attribute(current_participatory_process.description) %>
       </div>
       <%= attachments_for current_participatory_process %>
     </div>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -52,21 +52,21 @@
         <div class="section">
           <div class="callout success">
             <h5><%= t(".proposal_accepted_reason") %></h5>
-            <p><%= sanitize translated_attribute @proposal.answer %></p>
+            <p><%= decidim_sanitize translated_attribute @proposal.answer %></p>
           </div>
         </div>
       <% elsif @proposal.rejected? %>
         <div class="section">
           <div class="callout warning">
             <h5><%= t(".proposal_rejected_reason") %></h5>
-            <p><%= sanitize translated_attribute @proposal.answer %></p>
+            <p><%= decidim_sanitize translated_attribute @proposal.answer %></p>
           </div>
         </div>
       <% else %>
         <div class="section">
           <div class="callout secondary">
             <h5><%= t(".proposal_in_evaluation_reason") %></h5>
-            <p><%= sanitize translated_attribute @proposal.answer %></p>
+            <p><%= decidim_sanitize translated_attribute @proposal.answer %></p>
           </div>
         </div>
       <% end %>

--- a/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
@@ -9,7 +9,7 @@
   <h2 class="section-heading"><%= translated_attribute survey.title %></h2>
   <div class="row">
     <div class="columns large-6 medium-centered lead">
-      <%= sanitize translated_attribute survey.description %>
+      <%= decidim_sanitize translated_attribute survey.description %>
     </div>
   </div>
 </div>
@@ -71,7 +71,7 @@
                   <div class="row column">
                     <%= form.check_box :tos_agreement, label: t(".tos_agreement"), id: "survey_tos_agreement" %>
                     <div class="tos-agreement-help-text help-text">
-                      <%= sanitize translated_attribute survey.tos %>
+                      <%= decidim_sanitize translated_attribute survey.tos %>
                     </div>
                   </div>
 


### PR DESCRIPTION
#### :tophat: What? Why?
The Rails `sanitize` method is ignoring the `video` tag, so the video embeds are not being shown to end users. This PR fixes this by adding a custom Scrubber that takes into account this tag and related attributes.

#### :pushpin: Related Issues
- Fixes #2130 and https://github.com/AjuntamentdeBarcelona/decidim-barcelona/issues/171

#### :clipboard: Subtasks
- [x] Add scrubber
- [x] Add tests
- [x] Use the scrubber in all sanitize calls (maybe create a custom helper to hide this complexity)

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/SyhHXHG.png)

