### PR TITLE
Don't always login to docker hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,10 @@ jobs:
           version: 17.10.0-ce
       - run:
           name: Login to dockerhub
-          command: docker login -u $DOCKER_USER -p $DOCKER_PASS
+          command: |
+            if [ $CIRCLE_BRANCH = 'master' ]; then
+              docker login -u $DOCKER_USER -p $DOCKER_PASS
+            fi
       - run:
           name: Build, tag and push docker production image
           command: |


### PR DESCRIPTION
#### :tophat: What? Why?
This updates our `circle.yml` file so it only logins to docker hub on master (the only occasion where we actually have the login credentials). It fixes external PRs.

#### :pushpin: Related Issues
- Related to #2208 
- Related to #2194 
- Related to #2193

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*none*

#### :ghost: GIF
![](https://media.giphy.com/media/3ohzdIvnUKKjiAZTSU/giphy.gif)
