### PR TITLE
Fix flaky test

### DIFF
--- a/decidim-core/spec/features/notifications_spec.rb
+++ b/decidim-core/spec/features/notifications_spec.rb
@@ -82,6 +82,7 @@ describe "Notifications", type: :feature do
     context "when setting all notifications as read" do
       it "hides all notifications from the page" do
         click_link "Mark all as read"
+        expect(page).not_to have_selector("#notifications-list")
         expect(page).to have_content("No notifications yet")
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Following @deivid-rodriguez's series of flaky test fixes, I found another one:

https://circleci.com/gh/decidim/decidim/29929

The expectation is sometimes run before the JS has finished. Using the `have_selector` check ensures the JS will have finished, AFAIK.

#### :pushpin: Related Issues
None