### PR TITLE
Make all authorizations automatically expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ you need to change the following line in `config/environments/production.rb`:
 ```
 
 **Added**:
-- **decidim-verifications**: Let developrs specify for how long authorizations are valid. After this space of time passes, authorizations expire and users need to re-authorize [\#2311](https://github.com/decidim/decidim/pull/2311)
+- **decidim-verifications**: Let developers specify for how long authorizations are valid. After this space of time passes, authorizations expire and users need to re-authorize [\#2311](https://github.com/decidim/decidim/pull/2311)
 
 **Changed**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ you need to change the following line in `config/environments/production.rb`:
 ```
 
 **Added**:
+- **decidim-verifications**: Let developrs specify for how long authorizations are valid. After this space of time passes, authorizations expire and users need to re-authorize [\#2311](https://github.com/decidim/decidim/pull/2311)
 
 **Changed**:
 

--- a/decidim-core/app/models/decidim/authorization.rb
+++ b/decidim-core/app/models/decidim/authorization.rb
@@ -38,7 +38,7 @@ module Decidim
     def expires_at
       return unless workflow_manifest
       return if workflow_manifest.expires_in.zero?
-      granted_at + workflow_manifest.expires_in
+      (granted_at || created_at) + workflow_manifest.expires_in
     end
 
     def expired?
@@ -48,11 +48,7 @@ module Decidim
     private
 
     def active_handler?
-      if workflow_manifest.present?
-        true
-      else
-        false
-      end
+      workflow_manifest.present?
     end
 
     def workflow_manifest

--- a/decidim-core/app/models/decidim/authorization.rb
+++ b/decidim-core/app/models/decidim/authorization.rb
@@ -41,6 +41,10 @@ module Decidim
       granted_at + workflow_manifest.expires_in
     end
 
+    def expired?
+      expires_at.present? && expires_at < Time.zone.now
+    end
+
     private
 
     def active_handler?

--- a/decidim-core/app/models/decidim/authorization.rb
+++ b/decidim-core/app/models/decidim/authorization.rb
@@ -31,14 +31,28 @@ module Decidim
       !granted_at.nil?
     end
 
+    # Calculates at when this authorization will expire, if it needs to.
+    #
+    # Returns nil if the authorization does not expire.
+    # Returns an ActiveSupport::TimeWithZone if it expires.
+    def expires_at
+      return unless workflow_manifest
+      return if workflow_manifest.expires_in.zero?
+      granted_at + workflow_manifest.expires_in
+    end
+
     private
 
     def active_handler?
-      if Decidim::Verifications.find_workflow_manifest(name)
+      if workflow_manifest.present?
         true
       else
         false
       end
+    end
+
+    def workflow_manifest
+      @workflow_manifest ||= Decidim::Verifications.find_workflow_manifest(name)
     end
   end
 end

--- a/decidim-core/app/services/decidim/action_authorizer.rb
+++ b/decidim-core/app/services/decidim/action_authorizer.rb
@@ -108,7 +108,7 @@ module Decidim
     def authorization_expired?
       return false if authorization.expires_at.blank?
 
-      authorization.expires_at < Time.zone.today
+      authorization.expires_at < Time.zone.now
     end
 
     class AuthorizationStatus

--- a/decidim-core/app/services/decidim/action_authorizer.rb
+++ b/decidim-core/app/services/decidim/action_authorizer.rb
@@ -22,6 +22,8 @@ module Decidim
     # Broadcasts:
     #   ok           - When everything is OK and the user is correctly authorized.
     #   missing      - When no valid authorization can be found.
+    #   expired      - The validity time for the given authorization has run out, and
+    #                  needs to be re-validated.
     #   pending      - When an authorization was found, but is not complete (eg. is
     #                  waiting for admin manual confirmation).
     #   invalid      - When an authorization was found, but the value of some of its fields
@@ -29,8 +31,6 @@ module Decidim
     #                  but this action is only for users in scope B).
     #   incomplete   - An authorization was found, but lacks some required fields. User
     #                  should re-authenticate.
-    #   expired      - The validity time for the given authorization has run out, and
-    #                  needs to be re-validated.
     #
     # Returns nil.
     def authorize
@@ -48,14 +48,14 @@ module Decidim
         :ok
       elsif !authorization
         :missing
+      elsif authorization_expired?
+        :expired
       elsif !authorization.granted?
         :pending
       elsif unmatched_fields.any?
         [:invalid, fields: unmatched_fields]
       elsif missing_fields.any?
         [:incomplete, fields: missing_fields]
-      elsif authorization_expired?
-        :expired
       else
         :ok
       end

--- a/decidim-core/app/services/decidim/action_authorizer.rb
+++ b/decidim-core/app/services/decidim/action_authorizer.rb
@@ -106,13 +106,9 @@ module Decidim
     end
 
     def authorization_expired?
-      manifest = Decidim::Verifications.find_workflow_manifest(authorization_handler_name)
+      return false if authorization.expires_at.blank?
 
-      return unless manifest
-      return false if manifest.expires_in.zero?
-
-      expiry_date = authorization.granted_at + manifest.expires_in
-      expiry_date < Time.zone.today
+      authorization.expires_at < Time.zone.today
     end
 
     class AuthorizationStatus

--- a/decidim-core/app/services/decidim/action_authorizer.rb
+++ b/decidim-core/app/services/decidim/action_authorizer.rb
@@ -108,7 +108,7 @@ module Decidim
     def authorization_expired?
       return false if authorization.expires_at.blank?
 
-      authorization.expires_at < Time.zone.now
+      authorization.expired?
     end
 
     class AuthorizationStatus

--- a/decidim-core/app/views/decidim/shared/_action_authorization_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_action_authorization_modal.html.erb
@@ -44,6 +44,16 @@
             <%= link_to t('.missing.authorize', authorization: t("#{status.handler_name}.name", scope: "decidim.authorization_handlers")), authorize_action_path(action), class: "button expanded" %>
           </div>
         </div>
+      <% elsif status.code == :expired %>
+        <div class="reveal__header missing-authorization">
+          <h3 class="reveal__title"><%= t('.expired.title') %></h3>
+        </div>
+        <p><%= t ".expired.explanation", authorization: t("#{status.handler_name}.name", scope: "decidim.authorization_handlers") %></p>
+        <div class="row">
+          <div class="columns medium-8 medium-offset-2">
+            <%= link_to t('.expired.authorize', authorization: t("#{status.handler_name}.name", scope: "decidim.authorization_handlers")), authorize_action_path(action), class: "button expanded" %>
+          </div>
+        </div>
       <% elsif status.code == :invalid %>
         <div class="reveal__header invalid-authorization">
           <h3 class="reveal__title"><%= t('.unauthorized.title') %></h3>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -237,6 +237,10 @@ en:
         success: The report has been created successfully and it will be reviewed by an admin.
     shared:
       action_authorization_modal:
+        expired:
+          authorize: Reauthorize with "%{authorization}"
+          explanation: Your authorization has expired. In order to perform this action, you need to be reauthorized with "%{authorization}".
+          title: Authorization has expired
         incomplete:
           cancel: Cancel
           explanation: 'Even though you''re currently authorized with "%{authorization}", we need you to reauthorize because we lack the following data:'

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -70,6 +70,7 @@ en:
         name: Dummy authorization workflow
       errors:
         duplicate_authorization: A user is already authorized with the same data.
+      expires_at: Expires at %{timestamp}
       foo_authorization:
         fields:
           bar: Bar

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -70,6 +70,7 @@ en:
         name: Dummy authorization workflow
       errors:
         duplicate_authorization: A user is already authorized with the same data.
+      expired_at: Expired at %{timestamp}
       expires_at: Expires at %{timestamp}
       foo_authorization:
         fields:

--- a/decidim-core/spec/services/decidim/action_authorizer_spec.rb
+++ b/decidim-core/spec/services/decidim/action_authorizer_spec.rb
@@ -111,7 +111,7 @@ module Decidim
                 allow(authorizer)
                   .to receive(:authorization).and_return(authorization)
                 allow(authorization)
-                  .to receive(:expires_at).and_return(1.minute.ago)
+                  .to receive(:expired?).and_return(true)
               end
 
               it "returns expired" do
@@ -126,7 +126,7 @@ module Decidim
                 allow(authorizer)
                   .to receive(:authorization).and_return(authorization)
                 allow(authorization)
-                  .to receive(:expires_at).and_return(1.hour.from_now)
+                  .to receive(:expired?).and_return(false)
               end
 
               context "when it doesn't have options" do

--- a/decidim-core/spec/services/decidim/action_authorizer_spec.rb
+++ b/decidim-core/spec/services/decidim/action_authorizer_spec.rb
@@ -6,7 +6,8 @@ module Decidim
   describe ActionAuthorizer do
     subject { described_class.new(user, feature, action) }
 
-    let(:user) { create(:user) }
+    let(:organization) { create :organization }
+    let(:user) { create(:user, organization: organization) }
     let(:feature) { create(:feature, permissions: permissions) }
     let(:action) { "vote" }
     let(:permissions) { { action => permission } }
@@ -100,49 +101,73 @@ module Decidim
           end
 
           context "when the authorization type matches" do
-            context "when it doesn't have options" do
-              let(:options) { {} }
-
-              it "returns ok" do
-                expect(response).to be_ok
+            context "when it has expired" do
+              let!(:authorization) do
+                create(:authorization, :granted, name: name, metadata: metadata, granted_at: 2.months.ago)
               end
-            end
 
-            context "when has options that doesn't match the authorization" do
-              let(:options) { { postal_code: "789" } }
+              before do
+                allow_any_instance_of(Decidim::Verifications::WorkflowManifest)
+                  .to receive(:expires_in).and_return(1.month)
+              end
 
-              it "returns invalid" do
+              it "returns expired" do
                 expect(response).not_to be_ok
-                expect(response.code).to eq(:invalid)
+                expect(response.code).to eq(:expired)
                 expect(response.handler_name).to eq("dummy_authorization_handler")
-                expect(response.data).to include(fields: { "postal_code" => "789" })
               end
             end
 
-            context "when has options that exactly match the authorization" do
-              let(:options) { { postal_code: "1234", location: "Tomorrowland" } }
-
-              it "returns ok" do
-                expect(response).to be_ok
+            context "when it has not expired" do
+              before do
+                allow_any_instance_of(Decidim::Verifications::WorkflowManifest)
+                  .to receive(:expires_in).and_return(1.month)
               end
-            end
 
-            context "when has options that partially match the authorization" do
-              let(:options) { { postal_code: "1234" } }
+              context "when it doesn't have options" do
+                let(:options) { {} }
 
-              it "returns ok" do
-                expect(response).to be_ok
+                it "returns ok" do
+                  expect(response).to be_ok
+                end
               end
-            end
 
-            context "when has options that contains more keys than the authorization" do
-              let(:options) { { postal_code: "1234", age: 18 } }
+              context "when has options that doesn't match the authorization" do
+                let(:options) { { postal_code: "789" } }
 
-              it "returns incomplete with the fields" do
-                expect(response).not_to be_ok
-                expect(response.code).to eq(:incomplete)
-                expect(response.handler_name).to eq("dummy_authorization_handler")
-                expect(response.data).to include(fields: ["age"])
+                it "returns invalid" do
+                  expect(response).not_to be_ok
+                  expect(response.code).to eq(:invalid)
+                  expect(response.handler_name).to eq("dummy_authorization_handler")
+                  expect(response.data).to include(fields: { "postal_code" => "789" })
+                end
+              end
+
+              context "when has options that exactly match the authorization" do
+                let(:options) { { postal_code: "1234", location: "Tomorrowland" } }
+
+                it "returns ok" do
+                  expect(response).to be_ok
+                end
+              end
+
+              context "when has options that partially match the authorization" do
+                let(:options) { { postal_code: "1234" } }
+
+                it "returns ok" do
+                  expect(response).to be_ok
+                end
+              end
+
+              context "when has options that contains more keys than the authorization" do
+                let(:options) { { postal_code: "1234", age: 18 } }
+
+                it "returns incomplete with the fields" do
+                  expect(response).not_to be_ok
+                  expect(response.code).to eq(:incomplete)
+                  expect(response.handler_name).to eq("dummy_authorization_handler")
+                  expect(response.data).to include(fields: ["age"])
+                end
               end
             end
           end

--- a/decidim-core/spec/services/decidim/action_authorizer_spec.rb
+++ b/decidim-core/spec/services/decidim/action_authorizer_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 module Decidim
   describe ActionAuthorizer do
-    subject { described_class.new(user, feature, action) }
+    subject { authorizer }
 
     let(:organization) { create :organization }
     let(:user) { create(:user, organization: organization) }
@@ -12,6 +12,7 @@ module Decidim
     let(:action) { "vote" }
     let(:permissions) { { action => permission } }
     let(:name) { "dummy_authorization_handler" }
+    let(:authorizer) { described_class.new(user, feature, action) }
 
     let!(:authorization) do
       create(:authorization, :granted, name: name, metadata: metadata)
@@ -107,8 +108,10 @@ module Decidim
               end
 
               before do
-                allow_any_instance_of(Decidim::Verifications::WorkflowManifest)
-                  .to receive(:expires_in).and_return(1.month)
+                allow(authorizer)
+                  .to receive(:authorization).and_return(authorization)
+                allow(authorization)
+                  .to receive(:expires_at).and_return(1.month.ago)
               end
 
               it "returns expired" do
@@ -120,8 +123,10 @@ module Decidim
 
             context "when it has not expired" do
               before do
-                allow_any_instance_of(Decidim::Verifications::WorkflowManifest)
-                  .to receive(:expires_in).and_return(1.month)
+                allow(authorizer)
+                  .to receive(:authorization).and_return(authorization)
+                allow(authorization)
+                  .to receive(:expires_at).and_return(1.month.from_now)
               end
 
               context "when it doesn't have options" do

--- a/decidim-core/spec/services/decidim/action_authorizer_spec.rb
+++ b/decidim-core/spec/services/decidim/action_authorizer_spec.rb
@@ -111,7 +111,7 @@ module Decidim
                 allow(authorizer)
                   .to receive(:authorization).and_return(authorization)
                 allow(authorization)
-                  .to receive(:expires_at).and_return(1.month.ago)
+                  .to receive(:expires_at).and_return(1.minute.ago)
               end
 
               it "returns expired" do
@@ -126,7 +126,7 @@ module Decidim
                 allow(authorizer)
                   .to receive(:authorization).and_return(authorization)
                 allow(authorization)
-                  .to receive(:expires_at).and_return(1.month.from_now)
+                  .to receive(:expires_at).and_return(1.hour.from_now)
               end
 
               context "when it doesn't have options" do

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/authorization.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/authorization.rb
@@ -20,6 +20,7 @@ end
 
 Decidim::Verifications.register_workflow(:dummy_authorization_workflow) do |workflow|
   workflow.engine = Decidim::Verifications::DummyVerification::Engine
+  workflow.expires_in = 1.hour
 end
 
 RSpec.configure do |config|

--- a/decidim-verifications/app/views/decidim/verifications/authorizations/_granted_authorization.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/authorizations/_granted_authorization.html.erb
@@ -1,0 +1,27 @@
+<div class="card--list__item">
+  <div class="card--list__text">
+    <%= icon "lock-unlocked", class: "card--list__icon" %>
+    <div>
+      <h5 class="card--list__heading">
+        <%= t("#{authorization.name}.name", scope: "decidim.authorization_handlers") %>
+      </h5>
+      <span class="text-small">
+        <% if authorization.expired? %>
+          <%= t("expired_at", scope: "decidim.authorization_handlers", timestamp: l(authorization.expires_at, format: :long)) %>
+        <% else %>
+          <%= t("granted_at", scope: "decidim.authorization_handlers", timestamp: l(authorization.granted_at, format: :long)) %>
+          <% if authorization.expires_at.present? %>
+            <%= t("expires_at", scope: "decidim.authorization_handlers", timestamp: l(authorization.expires_at, format: :long)) %>
+          <% end %>
+        <% end %>
+      </span>
+    </div>
+  </div>
+  <% if authorization.expired? %>
+    <div class="card--list__data">
+      <span class="card--list__data__icon">
+        <%= icon "reload" %>
+      </span>
+    </div>
+  <% end %>
+</div>

--- a/decidim-verifications/app/views/decidim/verifications/authorizations/index.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/authorizations/index.html.erb
@@ -12,6 +12,9 @@
                 </h5>
                 <span class="text-small">
                   <%= t("granted_at", scope: "decidim.authorization_handlers", timestamp: l(authorization.granted_at, format: :long)) %>
+                  <% if authorization.expires_at.present? %>
+                    <%= t("expires_at", scope: "decidim.authorization_handlers", timestamp: l(authorization.expires_at, format: :long)) %>
+                  <% end %>
                 </span>
               </div>
             </div>

--- a/decidim-verifications/app/views/decidim/verifications/authorizations/index.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/authorizations/index.html.erb
@@ -3,22 +3,14 @@
     <% if @granted_authorizations.any? %>
       <div class="card card--list">
         <% @granted_authorizations.each do |authorization| %>
-          <div class="card--list__item">
-            <div class="card--list__text">
-              <%= icon "lock-unlocked", class: "card--list__icon" %>
-              <div>
-                <h5 class="card--list__heading">
-                  <%= t("#{authorization.name}.name", scope: "decidim.authorization_handlers") %>
-                </h5>
-                <span class="text-small">
-                  <%= t("granted_at", scope: "decidim.authorization_handlers", timestamp: l(authorization.granted_at, format: :long)) %>
-                  <% if authorization.expires_at.present? %>
-                    <%= t("expires_at", scope: "decidim.authorization_handlers", timestamp: l(authorization.expires_at, format: :long)) %>
-                  <% end %>
-                </span>
-              </div>
-            </div>
-          </div>
+          <% if authorization.expired? %>
+            <% authorization_method = Decidim::Verifications::Adapter.from_element(authorization.name) %>
+            <%= link_to authorization_method.root_path do %>
+              <% render partial: "granted_authorization", locals: { authorization: authorization } %>
+            <% end %>
+          <% else %>
+            <%= render partial: "granted_authorization", locals: { authorization: authorization } %>
+          <% end %>
         <% end %>
       </div>
     <% end %>

--- a/decidim-verifications/lib/decidim/verifications/dummy.rb
+++ b/decidim-verifications/lib/decidim/verifications/dummy.rb
@@ -2,4 +2,5 @@
 
 Decidim::Verifications.register_workflow(:dummy_authorization_handler) do |workflow|
   workflow.form = "Decidim::DummyAuthorizationHandler"
+  workflow.expires_in = 1.hour
 end

--- a/decidim-verifications/lib/decidim/verifications/workflow_manifest.rb
+++ b/decidim-verifications/lib/decidim/verifications/workflow_manifest.rb
@@ -28,6 +28,7 @@ module Decidim
       attribute :engine, Rails::Engine
       attribute :admin_engine, Rails::Engine
       attribute :form, String
+      attribute :expires_in, ActiveSupport::Duration, default: 0.minutes
 
       validate :engine_or_form
 

--- a/decidim-verifications/spec/features/action_authorization_spec.rb
+++ b/decidim-verifications/spec/features/action_authorization_spec.rb
@@ -53,6 +53,30 @@ describe "Action Authorization", type: :feature do
       end
     end
 
+    context "and action authorized and authorization expired" do
+      let(:permissions) do
+        { create: { authorization_handler_name: "dummy_authorization_handler" } }
+      end
+
+      before do
+        create(:authorization, name: "dummy_authorization_handler", user: user, granted_at: 1.month.ago)
+        visit main_feature_path(feature)
+        click_link "New proposal"
+      end
+
+      it "prompts user to check her authorization status" do
+        expect(page).to have_content("Authorization has expired")
+        expect(page)
+          .to have_content("Your authorization has expired. In order to perform this action, you need to be reauthorized with \"Example authorization\"")
+      end
+
+      it "redirects to resume authorization when modal clicked" do
+        click_link "Reauthorize with \"Example authorization\""
+
+        expect(page).to have_content("Verify with Example authorization")
+      end
+    end
+
     context "when action not authorized" do
       let(:permissions) { nil }
 
@@ -113,6 +137,30 @@ describe "Action Authorization", type: :feature do
         click_link "Check your \"Dummy authorization workflow\" authorization progress"
 
         expect(page).to have_content("CONTINUE YOUR VERIFICATION")
+      end
+    end
+
+    context "and action authorized and authorization expired" do
+      let(:permissions) do
+        { create: { authorization_handler_name: "dummy_authorization_workflow" } }
+      end
+
+      before do
+        create(:authorization, name: "dummy_authorization_workflow", user: user, granted_at: 1.month.ago)
+        visit main_feature_path(feature)
+        click_link "New proposal"
+      end
+
+      it "prompts user to check her authorization status" do
+        expect(page).to have_content("Authorization has expired")
+        expect(page)
+          .to have_content("Your authorization has expired. In order to perform this action, you need to be reauthorized with \"Dummy authorization workflow\"")
+      end
+
+      it "redirects to resume authorization when modal clicked" do
+        click_link "Reauthorize with \"Dummy authorization workflow\""
+
+        expect(page).to have_content("DUMMY VERIFICATION ENGINE")
       end
     end
 

--- a/decidim-verifications/spec/features/authorizations_spec.rb
+++ b/decidim-verifications/spec/features/authorizations_spec.rb
@@ -115,8 +115,49 @@ describe "Authorizations", type: :feature, with_authorization_workflows: ["dummy
 
         within ".authorizations-list" do
           expect(page).to have_content("Example authorization")
-          expect(page).to have_no_link("Example authorization")
-          expect(page).to have_content(I18n.localize(authorization.granted_at, format: :long))
+        end
+      end
+
+      context "when the authorization has not expired yet" do
+        let!(:authorization) do
+          create(:authorization, name: "dummy_authorization_handler", user: user, granted_at: 2.seconds.ago)
+        end
+
+        it "can't be renewed yet" do
+          within_user_menu do
+            click_link "My account"
+          end
+
+          click_link "Authorizations"
+
+          within ".authorizations-list" do
+            expect(page).to have_no_link("Example authorization")
+            expect(page).to have_content(I18n.localize(authorization.granted_at, format: :long))
+          end
+        end
+      end
+
+      context "when the authorization has expired" do
+        let!(:authorization) do
+          create(:authorization, name: "dummy_authorization_handler", user: user, granted_at: 2.months.ago)
+        end
+
+        it "can be renewed" do
+          within_user_menu do
+            click_link "My account"
+          end
+
+          click_link "Authorizations"
+
+          within ".authorizations-list" do
+            expect(page).to have_link("Example authorization")
+            click_link "Example authorization"
+          end
+
+          fill_in "Document number", with: "123456789X"
+          click_button "Send"
+
+          expect(page).to have_content("You've been successfully authorized")
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Let admins set how many months authorizations are valid since the day they were granted. Once those months have passed, users will have to re-authorize themselves.

#### :pushpin: Related Issues
- Fixes #2267

#### :clipboard: Subtasks
- [x] Set `expires_in` value for each authorization (Defaults to `0.minutes`). Dummy authorization handler expires in `1.hour`
- [x] Detect expired authorizations
- [x] Let users renew expired authorizations
- [x] Add CHANGELOG entry

### :camera: Screenshots (optional)
Granted authorizations list, showing the expiration date and time. If this authorization does not expire, then this part of text is not shown.
![](https://i.imgur.com/pTkVGj3.png)

When the authorization has expired, it is shown in the list of granted authorizations, but can be renewed:
![](https://i.imgur.com/FOX2gEz.png)

When trying to perform an action that requires an authorization, but the authorization has expired:
![](https://i.imgur.com/HffxTjJ.png)