### PR TITLE
Fix flaky first spec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,7 +190,7 @@ GEM
     builder (3.2.3)
     byebug (9.1.0)
     cancancan (2.0.0)
-    capybara (2.15.4)
+    capybara (2.16.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (>= 1.3.3)
@@ -394,7 +394,7 @@ GEM
     premailer-rails (1.9.7)
       actionmailer (>= 3, < 6)
       premailer (~> 1.7, >= 1.7.9)
-    public_suffix (3.0.0)
+    public_suffix (3.0.1)
     puma (3.10.0)
     rack (2.0.3)
     rack-cors (1.0.2)

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -22,11 +22,11 @@ module Decidim
 end
 
 Capybara.register_driver :headless_chrome do |app|
-  browser_options = ::Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << "--headless"
-  browser_options.args << "--no-sandbox"
-  browser_options.args << "--window-size=1024,768"
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
+  options = ::Selenium::WebDriver::Chrome::Options.new
+  options.args << "--headless"
+  options.args << "--no-sandbox"
+  options.args << "--window-size=1024,768"
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 
 Capybara::Screenshot.prune_strategy = :keep_last_run

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -22,11 +22,20 @@ module Decidim
 end
 
 Capybara.register_driver :headless_chrome do |app|
+  http_client = Selenium::WebDriver::Remote::Http::Default.new
+  http_client.read_timeout = 90
+
   options = ::Selenium::WebDriver::Chrome::Options.new
   options.args << "--headless"
   options.args << "--no-sandbox"
   options.args << "--window-size=1024,768"
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :chrome,
+    options: options,
+    http_client: http_client
+  )
 end
 
 Capybara::Screenshot.prune_strategy = :keep_last_run

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/webmock.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/webmock.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 require "webmock/rspec"
-WebMock.allow_net_connect!
+
+WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
#### :tophat: What? Why?

Sometimes the first integration test right after test app generation will timeout with a `Net::ReadTimeout` error because of asset precompilation. These changes increase `selenium`'s timeout so this no longer happens (at least on my machine).
 
#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![homy](https://user-images.githubusercontent.com/2887858/33022922-68974064-cde5-11e7-8d72-cff19c3cef00.gif)

