### PR TITLE
Debates: format fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 **Added**:
 
-- **decidim-proposals**: Copy proposals to another component [\#2619](https://github.com/decidim/decidim/issues/2619).
+- **decidim-meetings**: Add simple formatting to debates fields to improve readability [\#2670](https://github.com/decidim/decidim/issues/2670)
+- **decidim-proposals**: Copy proposals to another component [\#2619](https://github.com/decidim/decidim/issues/2619)
 - **decidim-meetings**: Notify participatory space followers when a meeting is created. [\#2646](https://github.com/decidim/decidim/pull/2646)
 - **decidim-proposals**: Notify participatory space followers when a proposal is created. [\#2646](https://github.com/decidim/decidim/pull/2646)
 

--- a/decidim-debates/app/forms/decidim/debates/debate_form.rb
+++ b/decidim-debates/app/forms/decidim/debates/debate_form.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module Debates
-    # This class holds a Form to create/update debates from Decidim's admin panel.
+    # This class holds a Form to create/update debates from Decidim's public views.
     class DebateForm < Decidim::Form
       include TranslatableAttributes
 

--- a/decidim-debates/app/views/decidim/debates/debates/show.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/show.html.erb
@@ -46,15 +46,15 @@
   </div>
   <div class="columns mediumlarge-8 mediumlarge-pull-4">
     <div class="section">
-      <p><%== translated_attribute debate.description %></p>
+      <p><%= simple_format(translated_attribute(debate.description)) %></p>
       <% if translated_attribute(debate.instructions).present? %>
         <div class="callout secondary">
-          <%== translated_attribute debate.instructions %>
+          <%= simple_format(translated_attribute(debate.instructions)) %>
         </div>
       <% end %>
       <% if translated_attribute(debate.information_updates).present? %>
         <div class="callout success">
-          <%== translated_attribute debate.information_updates %>
+          <%= simple_format(translated_attribute(debate.information_updates)) %>
         </div>
       <% end %>
       <% if debate.category %>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds simple formatting to debates views, so that readability is improved.

#### :pushpin: Related Issues
- Related to #2506 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
Screenshots are taken considering that the `textarea` has some newlines in it, so the formatting is not arbitrary.

Before:
![](https://i.imgur.com/Cny2ms3.png)

After:
![](https://i.imgur.com/EjfkwP1.png)
