### PR TITLE
[FIX] Hide withdraw button when user is not author.

### DIFF
--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -149,6 +149,13 @@ module Decidim
         authored_by?(user) && !answered? && within_edit_time_limit?
       end
 
+      # Checks whether the user can withdraw the given proposal.
+      #
+      # user - the user to check for withdrawability.
+      def withdrawable_by?(user)
+        authored_by?(user)
+      end
+
       # method for sort_link by number of comments
       ransacker :commentable_comments_count do
         query = <<-SQL

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -153,7 +153,7 @@ module Decidim
       #
       # user - the user to check for withdrawability.
       def withdrawable_by?(user)
-        authored_by?(user)
+        user && authored_by?(user)
       end
 
       # method for sort_link by number of comments

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -153,7 +153,7 @@ module Decidim
       #
       # user - the user to check for withdrawability.
       def withdrawable_by?(user)
-        user && authored_by?(user)
+        user && !withdrawn? && authored_by?(user)
       end
 
       # method for sort_link by number of comments

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -17,7 +17,7 @@
         <%= link_to_current_or_new_conversation_with(@proposal.author) %>
       <% end %>
     </div>
-    <% unless @proposal.withdrawn? %>
+    <% unless @proposal.withdrawn? or !@proposal.withdrawable_by?(current_user) %>
       <%= action_authorized_link_to :withdraw, withdraw_proposal_path(@proposal), method: :put, class: "title-action__action button small hollow", data: {confirm: t('.withdraw_confirmation')}  do %>
         <%= t('.withdraw_proposal') %>
         <%= icon "x" %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -17,7 +17,7 @@
         <%= link_to_current_or_new_conversation_with(@proposal.author) %>
       <% end %>
     </div>
-    <% unless @proposal.withdrawn? or !@proposal.withdrawable_by?(current_user) %>
+    <% if @proposal.withdrawn? && @proposal.withdrawable_by?(current_user) %>
       <%= action_authorized_link_to :withdraw, withdraw_proposal_path(@proposal), method: :put, class: "title-action__action button small hollow", data: {confirm: t('.withdraw_confirmation')}  do %>
         <%= t('.withdraw_proposal') %>
         <%= icon "x" %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -17,7 +17,7 @@
         <%= link_to_current_or_new_conversation_with(@proposal.author) %>
       <% end %>
     </div>
-    <% if @proposal.withdrawn? && @proposal.withdrawable_by?(current_user) %>
+    <% if @proposal.withdrawable_by?(current_user) %>
       <%= action_authorized_link_to :withdraw, withdraw_proposal_path(@proposal), method: :put, class: "title-action__action button small hollow", data: {confirm: t('.withdraw_confirmation')}  do %>
         <%= t('.withdraw_proposal') %>
         <%= icon "x" %>

--- a/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
@@ -148,6 +148,30 @@ module Decidim
           it { is_expected.not_to be_withdrawn }
         end
       end
+
+      describe "#withdrawable_by" do
+        let(:author) { build(:user, organization: organization) }
+
+        context "when user is author" do
+          let(:proposal) { build :proposal, feature: feature, author: author, created_at: Time.current }
+
+          it { is_expected.to be_withdrawable_by(author) }
+        end
+
+        context "when user is admin" do
+          let(:admin) { build(:user, :admin, organization: organization) }
+          let(:proposal) { build :proposal, feature: feature, author: author, created_at: Time.current}
+
+          it { is_expected.not_to be_withdrawable_by(admin) }
+        end
+
+        context "when user is not the author" do
+          let(:someone_else) { build(:user, organization: organization) }
+          let(:proposal) { build :proposal, feature: feature, author: author, created_at: Time.current}
+
+          it { is_expected.not_to be_withdrawable_by(someone_else) }
+        end
+      end
     end
   end
 end

--- a/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
@@ -160,14 +160,14 @@ module Decidim
 
         context "when user is admin" do
           let(:admin) { build(:user, :admin, organization: organization) }
-          let(:proposal) { build :proposal, feature: feature, author: author, created_at: Time.current}
+          let(:proposal) { build :proposal, feature: feature, author: author, created_at: Time.current }
 
           it { is_expected.not_to be_withdrawable_by(admin) }
         end
 
         context "when user is not the author" do
           let(:someone_else) { build(:user, organization: organization) }
-          let(:proposal) { build :proposal, feature: feature, author: author, created_at: Time.current}
+          let(:proposal) { build :proposal, feature: feature, author: author, created_at: Time.current }
 
           it { is_expected.not_to be_withdrawable_by(someone_else) }
         end

--- a/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
@@ -171,6 +171,12 @@ module Decidim
 
           it { is_expected.not_to be_withdrawable_by(someone_else) }
         end
+
+        context "when proposal is already withdrawn" do
+          let(:proposal) { build :proposal, :withdrawn, feature: feature, author: author, created_at: Time.current }
+
+          it { is_expected.not_to be_withdrawable_by(author) }
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
When current user is not the author of a proposal, the button was still appearing, but it shouldn't.

#### :pushpin: Related Issues
- Fixes #2606 

#### :clipboard: Subtasks

### :camera: Screenshots (optional)
