### PR TITLE
Move export button away from extra

### DIFF
--- a/decidim-accountability/app/views/decidim/accountability/admin/results/index.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/results/index.html.erb
@@ -6,7 +6,7 @@
       <div class="button--title">
         <%= link_to t("actions.new", scope: "decidim.accountability", name: t("models.result.name", scope: "decidim.accountability.admin")), new_result_path(parent_id: parent_result), class: 'button tiny button--simple' if can? :manage, current_feature %>
         <%= render partial: "decidim/accountability/admin/shared/subnav" unless parent_result %>
-        <%= render partial: "decidim/accountability/admin/shared/extra" %>
+        <%= export_dropdown %>
       </div>
     </h2>
   </div>

--- a/decidim-accountability/app/views/decidim/accountability/admin/shared/_extra.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/shared/_extra.html.erb
@@ -1,1 +1,0 @@
-<%= export_dropdown %>


### PR DESCRIPTION
#### :tophat: What? Why?
Moves the `export` dropdown away from the `extra` partial - we're recommending [deface](https://github.com/spree/deface) to override views on our end apps instead.

#### :pushpin: Related Issues
- Fixes #2532

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*