### PR TITLE
Use current_participatory_space instead of current_assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ you need to change the following line in `config/environments/production.rb`:
 
 **Fixed**:
 
+- **decidim-core**: Fix editing features in assemblies. [\#2524](https://github.com/decidim/decidim/pull/2524)
 - **decidim-admin**: Properly save features weight on creation [\#2499](https://github.com/decidim/decidim/pull/2499)
 - **decidim-core**: Fix after login redirect. [\#2321](https://github.com/decidim/decidim/pull/2321) [\#2504](https://github.com/decidim/decidim/pull/2504)
   With links or buttons that needs the user to be authorized or signed in you can now add a `data-redirect-url` attribute to redirect the user after they've signed in so they don't lose context.

--- a/decidim-assemblies/app/views/layouts/decidim/admin/assembly.html.erb
+++ b/decidim-assemblies/app/views/layouts/decidim/admin/assembly.html.erb
@@ -1,18 +1,18 @@
 <% content_for :secondary_nav do %>
   <div class="secondary-nav secondary-nav--subnav">
     <ul>
-      <% if can? :update, current_assembly %>
-        <li <% if is_active_link?(decidim_admin_assemblies.edit_assembly_path(current_assembly)) %> class="is-active" <% end %>>
-          <%= aria_selected_link_to t("info", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.edit_assembly_path(current_assembly) %>
+      <% if can? :update, current_participatory_space %>
+        <li <% if is_active_link?(decidim_admin_assemblies.edit_assembly_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("info", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.edit_assembly_path(current_participatory_space) %>
         </li>
       <% end %>
       <% if can? :read, Decidim::Feature %>
-        <li <% if is_active_link?(decidim_admin_assemblies.features_path(current_assembly)) %> class="is-active" <% end %>>
-          <%= aria_selected_link_to t("features", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.features_path(current_assembly) %>
+        <li <% if is_active_link?(decidim_admin_assemblies.features_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("features", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.features_path(current_participatory_space) %>
           <ul>
-            <% current_assembly.features.each do |feature| %>
+            <% current_participatory_space.features.each do |feature| %>
               <% if feature.manifest.admin_engine %>
-                <li <% if is_active_link?(manage_feature_path(feature)) || is_active_link?(decidim_admin_assemblies.edit_feature_path(current_assembly, feature)) || is_active_link?(decidim_admin_assemblies.edit_feature_permissions_path(current_assembly, feature)) %> class="is-active" <% end %>>
+                <li <% if is_active_link?(manage_feature_path(feature)) || is_active_link?(decidim_admin_assemblies.edit_feature_path(current_participatory_space, feature)) || is_active_link?(decidim_admin_assemblies.edit_feature_permissions_path(current_participatory_space, feature)) %> class="is-active" <% end %>>
                   <%= link_to manage_feature_path(feature) do %>
                     <%= translated_attribute feature.name %>
                     <% if feature.primary_stat.present? %>
@@ -26,23 +26,23 @@
         </li>
       <% end %>
       <% if can? :read, Decidim::Category %>
-        <li <% if is_active_link?(decidim_admin_assemblies.categories_path(current_assembly)) %> class="is-active" <% end %>>
-          <%= aria_selected_link_to t("categories", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.categories_path(current_assembly) %>
+        <li <% if is_active_link?(decidim_admin_assemblies.categories_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("categories", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.categories_path(current_participatory_space) %>
         </li>
       <% end %>
       <% if can? :read, Decidim::Attachment %>
-        <li <% if is_active_link?(decidim_admin_assemblies.assembly_attachments_path(current_assembly)) %> class="is-active" <% end %>>
-          <%= aria_selected_link_to t("attachments", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.assembly_attachments_path(current_assembly) %>
+        <li <% if is_active_link?(decidim_admin_assemblies.assembly_attachments_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("attachments", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.assembly_attachments_path(current_participatory_space) %>
         </li>
       <% end %>
       <% if can? :read, Decidim::AssemblyUserRole %>
-        <li <% if is_active_link?(decidim_admin_assemblies.assembly_user_roles_path(current_assembly)) %> class="is-active" <% end %>>
-          <%= aria_selected_link_to t("assembly_admins", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.assembly_user_roles_path(current_assembly) %>
+        <li <% if is_active_link?(decidim_admin_assemblies.assembly_user_roles_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("assembly_admins", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.assembly_user_roles_path(current_participatory_space) %>
         </li>
       <% end %>
       <% if can? :read, Decidim::Moderation %>
-        <li <% if is_active_link?(decidim_admin_assemblies.moderations_path(current_assembly)) %> class="is-active" <% end %>>
-          <%= aria_selected_link_to t("moderations", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.moderations_path(current_assembly) %>
+        <li <% if is_active_link?(decidim_admin_assemblies.moderations_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("moderations", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.moderations_path(current_participatory_space) %>
         </li>
       <% end %>
     </ul>
@@ -52,7 +52,7 @@
 <%= render "layouts/decidim/admin/application" do %>
   <div class="process-title">
     <div class="process-title-content">
-      <%= translated_attribute(current_assembly.title) %>
+      <%= translated_attribute(current_participatory_space.title) %>
     </div>
   </div>
   <%= yield %>


### PR DESCRIPTION
#### :tophat: What? Why?

The layout was using `current_assembly` but the method isn't available, so admins couldn't edit and use features in assemblies.

The problem is that all feature are tested against participatory processes, we should find a way to test it against processes, assemblies or initiatives, or have a dummy participatory space.