### PR TITLE
Fix spec flakyness

### DIFF
--- a/decidim-accountability/spec/features/comments_spec.rb
+++ b/decidim-accountability/spec/features/comments_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Accountability result comments", type: :feature, perform_enqueued: true do
+describe "Accountability result comments", type: :feature do
   let!(:feature) { create(:feature, manifest_name: :accountability, organization: organization) }
   let!(:commentable) { create(:result, feature: feature) }
 

--- a/decidim-accountability/spec/shared/export_results_examples.rb
+++ b/decidim-accountability/spec/shared/export_results_examples.rb
@@ -6,15 +6,9 @@ shared_examples "export results" do
 
   let!(:results) { create_list :result, 3, feature: current_feature }
 
-  around do |example|
-    perform_enqueued_jobs do
-      example.run
-    end
-  end
-
   it "exports a CSV" do
     find(".exports.dropdown").click
-    click_link "Results as CSV"
+    perform_enqueued_jobs { click_link "Results as CSV" }
 
     within ".callout.success" do
       expect(page).to have_content("in progress")
@@ -27,7 +21,7 @@ shared_examples "export results" do
 
   it "exports a JSON" do
     find(".exports.dropdown").click
-    click_link "Results as JSON"
+    perform_enqueued_jobs { click_link "Results as JSON" }
 
     within ".callout.success" do
       expect(page).to have_content("in progress")

--- a/decidim-accountability/spec/shared/manage_results_examples.rb
+++ b/decidim-accountability/spec/shared/manage_results_examples.rb
@@ -64,7 +64,7 @@ shared_examples "manage results" do
         ca: "Descripció més llarga"
       )
 
-      select2 translated(scope.name), id: "result_decidim_scope_id", search: true
+      select2 translated(scope.name), id: "result_decidim_scope_id", search: false
 
       select translated(category.name), from: :result_decidim_category_id
 

--- a/decidim-accountability/spec/shared/manage_results_examples.rb
+++ b/decidim-accountability/spec/shared/manage_results_examples.rb
@@ -64,8 +64,7 @@ shared_examples "manage results" do
         ca: "Descripció més llarga"
       )
 
-      select2 translated(scope.name), id: "result_decidim_scope_id"
-
+      select2 translated(scope.name), from: :result_decidim_scope_id
       select translated(category.name), from: :result_decidim_category_id
 
       find("*[type=submit]").click

--- a/decidim-accountability/spec/shared/manage_results_examples.rb
+++ b/decidim-accountability/spec/shared/manage_results_examples.rb
@@ -64,7 +64,7 @@ shared_examples "manage results" do
         ca: "Descripció més llarga"
       )
 
-      select2 translated(scope.name), id: "result_decidim_scope_id", search: false
+      select2 translated(scope.name), id: "result_decidim_scope_id"
 
       select translated(category.name), from: :result_decidim_category_id
 

--- a/decidim-accountability/spec/shared/manage_results_examples.rb
+++ b/decidim-accountability/spec/shared/manage_results_examples.rb
@@ -64,7 +64,7 @@ shared_examples "manage results" do
         ca: "Descripció més llarga"
       )
 
-      select2 translated(scope.name), xpath: '//select[@id="result_decidim_scope_id"]/..', search: true
+      select2 translated(scope.name), id: "result_decidim_scope_id", search: true
 
       select translated(category.name), from: :result_decidim_category_id
 

--- a/decidim-admin/spec/commands/impersonate_managed_user_spec.rb
+++ b/decidim-admin/spec/commands/impersonate_managed_user_spec.rb
@@ -50,8 +50,8 @@ describe Decidim::Admin::ImpersonateManagedUser do
       end.to change { Decidim::ImpersonationLog.count }.by(1)
     end
 
-    it "expires the impersonation session automatically", perform_enqueued: true do
-      subject.call
+    it "expires the impersonation session automatically" do
+      perform_enqueued_jobs { subject.call }
       travel Decidim::ImpersonationLog::SESSION_TIME_IN_MINUTES.minutes
       expect(Decidim::ImpersonationLog.last).to be_expired
     end

--- a/decidim-admin/spec/features/admin_invite_spec.rb
+++ b/decidim-admin/spec/features/admin_invite_spec.rb
@@ -26,11 +26,14 @@ describe "Admin invite", type: :feature do
   end
 
   before do
-    expect { Decidim::System::RegisterOrganization.new(form).call }.to broadcast(:ok)
+    expect do
+      perform_enqueued_jobs { Decidim::System::RegisterOrganization.new(form).call }
+    end.to broadcast(:ok)
+
     switch_to_host("decide.lvh.me")
   end
 
-  describe "Accept an invitation", perform_enqueued: true do
+  describe "Accept an invitation" do
     it "asks for a password and redirects to the organization dashboard" do
       visit last_email_link
 

--- a/decidim-admin/spec/features/admin_manages_newsletters_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_newsletters_spec.rb
@@ -12,12 +12,6 @@ describe "Admin manages newsletters", type: :feature do
     login_as user, scope: :user
   end
 
-  around do |example|
-    perform_enqueued_jobs do
-      example.run
-    end
-  end
-
   describe "creates and previews a newsletter" do
     it "allows a newsletter to be created" do
       visit decidim_admin.newsletters_path
@@ -119,7 +113,9 @@ describe "Admin manages newsletters", type: :feature do
       visit decidim_admin.newsletter_path(newsletter)
 
       within ".button--double" do
-        accept_confirm { find("*", text: "Deliver").click }
+        perform_enqueued_jobs do
+          accept_confirm { find("*", text: "Deliver").click }
+        end
       end
 
       expect(page).to have_content("NEWSLETTERS")

--- a/decidim-admin/spec/shared/manage_managed_users_examples.rb
+++ b/decidim-admin/spec/shared/manage_managed_users_examples.rb
@@ -110,11 +110,9 @@ shared_examples "manage managed users examples" do
     end
 
     context "when the admin is impersonating that user" do
-      before do
-        impersonate_the_managed_user
-      end
-
       it "closes the current session and check the logs" do
+        impersonate_the_managed_user
+
         visit decidim.root_path
 
         click_button "Close session"
@@ -124,7 +122,9 @@ shared_examples "manage managed users examples" do
         check_impersonation_logs
       end
 
-      it "spends all the session time and is redirected automatically", perform_enqueued: true do
+      it "spends all the session time and is redirected automatically" do
+        perform_enqueued_jobs { impersonate_the_managed_user }
+
         travel Decidim::ImpersonationLog::SESSION_TIME_IN_MINUTES.minutes
 
         expect(page).to have_content("expired")
