### PR TITLE
Fix user re-invite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ you need to change the following line in `config/environments/production.rb`:
 
 **Fixed**:
 
+- **decidim-core**: Fix user re-invite. [\#2626](https://github.com/decidim/decidim/pull/2626)
 - **decidim-core**: Fix editing features in assemblies. [\#2524](https://github.com/decidim/decidim/pull/2524)
 - **decidim-core**: Fix the texts of 'New Message' email notifications. [\#2588](https://github.com/decidim/decidim/pull/2588)
 - **decidim-admin**: Properly save features weight on creation [\#2499](https://github.com/decidim/decidim/pull/2499)

--- a/decidim-core/app/commands/decidim/invite_user_again.rb
+++ b/decidim-core/app/commands/decidim/invite_user_again.rb
@@ -14,7 +14,7 @@ module Decidim
     def call
       return broadcast(:invalid) unless user&.invited_to_sign_up?
 
-      user.deliver_invitation(invitation_instructions: instructions)
+      user.invite!(user.invited_by, invitation_instructions: instructions)
 
       broadcast(:ok)
     end

--- a/decidim-core/spec/commands/decidim/invite_user_again_spec.rb
+++ b/decidim-core/spec/commands/decidim/invite_user_again_spec.rb
@@ -22,6 +22,18 @@ module Decidim
       it "broadcasts ok" do
         expect { command.call }.to broadcast(:ok)
       end
+
+      it "regenerates the invitation token" do
+        expect do
+          command.call
+        end.to change { user.invitation_token }
+      end
+
+      it "regenerates the invitation due date" do
+        expect do
+          command.call
+        end.to change { user.invitation_due_at }
+      end
     end
 
     context "when the user was not invited initially" do


### PR DESCRIPTION
#### :tophat: What? Why?

Reinviting a user was only re-sending the email but it wasn't regenerating the token, so when the invitation had expired it was useless.

#### :pushpin: Related Issues
- Fixes #2616