### PR TITLE
Fix mailer links in development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@
 
 - **decidim-core**: Fixes to MigrateUserRolesToParticipatoryProcessRoles: avoid using relations and work with id's directly [\#2223](https://github.com/decidim/decidim/pull/2223)
 - **decidim-core**: Embedded videos were not displaying properly [\#2198](https://github.com/decidim/decidim/pull/2198)
+- **decidim-core**: Links in emails in development being generated without a port [\#2237](https://github.com/decidim/decidim/pull/2237)
 - **decidim-meetings**: Admins could not submit form after getting a validation error in the meeting registrations form [\2202](https://github.com/decidim/decidim/pull/2202)
-
 
 ## [v0.7.2](https://github.com/decidim/decidim/tree/v0.7.2) (2017-11-06)
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.7.1...v0.7.2)

--- a/decidim-core/lib/decidim/engine_router.rb
+++ b/decidim-core/lib/decidim/engine_router.rb
@@ -28,11 +28,13 @@ module Decidim
       new(target.mounted_admin_engine, target.mounted_params)
     end
 
-    attr_reader :default_url_options
-
     def initialize(engine, default_url_options)
       @engine = engine
       @default_url_options = default_url_options
+    end
+
+    def default_url_options
+      @default_url_options.reverse_merge(ActionMailer::Base.default_url_options)
     end
 
     def respond_to_missing?(method_name, include_private = false)

--- a/decidim-core/spec/presenters/decidim/resource_locator_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/resource_locator_presenter_spec.rb
@@ -23,6 +23,16 @@ module Decidim
         subject { described_class.new(resource).url }
 
         it { is_expected.to eq("http://1.lvh.me/processes/my-process/f/1/dummy_resources/1") }
+
+        context "when specific port configured" do
+          before do
+            allow(ActionMailer::Base)
+              .to receive(:default_url_options)
+              .and_return(port: 3000)
+          end
+
+          it { is_expected.to eq("http://1.lvh.me:3000/processes/my-process/f/1/dummy_resources/1") }
+        end
       end
 
       describe "#path" do

--- a/lib/generators/decidim/install_generator.rb
+++ b/lib/generators/decidim/install_generator.rb
@@ -106,6 +106,7 @@ module Decidim
           <<~RUBY.gsub(/^ *\|/, "")
             |
             |  config.action_mailer.delivery_method = :letter_opener_web
+            |  config.action_mailer.default_url_options = { port: 3000 }
           RUBY
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

Sets a default port for links in the development app, and defaults to it in our link generator.

#### :pushpin: Related Issues
- Fixes #2109.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![polar_floor](https://user-images.githubusercontent.com/2887858/33102157-3d6f3f84-cefa-11e7-9b0a-e44cd770a18c.gif)
