### PR TITLE
Only save reference on create and update

### DIFF
--- a/decidim-core/lib/decidim/has_reference.rb
+++ b/decidim-core/lib/decidim/has_reference.rb
@@ -9,7 +9,7 @@ module Decidim
     extend ActiveSupport::Concern
 
     included do
-      after_commit :store_reference
+      after_commit :store_reference, only: [:create, :update]
 
       validates :reference, presence: true, on: :update
 


### PR DESCRIPTION
#### :tophat: What? Why?
Only saves reference when the resource is created or updated, not when it's destroyed. This fixes a bug reported in #2527.

#### :pushpin: Related Issues
- Related to #2527
