### PR TITLE
Fix duplicated conversations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ you need to change the following line in `config/environments/production.rb`:
 
 **Fixed**:
 
+- **decidim-core**: Prevent many conversation with the same participants at the UI level. [\#2376](https://github.com/decidim/decidim/pull/2376)
 - **decidim-admin**: Admins no longer being able to impersonate a second time. [\#2372](https://github.com/decidim/decidim/pull/2372)
 - **decidim-core**: Impossible to access conversation page from mobile devices. [\#2364](https://github.com/decidim/decidim/pull/2364)
 - **decidim-admin**: User impersonation should only use authorization handlers and not authorization workflows. [\#2363](https://github.com/decidim/decidim/pull/2363)

--- a/decidim-core/app/controllers/decidim/messaging/conversations_controller.rb
+++ b/decidim-core/app/controllers/decidim/messaging/conversations_controller.rb
@@ -4,8 +4,10 @@ module Decidim
   module Messaging
     # The controller to handle the user's conversations.
     class ConversationsController < Decidim::ApplicationController
+      include ConversationHelper
       include FormFactory
 
+      helper ConversationHelper
       helper Decidim::DatetimeHelper
 
       before_action :authenticate_user!
@@ -14,8 +16,11 @@ module Decidim
 
       def new
         authorize! :create, Conversation
-
         @form = form(ConversationForm).from_params(params)
+
+        conversation = conversation_between(current_user, @form.recipient)
+
+        redirect_to conversation_path(conversation) if conversation
       end
 
       def create

--- a/decidim-core/app/helpers/decidim/messaging/conversation_helper.rb
+++ b/decidim-core/app/helpers/decidim/messaging/conversation_helper.rb
@@ -21,14 +21,18 @@ module Decidim
       def link_to_current_or_new_conversation_with(user)
         return decidim.new_user_session_path unless user_signed_in?
 
-        conversation_between = UserConversations.for(current_user).find do |conversation|
-          conversation.participants.to_set == [current_user, user].to_set
-        end
+        conversation = conversation_between(current_user, user)
 
-        if conversation_between
-          decidim.conversation_path(conversation_between)
+        if conversation
+          decidim.conversation_path(conversation)
         else
           decidim.new_conversation_path(recipient_id: user.id)
+        end
+      end
+
+      def conversation_between(one_user, another_user)
+        UserConversations.for(one_user).find do |conversation|
+          conversation.participants.to_set == [one_user, another_user].to_set
         end
       end
     end

--- a/decidim-core/spec/features/messaging/conversations_spec.rb
+++ b/decidim-core/spec/features/messaging/conversations_spec.rb
@@ -141,6 +141,8 @@ describe "Conversations", type: :feature do
     end
   end
 
+  private
+
   def visit_inbox
     visit decidim.root_path
 

--- a/decidim-core/spec/features/messaging/conversations_spec.rb
+++ b/decidim-core/spec/features/messaging/conversations_spec.rb
@@ -38,9 +38,15 @@ describe "Conversations", type: :feature do
     end
 
     it "allows sending an initial message" do
-      fill_in "conversation_body", with: "Is this a Ryanair style democracy?"
-      click_button "Send"
+      start_conversation("Is this a Ryanair style democracy?")
+      expect(page).to have_selector(".message:last-child", text: "Is this a Ryanair style democracy?")
+    end
 
+    it "redirects to an existing conversation if it exists already" do
+      start_conversation("Is this a Ryanair style democracy?")
+      expect(page).to have_selector(".message:last-child", text: "Is this a Ryanair style democracy?")
+
+      visit decidim.new_conversation_path(recipient_id: recipient.id)
       expect(page).to have_selector(".message:last-child", text: "Is this a Ryanair style democracy?")
     end
   end
@@ -142,6 +148,11 @@ describe "Conversations", type: :feature do
   end
 
   private
+
+  def start_conversation(message)
+    fill_in "conversation_body", with: message
+    click_button "Send"
+  end
 
   def visit_inbox
     visit decidim.root_path


### PR DESCRIPTION
#### :tophat: What? Why?

This PR prevents the creation of many conversation with the same participants at the UI level. Since things are prepared at a lower level to actually permit this (for a future "conversation groups" feature), I don't think this is worth enforcing at a lower level.

#### :pushpin: Related Issues
- Fixes #2375.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![plant_alive](https://user-images.githubusercontent.com/2887858/33997935-ce43b338-e0c4-11e7-818e-44afe298f040.gif)