### PR TITLE
Update home page stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 **Fixed**:
 
+- **decidim-core**: Update home page stat categories
+[\#2221](https://github.com/decidim/decidim/pull/2221)
+
 ## [v0.8.0](https://github.com/decidim/decidim/tree/v0.8.0) (2017-12-4)
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.7.0...v0.8.0)
 

--- a/decidim-accountability/lib/decidim/accountability/feature.rb
+++ b/decidim-accountability/lib/decidim/accountability/feature.rb
@@ -26,7 +26,7 @@ Decidim.register_feature(:accountability) do |feature|
     settings.attribute :heading_leaf_level_results, type: :string, translated: true, editor: true
   end
 
-  feature.register_stat :results_count, primary: true, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |features, start_at, end_at|
+  feature.register_stat :results_count, primary: true, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |features, _start_at, _end_at|
     Decidim::Accountability::Result.where(feature: features).count
   end
 

--- a/decidim-accountability/lib/decidim/accountability/feature.rb
+++ b/decidim-accountability/lib/decidim/accountability/feature.rb
@@ -26,6 +26,10 @@ Decidim.register_feature(:accountability) do |feature|
     settings.attribute :heading_leaf_level_results, type: :string, translated: true, editor: true
   end
 
+  feature.register_stat :results_count, primary: true, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |features, start_at, end_at|
+    Decidim::Accountability::Result.where(feature: features).count
+  end
+
   feature.settings(:step) do |settings|
     settings.attribute :comments_blocked, type: :boolean, default: false
   end

--- a/decidim-assemblies/lib/decidim/assemblies/engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/engine.rb
@@ -51,7 +51,7 @@ module Decidim
       end
 
       initializer "decidim.stats" do
-        Decidim.stats.register :assemblies_count, priority: StatsRegistry::HIGH_PRIORITY do |organization, start_at, end_at|
+        Decidim.stats.register :assemblies_count, priority: StatsRegistry::HIGH_PRIORITY do |organization, _start_at, _end_at|
           Decidim::Assembly.where(organization: organization).published.count
         end
       end

--- a/decidim-assemblies/lib/decidim/assemblies/engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/engine.rb
@@ -50,6 +50,12 @@ module Decidim
         end
       end
 
+      initializer "decidim.stats" do
+        Decidim.stats.register :assemblies_count, priority: StatsRegistry::HIGH_PRIORITY do |organization, start_at, end_at|
+          Decidim::Assembly.where(organization: organization).published.count
+        end
+      end
+
       initializer "decidim_assemblies.menu" do
         Decidim.menu :menu do |menu|
           menu.item I18n.t("menu.assemblies", scope: "decidim"),

--- a/decidim-budgets/lib/decidim/budgets/feature.rb
+++ b/decidim-budgets/lib/decidim/budgets/feature.rb
@@ -19,7 +19,7 @@ Decidim.register_feature(:budgets) do |feature|
     resource.template = "decidim/budgets/projects/linked_projects"
   end
 
-  feature.register_stat :projects_count, primary: true, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |features, start_at, end_at|
+  feature.register_stat :projects_count, primary: true, priority: Decidim::StatsRegistry::LOW_PRIORITY do |features, start_at, end_at|
     Decidim::Budgets::FilteredProjects.for(features, start_at, end_at).count
   end
 

--- a/decidim-core/app/presenters/decidim/home_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/home_stats_presenter.rb
@@ -49,7 +49,7 @@ module Decidim
     private
 
     def global_stats(conditions)
-      Decidim.stats.except([:users_count, :proposals_count])
+      Decidim.stats.except([:users_count, :processes_count])
              .filter(conditions)
              .with_context(published_features)
              .map { |name, data| [name, data] }

--- a/decidim-core/app/presenters/decidim/home_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/home_stats_presenter.rb
@@ -7,7 +7,7 @@ module Decidim
 
     # Public: Render a collection of primary stats.
     def highlighted
-      highlighted_stats = Decidim.stats.only([:users_count, :proposals_count]).with_context(organization).map { |name, data| [name, data] }
+      highlighted_stats = Decidim.stats.only([:users_count, :processes_count]).with_context(organization).map { |name, data| [name, data] }
       highlighted_stats = highlighted_stats.concat(global_stats(priority: StatsRegistry::HIGH_PRIORITY))
       highlighted_stats = highlighted_stats.concat(feature_stats(priority: StatsRegistry::HIGH_PRIORITY))
       highlighted_stats = highlighted_stats.reject(&:empty?)
@@ -56,9 +56,9 @@ module Decidim
     end
 
     def feature_stats(conditions)
