### PR TITLE
Fix meetings registrations admin form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - **decidim-core**: Hide link to register when user is already logged in [\#2088](https://github.com/decidim/decidim/pull/2088)
 - **decidim-proposals**: Change "Already voted" to "Unvote" on button hover [\#2096](https://github.com/decidim/decidim/pull/2096)
 
+**Fixed**:
+
+- **decidim-meetings**: Admins could not submit form after getting a validation error in the meeting registrations form [\2202](https://github.com/decidim/decidim/pull/2202)
+
 ## [v0.7.2](https://github.com/decidim/decidim/tree/v0.7.2) (2017-11-06)
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.7.1...v0.7.2)
 

--- a/decidim-meetings/app/forms/decidim/meetings/admin/meeting_registrations_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/meeting_registrations_form.rb
@@ -17,6 +17,15 @@ module Decidim
         validates :available_slots, numericality: { greater_than_or_equal_to: 0 }, if: ->(form) { form.registrations_enabled? }
         validate :available_slots_greater_than_or_equal_to_registrations_count, if: ->(form) { form.registrations_enabled? && form.available_slots.positive? }
 
+        # We need this method to ensure the form object will always have an ID,
+        # and thus its `to_param` method will always return a significant value.
+        # If we remove this method, get an error onn the `update` action and try
+        # to resubmit the form, the form will not hold an ID, so the `to_param`
+        # method will return an empty string and Rails will treat this as a
+        # `create` action, thus raising an error since this action is not defined
+        # for the controller we're using.
+        #
+        # TL;DR: if you remove this method, we'll get errors, so don't.
         def id
           return super if super.present?
           meeting.id

--- a/decidim-meetings/app/forms/decidim/meetings/admin/meeting_registrations_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/meeting_registrations_form.rb
@@ -17,6 +17,11 @@ module Decidim
         validates :available_slots, numericality: { greater_than_or_equal_to: 0 }, if: ->(form) { form.registrations_enabled? }
         validate :available_slots_greater_than_or_equal_to_registrations_count, if: ->(form) { form.registrations_enabled? && form.available_slots.positive? }
 
+        def id
+          return super if super.present?
+          meeting.id
+        end
+
         private
 
         def available_slots_greater_than_or_equal_to_registrations_count


### PR DESCRIPTION
#### :tophat: What? Why?
The admin meeting registrations form was not working properly when a validation error was raised and the user tried to resubmit the form. This PR ensures it works as expected.

When submitting a form without specifying the `method` (`PATCH` for update or `POST` for create), Rails deduces the method it needs to use by checking if the object that is used in the form responds to `to_param`. If it does and returns a significant value, then it will use `PATCH` to update the resource, if it doesn't then it means we're creating the resource and thus it will use `POST`.

Our form was correctly returning a significant value the first time we render the form, but if we get an error message then it wouldn't return a significant value. This is due to how we generate the form object and internals of `rectify`, the gem we're using to handle the form objects.

The fix ensures the `to_param` method of the form object will always have a significant value, as it calls the `id` method internally:

https://github.com/andypike/rectify/blob/dd77495f6d763bd28515b44e8b00af09562e0095/lib/rectify/form.rb#L86-L88

#### :pushpin: Related Issues
- Fixes #2178
