### PR TITLE
Avoid `with_clean_env`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -100,11 +100,9 @@ task :test_app do
     sh "rm -fR #{dummy_app_path}", verbose: false
   end
 
-  Bundler.with_clean_env do
-    Decidim::Generators::AppGenerator.start(
-      [dummy_app_path, "--path", "../..", "--recreate_db", "--demo"]
-    )
-  end
+  Decidim::Generators::AppGenerator.start(
+    [dummy_app_path, "--path", "../..", "--recreate_db", "--demo"]
+  )
 end
 
 desc "Generates a development app."
@@ -113,22 +111,18 @@ task :development_app do
     sh "rm -fR development_app", verbose: false
   end
 
-  Bundler.with_clean_env do
-    Decidim::Generators::AppGenerator.start(
-      ["development_app", "--path", "..", "--recreate_db", "--seed_db", "--demo"]
-    )
-  end
+  Decidim::Generators::AppGenerator.start(
+    ["development_app", "--path", "..", "--recreate_db", "--seed_db", "--demo"]
+  )
 end
 
 desc "Generates a development app based on Docker."
 task :docker_development_app do
   docker_app_path = __dir__ + "/docker_development_app"
 
-  Bundler.with_clean_env do
-    Decidim::Generators::DockerGenerator.start(
-      ["docker_development_app", "--docker_app_path", docker_app_path]
-    )
-  end
+  Decidim::Generators::DockerGenerator.start(
+    ["docker_development_app", "--docker_app_path", docker_app_path]
+  )
 end
 
 desc "Build webpack bundle files"

--- a/decidim-dev/lib/tasks/locale_checker.rake
+++ b/decidim-dev/lib/tasks/locale_checker.rake
@@ -12,7 +12,7 @@ namespace :decidim do
     Dir.chdir("tmp/decidim_repo") do
       env = { "ENFORCED_LOCALES" => Decidim.available_locales.join(",") }
 
-      Bundler.with_clean_env do
+      Bundler.with_original_env do
         system(env, "bundle install")
         system(env, "bundle exec rspec spec/i18n_spec.rb")
       end

--- a/lib/generators/decidim/app_generator.rb
+++ b/lib/generators/decidim/app_generator.rb
@@ -24,28 +24,35 @@ module Decidim
 
       source_root File.expand_path("templates", __dir__)
 
-      class_option :path, type: :string, default: nil,
+      class_option :path, type: :string,
+                          default: nil,
                           desc: "Path to the gem"
 
-      class_option :edge, type: :boolean, default: false,
+      class_option :edge, type: :boolean,
+                          default: false,
                           desc: "Use GitHub's edge version from master branch"
 
-      class_option :branch, type: :string, default: nil,
+      class_option :branch, type: :string,
+                            default: nil,
                             desc: "Use a specific branch from GitHub's version"
 
-      class_option :database, type: :string, aliases: "-d", default: "postgresql",
+      class_option :database, type: :string,
+                              default: "postgresql",
                               desc: "Configure for selected database (options: #{DATABASES.join("/")})"
 
-      class_option :recreate_db, type: :boolean, default: false,
+      class_option :recreate_db, type: :boolean,
+                                 default: false,
                                  desc: "Recreate test database"
 
-      class_option :seed_db, type: :boolean, default: false,
+      class_option :seed_db, type: :boolean,
+                             default: false,
                              desc: "Seed test database"
 
       class_option :app_const_base, type: :string,
                                     desc: "The application constant name"
 
-      class_option :skip_bundle, type: :boolean, aliases: "-B", default: true,
+      class_option :skip_bundle, type: :boolean,
+                                 default: true,
                                  desc: "Don't run bundle install"
 
       class_option :skip_gemfile, type: :boolean,

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 describe "Application generation" do
-  let(:status) { Bundler.clean_system(command, out: File::NULL) }
+  let(:status) do
+    Bundler.with_original_env { system(command, out: File::NULL) }
+  end
 
   let(:test_app) { "spec/generator_test_app" }
 


### PR DESCRIPTION
#### :tophat: What? Why?

Bundler is [deprecating this method](https://github.com/bundler/bundler/blob/060e2f953c8f08dd7bed9711863e6341eebe5fe2/lib/bundler.rb#L284), let's start using the alternative.

On some places I directly removed it since now we're using the exact same Gemfile in the root of the repo and the development & test application so it's not needed.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![cat_arms](https://user-images.githubusercontent.com/2887858/34309373-6f1becd2-e730-11e7-9c95-289b82433754.gif)
