### PR TITLE
Fix for a bug when there is an error editing a proposal. Checking test added.

### DIFF
--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -77,7 +77,6 @@ module Decidim
         authorize! :edit, @proposal
 
         @form = form(ProposalForm).from_params(params)
-
         UpdateProposal.call(@form, current_user, @proposal) do
           on(:ok) do |proposal|
             flash[:notice] = I18n.t("proposals.update.success", scope: "decidim")
@@ -86,7 +85,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("proposals.update.error", scope: "decidim")
-            render :new
+            render :edit
           end
         end
       end

--- a/decidim-proposals/spec/features/edit_proposal_spec.rb
+++ b/decidim-proposals/spec/features/edit_proposal_spec.rb
@@ -37,6 +37,24 @@ describe "Edit proposals", type: :feature do
       expect(page).to have_content(new_title)
       expect(page).to have_content(new_body)
     end
+
+    context "when updating with wrong data" do
+      let(:feature) { create(:proposal_feature, :with_creation_enabled, :with_attachments_allowed, participatory_space: participatory_process) }
+
+      it "returns an error message" do
+        visit_feature
+
+        click_link proposal.title
+        click_link "Edit proposal"
+
+        expect(page).to have_content "EDIT PROPOSAL"
+
+        fill_in "Body", with: "A"
+        click_button "Send"
+
+        expect(page).to have_content("Is using too much caps, Is too short, Is using too much caps, Is too short")
+      end
+    end
   end
 
   describe "editing someone else's proposal" do


### PR DESCRIPTION
#### :tophat: What? Why?
When updating a proposal and data has errors, it renders `new`template instead of `edit`template.

#### :pushpin: Related Issues

#### :clipboard: Subtasks

### :camera: Screenshots (optional)
![bug](https://user-images.githubusercontent.com/453545/34251796-7f089964-e641-11e7-9610-a2f19d2114a8.gif)

#### :ghost: GIF
![](http://i.imgur.com/ngqBdWe.gif)
