### PR TITLE
Fix nicknames migration on empty names

### DIFF
--- a/decidim-core/db/migrate/20171212103803_create_unique_nicknames.rb
+++ b/decidim-core/db/migrate/20171212103803_create_unique_nicknames.rb
@@ -10,7 +10,7 @@ class CreateUniqueNicknames < ActiveRecord::Migration[5.1]
   def up
     add_column :decidim_users, :nickname, :string, limit: 20
 
-    User.find_each do |user|
+    User.where.not(name: nil).find_each do |user|
       user.update!(nickname: User.nicknamize(user.name))
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
The nicknames migration will fail on users with empty names (`name` gets set to nil when the users are deleted).

#### :pushpin: Related Issues
- Related to #2360 

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*
