### PR TITLE
Restore js tests in CI and fix them

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,8 +222,8 @@ jobs:
           paths:
             - node_modules
       - run:
-          name: Run main folder yarn lint
-          command: yarn lint
+          name: Run main folder yarn lint & tests
+          command: yarn test:ci
       - restore_cache:
           keys:
             - bundler-dependencies-{{ checksum "Gemfile.lock" }}

--- a/Rakefile
+++ b/Rakefile
@@ -41,7 +41,7 @@ task :update_versions do
   replace_file(
     "#{__dir__}/package.json",
     /^  "version": "[^"]*"/,
-    "  \"version\": \"#{version}\""
+    "  \"version\": \"#{version.gsub(/\.pre/, "-pre")}\""
   )
 
   DECIDIM_GEMS.each do |name|

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "decidim",
   "description": "The participatory democracy framework",
-  "version": "0.9.0.pre",
+  "version": "0.9.0-pre",
   "repository": {
     "url": "git@github.com:decidim/decidim.git",
     "type": "git"
@@ -61,7 +61,7 @@
     "json-loader": "~0.5.7",
     "progress-bar-webpack-plugin": "^1.10.0",
     "raf": "^3.4.0",
-    "select2": "^4.0.3",
+    "select2": "=4.0.3",
     "source-map-loader": "^0.2.3",
     "ts-jest": "^21.1.3",
     "tslint": "^5.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5167,9 +5167,9 @@ sax@^1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
-select2@^4.0.3:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/select2/-/select2-4.0.5.tgz#7aac50692561985b34d3b82ec55e226f8960d40a"
+select2@=4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/select2/-/select2-4.0.3.tgz#207733fe91eacb9cb1a13f12463401f472449e0f"
   dependencies:
     almond "~0.3.1"
     jquery-mousewheel "~3.1.13"


### PR DESCRIPTION


#### :tophat: What? Why?

I noticed that we're no longer running js tests in CI... In this PR I restore that! I got a couple of failures locally:

* select2 4.0.5 seem to have changes that break our tests. Perfect timing for #2330 since that'll remove select2 :). I'm locking it for now since it seems that we have something broken here.

* package.json version was incorrect. `yarn` doesn't like the old format.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![damn_good_coffee](https://user-images.githubusercontent.com/2887858/33960356-4560bb92-e029-11e7-9870-853a00071cdf.gif)

