### PR TITLE
Notify proposal followers when it gets answered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ you need to change the following line in `config/environments/production.rb`:
 ```
 
 **Added**:
+- **decidim-proposals**: Notify proposal followers when it gets answered. [\#2508](https://github.com/decidim/decidim/pull/2508)
 - **decidim-core:** Extends public profile with personal URL and about text. Receive notifications when a profile is updated. [\2494](https://github.com/decidim/decidim/pull/2494)
 - **decidim-core:** Improve Newsletter adding unsubscribe link, see on website, UTM GET codes [\2359](https://github.com/decidim/decidim/pull/2359)
 - **decidim-verifications**: Added action authorizers for authorization handlers. [\#2438](https://github.com/decidim/decidim/pull/2438)

--- a/decidim-proposals/app/events/decidim/proposals/accepted_proposal_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/accepted_proposal_event.rb
@@ -1,0 +1,39 @@
+# frozen-string_literal: true
+
+module Decidim
+  module Proposals
+    class AcceptedProposalEvent < Decidim::Events::BaseEvent
+      include Decidim::Events::EmailEvent
+      include Decidim::Events::NotificationEvent
+
+      def email_subject
+        I18n.t(
+          "decidim.proposals.events.accepted_proposal_event.email_subject",
+          resource_title: resource_title
+        )
+      end
+
+      def email_intro
+        I18n.t(
+          "decidim.proposals.events.accepted_proposal_event.email_intro",
+          resource_title: resource_title
+        )
+      end
+
+      def email_outro
+        I18n.t(
+          "decidim.proposals.events.accepted_proposal_event.email_outro",
+          resource_title: resource_title
+        )
+      end
+
+      def notification_title
+        I18n.t(
+          "decidim.proposals.events.accepted_proposal_event.notification_title",
+          resource_title: resource_title,
+          resource_path: resource_path
+        ).html_safe
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/events/decidim/proposals/evaluating_proposal_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/evaluating_proposal_event.rb
@@ -1,0 +1,39 @@
+# frozen-string_literal: true
+
+module Decidim
+  module Proposals
+    class EvaluatingProposalEvent < Decidim::Events::BaseEvent
+      include Decidim::Events::EmailEvent
+      include Decidim::Events::NotificationEvent
+
+      def email_subject
+        I18n.t(
+          "decidim.proposals.events.evaluating_proposal_event.email_subject",
+          resource_title: resource_title
+        )
+      end
+
+      def email_intro
+        I18n.t(
+          "decidim.proposals.events.evaluating_proposal_event.email_intro",
+          resource_title: resource_title
+        )
+      end
+
+      def email_outro
+        I18n.t(
+          "decidim.proposals.events.evaluating_proposal_event.email_outro",
+          resource_title: resource_title
+        )
+      end
+
+      def notification_title
+        I18n.t(
+          "decidim.proposals.events.evaluating_proposal_event.notification_title",
+          resource_title: resource_title,
+          resource_path: resource_path
+        ).html_safe
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/events/decidim/proposals/rejected_proposal_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/rejected_proposal_event.rb
@@ -1,0 +1,39 @@
+# frozen-string_literal: true
+
+module Decidim
+  module Proposals
+    class RejectedProposalEvent < Decidim::Events::BaseEvent
+      include Decidim::Events::EmailEvent
+      include Decidim::Events::NotificationEvent
+
+      def email_subject
+        I18n.t(
+          "decidim.proposals.events.rejected_proposal_event.email_subject",
+          resource_title: resource_title
+        )
+      end
+
+      def email_intro
+        I18n.t(
+          "decidim.proposals.events.rejected_proposal_event.email_intro",
+          resource_title: resource_title
+        )
+      end
+
+      def email_outro
+        I18n.t(
+          "decidim.proposals.events.rejected_proposal_event.email_outro",
+          resource_title: resource_title
+        )
+      end
+
+      def notification_title
+        I18n.t(
+          "decidim.proposals.events.rejected_proposal_event.notification_title",
+          resource_title: resource_title,
+          resource_path: resource_path
+        ).html_safe
+      end
+    end
+  end
+end

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -84,6 +84,11 @@ en:
         error: There's been errors when saving the proposal.
         success: Proposal created successfully.
       events:
+        accepted_proposal_event:
+          email_intro: 'The proposal "%{resource_title}" has been accepted. You can read the answer in this page:'
+          email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
+          email_subject: A proposal you're following has been accepted
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal has been accepted.
         create_proposal_event:
           email_intro: |-
             Hi,
@@ -91,6 +96,16 @@ en:
           email_outro: You have received this notification because you are following %{author_nickname}. You can stop receiving notifications following the previous link.
           email_subject: New proposal by %{author_nickname}
           notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal was created by <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
+        evaluating_proposal_event:
+          email_intro: 'The proposal "%{resource_title}" is currently being evaluated. You can check for an answer in this page:'
+          email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
+          email_subject: A proposal you're following is being evaluated
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal is being evaluated.
+        rejected_proposal_event:
+          email_intro: 'The proposal "%{resource_title}" has been rejected. You can read the answer in this page:'
+          email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
+          email_subject: A proposal you're following has been rejected
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal has been rejected.
       models:
         proposal:
           fields:

--- a/decidim-proposals/spec/commands/decidim/proposals/answer_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/answer_proposal_spec.rb
@@ -46,6 +46,24 @@ module Decidim
 
               expect(proposal.reload).to be_answered
             end
+
+            context "when the state changes" do
+              it "notifies the proposal followers" do
+                follower = create(:user, organization: proposal.organization)
+                create(:follow, followable: proposal, user: follower)
+
+                expect(Decidim::EventsManager)
+                  .to receive(:publish)
+                  .with(
+                    event: "decidim.events.proposals.proposal_rejected",
+                    event_class: Decidim::Proposals::RejectedProposalEvent,
+                    resource: proposal,
+                    recipient_ids: [follower.id]
+                  )
+
+                command.call
+              end
+            end
           end
         end
       end

--- a/decidim-proposals/spec/events/decidim/proposals/accepted_proposal_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/accepted_proposal_event_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Proposals::AcceptedProposalEvent do
+  subject do
+    described_class.new(resource: proposal, event_name: event_name, user: user, extra: {})
+  end
+
+  let(:organization) { proposal.organization }
+  let(:proposal) { create :proposal }
+  let(:event_name) { "decidim.events.proposals.proposal_created" }
+  let(:user) { create :user, organization: organization }
+  let(:resource_path) { resource_locator(proposal).path }
+
+  describe "types" do
+    subject { described_class }
+
+    it "supports notifications" do
+      expect(subject.types).to include :notification
+    end
+
+    it "supports emails" do
+      expect(subject.types).to include :email
+    end
+  end
+
+  describe "email_subject" do
+    it "is generated correctly" do
+      expect(subject.email_subject).to eq("A proposal you're following has been accepted")
+    end
+  end
+
+  describe "email_intro" do
+    it "is generated correctly" do
+      expect(subject.email_intro)
+        .to eq("The proposal \"#{proposal.title}\" has been accepted. You can read the answer in this page:")
+    end
+  end
+
+  describe "email_outro" do
+    it "is generated correctly" do
+      expect(subject.email_outro)
+        .to eq("You have received this notification because you are following \"#{proposal.title}\". You can unfollow it from the previous link.")
+    end
+  end
+
+  describe "notification_title" do
+    it "is generated correctly" do
+      expect(subject.notification_title)
+        .to include("The <a href=\"#{resource_path}\">#{proposal.title}</a> proposal has been accepted")
+    end
+  end
+end

--- a/decidim-proposals/spec/events/decidim/proposals/evaluating_proposal_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/evaluating_proposal_event_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Proposals::EvaluatingProposalEvent do
+  subject do
+    described_class.new(resource: proposal, event_name: event_name, user: user, extra: {})
+  end
+
+  let(:organization) { proposal.organization }
+  let(:proposal) { create :proposal }
+  let(:event_name) { "decidim.events.proposals.proposal_created" }
+  let(:user) { create :user, organization: organization }
+  let(:resource_path) { resource_locator(proposal).path }
+
+  describe "types" do
+    subject { described_class }
+
+    it "supports notifications" do
+      expect(subject.types).to include :notification
+    end
+
+    it "supports emails" do
+      expect(subject.types).to include :email
+    end
+  end
+
+  describe "email_subject" do
+    it "is generated correctly" do
+      expect(subject.email_subject).to eq("A proposal you're following is being evaluated")
+    end
+  end
+
+  describe "email_intro" do
+    it "is generated correctly" do
+      expect(subject.email_intro)
+        .to eq("The proposal \"#{proposal.title}\" is currently being evaluated. You can check for an answer in this page:")
+    end
+  end
+
+  describe "email_outro" do
+    it "is generated correctly" do
+      expect(subject.email_outro)
+        .to eq("You have received this notification because you are following \"#{proposal.title}\". You can unfollow it from the previous link.")
+    end
+  end
+
+  describe "notification_title" do
+    it "is generated correctly" do
+      expect(subject.notification_title)
+        .to include("The <a href=\"#{resource_path}\">#{proposal.title}</a> proposal is being evaluated")
+    end
+  end
+end

--- a/decidim-proposals/spec/events/decidim/proposals/rejected_proposal_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/rejected_proposal_event_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Proposals::RejectedProposalEvent do
+  subject do
+    described_class.new(resource: proposal, event_name: event_name, user: user, extra: {})
+  end
+
+  let(:organization) { proposal.organization }
+  let(:proposal) { create :proposal }
+  let(:event_name) { "decidim.events.proposals.proposal_created" }
+  let(:user) { create :user, organization: organization }
+  let(:resource_path) { resource_locator(proposal).path }
+
+  describe "types" do
+    subject { described_class }
+
+    it "supports notifications" do
+      expect(subject.types).to include :notification
+    end
+
+    it "supports emails" do
+      expect(subject.types).to include :email
+    end
+  end
+
+  describe "email_subject" do
+    it "is generated correctly" do
+      expect(subject.email_subject).to eq("A proposal you're following has been rejected")
+    end
+  end
+
+  describe "email_intro" do
+    it "is generated correctly" do
+      expect(subject.email_intro)
+        .to eq("The proposal \"#{proposal.title}\" has been rejected. You can read the answer in this page:")
+    end
+  end
+
+  describe "email_outro" do
+    it "is generated correctly" do
+      expect(subject.email_outro)
+        .to eq("You have received this notification because you are following \"#{proposal.title}\". You can unfollow it from the previous link.")
+    end
+  end
+
+  describe "notification_title" do
+    it "is generated correctly" do
+      expect(subject.notification_title)
+        .to include("The <a href=\"#{resource_path}\">#{proposal.title}</a> proposal has been rejected")
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

When a proposal gets answered by an admin all of its followers will receive a new notification, it also works when a new answer is given.

#### :pushpin: Related Issues
- Related to #2334 
- Fixes #1195
- Fixes #1038