@@ -133,7 +133,7 @@ shared_examples "manage managed users examples" do
       end
     end
 
-    it "can promote the user inviting them to the application", perform_enqueued: true do
+    it "can promote the user inviting them to the application" do
       navigate_to_managed_users_page
 
       within find("tr", text: managed_user.name) do
@@ -144,7 +144,7 @@ shared_examples "manage managed users examples" do
         fill_in :managed_user_promotion_email, with: "foo@example.org"
       end
 
-      click_button "Promote"
+      perform_enqueued_jobs { click_button "Promote" }
 
       expect(page).to have_content("successfully")
       expect(page).to have_content(managed_user.name)

--- a/decidim-budgets/spec/features/comments_spec.rb
+++ b/decidim-budgets/spec/features/comments_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Comments", type: :feature, perform_enqueued: true do
+describe "Comments", type: :feature do
   let!(:feature) { create(:budget_feature, organization: organization) }
   let!(:commentable) { create(:project, feature: feature) }
 

--- a/decidim-budgets/spec/shared/manage_projects_examples.rb
+++ b/decidim-budgets/spec/shared/manage_projects_examples.rb
@@ -85,7 +85,7 @@ shared_examples "manage projects" do
       )
       fill_in :project_budget, with: 22_000_000
 
-      select2 translated(scope.name), id: "project_decidim_scope_id", search: false
+      select2 translated(scope.name), id: "project_decidim_scope_id"
       select translated(category.name), from: :project_decidim_category_id
 
       find("*[type=submit]").click

--- a/decidim-budgets/spec/shared/manage_projects_examples.rb
+++ b/decidim-budgets/spec/shared/manage_projects_examples.rb
@@ -85,7 +85,7 @@ shared_examples "manage projects" do
       )
       fill_in :project_budget, with: 22_000_000
 
-      select2 translated(scope.name), xpath: '//select[@id="project_decidim_scope_id"]/..', search: true
+      select2 translated(scope.name), id: "project_decidim_scope_id", search: true
       select translated(category.name), from: :project_decidim_category_id
 
       find("*[type=submit]").click

--- a/decidim-budgets/spec/shared/manage_projects_examples.rb
+++ b/decidim-budgets/spec/shared/manage_projects_examples.rb
@@ -85,7 +85,7 @@ shared_examples "manage projects" do
       )
       fill_in :project_budget, with: 22_000_000
 
-      select2 translated(scope.name), id: "project_decidim_scope_id", search: true
+      select2 translated(scope.name), id: "project_decidim_scope_id", search: false
       select translated(category.name), from: :project_decidim_category_id
 
       find("*[type=submit]").click

--- a/decidim-budgets/spec/shared/manage_projects_examples.rb
+++ b/decidim-budgets/spec/shared/manage_projects_examples.rb
@@ -85,7 +85,7 @@ shared_examples "manage projects" do
       )
       fill_in :project_budget, with: 22_000_000
 
-      select2 translated(scope.name), id: "project_decidim_scope_id"
+      select2 translated(scope.name), from: :project_decidim_scope_id
       select translated(category.name), from: :project_decidim_category_id
 
       find("*[type=submit]").click

--- a/decidim-comments/spec/features/comments_spec.rb
+++ b/decidim-comments/spec/features/comments_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Comments", type: :feature, perform_enqueued: true do
+describe "Comments", type: :feature do
   let!(:feature) { create(:feature, manifest_name: :dummy, organization: organization) }
   let!(:author) { create(:user, :confirmed, organization: organization) }
   let!(:commentable) { create(:dummy_resource, feature: feature, author: author) }

--- a/decidim-core/spec/commands/decidim/update_account_spec.rb
+++ b/decidim-core/spec/commands/decidim/update_account_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 module Decidim
-  describe UpdateAccount, perform_enqueued: true do
+  describe UpdateAccount do
     let(:command) { described_class.new(user, form) }
     let(:user) { create(:user, :confirmed) }
     let(:valid) { true }
@@ -64,7 +64,9 @@ module Decidim
         end
 
         it "sends a reconfirmation email" do
-          expect { command.call }.to broadcast(:ok, true)
+          expect do
+            perform_enqueued_jobs { command.call }
+          end.to broadcast(:ok, true)
           expect(last_email.to).to include("new@email.com")
         end
       end

--- a/decidim-core/spec/features/account_spec.rb
+++ b/decidim-core/spec/features/account_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Account", type: :feature, perform_enqueued: true do
+describe "Account", type: :feature do
   let(:user) { create(:user, :confirmed, password: "password1234", password_confirmation: "password1234") }
   let(:organization) { user.organization }
 

--- a/decidim-core/spec/features/authentication_spec.rb
+++ b/decidim-core/spec/features/authentication_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Authentication", type: :feature, perform_enqueued: true do
+describe "Authentication", type: :feature do
   let(:organization) { create(:organization) }
   let(:last_user) { Decidim::User.last }
 
@@ -214,7 +214,7 @@ describe "Authentication", type: :feature, perform_enqueued: true do
 
   describe "Confirm email" do
     it "confirms the user" do
-      create(:user, organization: organization)
+      perform_enqueued_jobs { create(:user, organization: organization) }
 
       visit last_email_link
 
@@ -224,14 +224,16 @@ describe "Authentication", type: :feature, perform_enqueued: true do
   end
 
   describe "Resend confirmation instructions" do
-    let(:user) { create(:user, organization: organization) }
+    let(:user) do
+      perform_enqueued_jobs { create(:user, organization: organization) }
+    end
 
     it "sends an email with the instructions" do
       visit decidim.new_user_confirmation_path
 
       within ".new_user" do
         fill_in :user_email, with: user.email
-        find("*[type=submit]").click
+        perform_enqueued_jobs { find("*[type=submit]").click }
       end
 
       expect(emails.count).to eq(2)
@@ -263,7 +265,7 @@ describe "Authentication", type: :feature, perform_enqueued: true do
 
         within ".new_user" do
           fill_in :user_email, with: user.email
-          find("*[type=submit]").click
+          perform_enqueued_jobs { find("*[type=submit]").click }
         end
 
         expect(page).to have_content("reset your password")
@@ -273,7 +275,7 @@ describe "Authentication", type: :feature, perform_enqueued: true do
 
     describe "Reset password" do
       before do
-        user.send_reset_password_instructions
+        perform_enqueued_jobs { user.send_reset_password_instructions }
       end
 
       it "sets a new password for the user" do

