### PR TITLE
Don't crash when no participatory space in scopes helper

### DIFF
--- a/decidim-core/app/helpers/decidim/scopes_helper.rb
+++ b/decidim-core/app/helpers/decidim/scopes_helper.rb
@@ -29,7 +29,7 @@ module Decidim
 
     def scopes_picker_filter(form, name)
       form.scopes_picker name, multiple: true, legend_title: I18n.t("decidim.scopes.scopes"), label: false do |scope|
-        { url: decidim.scopes_picker_path(root: current_participatory_space.scope, current: scope&.id, title: I18n.t("decidim.scopes.prompt"), global_value: "global"),
+        { url: decidim.scopes_picker_path(root: try(:current_participatory_space)&.scope, current: scope&.id, title: I18n.t("decidim.scopes.prompt"), global_value: "global"),
           text: scope_name_for_picker(scope, I18n.t("decidim.scopes.prompt")) }
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

Fixes a bug introduced by #2330. It was crashing at `decidim-initiatives` when no `current_participatory_space` exists.
