### PR TITLE
Notify admins when no valid authorization handlers are available to create managed users.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ you need to change the following line in `config/environments/production.rb`:
 
 **Fixed**:
 
+- **decidim-core**: Notify admins when no valid authorization handlers are available to create managed users. [\#2631](https://github.com/decidim/decidim/pull/2631)
 - **decidim-core**: Fix user re-invite. [\#2626](https://github.com/decidim/decidim/pull/2626)
 - **decidim-core**: Allow underscores at CTA button path. [\#2625](https://github.com/decidim/decidim/pull/2625)
 - **decidim-core**: Fix editing features in assemblies. [\#2524](https://github.com/decidim/decidim/pull/2524)

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -202,6 +202,7 @@ en:
         new:
           create: Create
           new_managed_user: New managed user
+          no_authorization_handlers: There are no available authorization handlers to manage users. Please contact your system administrator.
           select_authorization_method: Select an authorization method
           step: Step %{current} of %{total}
         promotion:


### PR DESCRIPTION
#### :tophat: What? Why?

Right now only simple authorization handlers that can be rendered as a form can be used to create managed users, multi-step verifications don't work and some of them could not even be useful for this use case (like the id document one).

#### :pushpin: Related Issues
- Fixes #2509
