### PR TITLE
Allow optional dates values to be cleared

### DIFF
--- a/decidim-core/vendor/assets/javascripts/form_datepicker.js.es6
+++ b/decidim-core/vendor/assets/javascripts/form_datepicker.js.es6
@@ -20,7 +20,10 @@
         leftArrow: '<<',
         rightArrow: '>>'
       }).on('changeDate', (ev) => {
-        let newDate = ev.date == null ? "" : exports.moment.utc(ev.date).format('YYYY-MM-DDTHH:mm:ss');
+        let newDate = "";
+        if (ev.date !== null) {
+          newDate = exports.moment.utc(ev.date).format('YYYY-MM-DDTHH:mm:ss');
+        }
         $(ev.target).siblings('input').val(newDate);
       });
     });

--- a/decidim-core/vendor/assets/javascripts/form_datepicker.js.es6
+++ b/decidim-core/vendor/assets/javascripts/form_datepicker.js.es6
@@ -20,8 +20,7 @@
         leftArrow: '<<',
         rightArrow: '>>'
       }).on('changeDate', (ev) => {
-        let newDate = exports.moment.utc(ev.date).format('YYYY-MM-DDTHH:mm:ss');
-
+        let newDate = ev.date == null ? "" : exports.moment.utc(ev.date).format('YYYY-MM-DDTHH:mm:ss');
         $(ev.target).siblings('input').val(newDate);
       });
     });

--- a/decidim-core/vendor/assets/javascripts/foundation-datepicker.js
+++ b/decidim-core/vendor/assets/javascripts/foundation-datepicker.js
@@ -173,6 +173,11 @@
         this.setDaysOfWeekDisabled(options.daysOfWeekDisabled || this.element.data('date-days-of-week-disabled'));
         this.setDatesDisabled(options.datesDisabled || this.element.data('dates-disabled'));
 
+        if (this.initialDate != null) {
+            this.date = this.viewDate = DPGlobal.parseDate(this.initialDate, this.format, this.language);
+            this.setValue();
+        }
+
         this.fillDow();
         this.fillMonths();
         this.update();
@@ -432,14 +437,10 @@
             if (arguments && arguments.length && (typeof arguments[0] === 'string' || arguments[0] instanceof Date)) {
                 date = arguments[0];
                 fromArgs = true;
-            } 
-            else if (!currentVal && this.initialDate != null) { // If value is not set, set it to the initialDate 
-                date = this.initialDate
             }
             else {
                 date = this.isInput ? this.element.val() : this.element.data('date') || this.element.find('input').val();
             }
-    
             if (date && date.length > this.formatText.length) {
                     $(this.picker).addClass('is-invalid')
                     $(this.element).addClass('is-invalid-input')
@@ -447,12 +448,18 @@
             } else {
                 $(this.picker).removeClass('is-invalid')
                 $(this.element).removeClass('is-invalid-input')
-                  
             }
         
-            this.date = DPGlobal.parseDate(date, this.format, this.language);  
+            this.date = DPGlobal.parseDate(date, this.format, this.language);
 
