### PR TITLE
Use all space types for homepage stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ you need to change the following line in `config/environments/production.rb`:
 - **decidim-core**: Add unique nicknames for participants. [\2360](https://github.com/decidim/decidim/pull/2360)
 - **decidom-admin**: Let admins officialize certain users from the admin dashboard and specify custom officialization text for them. [\2405](https://github.com/decidim/decidim/pull/2405)
 - **decidim-core**: Public profile page for participants, including name, nickname, follow button, avatar and officialization badge & text. [\2391](https://github.com/decidim/decidim/pull/2391), [\2360](https://github.com/decidim/decidim/pull/2360), [\2401](https://github.com/decidim/decidim/pull/2401) and [\2405](https://github.com/decidim/decidim/pull/2405).
+- **decidim-core**: Add a way for space manifests to publicize how to retrieve public spaces for a given organization [\#2384](https://github.com/decidim/decidim/pull/2384)
 - **decidim-participatory_processes**: Add missinng translations for processes [\#2380](https://github.com/decidim/decidim/pull/2380)
 - **decidim-verifications**: Let developers specify for how long authorizations are valid. After this space of time passes, authorizations expire and users need to re-authorize [\#2311](https://github.com/decidim/decidim/pull/2311)
 - **decidim**: Scopes picker that allows hierarchical browsing scope to select them ([\#2330](https://github.com/decidim/decidim/pull/2330)).

--- a/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
@@ -6,6 +6,10 @@ Decidim.register_participatory_space(:assemblies) do |participatory_space|
   participatory_space.icon = "decidim/assemblies/icon.svg"
   participatory_space.model_class_name = "Decidim::Assembly"
 
+  participatory_space.public_spaces do |organization|
+    Decidim::Assemblies::OrganizationPublishedAssemblies.new(organization).query
+  end
+
   participatory_space.seeds do
     organization = Decidim::Organization.first
     seeds_root = File.join(__dir__, "..", "..", "..", "db", "seeds")

--- a/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
@@ -6,8 +6,8 @@ Decidim.register_participatory_space(:assemblies) do |participatory_space|
   participatory_space.icon = "decidim/assemblies/icon.svg"
   participatory_space.model_class_name = "Decidim::Assembly"
 
-  participatory_space.public_spaces do |organization|
-    Decidim::Assemblies::OrganizationPublishedAssemblies.new(organization).query
+  participatory_space.participatory_spaces do |organization|
+    Decidim::Assemblies::OrganizationAssemblies.new(organization).query
   end
 
   participatory_space.seeds do

--- a/decidim-core/app/presenters/decidim/home_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/home_stats_presenter.rb
@@ -76,7 +76,7 @@ module Decidim
 
     def public_participatory_spaces
       @public_participatory_spaces ||= Decidim.participatory_space_manifests.flat_map do |manifest|
-        manifest.public_spaces.call(organization)
+        manifest.participatory_spaces.call(organization).public_spaces
       end
     end
 

--- a/decidim-core/app/presenters/decidim/home_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/home_stats_presenter.rb
@@ -74,8 +74,14 @@ module Decidim
       end
     end
 
+    def public_participatory_spaces
+      @public_participatory_spaces ||= Decidim.participatory_space_manifests.flat_map do |manifest|
+        manifest.public_spaces.call(organization)
+      end
+    end
+
     def published_features
-      @published_features ||= Feature.where(participatory_space: ParticipatoryProcesses::OrganizationPublishedParticipatoryProcesses.new(organization).query).published
+      @published_features ||= Feature.where(participatory_space: public_participatory_spaces).published
     end
   end
 end

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -406,7 +406,7 @@ en:
         participate: Participate
         welcome: Welcome to %{organization}!
       statistics:
-        answers_count: Answers
+        answers_count: Completed Surveys
         assemblies_count: Assemblies
         comments_count: Comments
         headline: Current state of %{organization}

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -4,6 +4,7 @@ require "decidim/faker/localized"
 require "decidim/dev"
 
 require "decidim/participatory_processes/test/factories"
+require "decidim/assemblies/test/factories"
 require "decidim/comments/test/factories"
 
 FactoryBot.define do

--- a/decidim-core/lib/decidim/participable.rb
+++ b/decidim-core/lib/decidim/participable.rb
@@ -80,6 +80,14 @@ module Decidim
       def participatory_space_manifest
         Decidim.find_participatory_space_manifest(name.demodulize.underscore.pluralize)
       end
+
+      # Public: Adds a sane default way to retrieve public spaces. Please, overwrite
+      # this from your model class in case this is not correct for your model.
+      #
+      # Returns an `ActiveRecord::Association`.
+      def public_spaces
+        published
+      end
     end
   end
 end

--- a/decidim-core/lib/decidim/participatory_space_manifest.rb
+++ b/decidim-core/lib/decidim/participatory_space_manifest.rb
@@ -51,8 +51,13 @@ module Decidim
       super || model_class_name.demodulize.underscore
     end
 
-    def public_spaces(&block)
-      @public_resources ||= block
+    # Public: A block that retrieves all the participatory spaces for the manifest.
+    # The block receives a `Decidim::Organization` as a parameter in order to filter.
+    # The block is expected to return an `ActiveRecord::Association`.
+    #
+    # Returns nothing.
+    def participatory_spaces(&block)
+      @participatory_spaces ||= block
     end
   end
 end

--- a/decidim-core/lib/decidim/participatory_space_manifest.rb
+++ b/decidim-core/lib/decidim/participatory_space_manifest.rb
@@ -50,5 +50,9 @@ module Decidim
     def route_name
       super || model_class_name.demodulize.underscore
     end
+
+    def public_spaces(&block)
+      @public_resources ||= block
+    end
   end
 end

--- a/decidim-core/spec/features/components_spec.rb
+++ b/decidim-core/spec/features/components_spec.rb
@@ -9,6 +9,18 @@ describe "Features can be navigated", type: :feature do
 
   describe "navigate to a component" do
     before do
+      I18n.backend.store_translations(
+        :en,
+        decidim: {
+          participatory_processes: {
+            statistics: {
+              dummies_count_medium: "Dummies medium",
+              dummies_count_high: "Dummies high"
+            }
+          }
+        }
+      )
+
       visit decidim_participatory_processes.participatory_process_path(participatory_process)
     end
 

--- a/decidim-core/spec/features/components_spec.rb
+++ b/decidim-core/spec/features/components_spec.rb
@@ -9,18 +9,6 @@ describe "Features can be navigated", type: :feature do
 
   describe "navigate to a component" do
     before do
-      I18n.backend.store_translations(
-        :en,
-        decidim: {
-          participatory_processes: {
-            statistics: {
-              dummies_count_medium: "Dummies medium",
-              dummies_count_high: "Dummies high"
-            }
-          }
-        }
-      )
-
       visit decidim_participatory_processes.participatory_process_path(participatory_process)
     end
 

--- a/decidim-core/spec/presenters/decidim/home_stats_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/home_stats_presenter_spec.rb
@@ -18,20 +18,6 @@ module Decidim
       Decidim.stats.register :bar, priority: StatsRegistry::MEDIUM_PRIORITY, &proc { 20 }
       Decidim.stats.register :baz, priority: StatsRegistry::LOW_PRIORITY, &proc { 30 }
 
-      I18n.backend.store_translations(
-        :en,
-        pages: {
-          home: {
-            statistics: {
-              dummies_count_medium: "Dummies medium",
-              dummies_count_high: "Dummies high",
-              foo: "Foo",
-              bar: "Bar"
-            }
-          }
-        }
-      )
-
       example.run
 
       Decidim.stats.stats.reject! { |s| s[:name] == :baz }

--- a/decidim-core/spec/presenters/decidim/home_stats_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/home_stats_presenter_spec.rb
@@ -8,7 +8,10 @@ module Decidim
 
     let!(:organization) { create(:organization) }
     let!(:user) { create(:user, :confirmed, organization: organization) }
-    let!(:process) { create(:participatory_process, organization: organization) }
+    let!(:process) { create(:participatory_process, :published, organization: organization) }
+    let!(:assembly) { create(:assembly, :published, organization: organization) }
+    let!(:process_feature) { create :feature, participatory_space: process }
+    let!(:assembly_feature) { create :feature, participatory_space: assembly }
 
     around do |example|
       Decidim.stats.register :foo, priority: StatsRegistry::HIGH_PRIORITY, &proc { 10 }
@@ -20,6 +23,8 @@ module Decidim
         pages: {
           home: {
             statistics: {
+              dummies_count_medium: "Dummies medium",
+              dummies_count_high: "Dummies high",
               foo: "Foo",
               bar: "Bar"
             }
@@ -35,7 +40,8 @@ module Decidim
     end
 
     before do
-      allow(Decidim).to receive(:feature_manifests).and_return([])
+      manifests = Decidim.feature_manifests.select { |manifest| manifest.name == :dummy }
+      allow(Decidim).to receive(:feature_manifests).and_return(manifests)
     end
 
     describe "#highlighted" do
@@ -53,8 +59,18 @@ module Decidim
           "</div>" \
           "<div class=\"home-pam__highlight\">" \
             "<div class=\"home-pam__data\">" \
+              "<h4 class=\"home-pam__title\">Assemblies</h4>" \
+              "<span class=\"home-pam__number assemblies_count\"> 1</span>" \
+            "</div>" \
+            "<div class=\"home-pam__data\">" \
               "<h4 class=\"home-pam__title\">Foo</h4>" \
               "<span class=\"home-pam__number foo\"> 10</span>" \
+            "</div>" \
+          "</div>" \
+          "<div class=\"home-pam__highlight\">" \
+            "<div class=\"home-pam__data\">" \
+              "<h4 class=\"home-pam__title\">Dummies high</h4>" \
+              "<span class=\"home-pam__number dummies_count_high\"> 20</span>" \
             "</div>" \
           "</div>"
         )
@@ -70,7 +86,8 @@ module Decidim
               "<span class=\"home-pam__number bar\"> 20</span>" \
             "</div>" \
             "<div class=\"home-pam__data\">" \
-              "&nbsp;" \
+              "<h4 class=\"home-pam__title\">Dummies medium</h4>" \
+              "<span class=\"home-pam__number dummies_count_medium\"> 200</span>" \
             "</div>" \
             "<div class=\"home-pam__data\">" \
               "&nbsp;" \

--- a/decidim-dev/config/locales/en.yml
+++ b/decidim-dev/config/locales/en.yml
@@ -5,6 +5,17 @@ en:
       admin:
         exports:
           dummies: Dummies
+    participatory_processes:
+      statistics:
+        dummies_count_high: Dummies high
+        dummies_count_medium: Dummies medium
     resource_links:
       test_link:
         dummy_resource_dummy: Related dummy
+  pages:
+    home:
+      statistics:
+        bar: Bar
+        dummies_count_high: Dummies high
+        dummies_count_medium: Dummies medium
+        foo: Foo

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
@@ -113,10 +113,6 @@ Decidim.register_feature(:dummy) do |feature|
     features.count * 100
   end
 
-  feature.register_stat :dummies_count_low do |features, _start_at, _end_at|
-    features.count * 200
-  end
-
   feature.exports :dummies do |exports|
     exports.collection do
       [1, 2, 3]

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
@@ -105,6 +105,18 @@ Decidim.register_feature(:dummy) do |feature|
     resource.template = "decidim/dummy_resource/linked_dummys"
   end
 
+  feature.register_stat :dummies_count_high, primary: true, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |features, _start_at, _end_at|
+    features.count * 10
+  end
+
+  feature.register_stat :dummies_count_medium, primary: true, priority: Decidim::StatsRegistry::MEDIUM_PRIORITY do |features, _start_at, _end_at|
+    features.count * 100
+  end
+
+  feature.register_stat :dummies_count_low do |features, _start_at, _end_at|
+    features.count * 200
+  end
+
   feature.exports :dummies do |exports|
     exports.collection do
       [1, 2, 3]

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
@@ -6,6 +6,10 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
   participatory_space.icon = "decidim/participatory_processes/icon.svg"
   participatory_space.model_class_name = "Decidim::ParticipatoryProcess"
 
+  participatory_space.public_spaces do |organization|
+    Decidim::ParticipatoryProcesses::OrganizationPublishedParticipatoryProcesses.new(organization).query
+  end
+
   participatory_space.seeds do
     organization = Decidim::Organization.first
     seeds_root = File.join(__dir__, "..", "..", "..", "db", "seeds")

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
@@ -6,8 +6,8 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
   participatory_space.icon = "decidim/participatory_processes/icon.svg"
   participatory_space.model_class_name = "Decidim::ParticipatoryProcess"
 
-  participatory_space.public_spaces do |organization|
-    Decidim::ParticipatoryProcesses::OrganizationPublishedParticipatoryProcesses.new(organization).query
+  participatory_space.participatory_spaces do |organization|
+    Decidim::ParticipatoryProcesses::OrganizationParticipatoryProcesses.new(organization).query
   end
 
   participatory_space.seeds do

--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -52,7 +52,7 @@ Decidim.register_feature(:proposals) do |feature|
     Decidim::Proposals::FilteredProposals.for(features, start_at, end_at).accepted.count
   end
 
-  feature.register_stat :votes_count, priority: Decidim::StatsRegistry::MEDIUM_PRIORITY do |features, start_at, end_at|
+  feature.register_stat :votes_count, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |features, start_at, end_at|
     proposals = Decidim::Proposals::FilteredProposals.for(features, start_at, end_at).not_hidden
     Decidim::Proposals::ProposalVote.where(proposal: proposals).count
   end

--- a/decidim-surveys/lib/decidim/surveys/feature.rb
+++ b/decidim-surveys/lib/decidim/surveys/feature.rb
@@ -27,7 +27,7 @@ Decidim.register_feature(:surveys) do |feature|
     surveys.count
   end
 
-  feature.register_stat :answers_count, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |features, start_at, end_at|
+  feature.register_stat :answers_count, priority: Decidim::StatsRegistry::MEDIUM_PRIORITY do |features, start_at, end_at|
     surveys = Decidim::Surveys::Survey.where(feature: features)
     answers = Decidim::Surveys::SurveyAnswer.where(survey: surveys)
     answers = answers.where("created_at >= ?", start_at) if start_at.present?


### PR DESCRIPTION
#### :tophat: What? Why?
After #2221, which improved the stats count in the homepage, we realized numbers were still wrong. Only processes were being used for these calculations, so assemblies or initiatives were excluded.

This PR adds a way for participatory space manifests to define how to retrieve public spaces for a given organization. Then these values are used to calculate all the stats.

Example: The development app has 2 processes and 2 assemblies by default, each of those has all possible features. This amount to 4 proposal features, 4 meeting features, etc. For meetings, for example, we create only 2 elements per feature. This should amount to 8 meetings.

Before this PR:
![](https://i.imgur.com/bzIqq8d.png)

After this PR:
![](https://i.imgur.com/nJDFaC3.png)

Number have doubled because we always create the same amount amount of resources per feature.

#### :pushpin: Related Issues
- Related to #2221

#### :clipboard: Subtasks
None