### PR TITLE
Add Swedish translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ We've set up a guide on how to install, set up and upgrade Decidim. See the [Get
 
 ### As a Translator
 
-Decidim is already translated on multiple languages (English, Spanish, Catalan, Basque, Italian, Finnish, Dutch, French, Russian and Ukrainian). You can help us at [Crowdin, the translation service](https://crowdin.com/project/decidim), reviewing these translations or proposing a new language to add to the platform.
+Decidim is already translated on multiple languages (English, Spanish, Catalan, Basque, Italian, Finnish, Dutch, French, Portuguese, Swedish, Russian and Ukrainian). You can help us at [Crowdin, the translation service](https://crowdin.com/project/decidim), reviewing these translations or proposing a new language to add to the platform.
 
 ### As a Developer
 

--- a/decidim-core/app/assets/javascripts/decidim/select2.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/select2.js.es6
@@ -7,5 +7,6 @@
 // = require select2_locale_it
 // = require select2_locale_nl
 // = require select2_locale_pt
+// = require select2_locale_sv
 // = require select2_locale_uk
 // = require select2_locale_ru

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -87,7 +87,7 @@ module Decidim
 
   # Exposes a configuration option: The application available locales.
   config_accessor :available_locales do
-    %w(en ca es eu it fi fr nl pt uk ru)
+    %w(en ca es eu it fi fr nl pt sv uk ru)
   end
 
   # Exposes a configuration option: The application default locale.

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -87,7 +87,7 @@ module Decidim
 
   # Exposes a configuration option: The application available locales.
   config_accessor :available_locales do
-    %w(en ca es eu it fi fr nl uk ru)
+    %w(en ca es eu it fi fr nl pt uk ru)
   end
 
   # Exposes a configuration option: The application default locale.

--- a/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.sv.js
+++ b/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.sv.js
@@ -1,0 +1,14 @@
+/**
+ * Swedish translation for foundation-datepicker
+ * Patrik Ragnarsson <patrik@starkast.net>
+ */
+;(function($){
+	$.fn.fdatepicker.dates['sv'] = {
+		days: ["Söndag", "Måndag", "Tisdag", "Onsdag", "Torsdag", "Fredag", "Lördag", "Söndag"],
+		daysShort: ["Sön", "Mån", "Tis", "Ons", "Tor", "Fre", "Lör", "Sön"],
+		daysMin: ["Sö", "Må", "Ti", "On", "To", "Fr", "Lö", "Sö"],
+		months: ["Januari", "Februari", "Mars", "April", "Maj", "Juni", "Juli", "Augusti", "September", "Oktober", "November", "December"],
+		monthsShort: ["Jan", "Feb", "Mar", "Apr", "Maj", "Jun", "Jul", "Aug", "Sep", "Okt", "Nov", "Dec"],
+		today: "I Dag"
+	};
+}(jQuery));


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds Swedish translations to Decidim, as per #2340. It also adds Portuguese missing translations in some places /cc @mllocs 

#### :pushpin: Related Issues
- Fixes #2340

#### :clipboard: Subtasks
None