### PR TITLE
Remove unnecessary codecov ignores

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -19,7 +19,3 @@ coverage:
 comment:
   layout: "header, diff"
   behavior: default
-
-ignore:
-  - package-lock.json
-  - *.md


### PR DESCRIPTION
#### :tophat: What? Why?

Back when we were using `rspec-repeat`, there were weird situations when coverage reported by codecov would fluctuate (and fail the codecov check). This happened because [the line](https://github.com/decidim/decidim/blob/27fa313e227340e0196a9b207314f92cfa81be85/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb#L58) where failure screenshots are taken would only be hit when flakies happened during the test run. That would cause wierd "random" fluctuations. These fluctuations can no longer happen because we're no longer using `rspec-repeat`, so if flakies happen, tests fail.

To prevent this, we incorrectly add the exclusions, but the problem had nothing to do with it. This PR just removes those exclusions now that we know the real culprit.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![cat asking](https://user-images.githubusercontent.com/2887858/34309538-498c2d46-e731-11e7-9d24-255d41b06f1d.gif)
