### PR TITLE
Save feature weight on create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ you need to change the following line in `config/environments/production.rb`:
 
 **Fixed**:
 
+- **decidim-admin**: Properly save features weight on creation [\#2499](https://github.com/decidim/decidim/pull/2499)
 - **decidim-core**: Fix after login redirect. [\#2321](https://github.com/decidim/decidim/pull/2321)
   With links or buttons that needs the user to be authorized or signed in you can now add a `data-redirect-url` attribute to redirect the user after they've signed in so they don't lose context.
 - **decidim-core**: Prevent many conversation with the same participants at the UI level. [\#2376](https://github.com/decidim/decidim/pull/2376)

--- a/decidim-admin/app/commands/decidim/admin/create_feature.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_feature.rb
@@ -38,6 +38,7 @@ module Decidim
           manifest_name: manifest.name,
           name: form.name,
           participatory_space: participatory_space,
+          weight: form.weight,
           settings: form.settings,
           default_step_settings: form.default_step_settings,
           step_settings: form.step_settings

--- a/decidim-admin/spec/commands/create_feature_spec.rb
+++ b/decidim-admin/spec/commands/create_feature_spec.rb
@@ -15,6 +15,7 @@ module Decidim::Admin
         },
         invalid?: !valid,
         valid?: valid,
+        weight: 2,
         settings: {
           dummy_global_attribute_1: true,
           dummy_global_attribute_2: false
@@ -50,6 +51,7 @@ module Decidim::Admin
         feature = participatory_process.features.first
         expect(feature.settings.dummy_global_attribute_1).to eq(true)
         expect(feature.settings.dummy_global_attribute_2).to eq(false)
+        expect(feature.weight).to eq 2
 
         step_settings = feature.step_settings[step.id.to_s]
         expect(step_settings.dummy_step_attribute_1).to eq(true)


### PR DESCRIPTION
#### :tophat: What? Why?
We are not saving the `weight` attribute for new features, but the value is saved when updating the feature.

#### :pushpin: Related Issues
- Fixes #2498
