### PR TITLE
Fix quilljs linebreaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ you need to change the following line in `config/environments/production.rb`:
 - **decidim-accountability**: Fix children results count [\#2483](https://github.com/decidim/decidim/pull/2483)
 - **decidim-accountability**: Keeps the current scope in the breadcumb links [\#2488](https://github.com/decidim/decidim/pull/2488)
 - **decidim-accountability**: Top level search searches on all results (not only the first level) [\#2545](https://github.com/decidim/decidim/pull/2545)
+- **decidim-admin**: Visual bug in quilljs editor misleading admins into introducing blank lines to separate paragraphs. [\#2565](https://github.com/decidim/decidim/pull/2565).
 
 **Removed**
 

--- a/decidim-core/app/assets/stylesheets/decidim/editor.sass
+++ b/decidim-core/app/assets/stylesheets/decidim/editor.sass
@@ -1,4 +1,0 @@
-@import "quill.snow"
-
-.editor-container
-  margin-bottom: 1.5rem

--- a/decidim-core/app/assets/stylesheets/decidim/editor.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/editor.scss
@@ -2,4 +2,10 @@
 
 .editor-container{
   margin-bottom: 1.5rem;
+
+  p{
+    line-height: $paragraph-lineheight;
+    margin-bottom: $paragraph-margin-bottom;
+    text-rendering: $paragraph-text-rendering;
+  }
 }

--- a/decidim-core/app/assets/stylesheets/decidim/editor.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/editor.scss
@@ -1,0 +1,5 @@
+@import "quill.snow";
+
+.editor-container{
+  margin-bottom: 1.5rem;
+}


### PR DESCRIPTION
#### :tophat: What? Why?

Sometimes decidim admins incorrectly introduce empty blank lines to split paragraphs when editing content. This is incorrect and causes very ugly whitespace in the final content in the main frontend. It's understandable though that they do this since the default style of the editor makes you think that the final content won't properly separate paragraphs.

This PR gives editor proper paragraph spacing so that admins won't do this anymore.

#### :pushpin: Related Issues
- Fixes #2000.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)

When introducing line breaks on quilljs editor:
 
#### Before

![before](https://user-images.githubusercontent.com/2887858/35359094-92391278-0137-11e8-80a7-d389922d169e.png)

#### After
![after](https://user-images.githubusercontent.com/2887858/35359107-9a53195e-0137-11e8-96d6-e93c39d6f17e.png)
