### PR TITLE
Fix Crowdin locale mapping

### DIFF
--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -4,7 +4,7 @@ files:
     languages_mapping:
       locale:
         ca: ca
-        es: es
+        es-ES: es
         eu: eu
         fi: fi
         fr: fr


### PR DESCRIPTION
#### :tophat: What? Why?
Crowdin locale mapping is wrong for Spanish, as it is being exported as `es-ES.yml` instead of the expected `es.yml`.

#### :pushpin: Related Issues
- Related to #2447 

#### :clipboard: Subtasks
None