### PR TITLE
Notify process followers when activating a step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ you need to change the following line in `config/environments/production.rb`:
 ```
 
 **Added**:
+- **decidim-admin**: Notify participatory process followers when a step becomes active. [\#2544](https://github.com/decidim/decidim/pull/2544)
 - **decidim-admin**: Notify participatory space followers when a new feature is published. [\#2515](https://github.com/decidim/decidim/pull/2515)
 - **decidim**: Add `decidim-assemblies` to the `decidim` metagem. [\#2495](https://github.com/decidim/decidim/pull/2510)
 - **decidim-proposals**: Notify proposal followers when it gets answered. [\#2508](https://github.com/decidim/decidim/pull/2508)
@@ -53,7 +54,7 @@ you need to change the following line in `config/environments/production.rb`:
   1. Return the current user locale translation if available.
   2. Fallback to organization default locale in case the user locale translation is not available.
   3. Otherwise return blank.
-- **decidim-core**: Forced order in covnersations (newest on top) and conversation messages (oldest on top). [\#2520](https://github.com/decidim/decidim/pull/2520)
+- **decidim-core**: Forced order in conversations (newest on top) and conversation messages (oldest on top). [\#2520](https://github.com/decidim/decidim/pull/2520)
 
 
   Now it follows these steps:

--- a/decidim-admin/app/controllers/decidim/admin/features_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/features_controller.rb
@@ -91,7 +91,7 @@ module Decidim
 
         @feature.publish!
 
-        if current_participatory_space.is_a?(Decidim::Followable)
+        if current_participatory_space.published? && current_participatory_space.is_a?(Decidim::Followable)
           Decidim::EventsManager.publish(
             event: "decidim.events.features.feature_published",
             event_class: Decidim::FeaturePublishedEvent,

--- a/decidim-admin/app/events/decidim/participatory_process_step_activated_event.rb
+++ b/decidim-admin/app/events/decidim/participatory_process_step_activated_event.rb
@@ -1,0 +1,55 @@
+# frozen-string_literal: true
+
+module Decidim
+  class ParticipatoryProcessStepActivatedEvent < Decidim::Events::BaseEvent
+    include Decidim::Events::EmailEvent
+    include Decidim::Events::NotificationEvent
+    include Rails.application.routes.mounted_helpers
+
+    def email_subject
+      I18n.t(
+        "decidim.events.participatory_process_step_activated_event.email_subject",
+        resource_title: resource_title,
+        resource_path: resource_path,
+        participatory_space_title: participatory_space_title
+      )
+    end
+
+    def email_intro
+      I18n.t(
+        "decidim.events.participatory_process_step_activated_event.email_intro",
+        resource_title: resource_title,
+        resource_path: resource_path,
+        participatory_space_title: participatory_space_title
+      )
+    end
+
+    def email_outro
+      I18n.t(
+        "decidim.events.participatory_process_step_activated_event.email_outro",
+        resource_title: resource_title,
+        resource_path: resource_path,
+        participatory_space_title: participatory_space_title
+      )
+    end
+
+    def notification_title
+      I18n.t(
+        "decidim.events.participatory_process_step_activated_event.notification_title",
+        resource_title: resource_title,
+        resource_path: resource_path,
+        participatory_space_title: participatory_space_title
+      ).html_safe
+    end
+
+    private
+
+    def resource_path
+      @resource_path ||= decidim_participatory_processes.participatory_process_participatory_process_steps_path(resource.participatory_process)
+    end
+
+    def participatory_space_title
+      resource.participatory_process.title[I18n.locale.to_s]
+    end
+  end
+end

--- a/decidim-admin/spec/events/decidim/participatory_process_step_activated_event_spec.rb
+++ b/decidim-admin/spec/events/decidim/participatory_process_step_activated_event_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::ParticipatoryProcessStepActivatedEvent do
+  include Rails.application.routes.mounted_helpers
+  subject do
+    described_class.new(resource: process_step, event_name: event_name, user: follower, extra: {})
+  end
+
+  let(:organization) { follower.organization }
+  let(:follower) { create :user }
+  let(:event_name) { "decidim.events.participatory_process_step_activated_event" }
+  let(:participatory_process) { process_step.participatory_process }
+  let(:resource_path) do
+    decidim_participatory_processes.participatory_process_participatory_process_steps_path(participatory_process)
+  end
+  let(:process_step) { create :participatory_process_step }
+
+  describe "types" do
+    subject { described_class }
+
+    it "supports notifications" do
+      expect(subject.types).to include :notification
+    end
+
+    it "supports emails" do
+      expect(subject.types).to include :email
+    end
+  end
+
+  describe "email_subject" do
+    it "is generated correctly" do
+      expect(subject.email_subject).to eq("An update to #{participatory_process.title["en"]}")
+    end
+  end
+
+  describe "email_intro" do
+    it "is generated correctly" do
+      expect(subject.email_intro)
+        .to eq("The #{process_step.title["en"]} step is now active for #{participatory_process.title["en"]}. You can see it from this page:")
+    end
+  end
+
+  describe "email_outro" do
+    it "is generated correctly" do
+      expect(subject.email_outro)
+        .to include("You have received this notification because you are following #{participatory_process.title["en"]}")
+    end
+  end
+
+  describe "notification_title" do
+    it "is generated correctly" do
+      expect(subject.notification_title)
+        .to eq("The #{process_step.title["en"]} step is now active for <a href=\"#{resource_path}\">#{participatory_process.title["en"]}</a>")
+    end
+  end
+end

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -137,6 +137,11 @@ en:
         notification_title: The %{resource_title} component is now active for <a href="%{resource_path}">%{participatory_space_title}</a>
       notification_event:
         notification_title: An event occured to <a href="%{resource_path}">%{resource_title}</a>.
+      participatory_process_step_activated_event:
+        email_intro: 'The %{resource_title} step is now active for %{participatory_space_title}. You can see it from this page:'
+        email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+        email_subject: An update to %{participatory_space_title}
+        notification_title: The %{resource_title} step is now active for <a href="%{resource_path}">%{participatory_space_title}</a>
       profile_updated_event:
         email_intro: The <a href="%{profile_path}">profile page</a> of %{name} (%{nickname}), who you are following, has been updated.
         email_outro: You have received this notification because you are following %{nickname}. You can stop receiving notifications following the previous link.

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/activate_participatory_process_step.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/activate_participatory_process_step.rb
@@ -25,7 +25,9 @@ module Decidim
           Decidim::ParticipatoryProcessStep.transaction do
             deactivate_active_steps
             activate_step
+            notify_followers
           end
+
           broadcast(:ok)
         end
 
@@ -41,6 +43,17 @@ module Decidim
 
         def activate_step
           step.update_attributes!(active: true)
+        end
+
+        def notify_followers
+          return unless step.participatory_process.published?
+
+          Decidim::EventsManager.publish(
+            event: "decidim.events.participatory_process.step_activated",
+            event_class: Decidim::ParticipatoryProcessStepActivatedEvent,
+            resource: step,
+            recipient_ids: step.participatory_process.followers.pluck(:id)
+          )
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

Adds a notification when a step becomes active for a participatory process.

#### :pushpin: Related Issues
- Related to #2446
