### PR TITLE
Fix admin menu highlight for scope type section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ you need to change the following line in `config/environments/production.rb`:
 - **decidim-accountability**: Keeps the current scope in the breadcumb links [\#2488](https://github.com/decidim/decidim/pull/2488)
 - **decidim-accountability**: Top level search searches on all results (not only the first level) [\#2545](https://github.com/decidim/decidim/pull/2545)
 - **decidim-admin**: Visual bug in quilljs editor misleading admins into introducing blank lines to separate paragraphs. [\#2565](https://github.com/decidim/decidim/pull/2565).
+- **decidim-admin**: Properly highlight the Settings admin menu item when visiting the scope types section. [\#2642](https://github.com/decidim/decidim/pull/2642)
 
 **Removed**
 

--- a/decidim-admin/lib/decidim/admin/engine.rb
+++ b/decidim-admin/lib/decidim/admin/engine.rb
@@ -74,7 +74,7 @@ module Decidim
                     decidim_admin.edit_organization_path,
                     icon_name: "wrench",
                     position: 7,
-                    active: [%w(decidim/admin/organization decidim/admin/scopes), []],
+                    active: [%w(decidim/admin/organization decidim/admin/scopes decidim/admin/scope_types), []],
                     if: can?(:read, current_organization)
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes the admin menu to highlight the "Settings" icon when configuring scope types.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
Before:
![](https://i.imgur.com/BVg3bUE.png)

After:
![Description](https://i.imgur.com/2qyyvDn.png)
