### PR TITLE
Keep current scope in breadcrumb links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ you need to change the following line in `config/environments/production.rb`:
 - **decidim-surveys**: Updated icon for surveys feature [\#2433](https://github.com/decidim/decidim/pull/2433)
 - **decidim-verifications**: Fixed a migration that broke feature permissions. If you already upgraded to `0.8.2` or less, please follow the instructions on the PR [\#2373](https://github.com/decidim/decidim/pull/2373)
 - **decidim-accountability**: Fix children results count [\#2483](https://github.com/decidim/decidim/pull/2483)
+- **decidim-accountability**: Keeps the current scope in the breadcumb links [\#2488](https://github.com/decidim/decidim/pull/2488)
 
 **Removed**
 - **decidim**: Select2 JS library and scope selector based on Select2.

--- a/decidim-accountability/app/views/decidim/accountability/results/_nav_breadcrumb.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_nav_breadcrumb.html.erb
@@ -5,7 +5,7 @@
   <% if category.present? && category.parent.present? %>
     <span class="breadcrumb--separator">></span>
     <div>
-      <%= link_to translated_attribute(category.parent.name), results_path(filter: { category_id: category.parent_id }) %>
+      <%= link_to translated_attribute(category.parent.name), results_path(filter: { category_id: category.parent_id, scope_id: current_scope }) %>
       <span class="percentage"><%= display_percentage progress_calculator(current_scope, category.parent_id) %></span>
     </div>
   <% end %>
@@ -13,7 +13,7 @@
   <% if category.present? %>
     <span class="breadcrumb--separator">></span>
     <div>
-      <%= link_to translated_attribute(category.name), results_path(filter: { category_id: category.id }) %>
+      <%= link_to translated_attribute(category.name), results_path(filter: { category_id: category.id, scope_id: current_scope }) %>
       <span class="percentage"><%= display_percentage progress_calculator(current_scope, category.id) %></span>
     </div>
   <% end %>
@@ -21,7 +21,7 @@
   <% if result && result.parent.present? %>
     <span class="breadcrumb--separator">></span>
     <div>
-      <%= link_to translated_attribute(result.parent.title), result_path(result.parent) %>
+      <%= link_to translated_attribute(result.parent.title), result_path(result.parent, filter: { scope_id: current_scope }) %>
       <span class="percentage"><%= display_percentage result.parent.progress %></span>
     </div>
   <% end %>

--- a/decidim-accountability/spec/features/explore_results_spec.rb
+++ b/decidim-accountability/spec/features/explore_results_spec.rb
@@ -43,6 +43,38 @@ describe "Explore results", versioning: true, type: :feature do
         expect(page).to have_content(translated(result.title))
       end
     end
+
+    context "with a category and a scope" do
+      let!(:category) { create :category, participatory_space: participatory_process }
+      let!(:scope) { create :scope, organization: organization }
+      let!(:result) do
+        result = results.first
+        result.category = category
+        result.scope = scope
+        result.save
+        result
+      end
+
+      let(:path) do
+        decidim_participatory_process_accountability.results_path(
+          participatory_process_slug: participatory_process.slug, feature_id: feature.id, filter: { category_id: category.id, scope_id: scope.id }
+        )
+      end
+
+      it "shows current scope active" do
+        within "ul.tags.tags--action li.active" do
+          expect(page).to have_content(translated(scope.name))
+        end
+      end
+
+      it "maintains scope filter" do
+        click_link translated(category.name)
+
+        within "ul.tags.tags--action li.active" do
+          expect(page).to have_content(translated(scope.name))
+        end
+      end
+    end
   end
 
   describe "show" do


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes the breadcrumb links in the accountability module, and now the current scope is passed as argument, so the user can change the category and the scope is maintained.

#### :pushpin: Related Issues

- Fixes #2487

#### :clipboard: Subtasks

None

### :camera: Screenshots (optional)

![screen shot 2018-01-12 at 16 38 39](https://user-images.githubusercontent.com/17616/34884453-131be7c8-f7bd-11e7-882b-42090f06f238.png)


#### :ghost: GIF
![](https://media.giphy.com/media/l378ndHJn4bvW8wWQ/giphy.gif)
