### PR TITLE
[DOC] Add bundle install step to getting started.

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -35,6 +35,7 @@ Afterwards, you can create an application with the nice `decidim` executable:
 ```
 $ decidim decidim_application
 $ cd decidim_application
+$ bundle install
 ```
 
 ### Initializing your app for local development


### PR DESCRIPTION
#### :tophat: What? Why?
Add the `bundle install` step to the "getting started" how to.

#### :pushpin: Related Issues
- Related to #? none
- Fixes #? none
