### PR TITLE
Attachment notifications

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/create_attachment.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_attachment.rb
@@ -27,6 +27,7 @@ module Decidim
 
         if @attachment.valid?
           @attachment.save!
+          notify_followers
           broadcast(:ok)
         else
           if @attachment.errors.has_key? :file
@@ -46,6 +47,17 @@ module Decidim
           description: form.description,
           file: form.file,
           attached_to: @attached_to
+        )
+      end
+
+      def notify_followers
+        return unless @attachment.attached_to.is_a?(Decidim::Followable)
+
+        Decidim::EventsManager.publish(
+          event: "decidim.events.attachments.attachment_created",
+          event_class: Decidim::AttachmentCreatedEvent,
+          resource: @attachment,
+          recipient_ids: @attachment.attached_to.followers.pluck(:id)
         )
       end
     end

--- a/decidim-admin/app/controllers/decidim/admin/features_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/features_controller.rb
@@ -91,14 +91,12 @@ module Decidim
 
         @feature.publish!
 
-        if current_participatory_space.published? && current_participatory_space.is_a?(Decidim::Followable)
-          Decidim::EventsManager.publish(
-            event: "decidim.events.features.feature_published",
-            event_class: Decidim::FeaturePublishedEvent,
-            resource: @feature,
-            recipient_ids: current_participatory_space.followers.pluck(:id)
-          )
-        end
+        Decidim::EventsManager.publish(
+          event: "decidim.events.features.feature_published",
+          event_class: Decidim::FeaturePublishedEvent,
+          resource: @feature,
+          recipient_ids: current_participatory_space.followers.pluck(:id)
+        )
 
         flash[:notice] = I18n.t("features.publish.success", scope: "decidim.admin")
         redirect_to action: :index

--- a/decidim-admin/app/events/decidim/attachment_created_event.rb
+++ b/decidim-admin/app/events/decidim/attachment_created_event.rb
@@ -1,0 +1,59 @@
+# frozen-string_literal: true
+
+module Decidim
+  class AttachmentCreatedEvent < Decidim::Events::BaseEvent
+    include Decidim::Events::EmailEvent
+    include Decidim::Events::NotificationEvent
+
+    def email_subject
+      I18n.t(
+        "decidim.events.attachments.attachment_created.email_subject",
+        resource_title: resource_title,
+        resource_path: resource_path
+      )
+    end
+
+    def email_intro
+      I18n.t(
+        "decidim.events.attachments.attachment_created.email_intro",
+        resource_title: resource_title,
+        resource_path: resource_path
+      )
+    end
+
+    def email_outro
+      I18n.t(
+        "decidim.events.attachments.attachment_created.email_outro",
+        resource_title: resource_title,
+        resource_path: resource_path
+      )
+    end
+
+    def notification_title
+      I18n.t(
+        "decidim.events.attachments.attachment_created.notification_title",
+        resource_title: resource_title,
+        resource_path: resource_path,
+        attached_to_url: attached_to_url
+      ).html_safe
+    end
+
+    def resource_path
+      @resource.url
+    end
+
+    def resource_url
+      @resource.url
+    end
+
+    private
+
+    def attached_to_url
+      resource_locator.url
+    end
+
+    def resource
+      @resource.attached_to
+    end
+  end
+end

--- a/decidim-admin/app/events/decidim/participatory_process_step_activated_event.rb
+++ b/decidim-admin/app/events/decidim/participatory_process_step_activated_event.rb
@@ -44,12 +44,16 @@ module Decidim
 
     private
 
+    def participatory_space
+      resource.participatory_process
+    end
+
     def resource_path
-      @resource_path ||= decidim_participatory_processes.participatory_process_participatory_process_steps_path(resource.participatory_process)
+      @resource_path ||= decidim_participatory_processes.participatory_process_participatory_process_steps_path(participatory_space)
     end
 
     def participatory_space_title
-      resource.participatory_process.title[I18n.locale.to_s]
+      participatory_space.title[I18n.locale.to_s]
     end
   end
 end

