### PR TITLE
Fix on new authorization form errors

### DIFF
--- a/decidim-verifications/app/views/decidim/verifications/authorizations/new.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/authorizations/new.html.erb
@@ -2,7 +2,7 @@
   <div class="row collapse">
     <div class="row collapse">
       <div class="columns large-8 large-centered text-center page-title">
-        <h1><%= t(".authorize_with", authorizer: t("#{params[:handler]}.name", scope: "decidim.authorization_handlers")) %></h1>
+        <h1><%= t(".authorize_with", authorizer: t("#{handler.handler_name}.name", scope: "decidim.authorization_handlers")) %></h1>
       </div>
     </div>
 

--- a/decidim-verifications/spec/features/authorizations_spec.rb
+++ b/decidim-verifications/spec/features/authorizations_spec.rb
@@ -97,6 +97,22 @@ describe "Authorizations", type: :feature, with_authorization_workflows: ["dummy
           expect(page).to have_no_link("Example authorization")
         end
       end
+      
+      it "checks if the given data is invalid" do
+        within_user_menu do
+          click_link "My account"
+        end
+
+        click_link "Authorizations"
+        click_link "Example authorization"
+
+        fill_in "Document number", with: "12345678"
+        page.execute_script("$('#date_field_authorization_handler_birthday').focus()")
+        page.find(".datepicker-dropdown .day", text: "12").click
+        click_button "Send"
+
+        expect(page).to have_content("There was an error creating the authorization.")
+      end
     end
 
     context "when the user has already been authorized" do

--- a/decidim-verifications/spec/features/authorizations_spec.rb
+++ b/decidim-verifications/spec/features/authorizations_spec.rb
@@ -97,7 +97,7 @@ describe "Authorizations", type: :feature, with_authorization_workflows: ["dummy
           expect(page).to have_no_link("Example authorization")
         end
       end
-      
+
       it "checks if the given data is invalid" do
         within_user_menu do
           click_link "My account"


### PR DESCRIPTION
#### :tophat: What? Why?
The form's submit URL doesn't include the `handler` param, so when there is an error on the form there is no value for `params[:handler]`. Then, it throws an i18n exception, because its trying to find `.name` key.

#### :pushpin: Related Issues

#### :clipboard: Subtasks

### :camera: Screenshots (optional)

#### :ghost: GIF
![giphy](https://user-images.githubusercontent.com/453545/34099427-ceeb8702-e3df-11e7-8ddb-9b778e8bfe4f.gif)