--- a/decidim-core/spec/features/authorizations_spec.rb
+++ b/decidim-core/spec/features/authorizations_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Authorizations", type: :feature, perform_enqueued: true do
+describe "Authorizations", type: :feature do
   before do
     switch_to_host(organization.host)
   end

--- a/decidim-core/spec/features/user_groups_spec.rb
+++ b/decidim-core/spec/features/user_groups_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "User groups", type: :feature, perform_enqueued: true do
+describe "User groups", type: :feature do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, :confirmed, organization: organization) }
 

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/action_mailer.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/action_mailer.rb
@@ -57,17 +57,3 @@ end
 RSpec.configure do |config|
   config.include MailerHelpers
 end
-
-RSpec.configure do |config|
-  config.before :example, perform_enqueued: true do
-    @old_perform_enqueued_jobs = ActiveJob::Base.queue_adapter.perform_enqueued_jobs
-    @old_perform_enqueued_at_jobs = ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs
-    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
-    ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = true
-  end
-
-  config.after :example, perform_enqueued: true do
-    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = @old_perform_enqueued_jobs
-    ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = @old_perform_enqueued_at_jobs
-  end
-end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/active_job.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/active_job.rb
@@ -2,10 +2,6 @@
 
 RSpec.configure do |config|
   config.include ActiveJob::TestHelper
-
-  config.before(:each) do
-    clear_enqueued_jobs
-  end
 end
 
 ActiveJob::Base.queue_adapter = :test

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara_select2.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara_select2.rb
@@ -4,30 +4,19 @@
 
 module Capybara
   module Select2
-    def select2(value, id:, search:)
+    def select2(value, id:)
       expect(page).to have_xpath("//select[@id='#{id}']/..")
       select2_container = find(:xpath, "//select[@id='#{id}']/..")
 
       expect(select2_container).to have_selector(".select2-selection")
       select2_container.find(".select2-selection").click
 
-      if search
-        body = find(:xpath, "//body")
-        expect(body).to have_selector(".select2-search input.select2-search__field")
-        body.find(".select2-search input.select2-search__field").set(value)
-
-        page.execute_script(%|$("input.select2-search__field:visible").keyup();|)
-        drop_container = ".select2-results"
-      else
-        drop_container = ".select2-dropdown"
-      end
-
       expect(page).to have_no_content("Searching...")
 
       body = find(:xpath, "//body")
-      expect(body).to have_selector("#{drop_container} li.select2-results__option", text: value)
+      expect(body).to have_selector(".select2-dropdown li.select2-results__option", text: value)
 
-      body.find("#{drop_container} li.select2-results__option", text: value).click
+      body.find(".select2-dropdown li.select2-results__option", text: value).click
       expect(page).to have_select(id, with_options: [value])
     end
   end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara_select2.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara_select2.rb
@@ -4,9 +4,9 @@
 
 module Capybara
   module Select2
-    def select2(value, xpath:, search:)
-      expect(page).to have_xpath(xpath)
-      select2_container = find(:xpath, xpath)
+    def select2(value, id:, search:)
+      expect(page).to have_xpath("//select[@id='#{id}']/..")
+      select2_container = find(:xpath, "//select[@id='#{id}']/..")
 
       expect(select2_container).to have_selector(".select2-selection")
       select2_container.find(".select2-selection").click
@@ -26,7 +26,9 @@ module Capybara
 
       body = find(:xpath, "//body")
       expect(body).to have_selector("#{drop_container} li.select2-results__option", text: value)
+
       body.find("#{drop_container} li.select2-results__option", text: value).click
+      expect(page).to have_select(id, with_options: [value])
     end
   end
 end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara_select2.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara_select2.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# Adapted from https://github.com/goodwill/capybara-select2
-
 module Capybara
   module Select2
     def select2(value, from:)

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara_select2.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara_select2.rb
@@ -4,9 +4,9 @@
 
 module Capybara
   module Select2
-    def select2(value, id:)
-      expect(page).to have_xpath("//select[@id='#{id}']/..")
-      select2_container = find(:xpath, "//select[@id='#{id}']/..")
+    def select2(value, from:)
+      expect(page).to have_xpath("//select[@id='#{from}']/..")
+      select2_container = find(:xpath, "//select[@id='#{from}']/..")
 
       expect(select2_container).to have_selector(".select2-selection")
       select2_container.find(".select2-selection").click
@@ -17,7 +17,7 @@ module Capybara
       expect(body).to have_selector(".select2-dropdown li.select2-results__option", text: value)
 
       body.find(".select2-dropdown li.select2-results__option", text: value).click
-      expect(page).to have_select(id, with_options: [value])
+      expect(page).to have_select(from, with_options: [value])
     end
   end
 end

--- a/decidim-meetings/spec/commands/invite_user_to_join_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/invite_user_to_join_meeting_spec.rb
@@ -24,12 +24,6 @@ describe Decidim::Meetings::Admin::InviteUserToJoinMeeting do
   let!(:feature) { create :meeting_feature, participatory_space: participatory_process }
   let!(:meeting) { create :meeting, feature: feature }
 
-  # around do |example|
-  #   perform_enqueued_jobs do
-  #     example.run
-  #   end
-  # end
-
   subject { described_class.new(form, meeting, current_user) }
 
   context "when everything is ok" do

--- a/decidim-meetings/spec/features/comments_spec.rb
+++ b/decidim-meetings/spec/features/comments_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Comments", type: :feature, perform_enqueued: true do
+describe "Comments", type: :feature do
   let!(:feature) { create(:feature, manifest_name: :meetings, organization: organization) }
   let!(:participatory_space) { feature.participatory_space }
   let!(:participatory_process_admin) do

--- a/decidim-meetings/spec/features/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/features/explore_meetings_spec.rb
@@ -64,7 +64,7 @@ describe "Explore meetings", type: :feature do
         visit_feature
 
         within ".filters" do
-          select2(translated(scope.name), id: "filter_scope_id")
+          select2(translated(scope.name), from: :filter_scope_id)
         end
 
         expect(page).to have_css(".card--meeting", count: 1)

--- a/decidim-meetings/spec/features/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/features/explore_meetings_spec.rb
@@ -64,7 +64,7 @@ describe "Explore meetings", type: :feature do
         visit_feature
 
         within ".filters" do
-          select2(translated(scope.name), id: "filter_scope_id", search: true)
+          select2(translated(scope.name), id: "filter_scope_id", search: false)
         end
 
         expect(page).to have_css(".card--meeting", count: 1)

--- a/decidim-meetings/spec/features/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/features/explore_meetings_spec.rb
@@ -64,7 +64,7 @@ describe "Explore meetings", type: :feature do
         visit_feature
 
         within ".filters" do
