### PR TITLE
Do not replace in inexisting file

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -44,12 +44,6 @@ task :update_versions do
     "  \"version\": \"#{version}\""
   )
 
-  replace_file(
-    "#{__dir__}/package-lock.json",
-    /^  "version": "[^"]*"/,
-    "  \"version\": \"#{version}\""
-  )
-
   DECIDIM_GEMS.each do |name|
     replace_file(
       "#{__dir__}/decidim-#{name}/lib/decidim/#{name}/version.rb",


### PR DESCRIPTION
#### :tophat: What? Why?
Since #2254 `package-lock.json` file does not exist, so we should not replace its contents when releasing new versions (we're preparing version 0.8.0 🎉 )

#### :pushpin: Related Issues
- Related to #2254
