### PR TITLE
Exact match on branch name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,11 +358,11 @@ workflows:
       - build_test_app:
           filters:
             branches:
-              ignore: /^l10n_.*/
+              ignore: /^l10n_master$/
       - main:
           filters:
             branches:
-              ignore: /^l10n_.*/
+              ignore: /^l10n_master$/
       - core:
           requires:
             - build_test_app


### PR DESCRIPTION
#### :tophat: What? Why?
This makes matching exact when ignoring the `l10_master` branch to prevent contributors from accidentally using that as a branch name.

#### :pushpin: Related Issues
- Related to #2294

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/73h3LBWraONTW/giphy.gif)
