### PR TITLE
Bump foundation_rails_helper to 3.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,6 @@ PATH
       devise (~> 4.2)
       devise-i18n (~> 1.2.0)
       devise_invitable (~> 1.7.0)
-      foundation_rails_helper (~> 3.0.0.rc)
       jquery-rails (~> 4.3.1)
       sassc-rails (~> 1.3.0)
       select2-rails (~> 4.0.3)
@@ -53,7 +52,7 @@ PATH
       devise-i18n (~> 1.2.0)
       file_validators (~> 2.1.0)
       foundation-rails (~> 6.3.0)
-      foundation_rails_helper (~> 3.0.0.rc)
+      foundation_rails_helper (~> 3.0.0)
       geocoder (~> 1.4.2)
       high_voltage (~> 3.0.0)
       invisible_captcha (~> 0.9.2)
@@ -124,7 +123,6 @@ PATH
       devise (~> 4.2)
       devise-i18n (~> 1.2.0)
       devise_invitable (~> 1.7.1)
-      foundation_rails_helper (~> 3.0.0)
       jquery-rails (~> 4.3.1)
       sassc-rails (~> 1.3.0)
 
@@ -387,7 +385,7 @@ GEM
       ast (~> 2.2)
     pg (0.21.0)
     powerpack (0.1.1)
-    premailer (1.11.0)
+    premailer (1.11.1)
       addressable
       css_parser (>= 1.6.0)
       htmlentities (>= 4.0.0)

--- a/decidim-admin/decidim-admin.gemspec
+++ b/decidim-admin/decidim-admin.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_dependency "devise", "~> 4.2"
   s.add_dependency "devise-i18n", "~> 1.2.0"
   s.add_dependency "devise_invitable", "~> 1.7.0"
-  s.add_dependency "foundation_rails_helper", "~> 3.0.0.rc"
   s.add_dependency "jquery-rails", "~> 4.3.1"
   s.add_dependency "sassc-rails", "~> 1.3.0"
   s.add_dependency "select2-rails", "~> 4.0.3"

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency "devise-i18n", "~> 1.2.0"
   s.add_dependency "file_validators", "~> 2.1.0"
   s.add_dependency "foundation-rails", "~> 6.3.0"
-  s.add_dependency "foundation_rails_helper", "~> 3.0.0.rc"
+  s.add_dependency "foundation_rails_helper", "~> 3.0.0"
   s.add_dependency "geocoder", "~> 1.4.2"
   s.add_dependency "high_voltage", "~> 3.0.0"
   s.add_dependency "invisible_captcha", "~> 0.9.2"

--- a/decidim-system/decidim-system.gemspec
+++ b/decidim-system/decidim-system.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.add_dependency "devise", "~> 4.2"
   s.add_dependency "devise-i18n", "~> 1.2.0"
   s.add_dependency "devise_invitable", "~> 1.7.1"
-  s.add_dependency "foundation_rails_helper", "~> 3.0.0"
   s.add_dependency "jquery-rails", "~> 4.3.1"
   s.add_dependency "sassc-rails", "~> 1.3.0"
 


### PR DESCRIPTION
#### :tophat: What? Why?

I noticed that we were using an rc version in some places and the released one in others. This PR centralizes the dependency in core. Seems the easiest thing to do for now.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![superman](https://user-images.githubusercontent.com/2887858/33097445-f8a74286-cee8-11e7-9662-d39d6f2cb885.gif)

