### PR TITLE
Fix migration when no permissions are set

### DIFF
--- a/decidim-verifications/db/migrate/20171030133426_move_authorizations_to_new_api.rb
+++ b/decidim-verifications/db/migrate/20171030133426_move_authorizations_to_new_api.rb
@@ -36,6 +36,8 @@ class MoveAuthorizationsToNewApi < ActiveRecord::Migration[5.1]
     end
 
     Feature.find_each do |feature|
+      next if feature.permissions.nil?
+
       feature.permissions.transform_values! do |value|
         value["authorization_handler_name"].classify.demodulize.underscore
       end


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes migration when no permissions are set.

#### :pushpin: Related Issues
- Fixes #2349

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
*None*
