### PR TITLE
Only show active processes in homepage (#2682)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - **decidim-comments**: Fix comment notifications listing. [\#2652](https://github.com/decidim/decidim/pull/2652)
 - **decidim-participatory_processes**: Fix editing a process after an error.[\#2653](https://github.com/decidim/decidim/pull/2653)
 - **decidim-assemblies**: Fix editing a process after an error.[\#2653](https://github.com/decidim/decidim/pull/2653)
+- **decidim-participatory_processes**: Ensure only active processes are shown in the highlighted processes section in the homepage[\#2682](https://github.com/decidim/decidim/pull/2682)
 
 ## [v0.9.0](https://github.com/decidim/decidim/tree/v0.9.0) (2018-2-5)
 [Full Changelog](https://github.com/decidim/decidim/compare/v0.8.0...v0.9.0)

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
@@ -65,7 +65,9 @@ module Decidim
       initializer "decidim_participatory_processes.view_hooks" do
         Decidim.view_hooks.register(:highlighted_elements, priority: Decidim::ViewHooks::HIGH_PRIORITY) do |view_context|
           highlighted_processes =
-            OrganizationPublishedParticipatoryProcesses.new(view_context.current_organization) | HighlightedParticipatoryProcesses.new
+            OrganizationPublishedParticipatoryProcesses.new(view_context.current_organization) |
+            HighlightedParticipatoryProcesses.new |
+            FilteredParticipatoryProcesses.new("active")
 
           next unless highlighted_processes.any?
 

--- a/decidim-participatory_processes/spec/system/homepage_view_hooks_spec.rb
+++ b/decidim-participatory_processes/spec/system/homepage_view_hooks_spec.rb
@@ -6,6 +6,15 @@ describe "Highlighted Processes", type: :system do
   let(:organization) { create(:organization) }
   let(:show_statistics) { true }
   let!(:promoted_process) { create(:participatory_process, :promoted, organization: organization) }
+  let!(:promoted_past_process) do
+    create(
+      :participatory_process,
+      :promoted,
+      organization: organization,
+      start_date: 1.month.ago,
+      end_date: 1.week.ago
+    )
+  end
   let!(:unpromoted_process) { create(:participatory_process, organization: organization) }
   let!(:promoted_external_process) { create(:participatory_process, :promoted) }
 
@@ -20,6 +29,7 @@ describe "Highlighted Processes", type: :system do
       expect(page).to have_i18n_content(promoted_process.title)
       expect(page).to have_i18n_content(unpromoted_process.title)
       expect(page).not_to have_i18n_content(promoted_external_process.title)
+      expect(page).not_to have_i18n_content(promoted_past_process.title)
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Backport #2682 to version 0.9.x