### PR TITLE
Use slug instead of id as space params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 **Fixed**:
 
 - **decidim-comments**: Fix comment notifications listing. [\#2652](https://github.com/decidim/decidim/pull/2652)
+- **decidim-participatory_processes**: Fix editing a process after an error.[\#2653](https://github.com/decidim/decidim/pull/2653)
+- **decidim-assemblies**: Fix editing a process after an error.[\#2653](https://github.com/decidim/decidim/pull/2653)
 
 ## [v0.9.0](https://github.com/decidim/decidim/tree/v0.9.0) (2018-2-5)
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.8.0...v0.9.0)

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
@@ -95,7 +95,7 @@ module Decidim
 
         def assembly_params
           {
-            id: params[:id],
+            id: params[:slug],
             hero_image: current_assembly.hero_image,
             banner_image: current_assembly.banner_image
           }.merge(params[:assembly].to_unsafe_h)

--- a/decidim-assemblies/spec/controllers/admin/assemblies_controller_spec.rb
+++ b/decidim-assemblies/spec/controllers/admin/assemblies_controller_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Assemblies
+    module Admin
+      describe AssembliesController, type: :controller do
+        routes { Decidim::Assemblies::AdminEngine.routes }
+
+        let(:organization) { create(:organization) }
+        let(:current_user) { create(:user, :confirmed, :admin, organization: organization) }
+        let!(:assembly) do
+          create(
+            :assembly,
+            :published,
+            organization: organization
+          )
+        end
+
+        before do
+          request.env["decidim.current_organization"] = organization
+          request.env["decidim.current_assembly"] = assembly
+          sign_in current_user
+        end
+
+        describe "PATCH update" do
+          let(:assembly_params) do
+            {
+              title: assembly.title,
+              subtitle: assembly.subtitle,
+              description: assembly.description,
+              short_description: assembly.short_description,
+              slug: assembly.slug,
+              scopes_enabled: assembly.scopes_enabled
+            }
+          end
+
+          it "uses the slug param as assembly id" do
+            expect(AssemblyForm).to receive(:from_params).with(hash_including(id: assembly.id.to_s)).and_call_original
+
+            patch :update, params: { slug: assembly.id, assembly: assembly_params }
+
+            expect(response).to redirect_to(edit_assembly_path(assembly.slug))
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_processes_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_processes_controller.rb
@@ -101,7 +101,7 @@ module Decidim
 
         def participatory_process_params
           {
-            id: params[:id],
+            id: params[:slug],
             hero_image: current_participatory_process.hero_image,
             banner_image: current_participatory_process.banner_image
           }.merge(params[:participatory_process].to_unsafe_h)

--- a/decidim-participatory_processes/spec/controllers/admin/participatory_processes_controller_spec.rb
+++ b/decidim-participatory_processes/spec/controllers/admin/participatory_processes_controller_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module ParticipatoryProcesses
+    module Admin
+      describe ParticipatoryProcessesController, type: :controller do
+        routes { Decidim::ParticipatoryProcesses::AdminEngine.routes }
+
+        let(:organization) { create(:organization) }
+        let(:current_user) { create(:user, :confirmed, :admin, organization: organization) }
+        let!(:participatory_process) do
+          create(
+            :participatory_process,
+            :published,
+            organization: organization
+          )
+        end
+
+        before do
+          request.env["decidim.current_organization"] = organization
+          request.env["decidim.current_participatory_process"] = participatory_process
+          sign_in current_user
+        end
+
+        describe "PATCH update" do
+          let(:participatory_process_params) do
+            {
+              title: participatory_process.title,
+              subtitle: participatory_process.subtitle,
+              description: participatory_process.description,
+              short_description: participatory_process.short_description,
+              slug: participatory_process.slug,
+              scopes_enabled: participatory_process.scopes_enabled
+            }
+          end
+
+          it "uses the slug param as participatory_process id" do
+            expect(ParticipatoryProcessForm).to receive(:from_params).with(hash_including(id: participatory_process.id.to_s)).and_call_original
+
+            patch :update, params: { slug: participatory_process.id, participatory_process: participatory_process_params }
+
+            expect(response).to redirect_to(edit_participatory_process_path(participatory_process.slug))
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

The routes are configured to use the slug instead of the id, so the id was nil and it was failing when we tried to update a process after an error.

#### :pushpin: Related Issues
- Fixes #2404 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
