### PR TITLE
Only require default locale translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 **Changed**:
 
+- **decidim-core**: Only require default locale translations for i18n fields [\#2204](https://github.com/decidim/decidim/pull/2204)
 - **decidim-admin**: Replace url to visit_url moderation admin [\#2129](https://github.com/decidim/decidim/pull/2129)
 - **decidim-core**: Hide link to register when user is already logged in [\#2088](https://github.com/decidim/decidim/pull/2088)
 - **decidim-proposals**: Change "Already voted" to "Unvote" on button hover [\#2096](https://github.com/decidim/decidim/pull/2096)

--- a/decidim-admin/lib/decidim/admin/test/forms/category_form_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/forms/category_form_examples.rb
@@ -48,11 +48,11 @@ module Decidim
         it { is_expected.to be_valid }
       end
 
-      context "when some language in name is missing" do
+      context "when default language in name is missing" do
         let(:name) do
           {
-            en: "Name",
-            ca: "Nombre"
+            ca: "Nom",
+            es: "Nombre"
           }
         end
 

--- a/decidim-admin/spec/forms/static_page_form_spec.rb
+++ b/decidim-admin/spec/forms/static_page_form_spec.rb
@@ -42,10 +42,10 @@ module Decidim
         it { is_expected.to be_valid }
       end
 
-      context "when some language in title is missing" do
+      context "when default language in title is missing" do
         let(:title) do
           {
-            en: "Title",
+            es: "Título",
             ca: "Títol"
           }
         end
@@ -53,7 +53,7 @@ module Decidim
         it { is_expected.to be_invalid }
       end
 
-      context "when some language in content is missing" do
+      context "when default language in content is missing" do
         let(:content) do
           {
             ca: "Descripció"

--- a/decidim-assemblies/spec/forms/assembly_form_spec.rb
+++ b/decidim-assemblies/spec/forms/assembly_form_spec.rb
@@ -94,10 +94,9 @@ module Decidim
           it { is_expected.not_to be_valid }
         end
 
-        context "when some language in title is missing" do
+        context "when default language in title is missing" do
           let(:title) do
             {
-              en: "Title",
               ca: "Títol"
             }
           end
@@ -105,10 +104,9 @@ module Decidim
           it { is_expected.to be_invalid }
         end
 
-        context "when some language in subtitle is missing" do
+        context "when default language in subtitle is missing" do
           let(:subtitle) do
             {
-              en: "Subtitle",
               ca: "Subtítol"
             }
           end
@@ -116,7 +114,7 @@ module Decidim
           it { is_expected.to be_invalid }
         end
 
-        context "when some language in description is missing" do
+        context "when default language in description is missing" do
           let(:description) do
             {
               ca: "Descripció"
@@ -126,10 +124,10 @@ module Decidim
           it { is_expected.to be_invalid }
         end
 
-        context "when some language in short_description is missing" do
+        context "when default language in short_description is missing" do
           let(:short_description) do
             {
-              en: "Short description"
+              ca: "Descripció curta"
             }
           end
 

--- a/decidim-core/app/forms/translatable_presence_validator.rb
+++ b/decidim-core/app/forms/translatable_presence_validator.rb
@@ -5,24 +5,21 @@
 #
 #   validates :my_i18n_field, translatable_presence: true
 #
-# This will automatically check for presence for each of the
-# `available_locales` of the form object (or the `available_locales` of the
-# form's organization) for the given field.
+# This will automatically check for presence for the default locale of the form
+# object (or the `default_locale` of the form's organization) for the given field.
 class TranslatablePresenceValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, _value)
-    available_locales_for(record).each do |locale|
-      translated_attr = "#{attribute}_#{locale}"
-      record.errors.add(translated_attr, :blank) if record.send(translated_attr).blank?
-    end
+    translated_attr = "#{attribute}_#{default_locale_for(record)}"
+    record.errors.add(translated_attr, :blank) if record.send(translated_attr).blank?
   end
 
   private
 
-  def available_locales_for(record)
-    return record.available_locales if record.respond_to?(:available_locales)
+  def default_locale_for(record)
+    return record.default_locale if record.respond_to?(:default_locale)
 
     if record.current_organization
-      record.current_organization.available_locales
+      record.current_organization.default_locale
     else
       record.errors.add(:current_organization, :blank)
       []

--- a/decidim-core/app/helpers/decidim/translations_helper.rb
+++ b/decidim-core/app/helpers/decidim/translations_helper.rb
@@ -4,14 +4,16 @@ module Decidim
   # Helper that provides convenient methods to deal with translated attributes.
   module TranslationsHelper
     # Public: Returns the translation of an attribute using the current locale,
-    # if available.
+    # if available. Checks for the organization default locale as fallback.
     #
     # attribute - A Hash where keys (strings) are locales, and their values are
     #             the translation for each locale.
     #
     # Returns a String with the translation.
     def translated_attribute(attribute)
-      attribute.try(:[], I18n.locale.to_s) || ""
+      attribute.try(:[], I18n.locale.to_s).presence ||
+        attribute.try(:[], current_organization.default_locale).presence ||
+        ""
     end
 
     # Public: Creates a translation for each available language in the list

--- a/decidim-core/spec/forms/translatable_presence_validator_spec.rb
+++ b/decidim-core/spec/forms/translatable_presence_validator_spec.rb
@@ -12,8 +12,15 @@ module Decidim
         translatable_attribute :description, String
       end.from_params({ participatory_process: { description: description } }, current_organization: organization)
     end
-    let(:organization) { build(:organization, available_locales: available_locales) }
+    let(:organization) do
+      build(
+        :organization,
+        available_locales: available_locales,
+        default_locale: default_locale
+      )
+    end
     let(:available_locales) { %w(en ca) }
+    let(:default_locale) { :en }
     let(:description) do
       {
         ca: "Descripció",
@@ -35,17 +42,30 @@ module Decidim
       end
     end
 
-    context "when some translations are missing" do
+    context "when only default translation is present" do
       let(:description) do
         {
           en: "Description"
         }
       end
 
+      it "validates the record" do
+        subject
+        expect(record).to be_valid
+      end
+    end
+
+    context "when default translation is missing" do
+      let(:description) do
+        {
+          ca: "Descripció"
+        }
+      end
+
       it "does not validate the record" do
         subject
         expect(record.errors).not_to be_empty
-        expect(record.errors[:description_ca]).to eq ["can't be blank"]
+        expect(record.errors[:description_en]).to eq ["can't be blank"]
       end
     end
   end

--- a/decidim-core/spec/helpers/decidim/translations_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/translations_helper_spec.rb
@@ -5,8 +5,11 @@ require "spec_helper"
 module Decidim
   describe TranslationsHelper do
     describe "#translated_attribute" do
+      let(:organization) { double(default_locale: "en") }
+
       before do
         allow(I18n.config).to receive(:enforce_available_locales).and_return(false)
+        allow(helper).to receive(:current_organization).and_return(organization)
       end
 
       it "translates the attribute against the current locale" do
@@ -17,12 +20,24 @@ module Decidim
         end
       end
 
-      context "when therte is no translation for the given locale" do
-        it "returns an empty string" do
-          attribute = { "ca" => "Hola" }
+      context "when there is no translation for the given locale" do
+        context "when the default_locale is present" do
+          it "uses the default locale" do
+            attribute = { "ca" => "Hola", "en" => "Hello" }
 
-          I18n.with_locale(:'zh-CN') do
-            expect(helper.translated_attribute(attribute)).to eq("")
+            I18n.with_locale(:'zh-CN') do
+              expect(helper.translated_attribute(attribute)).to eq("Hello")
+            end
+          end
+        end
+
+        context "when the default locale is not present" do
+          it "returns an empty string" do
+            attribute = { "ca" => "Hola" }
+
+            I18n.with_locale(:'zh-CN') do
+              expect(helper.translated_attribute(attribute)).to eq("")
+            end
           end
         end
       end

--- a/decidim-participatory_processes/spec/forms/participatory_process_form_spec.rb
+++ b/decidim-participatory_processes/spec/forms/participatory_process_form_spec.rb
@@ -91,10 +91,9 @@ module Decidim
           it { is_expected.not_to be_valid }
         end
 
-        context "when some language in title is missing" do
+        context "when default language in title is missing" do
           let(:title) do
             {
-              en: "Title",
               ca: "Títol"
             }
           end
@@ -102,10 +101,9 @@ module Decidim
           it { is_expected.to be_invalid }
         end
 
-        context "when some language in subtitle is missing" do
+        context "when default language in subtitle is missing" do
           let(:subtitle) do
             {
-              en: "Subtitle",
               ca: "Subtítol"
             }
           end
@@ -113,7 +111,7 @@ module Decidim
           it { is_expected.to be_invalid }
         end
 
-        context "when some language in description is missing" do
+        context "when default language in description is missing" do
           let(:description) do
             {
               ca: "Descripció"
@@ -123,10 +121,10 @@ module Decidim
           it { is_expected.to be_invalid }
         end
 
-        context "when some language in short_description is missing" do
+        context "when default language in short_description is missing" do
           let(:short_description) do
             {
-              en: "Short description"
+              ca: "Descripció curta"
             }
           end
 

--- a/decidim-participatory_processes/spec/forms/participatory_process_group_form_spec.rb
+++ b/decidim-participatory_processes/spec/forms/participatory_process_group_form_spec.rb
@@ -58,10 +58,9 @@ module Decidim
           it { is_expected.not_to be_valid }
         end
 
-        context "when some language in title is missing" do
+        context "when default language in title is missing" do
           let(:name) do
             {
-              en: "Title",
               ca: "Títol"
             }
           end
@@ -69,7 +68,7 @@ module Decidim
           it { is_expected.to be_invalid }
         end
 
-        context "when some language in description is missing" do
+        context "when default language in description is missing" do
           let(:description) do
             {
               ca: "Descripció"

--- a/decidim-participatory_processes/spec/forms/participatory_process_step_form_spec.rb
+++ b/decidim-participatory_processes/spec/forms/participatory_process_step_form_spec.rb
@@ -63,10 +63,9 @@ module Decidim
           it { is_expected.to be_valid }
         end
 
-        context "when some language in title is missing" do
+        context "when default language in title is missing" do
           let(:title) do
             {
-              en: "Title",
               ca: "Títol"
             }
           end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR drops the need to have all languages present for a translatable field to be valid. From now on, only the default locale translation will be required, and views will fallback to this translation if the current locale does not exist.

This opens some possibilities:

1. Testing is easier
1. Admins can publish things even if the translations are not complete
1. We can add new languages to existing organizations (note that this is currently not possible since all records would be invalid in the DB).

This adds some problems too:

1. Changing the default locale to one that is not complete might cause problems and will make records be invalid in the DB, as the translation for the default locale might not be present.

Future iterations:

1. Let admins specify the language fallbacks with a sortable UI, so that they could set the default language as the top one and then decide where to look for fallbacks. Would solve the problem this PR introduces, but we'd need to let them set the fallbacks for each `available_language`.

#### :pushpin: Related Issues
- Fixes #1127

#### :clipboard: Subtasks
- [x] Only require the default locale in validations
- [x] Fallback to the default locale if the current one does not have the translation
- [x] Fix tests

### :camera: Screenshots (optional)
![](URL)