-            if (fromArgs || this.initialDate != null) this.setValue();
+            if (fromArgs) {
+                this.setValue();
+            } else if (currentVal == "") {
+                this.element.trigger({
+                    type: 'changeDate',
+                    date: null
+                });
+            }
 
             if (this.date < this.startDate) {
                 this.viewDate = new Date(this.startDate.valueOf());

--- a/decidim-core/vendor/assets/javascripts/foundation-datepicker.js
+++ b/decidim-core/vendor/assets/javascripts/foundation-datepicker.js
@@ -386,9 +386,13 @@
 
         place: function() {
             if (this.isInline) return;
-            var zIndex = parseInt(this.element.parents().filter(function() {
-                return $(this).css('z-index') != 'auto';
-            }).first().css('z-index')) + 10;
+            var zIndexes = [];
+            this.element.parents().map(function() {
+                if ($(this).css('z-index') != 'auto') {
+                    zIndexes.push(parseInt($(this).css('z-index')));
+                }
+            });
+            var zIndex = zIndexes.sort(function(a, b) { return a - b; }).pop() + 10;
             var textbox = this.component ? this.component : this.element;
             var offset = textbox.offset();
             var height = textbox.outerHeight() + parseInt(textbox.css('margin-top'));
@@ -396,12 +400,17 @@
             var fullOffsetTop = offset.top + height;
             var offsetLeft = offset.left;
             this.picker.removeClass('datepicker-top datepicker-bottom');
-            // if the datepicker is going to be below the window, show it on top of the input
-            if ((fullOffsetTop + this.picker.outerHeight()) >= $(window).scrollTop() + $(window).height()) {
+            // can we show it on top?
+            var canShowTop = ($(window).scrollTop() < offset.top - this.picker.outerHeight());
+            var canShowBottom = (fullOffsetTop + this.picker.outerHeight()) < $(window).scrollTop() + $(window).height();
+            // If the datepicker is going to be below the window, show it on top of the input if it fits
+            if (!canShowBottom && canShowTop) {
                 fullOffsetTop = offset.top - this.picker.outerHeight();
                 this.picker.addClass('datepicker-top');
             }
             else {
+                // Scroll up if we cannot show it on bottom or top (for mobile devices)
+                if (!canShowBottom) $(window).scrollTop(offset.top);
                 this.picker.addClass('datepicker-bottom');
             }
 
@@ -498,7 +507,7 @@
                 today = new Date(),
                 titleFormat = dates[this.language].titleFormat || dates['en'].titleFormat;
             // this.picker.find('.datepicker-days thead th.date-switch')
-            // 			.text(DPGlobal.formatDate(new UTCDate(year, month), titleFormat, this.language));
+            //          .text(DPGlobal.formatDate(new UTCDate(year, month), titleFormat, this.language));
 
             this.picker.find('.datepicker-days thead th:eq(1)')
                 .text(dates[this.language].months[month] + ' ' + year);
@@ -1090,25 +1099,25 @@
                 }
             }
             /*
-            	vitalets: fixing bug of very special conditions:
-            	jquery 1.7.1 + webkit + show inline datepicker in bootstrap popover.
-            	Method show() does not set display css correctly and datepicker is not shown.
-            	Changed to .css('display', 'block') solve the problem.
-            	See https://github.com/vitalets/x-editable/issues/37
+                vitalets: fixing bug of very special conditions:
+                jquery 1.7.1 + webkit + show inline datepicker in bootstrap popover.
+                Method show() does not set display css correctly and datepicker is not shown.
+                Changed to .css('display', 'block') solve the problem.
+                See https://github.com/vitalets/x-editable/issues/37
 
-            	In jquery 1.7.2+ everything works fine.
+                In jquery 1.7.2+ everything works fine.
             */
             //this.picker.find('>div').hide().filter('.datepicker-'+DPGlobal.modes[this.viewMode].clsName).show();
             this.picker.find('>div').hide().filter('.datepicker-' + DPGlobal.modes[this.viewMode].clsName).css('display', 'block');
             this.updateNavArrows();
         },
-		
-		changeViewDate: function(date) {
-			this.date = date;
-			this.viewDate = date;
-			this.fill();
-		},
-		
+
+        changeViewDate: function(date) {
+            this.date = date;
+            this.viewDate = date;
+            this.fill();
+        },
+
         reset: function(e) {
             this._setDate(null, 'date');
         }


### PR DESCRIPTION
#### :tophat: What? Why?
Foundation DatePicker modified to allow users to delete a date value after it is set.
I also updated the JS file with last changes from its repo.

#### :pushpin: Related Issues
- Fixes #2218

#### :clipboard: Subtasks

### :camera: Screenshots (optional)

#### :ghost: GIF
![calendar-flip](https://user-images.githubusercontent.com/453545/35062971-0539d004-fbc6-11e7-9b83-3d0985e8eabb.gif)

