### PR TITLE
Fixed participatory processes groups page title.

### DIFF
--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -206,7 +206,7 @@ en:
     participatory_process_groups:
       show:
         group_participatory_processes: Processes for %{group}
-        title: Title
+        title: Participatory process groups
     participatory_process_steps:
       index:
         process_steps: Process steps


### PR DESCRIPTION
#### :tophat: What? Why?
Participatory processes groups page (/processes_groups/[:id]) "is using" Title as page title. This was fixed in spanish, catalan and basque translations (e.g. https://github.com/decidim/decidim/blob/master/decidim-participatory_processes/config/locales/es.yml#L208), but other languages are wrong. I guess this is because the translators are using English as base language.

The "is using" expression is because this only will have sense when #2303 is merged, since this translation is not visible in any page currently.

#### :pushpin: Related Issues
- Related to #2303

#### :ghost: GIF
![](http://uploads.webflow.com/5330b8d47d21afd9750002fc/55821762a01322e558ffcfcb_funny-karate-nija-baby-kid-animated-gif-pics.gif)
