### PR TITLE
Fix redirect after login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ you need to change the following line in `config/environments/production.rb`:
 
 **Fixed**:
 
+- **decidim-core**: Fix after login redirect. [\#2321](https://github.com/decidim/decidim/pull/2321)
+  With links or buttons that needs the user to be authorized or signed in you can now add a `data-redirect-url` attribute to redirect the user after they've signed in so they don't lose context.
 - **decidim-core**: Prevent many conversation with the same participants at the UI level. [\#2376](https://github.com/decidim/decidim/pull/2376)
 - **decidim-admin**: Admins no longer being able to impersonate a second time. [\#2372](https://github.com/decidim/decidim/pull/2372)
 - **decidim-admin**: User impersonation should only use authorization handlers and not authorization workflows. [\#2363](https://github.com/decidim/decidim/pull/2363)

--- a/decidim-budgets/app/views/decidim/budgets/projects/_project.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_project.html.erb
@@ -15,7 +15,7 @@
         <span class="card--list__data__number budget-list__number">
           <%= budget_to_currency(project.budget) %>
         </span>
-        <%= action_authorized_button_to "vote", order_line_item_path(project_id: project), method: :delete, remote: true, data: { disable: true, budget: project.budget }, disabled: !current_settings.votes_enabled? || current_order_checked_out?, class: "button tiny budget--list__action success" do %>
+        <%= action_authorized_button_to "vote", order_line_item_path(project_id: project), method: :delete, remote: true, data: { disable: true, budget: project.budget, "redirect-url": project_path(project) }, disabled: !current_settings.votes_enabled? || current_order_checked_out?, class: "button tiny budget--list__action success" do %>
           <%= icon("check", class: "icon--small", aria_label: t('.remove'), role: "img") %>
         <% end %>
         <% if current_settings.show_votes? %>
@@ -29,7 +29,7 @@
         <span class="card--list__data__number budget-list__number">
           <%= budget_to_currency(project.budget) %>
         </span>
-        <%= action_authorized_button_to "vote", order_line_item_path(project_id: project), method: :post, remote: true, data: { disable: true, budget: project.budget, add: true }, disabled: !current_settings.votes_enabled? || current_order_checked_out?, class: "button tiny hollow budget--list__action" do %>
+        <%= action_authorized_button_to "vote", order_line_item_path(project_id: project), method: :post, remote: true, data: { disable: true, budget: project.budget, add: true, "redirect-url": project_path(project) }, disabled: !current_settings.votes_enabled? || current_order_checked_out?, class: "button tiny hollow budget--list__action" do %>
           <%= icon("check", class: "icon--small", aria_label: t('.add'), role: "img") %>
         <% end %>
         <% if current_settings.show_votes? %>

--- a/decidim-budgets/app/views/decidim/budgets/projects/_project_budget_button.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_project_budget_button.html.erb
@@ -1,8 +1,8 @@
 <% if current_user.present? %>
   <% if current_order && current_order.projects.include?(project) %>
-    <%= action_authorized_button_to "vote", t('.added'), order_line_item_path(project_id: project), method: :delete, remote: true, data: { disable: true, budget: project.budget }, disabled: !current_settings.votes_enabled? || current_order_checked_out?, class: "button expanded button--sc success budget--list__action" %>
+    <%= action_authorized_button_to "vote", t('.added'), order_line_item_path(project_id: project), method: :delete, remote: true, data: { disable: true, budget: project.budget, "redirect-url": project_path(project) }, disabled: !current_settings.votes_enabled? || current_order_checked_out?, class: "button expanded button--sc success budget--list__action" %>
   <% else %>
-    <%= action_authorized_button_to "vote", t('.add'), order_line_item_path(project_id: project), method: :post, remote: true, data: { disable: true, budget: project.budget, add: true }, disabled: !current_settings.votes_enabled? || current_order_checked_out?, class: "button expanded button--sc budget--list__action" %>
+    <%= action_authorized_button_to "vote", t('.add'), order_line_item_path(project_id: project), method: :post, remote: true, data: { disable: true, budget: project.budget, add: true, "redirect-url": project_path(project) }, disabled: !current_settings.votes_enabled? || current_order_checked_out?, class: "button expanded button--sc budget--list__action" %>
   <% end %>
 <% else %>
   <button class="button expanded button--sc disabled" data-toggle="loginModal"><%= t('.add') %></button>

--- a/decidim-core/app/assets/javascripts/decidim.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim.js.es6
@@ -13,6 +13,7 @@
 // = require decidim/user_registrations
 // = require decidim/account_form
 // = require decidim/data_picker
+// = require decidim/append_redirect_url_to_modals
 
 /* globals svg4everybody */
 

--- a/decidim-core/app/assets/javascripts/decidim/append_redirect_url_to_modals.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/append_redirect_url_to_modals.js.es6
@@ -1,0 +1,63 @@
+/* eslint-disable multiline-ternary, no-ternary */
+// require self
+$(() => {
+  const removeUrlParameter = (url, parameter) => {
+    const urlParts = url.split('?');
+
+    if (urlParts.length >= 2) {
+      // Get first part, and remove from array
+      const urlBase = urlParts.shift();
+
+      // Join it back up
+      const queryString = urlParts.join('?');
+
+      const prefix = `${encodeURIComponent(parameter)}=`;
+      const parts = queryString.split(/[&;]/g);
+
+      // Reverse iteration as may be destructive
+      for (let index = parts.length; index > 0; index -= 1) {
+        // Idiom for string.startsWith
+        if (parts[index].lastIndexOf(prefix, 0) !== -1) {
+          parts.splice(index, 1);
+        }
+      }
+
+      if (parts.length === 0) {
+        return urlBase;
+      }
+
+      return `${urlBase}?${parts.join('&')}`;
+    }
+
+    return url;
+  }
+
+  $(document).on("click.zf.trigger", (event) => {
+    const target = `#${$(event.target).data("open")}`;
+    const redirectUrl = $(event.target).data("redirectUrl");
+
+    if (target && redirectUrl) {
+      $("<input type='hidden' />").
+        attr("id", "redirect_url").
+        attr("name", "redirect_url").
+        attr("value", redirectUrl).
+        appendTo(`${target} form`);
+
+      $(`${target} a`).attr("href", (index, href) => {
+        const querystring = jQuery.param({"redirect_url": redirectUrl});
+        return href + (href.match(/\?/) ? '&' : '?') + querystring;
+      });
+    }
+  });
+
+  $(document).on('closed.zf.reveal', (event) => {
+    $("#redirect_url", event.target).remove();
+    $("a", event.target).attr("href", (index, href) => {
+      if (href && href.indexOf("redirect_url") !== -1) {
+        return removeUrlParameter(href, "redirect_url");
+      }
+
+      return href;
+    });
+  });
+});

--- a/decidim-core/app/controllers/concerns/decidim/devise_controllers.rb
+++ b/decidim-core/app/controllers/concerns/decidim/devise_controllers.rb
@@ -25,12 +25,22 @@ module Decidim
       helper Decidim::OmniauthHelper
 
       layout "layouts/decidim/application"
+
+      # Saves the location before loading each page so we can return to the
+      # right page.
+      before_action :store_current_location
     end
 
     # Overwrites `cancancan`'s method to point to the correct ability class,
     # since the gem expects the ability class to be in the root namespace.
     def current_ability_klass
       Decidim::Abilities::BaseAbility
+    end
+
+    def store_current_location
+      return if params[:redirect_url].blank?
+
+      store_location_for(:user, params[:redirect_url])
     end
   end
 end

--- a/decidim-core/app/controllers/decidim/application_controller.rb
+++ b/decidim-core/app/controllers/decidim/application_controller.rb
@@ -20,12 +20,22 @@ module Decidim
     helper Decidim::FeaturePathHelper
     helper Decidim::ViewHooksHelper
 
+    # Saves the location before loading each page so we can return to the
+    # right page. If we're on a devise page, we don't want to store that as the
+    # place to return to (for example, we don't want to return to the sign in page
+    # after signing in), which is what the :unless prevents
+    before_action :store_current_location, unless: :devise_controller?
+
     protect_from_forgery with: :exception, prepend: true
     after_action :add_vary_header
 
     layout "layouts/decidim/application"
 
     private
+
+    def store_current_location
+      store_location_for(:user, request.url)
+    end
 
     def user_not_authorized_path
       decidim.root_path

--- a/decidim-core/app/controllers/decidim/application_controller.rb
+++ b/decidim-core/app/controllers/decidim/application_controller.rb
@@ -21,10 +21,8 @@ module Decidim
     helper Decidim::ViewHooksHelper
 
     # Saves the location before loading each page so we can return to the
-    # right page. If we're on a devise page, we don't want to store that as the
-    # place to return to (for example, we don't want to return to the sign in page
-    # after signing in), which is what the :unless prevents
-    before_action :store_current_location, unless: :devise_controller?
+    # right page.
+    before_action :store_current_location
 
     protect_from_forgery with: :exception, prepend: true
     after_action :add_vary_header
@@ -33,8 +31,16 @@ module Decidim
 
     private
 
+    # Stores the url where the user will be redirected after login.
+    #
+    # Uses the `redirect_url` param or the current url if there's no param.
+    # In Devise controllers we only store the URL if it's from the params, we don't
+    # want to overwrite the stored URL for a Devise one.
     def store_current_location
-      store_location_for(:user, request.url)
+      return if devise_controller? && params[:redirect_url].blank?
+
+      value = params[:redirect_url] || request.url
+      store_location_for(:user, value)
     end
 
     def user_not_authorized_path

--- a/decidim-core/app/controllers/decidim/cookie_policy_controller.rb
+++ b/decidim-core/app/controllers/decidim/cookie_policy_controller.rb
@@ -5,6 +5,8 @@ module Decidim
   class CookiePolicyController < Decidim::ApplicationController
     skip_authorization_check
 
+    skip_before_action :store_current_location
+
     def accept
       response.set_cookie "decidim-cc", value: "true",
                                         path: "/",

--- a/decidim-core/app/controllers/decidim/devise/invitations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/invitations_controller.rb
@@ -18,7 +18,7 @@ module Decidim
       # invitation. Using the param `invite_redirect` we can redirect the user
       # to a custom path after it has accepted the invitation.
       def after_accept_path_for(resource)
-        params[:invite_redirect] || super
+        params[:invite_redirect] || after_sign_in_path_for(resource)
       end
 
       # When a managed user accepts the invitation is promoted to non-managed user.

--- a/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
@@ -44,11 +44,19 @@ module Decidim
       end
 
       def after_sign_in_path_for(user)
-        if first_login_and_not_authorized?(user)
+        if !pending_redirect?(user) && first_login_and_not_authorized?(user)
           decidim_verifications.authorizations_path
         else
           super
         end
+      end
+
+      # Calling the `stored_location_for` method removes the key, so in order
+      # to check if there's any pending redirect after login I need to call
+      # this method and use the value to set a pending redirect. This is the
+      # only way to do this without checking the session directly.
+      def pending_redirect?(user)
+        store_location_for(user, stored_location_for(user))
       end
 
       def first_login_and_not_authorized?(user)

--- a/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
@@ -14,6 +14,14 @@ module Decidim
         end
       end
 
+      # Calling the `stored_location_for` method removes the key, so in order
+      # to check if there's any pending redirect after login I need to call
+      # this method and use the value to set a pending redirect. This is the
+      # only way to do this without checking the session directly.
+      def pending_redirect?(user)
+        store_location_for(user, stored_location_for(user))
+      end
+
       def first_login_and_not_authorized?(user)
         user.is_a?(User) && user.sign_in_count == 1 && current_organization.available_authorizations.any?
       end

--- a/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
@@ -7,7 +7,7 @@ module Decidim
       include Decidim::DeviseControllers
 
       def after_sign_in_path_for(user)
-        if first_login_and_not_authorized?(user) && !user.admin?
+        if first_login_and_not_authorized?(user) && !user.admin? && !pending_redirect?(user)
           decidim_verifications.first_login_authorizations_path
         else
           super

--- a/decidim-core/app/controllers/decidim/pages_controller.rb
+++ b/decidim-core/app/controllers/decidim/pages_controller.rb
@@ -14,6 +14,7 @@ module Decidim
     helper_method :page, :stats
     helper CtaButtonHelper
     helper Decidim::SanitizeHelper
+    skip_before_action :store_current_location
 
     def index
       @pages = current_organization.static_pages.all.to_a.sort do |a, b|

--- a/decidim-core/app/controllers/decidim/scopes_controller.rb
+++ b/decidim-core/app/controllers/decidim/scopes_controller.rb
@@ -3,6 +3,8 @@
 module Decidim
   # Exposes the scopes text search so users can choose a scope writing its name.
   class ScopesController < Decidim::ApplicationController
+    skip_before_action :store_current_location
+
     def picker
       authorize! :pick, Scope
 

--- a/decidim-core/app/helpers/decidim/action_authorization_helper.rb
+++ b/decidim-core/app/helpers/decidim/action_authorization_helper.rb
@@ -36,7 +36,7 @@ module Decidim
       unless current_user_authorized?(action)
         html_options ||= {}
         html_options["onclick"] = "event.preventDefault();"
-        html_options["data-toggle"] = current_user ? "#{action.to_s.underscore}AuthorizationModal" : "loginModal"
+        html_options["data-open"] = current_user ? "#{action.to_s.underscore}AuthorizationModal" : "loginModal"
         url = ""
       end
 
@@ -67,7 +67,7 @@ module Decidim
       end
 
       unless current_user_authorized?(action)
-        html_options["data-toggle"] = current_user ? "#{action.to_s.underscore}AuthorizationModal" : "loginModal"
+        html_options["data-open"] = current_user ? "#{action.to_s.underscore}AuthorizationModal" : "loginModal"
         url = ""
       end
 

--- a/decidim-core/spec/controllers/sessions_controller_spec.rb
+++ b/decidim-core/spec/controllers/sessions_controller_spec.rb
@@ -36,6 +36,14 @@ module Decidim
                 end
 
                 it { is_expected.to eq("/authorizations/first_login") }
+
+                context "when there's a pending redirection" do
+                  before do
+                    controller.store_location_for(user, account_path)
+                  end
+
+                  it { is_expected.to eq account_path }
+                end
               end
 
               context "otherwise", with_authorization_workflows: [] do

--- a/decidim-core/spec/helpers/decidim/action_authorization_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/action_authorization_helper_spec.rb
@@ -84,7 +84,7 @@ module Decidim
 
         it "renders a regular link" do
           rendered = helper.action_authorized_link_to("foo", "Link", "fake_path")
-          expect(rendered).not_to include("data-toggle")
+          expect(rendered).not_to include("data-open")
           expect(rendered).to include("<a")
           expect(rendered).to include("Link")
         end
@@ -92,7 +92,7 @@ module Decidim
         it "renders with a block" do
           rendered = helper.action_authorized_link_to("foo", "fake_path") { "Link" }
 
-          expect(rendered).not_to include("data-toggle")
+          expect(rendered).not_to include("data-open")
           expect(rendered).to include("<a")
           expect(rendered).to include("Link")
         end
@@ -105,7 +105,7 @@ module Decidim
         it "renders a link toggling the modal" do
           rendered = helper.action_authorized_link_to("foo", "Link", "fake_path")
           expect(rendered).not_to include("fake_path")
-          expect(rendered).to include('data-toggle="fooAuthorizationModal"')
+          expect(rendered).to include('data-open="fooAuthorizationModal"')
           expect(rendered).to include("<a")
         end
       end
@@ -118,7 +118,7 @@ module Decidim
 
         it "renders a regular button" do
           rendered = helper.action_authorized_button_to("foo", "Link", "fake_path")
-          expect(rendered).not_to include("data-toggle")
+          expect(rendered).not_to include("data-open")
           expect(rendered).to include("<input")
           expect(rendered).to include("type=\"submit\"")
           expect(rendered).to include("Link")
@@ -127,7 +127,7 @@ module Decidim
         it "renders with a block" do
           rendered = helper.action_authorized_button_to("foo", "fake_path") { "Link" }
 
-          expect(rendered).not_to include("data-toggle")
+          expect(rendered).not_to include("data-open")
           expect(rendered).to include("<button")
           expect(rendered).to include("type=\"submit\"")
           expect(rendered).to include("Link")
@@ -143,7 +143,7 @@ module Decidim
           expect(rendered).to include("<input")
           expect(rendered).to include("type=\"submit\"")
           expect(rendered).not_to include("fake_path")
-          expect(rendered).to include('data-toggle="fooAuthorizationModal"')
+          expect(rendered).to include('data-open="fooAuthorizationModal"')
         end
       end
     end

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -24,7 +24,7 @@
           <% if meeting.has_registration_for? current_user %>
             <%= action_authorized_button_to :leave, t('.going'), meeting_registration_path(meeting), method: :delete, class: "button expanded button--sc success", data: { disable: true } %>
           <% else %>
-            <%= action_authorized_button_to :join, meeting.has_available_slots? ? t('.join') : t('.no_slots_available'), "", class: "button expanded button--sc", disabled: !meeting.has_available_slots?, data: { toggle: current_user.present? ? "meeting-registration-confirm" : "loginModal" } %>
+            <%= action_authorized_button_to :join, meeting.has_available_slots? ? t('.join') : t('.no_slots_available'), "", class: "button expanded button--sc", disabled: !meeting.has_available_slots?, data: { open: current_user.present? ? "meeting-registration-confirm" : "loginModal" } %>
           <% end %>
           <% if meeting.available_slots.positive? %>
             <span><%= t(".remaining_slots", count: meeting.remaining_slots) %></span>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_vote_button.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_vote_button.html.erb
@@ -4,11 +4,11 @@
       <% if current_settings.votes_blocked? %>
         <%= action_authorized_button_to :vote, t('.votes_blocked'), proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list), class: "card__button button #{vote_button_classes(from_proposals_list)} disabled", disabled: true %>
       <% else %>
-        <%= action_authorized_button_to :vote, t('.vote'), proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list), class: "card__button button #{vote_button_classes(from_proposals_list)}", data: { disable: true } %>
+        <%= action_authorized_button_to :vote, t('.vote'), proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list), class: "card__button button #{vote_button_classes(from_proposals_list)}", data: { disable: true, "redirect-url": proposal_path(proposal) } %>
       <% end %>
     <% else %>
       <% if @voted_proposals ? @voted_proposals.include?(proposal.id) : proposal.voted_by?(current_user) %>
-        <%= action_authorized_button_to :vote, t('.already_voted'), proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list), method: :delete, remote: true, data: { disable: true, original: t('.already_voted'), replace: t('.already_voted_hover') }, class: "card__button button #{vote_button_classes(from_proposals_list)} success", id: "vote_button" %>
+        <%= action_authorized_button_to :vote, t('.already_voted'), proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list), method: :delete, remote: true, data: { disable: true, original: t('.already_voted'), replace: t('.already_voted_hover'), "redirect-url": proposal_path(proposal) }, class: "card__button button #{vote_button_classes(from_proposals_list)} success", id: "vote_button" %>
       <% else %>
         <% if proposal.maximum_votes_reached? %>
           <%= content_tag :span, t('.maximum_votes_reached'), class: "card__button button #{vote_button_classes(from_proposals_list)} disabled", disabled: true %>
