### PR TITLE
Fix migration on permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ you need to change the following line in `config/environments/production.rb`:
 - **decidim-core**: Impossible to access conversation page from mobile devices. [\#2364](https://github.com/decidim/decidim/pull/2364)
 - **decidim-core**: Update home page stat categories
 [\#2221](https://github.com/decidim/decidim/pull/2221)
+- **decidim-verifications**: Fixed a migration that broke feature permissions. If you already upgraded to `0.8.2` or less, please follow the instructions on the PR [\#2373](https://github.com/decidim/decidim/pull/2373)
 
 ## [v0.8.0](https://github.com/decidim/decidim/tree/v0.8.0) (2017-12-4)
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.7.0...v0.8.0)

--- a/decidim-verifications/db/migrate/20171030133426_move_authorizations_to_new_api.rb
+++ b/decidim-verifications/db/migrate/20171030133426_move_authorizations_to_new_api.rb
@@ -39,7 +39,12 @@ class MoveAuthorizationsToNewApi < ActiveRecord::Migration[5.1]
       next if feature.permissions.nil?
 
       feature.permissions.transform_values! do |value|
-        value["authorization_handler_name"]&.classify&.demodulize&.underscore
+        next if value.nil?
+
+        {
+          "authorization_handler_name" => value["authorization_handler_name"]&.classify&.demodulize&.underscore,
+          "options" => value["options"]
+        }
       end
 
       feature.save!


### PR DESCRIPTION
#### :tophat: What? Why?
This fixes a bad migration on feature permissions. Existing applications should run:

```ruby
Decidim::Feature.find_each do |feature|
  next if feature.permissions.nil?

  feature.permissions.transform_values! do |value|
    next if value.nil?

    {
      "authorization_handler_name" => value["authorization_handler_name"]&.classify&.demodulize&.underscore,
      "options" => value["options"]
    }
  end

  feature.save!
end
```

This will fix any existing bad permissions object. Needs to be backported.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
*None*
