### PR TITLE
Modules: namespacing and consistency at naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ you need to change the following line in `config/environments/production.rb`:
 
 **Changed
 
+- **decidim-core**: Fixes the documentation regarding gems, libraries, plugins and modules. We should always use module, and use decidim-module-<engine_name> nomenclature for repositories naming [\#2481](https://github.com/decidim/decidim/pull/2481).
 - **decidim-core**: translated_attribute helper changes its default behaviour. Previously it was following these steps:
   1. Return the current user locale translation if available.
   2. Fallback to organization default locale in case the user locale translation is not available.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Project management [[See on Waffle.io]](https://waffle.io/decidim/decidim)
 
 * [Get started with Decidim](#getting-started-with-decidim)
 * [Contribute to the project](#how-to-contribute)
-* [Decidim components](#officially-supported-libraries)
+* [Officially supported modules](#officially-supported-modules)
 * [How to test Decidim engines](docs/testing.md)
 * [Create & browse development app](#browse-decidim)
 * [Technical tradeoffs](#technical-tradeoffs)
@@ -106,18 +106,18 @@ After you create a development app (`bundle exec rake development_app`):
 * Go to 'http://localhost:3000/admin'
 * Login data: admin@example.org | decidim123456
 
-## Officially supported libraries
+## Officially supported modules
 
 | Library        | Description           |
 | ------------- |-------------|
-| [Admin](https://github.com/decidim/decidim/tree/master/decidim-admin)      | This library adds an administration dashboard so users can manage their organization and all other entities. |
-| [API](https://github.com/decidim/decidim/tree/master/decidim-api)      | This library exposes a GraphQL API to programatically interact with the Decidim platform via HTTP      |
+| [Admin](https://github.com/decidim/decidim/tree/master/decidim-admin)      | Adds an administration dashboard so users can manage their organization and all other entities. |
+| [API](https://github.com/decidim/decidim/tree/master/decidim-api)      | Exposes a GraphQL API to programatically interact with the Decidim platform via HTTP      |
 | [Assemblies](https://github.com/decidim/decidim/tree/master/decidim-assemblies) | Permanent participatory spaces. Currently in beta as an optional feature, can be included by explicitly adding `decidim-assemblies` to the Gemfile. |
 | [Budgets](https://github.com/decidim/decidim/tree/master/decidim-budgets) | Adds a participatory budgets system to any participatory space. |
 | [Comments](https://github.com/decidim/decidim/tree/master/decidim-comments) | The Comments module adds the ability to include comments to any resource which can be commentable by users.      |
 | [Core](https://github.com/decidim/decidim/tree/master/decidim-core) | The basics of Decidim: users, organizations, etc. This is the only required engine to run Decidim, all the others are optional. |
 | [Participatory Processes](https://github.com/decidim/decidim/tree/master/decidim-participatory_processes) | The main concept of a Decidim installation: participatory processes. |
-| [Dev](https://github.com/decidim/decidim/tree/master/decidim-dev) | This gem aids the local development of Decidim's features. |
+| [Dev](https://github.com/decidim/decidim/tree/master/decidim-dev) | Aids the local development of Decidim's features. |
 | [Meeting](https://github.com/decidim/decidim/tree/master/decidim-meetings) | The Meeting module adds meeting to any participatory space. It adds a CRUD engine to the admin and public view scoped inside the participatory space. |
 | [Pages](https://github.com/decidim/decidim/tree/master/decidim-pages) | The Pages module adds static page capabilities to any participatory space. It basically provides an interface to include arbitrary HTML content to any step. |
 | [Proposals](https://github.com/decidim/decidim/tree/master/decidim-proposals) | The Proposals module adds one of the main features of Decidim: allows users to contribute to a participatory space by creating proposals. |

--- a/decidim-admin/README.md
+++ b/decidim-admin/README.md
@@ -1,6 +1,6 @@
 # Decidim::Admin
 
-This library adds an administration dashboard so users can manage their
+Adds an administration dashboard so users can manage their
 organization, participatory processes and all other entities.
 
 ## Usage

--- a/decidim-api/README.md
+++ b/decidim-api/README.md
@@ -1,6 +1,6 @@
 # Decidim::Api
 
-This library exposes a [GraphQL](https://facebook.github.io/graphql/) API to programatically interact with the Decidim platform via HTTP.
+Exposes a [GraphQL](https://facebook.github.io/graphql/) API to programatically interact with the Decidim platform via HTTP.
 
 ## Usage
 

--- a/decidim-assemblies/README.md
+++ b/decidim-assemblies/README.md
@@ -9,7 +9,7 @@ can be fully managed via an administration UI.
 
 ## Usage
 
-This plugin provides:
+This module provides:
 
 * A CRUD engine to manage assemblies.
 

--- a/decidim-core/README.md
+++ b/decidim-core/README.md
@@ -4,7 +4,7 @@ Short description and motivation.
 
 ## Usage
 
-How to use my plugin.
+How to use my module.
 
 ## Installation
 

--- a/decidim-dev/README.md
+++ b/decidim-dev/README.md
@@ -1,11 +1,11 @@
 # Decidim::Dev
 
-This gem allows local development of decidim's features and other features.
+This module allows local development of decidim's features and other features.
 
 ## Usage
 
 `decidim-dev` provides some testing utils such as shared contexts, examples, and
-dummy assets or resources that you can use to test your own plugins. It also
+dummy assets or resources that you can use to test your own modules. It also
 provides a `decidim:generate_external_test_app` rails task that you can use to
 generate a dummy application to test your plugin.
 

--- a/decidim-participatory_processes/README.md
+++ b/decidim-participatory_processes/README.md
@@ -10,7 +10,7 @@ categories, and are fully manageable via an administration UI.
 
 ## Usage
 
-This plugin provides:
+This module provides:
 
 * A CRUD engine to manage participatory processes.
 

--- a/decidim-verifications/README.md
+++ b/decidim-verifications/README.md
@@ -1,7 +1,7 @@
 # Decidim::Verifications
 
 Decidim offers several methods for allowing participants to get authorization to
-perform certain privileged actions. This gem implements several of those methods
+perform certain privileged actions. This module implements several of those methods
 and also offers a way for installation to implement their custom verification
 methods.
 

--- a/decidim_app-design/README.md
+++ b/decidim_app-design/README.md
@@ -10,7 +10,7 @@ This approach has several benefits:
 
 * Gems that provide extra assets can also be used, ensuring we're always consistent with the prototypes.
 
-* Since it's a rails application, we can keep the assets and specific code need for prototyping separate from the actual `decidim-*` gems, preventing polluting the codebase.
+* Since it's a rails application, we can keep the assets and specific code need for prototyping separate from the actual `decidim-*` modules, preventing polluting the codebase.
 
 ## Usage
 

--- a/docs/how_to_create_a_module.md
+++ b/docs/how_to_create_a_module.md
@@ -156,7 +156,12 @@
     Decidim::Dev.dummy_app_path = File.expand_path(File.join("..", "spec", "decidim_dummy_app"))
 
     require "decidim/dev/test/base_spec_helper"
+
     ```
+
+1. Upload to GitHub with the naming *decidim-module-<engine_name>*, so it's easier to find on
+the [dependency graph](https://github.com/decidim/decidim/network/dependents).
+
 
 ## Experimental way
 


### PR DESCRIPTION
Fixes the documentation regarding gems, libraries, plugins and modules. We should always use module, and use decidim-module-<engine_name> nomenclature for repositories naming.

Closes #2396