### PR TITLE
es datepicker invalid format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 **Fixed**:
 
+- **decidim-core**: Fix foundation datepicker es date format [\#2278](https://github.com/decidim/decidim/pull/2278)
 - **decidim-admin**: Do not let newsletters have videos, as emails can't render them [\#2257](https://github.com/decidim/decidim/pull/2257)
 - **decidim-core**: Fixes ScopeType relation with Scope [\#2255](https://github.com/decidim/decidim/pull/2255)
 - **decidim-core**: Fixes to MigrateUserRolesToParticipatoryProcessRoles: avoid using relations and work with id's directly [\#2223](https://github.com/decidim/decidim/pull/2223)

--- a/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.es.js
+++ b/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.es.js
@@ -9,6 +9,8 @@
 		daysMin: ["Do", "Lu", "Ma", "Mi", "Ju", "Vi", "Sa", "Do"],
 		months: ["Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio", "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre"],
 		monthsShort: ["Ene", "Feb", "Mar", "Abr", "May", "Jun", "Jul", "Ago", "Sep", "Oct", "Nov", "Dic"],
-		today: "Hoy"
-	};
+		today: "Hoy",
+    weekStart: 1,
+    format: "dd/mm/yyyy"
+  };
 }(jQuery));


### PR DESCRIPTION
#### :tophat: What? Why?
When using datepicker for date_time in spanish the format is incorrect. Month and Day are swapped

#### :ghost: GIF
![]()
