### PR TITLE
Add assemblies to the `decidim` gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ you need to change the following line in `config/environments/production.rb`:
 ```
 
 **Added**:
+- **decidim**: Add `decidim-assemblies` to the `decidim` metage. [\#2495](https://github.com/decidim/decidim/pull/2510)
 - **decidim-proposals**: Notify proposal followers when it gets answered. [\#2508](https://github.com/decidim/decidim/pull/2508)
 - **decidim-core:** Extends public profile with personal URL and about text. Receive notifications when a profile is updated. [\2494](https://github.com/decidim/decidim/pull/2494)
 - **decidim-core:** Improve Newsletter adding unsubscribe link, see on website, UTM GET codes [\2359](https://github.com/decidim/decidim/pull/2359)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ you need to change the following line in `config/environments/production.rb`:
 ```
 
 **Added**:
-- **decidim**: Add `decidim-assemblies` to the `decidim` metage. [\#2495](https://github.com/decidim/decidim/pull/2510)
+- **decidim**: Add `decidim-assemblies` to the `decidim` metagem. [\#2495](https://github.com/decidim/decidim/pull/2510)
 - **decidim-proposals**: Notify proposal followers when it gets answered. [\#2508](https://github.com/decidim/decidim/pull/2508)
 - **decidim-core:** Extends public profile with personal URL and about text. Receive notifications when a profile is updated. [\2494](https://github.com/decidim/decidim/pull/2494)
 - **decidim-core:** Improve Newsletter adding unsubscribe link, see on website, UTM GET codes [\2359](https://github.com/decidim/decidim/pull/2359)

--- a/README.md
+++ b/README.md
@@ -108,22 +108,22 @@ After you create a development app (`bundle exec rake development_app`):
 
 ## Officially supported modules
 
-| Library        | Description           |
-| ------------- |-------------|
-| [Admin](https://github.com/decidim/decidim/tree/master/decidim-admin)      | Adds an administration dashboard so users can manage their organization and all other entities. |
-| [API](https://github.com/decidim/decidim/tree/master/decidim-api)      | Exposes a GraphQL API to programatically interact with the Decidim platform via HTTP      |
-| [Assemblies](https://github.com/decidim/decidim/tree/master/decidim-assemblies) | Permanent participatory spaces. Currently in beta as an optional feature, can be included by explicitly adding `decidim-assemblies` to the Gemfile. |
-| [Budgets](https://github.com/decidim/decidim/tree/master/decidim-budgets) | Adds a participatory budgets system to any participatory space. |
-| [Comments](https://github.com/decidim/decidim/tree/master/decidim-comments) | The Comments module adds the ability to include comments to any resource which can be commentable by users.      |
-| [Core](https://github.com/decidim/decidim/tree/master/decidim-core) | The basics of Decidim: users, organizations, etc. This is the only required engine to run Decidim, all the others are optional. |
-| [Participatory Processes](https://github.com/decidim/decidim/tree/master/decidim-participatory_processes) | The main concept of a Decidim installation: participatory processes. |
-| [Dev](https://github.com/decidim/decidim/tree/master/decidim-dev) | Aids the local development of Decidim's features. |
-| [Meeting](https://github.com/decidim/decidim/tree/master/decidim-meetings) | The Meeting module adds meeting to any participatory space. It adds a CRUD engine to the admin and public view scoped inside the participatory space. |
-| [Pages](https://github.com/decidim/decidim/tree/master/decidim-pages) | The Pages module adds static page capabilities to any participatory space. It basically provides an interface to include arbitrary HTML content to any step. |
-| [Proposals](https://github.com/decidim/decidim/tree/master/decidim-proposals) | The Proposals module adds one of the main features of Decidim: allows users to contribute to a participatory space by creating proposals. |
-| [Accountability](https://github.com/decidim/decidim/tree/master/decidim-accountability) | Adds an accountability section to any participatory space so users can follow along the state of the accepted proposals. |
-| [Surveys](https://github.com/decidim/decidim/tree/master/decidim-surveys) | Adds the ability for admins to create arbitrary surveys. |
-| [System](https://github.com/decidim/decidim/tree/master/decidim-system) | Multitenant Admin to manage multiple organizations in a single installation |
+| Library                                                                                                   | Description                                                                                                                                                  |
+| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [Admin](https://github.com/decidim/decidim/tree/master/decidim-admin)                                     | Adds an administration dashboard so users can manage their organization and all other entities.                                                              |
+| [API](https://github.com/decidim/decidim/tree/master/decidim-api)                                         | Exposes a GraphQL API to programatically interact with the Decidim platform via HTTP                                                                         |
+| [Assemblies](https://github.com/decidim/decidim/tree/master/decidim-assemblies)                           | Permanent participatory spaces.                                                                                                                              |
+| [Budgets](https://github.com/decidim/decidim/tree/master/decidim-budgets)                                 | Adds a participatory budgets system to any participatory space.                                                                                              |
+| [Comments](https://github.com/decidim/decidim/tree/master/decidim-comments)                               | The Comments module adds the ability to include comments to any resource which can be commentable by users.                                                  |
+| [Core](https://github.com/decidim/decidim/tree/master/decidim-core)                                       | The basics of Decidim: users, organizations, etc. This is the only required engine to run Decidim, all the others are optional.                              |
+| [Participatory Processes](https://github.com/decidim/decidim/tree/master/decidim-participatory_processes) | The main concept of a Decidim installation: participatory processes.                                                                                         |
+| [Dev](https://github.com/decidim/decidim/tree/master/decidim-dev)                                         | Aids the local development of Decidim's features.                                                                                                            |
+| [Meeting](https://github.com/decidim/decidim/tree/master/decidim-meetings)                                | The Meeting module adds meeting to any participatory space. It adds a CRUD engine to the admin and public view scoped inside the participatory space.        |
+| [Pages](https://github.com/decidim/decidim/tree/master/decidim-pages)                                     | The Pages module adds static page capabilities to any participatory space. It basically provides an interface to include arbitrary HTML content to any step. |
+| [Proposals](https://github.com/decidim/decidim/tree/master/decidim-proposals)                             | The Proposals module adds one of the main features of Decidim: allows users to contribute to a participatory space by creating proposals.                    |
+| [Accountability](https://github.com/decidim/decidim/tree/master/decidim-accountability)                   | Adds an accountability section to any participatory space so users can follow along the state of the accepted proposals.                                     |
+| [Surveys](https://github.com/decidim/decidim/tree/master/decidim-surveys)                                 | Adds the ability for admins to create arbitrary surveys.                                                                                                     |
+| [System](https://github.com/decidim/decidim/tree/master/decidim-system)                                   | Multitenant Admin to manage multiple organizations in a single installation                                                                                  |
 
 ## Technical tradeoffs
 

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -4,7 +4,6 @@ require "decidim/faker/localized"
 require "decidim/dev"
 
 require "decidim/participatory_processes/test/factories"
-require "decidim/assemblies/test/factories"
 require "decidim/comments/test/factories"
 
 FactoryBot.define do

--- a/decidim-core/spec/presenters/decidim/home_stats_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/home_stats_presenter_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "decidim/assemblies/test/factories"
 
 module Decidim
   describe HomeStatsPresenter do

--- a/decidim.gemspec
+++ b/decidim.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency "decidim-accountability", Decidim.version
   s.add_dependency "decidim-admin", Decidim.version
   s.add_dependency "decidim-api", Decidim.version
+  s.add_dependency "decidim-assemblies", Decidim.version
   s.add_dependency "decidim-budgets", Decidim.version
   s.add_dependency "decidim-comments", Decidim.version
   s.add_dependency "decidim-core", Decidim.version

--- a/lib/decidim.rb
+++ b/lib/decidim.rb
@@ -9,12 +9,7 @@ require "decidim/version"
 require "decidim/verifications"
 
 require "decidim/participatory_processes"
-
-begin
-  require "decidim/assemblies"
-rescue LoadError
-  nil
-end
+require "decidim/assemblies"
 
 require "decidim/pages"
 require "decidim/comments"


### PR DESCRIPTION
#### :tophat: What? Why?
The quarantine for `assemblies` is already due, so let's better put that into the `decidim` gem.

#### :pushpin: Related Issues
- Fixes #2500

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
*None*
