### PR TITLE
Allow users to change their nickname

### DIFF
--- a/decidim-core/app/commands/decidim/update_account.rb
+++ b/decidim-core/app/commands/decidim/update_account.rb
@@ -35,6 +35,7 @@ module Decidim
 
     def update_personal_data
       @user.name = @form.name
+      @user.nickname = @form.nickname
       @user.email = @form.email
       @user.personal_url = @form.personal_url
       @user.about = @form.about

--- a/decidim-core/app/views/decidim/account/show.html.erb
+++ b/decidim-core/app/views/decidim/account/show.html.erb
@@ -6,6 +6,7 @@
 
     <div class="columns large-8 end">
       <%= f.text_field :name %>
+      <%= f.text_field :nickname %>
       <%= f.email_field :email %>
       <%= f.url_field :personal_url %>
       <%= f.text_area :about, rows: 5 %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -9,6 +9,7 @@ en:
       user:
         email: Your email
         name: Your name
+        nickname: Your short, unique identifier in decidim
         password: New password
         password_confirmation: Confirm your new password
         remove_avatar: Remove avatar
@@ -89,14 +90,14 @@ en:
           email_already_exists: Another account is using the same email address
         new:
           complete_profile: Complete profile
-          nickname_help: Your unique identifier in decidim.
+          nickname_help: Your short, unique identifier in decidim
           sign_up: Please complete your profile
           subtitle: Please fill in the following form in order to complete the sign up
           username_help: Public name that appears on your posts. With the aim of guaranteeing the anonymity, can be any name.
       registrations:
         new:
           already_have_an_account?: Already have an account?
-          nickname_help: Your unique identifier in decidim.
+          nickname_help: Your short, unique identifier in decidim
           notifications: Receive information about relevant activity
           sign_in: Log in
           sign_up: Sign up

--- a/decidim-core/spec/commands/decidim/update_account_spec.rb
+++ b/decidim-core/spec/commands/decidim/update_account_spec.rb
@@ -55,7 +55,7 @@ module Decidim
       end
 
       it "updates the users's nickname" do
-        form.name = "pepito"
+        form.nickname = "pepito"
         expect { command.call }.to broadcast(:ok)
         expect(user.reload.nickname).to eq("pepito")
       end

--- a/decidim-core/spec/commands/decidim/update_account_spec.rb
+++ b/decidim-core/spec/commands/decidim/update_account_spec.rb
@@ -9,6 +9,7 @@ module Decidim
     let(:data) do
       {
         name: user.name,
+        nickname: user.nickname,
         email: user.email,
         password: nil,
         password_confirmation: nil,
@@ -22,6 +23,7 @@ module Decidim
     let(:form) do
       AccountForm.from_params(
         name: data[:name],
+        nickname: data[:nickname],
         email: data[:email],
         password: data[:password],
         password_confirmation: data[:password_confirmation],
@@ -50,6 +52,12 @@ module Decidim
         form.name = "Pepito de los palotes"
         expect { command.call }.to broadcast(:ok)
         expect(user.reload.name).to eq("Pepito de los palotes")
+      end
+
+      it "updates the users's nickname" do
+        form.name = "pepito"
+        expect { command.call }.to broadcast(:ok)
+        expect(user.reload.nickname).to eq("pepito")
       end
 
       it "updates the personal url" do

--- a/decidim-core/spec/forms/account_form_spec.rb
+++ b/decidim-core/spec/forms/account_form_spec.rb
@@ -8,6 +8,7 @@ module Decidim
       described_class.new(
         name: name,
         email: email,
+        nickname: nickname,
         password: password,
         password_confirmation: password_confirmation,
         avatar: avatar,
@@ -25,6 +26,7 @@ module Decidim
 
     let(:name) { "Lord of the Foo" }
     let(:email) { "depths@ofthe.bar" }
+    let(:nickname) { "foo_bar" }
     let(:password) { "abcde123" }
     let(:password_confirmation) { password }
     let(:avatar) { File.open("spec/assets/avatar.jpg") }
@@ -65,6 +67,32 @@ module Decidim
 
       context "when it's already in use in another organization" do
         let!(:existing_user) { create(:user, email: email) }
+
+        it "is valid" do
+          expect(subject).to be_valid
+        end
+      end
+    end
+
+    describe "nickname" do
+      context "with an empty nickname" do
+        let(:nickname) { "" }
+
+        it "is invalid" do
+          expect(subject).not_to be_valid
+        end
+      end
+
+      context "when it's already in use in the same organization" do
+        let!(:existing_user) { create(:user, nickname: nickname, organization: organization) }
+
+        it "is invalid" do
+          expect(subject).not_to be_valid
+        end
+      end
+
+      context "when it's already in use in another organization" do
+        let!(:existing_user) { create(:user, nickname: nickname) }
 
         it "is valid" do
           expect(subject).to be_valid


### PR DESCRIPTION
#### :tophat: What? Why?
Users can now change their (unique) nicknames. Changelog not needed as it fixes a currently unreleased feature (https://github.com/decidim/decidim/pull/2360).

#### :pushpin: Related Issues
- Fixes #2523

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/111746/35210929-7210ca34-ff54-11e7-9b5d-0731adb9071f.png)
