### PR TITLE
Use meaningful subject when inviting someone to join a meeting

### DIFF
--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -125,7 +125,7 @@ en:
       mailer:
         invite_join_meeting_mailer:
           invite:
-            subject: Subject
+            subject: Invitation to join a meeting
         registration_mailer:
           confirmation:
             subject: Your meeting's registration has been confirmed
@@ -194,4 +194,4 @@ en:
   devise:
     mailer:
       join_meeting:
-        subject: Subject
+        subject: Invitation to join a meeting


### PR DESCRIPTION
#### :tophat: What? Why?
Adds a meaningful subject for emails when inviting someone to join a meeting.

#### :pushpin: Related Issues
- Fixes #2228.

#### :clipboard: Subtasks
None