### PR TITLE
Update scope_type.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 **Fixed**:
 
+- **decidim-core**: Fixes ScopeType relation with Scope [\#2255](https://github.com/decidim/decidim/pull/2255)
 - **decidim-accountability**: Make accountability work with assemblies [\#2243](https://github.com/decidim/decidim/pull/2243)
 - **decidim-core**: Fixes to MigrateUserRolesToParticipatoryProcessRoles: avoid using relations and work with id's directly [\#2223](https://github.com/decidim/decidim/pull/2223)
 - **decidim-core**: Embedded videos were not displaying properly [\#2198](https://github.com/decidim/decidim/pull/2198)

--- a/decidim-core/app/models/decidim/scope_type.rb
+++ b/decidim-core/app/models/decidim/scope_type.rb
@@ -9,7 +9,7 @@ module Decidim
                class_name: "Decidim::Organization",
                inverse_of: :scope_types
 
-    has_many :scopes, foreign_key: "decidim_scope_type_id", class_name: "Decidim::Scope", inverse_of: :scope_type, dependent: :nullify
+    has_many :scopes, foreign_key: "scope_type_id", class_name: "Decidim::Scope", inverse_of: :scope_type, dependent: :nullify
 
     validates :name, presence: true
   end


### PR DESCRIPTION
Wrong name of foreign key of scopes

#### :tophat: What? Why?

When you use the relation to scopes fails. e.g. Decidim::ScopeType.first.scopes 

#### :ghost: GIF
![]()
