### PR TITLE
Import settings in editor

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/editor.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/editor.scss
@@ -1,9 +1,10 @@
 @import "quill.snow";
+@import "utils/settings";
 
-.editor-container{
+.editor-container {
   margin-bottom: 1.5rem;
 
-  p{
+  p {
     line-height: $paragraph-lineheight;
     margin-bottom: $paragraph-margin-bottom;
     text-rendering: $paragraph-text-rendering;

--- a/decidim-core/app/assets/stylesheets/decidim/editor.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/editor.scss
@@ -1,10 +1,10 @@
 @import "quill.snow";
 @import "utils/settings";
 
-.editor-container {
+.editor-container{
   margin-bottom: 1.5rem;
 
-  p {
+  p{
     line-height: $paragraph-lineheight;
     margin-bottom: $paragraph-margin-bottom;
     text-rendering: $paragraph-text-rendering;

--- a/decidim-core/app/assets/stylesheets/decidim/editor.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/editor.scss
@@ -1,4 +1,5 @@
 @import "quill.snow";
+@import "variables";
 @import "utils/settings";
 
 .editor-container{


### PR DESCRIPTION
#### :tophat: What? Why?
This imports the `settings.scss` files in `editor.scss` so it can use the variables when included separately (currently being done by `decidim-initiatives`).

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
*None*