### PR TITLE
Lock docker image to make sure test runs are deterministic (kind of)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 defaults: &defaults
   docker:
-    - image: decidim/decidim:latest-dev
+    - image: decidim/decidim:0.8-dev
       environment:
         BUNDLE_GEMFILE: /app/Gemfile
         SIMPLECOV: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,8 @@ version: 2
 
 defaults: &defaults
   docker:
+    # This is the sha of the latest `decidim/decidim:latest-dev` docker image. You can retrieve the
+    # latest digest by doing `$ docker pull decidim/decidim:latest-dev`.
     - image: decidim/decidim@sha256:d54f0b0d026ec5fda24b44d5a45ce0fbe9df201595f3d6cb82efb44183216c83
       environment:
         BUNDLE_GEMFILE: /app/Gemfile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 defaults: &defaults
   docker:
-    - image: decidim/decidim:0.8-dev
+    - image: decidim/decidim@sha256:d54f0b0d026ec5fda24b44d5a45ce0fbe9df201595f3d6cb82efb44183216c83
       environment:
         BUNDLE_GEMFILE: /app/Gemfile
         SIMPLECOV: true


### PR DESCRIPTION
#### :tophat: What? Why?
This locks the docker image to a particular sha to prevent CI to fail due to changes to `latest`.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
*None*
