### PR TITLE
Remove Sendgrid and Heroku references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ you need to change the following line in `config/environments/production.rb`:
 
 **Fixed**:
 
+- **decidim-core**: Remove Sendgrid and Heroku references. [\#2634](https://github.com/decidim/decidim/pull/2634)
 - **decidim-core**: Fix user re-invite. [\#2626](https://github.com/decidim/decidim/pull/2626)
 - **decidim-core**: Allow underscores at CTA button path. [\#2625](https://github.com/decidim/decidim/pull/2625)
 - **decidim-core**: Fix editing features in assemblies. [\#2524](https://github.com/decidim/decidim/pull/2524)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -79,8 +79,6 @@ We also have other guides on how to configure some extra features:
 
 ## Deploy
 
-Once you've generated the Decidim app you might need to do some changes in order to deploy it. You can check [`codegram/decidim-deploy-heroku`](https://github.com/codegram/decidim-deploy-heroku) for an opinionated example of things to do before deploying to Heroku, for example.
-
 Once you've successfully deployed your app to your favorite platform, you'll need to create your `System` user. First you'll need to create your `Decidim::System` user in your production Ruby on Rails console:
 
 ```ruby
@@ -104,7 +102,7 @@ If you want, you can create seed data in production. Run this command in your pr
 $ SEED=true rails db:seed
 ```
 
-If you used Codegram's [`decidim-deploy-heroku`](https://github.com/codegram/decidim-deploy-heroku), then you're all set. Otherwise you'll need to login as system user and edit the host for the organization. Set it to you production host, without the protocol and the port (so if your host is `https://my.host:3001`, you need to write `my.host`).
+You'll need to login as system user and edit the host for the organization. Set it to you production host, without the protocol and the port (so if your host is `https://my.host:3001`, you need to write `my.host`).
 
 ## Keeping your app up-to-date
 

--- a/lib/generators/decidim/install_generator.rb
+++ b/lib/generators/decidim/install_generator.rb
@@ -76,17 +76,6 @@ module Decidim
             |    :enable_starttls_auto => Rails.application.secrets.smtp_starttls_auto,
             |    :openssl_verify_mode => 'none'
             |  }
-            |
-            |  if Rails.application.secrets.sendgrid
-            |    config.action_mailer.default_options = {
-            |      "X-SMTPAPI" => {
-            |        filters:  {
-            |          clicktrack: { settings: { enable: 0 } },
-            |          opentrack:  { settings: { enable: 0 } }
-            |        }
-            |      }.to_json
-            |    }
-            |  end
           RUBY
         end
       end

--- a/lib/generators/decidim/templates/README.md.erb
+++ b/lib/generators/decidim/templates/README.md.erb
@@ -4,10 +4,6 @@ Citizen Participation and Open Government application.
 
 This is the open-source repository for <%= app_name %>, based on [Decidim](https://github.com/decidim/decidim).
 
-## Deploying the app
-
-An opinionated guide to deploy this app to Heroku can be found at [https://github.com/codegram/decidim-deploy-heroku](https://github.com/codegram/decidim-deploy-heroku).
-
 ## Setting up the application
 
 You will need to do some steps before having the app working properly once you've deployed it:

--- a/lib/generators/decidim/templates/database.yml.erb
+++ b/lib/generators/decidim/templates/database.yml.erb
@@ -73,7 +73,7 @@ test:
 # for a full rundown on how to provide these environment variables in a
 # production deployment.
 #
-# On Heroku and other platform providers, you may have a full connection URL
+# On some platform providers, you may have a full connection URL
 # available as an environment variable. For example:
 #
 #   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"

--- a/lib/generators/decidim/templates/secrets.yml.erb
+++ b/lib/generators/decidim/templates/secrets.yml.erb
@@ -52,11 +52,10 @@ test:
 production:
   <<: *default
   secret_key_base: <%%= ENV["SECRET_KEY_BASE"] %>
-  sendgrid: <%%= !ENV["SENDGRID_USERNAME"].blank? %>
-  smtp_username: <%%= ENV["SMTP_USERNAME"] || ENV["SENDGRID_USERNAME"] %>
-  smtp_password: <%%= ENV["SMTP_PASSWORD"] || ENV["SENDGRID_PASSWORD"] %>
-  smtp_address: <%%= ENV["SMTP_ADDRESS"] || "smtp.sendgrid.net" %>
-  smtp_domain: <%%= ENV["SMTP_DOMAIN"] || "heroku.com" %>
+  smtp_username: <%%= ENV["SMTP_USERNAME"] %>
+  smtp_password: <%%= ENV["SMTP_PASSWORD"] %>
+  smtp_address: <%%= ENV["SMTP_ADDRESS"] %>
+  smtp_domain: <%%= ENV["SMTP_DOMAIN"] %>
   smtp_port: "587"
   smtp_starttls_auto: true
   smtp_authentication: "plain"


### PR DESCRIPTION
#### :tophat: What? Why?

Remove all references and configuration for Sendgrid and Heroku since it's against the social contract.

#### :pushpin: Related Issues
- Fixes #2615