-          select2(translated(scope.name), id: "filter_scope_id", search: false)
+          select2(translated(scope.name), id: "filter_scope_id")
         end
 
         expect(page).to have_css(".card--meeting", count: 1)

--- a/decidim-meetings/spec/features/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/features/explore_meetings_spec.rb
@@ -64,7 +64,7 @@ describe "Explore meetings", type: :feature do
         visit_feature
 
         within ".filters" do
-          select2(translated(scope.name), xpath: '//select[@id="filter_scope_id"]/..', search: true)
+          select2(translated(scope.name), id: "filter_scope_id", search: true)
         end
 
         expect(page).to have_css(".card--meeting", count: 1)

--- a/decidim-meetings/spec/shared/manage_meetings_examples.rb
+++ b/decidim-meetings/spec/shared/manage_meetings_examples.rb
@@ -98,7 +98,7 @@ shared_examples "manage meetings" do
     page.find(".datepicker-dropdown .hour", text: "12:00").click
     page.find(".datepicker-dropdown .minute", text: "12:50").click
 
-    select2 translated(scope.name), id: "meeting_decidim_scope_id", search: false
+    select2 translated(scope.name), id: "meeting_decidim_scope_id"
     select translated(category.name), from: :meeting_decidim_category_id
 
     within ".new_meeting" do
@@ -211,7 +211,7 @@ shared_examples "manage meetings" do
       page.find(".datepicker-dropdown .hour", text: "12:00").click
       page.find(".datepicker-dropdown .minute", text: "12:50").click
 
-      select2 translated(scope.name), id: "meeting_decidim_scope_id", search: false
+      select2 translated(scope.name), id: "meeting_decidim_scope_id"
       select translated(category.name), from: :meeting_decidim_category_id
 
       within ".new_meeting" do

--- a/decidim-meetings/spec/shared/manage_meetings_examples.rb
+++ b/decidim-meetings/spec/shared/manage_meetings_examples.rb
@@ -98,7 +98,7 @@ shared_examples "manage meetings" do
     page.find(".datepicker-dropdown .hour", text: "12:00").click
     page.find(".datepicker-dropdown .minute", text: "12:50").click
 
-    select2 translated(scope.name), xpath: '//select[@id="meeting_decidim_scope_id"]/..', search: true
+    select2 translated(scope.name), id: "meeting_decidim_scope_id", search: true
     select translated(category.name), from: :meeting_decidim_category_id
 
     within ".new_meeting" do
@@ -211,7 +211,7 @@ shared_examples "manage meetings" do
       page.find(".datepicker-dropdown .hour", text: "12:00").click
       page.find(".datepicker-dropdown .minute", text: "12:50").click
 
-      select2 translated(scope.name), xpath: '//select[@id="meeting_decidim_scope_id"]/..', search: true
+      select2 translated(scope.name), id: "meeting_decidim_scope_id", search: true
       select translated(category.name), from: :meeting_decidim_category_id
 
       within ".new_meeting" do

--- a/decidim-meetings/spec/shared/manage_meetings_examples.rb
+++ b/decidim-meetings/spec/shared/manage_meetings_examples.rb
@@ -98,7 +98,7 @@ shared_examples "manage meetings" do
     page.find(".datepicker-dropdown .hour", text: "12:00").click
     page.find(".datepicker-dropdown .minute", text: "12:50").click
 
-    select2 translated(scope.name), id: "meeting_decidim_scope_id", search: true
+    select2 translated(scope.name), id: "meeting_decidim_scope_id", search: false
     select translated(category.name), from: :meeting_decidim_category_id
 
     within ".new_meeting" do
@@ -211,7 +211,7 @@ shared_examples "manage meetings" do
       page.find(".datepicker-dropdown .hour", text: "12:00").click
       page.find(".datepicker-dropdown .minute", text: "12:50").click
 
-      select2 translated(scope.name), id: "meeting_decidim_scope_id", search: true
+      select2 translated(scope.name), id: "meeting_decidim_scope_id", search: false
       select translated(category.name), from: :meeting_decidim_category_id
 
       within ".new_meeting" do

--- a/decidim-meetings/spec/shared/manage_meetings_examples.rb
+++ b/decidim-meetings/spec/shared/manage_meetings_examples.rb
@@ -98,7 +98,7 @@ shared_examples "manage meetings" do
     page.find(".datepicker-dropdown .hour", text: "12:00").click
     page.find(".datepicker-dropdown .minute", text: "12:50").click
 
-    select2 translated(scope.name), id: "meeting_decidim_scope_id"
+    select2 translated(scope.name), from: :meeting_decidim_scope_id
     select translated(category.name), from: :meeting_decidim_category_id
 
     within ".new_meeting" do
@@ -211,7 +211,7 @@ shared_examples "manage meetings" do
       page.find(".datepicker-dropdown .hour", text: "12:00").click
       page.find(".datepicker-dropdown .minute", text: "12:50").click
 
-      select2 translated(scope.name), id: "meeting_decidim_scope_id"
+      select2 translated(scope.name), from: :meeting_decidim_scope_id
       select translated(category.name), from: :meeting_decidim_category_id
 
       within ".new_meeting" do

--- a/decidim-meetings/spec/shared/manage_registrations_examples.rb
+++ b/decidim-meetings/spec/shared/manage_registrations_examples.rb
@@ -60,10 +60,12 @@ shared_examples "manage registrations" do
     end
 
     context "when inviting a unregistered user" do
-      it "the invited user sign up into the application and joins the meeting", perform_enqueued: true do
+      it "the invited user sign up into the application and joins the meeting" do
         visit_edit_registrations_page
 
-        fill_in_meeting_registration_invite name: "Foo", email: "foo@example.org"
+        perform_enqueued_jobs do
+          fill_in_meeting_registration_invite name: "Foo", email: "foo@example.org"
+        end
 
         logout :user
 
@@ -86,10 +88,12 @@ shared_examples "manage registrations" do
     context "when inviting a registered user" do
       let!(:registered_user) { create(:user, :confirmed, organization: organization) }
 
-      it "the invited user joins the meeting", perform_enqueued: true do
+      it "the invited user joins the meeting" do
         visit_edit_registrations_page
 
-        fill_in_meeting_registration_invite name: registered_user.name, email: registered_user.email
+        perform_enqueued_jobs do
+          fill_in_meeting_registration_invite name: registered_user.name, email: registered_user.email
+        end
 
         logout :user
 

