### PR TITLE
Broken pages title fixed

### DIFF
--- a/decidim-assemblies/app/views/decidim/assemblies/assemblies/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/assemblies/index.html.erb
@@ -1,4 +1,4 @@
-<% provide :meta_title, t("assemblies.index.title", scope: "decidim") %>
+<% add_decidim_meta_tags(title: t("assemblies.index.title", scope: "decidim")) %>
 
 <main class="wrapper">
   <% if promoted_assemblies.any? %>

--- a/decidim-core/app/views/pages/home.html.erb
+++ b/decidim-core/app/views/pages/home.html.erb
@@ -1,5 +1,3 @@
-<% add_decidim_meta_tags(title: current_organization.name) %>
-
 <%= render partial: 'pages/home/hero' %>
 
 <% if !translated_attribute(current_organization.description).blank? %>

--- a/decidim-core/app/views/pages/home.html.erb
+++ b/decidim-core/app/views/pages/home.html.erb
@@ -1,4 +1,4 @@
-<% provide(:meta_title, current_organization.name) %>
+<% add_decidim_meta_tags(title: current_organization.name) %>
 
 <%= render partial: 'pages/home/hero' %>
 

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_process_groups/show.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_process_groups/show.html.erb
@@ -1,4 +1,4 @@
-<% provide :meta_title, t("participatory_process_groups.show.title", scope: "decidim") %>
+<% add_decidim_meta_tags(title: t("participatory_process_groups.show.title", scope: "decidim")) %>
 
 <main class="wrapper">
   <section id="processes-grid" class="section row collapse">

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/index.html.erb
@@ -1,4 +1,4 @@
-<% provide :meta_title, t("participatory_processes.index.title", scope: "decidim") %>
+<% add_decidim_meta_tags(title: t("participatory_processes.index.title", scope: "decidim")) %>
 
 <main class="wrapper">
   <% if promoted_participatory_processes.any? %>


### PR DESCRIPTION
#### :tophat: What? Why?
Some pages are not showing its title properly, only showing the organization name (e.g. https://www.decidim.barcelona/processes).

It seems that we are still using `provide :meta_title, ...` instead of the `add_decidim_meta_tags` in 4 templates, while no other code uses that information: https://github.com/decidim/decidim/search?utf8=%E2%9C%93&q=meta_title&type=

In particular, home page is already showing the organization name, so I removed this code without replacing it.

#### :pushpin: Related Issues
- Related to #981
- Related to #675

#### :ghost: GIF
![](https://media.giphy.com/media/PB787iGN8rk2I/giphy.gif)