### PR TITLE
Use yarn.lock in cache keys in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,12 +211,12 @@ jobs:
           at: /app
       - restore_cache:
           keys:
-            - npm-dependencies-{{ checksum "package-lock.json" }}
+            - npm-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: Install npm dependencies
           command: npm install --no-save
       - save_cache:
-          key: npm-dependencies-{{ checksum "package-lock.json" }}
+          key: npm-dependencies-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,17 +211,17 @@ jobs:
           at: /app
       - restore_cache:
           keys:
-            - npm-dependencies-{{ checksum "yarn.lock" }}
+            - yarn-dependencies-{{ checksum "yarn.lock" }}
       - run:
-          name: Install npm dependencies
-          command: npm install --no-save
+          name: Install yarn dependencies
+          command: yarn
       - save_cache:
-          key: npm-dependencies-{{ checksum "yarn.lock" }}
+          key: yarn-dependencies-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
       - run:
-          name: Run main folder npm lint
-          command: npm run lint
+          name: Run main folder yarn lint
+          command: yarn lint
       - restore_cache:
           keys:
             - bundler-dependencies-{{ checksum "Gemfile.lock" }}


### PR DESCRIPTION
#### :tophat: What? Why?
Uses `yarn.lock` in CI cache keys instead of unexisting `package-lock.json` file, as per #2254.

#### :pushpin: Related Issues
- Related to #2254
