### PR TITLE
Fix nicknamize

### DIFF
--- a/decidim-core/lib/decidim/nicknamizable.rb
+++ b/decidim-core/lib/decidim/nicknamizable.rb
@@ -16,7 +16,7 @@ module Decidim
       # Allowed range for nickname length
       #
       def nickname_length_range
-        (0..nickname_max_length)
+        (0..(nickname_max_length - 1))
       end
 
       #
@@ -52,7 +52,7 @@ module Decidim
       def numbered_variation_of(name, number)
         appendix = "_#{number}"
 
-        "#{name[0..(nickname_max_length - appendix.length)]}#{appendix}"
+        "#{name[0..(nickname_max_length - 1 - appendix.length)]}#{appendix}"
       end
     end
   end

--- a/decidim-core/lib/decidim/nicknamizable.rb
+++ b/decidim-core/lib/decidim/nicknamizable.rb
@@ -8,17 +8,10 @@ module Decidim
     extend ActiveSupport::Concern
 
     included do
-      validates :nickname, length: { in: nickname_length_range }, allow_blank: true
+      validates :nickname, length: { maximum: nickname_max_length }, allow_blank: true
     end
 
     class_methods do
-      #
-      # Allowed range for nickname length
-      #
-      def nickname_length_range
-        (0..(nickname_max_length - 1))
-      end
-
       #
       # Maximum allowed nickname length
       #
@@ -39,6 +32,10 @@ module Decidim
 
       private
 
+      def nickname_length_range
+        (0...nickname_max_length)
+      end
+
       def disambiguate(name)
         candidate = name
 
@@ -52,7 +49,7 @@ module Decidim
       def numbered_variation_of(name, number)
         appendix = "_#{number}"
 
-        "#{name[0..(nickname_max_length - 1 - appendix.length)]}#{appendix}"
+        "#{name[0...(nickname_max_length - appendix.length)]}#{appendix}"
       end
     end
   end

--- a/decidim-core/spec/lib/nicknamizable_spec.rb
+++ b/decidim-core/spec/lib/nicknamizable_spec.rb
@@ -28,7 +28,7 @@ module Decidim
 
       it "trims very long usernames" do
         nickname = subject.nicknamize("Felipe Juan Froilan de todos los Santos")
-        expect(nickname).to eq("felipe_juan_froilan_d")
+        expect(nickname).to eq("felipe_juan_froilan_")
         expect(nickname.length).to eq(20)
       end
 

--- a/decidim-core/spec/lib/nicknamizable_spec.rb
+++ b/decidim-core/spec/lib/nicknamizable_spec.rb
@@ -27,8 +27,9 @@ module Decidim
       end
 
       it "trims very long usernames" do
-        expect(subject.nicknamize("Felipe Juan Froilan de todos los Santos"))
-          .to eq("felipe_juan_froilan_d")
+        nickname = subject.nicknamize("Felipe Juan Froilan de todos los Santos")
+        expect(nickname).to eq("felipe_juan_froilan_d")
+        expect(nickname.length).to eq(20)
       end
 
       it "resolves conflicts with current nicknames" do
@@ -40,7 +41,7 @@ module Decidim
       it "resolves conflicts with long current nicknames" do
         create(:user, nickname: "felipe_rocks_so_much")
 
-        expect(subject.nicknamize("Felipe Rocks So Much")).to eq("felipe_rocks_so_muc_2")
+        expect(subject.nicknamize("Felipe Rocks So Much")).to eq("felipe_rocks_so_mu_2")
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
This fixes nicknamize generating nicknames of the wrong max size (as a range from 0..20 is actually 21 characters long :trollface: ).

#### :pushpin: Related Issues
- Related to #2360

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/t6f2bNAjx7Bio/giphy.gif)
