### PR TITLE
Add missing i18n for processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ you need to change the following line in `config/environments/production.rb`:
 ```
 
 **Added**:
+- **decidim-participatory_processes**: Add missinng translations for processes [\#2380](https://github.com/decidim/decidim/pull/2380)
 - **decidim-verifications**: Let developers specify for how long authorizations are valid. After this space of time passes, authorizations expire and users need to re-authorize [\#2311](https://github.com/decidim/decidim/pull/2311)
 
 **Changed**:

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
@@ -103,6 +103,7 @@
 
     <div class="row column">
       <%= form.translated :editor, :announcement %>
+      <p class="help-text"><%== t(".announcement_help") %></p>
     </div>
   </div>
 </div>

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -3,6 +3,7 @@ en:
   activemodel:
     attributes:
       participatory_process:
+        announcement: Announcement
         banner_image: Banner image
         copy_categories: Copy categories
         copy_features: Copy features
@@ -22,6 +23,7 @@ en:
         scope_id: Scope
         scopes_enabled: Scopes enabled
         short_description: Short description
+        show_statistics: Show statistics
         slug: URL slug
         start_date: Start date
         subtitle: Subtitle
@@ -218,6 +220,7 @@ en:
             slug_help: 'URL slugs are used to generate the URLs that point to this process. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
         participatory_processes:
           form:
+            announcement_help: The text you enter here will be shown to the user right below the process information.
             slug_help: 'URL slugs are used to generate the URLs that point to this process. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
       index:
         title: Participatory processes


### PR DESCRIPTION
#### :tophat: What? Why?
Adds missing i18n strings for processes. It also adds some help text for the announcement field.

#### :pushpin: Related Issues
- Fixes #2362.