### PR TITLE
Convert doc reference from "rake" to "rails"

### DIFF
--- a/decidim-dev/README.md
+++ b/decidim-dev/README.md
@@ -6,7 +6,7 @@ This gem allows local development of decidim's features and other features.
 
 `decidim-dev` provides some testing utils such as shared contexts, examples, and
 dummy assets or resources that you can use to test your own plugins. It also
-provides a `decidim:generate_external_test_app` rake task that you can use to
+provides a `decidim:generate_external_test_app` rails task that you can use to
 generate a dummy application to test your plugin.
 
 ## Installation


### PR DESCRIPTION
#### :tophat: What? Why?

This PR updates documentation to reference `rails` instead of `rake` commands for tasks inside the generated app.

#### :pushpin: Related Issues
- Fixes #2386 

#### :clipboard: Subtasks
- N/A

### :camera: Screenshots (optional)
- N/A

#### :ghost: GIF
- N/A