### PR TITLE
Accountability: ship vendor folder

### DIFF
--- a/decidim-accountability/app/assets/javascripts/decidim/accountability/accountability.js.es6
+++ b/decidim-accountability/app/assets/javascripts/decidim/accountability/accountability.js.es6
@@ -1,3 +1,4 @@
+// = require diff
 // = require_tree .
 // = require_self
 

--- a/decidim-accountability/decidim-accountability.gemspec
+++ b/decidim-accountability/decidim-accountability.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.summary = "An accountability component for decidim's participatory processes."
   s.description = s.summary
 
-  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+  s.files = Dir["{app,config,db,lib,vendor}/**/*", "Rakefile", "README.md"]
 
   s.add_dependency "decidim-comments", Decidim::Accountability.version
   s.add_dependency "decidim-core", Decidim::Accountability.version


### PR DESCRIPTION
#### :tophat: What? Why?
Ships `vendor` folder from `decidim-accountability`. Once this is merged, this should be released as a patch version.

#### :pushpin: Related Issues
- Fixes #2328