--- a/decidim-participatory_processes/spec/features/admin/invite_process_admin_spec.rb
+++ b/decidim-participatory_processes/spec/features/admin/invite_process_admin_spec.rb
@@ -11,63 +11,59 @@ describe "Invite process administrator", type: :feature do
   end
 
   context "when the user does not exist" do
-    describe "Accept an invitation", perform_enqueued: true do
-      before do
-        invite_user
+    before do
+      perform_enqueued_jobs { invite_user }
+    end
+
+    it "asks for a password and redirects to the admin dashboard" do
+      visit last_email_link
+
+      within "form.new_user" do
+        fill_in :user_password, with: "123456"
+        fill_in :user_password_confirmation, with: "123456"
+        find("*[type=submit]").click
       end
 
-      it "asks for a password and redirects to the admin dashboard" do
-        visit last_email_link
+      expect(current_path).to eq "/admin/"
+      expect(page).to have_content("DASHBOARD")
 
-        within "form.new_user" do
-          fill_in :user_password, with: "123456"
-          fill_in :user_password_confirmation, with: "123456"
-          find("*[type=submit]").click
-        end
+      click_link "Processes"
 
-        expect(current_path).to eq "/admin/"
-        expect(page).to have_content("DASHBOARD")
+      within "#processes" do
+        expect(page).to have_i18n_content(participatory_process.title)
+        click_link translated(participatory_process.title)
+      end
 
-        click_link "Processes"
-
-        within "#processes" do
-          expect(page).to have_i18n_content(participatory_process.title)
-          click_link translated(participatory_process.title)
-        end
-
-        within ".secondary-nav" do
-          expect(page.text).to eq "Info Steps Features Categories Attachments Process users Moderations"
-        end
+      within ".secondary-nav" do
+        expect(page.text).to eq "Info Steps Features Categories Attachments Process users Moderations"
       end
     end
   end
 
   context "when the user already exists" do
-    describe "Accept an invitation", perform_enqueued: true do
-      let(:email) { "administrator@example.org" }
-      let(:administrator) { @administrator }
+    let(:email) { "administrator@example.org" }
+    let(:administrator) { @administrator }
 
-      before do
-        @administrator = create :user, :confirmed, email: email, organization: organization
-        invite_user
+    before do
+      @administrator = create :user, :confirmed, email: email, organization: organization
+      perform_enqueued_jobs { invite_user }
+    end
+
+    it "redirects the administrator to the admin dashboard" do
+      login_as administrator, scope: :user
+
+      visit decidim_admin.root_path
+      expect(page).to have_content("DASHBOARD")
+
+      click_link "Processes"
+
+      within "#processes" do
+        expect(page).to have_i18n_content(participatory_process.title)
+        click_link translated(participatory_process.title)
       end
 
-      it "redirects the administrator to the admin dashboard" do
-        login_as administrator, scope: :user
-
-        visit decidim_admin.root_path
-        expect(page).to have_content("DASHBOARD")
-
-        click_link "Processes"
-
-        within "#processes" do
-          expect(page).to have_i18n_content(participatory_process.title)
-          click_link translated(participatory_process.title)
-        end
-
-        within ".secondary-nav" do
-          expect(page.text).to eq "Info Steps Features Categories Attachments Process users Moderations"
-        end
+      within ".secondary-nav" do
+        expect(page.text).to eq "Info Steps Features Categories Attachments Process users Moderations"
       end
     end
   end

--- a/decidim-participatory_processes/spec/features/admin/invite_process_collaborator_spec.rb
+++ b/decidim-participatory_processes/spec/features/admin/invite_process_collaborator_spec.rb
@@ -11,53 +11,49 @@ describe "Invite process collaborator", type: :feature do
   end
 
   context "when the user does not exist" do
-    describe "Accept an invitation", perform_enqueued: true do
-      before do
-        invite_user
+    before do
+      perform_enqueued_jobs { invite_user }
+    end
+
+    it "asks for a password and redirects to the admin dashboard" do
+      visit last_email_link
+
+      within "form.new_user" do
+        fill_in :user_password, with: "123456"
+        fill_in :user_password_confirmation, with: "123456"
+        find("*[type=submit]").click
       end
 
-      it "asks for a password and redirects to the admin dashboard" do
-        visit last_email_link
+      expect(current_path).to eq "/admin/"
+      expect(page).to have_content("DASHBOARD")
 
-        within "form.new_user" do
-          fill_in :user_password, with: "123456"
-          fill_in :user_password_confirmation, with: "123456"
-          find("*[type=submit]").click
-        end
+      click_link "Processes"
 
-        expect(current_path).to eq "/admin/"
-        expect(page).to have_content("DASHBOARD")
-
-        click_link "Processes"
-
-        within "#processes" do
-          expect(page).to have_i18n_content(participatory_process.title)
-        end
+      within "#processes" do
+        expect(page).to have_i18n_content(participatory_process.title)
       end
     end
   end
 
   context "when the user already exists" do
-    describe "Accept an invitation", perform_enqueued: true do
-      let(:email) { "collaborator@example.org" }
-      let(:collaborator) { @collaborator }
+    let(:email) { "collaborator@example.org" }
+    let(:collaborator) { @collaborator }
 
-      before do
-        @collaborator = create :user, :confirmed, email: email, organization: organization
-        invite_user
-      end
+    before do
+      @collaborator = create :user, :confirmed, email: email, organization: organization
+      perform_enqueued_jobs { invite_user }
+    end
 
-      it "redirects the collaborator to the admin dashboard" do
-        login_as collaborator, scope: :user
+    it "redirects the collaborator to the admin dashboard" do
+      login_as collaborator, scope: :user
 
-        visit decidim_admin.root_path
-        expect(page).to have_content("DASHBOARD")
+      visit decidim_admin.root_path
+      expect(page).to have_content("DASHBOARD")
 
-        click_link "Processes"
+      click_link "Processes"
 
-        within "#processes" do
-          expect(page).to have_i18n_content(participatory_process.title)
-        end
+      within "#processes" do
+        expect(page).to have_i18n_content(participatory_process.title)
       end
     end
   end

--- a/decidim-participatory_processes/spec/features/admin/invite_process_moderator_spec.rb
+++ b/decidim-participatory_processes/spec/features/admin/invite_process_moderator_spec.rb
@@ -10,63 +10,59 @@ describe "Invite process moderator", type: :feature do
   end
 
   context "when the user does not exist" do