-      Decidim.feature_manifests.flat_map do |feature|
+      Decidim.feature_manifests.map do |feature|
         feature.stats.filter(conditions).with_context(published_features).map { |name, data| [name, data] }
-      end
+      end.flatten(1)
     end
 
     def render_stats_data(name, data)

--- a/decidim-core/app/presenters/decidim/home_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/home_stats_presenter.rb
@@ -56,9 +56,9 @@ module Decidim
     end
 
     def feature_stats(conditions)
-      Decidim.feature_manifests.map do |feature|
+      Decidim.feature_manifests.flat_map do |feature|
         feature.stats.filter(conditions).with_context(published_features).map { |name, data| [name, data] }
-      end.flatten(1)
+      end
     end
 
     def render_stats_data(name, data)

--- a/decidim-core/app/presenters/decidim/home_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/home_stats_presenter.rb
@@ -7,7 +7,7 @@ module Decidim
 
     # Public: Render a collection of primary stats.
     def highlighted
-      highlighted_stats = Decidim.stats.only([:users_count, :processes_count]).with_context(organization).map { |name, data| [name, data] }
+      highlighted_stats = Decidim.stats.only([:users_count, :proposals_count]).with_context(organization).map { |name, data| [name, data] }
       highlighted_stats = highlighted_stats.concat(global_stats(priority: StatsRegistry::HIGH_PRIORITY))
       highlighted_stats = highlighted_stats.concat(feature_stats(priority: StatsRegistry::HIGH_PRIORITY))
       highlighted_stats = highlighted_stats.reject(&:empty?)
@@ -49,7 +49,7 @@ module Decidim
     private
 
     def global_stats(conditions)
-      Decidim.stats.except([:users_count, :processes_count])
+      Decidim.stats.except([:users_count, :proposals_count])
              .filter(conditions)
              .with_context(published_features)
              .map { |name, data| [name, data] }
@@ -57,8 +57,8 @@ module Decidim
 
     def feature_stats(conditions)
       Decidim.feature_manifests.map do |feature|
-        feature.stats.filter(conditions).with_context(published_features).map { |name, data| [name, data] }.flatten
-      end
+        feature.stats.filter(conditions).with_context(published_features).map { |name, data| [name, data] }
+      end.flatten(1)
     end
 
     def render_stats_data(name, data)

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -391,6 +391,8 @@ en:
         processes_count: Processes
         projects_count: Projects
         proposals_count: Proposals
+        proposals_accepted: Accepted Proposals
+        assemblies_count: Assemblies
         results_count: Results
         surveys_count: Surveys
         users_count: Participants

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -391,8 +391,8 @@ en:
         pages_count: Pages
         processes_count: Processes
         projects_count: Projects
-        proposals_count: Proposals
         proposals_accepted: Accepted Proposals
+        proposals_count: Proposals
         results_count: Results
         surveys_count: Surveys
         users_count: Participants

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -383,6 +383,7 @@ en:
         welcome: Welcome to %{organization}!
       statistics:
         answers_count: Answers
+        assemblies_count: Assemblies
         comments_count: Comments
         headline: Current state of %{organization}
         meetings_count: Meetings
@@ -392,7 +393,6 @@ en:
         projects_count: Projects
         proposals_count: Proposals
         proposals_accepted: Accepted Proposals
-        assemblies_count: Assemblies
         results_count: Results
         surveys_count: Surveys
         users_count: Participants

--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -48,6 +48,10 @@ Decidim.register_feature(:proposals) do |feature|
     Decidim::Proposals::FilteredProposals.for(features, start_at, end_at).not_hidden.count
   end
 
+  feature.register_stat :proposals_accepted, primary: true, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |features, start_at, end_at|
+    Decidim::Proposals::FilteredProposals.for(features, start_at, end_at).accepted.count
+  end
+
   feature.register_stat :votes_count, priority: Decidim::StatsRegistry::MEDIUM_PRIORITY do |features, start_at, end_at|
     proposals = Decidim::Proposals::FilteredProposals.for(features, start_at, end_at).not_hidden
     Decidim::Proposals::ProposalVote.where(proposal: proposals).count


### PR DESCRIPTION
#### :tophat: What? Why?
Update the stats from the home page to display the most relevant information
The order is not identical to the one in the issue, but I wanted to show the progress so we can discuss farther actions.
The stats for `supports` I could not find where it was stored, I guess are the votes but with different name.

@xabier @mrcasals 

#### :pushpin: Related Issues
- Related to #2003 

#### :clipboard: Subtasks
- [x] Update Stats
- [x] Make sure everything is correct and add tests

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/4672858/32935506-d6004096-cb70-11e7-841a-c7c9baf91918.png)
