### PR TITLE
Do not allow attachments onn proposal edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ you need to change the following line in `config/environments/production.rb`:
 - **decidim-admin**: User impersonation should only use authorization handlers and not authorization workflows. [\#2363](https://github.com/decidim/decidim/pull/2363)
 - **decidim-core**: Impossible to access conversation page from mobile devices. [\#2364](https://github.com/decidim/decidim/pull/2364)
 - **decidim-core**: Update home page stat categories [\#2221](https://github.com/decidim/decidim/pull/2221)
+- **decidim-proposals**: Do not allow attachments on proposals edition [\#2221](https://github.com/decidim/decidim/pull/2221)
 - **decidim-verifications**: Fixed a migration that broke feature permissions. If you already upgraded to `0.8.2` or less, please follow the instructions on the PR [\#2373](https://github.com/decidim/decidim/pull/2373)
 
 ## [v0.8.0](https://github.com/decidim/decidim/tree/v0.8.0) (2017-12-4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,9 @@ you need to change the following line in `config/environments/production.rb`:
 **Fixed**:
 
 - **decidim-admin**: Admins no longer being able to impersonate a second time. [\#2372](https://github.com/decidim/decidim/pull/2372)
-- **decidim-core**: Impossible to access conversation page from mobile devices. [\#2364](https://github.com/decidim/decidim/pull/2364)
 - **decidim-admin**: User impersonation should only use authorization handlers and not authorization workflows. [\#2363](https://github.com/decidim/decidim/pull/2363)
-- **decidim-core**: Update home page stat categories
-[\#2221](https://github.com/decidim/decidim/pull/2221)
+- **decidim-core**: Impossible to access conversation page from mobile devices. [\#2364](https://github.com/decidim/decidim/pull/2364)
+- **decidim-core**: Update home page stat categories [\#2221](https://github.com/decidim/decidim/pull/2221)
 - **decidim-verifications**: Fixed a migration that broke feature permissions. If you already upgraded to `0.8.2` or less, please follow the instructions on the PR [\#2373](https://github.com/decidim/decidim/pull/2373)
 
 ## [v0.8.0](https://github.com/decidim/decidim/tree/v0.8.0) (2017-12-4)

--- a/decidim-proposals/app/views/decidim/proposals/proposals/edit.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/edit.html.erb
@@ -50,21 +50,6 @@
             </div>
           <% end %>
 
-          <% if feature_settings.attachments_allowed? %>
-            <fieldset>
-              <legend><%= t('.attachment_legend') %></legend>
-              <%= form.fields_for :attachment, @form.attachment do |form| %>
-                <div class="field">
-                  <%= form.text_field :title %>
-                </div>
-
-                <div class="field">
-                  <%= form.upload :file, optional: false %>
-                </div>
-              <% end %>
-            </fieldset>
-          <% end %>
-
           <div class="actions">
             <%= form.submit t(".send"), class: "button expanded", "data-disable-with" => "#{t('.send')}..." %>
           </div>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -106,7 +106,6 @@ en:
             one: 1 proposal
             other: "%{count} proposals"
         edit:
-          attachment_legend: "(Optional) Add an attachment"
           back: Back
           select_a_category: Please select a category
           send: Send

--- a/decidim-proposals/spec/commands/decidim/proposals/update_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/update_proposal_spec.rb
@@ -29,7 +29,6 @@ module Decidim
       let(:address) { nil }
       let(:latitude) { 40.1234 }
       let(:longitude) { 2.1234 }
-      let(:attachment_params) { nil }
 
       describe "call" do
         let(:form_params) do
@@ -38,7 +37,6 @@ module Decidim
             body: "A reasonable proposal body",
             address: address,
             has_address: has_address,
-            attachment: attachment_params,
             user_group_id: user_group.try(:id)
           }
         end
@@ -144,37 +142,6 @@ module Decidim
                   expect(proposal.latitude).to eq(latitude)
                   expect(proposal.longitude).to eq(longitude)
                 end
-              end
-            end
-          end
-
-          context "when attachments are allowed", processing_uploads_for: Decidim::AttachmentUploader do
-            let(:feature) { create(:proposal_feature, :with_attachments_allowed) }
-            let(:attachment_params) do
-              {
-                title: "My attachment",
-                file: Decidim::Dev.test_file("city.jpeg", "image/jpeg")
-              }
-            end
-
-            it "creates an atachment for the proposal" do
-              expect do
-                command.call
-              end.to change { Decidim::Attachment.count }.by(1)
-              last_proposal = Decidim::Proposals::Proposal.last
-              last_attachment = Decidim::Attachment.last
-              expect(last_attachment.attached_to).to eq(last_proposal)
-            end
-
-            context "when attachment is left blank" do
-              let(:attachment_params) do
-                {
-                  title: ""
-                }
-              end
-
-              it "broadcasts ok" do
-                expect { command.call }.to broadcast(:ok)
               end
             end
           end


### PR DESCRIPTION
#### :tophat: What? Why?
Do not allow attachments on proposal edition. I know this is not ideal, but this is to be released as a bugfix, and it's the best solution until we discuss how to proceed:

- Should we allow attachments to be removed on proposal edition?
- New uploads should replace old attachments, or should they add to the existing attachments?

#### :pushpin: Related Issues
None