--- a/decidim-admin/spec/commands/create_attachment_spec.rb
+++ b/decidim-admin/spec/commands/create_attachment_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Admin
+  describe CreateAttachment, processing_uploads_for: Decidim::AttachmentUploader do
+    subject { described_class.call(form, attached_to) }
+
+    let(:form) do
+      instance_double(
+        AttachmentForm,
+        title: {
+          en: "An image",
+          ca: "Una imatge",
+          es: "Una imagen"
+        },
+        description: {
+          en: "A city",
+          ca: "Una ciutat",
+          es: "Una ciudad"
+        },
+        file: file
+      )
+    end
+    let(:file) do
+      Rack::Test::UploadedFile.new(
+        Decidim::Dev.test_file("city.jpeg", "image/jpeg"),
+        "image/jpg"
+      )
+    end
+    let(:attached_to) { create(:participatory_process) }
+
+    describe "when valid" do
+      before do
+        allow(form).to receive(:invalid?).and_return(false)
+      end
+
+      it "broadcasts :ok and creates the feature" do
+        expect do
+          subject
+        end.to broadcast(:ok)
+
+        expect(Decidim::Attachment.count).to eq(1)
+      end
+
+      it "notifies the followers" do
+        follower = create(:user, organization: attached_to.organization)
+        create(:follow, followable: attached_to, user: follower)
+
+        expect(Decidim::EventsManager)
+          .to receive(:publish)
+          .with(
+            event: "decidim.events.attachments.attachment_created",
+            event_class: Decidim::AttachmentCreatedEvent,
+            resource: kind_of(Decidim::Attachment),
+            recipient_ids: [follower.id]
+          )
+
+        subject
+      end
+    end
+
+    describe "when invalid" do
+      before do
+        allow(form).to receive(:invalid?).and_return(true)
+      end
+
+      it "broadcasts invalid" do
+        expect do
+          subject
+        end.to broadcast(:invalid)
+
+        expect(Decidim::Attachment.count).to eq(0)
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/events/decidim/attachment_created_event_spec.rb
+++ b/decidim-admin/spec/events/decidim/attachment_created_event_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::AttachmentCreatedEvent do
+  subject do
+    described_class.new(resource: attachment, event_name: event_name, user: follower, extra: {})
+  end
+
+  let(:follower) { create :user }
+  let(:event_name) { "decidim.events.attachment_created_event" }
+  let(:attachment) { create(:attachment) }
+  let(:attached_to_url) { Decidim::ResourceLocatorPresenter.new(attachment.attached_to).url }
+  let(:resource_title) { attachment.attached_to.title["en"] }
+  let(:resource_path) { attachment.url }
+
+  describe "types" do
+    subject { described_class }
+
+    it "supports notifications" do
+      expect(subject.types).to include :notification
+    end
+
+    it "supports emails" do
+      expect(subject.types).to include :email
+    end
+  end
+
+  describe "email_subject" do
+    it "is generated correctly" do
+      expect(subject.email_subject).to eq("An update to #{resource_title}")
+    end
+  end
+
+  describe "email_intro" do
+    it "is generated correctly" do
+      expect(subject.email_intro).to eq("A new document has been added to #{resource_title}. You can see it from this page:")
+    end
+  end
+
+  describe "email_outro" do
+    it "is generated correctly" do
+      expect(subject.email_outro)
+        .to include("You have received this notification because you are following #{resource_title}")
+    end
+  end
+
+  describe "notification_title" do
+    it "is generated correctly" do
+      expect(subject.notification_title)
+        .to eq("A <a href=\"#{resource_path}\">new document</a> has been added to <a href=\"#{attached_to_url}\">#{resource_title}</a>")
+    end
+  end
+end

--- a/decidim-core/app/services/decidim/notification_generator_for_recipient.rb
+++ b/decidim-core/app/services/decidim/notification_generator_for_recipient.rb
@@ -29,6 +29,7 @@ module Decidim
       return unless event_class
       return unless resource
       return unless recipient
