### PR TITLE
Extend IconHelper to support other kind of resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## Unreleased
+
+**Added**:
+
+**Changed**:
+
+**Fixed**:
+
+**decidim-core**: Fix notifications list when the resource is a User. [\#2692](https://github.com/decidim/decidim/pull/2692)
+
 ## [v0.9.1](https://github.com/decidim/decidim/tree/v0.9.1) (2018-2-8)
 
 **Added**:

--- a/decidim-core/app/helpers/decidim/icon_helper.rb
+++ b/decidim-core/app/helpers/decidim/icon_helper.rb
@@ -40,8 +40,12 @@ module Decidim
     def resource_icon(resource, options = {})
       if resource.respond_to?(:feature)
         feature_icon(resource.feature, options)
-      else
+      elsif resource.respond_to?(:manifest)
         manifest_icon(resource.manifest, options)
+      elsif resource.is_a?(Decidim::User)
+        icon "person", options
+      else
+        icon "bell", options
       end
     end
   end

--- a/decidim-core/spec/helpers/decidim/icon_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/icon_helper_spec.rb
@@ -31,6 +31,46 @@ module Decidim
           SVG
         end
       end
+
+      describe "resource_icon" do
+        let(:result) { helper.resource_icon(resource) }
+
+        context "when it has a feature" do
+          let(:resource) { build :dummy_resource }
+
+          it "renders the feature icon" do
+            expect(helper).to receive(:feature_icon).with(resource.feature, {})
+
+            result
+          end
+        end
+
+        context "when it has a manifest" do
+          let(:resource) { build(:feature, manifest_name: :dummy) }
+
+          it "renders the manifest icon" do
+            expect(helper).to receive(:manifest_icon).with(resource.manifest, {})
+
+            result
+          end
+        end
+
+        context "when it is a user" do
+          let(:resource) { build :user }
+
+          it "renders a person icon" do
+            expect(result).to include("svg#icon-person")
+          end
+        end
+
+        context "and in other cases" do
+          let(:resource) { "Something" }
+
+          it "renders a generic icon" do
+            expect(result).to include("svg#icon-bell")
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Backports #2687 to `0.9-stable`.

#### :pushpin: Related Issues
- Related to #2687

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
*None*
