### PR TITLE
Remove global scope navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ you need to change the following line in `config/environments/production.rb`:
 
 **Removed**
 - **decidim**: Select2 JS library and scope selector based on Select2.
+- **dedicim-accountability**: Removed the Global scope navigation option ([\#2486](https://github.com/decidim/decidim/pull/2486))
 
 ## [v0.8.0](https://github.com/decidim/decidim/tree/v0.8.0) (2017-12-4)
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.7.0...v0.8.0)

--- a/decidim-accountability/app/views/decidim/accountability/results/_scope_filters.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_scope_filters.html.erb
@@ -4,7 +4,6 @@
 
     <ul class="tags tags--action">
       <li <%= active_class_if_current(nil) %>><%= link_to t("results.filters.all", scope: "decidim.accountability"), url_for(filter: { category_id: category.try(:id) }) %></li>
-      <li <%= active_class_if_current("global") %>><%= link_to t("results.filters.global", scope: "decidim.accountability"), url_for(filter: { scope_id: "global", category_id: category.try(:id) }) %></li>
 
       <% current_participatory_space.subscopes.each do |scope| %>
         <li <%= active_class_if_current(scope.id) %>><%= link_to translated_attribute(scope.name), url_for(filter: { scope_id: scope.id, category_id: category.try(:id) }) %></li>

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -120,7 +120,6 @@ en:
             other: "%{count} results"
         filters:
           all: All
-          global: Global
           scopes: Scopes
         home:
           categories_label: Categories


### PR DESCRIPTION
#### :tophat: What? Why?

In this PR the option "Global" from the scopes navigation has been removed.

#### :pushpin: Related Issues

- Related to #2484 

#### :clipboard: Subtasks

None

### :camera: Screenshots (optional)

![screen shot 2018-01-12 at 16 31 56](https://user-images.githubusercontent.com/17616/34882220-259d544c-f7b6-11e7-8ea6-86b1755701cf.png)

#### :ghost: GIF

![](https://media1.giphy.com/media/3otPosTkbdkUxVojkI/giphy.gif)
