### PR TITLE
Skip verification sub-engine migrations

### DIFF
--- a/decidim-verifications/lib/decidim/verifications/id_documents/admin_engine.rb
+++ b/decidim-verifications/lib/decidim/verifications/id_documents/admin_engine.rb
@@ -6,6 +6,7 @@ module Decidim
       # This is an engine that performs an example user authorization.
       class AdminEngine < ::Rails::Engine
         isolate_namespace Decidim::Verifications::IdDocuments::Admin
+        paths["db/migrate"] = nil
 
         routes do
           resources :pending_authorizations, only: :index do

--- a/decidim-verifications/lib/decidim/verifications/id_documents/engine.rb
+++ b/decidim-verifications/lib/decidim/verifications/id_documents/engine.rb
@@ -6,6 +6,7 @@ module Decidim
       # This is an engine that performs an example user authorization.
       class Engine < ::Rails::Engine
         isolate_namespace Decidim::Verifications::IdDocuments
+        paths["db/migrate"] = nil
 
         routes do
           resource :authorizations, only: [:new, :create, :edit, :update], as: :authorization

--- a/decidim-verifications/lib/decidim/verifications/postal_letter/admin_engine.rb
+++ b/decidim-verifications/lib/decidim/verifications/postal_letter/admin_engine.rb
@@ -7,6 +7,7 @@ module Decidim
       # user authorization by postal letter code.
       class AdminEngine < ::Rails::Engine
         isolate_namespace Decidim::Verifications::PostalLetter::Admin
+        paths["db/migrate"] = nil
 
         routes do
           resources :pending_authorizations, only: :index do

--- a/decidim-verifications/lib/decidim/verifications/postal_letter/engine.rb
+++ b/decidim-verifications/lib/decidim/verifications/postal_letter/engine.rb
@@ -6,6 +6,7 @@ module Decidim
       # This is an engine that performs an example user authorization.
       class Engine < ::Rails::Engine
         isolate_namespace Decidim::Verifications::PostalLetter
+        paths["db/migrate"] = nil
 
         routes do
           resource :authorizations, only: [:new, :create, :edit, :update], as: :authorization


### PR DESCRIPTION
#### :tophat: What? Why?
This ignores the sub-engine migrations of the engines in `verifications`. Otherwise, a you'll see *duplicated migration* warnings on the console when copying the migrations. Harmless, but still quite annoying.

#### :pushpin: Related Issues
- Fixes #2346 (thanks @jsperezg for reporting this)

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
*None*
