### PR TITLE
Ensure locale is kept between feature pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - **decidim-core**: Fixes to MigrateUserRolesToParticipatoryProcessRoles: avoid using relations and work with id's directly [\#2223](https://github.com/decidim/decidim/pull/2223)
 - **decidim-core**: Embedded videos were not displaying properly [\#2198](https://github.com/decidim/decidim/pull/2198)
 - **decidim-core**: Links in emails in development being generated without a port [\#2237](https://github.com/decidim/decidim/pull/2237)
+- **decidim-core**: Ensure locale is kept between feature pages [\#2310](https://github.com/decidim/decidim/pull/2310)
 - **decidim-participatory-processes**: Fixes active processes and adds all processes filters [\#2081](https://github.com/decidim/decidim/pull/2131)
 
 ## [v0.7.4](https://github.com/decidim/decidim/tree/v0.7.4) (2017-11-23)

--- a/decidim-core/app/helpers/decidim/feature_path_helper.rb
+++ b/decidim-core/app/helpers/decidim/feature_path_helper.rb
@@ -9,7 +9,8 @@ module Decidim
     #
     # Returns a url.
     def main_feature_path(feature)
-      EngineRouter.main_proxy(feature).root_path
+      current_params = try(:params) || {}
+      EngineRouter.main_proxy(feature).root_path(locale: current_params[:locale])
     end
 
     # Returns the defined admin root path for a given feature.
@@ -18,7 +19,8 @@ module Decidim
     #
     # Returns a url.
     def manage_feature_path(feature)
-      EngineRouter.admin_proxy(feature).root_path
+      current_params = try(:params) || {}
+      EngineRouter.admin_proxy(feature).root_path(locale: current_params[:locale])
     end
   end
 end

--- a/decidim-core/spec/helpers/decidim/feature_path_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/feature_path_helper_spec.rb
@@ -14,12 +14,33 @@ module Decidim
       it "resolves the root path for the feature" do
         expect(helper.main_feature_path(feature)).to eq("/processes/my-process/f/21/")
       end
+
+      context "when a secondary locale is set" do
+        before do
+          params[:locale] = "ca"
+        end
+
+        it "adds the locale to the path" do
+          expect(helper.main_feature_path(feature)).to eq("/processes/my-process/f/21/?locale=ca")
+        end
+      end
     end
 
     describe "manage_feature_path" do
       it "resolves the admin root path for the feature" do
-        expect(helper.manage_feature_path(feature)).to \
-          eq("/admin/participatory_processes/my-process/features/21/manage/")
+        expect(helper.manage_feature_path(feature))
+          .to eq("/admin/participatory_processes/my-process/features/21/manage/")
+      end
+
+      context "when a secondary locale is set" do
+        before do
+          params[:locale] = "ca"
+        end
+
+        it "adds the locale to the path" do
+          expect(helper.manage_feature_path(feature))
+            .to eq("/admin/participatory_processes/my-process/features/21/manage/?locale=ca")
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
As reported at #2308, when an anonymous user is visiting the website in a secondary locale (that is, a locale that is not the default one), links between participatory space features lose the locale, so when you visit a feature the locale is reset to the default one.

This PR fixes it.

#### :pushpin: Related Issues
- Fixes #2308