-    describe "Accept an invitation", perform_enqueued: true do
-      before do
-        invite_user
+    before do
+      perform_enqueued_jobs { invite_user }
+    end
+
+    it "asks for a password and redirects to the admin dashboard" do
+      visit last_email_link
+
+      within "form.new_user" do
+        fill_in :user_password, with: "123456"
+        fill_in :user_password_confirmation, with: "123456"
+        find("*[type=submit]").click
       end
 
-      it "asks for a password and redirects to the admin dashboard" do
-        visit last_email_link
+      expect(current_path).to eq "/admin/"
+      expect(page).to have_content("DASHBOARD")
 
-        within "form.new_user" do
-          fill_in :user_password, with: "123456"
-          fill_in :user_password_confirmation, with: "123456"
-          find("*[type=submit]").click
-        end
+      click_link "Processes"
 
-        expect(current_path).to eq "/admin/"
-        expect(page).to have_content("DASHBOARD")
+      within "#processes" do
+        expect(page).to have_i18n_content(participatory_process.title)
+        click_link translated(participatory_process.title)
+      end
 
-        click_link "Processes"
-
-        within "#processes" do
-          expect(page).to have_i18n_content(participatory_process.title)
-          click_link translated(participatory_process.title)
-        end
-
-        within ".secondary-nav" do
-          expect(page.text).to eq "Moderations"
-        end
+      within ".secondary-nav" do
+        expect(page.text).to eq "Moderations"
       end
     end
   end
 
   context "when the user already exists" do
-    describe "Accept an invitation", perform_enqueued: true do
-      let(:email) { "moderator@example.org" }
-      let(:moderator) { @moderator }
+    let(:email) { "moderator@example.org" }
+    let(:moderator) { @moderator }
 
-      before do
-        @moderator = create :user, :confirmed, email: email, organization: organization
-        invite_user
+    before do
+      @moderator = create :user, :confirmed, email: email, organization: organization
+      perform_enqueued_jobs { invite_user }
+    end
+
+    it "redirects the moderator to the admin dashboard" do
+      login_as moderator, scope: :user
+
+      visit decidim_admin.root_path
+      expect(page).to have_content("DASHBOARD")
+
+      click_link "Processes"
+
+      within "#processes" do
+        expect(page).to have_i18n_content(participatory_process.title)
+        click_link translated(participatory_process.title)
       end
 
-      it "redirects the moderator to the admin dashboard" do
-        login_as moderator, scope: :user
-
-        visit decidim_admin.root_path
-        expect(page).to have_content("DASHBOARD")
-
-        click_link "Processes"
-
-        within "#processes" do
-          expect(page).to have_i18n_content(participatory_process.title)
-          click_link translated(participatory_process.title)
-        end
-
-        within ".secondary-nav" do
-          expect(page.text).to eq "Moderations"
-        end
+      within ".secondary-nav" do
+        expect(page.text).to eq "Moderations"
       end
     end
   end

--- a/decidim-proposals/spec/features/comments_spec.rb
+++ b/decidim-proposals/spec/features/comments_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Comments", type: :feature, perform_enqueued: true do
+describe "Comments", type: :feature do
   let!(:feature) { create(:proposal_feature, organization: organization) }
   let!(:author) { create(:user, :confirmed, organization: organization) }
   let!(:commentable) { create(:proposal, feature: feature, author: author) }

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -74,7 +74,7 @@ describe "Proposals", type: :feature do
             fill_in :proposal_title, with: "Oriol for president"
             fill_in :proposal_body, with: "He will solve everything"
             select translated(category.name), from: :proposal_category_id
-            select2 translated(scope.name), xpath: '//select[@id="proposal_scope_id"]/..', search: true
+            select2 translated(scope.name), id: "proposal_scope_id", search: true
 
             find("*[type=submit]").click
           end
@@ -109,7 +109,7 @@ describe "Proposals", type: :feature do
 
               fill_in :proposal_address, with: address
               select translated(category.name), from: :proposal_category_id
-              select2 translated(scope.name), xpath: '//select[@id="proposal_scope_id"]/..', search: true
+              select2 translated(scope.name), id: "proposal_scope_id", search: true
 
               find("*[type=submit]").click
             end
@@ -139,7 +139,7 @@ describe "Proposals", type: :feature do
               fill_in :proposal_title, with: "Oriol for president"
               fill_in :proposal_body, with: "He will solve everything"
               select translated(category.name), from: :proposal_category_id
-              select2 translated(scope.name), xpath: '//select[@id="proposal_scope_id"]/..', search: true
+              select2 translated(scope.name), id: "proposal_scope_id", search: true
               select user_group.name, from: :proposal_user_group_id
 
               find("*[type=submit]").click
@@ -174,7 +174,7 @@ describe "Proposals", type: :feature do
 
                 fill_in :proposal_address, with: address
                 select translated(category.name), from: :proposal_category_id
-                select2 translated(scope.name), xpath: '//select[@id="proposal_scope_id"]/..', search: true
+                select2 translated(scope.name), id: "proposal_scope_id", search: true
                 select user_group.name, from: :proposal_user_group_id
 
                 find("*[type=submit]").click
@@ -665,7 +665,7 @@ describe "Proposals", type: :feature do
         context "selecting the global scope" do
           it "lists the filtered proposals" do
             within ".filters" do
-              select2("Global scope", xpath: '//select[@id="filter_scope_id"]/..', search: false)
+              select2("Global scope", id: "filter_scope_id", search: false)
             end
 
             expect(page).to have_css(".card--proposal", count: 1)
@@ -676,7 +676,7 @@ describe "Proposals", type: :feature do
         context "selecting one scope" do
           it "lists the filtered proposals" do
             within ".filters" do
-              select2(translated(scope.name), xpath: '//select[@id="filter_scope_id"]/..', search: true)
+              select2(translated(scope.name), id: "filter_scope_id", search: true)
             end
 
             expect(page).to have_css(".card--proposal", count: 2)
@@ -687,8 +687,8 @@ describe "Proposals", type: :feature do
         context "selecting the global scope and another scope" do
           it "lists the filtered proposals" do
             within ".filters" do
-              select2(translated(scope.name), xpath: '//select[@id="filter_scope_id"]/..', search: true)
-              select2("Global scope", xpath: '//select[@id="filter_scope_id"]/..', search: false)
+              select2(translated(scope.name), id: "filter_scope_id", search: true)
+              select2("Global scope", id: "filter_scope_id", search: false)
             end
 
             expect(page).to have_css(".card--proposal", count: 3)

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -74,7 +74,7 @@ describe "Proposals", type: :feature do
             fill_in :proposal_title, with: "Oriol for president"
             fill_in :proposal_body, with: "He will solve everything"
             select translated(category.name), from: :proposal_category_id
