### PR TITLE
The end of flakyness (part VII)

### DIFF
--- a/decidim-accountability/spec/shared/manage_child_results_examples.rb
+++ b/decidim-accountability/spec/shared/manage_child_results_examples.rb
@@ -39,7 +39,7 @@ RSpec.shared_examples "manage child results" do
   end
 
   it "creates a new child result" do
-    click_link "New Result"
+    click_link "New Result", match: :first
 
     within ".new_result" do
       fill_in_i18n(

--- a/decidim-accountability/spec/shared/manage_results_examples.rb
+++ b/decidim-accountability/spec/shared/manage_results_examples.rb
@@ -42,7 +42,7 @@ shared_examples "manage results" do
   end
 
   it "creates a new result" do
-    click_link "New Result"
+    click_link "New Result", match: :first
 
     within ".new_result" do
       fill_in_i18n(

--- a/decidim-admin/app/helpers/decidim/admin/icon_link_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/icon_link_helper.rb
@@ -22,7 +22,7 @@ module Decidim
                 title: title,
                 target: options[:target]) do
           content_tag(:span, class: "simple-has-tip",
-                             data: { tooltip: true, disable_hover: false },
+                             data: { tooltip: true, disable_hover: false, click_open: false },
                              title: title) do
             icon(icon_name)
           end

--- a/decidim-admin/app/helpers/decidim/admin/icon_link_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/icon_link_helper.rb
@@ -18,10 +18,14 @@ module Decidim
         link_to(link,
                 method: options[:method],
                 class: "action-icon #{options[:class]}",
-                data: { tooltip: true, disable_hover: false }.merge(options[:data] || {}),
+                data: options[:data] || {},
                 title: title,
                 target: options[:target]) do
-          icon(icon_name)
+          content_tag(:span, class: "simple-has-tip",
+                             data: { tooltip: true, disable_hover: false },
+                             title: title) do
+            icon(icon_name)
+          end
         end
       end
     end

--- a/decidim-admin/app/helpers/decidim/admin/icon_link_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/icon_link_helper.rb
@@ -19,8 +19,6 @@ module Decidim
                 method: options[:method],
                 class: "action-icon #{options[:class]}",
                 data: { tooltip: true, disable_hover: false }.merge(options[:data] || {}),
-                tooltip: true,
-                disable_hover: false,
                 title: title,
                 target: options[:target]) do
           icon(icon_name)

--- a/decidim-admin/lib/decidim/admin/test/manage_feature_permissions_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_feature_permissions_examples.rb
@@ -16,7 +16,7 @@ shared_examples "Managing feature permissions" do
     visit participatory_space_engine.features_path(participatory_space)
 
     within ".feature-#{feature.id}" do
-      page.find(".action-icon--permissions").click
+      click_link "Permissions"
     end
   end
 

--- a/decidim-admin/spec/features/admin_manages_organization_admins_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_organization_admins_spec.rb
@@ -74,7 +74,7 @@ describe "Organization admins", type: :feature do
 
       it "can resend the invitation" do
         within "tr[data-user-id=\"#{user.id}\"]" do
-          page.find(".action-icon.resend-invitation").click
+          click_link "Resend invitation"
         end
 
         expect(page).to have_content("Invitation resent successfully")

--- a/decidim-assemblies/spec/features/admin/admin_copy_assembly_spec.rb
+++ b/decidim-assemblies/spec/features/admin/admin_copy_assembly_spec.rb
@@ -22,7 +22,7 @@ describe "Admin copies assembly", type: :feature do
 
   context "without any context" do
     it "copies the assembly with the basic fields" do
