### PR TITLE
Search all results when `parent_id` is `nil`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,8 +88,10 @@ you need to change the following line in `config/environments/production.rb`:
 - **decidim-verifications**: Fixed a migration that broke feature permissions. If you already upgraded to `0.8.2` or less, please follow the instructions on the PR [\#2373](https://github.com/decidim/decidim/pull/2373)
 - **decidim-accountability**: Fix children results count [\#2483](https://github.com/decidim/decidim/pull/2483)
 - **decidim-accountability**: Keeps the current scope in the breadcumb links [\#2488](https://github.com/decidim/decidim/pull/2488)
+- **decidim-accountability**: Top level search searches on all results (not only the first level) [\#2545](https://github.com/decidim/decidim/pull/2545)
 
 **Removed**
+
 - **decidim**: Select2 JS library and scope selector based on Select2.
 - **dedicim-accountability**: Removed the Global scope navigation option ([\#2486](https://github.com/decidim/decidim/pull/2486))
 

--- a/decidim-accountability/app/services/decidim/accountability/result_search.rb
+++ b/decidim-accountability/app/services/decidim/accountability/result_search.rb
@@ -15,7 +15,12 @@ module Decidim
       #          * organization - A Decidim::Organization object.
       #          * parent_id - The parent ID of the result. The value is forced to false to force
       #                        the filter execution when the value is nil
+      #          * deep_search - Wether to perform the search on all children levels or just the
+      #                          first one.
       def initialize(options = {})
+        options = options.dup
+        options[:deep_search] = true if options[:deep_search].nil?
+        options[:parent_id] = "root" if options[:parent_id].nil?
         super(Result.all, options)
       end
 
@@ -28,15 +33,21 @@ module Decidim
 
       # Handle parent_id filter
       def search_parent_id
-        return query if options[:parent_id].blank?
-        query.where(parent_id: children_ids(options[:parent_id]))
+        parent_id = options[:parent_id]
+        parent_id = nil if parent_id == "root"
+
+        if options[:deep_search]
+          query.where(parent_id: [parent_id] + children_ids(parent_id))
+        else
+          query.where(parent_id: parent_id)
+        end
       end
 
       private
 
       def children_ids(parent_id)
-        [parent_id] + Result.where(parent_id: parent_id).pluck(:id).flat_map do |child_id|
-          children_ids(child_id)
+        Result.where(parent_id: parent_id).pluck(:id).flat_map do |child_id|
+          [child_id] + children_ids(child_id)
         end
       end
 

--- a/decidim-accountability/app/services/decidim/accountability/result_search.rb
+++ b/decidim-accountability/app/services/decidim/accountability/result_search.rb
@@ -16,8 +16,6 @@ module Decidim
       #          * parent_id - The parent ID of the result. The value is forced to false to force
       #                        the filter execution when the value is nil
       def initialize(options = {})
-        options[:parent_id] = false if options[:parent_id].nil?
-
         super(Result.all, options)
       end
 
@@ -30,10 +28,10 @@ module Decidim
 
       # Handle parent_id filter
       def search_parent_id
-        if options[:parent_id] == false
-          query.where(parent_id: nil)
-        else
+        if options[:parent_id].present?
           query.where(parent_id: options[:parent_id])
+        else
+          query
         end
       end
 

--- a/decidim-accountability/app/services/decidim/accountability/result_search.rb
+++ b/decidim-accountability/app/services/decidim/accountability/result_search.rb
@@ -28,14 +28,17 @@ module Decidim
 
       # Handle parent_id filter
       def search_parent_id
-        if options[:parent_id].present?
-          query.where(parent_id: options[:parent_id])
-        else
-          query
-        end
+        return query if options[:parent_id].blank?
+        query.where(parent_id: children_ids(options[:parent_id]))
       end
 
       private
+
+      def children_ids(parent_id)
+        [parent_id] + Result.where(parent_id: parent_id).pluck(:id).flat_map do |child_id|
+          children_ids(child_id)
+        end
+      end
 
       # Internal: builds the needed query to search for a text in the organization's
       # available locales. Note that it is intended to be used as follows:

--- a/decidim-accountability/app/services/decidim/accountability/result_search.rb
+++ b/decidim-accountability/app/services/decidim/accountability/result_search.rb
@@ -15,8 +15,8 @@ module Decidim
       #          * organization - A Decidim::Organization object.
       #          * parent_id - The parent ID of the result. The value is forced to false to force
       #                        the filter execution when the value is nil
-      #          * deep_search - Wether to perform the search on all children levels or just the
-      #                          first one.
+      #          * deep_search - Whether to perform the search on all children levels or just the
+      #                          first one. True by default.
       def initialize(options = {})
         options = options.dup
         options[:deep_search] = true if options[:deep_search].nil?

--- a/decidim-accountability/app/services/decidim/accountability/results_calculator.rb
+++ b/decidim-accountability/app/services/decidim/accountability/results_calculator.rb
@@ -22,7 +22,11 @@ module Decidim
       attr_reader :feature, :scope_id, :category_id
 
       def results
-        @results ||= ResultSearch.new(feature: feature, scope_id: scope_id, category_id: category_id).results
+        @results ||= ResultSearch.new(
+          feature: feature,
+          scope_id: scope_id,
+          category_id: category_id
+        ).where(parent_id: nil).results
       end
     end
   end

--- a/decidim-accountability/app/services/decidim/accountability/results_calculator.rb
+++ b/decidim-accountability/app/services/decidim/accountability/results_calculator.rb
@@ -25,8 +25,9 @@ module Decidim
         @results ||= ResultSearch.new(
           feature: feature,
           scope_id: scope_id,
-          category_id: category_id
-        ).where(parent_id: nil).results
+          category_id: category_id,
+          deep_search: false
+        ).results
       end
     end
   end

--- a/decidim-accountability/app/services/decidim/accountability/results_calculator.rb
+++ b/decidim-accountability/app/services/decidim/accountability/results_calculator.rb
@@ -22,7 +22,7 @@ module Decidim
       attr_reader :feature, :scope_id, :category_id
 
       def results
-        @results ||= ResultSearch.new(feature: feature, scope_id: scope_id, category_id: category_id, parent_id: nil).results
+        @results ||= ResultSearch.new(feature: feature, scope_id: scope_id, category_id: category_id).results
       end
     end
   end

--- a/decidim-accountability/spec/services/decidim/accountability/result_search_spec.rb
+++ b/decidim-accountability/spec/services/decidim/accountability/result_search_spec.rb
@@ -122,15 +122,15 @@ module Decidim::Accountability
         context "when the parent_id is nil" do
           let(:params) { default_params.merge(parent_id: nil) }
 
-          it "returns results all parent results" do
-            expect(subject.results).to match_array [result2, result1]
+          it "returns the search on all results" do
+            expect(subject.results).to match_array [result1, result2, result3]
           end
         end
 
         context "when the parent_id is result1" do
           let(:params) { default_params.merge(parent_id: result1.id) }
 
-          it "returns results the children" do
+          it "returns the search on the children of result``" do
             expect(subject.results).to match_array [result3]
           end
         end

--- a/decidim-accountability/spec/services/decidim/accountability/result_search_spec.rb
+++ b/decidim-accountability/spec/services/decidim/accountability/result_search_spec.rb
@@ -28,7 +28,7 @@ module Decidim::Accountability
         feature: current_feature,
         category: subcategory,
         scope: scope2,
-        parent: nil
+        parent: result1
       )
     end
     let!(:result3) do
@@ -37,7 +37,7 @@ module Decidim::Accountability
         feature: current_feature,
         category: parent_category,
         scope: scope3,
-        parent: result1
+        parent: result2
       )
     end
     let(:external_result) { create :result }
@@ -105,7 +105,7 @@ module Decidim::Accountability
           let(:params) { default_params.merge(category_id: parent_category.id) }
 
           it "returns results from this category and its children's" do
-            expect(subject.results).to match_array [result2, result1]
+            expect(subject.results).to match_array [result1, result2, result3]
           end
         end
 
@@ -131,7 +131,15 @@ module Decidim::Accountability
         context "when the parent_id is result1" do
           let(:params) { default_params.merge(parent_id: result1.id) }
 
-          it "returns the search on the children of result``" do
+          it "returns the search on the children of result" do
+            expect(subject.results).to match_array [result2, result3]
+          end
+        end
+
+        context "when the parent_id is result1" do
+          let(:params) { default_params.merge(parent_id: result2.id) }
+
+          it "returns the search on the children of result" do
             expect(subject.results).to match_array [result3]
           end
         end

--- a/decidim-accountability/spec/services/decidim/accountability/result_search_spec.rb
+++ b/decidim-accountability/spec/services/decidim/accountability/result_search_spec.rb
@@ -9,6 +9,7 @@ module Decidim::Accountability
     let(:current_feature) { create :accountability_feature }
     let(:scope1) { create :scope, organization: current_feature.organization }
     let(:scope2) { create :scope, organization: current_feature.organization }
+    let(:scope3) { create :scope, organization: current_feature.organization }
     let(:participatory_space) { current_feature.participatory_space }
     let(:parent_category) { create :category, participatory_space: participatory_space }
     let(:subcategory) { create :subcategory, parent: parent_category }
@@ -35,7 +36,7 @@ module Decidim::Accountability
         :result,
         feature: current_feature,
         category: parent_category,
-        scope: scope1,
+        scope: scope3,
         parent: result1
       )
     end


### PR DESCRIPTION
#### :tophat: What? Why?
This fixes the search so a search applied within a branch is done on all sub-branches of the results tree.

#### :pushpin: Related Issues
- Fixes #2531

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*