-            select2 translated(scope.name), id: "proposal_scope_id", search: true
+            select2 translated(scope.name), id: "proposal_scope_id", search: false
 
             find("*[type=submit]").click
           end
@@ -109,7 +109,7 @@ describe "Proposals", type: :feature do
 
               fill_in :proposal_address, with: address
               select translated(category.name), from: :proposal_category_id
-              select2 translated(scope.name), id: "proposal_scope_id", search: true
+              select2 translated(scope.name), id: "proposal_scope_id", search: false
 
               find("*[type=submit]").click
             end
@@ -139,7 +139,7 @@ describe "Proposals", type: :feature do
               fill_in :proposal_title, with: "Oriol for president"
               fill_in :proposal_body, with: "He will solve everything"
               select translated(category.name), from: :proposal_category_id
-              select2 translated(scope.name), id: "proposal_scope_id", search: true
+              select2 translated(scope.name), id: "proposal_scope_id", search: false
               select user_group.name, from: :proposal_user_group_id
 
               find("*[type=submit]").click
@@ -174,7 +174,7 @@ describe "Proposals", type: :feature do
 
                 fill_in :proposal_address, with: address
                 select translated(category.name), from: :proposal_category_id
-                select2 translated(scope.name), id: "proposal_scope_id", search: true
+                select2 translated(scope.name), id: "proposal_scope_id", search: false
                 select user_group.name, from: :proposal_user_group_id
 
                 find("*[type=submit]").click
@@ -676,7 +676,7 @@ describe "Proposals", type: :feature do
         context "selecting one scope" do
           it "lists the filtered proposals" do
             within ".filters" do
-              select2(translated(scope.name), id: "filter_scope_id", search: true)
+              select2(translated(scope.name), id: "filter_scope_id", search: false)
             end
 
             expect(page).to have_css(".card--proposal", count: 2)
@@ -687,7 +687,7 @@ describe "Proposals", type: :feature do
         context "selecting the global scope and another scope" do
           it "lists the filtered proposals" do
             within ".filters" do
-              select2(translated(scope.name), id: "filter_scope_id", search: true)
+              select2(translated(scope.name), id: "filter_scope_id", search: false)
               select2("Global scope", id: "filter_scope_id", search: false)
             end
 

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -74,7 +74,7 @@ describe "Proposals", type: :feature do
             fill_in :proposal_title, with: "Oriol for president"
             fill_in :proposal_body, with: "He will solve everything"
             select translated(category.name), from: :proposal_category_id
-            select2 translated(scope.name), id: "proposal_scope_id", search: false
+            select2 translated(scope.name), id: "proposal_scope_id"
 
             find("*[type=submit]").click
           end
@@ -109,7 +109,7 @@ describe "Proposals", type: :feature do
 
               fill_in :proposal_address, with: address
               select translated(category.name), from: :proposal_category_id
-              select2 translated(scope.name), id: "proposal_scope_id", search: false
+              select2 translated(scope.name), id: "proposal_scope_id"
 
               find("*[type=submit]").click
             end
@@ -139,7 +139,7 @@ describe "Proposals", type: :feature do
               fill_in :proposal_title, with: "Oriol for president"
               fill_in :proposal_body, with: "He will solve everything"
               select translated(category.name), from: :proposal_category_id
-              select2 translated(scope.name), id: "proposal_scope_id", search: false
+              select2 translated(scope.name), id: "proposal_scope_id"
               select user_group.name, from: :proposal_user_group_id
 
               find("*[type=submit]").click
@@ -174,7 +174,7 @@ describe "Proposals", type: :feature do
 
                 fill_in :proposal_address, with: address
                 select translated(category.name), from: :proposal_category_id
-                select2 translated(scope.name), id: "proposal_scope_id", search: false
+                select2 translated(scope.name), id: "proposal_scope_id"
                 select user_group.name, from: :proposal_user_group_id
 
                 find("*[type=submit]").click
@@ -665,7 +665,7 @@ describe "Proposals", type: :feature do
         context "selecting the global scope" do
           it "lists the filtered proposals" do
             within ".filters" do
-              select2("Global scope", id: "filter_scope_id", search: false)
+              select2("Global scope", id: "filter_scope_id")
             end
 
             expect(page).to have_css(".card--proposal", count: 1)
@@ -676,7 +676,7 @@ describe "Proposals", type: :feature do
         context "selecting one scope" do
           it "lists the filtered proposals" do
             within ".filters" do
-              select2(translated(scope.name), id: "filter_scope_id", search: false)
+              select2(translated(scope.name), id: "filter_scope_id")
             end
 
             expect(page).to have_css(".card--proposal", count: 2)
@@ -687,8 +687,8 @@ describe "Proposals", type: :feature do
         context "selecting the global scope and another scope" do
           it "lists the filtered proposals" do
             within ".filters" do
-              select2(translated(scope.name), id: "filter_scope_id", search: false)
-              select2("Global scope", id: "filter_scope_id", search: false)
+              select2(translated(scope.name), id: "filter_scope_id")
+              select2("Global scope", id: "filter_scope_id")
             end
 
             expect(page).to have_css(".card--proposal", count: 3)

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -74,7 +74,7 @@ describe "Proposals", type: :feature do
             fill_in :proposal_title, with: "Oriol for president"
             fill_in :proposal_body, with: "He will solve everything"
             select translated(category.name), from: :proposal_category_id
-            select2 translated(scope.name), id: "proposal_scope_id"
+            select2 translated(scope.name), from: :proposal_scope_id
 
             find("*[type=submit]").click
           end
@@ -109,7 +109,7 @@ describe "Proposals", type: :feature do
 
               fill_in :proposal_address, with: address
               select translated(category.name), from: :proposal_category_id
-              select2 translated(scope.name), id: "proposal_scope_id"
+              select2 translated(scope.name), from: :proposal_scope_id
 
               find("*[type=submit]").click
             end
@@ -139,7 +139,7 @@ describe "Proposals", type: :feature do
               fill_in :proposal_title, with: "Oriol for president"
               fill_in :proposal_body, with: "He will solve everything"
               select translated(category.name), from: :proposal_category_id
-              select2 translated(scope.name), id: "proposal_scope_id"
+              select2 translated(scope.name), from: :proposal_scope_id
               select user_group.name, from: :proposal_user_group_id
 
               find("*[type=submit]").click
@@ -174,7 +174,7 @@ describe "Proposals", type: :feature do
 
                 fill_in :proposal_address, with: address
                 select translated(category.name), from: :proposal_category_id
