### PR TITLE
Bug/2479 counting results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ you need to change the following line in `config/environments/production.rb`:
 - **decidim-surveys**: Prevent double-click form submissions [\#2379](https://github.com/decidim/decidim/pull/2379)
 - **decidim-surveys**: Updated icon for surveys feature [\#2433](https://github.com/decidim/decidim/pull/2433)
 - **decidim-verifications**: Fixed a migration that broke feature permissions. If you already upgraded to `0.8.2` or less, please follow the instructions on the PR [\#2373](https://github.com/decidim/decidim/pull/2373)
+- **decidim-accountability**: Fix children results count [\#2483](https://github.com/decidim/decidim/pull/2483)
 
 **Removed**
 - **decidim**: Select2 JS library and scope selector based on Select2.

--- a/decidim-accountability/app/services/decidim/accountability/result_search.rb
+++ b/decidim-accountability/app/services/decidim/accountability/result_search.rb
@@ -13,7 +13,11 @@ module Decidim
       #          methods. (Default {})
       #          * feature - A Decidim::Feature to get the results from.
       #          * organization - A Decidim::Organization object.
+      #          * parent_id - The parent ID of the result. The value is forced to false to force
+      #                        the filter execution when the value is nil
       def initialize(options = {})
+        options[:parent_id] = false if options[:parent_id].nil?
+
         super(Result.all, options)
       end
 
@@ -22,6 +26,15 @@ module Decidim
         query
           .where(localized_search_text_in(:title), text: "%#{search_text}%")
           .or(query.where(localized_search_text_in(:description), text: "%#{search_text}%"))
+      end
+
+      # Handle parent_id filter
+      def search_parent_id
+        if options[:parent_id] == false
+          query.where(parent_id: nil)
+        else
+          query.where(parent_id: options[:parent_id])
+        end
       end
 
       private

--- a/decidim-accountability/app/services/decidim/accountability/results_calculator.rb
+++ b/decidim-accountability/app/services/decidim/accountability/results_calculator.rb
@@ -11,15 +11,10 @@ module Decidim
         @category_id = category_id
       end
 
+      delegate :count, to: :results
+
       def progress
         results.average(:progress)
-      end
-
-      def count
-        # if there are children return the total number of children results
-        # if not return the count of results (they are leafs)
-        children = results.sum(:children_count)
-        children.positive? ? children : results.count
       end
 
       private

--- a/decidim-accountability/spec/services/decidim/accountability/result_search_spec.rb
+++ b/decidim-accountability/spec/services/decidim/accountability/result_search_spec.rb
@@ -17,7 +17,8 @@ module Decidim::Accountability
         :result,
         feature: current_feature,
         category: parent_category,
-        scope: scope1
+        scope: scope1,
+        parent: nil
       )
     end
     let!(:result2) do
@@ -25,7 +26,17 @@ module Decidim::Accountability
         :result,
         feature: current_feature,
         category: subcategory,
-        scope: scope2
+        scope: scope2,
+        parent: nil
+      )
+    end
+    let!(:result3) do
+      create(
+        :result,
+        feature: current_feature,
+        category: parent_category,
+        scope: scope1,
+        parent: result1
       )
     end
     let(:external_result) { create :result }
@@ -103,6 +114,24 @@ module Decidim::Accountability
 
           it "returns an empty array" do
             expect(subject.results).to eq []
+          end
+        end
+      end
+
+      describe "parent_id" do
+        context "when the parent_id is nil" do
+          let(:params) { default_params.merge(parent_id: nil) }
+
+          it "returns results all parent results" do
+            expect(subject.results).to match_array [result2, result1]
+          end
+        end
+
+        context "when the parent_id is result1" do
+          let(:params) { default_params.merge(parent_id: result1.id) }
+
+          it "returns results the children" do
+            expect(subject.results).to match_array [result3]
           end
         end
       end

--- a/decidim-accountability/spec/services/decidim/accountability/results_calculator_spec.rb
+++ b/decidim-accountability/spec/services/decidim/accountability/results_calculator_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Accountability
+  describe ResultsCalculator do
+    subject { described_class.new(current_feature, scope.id, category.id) }
+
+    let(:participatory_process) { create(:participatory_process, :with_steps) }
+    let(:current_feature) { create :accountability_feature, participatory_space: participatory_process }
+    let(:scope) { create :scope, organization: current_feature.organization }
+    let(:category) { create :category, participatory_space: current_feature.participatory_space }
+    let!(:parent_result) do
+      create(
+        :result,
+        feature: current_feature,
+        category: category,
+        scope: scope,
+        parent: nil
+      )
+    end
+    let!(:child_result1) do
+      create(
+        :result,
+        feature: current_feature,
+        category: category,
+        scope: scope,
+        parent: parent_result
+
+      )
+    end
+    let!(:child_result2) do
+      create(
+        :result,
+        feature: current_feature,
+        category: category,
+        scope: scope,
+        parent: parent_result
+      )
+    end
+
+    describe "count" do
+      it "counts the results" do
+        expect(subject.count).to eq 1
+      end
+    end
+
+    describe "progress" do
+      it "calculates an average of the progress" do
+        expect(subject.progress).to eq parent_result.progress
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes `ResultsCalculator` count method.

#### :pushpin: Related Issues

- Fixes #2479

#### :clipboard: Subtasks

- [ ] I also fixed `ResultSearch` to support `parent_id` filtering. I'd like you to review this carefully because I haven't found a way to force the filter to be applied when the option is nil. I basically made a dirty hack I'm not very happy with, but I couldn't find any tip in the documentation.

### :camera: Screenshots (optional)

Before:

![screen shot 2018-01-12 at 11 13 36](https://user-images.githubusercontent.com/17616/34875073-0fb20444-f79c-11e7-8532-7356e704d3b9.png)

Now:

![screen shot 2018-01-12 at 13 25 00](https://user-images.githubusercontent.com/17616/34875065-09cdb730-f79c-11e7-933d-f9c32362e3f0.png)


#### :ghost: GIF
![](https://media.giphy.com/media/v1dTuaCHDuEA8/giphy.gif)
