### PR TITLE
Deterministic seeds

### DIFF
--- a/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
@@ -22,7 +22,7 @@ Decidim.register_participatory_space(:assemblies) do |participatory_space|
     organization = Decidim::Organization.first
     seeds_root = File.join(__dir__, "..", "..", "..", "db", "seeds")
 
-    2.times do
+    2.times do |n|
       assembly = Decidim::Assembly.create!(
         title: Decidim::Faker::Localized.sentence(5),
         slug: Faker::Internet.unique.slug(nil, "-"),
@@ -45,7 +45,7 @@ Decidim.register_participatory_space(:assemblies) do |participatory_space|
         target: Decidim::Faker::Localized.sentence(3),
         participatory_scope: Decidim::Faker::Localized.sentence(1),
         participatory_structure: Decidim::Faker::Localized.sentence(2),
-        scope: Faker::Boolean.boolean(0.5) ? nil : Decidim::Scope.reorder("RANDOM()").first
+        scope: n.positive? ? Decidim::Scope.reorder("RANDOM()").first : nil
       )
 
       Decidim::Attachment.create!(

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
@@ -35,7 +35,7 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
       )
     end
 
-    2.times do
+    2.times do |n|
       process = Decidim::ParticipatoryProcess.create!(
         title: Decidim::Faker::Localized.sentence(5),
         slug: Faker::Internet.unique.slug(nil, "-"),
@@ -61,7 +61,7 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
         start_date: Time.current,
         end_date: 2.months.from_now.at_midnight,
         participatory_process_group: process_groups.sample,
-        scope: Faker::Boolean.boolean(0.5) ? nil : Decidim::Scope.reorder("RANDOM()").first
+        scope: n.positive? ? nil : Decidim::Scope.reorder("RANDOM()").first
       )
 
       Decidim::ParticipatoryProcessStep.find_or_initialize_by(


### PR DESCRIPTION
#### :tophat: What? Why?

Sometimes we get weird coverage fluctuations in PRs, see [this codecov report](https://codecov.io/gh/decidim/decidim/pull/2554/src/decidim-proposals/lib/decidim/proposals/feature.rb) for an example. This is because seeds will sometimes randomly create no participatory spaces with scopes, and that means some lines of code will randomly not be covered.

This commit fixes that by making sure seeds always create participatory spaces with associated scopes.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.