@@ -18,7 +18,7 @@
           <% elsif current_settings.votes_blocked? %>
             <%= content_tag :span, t('.votes_blocked'), class: "card__button button #{vote_button_classes(from_proposals_list)} disabled", disabled: true %>
           <% else %>
-            <%= action_authorized_button_to :vote, t('.vote'), proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list), remote: true, data: { disable: true }, class: "card__button button #{vote_button_classes(from_proposals_list)}" %>
+            <%= action_authorized_button_to :vote, t('.vote'), proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list), remote: true, data: { disable: true, "redirect-url": proposal_path(proposal) }, class: "card__button button #{vote_button_classes(from_proposals_list)}" %>
           <% end %>
         <% end %>
       <% end %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
@@ -34,7 +34,7 @@
       <%= render partial: "count" %>
     </h2>
     <% if current_settings.creation_enabled %>
-      <%= action_authorized_link_to :create, new_proposal_path, class: "title-action__action button small hollow" do %>
+      <%= action_authorized_link_to :create, new_proposal_path, class: "title-action__action button small hollow", data: { "redirect_url" => new_proposal_path } do %>
         <%= t(".new_proposal") %>
         <%= icon "plus" %>
       <% end %>

--- a/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
@@ -14,6 +14,7 @@ module Decidim
       helper Decidim::AuthorizationFormHelper
 
       layout "layouts/decidim/user_profile", only: [:index]
