### PR TITLE
Fix missing button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ you need to change the following line in `config/environments/production.rb`:
 - **decidim-meetings**: Prevent double-click form submissions [\#2379](https://github.com/decidim/decidim/pull/2379)
 - **decidim-proposals**: Do not allow attachments on proposals edition [\#2221](https://github.com/decidim/decidim/pull/2221)
 - **decidim-proposals**: Prevent double-click form submissions [\#2379](https://github.com/decidim/decidim/pull/2379)
+- **decidim-proposals**: Fix missing icon on proposal reply.
 - **decidim-surveys**: Prevent double-click form submissions [\#2379](https://github.com/decidim/decidim/pull/2379)
 - **decidim-verifications**: Fixed a migration that broke feature permissions. If you already upgraded to `0.8.2` or less, please follow the instructions on the PR [\#2373](https://github.com/decidim/decidim/pull/2373)
 

--- a/decidim-core/app/views/decidim/notifications/_notification.html.erb
+++ b/decidim-core/app/views/decidim/notifications/_notification.html.erb
@@ -1,7 +1,7 @@
 <div class="card--list__item">
   <div class="card--list__text">
     <%= link_to notification.event_class_instance.resource_path do %>
-      <%= resource_icon notification.resource, class: "icon--conversation card--list__icon" %>
+      <%= resource_icon notification.resource, class: "icon--chat card--list__icon" %>
     <% end %>
     <div>
       <h5 class="card--list__heading">


### PR DESCRIPTION
#### :tophat: What? Why?
Fix bug introduced by the renaming of `conversations` to `chats`. Silliest bug evar. @deivid-rodriguez check this out hahahaha.

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/metadecidim/issues/9

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
*None*
