### PR TITLE
Dont add redis in docker compose

### DIFF
--- a/lib/generators/decidim/app_generator.rb
+++ b/lib/generators/decidim/app_generator.rb
@@ -64,7 +64,7 @@ module Decidim
       end
 
       def docker
-        template "Dockerfile", "Dockerfile"
+        template "Dockerfile.erb", "Dockerfile"
         template "docker-compose.yml.erb", "docker-compose.yml"
       end
 

--- a/lib/generators/decidim/templates/Dockerfile
+++ b/lib/generators/decidim/templates/Dockerfile
@@ -1,1 +1,0 @@
-FROM decidim/decidim

--- a/lib/generators/decidim/templates/Dockerfile.erb
+++ b/lib/generators/decidim/templates/Dockerfile.erb
@@ -1,0 +1,1 @@
+FROM decidim/decidim:<%= Decidim.version %>

--- a/lib/generators/decidim/templates/docker-compose.yml.erb
+++ b/lib/generators/decidim/templates/docker-compose.yml.erb
@@ -11,37 +11,16 @@ services:
       - DATABASE_HOST=pg
       - DATABASE_USERNAME=postgres
       - RAILS_ENV=development
-      - REDIS_URL=redis://redis:6379
     ports:
       - 3000:3000
     links:
       - pg
-      - redis
     command: bundle exec puma
-  worker:
-    image: decidim/decidim:latest-dev
-    volumes:
-      - .:/app
-      - bundle:/usr/local/bundle
-    environment:
-      - DATABASE_HOST=pg
-      - DATABASE_USERNAME=postgres
-      - RAILS_ENV=development
-      - REDIS_URL=redis://redis:6379
-    links:
-      - pg
-      - redis
-    command: bundle exec sidekiq
   pg:
     image: postgres
     volumes:
       - pg-data:/var/lib/postgresql/data
-  redis:
-    image: redis
-    volumes:
-      - redis-data:/data
 volumes:
   node_modules: {}
   bundle: {}
   pg-data: {}
-  redis-data: {}

--- a/lib/generators/decidim/templates/docker-compose.yml.erb
+++ b/lib/generators/decidim/templates/docker-compose.yml.erb
@@ -1,7 +1,7 @@
 version: '3'
 services:
   app:
-    image: decidim/decidim:latest-dev
+    image: decidim/decidim:<%= Decidim.version %>
     volumes:
       - .:/app
       - bundle:/usr/local/bundle


### PR DESCRIPTION
#### :tophat: What? Why?
Redis isn't needed in a standard rails installation, so let's better not add it on the generated `docker-compose` file.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
*None*
