### PR TITLE
Change queue name from `decidim_events` to `events`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 **Changed**:
 
 - **decidim-core**: Only require default locale translations for i18n fields [\#2204](https://github.com/decidim/decidim/pull/2204)
+- **decidim-core**: Changed `ActiveJob` queue name from `decidim_events` to `events` for consistency reasons [\#2229](https://github.com/decidim/decidim/pull/2229).
 - **decidim-admin**: Replace url to visit_url moderation admin [\#2129](https://github.com/decidim/decidim/pull/2129)
 - **decidim-core**: Hide link to register when user is already logged in [\#2088](https://github.com/decidim/decidim/pull/2088)
 - **decidim-proposals**: Change "Already voted" to "Unvote" on button hover [\#2096](https://github.com/decidim/decidim/pull/2096)

--- a/decidim-core/app/jobs/decidim/email_notification_generator_job.rb
+++ b/decidim-core/app/jobs/decidim/email_notification_generator_job.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   class EmailNotificationGeneratorJob < ApplicationJob
-    queue_as :decidim_events
+    queue_as :events
 
     def perform(event, event_class_name, resource, recipient_ids, extra)
       event_class = event_class_name.constantize

--- a/decidim-core/app/jobs/decidim/notification_generator_for_recipient_job.rb
+++ b/decidim-core/app/jobs/decidim/notification_generator_for_recipient_job.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   class NotificationGeneratorForRecipientJob < ApplicationJob
-    queue_as :decidim_events
+    queue_as :events
 
     def perform(event, event_class_name, resource, recipient_id, extra)
       event_class = event_class_name.constantize

--- a/decidim-core/app/jobs/decidim/notification_generator_job.rb
+++ b/decidim-core/app/jobs/decidim/notification_generator_job.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   class NotificationGeneratorJob < ApplicationJob
-    queue_as :decidim_events
+    queue_as :events
 
     def perform(event, event_class_name, resource, recipient_ids, extra)
       event_class = event_class_name.constantize

--- a/decidim-core/spec/jobs/decidim/email_notification_generator_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/email_notification_generator_job_spec.rb
@@ -7,7 +7,7 @@ describe Decidim::EmailNotificationGeneratorJob do
 
   describe "queue" do
     it "is queued to events" do
-      expect(subject.queue_name).to eq "decidim_events"
+      expect(subject.queue_name).to eq "events"
     end
   end
 

--- a/decidim-core/spec/jobs/decidim/notification_generator_for_recipient_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/notification_generator_for_recipient_job_spec.rb
@@ -7,7 +7,7 @@ describe Decidim::NotificationGeneratorForRecipientJob do
 
   describe "queue" do
     it "is queued to events" do
-      expect(subject.queue_name).to eq "decidim_events"
+      expect(subject.queue_name).to eq "events"
     end
   end
 

--- a/decidim-core/spec/jobs/decidim/notification_generator_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/notification_generator_job_spec.rb
@@ -7,7 +7,7 @@ describe Decidim::NotificationGeneratorJob do
 
   describe "queue" do
     it "is queued to events" do
-      expect(subject.queue_name).to eq "decidim_events"
+      expect(subject.queue_name).to eq "events"
     end
   end
 

--- a/decidim-meetings/app/jobs/decidim/meetings/upcoming_meeting_notification_job.rb
+++ b/decidim-meetings/app/jobs/decidim/meetings/upcoming_meeting_notification_job.rb
@@ -3,7 +3,7 @@
 module Decidim
   module Meetings
     class UpcomingMeetingNotificationJob < ApplicationJob
-      queue_as :decidim_events
+      queue_as :events
 
       def perform(meeting_id, checksum)
         meeting = Decidim::Meetings::Meeting.find(meeting_id)


### PR DESCRIPTION
#### :tophat: What? Why?
This changes the queue name from `decidim_events` to `events` for consistency reasons.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
*None*
