### PR TITLE
Add change log entries for officializations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ you need to change the following line in `config/environments/production.rb`:
 **Added**:
 - **decidim-core**: Follow users and get notifications about their actions. [\2401](https://github.com/decidim/decidim/pull/2401)
 - **decidim-core**: Add unique nicknames for participants. [\2360](https://github.com/decidim/decidim/pull/2360)
-- **decidim-core**: Public profile page for participants. [\2391](https://github.com/decidim/decidim/pull/2391)
+- **decidom-admin**: Let admins officialize certain users from the admin dashboard and specify custom officialization text for them. [\2405](https://github.com/decidim/decidim/pull/2405)
+- **decidim-core**: Public profile page for participants, including name, nickname, follow button, avatar and officialization badge & text. [\2391](https://github.com/decidim/decidim/pull/2391), [\2360](https://github.com/decidim/decidim/pull/2360), [\2401](https://github.com/decidim/decidim/pull/2401) and [\2405](https://github.com/decidim/decidim/pull/2405).
 - **decidim-participatory_processes**: Add missinng translations for processes [\#2380](https://github.com/decidim/decidim/pull/2380)
 - **decidim-verifications**: Let developers specify for how long authorizations are valid. After this space of time passes, authorizations expire and users need to re-authorize [\#2311](https://github.com/decidim/decidim/pull/2311)
 - **decidim**: Scopes picker that allows hierarchical browsing scope to select them ([\#2330](https://github.com/decidim/decidim/pull/2330)).


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds missing change log entries for the latest changes adding the ability to officialize users.

#### :pushpin: Related Issues
- Related to #2405.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
![smile_elf](https://user-images.githubusercontent.com/2887858/34319761-af989628-e7c8-11e7-9b91-dee95d59183f.gif)
