### PR TITLE
Allow underscores at CTA button path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ you need to change the following line in `config/environments/production.rb`:
 
 **Fixed**:
 
+- **decidim-core**: Allow underscores at CTA button path. [\#2625](https://github.com/decidim/decidim/pull/2625)
 - **decidim-core**: Fix editing features in assemblies. [\#2524](https://github.com/decidim/decidim/pull/2524)
 - **decidim-core**: Fix the texts of 'New Message' email notifications. [\#2588](https://github.com/decidim/decidim/pull/2588)
 - **decidim-admin**: Properly save features weight on creation [\#2499](https://github.com/decidim/decidim/pull/2499)

--- a/decidim-admin/app/forms/decidim/admin/organization_appearance_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_appearance_form.rb
@@ -33,7 +33,7 @@ module Decidim
       translatable_attribute :omnipresent_banner_title, String
       translatable_attribute :omnipresent_banner_short_description, String
 
-      validates :cta_button_path, format: { with: %r{\A[a-zA-Z]+[a-zA-Z0-9\-/]+\z} }, allow_blank: true
+      validates :cta_button_path, format: { with: %r{\A[a-zA-Z]+[a-zA-Z0-9\-\_/]+\z} }, allow_blank: true
       validates :official_img_header,
                 :official_img_footer,
                 :homepage_image,

--- a/decidim-admin/spec/forms/organization_appearance_form_spec.rb
+++ b/decidim-admin/spec/forms/organization_appearance_form_spec.rb
@@ -83,6 +83,12 @@ module Decidim
         it { is_expected.to be_valid }
       end
 
+      context "when cta_button_path is a valid path with underscore" do
+        let(:cta_button_path) { "processes/my_process/" }
+
+        it { is_expected.to be_valid }
+      end
+
       context "when enable_omnipresent_banner is true" do
         let(:enable_omnipresent_banner) { true }
         let(:omnipresent_banner_url) { "http://www.example.org/random_url" }

--- a/decidim-debates/decidim-debates.gemspec
+++ b/decidim-debates/decidim-debates.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.summary = "Decidim debates module"
   s.description = "A debates component for decidim's participatory spaces."
   s.version = Decidim::Debates.version
-  s.authors = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva", "Genís Matutes Pujol"]
+  s.authors = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva", "Genis Matutes Pujol"]
   s.email = ["josepjaume@gmail.com", "mrc2407@gmail.com", "oriolgual@gmail.com", "genis.matutes@gmail.com"]
 
   s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]


### PR DESCRIPTION
#### :tophat: What? Why?

It was missing the underscore at the regex.

#### :pushpin: Related Issues
- Fixes #2621