### PR TITLE
Fix missing icon in proposal's admin index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ you need to change the following line in `config/environments/production.rb`:
 - **decidim-proposals**: Do not allow attachments on proposals edition [\#2221](https://github.com/decidim/decidim/pull/2221)
 - **decidim-proposals**: Prevent double-click form submissions [\#2379](https://github.com/decidim/decidim/pull/2379)
 - **decidim-proposals**: Fix missing icon on proposal reply.
+- **decidim-proposals**: Fix missing icon on proposal admin index.
 - **decidim-surveys**: Prevent double-click form submissions [\#2379](https://github.com/decidim/decidim/pull/2379)
 - **decidim-verifications**: Fixed a migration that broke feature permissions. If you already upgraded to `0.8.2` or less, please follow the instructions on the PR [\#2373](https://github.com/decidim/decidim/pull/2373)
 

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -70,7 +70,7 @@
               <% end %>
               <td class="table-list__actions">
                 <% if can? :update, proposal %>
-                  <%= icon_link_to "conversation", edit_proposal_proposal_answer_path(proposal_id: proposal.id, id: proposal.id), t("actions.answer", scope: "decidim.proposals"), class: "action-icon--edit-answer" %>
+                  <%= icon_link_to "chat", edit_proposal_proposal_answer_path(proposal_id: proposal.id, id: proposal.id), t("actions.answer", scope: "decidim.proposals"), class: "action-icon--edit-answer" %>
                 <% end %>
                 <%= icon_link_to "eye", resource_locator(proposal).path, t("actions.preview", scope: "decidim.proposals.admin"), class: "action-icon--preview", target: :blank %>
               </td>


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes another invisible icon in the admin dashboard.

#### :pushpin: Related Issues
- Related to #2399.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![tails](https://user-images.githubusercontent.com/2887858/34310235-194d45d0-e735-11e7-9d3e-95422426324c.gif)
