### PR TITLE
Add missing i18n key in debates

### DIFF
--- a/decidim-debates/config/locales/en.yml
+++ b/decidim-debates/config/locales/en.yml
@@ -3,7 +3,7 @@ en:
   activemodel:
     attributes:
       debate:
-        decidim_category_id: Category
+        category_id: Category
         description: Description
         end_time: Ends at
         information_updates: Information updates


### PR DESCRIPTION
#### :tophat: What? Why?
Add missing i18n key in debates.

#### :pushpin: Related Issues
- Related to #2506 

#### :clipboard: Subtasks
None