### PR TITLE
Start tagging slow specs to prevent flakies

### DIFF
--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -23,7 +23,7 @@ shared_examples "comments" do
     end
   end
 
-  it "allows user to sort the comments" do
+  it "allows user to sort the comments", :slow do
     comment = create(:comment, commentable: commentable, body: "Most Rated Comment")
     create(:comment_vote, comment: comment, author: user, weight: 1)
 

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -71,5 +71,13 @@ RSpec.configure do |config|
     switch_to_default_host
   end
 
+  config.around :each, :slow do |example|
+    max_wait_time_for_slow_specs = 7
+
+    using_wait_time(max_wait_time_for_slow_specs) do
+      example.run
+    end
+  end
+
   config.include Decidim::CapybaraTestHelpers, type: :feature
 end


### PR DESCRIPTION
#### :tophat: What? Why?

This is what I'm proposing to do for now to avoid specs that are too slow from getting in the middle.

* Every time we get one of this flakies, add a 2 second delay server side locally and confirm that the failure reliably reproduces. Then confirm that tagging the specs as slow fixes it.

* Open an issue to tackle the real source of this performance problems and fix them.

#### :pushpin: Related Issues
- Related to #2367.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![coffeegiven](https://user-images.githubusercontent.com/2887858/34075460-6bc61348-e2a6-11e7-8b01-38c61909cee1.gif)

