### PR TITLE
Specify minimum git version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Decidim is already translated on multiple languages (English, Spanish, Catalan, 
 
 In order to develop on decidim, you'll need:
 
+* **Git** 2.15+
 * **PostgreSQL** 9.4+
 * **Ruby** 2.4.1
 * **NodeJS** 8.x.x


### PR DESCRIPTION
#### :tophat: What? Why?

@jsperezg & I were going nuts trying to figure out why he was not able to undo some unwanted changes in #2193. It turned out to be a problem with an older git version and it got fixed after upgrading to 2.15.

So I'm adding this sentence to the README in case it might help someone in the future... 

#### :pushpin: Related Issues
- Related to #2193.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![sergio-massa-botella-gif](https://user-images.githubusercontent.com/2887858/32745519-bf88d9d6-c891-11e7-9054-06932bbe8ff7.gif)

