### PR TITLE
Change create static page button text.

### DIFF
--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -415,7 +415,7 @@ en:
           title: Edit page
           update: Update
         new:
-          create: New
+          create: Create
           title: New page
         update:
           error: There was an error when updating this page.


### PR DESCRIPTION
#### :tophat: What? Why?
When creating an static page on admin, the text "New" for the submit button is a bit confusing. It should be an action, like "Create" or "Update", as in other forms (scopes, managed users, ...).

#### :pushpin: Related Issues

#### :clipboard: Subtasks

### :camera: Screenshots (optional)
![new button](https://user-images.githubusercontent.com/453545/34953841-5aa9645e-fa1e-11e7-97a9-9c0ad062f7e0.png)

#### :ghost: GIF
![new](https://user-images.githubusercontent.com/453545/34953991-01353406-fa1f-11e7-94cb-ce4a61745b10.gif)