-                select2 translated(scope.name), id: "proposal_scope_id"
+                select2 translated(scope.name), from: :proposal_scope_id
                 select user_group.name, from: :proposal_user_group_id
 
                 find("*[type=submit]").click
@@ -665,7 +665,7 @@ describe "Proposals", type: :feature do
         context "selecting the global scope" do
           it "lists the filtered proposals" do
             within ".filters" do
-              select2("Global scope", id: "filter_scope_id")
+              select2("Global scope", from: :filter_scope_id)
             end
 
             expect(page).to have_css(".card--proposal", count: 1)
@@ -676,7 +676,7 @@ describe "Proposals", type: :feature do
         context "selecting one scope" do
           it "lists the filtered proposals" do
             within ".filters" do
-              select2(translated(scope.name), id: "filter_scope_id")
+              select2(translated(scope.name), from: :filter_scope_id)
             end
 
             expect(page).to have_css(".card--proposal", count: 2)
@@ -687,8 +687,8 @@ describe "Proposals", type: :feature do
         context "selecting the global scope and another scope" do
           it "lists the filtered proposals" do
             within ".filters" do
-              select2(translated(scope.name), id: "filter_scope_id")
-              select2("Global scope", id: "filter_scope_id")
+              select2(translated(scope.name), from: :filter_scope_id)
+              select2("Global scope", from: :filter_scope_id)
             end
 
             expect(page).to have_css(".card--proposal", count: 3)
@@ -819,7 +819,7 @@ describe "Proposals", type: :feature do
           visit_feature
 
           within "form.new_filter" do
-            select category.name[I18n.locale.to_s], from: "filter_category_id"
+            select category.name[I18n.locale.to_s], from: :filter_category_id
           end
 
           expect(page).to have_css(".card--proposal", count: 1)

--- a/decidim-proposals/spec/shared/export_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/export_proposals_examples.rb
@@ -3,15 +3,9 @@
 shared_examples "export proposals" do
   let!(:proposals) { create_list :proposal, 3, feature: current_feature }
 
-  around do |example|
-    perform_enqueued_jobs do
-      example.run
-    end
-  end
-
   it "exports a CSV" do
     find(".exports.dropdown").click
-    click_link "Proposals as CSV"
+    perform_enqueued_jobs { click_link "Proposals as CSV" }
 
     within ".callout.success" do
       expect(page).to have_content("in progress")
@@ -24,7 +18,7 @@ shared_examples "export proposals" do
 
   it "exports a JSON" do
     find(".exports.dropdown").click
-    click_link "Proposals as JSON"
+    perform_enqueued_jobs { click_link "Proposals as JSON" }
 
     within ".callout.success" do
       expect(page).to have_content("in progress")

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -64,7 +64,7 @@ shared_examples "manage proposals" do
               fill_in :proposal_title, with: "Make decidim great again"
               fill_in :proposal_body, with: "Decidim is great but it can be better"
               select translated(category.name), from: :proposal_category_id
-              select2 translated(scope.name), id: "proposal_scope_id"
+              select2 translated(scope.name), from: :proposal_scope_id
 
               find("*[type=submit]").click
             end

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -64,7 +64,7 @@ shared_examples "manage proposals" do
               fill_in :proposal_title, with: "Make decidim great again"
               fill_in :proposal_body, with: "Decidim is great but it can be better"
               select translated(category.name), from: :proposal_category_id
-              select2 translated(scope.name), id: "proposal_scope_id", search: false
+              select2 translated(scope.name), id: "proposal_scope_id"
 
               find("*[type=submit]").click
             end

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -64,7 +64,7 @@ shared_examples "manage proposals" do
               fill_in :proposal_title, with: "Make decidim great again"
               fill_in :proposal_body, with: "Decidim is great but it can be better"
               select translated(category.name), from: :proposal_category_id
-              select2 translated(scope.name), id: "proposal_scope_id", search: true
+              select2 translated(scope.name), id: "proposal_scope_id", search: false
 
               find("*[type=submit]").click
             end

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -64,7 +64,7 @@ shared_examples "manage proposals" do
               fill_in :proposal_title, with: "Make decidim great again"
               fill_in :proposal_body, with: "Decidim is great but it can be better"
               select translated(category.name), from: :proposal_category_id
-              select2 translated(scope.name), xpath: '//select[@id="proposal_scope_id"]/..', search: true
+              select2 translated(scope.name), id: "proposal_scope_id", search: true
 
               find("*[type=submit]").click
             end

--- a/decidim-surveys/spec/shared/export_survey_user_answers_examples.rb
+++ b/decidim-surveys/spec/shared/export_survey_user_answers_examples.rb
@@ -8,17 +8,11 @@ shared_examples "export survey user answers" do
     end.flatten
   end
 
-  around do |example|
-    perform_enqueued_jobs do
-      example.run
-    end
-  end
-
   it "exports a CSV" do
     visit_feature_admin
 
     find(".exports.dropdown").click
-    click_link "CSV"
+    perform_enqueued_jobs { click_link "CSV" }
 
     within ".callout.success" do
       expect(page).to have_content("in progress")
@@ -33,7 +27,7 @@ shared_examples "export survey user answers" do
     visit_feature_admin
 
     find(".exports.dropdown").click
-    click_link "JSON"
+    perform_enqueued_jobs { click_link "JSON" }
 
     within ".callout.success" do
       expect(page).to have_content("in progress")

--- a/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
@@ -49,8 +49,10 @@ module Decidim
             expect(admin).to be_created_by_invite
           end
 
-          it "sends a custom email", perform_enqueued: true do
-            expect { command.call }.to change { emails.count }.by(1)
+          it "sends a custom email" do
+            expect do
+              perform_enqueued_jobs { command.call }
+            end.to change { emails.count }.by(1)
             expect(last_email_body).to include(URI.encode_www_form(["/admin"]))
           end
 


### PR DESCRIPTION
#### :tophat: What? Why?

I started running tests locally using our test docker image. It worked great but it surfaced some flakyness in the specs. This PR fixes them. It includes:

* Avoid using the `perform_enqueued` callback. It somehow conflicts with the default `ActiveJob` test helper callbacks and causes failures sometimes. Instead, I use `perform_enqueued_jobs` whenever is needed.

* Simplify & improve our select2 test helper. It was unnecessarily complex and it seems that complexity caused some flakies. Also took the chance the make its API consistent with the default `select` capybara helper.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![wtf_gorila](https://user-images.githubusercontent.com/2887858/32872227-5aa42b7c-ca64-11e7-810f-ed18959256ec.gif)
