### PR TITLE
Use participatory space instead of process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 **Fixed**:
 
+- **decidim-accountability**: Make accountability work with assemblies [\#2243](https://github.com/decidim/decidim/pull/2243)
 - **decidim-core**: Fixes to MigrateUserRolesToParticipatoryProcessRoles: avoid using relations and work with id's directly [\#2223](https://github.com/decidim/decidim/pull/2223)
 - **decidim-core**: Embedded videos were not displaying properly [\#2198](https://github.com/decidim/decidim/pull/2198)
 - **decidim-core**: Links in emails in development being generated without a port [\#2237](https://github.com/decidim/decidim/pull/2237)

--- a/decidim-accountability/app/controllers/decidim/accountability/results_controller.rb
+++ b/decidim-accountability/app/controllers/decidim/accountability/results_controller.rb
@@ -41,12 +41,12 @@ module Decidim
       end
 
       def first_class_categories
-        @first_class_categories ||= current_participatory_process.categories.first_class
+        @first_class_categories ||= current_participatory_space.categories.first_class
       end
 
       def category
         if params[:filter] && params[:filter][:category_id].present?
-          current_participatory_process.categories.find(params[:filter][:category_id])
+          current_participatory_space.categories.find(params[:filter][:category_id])
         end
       end
 

--- a/decidim-accountability/app/views/decidim/accountability/admin/results/_form.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/results/_form.html.erb
@@ -27,7 +27,7 @@
       <% end %>
 
       <div class="row column">
-        <%= form.categories_select :decidim_category_id, current_participatory_process.categories, include_blank: true, disable_parents: false %>
+        <%= form.categories_select :decidim_category_id, current_participatory_space.categories, include_blank: true, disable_parents: false %>
       </div>
 
     <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
`deicdim-accountability` is using `current_participatory_process` at some methods instead of using the general `current_participatory_space`. This causes the app to break when visiting the feature when it belongs to an assembly.

This PR fixes the problem.

#### :pushpin: Related Issues
None