### PR TITLE
Enable notifications on users by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ you need to change the following line in `config/environments/production.rb`:
 - **decidim-core**: [Breaking change] Changes the participatory space's contracts introducing `context`. This was done to fix a bug caused by dynamically extending some controllers. [\#2465](https://github.com/decidim/decidim/pull/2465)
 - **decidim-core**: Removed horizontal scroll from process navigation bar. [\#2495](https://github.com/decidim/decidim/pull/2495)
 - **decidim-core**: Fixes the documentation regarding gems, libraries, plugins and modules. We should always use module, and use decidim-module-<engine_name> nomenclature for repositories naming [\#2481](https://github.com/decidim/decidim/pull/2481).
+- **decidim-core**: Users have notifications enabled by default unless they explicitly uncheck it during registration. [\#2517](https://github.com/decidim/decidim/pull/2517)
 - **decidim-core**: translated_attribute helper changes its default behaviour. Previously it was following these steps:
   1. Return the current user locale translation if available.
   2. Fallback to organization default locale in case the user locale translation is not available.

--- a/decidim-core/app/commands/decidim/create_omniauth_registration.rb
+++ b/decidim-core/app/commands/decidim/create_omniauth_registration.rb
@@ -51,6 +51,8 @@ module Decidim
         @user.email = (verified_email || form.email)
         @user.name = form.name
         @user.nickname = form.normalized_nickname
+        @user.newsletter_notifications = true
+        @user.email_on_notification = true
         @user.password = generated_password
         @user.password_confirmation = generated_password
         @user.skip_confirmation! if verified_email

--- a/decidim-core/app/commands/decidim/create_registration.rb
+++ b/decidim-core/app/commands/decidim/create_registration.rb
@@ -40,7 +40,8 @@ module Decidim
                            password_confirmation: form.password_confirmation,
                            organization: form.current_organization,
                            tos_agreement: form.tos_agreement,
-                           newsletter_notifications: form.newsletter_notifications)
+                           newsletter_notifications: form.notifications,
+                           email_on_notification: form.notifications)
     end
 
     def create_user_group

--- a/decidim-core/app/forms/decidim/registration_form.rb
+++ b/decidim-core/app/forms/decidim/registration_form.rb
@@ -11,7 +11,7 @@ module Decidim
     attribute :email, String
     attribute :password, String
     attribute :password_confirmation, String
-    attribute :newsletter_notifications, Boolean
+    attribute :notifications, Boolean
     attribute :tos_agreement, Boolean
 
     attribute :user_group_name, String

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -71,7 +71,7 @@
 
             <fieldset>
               <div class="field">
-                <%= f.check_box :newsletter_notifications, label: t(".newsletter_notifications") %>
+                <%= f.check_box :notifications, label: t(".notifications"), checked: true %>
               </div>
 
               <div class="field">

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -96,7 +96,7 @@ en:
       registrations:
         new:
           already_have_an_account?: Already have an account?
-          newsletter_notifications: Receive information about relevant activity
+          notifications: Receive information about relevant activity
           nickname_help: Your unique identifier in decidim.
           sign_in: Log in
           sign_up: Sign up
@@ -225,7 +225,7 @@ en:
     notifications_settings:
       show:
         email_on_notification: I want to receive an email every time I receive a notification.
-        newsletter_notifications: I want to receive information about relevant activity
+        newsletter_notifications: I want to receive newsletters
         update_notifications_settings: Save changes
       update:
         error: There's been an error updating your notifications settings.

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -96,8 +96,8 @@ en:
       registrations:
         new:
           already_have_an_account?: Already have an account?
-          notifications: Receive information about relevant activity
           nickname_help: Your unique identifier in decidim.
+          notifications: Receive information about relevant activity
           sign_in: Log in
           sign_up: Sign up
           sign_up_as:

--- a/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
@@ -74,6 +74,8 @@ module Decidim
             expect(user.encrypted_password).not_to be_nil
             expect(user.email).to eq(form.email)
             expect(user.organization).to eq(organization)
+            expect(user.newsletter_notifications).to eq(true)
+            expect(user.email_on_notification).to eq(true)
             expect(user).to be_confirmed
             expect(user.valid_password?("abcde1234")).to eq(true)
           end

--- a/decidim-core/spec/commands/decidim/create_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_registration_spec.rb
@@ -15,7 +15,7 @@ module Decidim
         let(:password) { "password1234" }
         let(:password_confirmation) { password }
         let(:tos_agreement) { "1" }
-        let(:newsletter_notifications) { "1" }
+        let(:notifications) { "1" }
 
         let(:user_group_name) { "My organization" }
         let(:user_group_document_number) { "123456789Z" }
@@ -31,7 +31,7 @@ module Decidim
               "password" => password,
               "password_confirmation" => password_confirmation,
               "tos_agreement" => tos_agreement,
-              "newsletter_notifications" => newsletter_notifications,
+              "notifications" => newsletter_notifications,
               "user_group_name" => user_group_name,
               "user_group_document_number" => user_group_document_number,
               "user_group_phone" => user_group_phone
@@ -76,7 +76,8 @@ module Decidim
               password: form.password,
               password_confirmation: form.password_confirmation,
               tos_agreement: form.tos_agreement,
-              newsletter_notifications: form.newsletter_notifications,
+              newsletter_notifications: form.notifications,
+              email_on_notification: form.notifications,
               organization: organization
             ).and_call_original
 

--- a/decidim-core/spec/commands/decidim/create_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_registration_spec.rb
@@ -31,7 +31,7 @@ module Decidim
               "password" => password,
               "password_confirmation" => password_confirmation,
               "tos_agreement" => tos_agreement,
-              "notifications" => newsletter_notifications,
+              "notifications" => notifications,
               "user_group_name" => user_group_name,
               "user_group_document_number" => user_group_document_number,
               "user_group_phone" => user_group_phone

--- a/decidim-core/spec/controllers/registrations_controller_spec.rb
+++ b/decidim-core/spec/controllers/registrations_controller_spec.rb
@@ -25,7 +25,7 @@ module Decidim
             password: "password1234",
             password_confirmation: "password1234",
             tos_agreement: "1",
-            newsletter_notifications: "1"
+            notifications: "1"
           }
         }
       end


### PR DESCRIPTION
#### :tophat: What? Why?
This enables notifications on users by default, unless they uncheck the checkbox on registration.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/5Dxi2HnFkF0wE/giphy.gif)