### PR TITLE
Allow AuthorizationHandlers to customize authorization status check process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,13 @@ you need to change the following line in `config/environments/production.rb`:
 + config.assets.js_compressor = Uglifier.new(:harmony => true)
 ```
 
-- **decidim-verifications**: Added authorization hooks. [\#2438](https://github.com/decidim/decidim/pull/2438)
+**Added**:
+- **decidim-verifications**: Added action authorizers for authorization handlers. [\#2438](https://github.com/decidim/decidim/pull/2438)
 - **decidim-accountability**: Add feature to link projects with results [\#2467](https://github.com/decidim/decidim/pull/2467)
 - **decidim-proposals**: Improve proposals admin panel usability (sorting). [\#2419](https://github.com/decidim/decidim/pull/2419)
 - **decidim-core**: Follow users and get notifications about their actions. [\#2401](https://github.com/decidim/decidim/pull/2401)
 - **decidim-core**: Add unique nicknames for participants. [\#2360](https://github.com/decidim/decidim/pull/2360)
-- **decidom-admin**: Let admins officialize certain users from the admin dashboard and specify custom officialization text for them. [\#2405](https://github.com/decidim/decidim/pull/2405)
+- **decidim-admin**: Let admins officialize certain users from the admin dashboard and specify custom officialization text for them. [\#2405](https://github.com/decidim/decidim/pull/2405)
 - **decidim-core**: Public profile page for participants, including name, nickname, follow button, avatar and officialization badge & text. [\#2391](https://github.com/decidim/decidim/pull/2391), [\#2360](https://github.com/decidim/decidim/pull/2360), [\#2401](https://github.com/decidim/decidim/pull/2401) and [\#2405](https://github.com/decidim/decidim/pull/2405).
 - **decidim-core**: Add a way for space manifests to publicize how to retrieve public spaces for a given organization [\#2384](https://github.com/decidim/decidim/pull/2384)
 - **decidim-participatory_processes**: Add missinng translations for processes [\#2380](https://github.com/decidim/decidim/pull/2380)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,13 @@ you need to change the following line in `config/environments/production.rb`:
 + config.assets.js_compressor = Uglifier.new(:harmony => true)
 ```
 
