### PR TITLE
Let admins always import proposals

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -8,11 +8,9 @@
           <%= link_to t("actions.new", scope: "decidim.proposals", name: t("models.proposal.name", scope: "decidim.proposals.admin")), new_proposal_path, class: 'button tiny button--simple' if can? :manage, current_feature %>
         <% end %>
 
-        <% if proposals.any? %>
-          <%= link_to t("actions.import", scope: "decidim.proposals", name: t("models.proposal.name", scope: "decidim.proposals.admin")), new_proposals_import_path, class: 'button tiny button--simple' if can? :manage, current_feature %>
+        <%= link_to t("actions.import", scope: "decidim.proposals", name: t("models.proposal.name", scope: "decidim.proposals.admin")), new_proposals_import_path, class: 'button tiny button--simple' if can? :manage, current_feature %>
 
-          <%= export_dropdown %>
-        <% end %>
+        <%= export_dropdown %>
       </div>
     </h2>
   </div>


### PR DESCRIPTION
#### :tophat: What? Why?
Right now only after a proposal is created they can be imported.
This is caused by the PR being moved, as it was first thought as an
"export proposals" feature, so it made no sense to export them if there
were no proposals.

#### :pushpin: Related Issues
- Related to #2619

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
No proposals present, they can be imported anyway:

![Description](https://i.imgur.com/JfmcvRq.png)
