### PR TITLE
Skip normalization checking on release

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -50,7 +50,7 @@ end
 
 desc "Makes sure all official locales are complete and clean."
 task :check_locale_completeness do
-  system({ "ENFORCED_LOCALES" => "en,ca,es" }, "rspec spec/i18n_spec.rb")
+  system({ "ENFORCED_LOCALES" => "en,ca,es", "SKIP_NORMALIZATION" => true }, "rspec spec/i18n_spec.rb")
 end
 
 desc "Generates a dummy app for testing"

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -19,13 +19,15 @@ describe "I18n sanity" do
     expect(unused_keys).to be_empty, "#{unused_keys.inspect} are unused"
   end
 
-  it "is normalized" do
-    previous_locale_hashes = locale_hashes
-    i18n.normalize_store!
-    new_locale_hashes = locale_hashes
+  unless ENV["SKIP_NORMALIZATION"]
+    it "is normalized" do
+      previous_locale_hashes = locale_hashes
+      i18n.normalize_store!
+      new_locale_hashes = locale_hashes
 
-    expect(previous_locale_hashes).to eq(new_locale_hashes),
-                                      "Please normalize your locale files with `i18n-tasks normalize`"
+      expect(previous_locale_hashes).to eq(new_locale_hashes),
+                                        "Please normalize your locale files with `i18n-tasks normalize`"
+    end
   end
 
   def locale_hashes


### PR DESCRIPTION
#### :tophat: What? Why?
This disables normalization checking on release, since it doesn't provide any value and conflicts with Crowdin's normalization format. We only want to check for locale completeness.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*
