### PR TITLE
Lock uglifier version to `4.0.0` and add release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased](https://github.com/decidim/decidim/tree/HEAD)
 
+**Upgrade notes**:
+
+Since uglifier `4.0.0`, we need to set `harmony: true` as options in uglifier. This means
+you need to change the following line in `config/environments/production.rb`:
+
+```diff
+- config.assets.js_compressor = :uglifier
++ config.assets.js_compressor = Uglifier.new(:harmony => true)
+```
+
 **Added**:
 
 **Changed**:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ PATH
       spreadsheet (~> 1.1)
       sprockets-es6 (~> 0.9.2)
       truncato (~> 0.7.10)
+      uglifier (~> 4.0.0)
       valid_email2 (~> 2.1.1)
       wisper (~> 2.0.0)
     decidim-dev (0.9.0.pre)

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -50,6 +50,7 @@ Gem::Specification.new do |s|
   s.add_dependency "spreadsheet", "~> 1.1"
   s.add_dependency "sprockets-es6", "~> 0.9.2"
   s.add_dependency "truncato", "~> 0.7.10"
+  s.add_dependency "uglifier", "~> 4.0.0"
   s.add_dependency "valid_email2", "~> 2.1.1"
   s.add_dependency "wisper", "~> 2.0.0"
 

--- a/lib/generators/decidim/install_generator.rb
+++ b/lib/generators/decidim/install_generator.rb
@@ -57,6 +57,10 @@ module Decidim
         template "decidim.scss.erb", "app/assets/stylesheets/decidim.scss", force: true
       end
 
+      def configure_js_compressor
+        gsub_file "config/environments/production.rb", "config.assets.js_compressor = :uglifier", "config.assets.js_compressor = Uglifier.new(:harmony => true)"
+      end
+
       def smtp_environment
         inject_into_file "config/environments/production.rb",
                          after: "config.log_formatter = ::Logger::Formatter.new" do


### PR DESCRIPTION
#### :tophat: What? Why?
Since `uglifier 4.0.0`, options have to be set in your app's `config/environment/production.rb`. This adds a note explaining that and makes sure new installations are set correctly.

#### :pushpin: Related Issues
- Related to #2341

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
*None*
