### PR TITLE
Add conversations to side menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ you need to change the following line in `config/environments/production.rb`:
 
 **Fixed**:
 
+- **decidim-core**: Impossible to access conversation page from mobile devices. [\#2364](https://github.com/decidim/decidim/pull/2364)
 - **decidim-core**: Update home page stat categories
 [\#2221](https://github.com/decidim/decidim/pull/2221)
 

--- a/decidim-core/app/views/layouts/decidim/_user_menu.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_user_menu.html.erb
@@ -1,5 +1,6 @@
 <li><%= link_to t(".profile"), decidim.account_path %></li>
 <li><%= link_to t(".notifications"), decidim.notifications_path %></li>
+<li><%= link_to t(".conversations"), decidim.conversations_path %></li>
 <% if can? :read, :admin_dashboard %>
   <li><%= link_to t(".admin_dashboard"), decidim_admin.root_path %></li>
 <% end %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -349,6 +349,7 @@ en:
         title: Notifications
       user_menu:
         admin_dashboard: Admin dashboard
+        conversations: Conversations
         notifications: Notifications
         profile: My account
         sign_out: Sign out


### PR DESCRIPTION
#### :tophat: What? Why?

Conversation page was not accessible from mobile devices. This PR adds a link to the hamburguer menu to fix that.

#### :pushpin: Related Issues
- Fixes #2358.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![giphy 1](https://user-images.githubusercontent.com/2887858/33908961-cd01e65a-df68-11e7-8201-796dcc1f3955.gif)