### PR TITLE
Use latest ruby image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
           command: rake test_app
       - run:
           name: Precompile test app assets
-          command: cd spec/decidim_dummy_app && rails assets:precompile
+          command: cd /decidim/spec/decidim_dummy_app && rails assets:precompile
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,8 +79,8 @@ jobs:
       - persist_to_workspace:
           root: /
           paths:
-            - "/usr/local/bundle/gems/*"
-            - "/decidim/*"
+            - "usr/local/bundle/gems/*"
+            - "decidim/*"
   main:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,10 @@ jobs:
           command: rake test_app
       - run:
           name: Precompile test app assets
-          command: cd /decidim/spec/decidim_dummy_app && rails assets:precompile
+          command: |
+            cd /decidim/spec/decidim_dummy_app
+            bundle install
+            rails assets:precompile
       - save_cache:
           key: decidim-{{ .Branch }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 defaults: &defaults
   docker:
-    - image: codegram/decidim:test-latest
+    - image: codegram/decidim:test-$CIRCLE_SHA1
       environment:
         SIMPLECOV: true
         DATABASE_USERNAME: postgres
@@ -43,6 +43,7 @@ jobs:
               docker push codegram/decidim:test-latest
             else
               docker build -f Dockerfile.ci --build-arg BASE_IMAGE_TAG=prod-$CIRCLE_SHA1 --tag codegram/decidim:test-$CIRCLE_SHA1 --cache-from codegram/decidim:test-latest .
+              docker push codegram/decidim:test-$CIRCLE_SHA1
             fi
   build_test_app:
     <<: *defaults
@@ -380,8 +381,12 @@ workflows:
   build_and_test:
     jobs:
       - build_docker_images
-      - build_test_app
-      - main
+      - build_test_app:
+          requires:
+            - build_docker_images
+      - main:
+          requires:
+            - build_docker_images
       - core:
           requires:
             - build_test_app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,10 +59,10 @@ jobs:
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run:
           name: Generate test app
-          command: bundle exec rake test_app
+          command: rake test_app
       - run:
           name: Precompile test app assets
-          command: cd spec/decidim_dummy_app && bundle exec rails assets:precompile
+          command: cd spec/decidim_dummy_app && rails assets:precompile
       - persist_to_workspace:
           root: .
           paths:
@@ -80,7 +80,7 @@ jobs:
           command: npm run lint
       - run:
           name: Run main folder RSpec
-          command: bundle exec rspec
+          command: rspec
   core:
     <<: *defaults
     steps:
@@ -92,13 +92,13 @@ jobs:
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run:
           name: Create test DB
-          command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+          command: cd spec/decidim_dummy_app && RAILS_ENV=test rake db:create db:schema:load
       - run:
           name: Run core JS tests
           command: npm test -- decidim-core
       - run:
           name: Run core RSpec
-          command: cd decidim-core && bundle exec rake
+          command: cd decidim-core && rake
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   assemblies:
@@ -112,13 +112,13 @@ jobs:
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run:
           name: Create test DB
-          command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+          command: cd spec/decidim_dummy_app && RAILS_ENV=test rake db:create db:schema:load
       - run:
           name: Run assemblies JS tests
           command: npm test -- decidim-assemblies
       - run:
           name: Run assemblies RSpec
-          command: cd decidim-assemblies && bundle exec rake
+          command: cd decidim-assemblies && rake
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   api:
@@ -132,13 +132,13 @@ jobs:
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run:
           name: Create test DB
-          command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+          command: cd spec/decidim_dummy_app && RAILS_ENV=test rake db:create db:schema:load
       - run:
           name: Run api JS tests
           command: npm test -- decidim-api
       - run:
           name: Run api RSpec
-          command: cd decidim-api && bundle exec rake
+          command: cd decidim-api && rake
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   processes:
@@ -152,13 +152,13 @@ jobs:
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run:
           name: Create test DB
-          command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+          command: cd spec/decidim_dummy_app && RAILS_ENV=test rake db:create db:schema:load
       - run:
           name: Run participatory_processes JS tests
           command: npm test -- decidim-participatory_processes
       - run:
           name: Run participatory_processes RSpec
-          command: cd decidim-participatory_processes && bundle exec rake
+          command: cd decidim-participatory_processes && rake
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   admin:
@@ -172,13 +172,13 @@ jobs:
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run:
           name: Create test DB
-          command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+          command: cd spec/decidim_dummy_app && RAILS_ENV=test rake db:create db:schema:load
       - run:
           name: Run admin JS tests
           command: npm test -- decidim-admin
       - run:
           name: Run admin RSpec
-          command: cd decidim-admin && bundle exec rake
+          command: cd decidim-admin && rake
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   system:
@@ -192,13 +192,13 @@ jobs:
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run:
           name: Create test DB
-          command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+          command: cd spec/decidim_dummy_app && RAILS_ENV=test rake db:create db:schema:load
       - run:
           name: Run system JS tests
           command: npm test -- decidim-system
       - run:
           name: Run system RSpec
-          command: cd decidim-system && bundle exec rake
+          command: cd decidim-system && rake
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   proposals:
@@ -212,13 +212,13 @@ jobs:
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run:
           name: Create test DB
-          command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+          command: cd spec/decidim_dummy_app && RAILS_ENV=test rake db:create db:schema:load
       - run:
           name: Run proposals JS tests
           command: npm test -- decidim-proposals
       - run:
           name: Run proposals RSpec
-          command: cd decidim-proposals && bundle exec rake
+          command: cd decidim-proposals && rake
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   comments:
@@ -232,13 +232,13 @@ jobs:
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run:
           name: Create test DB
-          command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+          command: cd spec/decidim_dummy_app && RAILS_ENV=test rake db:create db:schema:load
       - run:
           name: Run comments JS tests
           command: npm test -- decidim-comments
       - run:
           name: Run comments RSpec
-          command: cd decidim-comments && bundle exec rake
+          command: cd decidim-comments && rake
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   meetings:
@@ -252,13 +252,13 @@ jobs:
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run:
           name: Create test DB
-          command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+          command: cd spec/decidim_dummy_app && RAILS_ENV=test rake db:create db:schema:load
       - run:
           name: Run meetings JS tests
           command: npm test -- decidim-meetings
       - run:
           name: Run meetings RSpec
-          command: cd decidim-meetings && bundle exec rake
+          command: cd decidim-meetings && rake
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   pages:
@@ -272,13 +272,13 @@ jobs:
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run:
           name: Create test DB
-          command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+          command: cd spec/decidim_dummy_app && RAILS_ENV=test rake db:create db:schema:load
       - run:
           name: Run pages JS tests
           command: npm test -- decidim-pages
       - run:
           name: Run pages RSpec
-          command: cd decidim-pages && bundle exec rake
+          command: cd decidim-pages && rake
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   accountability:
@@ -292,13 +292,13 @@ jobs:
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run:
           name: Create test DB
-          command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+          command: cd spec/decidim_dummy_app && RAILS_ENV=test rake db:create db:schema:load
       - run:
           name: Run accountability JS tests
           command: npm test -- decidim-accountability
       - run:
           name: Run accountability RSpec
-          command: cd decidim-accountability && bundle exec rake
+          command: cd decidim-accountability && rake
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   budgets:
@@ -312,13 +312,13 @@ jobs:
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run:
           name: Create test DB
-          command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+          command: cd spec/decidim_dummy_app && RAILS_ENV=test rake db:create db:schema:load
       - run:
           name: Run budgets JS tests
           command: npm test -- decidim-budgets
       - run:
           name: Run budgets RSpec
-          command: cd decidim-budgets && bundle exec rake
+          command: cd decidim-budgets && rake
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
   surveys:
@@ -332,13 +332,13 @@ jobs:
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run:
           name: Create test DB
-          command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rake db:create db:schema:load
+          command: cd spec/decidim_dummy_app && RAILS_ENV=test rake db:create db:schema:load
       - run:
           name: Run surveys JS tests
           command: npm test -- decidim-surveys
       - run:
           name: Run surveys RSpec
-          command: cd decidim-surveys && bundle exec rake
+          command: cd decidim-surveys && rake
       - store_artifacts:
           path: /decidim/spec/decidim_dummy_app/tmp/capybara
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,8 +79,8 @@ jobs:
       - persist_to_workspace:
           root: /
           paths:
-            - "/usr/local/bundle/gems"
-            - "/decidim"
+            - "/usr/local/bundle/gems/*"
+            - "/decidim/*"
   main:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
           name: "Remove image's decidim folder"
           command: rm -fR /decidim
       - attach_workspace:
-          at: /decidim
+          at: /
       - checkout
       - restore_cache:
          keys:
@@ -75,12 +75,12 @@ jobs:
       - save_cache:
           key: decidim-{{ .Branch }}
           paths:
-            - /decidim/node_modules
             - /usr/local/bundle/gems
       - persist_to_workspace:
-          root: .
+          root: /
           paths:
-            - "*"
+            - "/usr/local/bundle/gems"
+            - "/decidim"
   main:
     <<: *defaults
     steps:
@@ -88,7 +88,7 @@ jobs:
           name: "Remove image's decidim folder"
           command: rm -fR /decidim
       - attach_workspace:
-          at: /decidim
+          at: /
       - checkout
       - restore_cache:
          keys:
@@ -118,7 +118,7 @@ jobs:
     <<: *defaults
     steps:
       - attach_workspace:
-          at: /decidim
+          at: /
       - run: export CODECOV_FLAG=core
       - run:
           name: Wait for db
@@ -138,7 +138,7 @@ jobs:
     <<: *defaults
     steps:
       - attach_workspace:
-          at: /decidim
+          at: /
       - run: export CODECOV_FLAG=assemblies
       - run:
           name: Wait for db
@@ -158,7 +158,7 @@ jobs:
     <<: *defaults
     steps:
       - attach_workspace:
-          at: /decidim
+          at: /
       - run: export CODECOV_FLAG=api
       - run:
           name: Wait for db
@@ -178,7 +178,7 @@ jobs:
     <<: *defaults
     steps:
       - attach_workspace:
-          at: /decidim
+          at: /
       - run: export CODECOV_FLAG=processes
       - run:
           name: Wait for db
@@ -198,7 +198,7 @@ jobs:
     <<: *defaults
     steps:
       - attach_workspace:
-          at: /decidim
+          at: /
       - run: export CODECOV_FLAG=admin
       - run:
           name: Wait for db
@@ -218,7 +218,7 @@ jobs:
     <<: *defaults
     steps:
       - attach_workspace:
-          at: /decidim
+          at: /
       - run: export CODECOV_FLAG=system
       - run:
           name: Wait for db
@@ -238,7 +238,7 @@ jobs:
     <<: *defaults
     steps:
       - attach_workspace:
-          at: /decidim
+          at: /
       - run: export CODECOV_FLAG=proposals
       - run:
           name: Wait for db
@@ -258,7 +258,7 @@ jobs:
     <<: *defaults
     steps:
       - attach_workspace:
-          at: /decidim
+          at: /
       - run: export CODECOV_FLAG=comments
       - run:
           name: Wait for db
@@ -278,7 +278,7 @@ jobs:
     <<: *defaults
     steps:
       - attach_workspace:
-          at: /decidim
+          at: /
       - run: export CODECOV_FLAG=meetings
       - run:
           name: Wait for db
@@ -298,7 +298,7 @@ jobs:
     <<: *defaults
     steps:
       - attach_workspace:
-          at: /decidim
+          at: /
       - run: export CODECOV_FLAG=pages
       - run:
           name: Wait for db
@@ -318,7 +318,7 @@ jobs:
     <<: *defaults
     steps:
       - attach_workspace:
-          at: /decidim
+          at: /
       - run: export CODECOV_FLAG=accountability
       - run:
           name: Wait for db
@@ -338,7 +338,7 @@ jobs:
     <<: *defaults
     steps:
       - attach_workspace:
-          at: /decidim
+          at: /
       - run: export CODECOV_FLAG=budgets
       - run:
           name: Wait for db
@@ -358,7 +358,7 @@ jobs:
     <<: *defaults
     steps:
       - attach_workspace:
-          at: /decidim
+          at: /
       - run: export CODECOV_FLAG=surveys
       - run:
           name: Wait for db

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 pkg/
 .git
 .github
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 spec/decidim_dummy_app/
+spec/generator_test_app/
 .byebug_history
 pkg/
 */Gemfile.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.4.2-alpine
 MAINTAINER david.morcillo@codegram.com
 WORKDIR /decidim
 
-RUN apk add --update nodejs 
+RUN apk add --update nodejs
 RUN apk add --update git
 
 RUN apk add --update ruby-dev build-base \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM deividrodriguez/ruby-2.4.2-rubygems-2.6.13:latest
+FROM ruby:2.4.2-alpine
 MAINTAINER david.morcillo@codegram.com
 
 ENV APP_HOME /decidim
 
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash && \
-    apt-get install -y nodejs
+RUN apk add --update nodejs nodejs-npm
 
 COPY Gemfile /tmp/Gemfile
 COPY Gemfile.lock /tmp/Gemfile.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN apk add --update ruby-dev build-base \
     libxml2-dev libxslt-dev pcre-dev libffi-dev \
     postgresql-dev
 
+RUN apk add --update tzdata
+
 RUN git init .
 COPY .gitignore .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apk add --update ruby-dev build-base \
     libxml2-dev libxslt-dev pcre-dev libffi-dev \
     postgresql-dev
 
+RUN apk add --update imagemagick
 RUN apk add --update tzdata
 
 RUN git init .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,65 +1,70 @@
 FROM ruby:2.4.2-alpine
 MAINTAINER david.morcillo@codegram.com
+WORKDIR /decidim
 
-ENV APP_HOME /decidim
+RUN apk add --update nodejs 
+RUN apk add --update git
 
-RUN apk add --update nodejs nodejs-npm
+RUN apk add --update ruby-dev build-base \
+    libxml2-dev libxslt-dev pcre-dev libffi-dev \
+    postgresql-dev
 
-COPY Gemfile /tmp/Gemfile
-COPY Gemfile.lock /tmp/Gemfile.lock
+RUN git init .
+COPY .gitignore .
 
-COPY decidim.gemspec /tmp/decidim.gemspec
-COPY lib/decidim/version.rb /tmp/lib/decidim/version.rb
+COPY Gemfile .
+COPY Gemfile.lock .
 
-COPY decidim-core/decidim-core.gemspec /tmp/decidim-core/decidim-core.gemspec
-COPY decidim-core/lib/decidim/core/version.rb /tmp/decidim-core/lib/decidim/core/version.rb
+COPY decidim.gemspec decidim.gemspec
+COPY lib/decidim/version.rb lib/decidim/version.rb
 
-COPY decidim-participatory_processes/decidim-participatory_processes.gemspec /tmp/decidim-participatory_processes/decidim-participatory_processes.gemspec
-COPY decidim-participatory_processes/lib/decidim/participatory_processes/version.rb /tmp/decidim-participatory_processes/lib/decidim/participatory_processes/version.rb
+COPY decidim-core/decidim-core.gemspec decidim-core/decidim-core.gemspec
+COPY decidim-core/lib/decidim/core/version.rb decidim-core/lib/decidim/core/version.rb
 
-COPY decidim-assemblies/decidim-assemblies.gemspec /tmp/decidim-assemblies/decidim-assemblies.gemspec
-COPY decidim-assemblies/lib/decidim/assemblies/version.rb /tmp/decidim-assemblies/lib/decidim/assemblies/version.rb
+COPY decidim-participatory_processes/decidim-participatory_processes.gemspec decidim-participatory_processes/decidim-participatory_processes.gemspec
+COPY decidim-participatory_processes/lib/decidim/participatory_processes/version.rb decidim-participatory_processes/lib/decidim/participatory_processes/version.rb
 
-COPY decidim-system/decidim-system.gemspec /tmp/decidim-system/decidim-system.gemspec
-COPY decidim-system/lib/decidim/system/version.rb /tmp/decidim-system/lib/decidim/system/version.rb
+COPY decidim-assemblies/decidim-assemblies.gemspec decidim-assemblies/decidim-assemblies.gemspec
+COPY decidim-assemblies/lib/decidim/assemblies/version.rb decidim-assemblies/lib/decidim/assemblies/version.rb
 
-COPY decidim-admin/decidim-admin.gemspec /tmp/decidim-admin/decidim-admin.gemspec
-COPY decidim-admin/lib/decidim/admin/version.rb /tmp/decidim-admin/lib/decidim/admin/version.rb
+COPY decidim-system/decidim-system.gemspec decidim-system/decidim-system.gemspec
+COPY decidim-system/lib/decidim/system/version.rb decidim-system/lib/decidim/system/version.rb
 
-COPY decidim-dev/decidim-dev.gemspec /tmp/decidim-dev/decidim-dev.gemspec
-COPY decidim-dev/lib/decidim/dev/version.rb /tmp/decidim-dev/lib/decidim/dev/version.rb
+COPY decidim-admin/decidim-admin.gemspec decidim-admin/decidim-admin.gemspec
+COPY decidim-admin/lib/decidim/admin/version.rb decidim-admin/lib/decidim/admin/version.rb
 
-COPY decidim-api/decidim-api.gemspec /tmp/decidim-api/decidim-api.gemspec
-COPY decidim-api/lib/decidim/api/version.rb /tmp/decidim-api/lib/decidim/api/version.rb
+COPY decidim-dev/decidim-dev.gemspec decidim-dev/decidim-dev.gemspec
+COPY decidim-dev/lib/decidim/dev/version.rb decidim-dev/lib/decidim/dev/version.rb
 
-COPY decidim-pages/decidim-pages.gemspec /tmp/decidim-pages/decidim-pages.gemspec
-COPY decidim-pages/lib/decidim/pages/version.rb /tmp/decidim-pages/lib/decidim/pages/version.rb
+COPY decidim-api/decidim-api.gemspec decidim-api/decidim-api.gemspec
+COPY decidim-api/lib/decidim/api/version.rb decidim-api/lib/decidim/api/version.rb
 
-COPY decidim-comments/decidim-comments.gemspec /tmp/decidim-comments/decidim-comments.gemspec
-COPY decidim-comments/lib/decidim/comments/version.rb /tmp/decidim-comments/lib/decidim/comments/version.rb
+COPY decidim-pages/decidim-pages.gemspec decidim-pages/decidim-pages.gemspec
+COPY decidim-pages/lib/decidim/pages/version.rb decidim-pages/lib/decidim/pages/version.rb
 
-COPY decidim-meetings/decidim-meetings.gemspec /tmp/decidim-meetings/decidim-meetings.gemspec
-COPY decidim-meetings/lib/decidim/meetings/version.rb /tmp/decidim-meetings/lib/decidim/meetings/version.rb
+COPY decidim-comments/decidim-comments.gemspec decidim-comments/decidim-comments.gemspec
+COPY decidim-comments/lib/decidim/comments/version.rb decidim-comments/lib/decidim/comments/version.rb
 
-COPY decidim-proposals/decidim-proposals.gemspec /tmp/decidim-proposals/decidim-proposals.gemspec
-COPY decidim-proposals/lib/decidim/proposals/version.rb /tmp/decidim-proposals/lib/decidim/proposals/version.rb
+COPY decidim-meetings/decidim-meetings.gemspec decidim-meetings/decidim-meetings.gemspec
+COPY decidim-meetings/lib/decidim/meetings/version.rb decidim-meetings/lib/decidim/meetings/version.rb
 
-COPY decidim-budgets/decidim-budgets.gemspec /tmp/decidim-budgets/decidim-budgets.gemspec
-COPY decidim-budgets/lib/decidim/budgets/version.rb /tmp/decidim-budgets/lib/decidim/budgets/version.rb
+COPY decidim-proposals/decidim-proposals.gemspec decidim-proposals/decidim-proposals.gemspec
+COPY decidim-proposals/lib/decidim/proposals/version.rb decidim-proposals/lib/decidim/proposals/version.rb
 
-COPY decidim-surveys/decidim-surveys.gemspec /tmp/decidim-surveys/decidim-surveys.gemspec
-COPY decidim-surveys/lib/decidim/surveys/version.rb /tmp/decidim-surveys/lib/decidim/surveys/version.rb
+COPY decidim-budgets/decidim-budgets.gemspec decidim-budgets/decidim-budgets.gemspec
+COPY decidim-budgets/lib/decidim/budgets/version.rb decidim-budgets/lib/decidim/budgets/version.rb
 
-COPY decidim-accountability/decidim-accountability.gemspec /tmp/decidim-accountability/decidim-accountability.gemspec
-COPY decidim-accountability/lib/decidim/accountability/version.rb /tmp/decidim-accountability/lib/decidim/accountability/version.rb
+COPY decidim-surveys/decidim-surveys.gemspec decidim-surveys/decidim-surveys.gemspec
+COPY decidim-surveys/lib/decidim/surveys/version.rb decidim-surveys/lib/decidim/surveys/version.rb
 
-RUN cd /tmp && bundle install
+COPY decidim-accountability/decidim-accountability.gemspec decidim-accountability/decidim-accountability.gemspec
+COPY decidim-accountability/lib/decidim/accountability/version.rb decidim-accountability/lib/decidim/accountability/version.rb
 
-WORKDIR $APP_HOME
+RUN bundle install
 
-COPY package.json $APP_HOME/package.json
-COPY package-lock.json $APP_HOME/package-lock.json
+COPY package.json .
+COPY package-lock.json .
 
 RUN npm i
 
-COPY . ./
+COPY . .

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,28 +1,11 @@
-ARG BASE_IMAGE_TAG=latest
-
-FROM codegram/decidim:$BASE_IMAGE_TAG
+FROM codegram/decidim:latest
 MAINTAINER deivid.rodriguez@riseup.net
 
-USER root
+RUN apk add --update curl bash
+RUN apk add --update chromium chromium-chromedriver
+RUN apk add --update openssl
 
-RUN apt-get update \
-  && apt-get install -y unzip
-
-RUN DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/dockerize-latest.tar.gz" \
-  && curl --silent --show-error --location --fail --retry 3 --output /tmp/dockerize-linux-amd64.tar.gz $DOCKERIZE_URL \
-  && tar -C /usr/local/bin -xzvf /tmp/dockerize-linux-amd64.tar.gz \
-  && rm /tmp/dockerize-linux-amd64.tar.gz \
-  && dockerize --version
-
-RUN CHROME_URL="https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
-  && curl --silent --show-error --location --fail --retry 3 --output /tmp/google-chrome-stable_current_amd64.deb $CHROME_URL \
-  && (dpkg -i /tmp/google-chrome-stable_current_amd64.deb || apt-get -fy install) \
-  && rm /tmp/google-chrome-stable_current_amd64.deb \
-  && google-chrome-stable --version
-
-RUN CHROMEDRIVER_RELEASE=$(curl --location --fail --retry 3 http://chromedriver.storage.googleapis.com/LATEST_RELEASE) \
-  && CHROMEDRIVER_URL="http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_RELEASE/chromedriver_linux64.zip" \
-  && curl --silent --show-error --location --fail --retry 3 --output /tmp/chromedriver_linux64.zip $CHROMEDRIVER_URL \
-  && unzip /tmp/chromedriver_linux64.zip chromedriver -d /usr/local/bin \
-  && rm /tmp/chromedriver_linux64.zip \
-  && chromedriver --version
+ENV DOCKERIZE_VERSION v0.5.0
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,6 @@
-FROM codegram/decidim:latest
+ARG BASE_IMAGE_TAG=latest
+
+FROM codegram/decidim:$BASE_IMAGE_TAG
 MAINTAINER deivid.rodriguez@riseup.net
 
 RUN apk add --update curl bash

--- a/Rakefile
+++ b/Rakefile
@@ -95,7 +95,7 @@ task :test_app do
 
   Bundler.with_clean_env do
     Decidim::Generators::DummyGenerator.start(
-      ["--dummy_app_path=#{dummy_app_path}"]
+      ["--dummy_app_path=#{dummy_app_path} --skip-bundle"]
     )
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -94,7 +94,7 @@ task :test_app do
   dummy_app_path = File.expand_path(File.join(Dir.pwd, "spec", "decidim_dummy_app"))
 
   Decidim::Generators::DummyGenerator.start(
-    ["--dummy_app_path=#{dummy_app_path} --skip-bundle"]
+    ["--dummy_app_path=#{dummy_app_path}"]
   )
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -93,11 +93,9 @@ desc "Generates a dummy app for testing"
 task :test_app do
   dummy_app_path = File.expand_path(File.join(Dir.pwd, "spec", "decidim_dummy_app"))
 
-  Bundler.with_clean_env do
-    Decidim::Generators::DummyGenerator.start(
-      ["--dummy_app_path=#{dummy_app_path} --skip-bundle"]
-    )
-  end
+  Decidim::Generators::DummyGenerator.start(
+    ["--dummy_app_path=#{dummy_app_path} --skip-bundle"]
+  )
 end
 
 desc "Generates a development app."
@@ -106,22 +104,18 @@ task :development_app do
     sh "rm -fR development_app", verbose: false
   end
 
-  Bundler.with_clean_env do
-    Decidim::Generators::AppGenerator.start(
-      ["development_app", "--path", "..", "--recreate_db", "--seed_db", "--demo"]
-    )
-  end
+  Decidim::Generators::AppGenerator.start(
+    ["development_app", "--path", "..", "--recreate_db", "--seed_db", "--demo"]
+  )
 end
 
 desc "Generates a development app based on Docker."
 task :docker_development_app do
   docker_app_path = __dir__ + "/docker_development_app"
 
-  Bundler.with_clean_env do
-    Decidim::Generators::DockerGenerator.start(
-      ["docker_development_app", "--docker_app_path", docker_app_path]
-    )
-  end
+  Decidim::Generators::DockerGenerator.start(
+    ["docker_development_app", "--docker_app_path", docker_app_path]
+  )
 end
 
 desc "Build webpack bundle files"

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe "Application generation" do
-  let(:status) { Bundler.clean_system(command) }
+  let(:status) { Bundler.clean_system(command, out: File::NULL) }
 
   let(:test_app) { "spec/generator_test_app" }
 

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe "Application generation" do
-  let(:status) { Bundler.clean_system(command, out: File::NULL) }
+  let(:status) { Bundler.clean_system(command) }
 
   let(:test_app) { "spec/generator_test_app" }
 
@@ -14,32 +14,32 @@ describe "Application generation" do
   end
 
   context "without flags" do
-    let(:command) { "bundle exec rake install_all && bin/decidim #{test_app}" }
+    let(:command) { "bundle exec decidim #{test_app}" }
 
     it_behaves_like "a sane generator"
   end
 
   context "with --edge flag" do
-    let(:command) { "bin/decidim --edge #{test_app}" }
+    let(:command) { "bundle exec decidim --edge #{test_app}" }
 
     it_behaves_like "a sane generator"
   end
 
   context "with --branch flag" do
-    let(:command) { "bin/decidim --branch master #{test_app}" }
+    let(:command) { "bundle exec decidim --branch master #{test_app}" }
 
     it_behaves_like "a sane generator"
   end
 
   context "with --path flag" do
-    let(:command) { "bin/decidim --path #{File.expand_path("..", __dir__)} #{test_app}" }
+    let(:command) { "bundle exec decidim --path #{File.expand_path("..", __dir__)} #{test_app}" }
 
     it_behaves_like "a sane generator"
   end
 
   context "development application" do
     let(:command) do
-      "bin/decidim --path #{File.expand_path("..", __dir__)} #{test_app} --recreate_db --seed_db"
+      "bundle exec decidim --path #{File.expand_path("..", __dir__)} #{test_app} --recreate_db --seed_db"
     end
 
     it_behaves_like "a sane generator"


### PR DESCRIPTION
#### :tophat: What? Why?
This uses the latest ruby image which seems to fix bundler issues. It also switches to the `alpine` build which is way more lightweight and flexible.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![image](https://user-images.githubusercontent.com/111746/32774642-3f91b832-c92d-11e7-84ca-d196a06328a7.png)