### PR TITLE
Added current_organization helper to System's Organizations controller.

### DIFF
--- a/decidim-system/app/controllers/decidim/system/organizations_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/organizations_controller.rb
@@ -5,6 +5,8 @@ module Decidim
     # Controller to manage Organizations (tenants).
     #
     class OrganizationsController < Decidim::System::ApplicationController
+      helper_method :current_organization
+
       def new
         @form = form(RegisterOrganizationForm).instance
       end
@@ -52,6 +54,13 @@ module Decidim
             render :edit
           end
         end
+      end
+
+      # The current organization for the request.
+      #
+      # Returns an Organization.
+      def current_organization
+        @organization
       end
     end
   end

--- a/decidim-system/spec/features/organizations_spec.rb
+++ b/decidim-system/spec/features/organizations_spec.rb
@@ -43,6 +43,24 @@ describe "Organizations", type: :feature do
       end
     end
 
+    describe "showing an organization with different locale than user" do
+      let!(:organization) do
+        create(:organization, name: "Citizen Corp", default_locale: :es, available_locales: ["es"], description: { es: "Un texto largo" })
+      end
+
+      before do
+        click_link "Organizations"
+        within "table tbody" do
+          first("tr").click_link "Citizen Corp"
+        end
+      end
+
+      it "shows the organization data" do
+        expect(page).to have_content("Citizen Corp")
+        expect(page).to have_content("Un texto largo")
+      end
+    end
+
     describe "editing an organization" do
       let!(:organization) { create(:organization, name: "Citizen Corp") }
 


### PR DESCRIPTION
#### :tophat: What? Why?
On system component, an error is raised when viewing an organization details that doesn't have a description in the user language. This occurs because there is no `current_organization` helper, and this is used for translations since #2204. I've added only to `OrganizationsController` and not to `ApplicationController`, because I understand that it doesn't apply to others controllers, as in other Decidim components.

#### :pushpin: Related Issues
- Related to #2204

#### :clipboard: Subtasks

### :camera: Screenshots (optional)

#### :ghost: GIF


  