### PR TITLE
Add pt foundation datepicker translations and format options

### DIFF
--- a/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.pt.js
+++ b/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.pt.js
@@ -9,6 +9,10 @@
     daysShort: ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb", "Dom"],
     daysMin: ["Do", "Se", "Te", "Qu", "Qu", "Se", "Sa", "Do"],
     months: ["Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"],
-    monthsShort: ["Jan", "Fev", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Out", "Nov", "Dez"]
+    monthsShort: ["Jan", "Fev", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Out", "Nov", "Dez"],
+    today: "Hoje",
+    clear: "Limpar",
+    weekStart: 1,
+    format: "dd/mm/yyyy"
   };
 }(jQuery));


### PR DESCRIPTION
#### :tophat: What? Why?

I've been investigating an issue that affected the datepickers while using the Portuguese version. The bug is that, when a datepicker is not empty, instead of showing the current value the form looks like this:

<img width="740" alt="screen shot 2017-12-13 at 12 50 33" src="https://user-images.githubusercontent.com/935744/33939753-3dce360e-e004-11e7-90f0-a591cf24e532.png">

After doing some research I noticed that the `startdate` value stored in the data attribute had a weird format (notice the spaces wrapping the slashes): 

<img width="366" alt="screen shot 2017-12-13 at 12 51 34" src="https://user-images.githubusercontent.com/935744/33939798-652de9ce-e004-11e7-8eb5-ee7bbbc3da86.png">

To fix the issue I did a couple of things:

- Fix the localised datetime format in Crowdin (https://github.com/decidim/decidim/pull/2357/commits/4e112c28a245e17084cde7387eb6339f88d15356).
- Add the `format` attribute in the foundation-datepicker localisation to see dates in `dd/mm/yyyy` instead of `mm/dd/yyyy` (this PR).

I believe that other languages might be broken as well, doing a quick overlook, Euskera, Italian and Dutch also have these weird spaces between variables:

https://github.com/decidim/decidim/blob/9fbbabfd5515565727ad4604783db34adc647d7e/decidim-admin/config/locales/nl.yml#L86

which I think that were introduced automatically by Crowdin. 

🎩 

