### PR TITLE
Allow participatory spaces to change they scope to any scope.

### DIFF
--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
@@ -72,7 +72,7 @@
     </div>
 
     <div class="row column">
-      <%= scopes_picker_field form, :scope_id %>
+      <%= scopes_picker_field form, :scope_id, root: nil %>
     </div>
 
     <div class="row column">

--- a/decidim-core/app/helpers/decidim/scopes_helper.rb
+++ b/decidim-core/app/helpers/decidim/scopes_helper.rb
@@ -33,9 +33,10 @@ module Decidim
     # name - attribute name
     #
     # Returns nothing.
-    def scopes_picker_field(form, name)
+    def scopes_picker_field(form, name, root: false)
+      root = try(:current_participatory_space)&.scope if root == false
       form.scopes_picker name do |scope|
-        { url: decidim.scopes_picker_path(root: try(:current_participatory_space)&.scope, current: scope&.id, field: form.label_for(name)),
+        { url: decidim.scopes_picker_path(root: root, current: scope&.id, field: form.label_for(name)),
           text: scope_name_for_picker(scope, I18n.t("decidim.scopes.global")) }
       end
     end

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
@@ -80,7 +80,7 @@
     </div>
 
     <div class="row column">
-      <%= scopes_picker_field form, :scope_id %>
+      <%= scopes_picker_field form, :scope_id, root: nil %>
     </div>
 
     <div class="row column">


### PR DESCRIPTION
#### :tophat: What? Why?
When editing a participatory space (process or assembly), scope picker only allows to select a descendant scope from current scope. 

This occurs because the `scopes_picker_field` helper uses the `current_participatory_space`'s scope as root.

These changes allow to override the root scope in the helper, and passes a `nil` root when editing a process or an assembly.

#### :pushpin: Related Issues

#### :clipboard: Subtasks

### :camera: Screenshots (optional)

#### :ghost: GIF
![u5epacx](https://user-images.githubusercontent.com/453545/35337738-43a6d408-011c-11e8-8a5b-eb97fd149f89.gif)