+      skip_before_action :store_current_location
 
       def new; end
 

--- a/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
@@ -14,7 +14,6 @@ module Decidim
       helper Decidim::AuthorizationFormHelper
 
       layout "layouts/decidim/user_profile", only: [:index]
-      skip_before_action :store_current_location
 
       def new; end
 
@@ -86,6 +85,12 @@ module Decidim
 
       def pending_authorizations
         Authorizations.new(user: current_user, granted: false)
+      end
+
+      def store_current_location
+        return if params[:redirect_url].blank?
+
+        store_location_for(:user, params[:redirect_url])
       end
     end
   end

--- a/decidim-verifications/spec/features/authorizations_spec.rb
+++ b/decidim-verifications/spec/features/authorizations_spec.rb
@@ -38,6 +38,7 @@ describe "Authorizations", type: :feature, with_authorization_workflows: ["dummy
       it "allows the user to skip it" do
         click_link "start exploring"
         expect(page).to have_current_path decidim.account_path
+        expect(page).to have_content("User settings")
       end
     end
 

--- a/decidim-verifications/spec/views/decidim/verifications/authorizations/new.html.erb_spec.rb
+++ b/decidim-verifications/spec/views/decidim/verifications/authorizations/new.html.erb_spec.rb
@@ -17,6 +17,7 @@ module Decidim
       allow(view).to receive(:handler).and_return(handler)
       allow(view).to receive(:params).and_return(handler: "dummy_authorization_handler")
       allow(view).to receive(:authorizations_path).and_return("/authorizations")
+      allow(view).to receive(:stored_location).and_return("/processes")
     end
 
     context "when there's a partial to render the form" do


### PR DESCRIPTION
#### :tophat: What? Why?

Fixes #2321. 

I've reverted the commit that removed the after login redirect and added new code that will redirect to the proper page after login.

As an example, if you click on the Vote button for a proposal from the index and you aren't logged in or authorised, you'll get redirected to the proposal view.

#### :pushpin: Related Issues
- Related to #1916