### PR TITLE
Backport/fix user renderer regexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## Unreleased
+
+**Added**:
+
+**Changed**:
+
+**Fixed**:
+
+**decidim-core**: Fix mention rendering when there's more than one mention. [\2691](https://github.com/decidim/decidim/pull/2691)
+
 ## [v0.9.1](https://github.com/decidim/decidim/tree/v0.9.1) (2018-2-8)
 
 **Added**:

--- a/decidim-core/lib/decidim/content_renderers/user_renderer.rb
+++ b/decidim-core/lib/decidim/content_renderers/user_renderer.rb
@@ -10,7 +10,7 @@ module Decidim
     # @see BaseRenderer Examples of how to use a content renderer
     class UserRenderer < BaseRenderer
       # Matches a global id representing a Decidim::User
-      GLOBAL_ID_REGEX = %r{gid://.*/Decidim::User/\d+}
+      GLOBAL_ID_REGEX = %r{gid://\S+/Decidim::User/\d+}
 
       # Replaces found Global IDs matching an existing user with
       # a link to their profile. The Global IDs representing an

--- a/decidim-core/spec/content_renderers/decidim/user_renderer_spec.rb
+++ b/decidim-core/spec/content_renderers/decidim/user_renderer_spec.rb
@@ -16,6 +16,16 @@ module Decidim
       end
     end
 
+    context "when content has more than one Decidim::User Global ID" do
+      let(:content) { "This text contains two valid Decidim::User Global ID: #{user.to_global_id} #{user.to_global_id}" }
+
+      it "renders the two mentions" do
+        rendered = renderer.render
+        mention = %(<a class="user-mention" href="/profiles/#{user.nickname}">@#{user.nickname}</a>)
+        expect(rendered.scan(mention).length).to eq(2)
+      end
+    end
+
     context "when content has an unparsed mention" do
       let(:content) { "This text mentions a non valid user: @unvalid" }
 


### PR DESCRIPTION
#### :tophat: What? Why?
Fix the user renderer regexp (backport to `0.9-stable`).

#### :pushpin: Related Issues
- Related to #2690
- Fixes #2689

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
*None*