-**Added**:
-- **decidim-accountability**: Add feature to link projects with results [\2467](https://github.com/decidim/decidim/pull/2467)
-- **decidim-proposals**: Improve proposals admin panel usability (sorting). [\2419](https://github.com/decidim/decidim/pull/2419)
-- **decidim-core**: Follow users and get notifications about their actions. [\2401](https://github.com/decidim/decidim/pull/2401) and [\2452](https://github.com/decidim/decidim/pull/2452)
-- **decidim-core**: Add unique nicknames for participants. [\2360](https://github.com/decidim/decidim/pull/2360)
-- **decidom-admin**: Let admins officialize certain users from the admin dashboard and specify custom officialization text for them. [\2405](https://github.com/decidim/decidim/pull/2405)
-- **decidim-core**: Public profile page for participants, including name, nickname, follow button, avatar and officialization badge & text. [\2391](https://github.com/decidim/decidim/pull/2391), [\2360](https://github.com/decidim/decidim/pull/2360), [\2401](https://github.com/decidim/decidim/pull/2401) and [\2405](https://github.com/decidim/decidim/pull/2405).
+- **decidim-verifications**: Added authorization hooks. [\#2438](https://github.com/decidim/decidim/pull/2438)
+- **decidim-accountability**: Add feature to link projects with results [\#2467](https://github.com/decidim/decidim/pull/2467)
+- **decidim-proposals**: Improve proposals admin panel usability (sorting). [\#2419](https://github.com/decidim/decidim/pull/2419)
+- **decidim-core**: Follow users and get notifications about their actions. [\#2401](https://github.com/decidim/decidim/pull/2401)
+- **decidim-core**: Add unique nicknames for participants. [\#2360](https://github.com/decidim/decidim/pull/2360)
+- **decidom-admin**: Let admins officialize certain users from the admin dashboard and specify custom officialization text for them. [\#2405](https://github.com/decidim/decidim/pull/2405)
+- **decidim-core**: Public profile page for participants, including name, nickname, follow button, avatar and officialization badge & text. [\#2391](https://github.com/decidim/decidim/pull/2391), [\#2360](https://github.com/decidim/decidim/pull/2360), [\#2401](https://github.com/decidim/decidim/pull/2401) and [\#2405](https://github.com/decidim/decidim/pull/2405).
 - **decidim-core**: Add a way for space manifests to publicize how to retrieve public spaces for a given organization [\#2384](https://github.com/decidim/decidim/pull/2384)
 - **decidim-participatory_processes**: Add missinng translations for processes [\#2380](https://github.com/decidim/decidim/pull/2380)
 - **decidim-verifications**: Let developers specify for how long authorizations are valid. After this space of time passes, authorizations expire and users need to re-authorize [\#2311](https://github.com/decidim/decidim/pull/2311)

--- a/decidim-core/app/controllers/concerns/decidim/action_authorization.rb
+++ b/decidim-core/app/controllers/concerns/decidim/action_authorization.rb
@@ -19,7 +19,7 @@ module Decidim
       status = action_authorization(action_name)
 
       return if status.ok?
-      raise Unauthorized if status.code == :invalid
+      raise Unauthorized if status.code == :unauthorized
 
       redirect_to authorize_action_path(action_name, redirect_url: redirect_url)
     end

--- a/decidim-core/app/services/decidim/action_authorizer.rb
+++ b/decidim-core/app/services/decidim/action_authorizer.rb
@@ -4,8 +4,6 @@ module Decidim
   # This class is used to authorize a user against an action in the context of a
   # feature.
   class ActionAuthorizer
-    include Wisper::Publisher
-
     #
     # Initializes the ActionAuthorizer.
     #

--- a/decidim-core/app/services/decidim/action_authorizer.rb
+++ b/decidim-core/app/services/decidim/action_authorizer.rb
@@ -18,17 +18,17 @@ module Decidim
     end
 
     #
-    # Checks the status of the given authorization.
+    # Authorize user to perform an action in the context of a feature.
     #
     # Returns:
     #   :ok an empty hash                      - When there is no authorization handler related to the action.
-    #   result of authorization handler check  - When there is an authorization handler related to the action. Check Decidim::Verifications::Hooks class docs.
+    #   result of authorization handler check  - When there is an authorization handler related to the action. Check Decidim::Verifications::DefaultActionAuthorizer class docs.
     #
     def authorize
       raise AuthorizationError, "Missing data" unless feature && action
 
       status_code, data = if authorization_handler_name
-                            authorization_handler.authorization_status(authorization, permission_options)
+                            authorization_handler.authorize(authorization, permission_options)
                           else
                             [:ok, {}]
                           end

--- a/decidim-core/app/views/decidim/shared/_action_authorization_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_action_authorization_modal.html.erb
@@ -6,69 +6,33 @@
               type="button">
         <span aria-hidden="true">&times;</span>
       </button>
-      <% if status.code == :pending %>
-        <div class="reveal__header pending-authorization">
-          <h3 class="reveal__title"><%= t('.pending.title') %></h3>
-        </div>
-        <p><%= t ".pending.explanation", authorization: t("#{status.handler_name}.name", scope: "decidim.authorization_handlers") %></p>
-        <div class="row">
-          <div class="columns medium-8 medium-offset-2">
-            <%= link_to t('.pending.resume', authorization: t("#{status.handler_name}.name", scope: "decidim.authorization_handlers")), authorize_action_path(action), class: "button expanded" %>
-          </div>
-        </div>
-      <% elsif status.code == :incomplete %>
-        <div class="reveal__header incomplete-authorization">
-          <h3 class="reveal__title"><%= t('.incomplete.title') %></h3>
-        </div>
-        <p><%= t ".incomplete.explanation", authorization: t("#{status.handler_name}.name", scope: "decidim.authorization_handlers") %></p>
-        <ul>
-          <% status.data[:fields].each do |field| %>
-            <li><strong><%= t("#{status.handler_name}.fields.#{field}", scope: "decidim.authorization_handlers") %></strong></li>
+      <div class="reveal__header <%= status.code %>-authorization">
+        <h3 class="reveal__title"><%= t ".#{status.code}.title" %></h3>
+      </div>
+      <p><%= t ".#{status.code}.explanation", authorization: t("#{status.handler_name}.name", scope: "decidim.authorization_handlers") %></p>
+      <% if status.data[:extra_explanation] %>
+      <p><%= t status.data[:extra_explanation][:key], **status.data[:extra_explanation][:params] %></p>
+      <% end %>
+      <% if status.data[:fields] %>
+      <ul>
+        <% status.data[:fields].each do |field, value| %>
+          <li><strong><%= t ".#{status.code}.invalid_field", field: t("#{status.handler_name}.fields.#{field}", scope: "decidim.authorization_handlers"), value: value ? "(#{value})" : "" %></strong></li>
+        <% end %>
+      </ul>
+      <% end %>
+      <div class="row">
+        <div class="columns medium-8 medium-offset-2">
+          <% if status.data[:action].present? %>
+            <%= link_to t(".#{status.code}.#{status.data[:action]}", authorization: t("#{status.handler_name}.name", scope: "decidim.authorization_handlers")), authorize_action_path(action), class: "button expanded" %>
+          <% else %>
+            <button class="button expanded" data-close><%= t ".#{status.code}.ok" %></button>
           <% end %>
-        </ul>
-        <div class="row">
-          <div class="columns medium-8 medium-offset-2">
-            <%= link_to t('.incomplete.reauthorize'), authorize_action_path(action), class: "button expanded" %>
-          </div>
         </div>
-        <div class="text-center">
-          <button class="link" data-close><%=t ".incomplete.cancel" %></button>
-        </div>
-      <% elsif status.code == :missing %>
-        <div class="reveal__header missing-authorization">
-          <h3 class="reveal__title"><%= t('.missing.title') %></h3>
-        </div>
-        <p><%= t ".missing.explanation", authorization: t("#{status.handler_name}.name", scope: "decidim.authorization_handlers") %></p>
-        <div class="row">
-          <div class="columns medium-8 medium-offset-2">
-            <%= link_to t('.missing.authorize', authorization: t("#{status.handler_name}.name", scope: "decidim.authorization_handlers")), authorize_action_path(action), class: "button expanded" %>
-          </div>
-        </div>
-      <% elsif status.code == :expired %>
-        <div class="reveal__header missing-authorization">
-          <h3 class="reveal__title"><%= t('.expired.title') %></h3>
-        </div>
-        <p><%= t ".expired.explanation", authorization: t("#{status.handler_name}.name", scope: "decidim.authorization_handlers") %></p>
-        <div class="row">
-          <div class="columns medium-8 medium-offset-2">
-            <%= link_to t('.expired.authorize', authorization: t("#{status.handler_name}.name", scope: "decidim.authorization_handlers")), authorize_action_path(action), class: "button expanded" %>
-          </div>
-        </div>
-      <% elsif status.code == :invalid %>
-        <div class="reveal__header invalid-authorization">
-          <h3 class="reveal__title"><%= t('.unauthorized.title') %></h3>
-        </div>
-        <p><%= t ".unauthorized.explanation", authorization: t("#{status.handler_name}.name", scope: "decidim.authorization_handlers") %></p>
-        <ul>
-          <% status.data[:fields].each do |field, value| %>
-            <li><strong><%= t(".unauthorized.invalid", field: t("#{status.handler_name}.fields.#{field}", scope: "decidim.authorization_handlers")) %></strong></li>
-          <% end %>
-        </ul>
-        <div class="row">
-          <div class="columns medium-8 medium-offset-2">
-            <button class="button expanded" data-close><%=t ".unauthorized.ok" %></button>
-          </div>
-        </div>
+      </div>
+      <% if status.data[:cancel] %>
+      <div class="text-center">
+        <button class="link" data-close><%= t ".#{status.code}.cancel" %></button>
+      </div>
       <% end %>
     </div>
   <% end %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -258,6 +258,7 @@ en:
         incomplete:
           cancel: Cancel
           explanation: 'Even though you''re currently authorized with "%{authorization}", we need you to reauthorize because we lack the following data:'
+          invalid_field: "%{field}"
           reauthorize: Reauthorize
           title: Please reauthorize
         missing:
@@ -270,7 +271,7 @@ en:
           title: Authorization is still in progress
         unauthorized:
           explanation: Sorry, you can't perform this action as some of your authorization data doesn't match.
-          invalid: "%{field} isn't valid."
+          invalid_field: "%{field} value %{value} isn't valid."
           ok: Ok
           title: Not authorized
       author:

--- a/decidim-core/spec/helpers/decidim/action_authorization_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/action_authorization_helper_spec.rb
@@ -20,7 +20,9 @@ module Decidim
     let(:ok?) { false }
     let(:code) { :missing }
     let(:handler_name) { "foo_authorization" }
-    let(:data) { { fields: %w(foo bar) } }
+    let(:data) { { action: data_action, fields: data_fields } }
+    let(:data_action) { :authorize }
+    let(:data_fields) { nil }
 
     before do
       allow(helper).to receive(:current_user).and_return(user)
@@ -58,6 +60,8 @@ module Decidim
 
       context "when incomplete" do
         let(:code) { :incomplete }
+        let(:data_action) { :reauthorize }
+        let(:data_fields) { %w(foo bar) }
         let(:ok?) { false }
 
         it "renders a modal with the missing information" do
@@ -73,6 +77,8 @@ module Decidim
 
       context "when unauthorized" do
         let(:code) { :unauthorized }
+        let(:data_action) { nil }
+        let(:data_fields) { %w(foo bar) }
         let(:ok?) { false }
 
         it "renders a modal with the unauthorized information" do
@@ -85,7 +91,7 @@ module Decidim
       end
 
       context "when ok" do
-        let(:code) { :authorized }
+        let(:code) { :ok }
         let(:ok?) { true }
 
         it "renders blank" do
@@ -96,7 +102,7 @@ module Decidim
 
     describe "action_authorized_link_to" do
       context "when the action is authorized" do
-        let(:code) { :authorized }
+        let(:code) { :ok }
         let(:ok?) { true }
 
         it "renders a regular link" do
@@ -130,7 +136,7 @@ module Decidim
 
     describe "action_authorized_button_to" do
       context "when the action is authorized" do
-        let(:code) { :authorized }
+        let(:code) { :ok }
         let(:ok?) { true }
 
         it "renders a regular button" do

--- a/decidim-core/spec/helpers/decidim/action_authorization_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/action_authorization_helper_spec.rb
@@ -36,8 +36,23 @@ module Decidim
           expect(helper).to receive(:authorize_action_path).with("foo").and_return "authorization_route"
           rendered = helper.action_authorization_modal("foo")
           expect(rendered).to include("missing-authorization")
+          expect(rendered).not_to include("expired-authorization")
           expect(rendered).not_to include("incomplete-authorization")
-          expect(rendered).not_to include("invalid-authorization")
+          expect(rendered).not_to include("unauthorized-authorization")
+        end
+      end
+
+      context "when expired" do
+        let(:code) { :expired }
+        let(:ok?) { false }
+
+        it "renders a modal with the expired information" do
+          expect(helper).to receive(:authorize_action_path).with("foo").and_return "authorization_route"
+          rendered = helper.action_authorization_modal("foo")
+          expect(rendered).to include("expired-authorization")
+          expect(rendered).not_to include("missing-authorization")
+          expect(rendered).not_to include("incomplete-authorization")
+          expect(rendered).not_to include("unauthorized-authorization")
         end
       end
 
@@ -50,18 +65,20 @@ module Decidim
           rendered = helper.action_authorization_modal("foo")
           expect(rendered.downcase).to include("reauthorize")
           expect(rendered).to include("incomplete-authorization")
+          expect(rendered).not_to include("expired-authorization")
           expect(rendered).not_to include("missing-authorization")
-          expect(rendered).not_to include("invalid-authorization")
+          expect(rendered).not_to include("unauthorized-authorization")
         end
       end
 
-      context "when invalid" do
-        let(:code) { :invalid }
+      context "when unauthorized" do
+        let(:code) { :unauthorized }
         let(:ok?) { false }
 
-        it "renders a modal with the invalid information" do
+        it "renders a modal with the unauthorized information" do
           rendered = helper.action_authorization_modal("foo")
-          expect(rendered).to include("invalid-authorization")
+          expect(rendered).to include("unauthorized-authorization")
+          expect(rendered).not_to include("expired-authorization")
           expect(rendered).not_to include("missing-authorization")
           expect(rendered).not_to include("incomplete-authorization")
         end

--- a/decidim-core/spec/services/decidim/action_authorizer_spec.rb
+++ b/decidim-core/spec/services/decidim/action_authorizer_spec.rb
@@ -48,7 +48,7 @@ module Decidim
             expect(response).not_to be_ok
             expect(response.code).to eq(:missing)
             expect(response.handler_name).to eq("dummy_authorization_handler")
-            expect(response.data).to be_empty
+            expect(response.data).to eq(action: :authorize)
           end
         end
 
@@ -84,7 +84,7 @@ module Decidim
             expect(response).not_to be_ok
             expect(response.code).to eq(:missing)
             expect(response.handler_name).to eq("dummy_authorization_handler")
-            expect(response.data).to be_empty
+            expect(response.data).to eq(action: :authorize)
           end
         end
 
@@ -140,9 +140,9 @@ module Decidim
               context "when has options that doesn't match the authorization" do
                 let(:options) { { postal_code: "789" } }
 
-                it "returns invalid" do
+                it "returns unauthorized" do
                   expect(response).not_to be_ok
-                  expect(response.code).to eq(:invalid)
+                  expect(response.code).to eq(:unauthorized)
                   expect(response.handler_name).to eq("dummy_authorization_handler")
                   expect(response.data).to include(fields: { "postal_code" => "789" })
                 end

--- a/decidim-core/spec/services/decidim/action_authorizer_spec.rb
+++ b/decidim-core/spec/services/decidim/action_authorizer_spec.rb
@@ -178,7 +178,7 @@ module Decidim
                 end
               end
 
-              context "when custom hooks options are present and match the authorization" do
+              context "when custom action authorizer options are present and match the authorization" do
                 let(:options) { { allowed_postal_codes: %w(1234 4567) } }
 
                 it "returns ok" do
@@ -190,7 +190,7 @@ module Decidim
                 end
               end
 
-              context "when custom hooks are present and don't match the authorization" do
+              context "when custom action authorizer options are present and don't match the authorization" do
                 let(:options) { { allowed_postal_codes: %w(2345 4567) } }
 
                 it "returns unauthorized" do

--- a/decidim-verifications/README.md
+++ b/decidim-verifications/README.md
@@ -75,22 +75,26 @@ Decidim implements two type of authorization methods:
   * `edit_authorization_path`: This is the entry point to resume an existing
     authorization process.
 
-## Authorization hooks
+## Custom action authorizers
 
-Authorization hooks are an advanced feature that can be used in both types of
+Custom action authorizers are an advanced feature that can be used in both types of
 authorization methods to customize some parts of the authorization process.
 These are particulary useful when used within verification options, which are
 set in the admin zone related to a feature action. As a result, a verification
 method will be allowed to change the authorization logic and the appearance based
 on the context where the authorization is being performed.
 
-You can implement this hooks through a class that should inherit form
-`Decidim::Verifications::Hooks` class and override any of the following
-methods:
+You can override default behavior implementing a class that inherits form
+`Decidim::Verifications::DefaultActionAuthorizer` and override some methods or that
+implement its public methods:
 
-* The `authorization_status` method is responsible of evaluating the current
-authorization user state and the permission `options` related to an action and
-determine if the user authorization is `:ok` or in any other status.
+* The `initialize` method receives the current authorization process context and
+saves it in local variables. This include the current authorization user state (an
+`Authorization` record) and permission `options` related to the action is trying to
+perform.
+
+* The `authorize` method is responsible of evaluating the authorization process
+context and determine if the user authorization is `:ok` or in any other status.
 
 * The `redirect_params` method allows to add additional query string parameters
 when redirecting to the authorization form. This is useful to send to the
@@ -106,12 +110,12 @@ its workflow manifest:
 Decidim::Verifications.register_workflow(:sms_verification) do |workflow|
   workflow.engine = Decidim::Verifications::SmsVerification::Engine
   workflow.admin_engine = Decidim::Verifications::SmsVerification::AdminEngine
-  workflow.hooks = "Decidim::Verifications::MySmsHooks"
+  workflow.action_authorizer = "Decidim::Verifications::SmsVerification::ActionAuthorizer"
 end
 ```
 
 Check the [example authorization handler](https://github.com/decidim/decidim/blob/master/decidim-verifications/app/services/decidim/dummy_authorization_handler.rb)
-and the [Hooks class](https://github.com/decidim/decidim/blob/master/decidim-verifications/lib/decidim/verifications/hooks.rb)
+and the [DefaultActionAuthorizer class](https://github.com/decidim/decidim/blob/master/decidim-verifications/lib/decidim/verifications/default_action_authorizer.rb)
 for additional technical details.
 
 ## Installation

--- a/decidim-verifications/README.md
+++ b/decidim-verifications/README.md
@@ -75,6 +75,45 @@ Decidim implements two type of authorization methods:
   * `edit_authorization_path`: This is the entry point to resume an existing
     authorization process.
 
+## Authorization hooks
+
+Authorization hooks are an advanced feature that can be used in both types of
+authorization methods to customize some parts of the authorization process.
+These are particulary useful when used within verification options, which are
+set in the admin zone related to a feature action. As a result, a verification
+method will be allowed to change the authorization logic and the appearance based
+on the context where the authorization is being performed.
+
+You can implement this hooks through a class that should inherit form
+`Decidim::Verifications::Hooks` class and override any of the following
+methods:
+
+* The `authorization_status` method is responsible of evaluating the current
+authorization user state and the permission `options` related to an action and
+determine if the user authorization is `:ok` or in any other status.
+
+* The `redirect_params` method allows to add additional query string parameters
+when redirecting to the authorization form. This is useful to send to the
+authorization form the permission `options` information that could be useful to
+adapt its behavior or appearance.
+
+To be used by the verification method, this class should be referenced by name in
+its workflow manifest:
+
+```ruby
+# config/initializers/decidim.rb
+
+Decidim::Verifications.register_workflow(:sms_verification) do |workflow|
+  workflow.engine = Decidim::Verifications::SmsVerification::Engine
+  workflow.admin_engine = Decidim::Verifications::SmsVerification::AdminEngine
+  workflow.hooks = "Decidim::Verifications::MySmsHooks"
+end
+```
+
+Check the [example authorization handler](https://github.com/decidim/decidim/blob/master/decidim-verifications/app/services/decidim/dummy_authorization_handler.rb)
+and the [Hooks class](https://github.com/decidim/decidim/blob/master/decidim-verifications/lib/decidim/verifications/hooks.rb)
+for additional technical details.
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/decidim-verifications/README.md
+++ b/decidim-verifications/README.md
@@ -84,6 +84,14 @@ set in the admin zone related to a feature action. As a result, a verification
 method will be allowed to change the authorization logic and the appearance based
 on the context where the authorization is being performed.
 
+For example, you can require authorization for supporting proposals in a participatory
+process, and also restrict it to users with postal codes 12345 and 12346. The
+[example authorization handler](https://github.com/decidim/decidim/blob/master/decidim-verifications/app/services/decidim/dummy_authorization_handler.rb)
+included in this module allows to do that. As an admin user, you should visit
+the proposals componenent permissions screen, choose the `Example authorization`
+as the authorization handler name for the `vote` action and type something like
+`{ allowed_postal_codes: ["12345", "12346"] }` in the `Options` field placed below.
+
 You can override default behavior implementing a class that inherits form
 `Decidim::Verifications::DefaultActionAuthorizer` and override some methods or that
 implement its public methods:

--- a/decidim-verifications/app/services/decidim/dummy_authorization_handler.rb
+++ b/decidim-verifications/app/services/decidim/dummy_authorization_handler.rb
@@ -24,13 +24,13 @@ module Decidim
       errors.add(:document_number, :invalid) unless document_number.to_s.end_with?("X")
     end
 
-    # An example implementation of a Hooks inherited class to override authorization status checking process.
-    # In this case, it allows to set a list of valid postal codes for an authorization.
-    class Hooks < Decidim::Verifications::Hooks
+    # An example implementation of a DefaultActionAuthorizer inherited class to override authorization status
+    # checking process. In this case, it allows to set a list of valid postal codes for an authorization.
+    class ActionAuthorizer < Decidim::Verifications::DefaultActionAuthorizer
       attr_reader :allowed_postal_codes
 
       # Overrides the parent class method, but it still uses it to keep the base behavior
-      def authorization_status
+      def authorize
         # Remove the additional setting from the options hash to avoid to be considered missing.
         @allowed_postal_codes ||= options.delete("allowed_postal_codes")
 

--- a/decidim-verifications/app/views/dummy_authorization/_form.html.erb
+++ b/decidim-verifications/app/views/dummy_authorization/_form.html.erb
@@ -1,6 +1,6 @@
 <% if request["postal_codes"]
   postal_codes = request["postal_codes"].split("-")%>
-  <p><%= t("extra_explanation", scope: "decidim.verifications.dummy_authorization", postal_codes: postal_codes.to_sentence, count: postal_codes.count) %></p>
+  <p><%= t("extra_explanation", scope: "decidim.verifications.dummy_authorization", postal_codes: postal_codes.join(", "), count: postal_codes.count) %></p>
 <% end %>
 <%= form.all_fields %>
 <div class="actions partial-demo">

--- a/decidim-verifications/app/views/dummy_authorization/_form.html.erb
+++ b/decidim-verifications/app/views/dummy_authorization/_form.html.erb
@@ -1,0 +1,8 @@
+<% if request["postal_codes"]
+  postal_codes = request["postal_codes"].split("-")%>
+  <p><%= t("extra_explanation", scope: "decidim.verifications.dummy_authorization", postal_codes: postal_codes.to_sentence, count: postal_codes.count) %></p>
+<% end %>
+<%= form.all_fields %>
+<div class="actions partial-demo">
+  <%= form.submit t("decidim.verifications.authorizations.new.authorize"), class: "button expanded" %>
+</div>

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -56,6 +56,10 @@ en:
           authorize_with: Verify with %{authorizer}
         skip_verification: You can skip this for now and %{link}
         start_exploring: start exploring
+      dummy_authorization:
+        extra_explanation:
+          one: Participation is restricted to users with the postal code %{postal_codes}.
+          other: 'Participation is restricted to users with any of the following postal codes: %{postal_codes}.'
       id_documents:
         admin:
           confirmations:

--- a/decidim-verifications/lib/decidim/verifications.rb
+++ b/decidim-verifications/lib/decidim/verifications.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "decidim/verifications/engine"
+require "decidim/verifications/hooks"
 require "decidim/verifications/workflows"
 
 require "decidim/verifications/id_documents"

--- a/decidim-verifications/lib/decidim/verifications.rb
+++ b/decidim-verifications/lib/decidim/verifications.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "decidim/verifications/engine"
-require "decidim/verifications/hooks"
+require "decidim/verifications/default_action_authorizer"
 require "decidim/verifications/workflows"
 
 require "decidim/verifications/id_documents"

--- a/decidim-verifications/lib/decidim/verifications/adapter.rb
+++ b/decidim-verifications/lib/decidim/verifications/adapter.rb
@@ -77,16 +77,17 @@ module Decidim
       end
 
       #
-      # Saves a hooks object for the authorization context and use it to check authorization status.
+      # Authorize user to perform an action using the authorization handler action authorizer.
+      # Saves the action_authorizer object with its context for subsequent methods calls.
       #
       # authorization - The existing authorization record to be evaluated. Can be nil.
       # options       - A hash with options related only to the current authorization process.
       #
-      # Returns the result of authorization handler check. Check Decidim::Verifications::Hooks class docs.
+      # Returns the result of authorization handler check. Check Decidim::Verifications::DefaultActionAuthorizer class docs.
       #
-      def authorization_status(authorization, options)
-        @hooks = @manifest.hooks_class.new(authorization, options)
-        @hooks.authorization_status
+      def authorize(authorization, options)
+        @action_authorizer = @manifest.action_authorizer_class.new(authorization, options)
+        @action_authorizer.authorize
       end
 
       private
@@ -98,8 +99,8 @@ module Decidim
       end
 
       def redirect_params(params = {})
-        # Could add redirect params if a Hooks object was previously set.
-        params.merge(@hooks&.redirect_params || {})
+        # Could add redirect params if a ActionAuthorizer object was previously set.
+        params.merge(@action_authorizer&.redirect_params || {})
       end
     end
   end

--- a/decidim-verifications/lib/decidim/verifications/default_action_authorizer.rb
+++ b/decidim-verifications/lib/decidim/verifications/default_action_authorizer.rb
@@ -2,9 +2,9 @@
 
 module Decidim
   module Verifications
-    class Hooks
+    class DefaultActionAuthorizer
       #
-      # Initializes the Hooks class.
+      # Initializes the DefaultActionAuthorizer class.
       #
       # authorization - The existing authorization record to be evaluated. Can be nil.
       # options       - A hash with options related only to the current authorization process.
@@ -36,7 +36,7 @@ module Decidim
       #     fields            - Wrong fields to be shown. It could be a list of names or a hash with names a current values.
       #     extra_explanation - Hash with an additional key and params to be translated and shown to the user.
       #
-      def authorization_status
+      def authorize
         if !authorization
           [:missing, action: :authorize]
         elsif authorization_expired?

--- a/decidim-verifications/lib/decidim/verifications/dummy.rb
+++ b/decidim-verifications/lib/decidim/verifications/dummy.rb
@@ -2,6 +2,6 @@
 
 Decidim::Verifications.register_workflow(:dummy_authorization_handler) do |workflow|
   workflow.form = "Decidim::DummyAuthorizationHandler"
-  workflow.hooks = "Decidim::DummyAuthorizationHandler::Hooks"
+  workflow.action_authorizer = "Decidim::DummyAuthorizationHandler::ActionAuthorizer"
   workflow.expires_in = 1.hour
 end

--- a/decidim-verifications/lib/decidim/verifications/dummy.rb
+++ b/decidim-verifications/lib/decidim/verifications/dummy.rb
@@ -2,5 +2,6 @@
 
 Decidim::Verifications.register_workflow(:dummy_authorization_handler) do |workflow|
   workflow.form = "Decidim::DummyAuthorizationHandler"
+  workflow.hooks = "Decidim::DummyAuthorizationHandler::Hooks"
   workflow.expires_in = 1.hour
 end

--- a/decidim-verifications/lib/decidim/verifications/workflow_manifest.rb
+++ b/decidim-verifications/lib/decidim/verifications/workflow_manifest.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module Verifications
-    autoload :Hooks, "decidim/verifications/hooks"
+    autoload :DefaultActionAuthorizer, "decidim/verifications/default_action_authorizer"
 
     #
     # This class serves as a DSL to declaratively specify a verification method.
@@ -31,7 +31,7 @@ module Decidim
       attribute :admin_engine, Rails::Engine
       attribute :form, String
       attribute :expires_in, ActiveSupport::Duration, default: 0.minutes
-      attribute :hooks, String
+      attribute :action_authorizer, String
 
       validate :engine_or_form
 
@@ -56,11 +56,11 @@ module Decidim
         "#{fullname} (#{I18n.t(type, scope: "decidim.authorization_handlers")})"
       end
 
-      def hooks_class
-        if @hooks.present?
-          @hooks.constantize
+      def action_authorizer_class
+        if @action_authorizer.present?
+          @action_authorizer.constantize
         else
-          Hooks
+          DefaultActionAuthorizer
         end
       end
     end

--- a/decidim-verifications/lib/decidim/verifications/workflow_manifest.rb
+++ b/decidim-verifications/lib/decidim/verifications/workflow_manifest.rb
@@ -2,6 +2,8 @@
 
 module Decidim
   module Verifications
+    autoload :Hooks, "decidim/verifications/hooks"
+
     #
     # This class serves as a DSL to declaratively specify a verification method.
     #
@@ -29,6 +31,7 @@ module Decidim
       attribute :admin_engine, Rails::Engine
       attribute :form, String
       attribute :expires_in, ActiveSupport::Duration, default: 0.minutes
+      attribute :hooks, String
 
       validate :engine_or_form
 
@@ -51,6 +54,14 @@ module Decidim
 
       def description
         "#{fullname} (#{I18n.t(type, scope: "decidim.authorization_handlers")})"
+      end
+
+      def hooks_class
+        if @hooks.present?
+          @hooks.constantize
+        else
+          Hooks
+        end
       end
     end
   end

--- a/decidim-verifications/spec/features/action_authorization_spec.rb
+++ b/decidim-verifications/spec/features/action_authorization_spec.rb
@@ -53,7 +53,7 @@ describe "Action Authorization", type: :feature do
       end
     end
 
-    context "and action authorized with custom hooks options" do
+    context "and action authorized with custom action authorizer options" do
       let(:permissions) do
         { create: { authorization_handler_name: "dummy_authorization_handler", options: { allowed_postal_codes: %w(1234 4567) } } }
       end

--- a/decidim-verifications/spec/features/action_authorization_spec.rb
+++ b/decidim-verifications/spec/features/action_authorization_spec.rb
@@ -53,6 +53,30 @@ describe "Action Authorization", type: :feature do
       end
     end
 
+    context "and action authorized with custom hooks options" do
+      let(:permissions) do
+        { create: { authorization_handler_name: "dummy_authorization_handler", options: { allowed_postal_codes: %w(1234 4567) } } }
+      end
+
+      before do
+        visit main_feature_path(feature)
+        click_link "New proposal"
+      end
+
+      it "prompts user to authorize" do
+        expect(page).to have_content("Authorization required")
+        expect(page).to have_content("In order to perform this action, you need to be authorized with \"Example authorization\"")
+        expect(page).to have_content("Participation is restricted to users with any of the following postal codes: 1234, 4567.")
+      end
+
+      it "redirects to authorization when modal clicked" do
+        click_link "Authorize with \"Example authorization\""
+
+        expect(page).to have_selector("h1", text: "Verify with Example authorization")
+        expect(page).to have_content("Participation is restricted to users with any of the following postal codes: 1234, 4567.")
+      end
+    end
+
     context "and action authorized and authorization expired" do
       let(:permissions) do
         { create: { authorization_handler_name: "dummy_authorization_handler" } }

--- a/decidim-verifications/spec/services/decidim/dummy_authorization_handler_spec.rb
+++ b/decidim-verifications/spec/services/decidim/dummy_authorization_handler_spec.rb
@@ -13,15 +13,15 @@ module Decidim
     describe "metadata" do
       subject { handler.metadata }
 
-      let(:params) { { document_number: "123456" } }
+      let(:params) { { document_number: "123456", postal_code: "123456" } }
 
-      it { is_expected.to eq(document_number: "123456") }
+      it { is_expected.to eq(document_number: "123456", postal_code: "123456") }
     end
 
     describe "valid?" do
       subject { handler.valid? }
 
-      let(:params) { { document_number: document_number } }
+      let(:params) { { document_number: document_number, postal_code: "123456" } }
 
       context "when no document number" do
         let(:document_number) { nil }

--- a/decidim-verifications/spec/views/decidim/verifications/authorizations/new.html.erb_spec.rb
+++ b/decidim-verifications/spec/views/decidim/verifications/authorizations/new.html.erb_spec.rb
@@ -20,21 +20,17 @@ module Decidim
       allow(view).to receive(:stored_location).and_return("/processes")
     end
 
-    context "when there's a partial to render the form" do
-      around do |example|
-        filepath = File.join(Dir.pwd, "/app/views/", handler.to_partial_path).split("/")
-        filename = "_" + filepath.pop + ".html.erb"
-        filepath = filepath.join("/")
-        FileUtils.mkdir_p(filepath)
-        File.open(File.join(filepath, "/", filename), "w") { |file| file.write("Custom partial") }
+    it "renders the form the partial" do
+      expect(render).to include("partial-demo")
+    end
 
-        example.run
-
-        FileUtils.rm_rf(filepath)
+    context "when there's not a partial to render the form" do
+      before do
+        allow(handler).to receive(:to_partial_path).and_return("inexisting_partial")
       end
 
-      it "renders the form with the partial" do
-        expect(render).to include("Custom partial")
+      it "renders the form without the partial" do
+        expect(render).not_to include("partial-demo")
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
This change is the second part of #2435, explained in #2314. It adds a `DefaultActionAuthorizer` class with public methods that could be overriden by child classes. The class to be used for each handler is defined in the handler's `WorkflowManifest`.

Most of the logic of the `status_data` method of the `ActionAuthorizer` class was moved to the `authorize` method of the new class.

More than the half of the effort of this PR was to allow authorization handler to inform the user about the implemented logic, this include:
 - Allow to define new status codes, with all it related translations. [Authorization modals view](https://github.com/decidim/decidim/compare/master...podemos-info:enhancement/improved-authorizations-step2?expand=1#diff-db71a25c43a5de28bd4c4198950d6783) was refactored to implement this.
 - Show additional messages to the user. This change is also included in [authorization modals view changes](https://github.com/decidim/decidim/compare/master...podemos-info:enhancement/improved-authorizations-step2?expand=1#diff-db71a25c43a5de28bd4c4198950d6783).
 - Allow forms to change behavior based on the authorization options. These options are added to query string when redirecting the user to the form.

A future PR should allow authorization handlers to define forms for options setting and avoid admin users to learn JSON.

#### :pushpin: Related Issues
- Related to #2314 
- Related to #2435

#### :clipboard: Subtasks
- [x] Add hooks
- [x] Add an example of use
- [x] Complete tests
- [x] Update docs and changelog

### :camera: Screenshots (optional)
![admin](https://user-images.githubusercontent.com/453545/34577683-52cbd2fc-f182-11e7-871e-2303fb7fca98.png)
![modal](https://user-images.githubusercontent.com/453545/34577684-52ccba0a-f182-11e7-8be8-53cd90e10f4a.png)
![form](https://user-images.githubusercontent.com/453545/34577685-52ce5c48-f182-11e7-8ef4-8747102b8358.png)

#### :ghost: GIF
![hook](https://user-images.githubusercontent.com/453545/34577192-9dbc7f5c-f180-11e7-9330-b4a3ed326f3d.gif)


  