### PR TITLE
Fix admins being prevented from impersonating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ you need to change the following line in `config/environments/production.rb`:
 
 **Fixed**:
 
+- **decidim-admin**: Admins no longer being able to impersonate a second time. [\#2372](https://github.com/decidim/decidim/pull/2372)
 - **decidim-core**: Impossible to access conversation page from mobile devices. [\#2364](https://github.com/decidim/decidim/pull/2364)
 - **decidim-admin**: User impersonation should only use authorization handlers and not authorization workflows. [\#2363](https://github.com/decidim/decidim/pull/2363)
 - **decidim-core**: Update home page stat categories

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ you need to change the following line in `config/environments/production.rb`:
 **Fixed**:
 
 - **decidim-core**: Impossible to access conversation page from mobile devices. [\#2364](https://github.com/decidim/decidim/pull/2364)
+- **decidim-admin**: User impersonation should only use authorization handlers and not authorization workflows. [\#2363](https://github.com/decidim/decidim/pull/2363)
 - **decidim-core**: Update home page stat categories
 [\#2221](https://github.com/decidim/decidim/pull/2221)
 

--- a/decidim-admin/app/commands/decidim/admin/impersonate_managed_user.rb
+++ b/decidim-admin/app/commands/decidim/admin/impersonate_managed_user.rb
@@ -25,7 +25,7 @@ module Decidim
         return broadcast(:invalid) if !user.managed? || !authorization_valid?
 
         create_impersonation_log
-        enque_expire_job
+        enqueue_expire_job
 
         broadcast(:ok)
       end
@@ -51,7 +51,7 @@ module Decidim
         )
       end
 
-      def enque_expire_job
+      def enqueue_expire_job
         Decidim::Admin::ExpireImpersonationJob
           .set(wait: Decidim::ImpersonationLog::SESSION_TIME_IN_MINUTES.minutes)
           .perform_later(user, current_user)

--- a/decidim-admin/app/controllers/decidim/admin/managed_users_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/managed_users_controller.rb
@@ -9,7 +9,7 @@ module Decidim
     class ManagedUsersController < Admin::ApplicationController
       layout "decidim/admin/users"
 
-      helper_method :available_authorizations, :more_than_one_authorization?
+      helper_method :available_authorization_handlers, :more_than_one_authorization_handler?
 
       def index
         authorize! :index, :managed_users
@@ -53,16 +53,18 @@ module Decidim
       end
 
       def handler_name
-        return params[:handler_name] if more_than_one_authorization?
-        available_authorizations.first
+        return params[:handler_name] if more_than_one_authorization_handler?
+        available_authorization_handlers.first.name
       end
 
-      def available_authorizations
-        current_organization.available_authorizations.map(&:underscore)
+      def available_authorization_handlers
+        Verifications::Adapter.from_collection(
+          current_organization.available_authorizations & Decidim.authorization_handlers.map(&:name)
+        )
       end
 
-      def more_than_one_authorization?
-        available_authorizations.length > 1
+      def more_than_one_authorization_handler?
+        available_authorization_handlers.length > 1
       end
     end
   end

--- a/decidim-admin/app/views/decidim/admin/managed_users/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/managed_users/new.html.erb
@@ -1,17 +1,17 @@
 <h2 class="process-title-summary">
   <%= t('.new_managed_user') %>
-  <% if more_than_one_authorization? %>
+  <% if more_than_one_authorization_handler? %>
     <span class="text-muted float-right"><%= t('.step', current: params[:handler_name].present? ? 2 : 1, total: 2) %></span>
   <% end %>
 </h2>
 
-<% if more_than_one_authorization? && params[:handler_name].nil? %>
+<% if more_than_one_authorization_handler? && params[:handler_name].nil? %>
   <div class="card card--list">
     <div class="card-divider">
       <h2 class="card-title"><%= t ".select_authorization_method" %></h2>
     </div>
     <div class="card-section">
-      <% available_authorizations.each do |handler_name| %>
+      <% available_authorization_handlers.each do |handler| %>
         <div class="card--list__item">
           <div class="card--list__text">
             <a href="#">
@@ -19,12 +19,12 @@
             </a>
             <div>
               <h5 class="card--list__heading">
-                <%= link_to t("#{handler_name}.name", scope: "decidim.authorization_handlers"), new_managed_user_path(handler_name: handler_name) %>
+                <%= link_to handler.fullname, new_managed_user_path(handler_name: handler.name) %>
               </h5>
             </div>
           </div>
           <div class="card--list__data">
-            <%= link_to new_managed_user_path(handler_name: handler_name), class: "card--list__data__icon" do %>
+            <%= link_to new_managed_user_path(handler_name: handler.name), class: "card--list__data__icon" do %>
               <%= icon "chevron-right" %>
             <% end %>
           </div>

--- a/decidim-admin/spec/shared/manage_managed_users_examples.rb
+++ b/decidim-admin/spec/shared/manage_managed_users_examples.rb
@@ -11,47 +11,6 @@ shared_examples "manage managed users examples" do
     login_as user, scope: :user
   end
 
-  def fill_in_the_managed_user_form
-    within "form.new_managed_user" do
-      fill_in :managed_user_name, with: "Foo"
-      fill_in :managed_user_authorization_document_number, with: "123456789X"
-      fill_in :managed_user_authorization_postal_code, with: "08224"
-      page.execute_script("$('#managed_user_authorization_birthday').siblings('input:first').focus()")
-    end
-
-    page.find(".datepicker-dropdown .day", text: "12").click
-    click_button "Create"
-  end
-
-  def fill_in_the_impersonation_form
-    within "form.new_managed_user_impersonation" do
-      fill_in :impersonate_managed_user_authorization_document_number, with: "123456789X"
-      fill_in :impersonate_managed_user_authorization_postal_code, with: "08224"
-      page.execute_script("$('#impersonate_managed_user_authorization_birthday').siblings('input:first').focus()")
-    end
-
-    page.find(".datepicker-dropdown .day", text: "12").click
-    click_button "Impersonate"
-  end
-
-  def impersonate_the_managed_user
-    navigate_to_managed_users_page
-
-    within find("tr", text: managed_user.name) do
-      click_link "Impersonate"
-    end
-
-    fill_in_the_impersonation_form
-  end
-
-  def check_impersonation_logs
-    within find("tr", text: managed_user.name) do
-      click_link "View logs"
-    end
-
-    expect(page).to have_selector("tbody tr", count: 1)
-  end
-
   context "when the organization doesn't have any authorization available" do
     let(:available_authorizations) { [] }
 
@@ -167,5 +126,48 @@ shared_examples "manage managed users examples" do
       navigate_to_managed_users_page
       expect(page).to have_no_content(managed_user.name)
     end
+  end
+
+  private
+
+  def fill_in_the_managed_user_form
+    within "form.new_managed_user" do
+      fill_in :managed_user_name, with: "Foo"
+      fill_in :managed_user_authorization_document_number, with: "123456789X"
+      fill_in :managed_user_authorization_postal_code, with: "08224"
+      page.execute_script("$('#managed_user_authorization_birthday').siblings('input:first').focus()")
+    end
+
+    page.find(".datepicker-dropdown .day", text: "12").click
+    click_button "Create"
+  end
+
+  def fill_in_the_impersonation_form
+    within "form.new_managed_user_impersonation" do
+      fill_in :impersonate_managed_user_authorization_document_number, with: "123456789X"
+      fill_in :impersonate_managed_user_authorization_postal_code, with: "08224"
+      page.execute_script("$('#impersonate_managed_user_authorization_birthday').siblings('input:first').focus()")
+    end
+
+    page.find(".datepicker-dropdown .day", text: "12").click
+    click_button "Impersonate"
+  end
+
+  def impersonate_the_managed_user
+    navigate_to_managed_users_page
+
+    within find("tr", text: managed_user.name) do
+      click_link "Impersonate"
+    end
+
+    fill_in_the_impersonation_form
+  end
+
+  def check_impersonation_logs
+    within find("tr", text: managed_user.name) do
+      click_link "View logs"
+    end
+
+    expect(page).to have_selector("tbody tr", count: 1)
   end
 end

--- a/decidim-admin/spec/shared/manage_managed_users_examples.rb
+++ b/decidim-admin/spec/shared/manage_managed_users_examples.rb
@@ -116,6 +116,16 @@ shared_examples "manage managed users examples" do
 
         check_impersonation_logs
       end
+
+      it "can impersonate again after an impersonation session expiration" do
+        impersonate_the_managed_user
+
+        simulate_session_expiration
+
+        navigate_to_managed_users_page
+
+        expect(page).to have_link("Impersonate")
+      end
     end
 
     it "can promote the user inviting them to the application" do

--- a/decidim-core/app/models/decidim/impersonation_log.rb
+++ b/decidim-core/app/models/decidim/impersonation_log.rb
@@ -10,7 +10,8 @@ module Decidim
 
     validate :same_organization, :non_active_impersonation
 
-    scope :active, -> { where(ended_at: nil) }
+    scope :active, -> { where(ended_at: nil, expired_at: nil) }
+    scope :expired, -> { where(ended_at: nil).where.not(expired_at: nil) }
 
     def ended?
       ended_at.present?

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -29,6 +29,8 @@ shared_examples "comments" do
 
     visit resource_path
 
+    expect(page).to have_no_content("Comments are disabled at this time")
+
     expect(page).to have_css(".comment", minimum: 1)
     page.find(".order-by .dropdown.menu .is-dropdown-submenu-parent").hover
 

--- a/decidim-core/spec/features/cookies_spec.rb
+++ b/decidim-core/spec/features/cookies_spec.rb
@@ -12,14 +12,14 @@ describe "Cookies", type: :feature do
   end
 
   it "user see the cookie policy" do
-    expect(page).to have_selector ".cookie-warning"
+    expect(page).to have_content "This site uses cookies."
   end
 
   it "user accept the cookie policy and he doesn't see it anymore'" do
-    page.find(".cookie-warning *[type='submit']").click
-    expect(page).to have_no_selector ".cookie-warning"
+    click_button "I agree"
+    expect(page).to have_no_content "This site uses cookies."
 
     visit decidim.root_path
-    expect(page).to have_no_selector ".cookie-warning"
+    expect(page).to have_no_content "This site uses cookies."
   end
 end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara_select2.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara_select2.rb
@@ -9,9 +9,8 @@ module Capybara
       expect(select2_container).to have_selector(".select2-selection")
       select2_container.find(".select2-selection").click
 
-      expect(page).to have_no_content("Searching…")
-
       body = find(:xpath, "//body")
+      expect(body).to have_no_content("Searching…")
       expect(body).to have_selector(".select2-dropdown li.select2-results__option", text: value)
 
       body.find(".select2-dropdown li.select2-results__option", text: value).click

--- a/decidim-verifications/lib/decidim/verifications/registry.rb
+++ b/decidim-verifications/lib/decidim/verifications/registry.rb
@@ -14,6 +14,10 @@ module Decidim
         add_workflow(manifest)
       end
 
+      def unregister_workflow(manifest)
+        workflow_collection.delete(manifest)
+      end
+
       def add_workflow(manifest)
         manifest.validate!
         workflow_collection.add(manifest)

--- a/decidim-verifications/lib/decidim/verifications/workflow_manifest.rb
+++ b/decidim-verifications/lib/decidim/verifications/workflow_manifest.rb
@@ -46,7 +46,7 @@ module Decidim
       alias key name
 
       def fullname
-        I18n.t("#{key}.name", scope: "decidim.authorization_handlers")
+        I18n.t("#{key}.name", scope: "decidim.authorization_handlers", default: name.humanize)
       end
 
       def description

--- a/decidim-verifications/lib/decidim/verifications/workflows.rb
+++ b/decidim-verifications/lib/decidim/verifications/workflows.rb
@@ -28,6 +28,15 @@ module Decidim
       end
 
       #
+      # Registers a verification workflow using the workflow manifest API
+      #
+      def unregister_workflow(name)
+        manifest = find_workflow_manifest(name)
+
+        registry.unregister_workflow(manifest)
+      end
+
+      #
       # Finds a verification workflow by name
       #
       def find_workflow_manifest(name)


### PR DESCRIPTION
#### :tophat: What? Why?

This was a tricky one.

If after an impersonation expiration, the impersonating user goes directly to the admin console, she will lose the impersonation session and it won't get properly expired. That results in the user not being able to impersonate again.

#### :pushpin: Related Issues
- Fixes one of the issues mentioned in #2101.
- Sits on top #2363, because it affects the same area of the code and I don't want to get conflicts or suffer from the issues #2363 fixes.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![yeeeeeeah](https://user-images.githubusercontent.com/2887858/33969442-2547d8d6-e04c-11e7-96e6-fbcede09d287.gif)