### PR TITLE
Translate admin logout link

### DIFF
--- a/decidim-admin/app/views/layouts/decidim/admin/_title_bar.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_title_bar.html.erb
@@ -28,7 +28,7 @@
         <li class="is-dropdown-submenu-parent">
           <a href="#"><%= current_user.email %></a>
           <ul class="menu is-dropdown-submenu">
-            <li><%= link_to('Logout', decidim.destroy_user_session_path, method: :delete) %></li>
+            <li><%= link_to(t("layouts.decidim.user_menu.sign_out"), decidim.destroy_user_session_path, method: :delete) %></li>
           </ul>
         </li>
       </ul>


### PR DESCRIPTION
#### :tophat: What? Why?
The link to log out in the admin component was not translated. This PR translates the link.

#### :pushpin: Related Issues
- Fixes #2528

