### PR TITLE
Recover lose part of an entry in the changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ you need to change the following line in `config/environments/production.rb`:
 - **decidim-verifications**: Added action authorizers for authorization handlers. [\#2438](https://github.com/decidim/decidim/pull/2438)
 - **decidim-accountability**: Add feature to link projects with results [\#2467](https://github.com/decidim/decidim/pull/2467)
 - **decidim-proposals**: Improve proposals admin panel usability (sorting). [\#2419](https://github.com/decidim/decidim/pull/2419)
-- **decidim-core**: Follow users and get notifications about their actions. [\#2401](https://github.com/decidim/decidim/pull/2401)
+- **decidim-core**: Follow users and get notifications about their actions [\#2401](https://github.com/decidim/decidim/pull/2401) and [\#2452](https://github.com/decidim/decidim/pull/2452).
 - **decidim-core**: Add unique nicknames for participants. [\#2360](https://github.com/decidim/decidim/pull/2360)
 - **decidim-admin**: Let admins officialize certain users from the admin dashboard and specify custom officialization text for them. [\#2405](https://github.com/decidim/decidim/pull/2405)
 - **decidim-core**: Public profile page for participants, including name, nickname, follow button, avatar and officialization badge & text. [\#2391](https://github.com/decidim/decidim/pull/2391), [\#2360](https://github.com/decidim/decidim/pull/2360), [\#2401](https://github.com/decidim/decidim/pull/2401) and [\#2405](https://github.com/decidim/decidim/pull/2405).


### PR DESCRIPTION
#### :tophat: What? Why?
I discovered that an update of an entry in the CHANGELOG was lost during #2438. This PR recovers it. I triple-checked the changes and everything else is OK.

#### :pushpin: Related Issues
- Related to #2438

#### :clipboard: Subtasks

### :camera: Screenshots (optional)

#### :ghost: GIF
![giphy](https://user-images.githubusercontent.com/453545/34870459-681acfc4-f78a-11e7-90a8-c9417eaef471.gif)
