### PR TITLE
Use the user's organization instead of the resource's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 **Fixed**:
 
+- **decidim-core**: Fix notification mailer when a resource doesn't have an organization. [\#2661](https://github.com/decidim/decidim/pull/2661)
 - **decidim-comments**: Fix comment notifications listing. [\#2652](https://github.com/decidim/decidim/pull/2652)
 - **decidim-participatory_processes**: Fix editing a process after an error.[\#2653](https://github.com/decidim/decidim/pull/2653)
 - **decidim-assemblies**: Fix editing a process after an error.[\#2653](https://github.com/decidim/decidim/pull/2653)

--- a/decidim-core/app/mailers/decidim/notification_mailer.rb
+++ b/decidim-core/app/mailers/decidim/notification_mailer.rb
@@ -8,7 +8,7 @@ module Decidim
 
     def event_received(event, event_class_name, resource, user, extra)
       with_user(user) do
-        @organization = resource.organization
+        @organization = user.organization
         event_class = event_class_name.constantize
         @event_instance = event_class.new(resource: resource, event_name: event, user: user, extra: extra)
         subject = @event_instance.email_subject

--- a/decidim-core/spec/mailers/notification_mailer_spec.rb
+++ b/decidim-core/spec/mailers/notification_mailer_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe NotificationMailer, type: :mailer do
+    let(:user) { create(:user, name: "Sarah Connor") }
+    let(:resource) { user }
+    let(:event_class_name) { "Decidim::ProfileUpdatedEvent" }
+    let(:extra) { { foo: "bar" } }
+    let(:event) { "decidim.events.users.profile_updated" }
+    let(:event_instance) do
+      event_class_name.constantize.new(resource: resource, event_name: event, user: user, extra: extra)
+    end
+
+    describe "event_received" do
+      let(:mail) { described_class.event_received(event, event_class_name, resource, user, extra) }
+
+      it "gets the subject from the event" do
+        expect(mail.subject).to include("updated their profile")
+      end
+
+      it "delivers the email to the user" do
+        expect(mail.to).to eq([user.email])
+      end
+
+      it "includes the organization data" do
+        expect(mail.body).to include(user.organization.name)
+      end
+
+      it "includes the greeting" do
+        expect(mail.body).to include(event_instance.email_greeting)
+      end
+
+      it "includes the intro" do
+        expect(mail.body).to include(event_instance.email_intro)
+      end
+
+      it "includes the outro" do
+        expect(mail.body).to include(event_instance.email_outro)
+      end
+
+      it "includes the resource url" do
+        expect(mail.body).to include(event_instance.resource_url)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Not all resources respond to `organization` so it's better to use the user's one (since it should be the same) in `NotificationMailer`.

#### :pushpin: Related Issues
- Related to #2549 
