### PR TITLE
Get notifications when a user is officialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ you need to change the following line in `config/environments/production.rb`:
 ```
 
 **Added**:
-- **decidim-core**: Follow users and get notifications about their actions. [\2401](https://github.com/decidim/decidim/pull/2401)
+- **decidim-core**: Follow users and get notifications about their actions. [\2401](https://github.com/decidim/decidim/pull/2401) and [\2452](https://github.com/decidim/decidim/pull/2452)
 - **decidim-core**: Add unique nicknames for participants. [\2360](https://github.com/decidim/decidim/pull/2360)
 - **decidom-admin**: Let admins officialize certain users from the admin dashboard and specify custom officialization text for them. [\2405](https://github.com/decidim/decidim/pull/2405)
 - **decidim-core**: Public profile page for participants, including name, nickname, follow button, avatar and officialization badge & text. [\2391](https://github.com/decidim/decidim/pull/2391), [\2360](https://github.com/decidim/decidim/pull/2360), [\2401](https://github.com/decidim/decidim/pull/2401) and [\2405](https://github.com/decidim/decidim/pull/2405).

--- a/decidim-admin/app/commands/decidim/admin/officialize_user.rb
+++ b/decidim-admin/app/commands/decidim/admin/officialize_user.rb
@@ -22,6 +22,13 @@ module Decidim
 
         officialize_user
 
+        Decidim::EventsManager.publish(
+          event: "decidim.events.users.user_officialized",
+          event_class: Decidim::Admin::UserOfficializedEvent,
+          resource: form.user,
+          recipient_ids: form.user.followers.pluck(:id)
+        )
+
         broadcast(:ok, form.user)
       end
 

--- a/decidim-admin/app/events/decidim/admin/user_officialized_event.rb
+++ b/decidim-admin/app/events/decidim/admin/user_officialized_event.rb
@@ -1,0 +1,52 @@
+# frozen-string_literal: true
+
+module Decidim
+  module Admin
+    class UserOfficializedEvent < Decidim::Events::BaseEvent
+      include Decidim::Events::EmailEvent
+      include Decidim::Events::NotificationEvent
+
+      def email_subject
+        I18n.t(
+          "decidim.admin.events.user_officialized_event.email_subject",
+          profile_path: official_user.profile_path,
+          nickname: official_user.nickname,
+          name: official_user.name
+        )
+      end
+
+      def email_intro
+        I18n.t(
+          "decidim.admin.events.user_officialized_event.email_intro",
+          profile_path: official_user.profile_path,
+          nickname: official_user.nickname,
+          name: official_user.name
+        )
+      end
+
+      def email_outro
+        I18n.t(
+          "decidim.admin.events.user_officialized_event.email_outro",
+          profile_path: official_user.profile_path,
+          nickname: official_user.nickname,
+          name: official_user.name
+        )
+      end
+
+      def notification_title
+        I18n.t(
+          "decidim.admin.events.user_officialized_event.notification_title",
+          profile_path: official_user.profile_path,
+          nickname: official_user.nickname,
+          name: official_user.name
+        ).html_safe
+      end
+
+      private
+
+      def official_user
+        @official_user ||= Decidim::UserPresenter.new(resource)
+      end
+    end
+  end
+end

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -134,6 +134,12 @@ en:
       dashboard:
         show:
           welcome: Welcome to the Decidim Admin Panel.
+      events:
+        user_officialized_event:
+          email_intro: The <a href="%{profile_path}">profile page</a> of %{name} (%{nickname}), who you are following, has been updated.
+          email_outro: You have received this notification because you are following %{nickname}. You can stop receiving notifications following the previous link.
+          email_subject: "%{nickname} updated their profile"
+          notification_title: The <a href="%{profile_path}">profile page</a> of %{name} (%{nickname}), who you are following, has been updated.
       exports:
         export_as: "%{name} as %{export_format}"
         notice: Your export is currently in progress. You'll receive an email when it's complete.

--- a/decidim-admin/spec/commands/officialize_user_spec.rb
+++ b/decidim-admin/spec/commands/officialize_user_spec.rb
@@ -45,6 +45,22 @@ module Decidim::Admin
 
         expect(user.reload).to be_officialized
       end
+
+      it "notifies the user's followers" do
+        follower = create(:user, organization: organization)
+        create(:follow, followable: user, user: follower)
+
+        expect(Decidim::EventsManager)
+          .to receive(:publish)
+          .with(
+            event: "decidim.events.users.user_officialized",
+            event_class: Decidim::Admin::UserOfficializedEvent,
+            resource: kind_of(Decidim::User),
+            recipient_ids: [follower.id]
+          )
+
+        subject.call
+      end
     end
   end
 end

--- a/decidim-admin/spec/events/decidim/admin/user_officialized_event_spec.rb
+++ b/decidim-admin/spec/events/decidim/admin/user_officialized_event_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Admin::UserOfficializedEvent do
+  subject do
+    described_class.new(resource: user, event_name: event_name, user: follower, extra: {})
+  end
+
+  let(:organization) { follower.organization }
+  let(:follower) { create :user }
+  let(:event_name) { "decidim.events.users.user_officialized" }
+  let(:user) { create :user, organization: organization }
+
+  describe "types" do
+    subject { described_class }
+
+    it "supports notifications" do
+      expect(subject.types).to include :notification
+    end
+
+    it "supports emails" do
+      expect(subject.types).to include :email
+    end
+  end
+
+  describe "email_subject" do
+    it "is generated correctly" do
+      expect(subject.email_subject).to eq("@#{user.nickname} updated their profile")
+    end
+  end
+
+  describe "email_intro" do
+    it "is generated correctly" do
+      expect(subject.email_intro)
+        .to eq("The <a href=\"/profiles/#{user.nickname}\">profile page</a> of #{user.name} (@#{user.nickname}), who you are following, has been updated.")
+    end
+  end
+
+  describe "email_outro" do
+    it "is generated correctly" do
+      expect(subject.email_outro)
+        .to eq("You have received this notification because you are following @#{user.nickname}. You can stop receiving notifications following the previous link.")
+    end
+  end
+
+  describe "notification_title" do
+    it "is generated correctly" do
+      expect(subject.notification_title).to include("<a href=\"/profiles/#{user.nickname}\">profile page</a>")
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Continues implementing new notifications defined at #2395.