### PR TITLE
Don't allow conversations between the same user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ you need to change the following line in `config/environments/production.rb`:
 
 **Fixed**:
 
+- **decidim-core**: Don't allow conversations between the same user. [\#2630](https://github.com/decidim/decidim/pull/2630)
 - **decidim-core**: Remove Sendgrid and Heroku references. [\#2634](https://github.com/decidim/decidim/pull/2634)
 - **decidim-core**: Notify admins when no valid authorization handlers are available to create managed users. [\#2631](https://github.com/decidim/decidim/pull/2631)
 - **decidim-core**: Fix user re-invite. [\#2626](https://github.com/decidim/decidim/pull/2626)

--- a/decidim-core/app/controllers/decidim/messaging/conversations_controller.rb
+++ b/decidim-core/app/controllers/decidim/messaging/conversations_controller.rb
@@ -17,8 +17,9 @@ module Decidim
         authorize! :create, Conversation
         @form = form(ConversationForm).from_params(params)
 
-        conversation = conversation_between(current_user, @form.recipient)
+        redirect_back(fallback_location: profile_path(current_user.nickname)) && return unless @form.recipient
 
+        conversation = conversation_between(current_user, @form.recipient)
         redirect_to conversation_path(conversation) if conversation
       end
 

--- a/decidim-core/app/forms/decidim/messaging/conversation_form.rb
+++ b/decidim-core/app/forms/decidim/messaging/conversation_form.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module Messaging
-    # A form object to be used when users want to follow a followable resource.
+    # A form object to be used when users want to message another user.
     class ConversationForm < Decidim::Form
       mimic :conversation
 
@@ -12,7 +12,10 @@ module Decidim
       validates :body, :recipient, presence: true
 
       def recipient
-        Decidim::User.find_by(id: recipient_id)
+        @recipient ||= Decidim::User
+                       .where.not(id: current_user.id)
+                       .where(organization: current_user.organization)
+                       .find_by(id: recipient_id)
       end
     end
   end

--- a/decidim-core/app/helpers/decidim/messaging/conversation_helper.rb
+++ b/decidim-core/app/helpers/decidim/messaging/conversation_helper.rb
@@ -47,6 +47,8 @@ module Decidim
       #
       # @return [Decidim::Messaging::Conversation]
       def conversation_between(*participants)
+        return if participants.to_set.length <= 1
+
         UserConversations.for(participants.first).find do |conversation|
           conversation.participants.to_set == participants.to_set
         end

--- a/decidim-core/app/views/decidim/profiles/show.html.erb
+++ b/decidim-core/app/views/decidim/profiles/show.html.erb
@@ -13,9 +13,11 @@
             <strong><%= profile_user.name %></strong>
             <div class="user-nickname">
               <%= profile_user.nickname %>
-              <span class="user-contact_link">
-                <%= link_to_current_or_new_conversation_with(user) %>
-              </span>
+              <% if !current_user || (current_user && current_user != user) %>
+                <span class="user-contact_link">
+                  <%= link_to_current_or_new_conversation_with(user) %>
+                </span>
+              <% end %>
             </div>
 
             <% if current_user && current_user != user %>

--- a/decidim-core/spec/commands/decidim/messaging/start_conversation_spec.rb
+++ b/decidim-core/spec/commands/decidim/messaging/start_conversation_spec.rb
@@ -7,11 +7,11 @@ module Decidim::Messaging
     let(:organization) { create(:organization) }
     let(:user) { create(:user, :confirmed, organization: organization) }
     let!(:command) { described_class.new(form) }
-    let(:interlocutor) { create(:user) }
+    let(:interlocutor) { create(:user, organization: organization) }
 
     context "when the form is invalid" do
       let(:form) do
-        ConversationForm.from_params(body: "", recipient_id: interlocutor.id)
+        ConversationForm.from_params(body: "", recipient_id: interlocutor.id).with_context(current_user: user)
       end
 
       it "does not create a conversation" do

--- a/decidim-core/spec/controllers/messaging/conversations_controller_spec.rb
+++ b/decidim-core/spec/controllers/messaging/conversations_controller_spec.rb
@@ -22,6 +22,16 @@ module Decidim
       sign_in user
     end
 
+    describe "GET new" do
+      context "when is the same user" do
+        subject { get :new, params: { recipient_id: user.id } }
+
+        it "redirects to the profile path" do
+          expect(subject).to redirect_to profile_path(user.nickname)
+        end
+      end
+    end
+
     describe "POST create" do
       context "when invalid" do
         it "renders an error message" do

--- a/decidim-core/spec/forms/decidim/messaging/conversation_form_spec.rb
+++ b/decidim-core/spec/forms/decidim/messaging/conversation_form_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Messaging
+    describe ConversationForm do
+      subject { form }
+
+      let(:body) { "Hi!" }
+      let(:recipient_id) { create(:user, organization: current_user.organization).id }
+      let(:current_user) { create(:user) }
+      let(:params) do
+        {
+          body: body,
+          recipient_id: recipient_id
+        }
+      end
+      let(:form) do
+        described_class.from_params(params).with_context(current_user: current_user)
+      end
+
+      context "when everything is OK" do
+        it { is_expected.to be_valid }
+      end
+
+      context "when no body" do
+        let(:body) { nil }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "when no recipient" do
+        let(:recipient_id) { nil }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "when the recipient and the user are the same" do
+        let(:recipient_id) { current_user.id }
+
+        it { is_expected.to be_invalid }
+      end
+    end
+  end
+end

--- a/decidim-core/spec/system/messaging/conversations_spec.rb
+++ b/decidim-core/spec/system/messaging/conversations_spec.rb
@@ -27,7 +27,7 @@ describe "Conversations", type: :system do
   end
 
   context "when starting a conversation" do
-    let(:recipient) { create(:user) }
+    let(:recipient) { create(:user, organization: organization) }
 
     before do
       visit decidim.new_conversation_path(recipient_id: recipient.id)
@@ -52,7 +52,7 @@ describe "Conversations", type: :system do
   end
 
   context "when user has conversations" do
-    let(:interlocutor) { create(:user, :confirmed) }
+    let(:interlocutor) { create(:user, :confirmed, organization: organization) }
 
     let!(:conversation) do
       Decidim::Messaging::Conversation.start!(


### PR DESCRIPTION
#### :tophat: What? Why?

Users shouldn't be able to start a conversation with themselves.

#### :pushpin: Related Issues
- Fixes #2464