### PR TITLE
Ignore builds that start with l10n

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,8 +358,11 @@ workflows:
       - build_test_app:
           filters:
             branches:
-              ignore: /^l10n_/
-      - main
+              ignore: /^l10n_.*/
+      - main:
+          filters:
+            branches:
+              ignore: /^l10n_.*/
       - core:
           requires:
             - build_test_app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,7 +355,10 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build_test_app
+      - build_test_app:
+          filters:
+            branches:
+              ignore: /^l10n_/
       - main
       - core:
           requires:


### PR DESCRIPTION
#### :tophat: What? Why?
Crowdin Translation PRs and CircleCI workflows aren't best friends. One keeps stepping at the other.

This will ignore test runs on translation PRs, so we can issue PRs manually afterwards.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
*None*