-      page.find(".action-icon--copy", match: :first).click
+      click_link "Duplicate", match: :first
 
       within ".copy_assembly" do
         fill_in_i18n(
@@ -44,7 +44,7 @@ describe "Admin copies assembly", type: :feature do
 
   context "with context" do
     before do
-      page.find(".action-icon--copy", match: :first).click
+      click_link "Duplicate", match: :first
 
       within ".copy_assembly" do
         fill_in_i18n(

--- a/decidim-assemblies/spec/features/admin/admin_manages_assembly_features_spec.rb
+++ b/decidim-assemblies/spec/features/admin/admin_manages_assembly_features_spec.rb
@@ -52,7 +52,7 @@ describe "Admin manages assembly features", type: :feature do
     context "and then edit it" do
       before do
         within find("tr", text: "My feature") do
-          page.find(".action-icon--configure").click
+          click_link "Configure"
         end
       end
 
@@ -93,7 +93,7 @@ describe "Admin manages assembly features", type: :feature do
 
     it "updates the feature" do
       within ".feature-#{feature.id}" do
-        page.find(".action-icon--configure").click
+        click_link "Configure"
       end
 
       within ".edit_feature" do
@@ -120,7 +120,7 @@ describe "Admin manages assembly features", type: :feature do
       expect(page).to have_content("My updated feature")
 
       within find("tr", text: "My updated feature") do
-        page.find(".action-icon--configure").click
+        click_link "Configure"
       end
 
       within ".global-settings" do
@@ -173,7 +173,7 @@ describe "Admin manages assembly features", type: :feature do
     context "when the feature is unpublished" do
       it "publishes the feature" do
         within ".feature-#{feature.id}" do
-          page.find(".action-icon--publish").click
+          click_link "Publish"
         end
 
         within ".feature-#{feature.id}" do
@@ -187,7 +187,7 @@ describe "Admin manages assembly features", type: :feature do
 
       it "unpublishes the feature" do
         within ".feature-#{feature.id}" do
-          page.find(".action-icon--unpublish").click
+          click_link "Unpublish"
         end
 
         within ".feature-#{feature.id}" do

--- a/decidim-meetings/spec/shared/manage_meetings_examples.rb
+++ b/decidim-meetings/spec/shared/manage_meetings_examples.rb
@@ -245,9 +245,7 @@ shared_examples "manage meetings" do
       expect(page).to have_admin_callout("Meeting successfully closed")
 
       within find("tr", text: translated(meeting.title)) do
-        within find("td:nth-child(4)") do
-          expect(page).to have_content("Yes")
-        end
+        expect(page).to have_content("Yes")
       end
     end
 

--- a/decidim-participatory_processes/spec/features/admin/admin_copy_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/features/admin/admin_copy_participatory_process_spec.rb
@@ -22,7 +22,7 @@ describe "Admin copies participatory process", type: :feature do
 
   context "without any context" do
     it "copies the process with the basic fields" do
-      page.find(".action-icon--copy", match: :first).click
+      click_link "Duplicate", match: :first
 
       within ".copy_participatory_process" do
         fill_in_i18n(
@@ -44,7 +44,7 @@ describe "Admin copies participatory process", type: :feature do
 
   context "with context" do
     before do
-      page.find(".action-icon--copy", match: :first).click
+      click_link "Duplicate", match: :first
 
       within ".copy_participatory_process" do
         fill_in_i18n(

--- a/decidim-participatory_processes/spec/features/admin/admin_manages_participatory_process_features_spec.rb
+++ b/decidim-participatory_processes/spec/features/admin/admin_manages_participatory_process_features_spec.rb
@@ -57,7 +57,7 @@ describe "Admin manages participatory process features", type: :feature do
       context "and then edit it" do
         before do
           within find("tr", text: "My feature") do
-            page.find(".action-icon--configure").click
+            click_link "Configure"
           end
         end
 
@@ -120,7 +120,7 @@ describe "Admin manages participatory process features", type: :feature do
       context "and then edit it" do
         before do
           within find("tr", text: "My feature") do
-            page.find(".action-icon--configure").click
+            click_link "Configure"
           end
         end
 
@@ -162,7 +162,7 @@ describe "Admin manages participatory process features", type: :feature do
 
     it "updates the feature" do
       within ".feature-#{feature.id}" do
-        page.find(".action-icon--configure").click
+        click_link "Configure"
       end
 
       within ".edit_feature" do
@@ -189,7 +189,7 @@ describe "Admin manages participatory process features", type: :feature do
       expect(page).to have_content("My updated feature")
 
       within find("tr", text: "My updated feature") do
-        page.find(".action-icon--configure").click
+        click_link "Configure"
       end
 
       within ".global-settings" do
@@ -206,7 +206,7 @@ describe "Admin manages participatory process features", type: :feature do
 
       it "updates the default step settings" do
         within ".feature-#{feature.id}" do
-          page.find(".action-icon--configure").click
+          click_link "Configure"
         end
 
         within ".edit_feature" do
@@ -220,7 +220,7 @@ describe "Admin manages participatory process features", type: :feature do
         expect(page).to have_admin_callout("successfully")
 
         within find("tr", text: "My feature") do
-          page.find(".action-icon--configure").click
+          click_link "Configure"
         end
 
         within ".default-step-settings" do
@@ -270,7 +270,7 @@ describe "Admin manages participatory process features", type: :feature do
     context "when the feature is unpublished" do
       it "publishes the feature" do
         within ".feature-#{feature.id}" do
-          page.find(".action-icon--publish").click
+          click_link "Publish"
         end
 
         within ".feature-#{feature.id}" do
@@ -284,7 +284,7 @@ describe "Admin manages participatory process features", type: :feature do
 
       it "unpublishes the feature" do
         within ".feature-#{feature.id}" do
-          page.find(".action-icon--unpublish").click
+          click_link "Unpublish"
         end
 
         within ".feature-#{feature.id}" do

--- a/decidim-participatory_processes/spec/features/admin/admin_manages_user_groups_spec.rb
+++ b/decidim-participatory_processes/spec/features/admin/admin_manages_user_groups_spec.rb
@@ -19,7 +19,7 @@ describe "Admin manages user groups", type: :feature do
 
   it "verifies a user group" do
     within "tr[data-user-group-id=\"#{user_group.id}\"]" do
-      page.find(".action-icon--verify", match: :first).click
+      click_link "Verify", match: :first
     end
 
     expect(page).to have_content("verified successfully")
@@ -31,7 +31,7 @@ describe "Admin manages user groups", type: :feature do
 
   it "reject a user group" do
     within "tr[data-user-group-id=\"#{user_group.id}\"]" do
-      page.find(".action-icon--reject", match: :first).click
+      click_link "Reject", match: :first
     end
 
     expect(page).to have_content("rejected successfully")

--- a/decidim-participatory_processes/spec/shared/manage_process_admins_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_process_admins_examples.rb
@@ -101,7 +101,7 @@ shared_examples "manage process admins examples" do
       it "resends the invitation to the user" do
         within "#process_admins" do
           within find("#process_admins tr", text: "test@example.org") do
-            page.find(".action-icon.resend-invitation").click
+            click_link "Resend invitation"
           end
         end
 

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -386,7 +386,7 @@ shared_examples "manage proposals" do
 
   def go_to_edit_answer(proposal)
     within find("tr", text: proposal.title) do
-      find("a.action-icon--edit-answer").click
+      click_link "Answer"
     end
 
     expect(page).to have_selector(".edit_proposal_answer")

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -228,11 +228,7 @@ shared_examples "manage proposals" do
       end
 
       it "can reject a proposal" do
-        within find("tr", text: proposal.title) do
-          find("a.action-icon--edit-answer").click
-        end
-
-        expect(page).to have_selector(".edit_proposal_answer")
+        go_to_edit_answer(proposal)
 
         within ".edit_proposal_answer" do
           fill_in_i18n_editor(
@@ -254,11 +250,7 @@ shared_examples "manage proposals" do
       end
 
       it "can accept a proposal" do
-        within find("tr", text: proposal.title) do
-          find("a.action-icon--edit-answer").click
-        end
-
-        expect(page).to have_selector(".edit_proposal_answer")
+        go_to_edit_answer(proposal)
 
         within ".edit_proposal_answer" do
           choose "Accepted"
@@ -273,11 +265,7 @@ shared_examples "manage proposals" do
       end
 
       it "can mark a proposal as evaluating" do
-        within find("tr", text: proposal.title) do
-          find("a.action-icon--edit-answer").click
-        end
-
-        expect(page).to have_selector(".edit_proposal_answer")
+        go_to_edit_answer(proposal)
 
         within ".edit_proposal_answer" do
           choose "Evaluating"
@@ -306,11 +294,7 @@ shared_examples "manage proposals" do
           expect(page).to have_content("Rejected")
         end
 
-        within find("tr", text: proposal.title) do
-          find("a.action-icon--edit-answer").click
-        end
-
-        expect(page).to have_selector(".edit_proposal_answer")
+        go_to_edit_answer(proposal)
 
         within ".edit_proposal_answer" do
           choose "Accepted"
@@ -398,5 +382,13 @@ shared_examples "manage proposals" do
         expect(page).to have_content("VOTES")
       end
     end
+  end
+
+  def go_to_edit_answer(proposal)
+    within find("tr", text: proposal.title) do
+      find("a.action-icon--edit-answer").click
+    end
+
+    expect(page).to have_selector(".edit_proposal_answer")
   end
 end

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -249,9 +249,7 @@ shared_examples "manage proposals" do
         expect(page).to have_admin_callout("Proposal successfully answered")
 
         within find("tr", text: proposal.title) do
-          within find("td:nth-child(5)") do
-            expect(page).to have_content("Rejected")
-          end
+          expect(page).to have_content("Rejected")
         end
       end
 
@@ -270,9 +268,7 @@ shared_examples "manage proposals" do
         expect(page).to have_admin_callout("Proposal successfully answered")
 
         within find("tr", text: proposal.title) do
-          within find("td:nth-child(5)") do
-            expect(page).to have_content("Accepted")
-          end
+          expect(page).to have_content("Accepted")
         end
       end
 
@@ -291,9 +287,7 @@ shared_examples "manage proposals" do
         expect(page).to have_admin_callout("Proposal successfully answered")
 
         within find("tr", text: proposal.title) do
-          within find("td:nth-child(5)") do
-            expect(page).to have_content("Evaluating")
-          end
+          expect(page).to have_content("Evaluating")
         end
       end
 
@@ -309,9 +303,7 @@ shared_examples "manage proposals" do
         visit_feature_admin
 
         within find("tr", text: proposal.title) do
-          within find("td:nth-child(5)") do
-            expect(page).to have_content("Rejected")
-          end
+          expect(page).to have_content("Rejected")
           find("a.action-icon--edit-answer").click
         end
 
@@ -325,9 +317,7 @@ shared_examples "manage proposals" do
         expect(page).to have_admin_callout("Proposal successfully answered")
 
         within find("tr", text: proposal.title) do
-          within find("td:nth-child(5)") do
-            expect(page).to have_content("Accepted")
-          end
+          expect(page).to have_content("Accepted")
         end
       end
     end

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -304,6 +304,9 @@ shared_examples "manage proposals" do
 
         within find("tr", text: proposal.title) do
           expect(page).to have_content("Rejected")
+        end
+
+        within find("tr", text: proposal.title) do
           find("a.action-icon--edit-answer").click
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?

This is like the 7th PR I open asserting that flakyness is finally gone. Ok, now I'm serious. It's gone :smile: 

In this case the problem was two javascript link enhancements competing to take over the link: foundation's tooltip and rails ujs to send a post request from the link. I fixed it by disabling any tooltip behavior on click and by moving the tooltip to an span inside the link. Also make the tests better by using link's titles instead of specific markup.

#### :pushpin: Related Issues
- Related to #1376 
- Related to #1402
- Related to #1426 
- Related to #1530 
- Related to #2231 
- Related to #1426 
 
#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![shower_tortuga](https://user-images.githubusercontent.com/2887858/33191001-d2214e6c-d092-11e7-974c-199176c9e6ad.gif)
