### PR TITLE
Add configurable proposal body length

### DIFF
--- a/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
@@ -16,10 +16,9 @@ module Decidim
       attribute :user_group_id, Integer
       attribute :has_address, Boolean
       attribute :attachment, AttachmentForm
-
       validates :title, :body, presence: true, etiquette: true
       validates :title, length: { maximum: 150 }
-      validates :body, length: { maximum: 500 }, etiquette: true
+      validate :proposal_length
       validates :address, geocoding: true, if: ->(form) { Decidim.geocoder.present? && form.has_address? }
       validates :address, presence: true, if: ->(form) { form.has_address? }
       validates :category, presence: true, if: ->(form) { form.category_id.present? }
@@ -35,7 +34,6 @@ module Decidim
       end
 
       alias feature current_feature
-
       # Finds the Category from the category_id.
       #
       # Returns a Decidim::Category
@@ -60,6 +58,12 @@ module Decidim
       def has_address?
         current_feature.settings.geocoding_enabled? && has_address
       end
+
+      def proposal_length
+        length = current_feature.settings.proposal_length
+        errors.add(:body, :too_long, count: length) if body.length > length
+      end
+
     end
   end
 end

--- a/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
@@ -63,7 +63,6 @@ module Decidim
         length = current_feature.settings.proposal_length
         errors.add(:body, :too_long, count: length) if body.length > length
       end
-
     end
   end
 end

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -53,6 +53,7 @@ en:
             proposal_edit_before_minutes: Proposals can be edited by authors before this many minutes passes
             proposal_limit: Proposal limit per user
             vote_limit: Vote limit per user
+            proposal_length: Maximum proposal body length
           step:
             announcement: Announcement
             comments_blocked: Comments blocked

--- a/decidim-proposals/config/locales/es.yml
+++ b/decidim-proposals/config/locales/es.yml
@@ -52,6 +52,7 @@ es:
             proposal_edit_before_minutes: Las propuestas pueden ser editadas por los autores antes de que pasen estos minutos
             proposal_limit: Límite de propuestas por usuario
             vote_limit: Límite de votos por usuario
+            proposal_length: Tamaño máximo del cuerpo de la propuesta
           step:
             announcement: Aviso
             comments_blocked: Comentarios bloqueados

--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -16,6 +16,7 @@ Decidim.register_feature(:proposals) do |feature|
   feature.settings(:global) do |settings|
     settings.attribute :vote_limit, type: :integer, default: 0
     settings.attribute :proposal_limit, type: :integer, default: 0
+    settings.attribute :proposal_length, type: :integer, default: 500
     settings.attribute :proposal_edit_before_minutes, type: :integer, default: 5
     settings.attribute :maximum_votes_per_proposal, type: :integer, default: 0
     settings.attribute :proposal_answering_enabled, type: :boolean, default: true


### PR DESCRIPTION
#### :tophat: What? Why?
Many users want to have more length in the body of a proposal, so i enable the posibility to handle a configurable body length from the feature settings, so if you want to define the proposal body of a specific participatory process you can easily configure that.

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry

### :camera: Screenshots (optional)

![Configure proposal body length](https://user-images.githubusercontent.com/1911813/35747026-d4b1669c-0816-11e8-868f-cef23b5e20f2.png)

![Check proposal body length](https://user-images.githubusercontent.com/1911813/35747060-ed94ee9a-0816-11e8-92c6-eacd289769f2.png)

