### PR TITLE
Fetch just the following level of children

### DIFF
--- a/decidim-accountability/app/services/decidim/accountability/result_search.rb
+++ b/decidim-accountability/app/services/decidim/accountability/result_search.rb
@@ -46,9 +46,7 @@ module Decidim
       private
 
       def children_ids(parent_id)
-        Result.where(parent_id: parent_id).pluck(:id).flat_map do |child_id|
-          [child_id] + children_ids(child_id)
-        end
+        Result.where(parent_id: parent_id).pluck(:id)
       end
 
       # Internal: builds the needed query to search for a text in the organization's

--- a/decidim-accountability/spec/services/decidim/accountability/result_search_spec.rb
+++ b/decidim-accountability/spec/services/decidim/accountability/result_search_spec.rb
@@ -107,7 +107,7 @@ module Decidim::Accountability
           let(:params) { default_params.merge(category_id: parent_category.id) }
 
           it "returns results from this category and its children's" do
-            expect(subject.results).to match_array [result1, result2, result3]
+            expect(subject.results).to match_array [result1, result2]
           end
         end
 

--- a/decidim-accountability/spec/services/decidim/accountability/result_search_spec.rb
+++ b/decidim-accountability/spec/services/decidim/accountability/result_search_spec.rb
@@ -127,7 +127,7 @@ module Decidim::Accountability
             let(:params) { default_params.merge(parent_id: nil) }
 
             it "returns the search on all results" do
-              expect(subject.results).to match_array [result1, result2, result3]
+              expect(subject.results).to match_array [result1, result2]
             end
           end
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR avoids the N+1 when fetching the children results, considering that there will be just two levels in the relationship (parent and children). 

#### :pushpin: Related Issues

- Fixes #2613

#### :clipboard: Subtasks

- [x] Add `CHANGELOG` entry
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
