### PR TITLE
Translated attribute improvements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,20 @@ you need to change the following line in `config/environments/production.rb`:
 - **decidim-participatory_processes**: Add missinng translations for processes [\#2380](https://github.com/decidim/decidim/pull/2380)
 - **decidim-verifications**: Let developers specify for how long authorizations are valid. After this space of time passes, authorizations expire and users need to re-authorize [\#2311](https://github.com/decidim/decidim/pull/2311)
 
-**Changed**:
+**Changed
+
+- **decidim-core**: translated_attribute helper changes its default behaviour. Previously it was following these steps:
+  1. Return the current user locale translation if available.
+  2. Fallback to organization default locale in case the user locale translation is not available.
+  3. Otherwise return blank.
+
+
+  Now it follows these steps:
+
+  1. Return the current user locale translation if available.
+  2. Fallback to organization default locale in case the user locale translation is not available.
+  3. Fallback to the first available translation in case there was no user nor default organization locale translations.
+  4. Otherwise return blank.
 
 **Fixed**:
 

--- a/decidim-core/app/helpers/decidim/translations_helper.rb
+++ b/decidim-core/app/helpers/decidim/translations_helper.rb
@@ -11,8 +11,12 @@ module Decidim
     #
     # Returns a String with the translation.
     def translated_attribute(attribute)
-      attribute.try(:[], I18n.locale.to_s).presence ||
-        attribute.try(:[], current_organization.default_locale).presence ||
+      return "" if attribute.nil?
+      return attribute unless attribute.is_a?(Hash)
+
+      attribute[I18n.locale.to_s].presence ||
+        attribute[current_organization.default_locale].presence ||
+        attribute[attribute.keys.first].presence ||
         ""
     end
 

--- a/decidim-core/spec/helpers/decidim/translations_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/translations_helper_spec.rb
@@ -32,11 +32,11 @@ module Decidim
         end
 
         context "when the default locale is not present" do
-          it "returns an empty string" do
+          it "returns the first available string" do
             attribute = { "ca" => "Hola" }
 
             I18n.with_locale(:'zh-CN') do
-              expect(helper.translated_attribute(attribute)).to eq("")
+              expect(helper.translated_attribute(attribute)).to eq("Hola")
             end
           end
         end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     entrypoint: []
     command: decidim
     working_dir: "/code"
+    ports:
+      - "3000:3000"
     volumes:
       - .:/code
       - bundle:/usr/local/bundle


### PR DESCRIPTION


#### :tophat: What? Why?
translated_attribute fallbacks to the first available translation before
returning an empty  string. This change is necessary in order to being
able to use this method in initiatives: Initiatives will have only one
translation that might not be necessarily the current locale nor the
default  locale.

#### :pushpin: Related Issues

Check translation related issues in decidim-initiatives.
