### PR TITLE
Follow a participatory space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ you need to change the following line in `config/environments/production.rb`:
 ```
 
 **Added**:
+- **decidim-admin**: Notify participatory space followers when a new feature is published. [\#2515](https://github.com/decidim/decidim/pull/2515)
 - **decidim**: Add `decidim-assemblies` to the `decidim` metagem. [\#2495](https://github.com/decidim/decidim/pull/2510)
 - **decidim-proposals**: Notify proposal followers when it gets answered. [\#2508](https://github.com/decidim/decidim/pull/2508)
 - **decidim-core:** Extends public profile with personal URL and about text. Receive notifications when a profile is updated. [\2494](https://github.com/decidim/decidim/pull/2494)

--- a/decidim-admin/app/controllers/decidim/admin/features_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/features_controller.rb
@@ -91,6 +91,15 @@ module Decidim
 
         @feature.publish!
 
+        if current_participatory_space.is_a?(Decidim::Followable)
+          Decidim::EventsManager.publish(
+            event: "decidim.events.features.feature_published",
+            event_class: Decidim::FeaturePublishedEvent,
+            resource: @feature,
+            recipient_ids: current_participatory_space.followers.pluck(:id)
+          )
+        end
+
         flash[:notice] = I18n.t("features.publish.success", scope: "decidim.admin")
         redirect_to action: :index
       end

--- a/decidim-admin/app/events/decidim/feature_published_event.rb
+++ b/decidim-admin/app/events/decidim/feature_published_event.rb
@@ -1,0 +1,59 @@
+# frozen-string_literal: true
+
+module Decidim
+  class FeaturePublishedEvent < Decidim::Events::BaseEvent
+    include Decidim::Events::EmailEvent
+    include Decidim::Events::NotificationEvent
+    include Decidim::FeaturePathHelper
+
+    def email_subject
+      I18n.t(
+        "decidim.events.feature_published_event.email_subject",
+        resource_title: resource_title,
+        resource_path: resource_path,
+        participatory_space_title: participatory_space_title
+      )
+    end
+
+    def email_intro
+      I18n.t(
+        "decidim.events.feature_published_event.email_intro",
+        resource_title: resource_title,
+        resource_path: resource_path,
+        participatory_space_title: participatory_space_title
+      )
+    end
+
+    def email_outro
+      I18n.t(
+        "decidim.events.feature_published_event.email_outro",
+        resource_title: resource_title,
+        resource_path: resource_path,
+        participatory_space_title: participatory_space_title
+      )
+    end
+
+    def notification_title
+      I18n.t(
+        "decidim.events.feature_published_event.notification_title",
+        resource_title: resource_title,
+        resource_path: resource_path,
+        participatory_space_title: participatory_space_title
+      ).html_safe
+    end
+
+    private
+
+    def resource_path
+      @resource_path ||= main_feature_path(resource)
+    end
+
+    def participatory_space_title
+      resource.participatory_space.title[I18n.locale.to_s]
+    end
+
+    def resource_title
+      @resource_title ||= resource.name[I18n.locale.to_s]
+    end
+  end
+end

--- a/decidim-admin/spec/events/decidim/feature_published_event_spec.rb
+++ b/decidim-admin/spec/events/decidim/feature_published_event_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::FeaturePublishedEvent do
+  include Decidim::FeaturePathHelper
+
+  subject do
+    described_class.new(resource: feature, event_name: event_name, user: follower, extra: {})
+  end
+
+  let(:organization) { follower.organization }
+  let(:follower) { create :user }
+  let(:event_name) { "decidim.events.feature_published_event" }
+  let(:feature) { create(:feature, organization: organization) }
+  let(:participatory_space) { feature.participatory_space }
+  let(:resource_path) { main_feature_path(feature) }
+
+  describe "types" do
+    subject { described_class }
+
+    it "supports notifications" do
+      expect(subject.types).to include :notification
+    end
+
+    it "supports emails" do
+      expect(subject.types).to include :email
+    end
+  end
+
+  describe "email_subject" do
+    it "is generated correctly" do
+      expect(subject.email_subject).to eq("An update to #{participatory_space.title["en"]}")
+    end
+  end
+
+  describe "email_intro" do
+    it "is generated correctly" do
+      expect(subject.email_intro)
+        .to eq("The #{feature.name["en"]} component is now active for #{participatory_space.title["en"]}. You can see it from this page:")
+    end
+  end
+
+  describe "email_outro" do
+    it "is generated correctly" do
+      expect(subject.email_outro)
+        .to include("You have received this notification because you are following #{participatory_space.title["en"]}")
+    end
+  end
+
+  describe "notification_title" do
+    it "is generated correctly" do
+      expect(subject.notification_title)
+        .to eq("The #{feature.name["en"]} component is now active for <a href=\"#{resource_path}\">#{participatory_space.title["en"]}</a>")
+    end
+  end
+end

--- a/decidim-assemblies/app/models/decidim/assembly.rb
+++ b/decidim-assemblies/app/models/decidim/assembly.rb
@@ -9,6 +9,7 @@ module Decidim
     include Decidim::Participable
     include Decidim::Publicable
     include Decidim::Scopable
+    include Decidim::Followable
 
     belongs_to :organization,
                foreign_key: "decidim_organization_id",

--- a/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
@@ -18,6 +18,11 @@
       <%= attachments_for current_participatory_space %>
     </div>
     <div class="section columns medium-5 mediumlarge-4 large-3">
+      <div class="card extra">
+        <div class="card__content">
+          <%= render partial: "decidim/shared/follow_button", locals: { followable: current_participatory_space } %>
+        </div>
+      </div>
       <div class="card extra definition-data">
         <% if translated_attribute(current_participatory_space.meta_scope).present? %>
           <div class="definition-data__item scope">

--- a/decidim-assemblies/spec/shared/manage_assembly_features.rb
+++ b/decidim-assemblies/spec/shared/manage_assembly_features.rb
@@ -173,6 +173,17 @@ shared_examples "manage assembly features" do
           expect(page).to have_css(".action-icon--unpublish")
         end
       end
+
+      it "notifies its followers" do
+        follower = create(:user, organization: assembly.organization)
+        create(:follow, followable: assembly, user: follower)
+
+        within ".feature-#{feature.id}" do
+          click_link "Publish"
+        end
+
+        expect(enqueued_jobs.last[:args]).to include("decidim.events.features.feature_published")
+      end
     end
 
     context "when the feature is published" do

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -129,6 +129,11 @@ en:
         email_intro: 'There has been an update to "%{resource_title}". You can see it from this page:'
         email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
         email_subject: An update to %{resource_title}
+      feature_published_event:
+        email_intro: 'The %{resource_title} component is now active for %{participatory_space_title}. You can see it from this page:'
+        email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+        email_subject: An update to %{participatory_space_title}
+        notification_title: The %{resource_title} component is now active for <a href="%{resource_path}">%{participatory_space_title}</a>
       notification_event:
         notification_title: An event occured to <a href="%{resource_path}">%{resource_title}</a>.
       profile_updated_event:

--- a/decidim-participatory_processes/app/models/decidim/participatory_process.rb
+++ b/decidim-participatory_processes/app/models/decidim/participatory_process.rb
@@ -11,6 +11,7 @@ module Decidim
     include Decidim::Participable
     include Decidim::Publicable
     include Decidim::Scopable
+    include Decidim::Followable
 
     belongs_to :organization,
                foreign_key: "decidim_organization_id",

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
@@ -22,6 +22,11 @@
       <%= attachments_for current_participatory_space %>
     </div>
     <div class="section columns medium-5 mediumlarge-4 large-3">
+      <div class="card extra">
+        <div class="card__content">
+          <%= render partial: "decidim/shared/follow_button", locals: { followable: current_participatory_space } %>
+        </div>
+      </div>
       <div class="card extra definition-data">
         <% if translated_attribute(current_participatory_space.participatory_scope).present? %>
           <div class="definition-data__item participatory_scope">

--- a/decidim-participatory_processes/spec/features/admin/admin_manages_participatory_process_features_spec.rb
+++ b/decidim-participatory_processes/spec/features/admin/admin_manages_participatory_process_features_spec.rb
@@ -277,6 +277,17 @@ describe "Admin manages participatory process features", type: :feature do
           expect(page).to have_css(".action-icon--unpublish")
         end
       end
+
+      it "notifies its followers" do
+        follower = create(:user, organization: participatory_process.organization)
+        create(:follow, followable: participatory_process, user: follower)
+
+        within ".feature-#{feature.id}" do
+          click_link "Publish"
+        end
+
+        expect(enqueued_jobs.last[:args]).to include("decidim.events.features.feature_published")
+      end
     end
 
     context "when the feature is published" do


### PR DESCRIPTION
#### :tophat: What? Why?

Adds a button to follow participatory processes and assemblies and notifies its followers when a new feature is published.

#### :pushpin: Related Issues
- Related to #2446