### PR TITLE
Add a note on how to generate schema types.

### DIFF
--- a/decidim-comments/README.md
+++ b/decidim-comments/README.md
@@ -71,6 +71,13 @@ yarn run graphql:generate_schema_types
 
 This command will create a file called `app/frontend/support/schema.ts` that can be used to strict type checking in our components.
 
+In order for this to work your Rails server must be running at `localhost:3000`, if you're using a different host you can set it with `DECIDIM_HOST`:
+
+
+```bash
+DECIDIM_HOST=myhost:3000 yarn run graphql:generate_schema_types
+```
+
 ## Contributing
 
 See [Decidim](https://github.com/decidim/decidim).

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "jest",
     "test:watch": "yarn test -- --watch",
     "test:ci": "yarn run lint && yarn test",
-    "graphql:download_schema": "apollo-codegen download-schema http://localhost:3000/api --output schema.json",
+    "graphql:download_schema": "apollo-codegen download-schema http://${DECIDIM_HOST:-localhost:3000}/api --output schema.json",
     "pregraphql:generate_schema_types": "yarn run graphql:download_schema",
     "graphql:generate_schema_types": "apollo-codegen generate decidim-comments/**/*.graphql --schema schema.json --target typescript --output decidim-comments/app/frontend/support/schema.ts"
   },


### PR DESCRIPTION
#### :tophat: What? Why?

In order to generate the GraphQL schema types the Rails server must be running at `localhost:3000`

#### :pushpin: Related Issues
- Fixes #2539
