### PR TITLE
Remove video from newsletter editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 **Fixed**:
 
+- **decidim-admin**: Do not let newsletters have videos, as emails can't render them [\#2257](https://github.com/decidim/decidim/pull/2257)
 - **decidim-core**: Fixes ScopeType relation with Scope [\#2255](https://github.com/decidim/decidim/pull/2255)
 - **decidim-core**: Fixes to MigrateUserRolesToParticipatoryProcessRoles: avoid using relations and work with id's directly [\#2223](https://github.com/decidim/decidim/pull/2223)
 - **decidim-core**: Embedded videos were not displaying properly [\#2198](https://github.com/decidim/decidim/pull/2198)

--- a/decidim-admin/app/views/decidim/admin/newsletters/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/newsletters/_form.html.erb
@@ -3,7 +3,7 @@
 </div>
 
 <div class="row column">
-  <%= form.translated :editor, :body %>
+  <%= form.translated :editor, :body, toolbar: "basic-no-video" %>
 </div>
 
 <div class="row column">

--- a/decidim-core/app/assets/javascripts/decidim/editor.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/editor.js.es6
@@ -11,13 +11,19 @@ $(() => {
     let quillToolbar = [
       ['bold', 'italic', 'underline'],
       [{ list: 'ordered' }, { list: 'bullet' }],
-      ['link', 'video', 'clean']
+      ['link', 'clean']
     ];
 
     if (toolbar === 'full') {
       quillToolbar = [
         [{ header: [1, 2, 3, 4, 5, 6, false] }],
-        ...quillToolbar
+        ...quillToolbar,
+        ['video']
+      ];
+    } else if (toolbar === 'basic') {
+      quillToolbar = [
+        ...quillToolbar,
+        ['video']
       ];
     }
 


### PR DESCRIPTION
#### :tophat: What? Why?
Removes the video element from the newsletter editor, while keeping it in the other places.

#### :pushpin: Related Issues
- Fixes #2227

### :camera: Screenshots (optional)
Newsletter editor:
![Description](https://i.imgur.com/MOFFOS4.png)

Process editors:
![](https://i.imgur.com/i42hkFT.png)
