### PR TITLE
Don't store current location on locales controller.

### DIFF
--- a/decidim-core/app/controllers/decidim/locales_controller.rb
+++ b/decidim-core/app/controllers/decidim/locales_controller.rb
@@ -3,6 +3,7 @@
 module Decidim
   # A controller to allow users switching their locale.
   class LocalesController < Decidim::ApplicationController
+    skip_before_action :store_current_location
     authorize_resource :locales, class: false
 
     def create


### PR DESCRIPTION
#### :tophat: What? Why?
While browsing my development app, I've been redirected to locale page after login. So, I've added the `skip_before_action` in that controller to avoid this to happen again.

#### :pushpin: Related Issues
- Related to #2468

#### :clipboard: Subtasks

### :camera: Screenshots (optional)

#### :ghost: GIF
![giphy](https://user-images.githubusercontent.com/453545/35165455-a2b36a28-fd4e-11e7-9940-ba53bfeb8f0b.gif)

