### PR TITLE
Don't scroll on process navigation bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ you need to change the following line in `config/environments/production.rb`:
 
 **Changed
 
+- **decidim-core**: Removed horizontal scroll from process navigation bar. [\#2495](https://github.com/decidim/decidim/pull/2495)
 - **decidim-core**: Fixes the documentation regarding gems, libraries, plugins and modules. We should always use module, and use decidim-module-<engine_name> nomenclature for repositories naming [\#2481](https://github.com/decidim/decidim/pull/2481).
 - **decidim-core**: translated_attribute helper changes its default behaviour. Previously it was following these steps:
   1. Return the current user locale translation if available.

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_process-nav.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_process-nav.scss
@@ -2,7 +2,7 @@
 
 /* Navigation */
 
-.process-nav {
+.process-nav{
   background-color: $white;
   border: $border;
   padding: .75rem $container-padding-y;
@@ -33,7 +33,7 @@
       display: none;
     }
 
-    ul::after {
+    ul::after{
       display: inline-block;
       flex-grow: 1;
       content: "";

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_process-nav.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_process-nav.scss
@@ -5,7 +5,7 @@
 .process-nav {
   background-color: $white;
   border: $border;
-  padding: .75rem $container-padding-y 0;
+  padding: .75rem $container-padding-y;
 
   ul{
     margin: 0;
@@ -17,6 +17,8 @@
   }
 
   @include breakpoint(medium){
+    padding: .25rem;
+
     ul{
       overflow-x: auto;
       -webkit-overflow-scrolling: touch;
@@ -24,16 +26,22 @@
       display: flex;
       align-items: center;
       flex-wrap: wrap;
+      justify-content: space-between;
     }
 
     ul::-webkit-scrollbar{
       display: none;
     }
 
+    ul::after {
+      display: inline-block;
+      flex-grow: 1;
+      content: "";
+    }
+
     li{
       display: inline-block;
-      margin-right: 1.5rem;
-      margin-bottom: .75rem;
+      margin: .5rem .75rem;
     }
 
     .about-link{

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_process-nav.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_process-nav.scss
@@ -2,10 +2,10 @@
 
 /* Navigation */
 
-.process-nav{
+.process-nav {
   background-color: $white;
   border: $border;
-  padding: .75rem $container-padding-y;
+  padding: .75rem $container-padding-y 0;
 
   ul{
     margin: 0;
@@ -23,6 +23,7 @@
       white-space: nowrap;
       display: flex;
       align-items: center;
+      flex-wrap: wrap;
     }
 
     ul::-webkit-scrollbar{
@@ -32,6 +33,7 @@
     li{
       display: inline-block;
       margin-right: 1.5rem;
+      margin-bottom: .75rem;
     }
 
     .about-link{


### PR DESCRIPTION
#### :tophat: What? Why?
Horizontal scroll in the process navigation bar is unpleasant and hard to use. This PR breaks the list into multiple lines if needed.
I don't know if items justification is better than aligning all to the left, maybe it should be discussed before merging.

#### :pushpin: Related Issues

#### :clipboard: Subtasks

### :camera: Screenshots (optional)
Before:
![imagen](https://user-images.githubusercontent.com/453545/34939077-da52d8fe-f9ea-11e7-9079-da290953fe3c.png)

After:
![imagen](https://user-images.githubusercontent.com/453545/34939115-f2198046-f9ea-11e7-8740-459d8f901915.png)
![imagen](https://user-images.githubusercontent.com/453545/34939134-0389e302-f9eb-11e7-9cd8-9bc792860894.png)
![imagen](https://user-images.githubusercontent.com/453545/34939184-387c9b90-f9eb-11e7-80c2-7c07139d3fa7.png)

Without items justification:
![after](https://user-images.githubusercontent.com/453545/34939457-1d46e320-f9ec-11e7-9f2b-e4ba0d0f8a7b.png)

#### :ghost: GIF
![scroll](https://user-images.githubusercontent.com/453545/34936930-56b7001c-f9e3-11e7-9b90-c3140f8e6bc0.gif)