+      return unless event.notifiable?
 
       Notification.create!(
         user: recipient,

--- a/decidim-core/app/services/decidim/notification_generator_for_recipient.rb
+++ b/decidim-core/app/services/decidim/notification_generator_for_recipient.rb
@@ -29,9 +29,15 @@ module Decidim
       return unless event_class
       return unless resource
       return unless recipient
-      return unless event.notifiable?
+      return unless notification.event_class_instance.notifiable?
 
-      Notification.create!(
+      notification.save!
+    end
+
+    private
+
+    def notification
+      @notification ||= Notification.new(
         user: recipient,
         event_class: event_class,
         resource: resource,
@@ -39,8 +45,6 @@ module Decidim
         extra: extra
       )
     end
-
-    private
 
     attr_reader :event, :event_class, :resource, :recipient_id, :extra
 

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -125,6 +125,12 @@ en:
         content_doesnt_exist: This address is incorrect or has been removed.
         title: The page you're looking for can't be found
     events:
+      attachments:
+        attachment_created:
+          email_intro: 'A new document has been added to %{resource_title}. You can see it from this page:'
+          email_outro: You have received this notification because you are following %{resource_title}. You can stop receiving notifications following the previous link.
+          email_subject: An update to %{resource_title}
+          notification_title: A <a href="%{resource_path}">new document</a> has been added to <a href="%{attached_to_url}">%{resource_title}</a>
       email_event:
         email_greeting: Hello %{user_name},
         email_intro: 'There has been an update to "%{resource_title}". You can see it from this page:'

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -184,6 +184,8 @@ FactoryBot.define do
     description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
     file { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
     attached_to { build(:participatory_process) }
+    content_type { "image/jpeg" }
+    file_size { 108_908 }
 
     trait :with_image do
       file { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
@@ -191,6 +193,8 @@ FactoryBot.define do
 
     trait :with_pdf do
       file { Decidim::Dev.test_file("Exampledocument.pdf", "application/pdf") }
+      content_type { "application/pdf" }
+      file_size { 17_525 }
     end
   end
 

--- a/decidim-core/lib/decidim/events/base_event.rb
+++ b/decidim-core/lib/decidim/events/base_event.rb
@@ -58,9 +58,31 @@ module Decidim
         @resource_url ||= resource_locator.url
       end
 
+      # Whether this event should be notified or not. Useful when you want the
+      # event to decide based on the params.
+      #
+      # It returns false when the resource or any element in the chain is a
+      # `Decidim::Publicable` and it isn't published.
+      def notifiable?
+        return false if resource.is_a?(Decidim::Publicable) && !resource.published?
+        return false if participatory_space.is_a?(Decidim::Publicable) && !participatory_space&.published?
+        return false unless feature&.published?
+
+        true
+      end
+
       private
 
       attr_reader :event_name, :resource, :user, :extra
+
+      def feature
+        return resource.feature if resource.is_a?(Decidim::HasFeature)
+        return resource if resource.is_a?(Decidim::Feature)
+      end
+
+      def participatory_space
+        return feature.participatory_space if feature
+      end
 
       def resource_title
         resource.title.is_a?(Hash) ? resource.title[I18n.locale.to_s] : resource.title

--- a/decidim-core/spec/lib/events/base_event_spec.rb
+++ b/decidim-core/spec/lib/events/base_event_spec.rb
@@ -11,5 +11,92 @@ module Decidim
         expect(subject.types).to eq []
       end
     end
+
+    describe "notifiable?" do
+      subject do
+        described_class.new(
+          resource: resource,
+          event_name: "some.event",
+          user: build(:user),
+          extra: {}
+        )
+      end
+
+      context "when the resource is publicable" do
+        let(:resource) { build(:dummy_resource) }
+
+        context "when it is published" do
+          before do
+            resource.published_at = Time.current
+          end
+
+          it { is_expected.to be_notifiable }
+        end
+
+        context "when it is not published" do
+          before do
+            resource.published_at = nil
+          end
+
+          it { is_expected.not_to be_notifiable }
+        end
+      end
+
+      context "when there's a feature" do
+        let(:resource) { build(:dummy_resource) }
+
+        context "when it is published" do
+          before do
+            resource.published_at = Time.current
+            resource.feature.published_at = Time.current
+          end
+
+          it { is_expected.to be_notifiable }
+        end
+
+        context "when it is not published" do
+          before do
+            resource.published_at = Time.current
+            resource.feature.published_at = nil
+          end
+
+          it { is_expected.not_to be_notifiable }
+        end
+      end
+
+      context "when there's a participatory space" do
+        let(:resource) { build(:dummy_resource) }
+
+        context "when it is published" do
+          before do
+            resource.published_at = Time.current
+            resource.feature.participatory_space.published_at = Time.current
+          end
+
+          it { is_expected.to be_notifiable }
+        end
+
+        context "when it is not published" do
+          before do
+            resource.published_at = Time.current
+            resource.feature.participatory_space.published_at = nil
+          end
+
+          it { is_expected.not_to be_notifiable }
+        end
+      end
+
+      context "when the resource is a feature" do
+        let(:resource) { build(:feature) }
+
+        it { is_expected.to be_notifiable }
+
+        context "when it is not published" do
+          let(:resource) { build(:feature, :unpublished) }
+
+          it { is_expected.not_to be_notifiable }
+        end
+      end
+    end
   end
 end

--- a/decidim-core/spec/services/decidim/notification_generator_for_recipient_spec.rb
+++ b/decidim-core/spec/services/decidim/notification_generator_for_recipient_spec.rb
@@ -6,7 +6,7 @@ describe Decidim::NotificationGeneratorForRecipient do
   subject { described_class.new(event, event_class, resource, recipient.id, extra) }
 
   let(:event) { "decidim.events.dummy.dummy_resource_updated" }
-  let(:resource) { create(:dummy_resource) }
+  let(:resource) { create(:dummy_resource, published_at: Time.current) }
   let(:follow) { create(:follow, followable: resource, user: recipient) }
   let(:recipient) { resource.author }
   let(:extra) { double }

--- a/decidim-core/spec/services/decidim/notification_generator_for_recipient_spec.rb
+++ b/decidim-core/spec/services/decidim/notification_generator_for_recipient_spec.rb
@@ -23,5 +23,20 @@ describe Decidim::NotificationGeneratorForRecipient do
       expect(notification.event_name).to eq event
       expect(notification.resource).to eq resource
     end
+
+    context "when the event is not notifiable" do
+      class NonNotifiableEvent < Decidim::Events::BaseEvent
+        def notifiable?
+          false
+        end
+      end
+      let(:event_class) { NonNotifiableEvent }
+
+      it "does not create the notification" do
+        expect do
+          subject.generate
+        end.not_to change(Decidim::Notification, :count)
+      end
+    end
   end
 end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
@@ -42,6 +42,7 @@ module Decidim
       include Decidim::Comments::Commentable
       include Followable
       include Traceable
+      include Publicable
 
       feature_manifest_name "dummy"
 
@@ -131,6 +132,7 @@ RSpec.configure do |config|
           t.text :address
           t.float :latitude
           t.float :longitude
+          t.datetime :published_at
 
           t.references :decidim_feature, index: true
           t.references :decidim_author, index: true

--- a/decidim-meetings/app/commands/decidim/meetings/admin/close_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/close_meeting.rb
@@ -41,6 +41,7 @@ module Decidim
             attending_organizations: form.attending_organizations,
             closed_at: form.closed_at
           )
+
           Decidim::EventsManager.publish(
             event: "decidim.events.meetings.meeting_closed",
             event_class: Decidim::Meetings::CloseMeetingEvent,

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/activate_participatory_process_step.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/activate_participatory_process_step.rb
@@ -46,8 +46,6 @@ module Decidim
         end
 
         def notify_followers
-          return unless step.participatory_process.published?
-
           Decidim::EventsManager.publish(
             event: "decidim.events.participatory_process.step_activated",
             event_class: Decidim::ParticipatoryProcessStepActivatedEvent,


### PR DESCRIPTION
#### :tophat: What? Why?

Sends a notification when an attachment is created from the admin panel.

#### :pushpin: Related Issues
- Related to #2446
