### PR TITLE
resource_path and resource_url should be public for events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 **Fixed**:
 
+- **decidim-comments**: Fix comment notifications listing. [\#2652](https://github.com/decidim/decidim/pull/2652)
+
 ## [v0.9.0](https://github.com/decidim/decidim/tree/v0.9.0) (2018-2-5)
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.8.0...v0.9.0)
 **Upgrade notes**:

--- a/decidim-admin/app/events/decidim/feature_published_event.rb
+++ b/decidim-admin/app/events/decidim/feature_published_event.rb
@@ -6,8 +6,6 @@ module Decidim
 
     i18n_attributes :participatory_space_title
 
-    private
-
     def resource_path
       @resource_path ||= main_feature_path(resource)
     end

--- a/decidim-admin/app/events/decidim/participatory_process_step_activated_event.rb
+++ b/decidim-admin/app/events/decidim/participatory_process_step_activated_event.rb
@@ -6,12 +6,6 @@ module Decidim
 
     i18n_attributes :participatory_space_title
 
-    private
-
-    def participatory_space
-      resource.participatory_process
-    end
-
     def resource_path
       @resource_path ||= decidim_participatory_processes.participatory_process_participatory_process_steps_path(participatory_space)
     end
@@ -24,8 +18,14 @@ module Decidim
                         )
     end
 
+    private
+
     def participatory_space_title
       participatory_space.title[I18n.locale.to_s]
+    end
+
+    def participatory_space
+      resource.participatory_process
     end
   end
 end

--- a/decidim-admin/spec/events/decidim/attachment_created_event_spec.rb
+++ b/decidim-admin/spec/events/decidim/attachment_created_event_spec.rb
@@ -11,6 +11,10 @@ describe Decidim::AttachmentCreatedEvent do
   let(:resource_title) { resource.attached_to.title["en"] }
   let(:resource_path) { resource.url }
 
+  before do
+    resource.file.class.configure { |config| config.asset_host = "http://example.org" }
+  end
+
   it_behaves_like "an simple event"
 
   describe "email_subject" do

--- a/decidim-comments/app/events/decidim/comments/comment_created_event.rb
+++ b/decidim-comments/app/events/decidim/comments/comment_created_event.rb
@@ -5,7 +5,7 @@ module Decidim
     class CommentCreatedEvent < Decidim::Events::SimpleEvent
       include Decidim::Events::AuthorEvent
 
-      private
+      delegate :author, to: :comment
 
       def i18n_scope
         "decidim.events.comments.comment_created.#{comment_type}"
@@ -19,9 +19,7 @@ module Decidim
         resource_locator.url(url_params)
       end
 
-      def author
-        comment.author
-      end
+      private
 
       def comment
         @comment ||= Decidim::Comments::Comment.find(extra[:comment_id])

--- a/decidim-comments/app/events/decidim/comments/user_mentioned_event.rb
+++ b/decidim-comments/app/events/decidim/comments/user_mentioned_event.rb
@@ -5,7 +5,7 @@ module Decidim
     class UserMentionedEvent < Decidim::Events::SimpleEvent
       include Decidim::Events::AuthorEvent
 
-      private
+      delegate :author, to: :comment
 
       def i18n_scope
         "decidim.events.comments.user_mentioned"
@@ -19,9 +19,7 @@ module Decidim
         resource_locator.url(url_params)
       end
 
-      def author
-        comment.author
-      end
+      private
 
       def comment
         @comment ||= Decidim::Comments::Comment.find(extra[:comment_id])

--- a/decidim-core/app/events/decidim/profile_updated_event.rb
+++ b/decidim-core/app/events/decidim/profile_updated_event.rb
@@ -6,8 +6,6 @@ module Decidim
 
     delegate :profile_path, :profile_url, :nickname, :name, to: :updated_user
 
-    private
-
     def resource_path
       profile_path
     end
@@ -19,6 +17,8 @@ module Decidim
     def resource_url
       profile_url
     end
+
+    private
 
     def updated_user
       @updated_user ||= Decidim::UserPresenter.new(resource)

--- a/decidim-core/lib/decidim/core/test/shared_examples/simple_event.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/simple_event.rb
@@ -70,4 +70,17 @@ shared_examples_for "an simple event" do
       expect(subject.notification_title).to be_kind_of(String)
     end
   end
+
+  describe "resource_path" do
+    it "is generated correctly" do
+      expect(subject.resource_path).to be_kind_of(String)
+    end
+  end
+
+  describe "resource_url" do
+    it "is generated correctly" do
+      expect(subject.resource_url).to be_kind_of(String)
+      expect(subject.resource_url).to start_with("http")
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

When listing notifications at the user panel the `resource_path` or `resource_url` could be used by the views, so we need to make sure these methods are public.

#### :pushpin: Related Issues
- Related to #2446 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
