### PR TITLE
Manually set the locale mapping in Crowdin

### DIFF
--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -1,3 +1,19 @@
 files:
   - source: /**/locales/en.yml
-    translation: /**/locales/%two_letters_code%.yml
+    translation: /**/locales/%locale%.yml
+    languages_mapping:
+      locale:
+        ca: ca
+        es: es
+        eu: eu
+        fi: fi
+        fr: fr
+        gl: gl
+        it: it
+        nl: nl
+        pl: pl
+        pt-BR: pt-BR
+        pt-PT: pt
+        rumany: ru
+        sv-SE: sv
+        ukmany: uk

--- a/docs/managing_translations_i18n.md
+++ b/docs/managing_translations_i18n.md
@@ -11,6 +11,7 @@ Decidim uses [Crowdin](https://crowdin.com/) to manage the translations.
 ## Adding a new language
 
 - Setup the new language in [_Crowdin's Decidim project_](https://crowdin.com/project/decidim) (or open an issue on Github asking an admin to do that).
+- Add the locale mapping in the `crowdin.yml` file
 - Translate at least one key from every engine, so, your _yaml_ files are not empty. The easiest way to do this is to automatically translate and sync all the content. Later you'll be able to fix the content that wasn't properly translated.
 - Add [Foundation Datepicker](https://github.com/najlepsiwebdesigner/foundation-datepicker/tree/master/js/locales)'s translations ([PR](https://github.com/decidim/decidim/pull/2039)).
 - Add Select2 translations ([PR](https://github.com/decidim/decidim/pull/2214)).


### PR DESCRIPTION
#### :tophat: What? Why?
Using the `two_letter_code` makes dialects of the same language overwrite each other. This unblocks #2443.

#### :pushpin: Related Issues
- Related to #2443.

#### :clipboard: Subtasks
None