### PR TITLE
Absolute threshold for proposals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Added**:
 
+- **decidim-proposals**: Proposals can accumulate more votes than the maximum [\#2693](https://github.com/decidim/decidim/pull/2693)
 - **decidim-proposals**: Added a wizard for the creation of proposals in the public site [\#2697](https://github.com/decidim/decidim/pull/2697).
 - **decidim-assemblies**: Assemblies now have a reference [\#2557](https://github.com/decidim/decidim/pull/2557)
 - **decidim-core**: Let participatory spaces have reference [\#2557](https://github.com/decidim/decidim/pull/2557)

--- a/decidim-proposals/app/commands/decidim/proposals/vote_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/vote_proposal.rb
@@ -20,7 +20,7 @@ module Decidim
       #
       # Returns nothing.
       def call
-        return broadcast(:invalid) if @proposal.maximum_votes_reached?
+        return broadcast(:invalid) if @proposal.maximum_votes_reached? && !@proposal.can_accumulate_more_than_maximum
 
         build_proposal_vote
         return broadcast(:invalid) unless vote.valid?

--- a/decidim-proposals/app/commands/decidim/proposals/vote_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/vote_proposal.rb
@@ -20,7 +20,7 @@ module Decidim
       #
       # Returns nothing.
       def call
-        return broadcast(:invalid) if @proposal.maximum_votes_reached? && !@proposal.can_accumulate_more_than_maximum
+        return broadcast(:invalid) if @proposal.maximum_votes_reached? && !@proposal.can_accumulate_supports_beyond_threshold
 
         build_proposal_vote
         return broadcast(:invalid) unless vote.valid?

--- a/decidim-proposals/app/helpers/decidim/proposals/proposal_votes_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/proposal_votes_helper.rb
@@ -57,8 +57,8 @@ module Decidim
       # Public: Checks if can accumulate more than maxium is enabled
       #
       # Returns true if enabled, false otherwise.
-      def can_accumulate_more_than_maximum?
-        feature_settings.can_accumulate_more_than_maximum
+      def can_accumulate_supports_beyond_threshold?
+        feature_settings.can_accumulate_supports_beyond_threshold
       end
 
       # Public: Checks if voting is enabled in this step.

--- a/decidim-proposals/app/helpers/decidim/proposals/proposal_votes_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/proposal_votes_helper.rb
@@ -54,6 +54,13 @@ module Decidim
         feature_settings.maximum_votes_per_proposal
       end
 
+      # Public: Checks if can accumulate more than maxium is enabled
+      #
+      # Returns true if enabled, false otherwise.
+      def can_accumulate_more_than_maximum?
+        feature_settings.can_accumulate_more_than_maximum
+      end
+
       # Public: Checks if voting is enabled in this step.
       #
       # Returns true if enabled, false otherwise.

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -117,13 +117,11 @@ module Decidim
         votes.count >= maximum_votes
       end
 
+      # Public: Can accumulate more votres than maximum for this proposal.
+      #
+      # Returns true if can accumulate, false otherwise
       def can_accumulate_more_than_maximum
         feature.settings.can_accumulate_more_than_maximum
-      end
-
-      def can_accumulate_more_than_maximum?
-        return false unless can_accumulate_more_than_maximum
-        true
       end
 
       # Checks whether the user can edit the given proposal.

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -120,8 +120,8 @@ module Decidim
       # Public: Can accumulate more votres than maximum for this proposal.
       #
       # Returns true if can accumulate, false otherwise
-      def can_accumulate_more_than_maximum
-        feature.settings.can_accumulate_more_than_maximum
+      def can_accumulate_supports_beyond_threshold
+        feature.settings.can_accumulate_supports_beyond_threshold
       end
 
       # Checks whether the user can edit the given proposal.

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -117,6 +117,15 @@ module Decidim
         votes.count >= maximum_votes
       end
 
+      def can_accumulate_more_than_maximum
+        feature.settings.can_accumulate_more_than_maximum
+      end
+
+      def can_accumulate_more_than_maximum?
+        return false unless can_accumulate_more_than_maximum
+        true
+      end
+
       # Checks whether the user can edit the given proposal.
       #
       # user - the user to check for authorship

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_vote_button.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_vote_button.html.erb
@@ -10,7 +10,7 @@
       <% if @voted_proposals ? @voted_proposals.include?(proposal.id) : proposal.voted_by?(current_user) %>
         <%= action_authorized_button_to :vote, t('.already_voted'), proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list), method: :delete, remote: true, data: { disable: true, original: t('.already_voted'), replace: t('.already_voted_hover'), "redirect-url": proposal_path(proposal) }, class: "card__button button #{vote_button_classes(from_proposals_list)} success", id: "vote_button" %>
       <% else %>
-        <% if proposal.maximum_votes_reached? && !proposal.can_accumulate_more_than_maximum %>
+        <% if proposal.maximum_votes_reached? && !proposal.can_accumulate_supports_beyond_threshold %>
           <%= content_tag :span, t('.maximum_votes_reached'), class: "card__button button #{vote_button_classes(from_proposals_list)} disabled", disabled: true %>
         <% else %>
           <% if vote_limit_enabled? && remaining_votes_count_for(current_user) == 0 %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_vote_button.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_vote_button.html.erb
@@ -10,7 +10,7 @@
       <% if @voted_proposals ? @voted_proposals.include?(proposal.id) : proposal.voted_by?(current_user) %>
         <%= action_authorized_button_to :vote, t('.already_voted'), proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list), method: :delete, remote: true, data: { disable: true, original: t('.already_voted'), replace: t('.already_voted_hover'), "redirect-url": proposal_path(proposal) }, class: "card__button button #{vote_button_classes(from_proposals_list)} success", id: "vote_button" %>
       <% else %>
-        <% if proposal.maximum_votes_reached? %>
+        <% if proposal.maximum_votes_reached? && !proposal.can_accumulate_more_than_maximum %>
           <%= content_tag :span, t('.maximum_votes_reached'), class: "card__button button #{vote_button_classes(from_proposals_list)} disabled", disabled: true %>
         <% else %>
           <% if vote_limit_enabled? && remaining_votes_count_for(current_user) == 0 %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_votes_count.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_votes_count.html.erb
@@ -1,10 +1,26 @@
 <div id="proposal-<%= proposal.id %>-votes-count" class="card__support__data">
   <% if !current_settings.votes_hidden? %>
-    <span class="<%= votes_count_classes(from_proposals_list)[:number] %>">
-      <%= proposal.proposal_votes_count %>
-    </span>
-    <span class="<%= votes_count_classes(from_proposals_list)[:label]  %>">
-      <%= t('.count', count: proposal.proposal_votes_count) %>
-    </span>
+    <% progress ||= proposal.proposal_votes_count || 0 %>
+    <% total ||= proposal.maximum_votes || 0  %>
+    <% percent = (progress.to_f/total) * 100 %>
+    <% vertical ||= from_proposals_list %>
+    <div class="progress__bar<%= (!vertical) ? ' progress__bar--vertical' : '' %>">
+      <div class="progress__bar__title">
+        <span class="progress__bar__number"><%= progress %></span>/<%= total %>
+        <span class="progress__bar__text"><%= t('.count', count: proposal.proposal_votes_count) %></span>
+      </div>
+      <div class="progress progress__bar__bar" role="progressbar" tabindex="0" aria-valuenow="<%= percent %>" aria-valuemin="0" aria-valuetext="<%= percent %> percent" aria-valuemax="100">
+        <div class="progress-meter progress__bar__bar--complete" style="width: <%= percent %>%"></div>
+        <div class="progress__bar__bar--incomplete" style="width:calc(100% - <%= percent %>%);"></div>
+      </div>
+      <div class="progress__bar__subtitle">
+        <% if progress >= total %>
+          <%= t('.most_popular_proposal') %>
+        <% else %>
+          <%= t('.need_more_votes') %>
+        <% end %>
+      </div>
+    </div>
+
   <% end %>
 </div>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_voting_rules.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_voting_rules.html.erb
@@ -1,4 +1,4 @@
-<% if votes_enabled? && (vote_limit_enabled? || maximum_votes_per_proposal_enabled? || proposal_limit_enabled?) %>
+<% if votes_enabled? && (vote_limit_enabled? || maximum_votes_per_proposal_enabled? || proposal_limit_enabled? || can_accumulate_more_than_maximum?) %>
   <div class="row column">
     <div class="callout secondary voting-rules">
       <div class="row">
@@ -15,6 +15,10 @@
 
             <% if maximum_votes_per_proposal_enabled? %>
               <li><%= t('.maximum_votes_per_proposal.description', limit: maximum_votes_per_proposal) %></li>
+            <% end %>
+
+            <% if can_accumulate_more_than_maximum? %>
+              <li><%= t('.can_accumulate_more_than_maximum.description') %></li>
             <% end %>
           </ul>
         </div>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_voting_rules.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_voting_rules.html.erb
@@ -1,4 +1,4 @@
-<% if votes_enabled? && (vote_limit_enabled? || maximum_votes_per_proposal_enabled? || proposal_limit_enabled? || can_accumulate_more_than_maximum?) %>
+can_accumulate_supports_beyond_threshold<% if votes_enabled? && (vote_limit_enabled? || maximum_votes_per_proposal_enabled? || proposal_limit_enabled? || can_accumulate_supports_beyond_threshold?) %>
   <div class="row column">
     <div class="callout secondary voting-rules">
       <div class="row">
@@ -17,8 +17,8 @@
               <li><%= t('.maximum_votes_per_proposal.description', limit: maximum_votes_per_proposal) %></li>
             <% end %>
 
-            <% if can_accumulate_more_than_maximum? %>
-              <li><%= t('.can_accumulate_more_than_maximum.description') %></li>
+            <% if can_accumulate_supports_beyond_threshold? %>
+              <li><%= t('.can_accumulate_supports_beyond_threshold.description') %></li>
             <% end %>
           </ul>
         </div>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -278,6 +278,8 @@ en:
           count:
             one: VOTE
             other: VOTES
+          most_popular_proposal: Most popular proposal
+          need_more_votes: Need more votes
         voting_rules:
           can_accumulate_more_than_maximum:
             description: Each proposal can accumulate more than maximum votes

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -59,7 +59,7 @@ en:
           global:
             announcement: Announcement
             attachments_allowed: Allow attachments
-            can_accumulate_more_than_maximum: Can accumulate more than maximum votes
+            can_accumulate_supports_beyond_threshold: Can accumulate supports beyond threshold
             comments_enabled: Comments enabled
             geocoding_enabled: Geocoding enabled
             maximum_votes_per_proposal: Maximum votes per proposal
@@ -281,7 +281,7 @@ en:
           most_popular_proposal: Most popular proposal
           need_more_votes: Need more votes
         voting_rules:
-          can_accumulate_more_than_maximum:
+          can_accumulate_supports_beyond_threshold:
             description: Each proposal can accumulate more than maximum votes
           maximum_votes_per_proposal:
             description: Each proposal can receive a maximum of %{limit} votes.

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -59,6 +59,7 @@ en:
           global:
             announcement: Announcement
             attachments_allowed: Allow attachments
+            can_accumulate_more_than_maximum: Can accumulate more than maximum votes
             comments_enabled: Comments enabled
             geocoding_enabled: Geocoding enabled
             maximum_votes_per_proposal: Maximum votes per proposal
@@ -278,6 +279,8 @@ en:
             one: VOTE
             other: VOTES
         voting_rules:
+          can_accumulate_more_than_maximum:
+            description: Each proposal can accumulate more than maximum votes
           maximum_votes_per_proposal:
             description: Each proposal can receive a maximum of %{limit} votes.
           proposal_limit:

--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -18,7 +18,7 @@ Decidim.register_feature(:proposals) do |feature|
     settings.attribute :proposal_limit, type: :integer, default: 0
     settings.attribute :proposal_edit_before_minutes, type: :integer, default: 5
     settings.attribute :maximum_votes_per_proposal, type: :integer, default: 0
-    settings.attribute :can_accumulate_more_than_maximum, type: :boolean, default: false
+    settings.attribute :can_accumulate_supports_beyond_threshold, type: :boolean, default: false
     settings.attribute :proposal_answering_enabled, type: :boolean, default: true
     settings.attribute :official_proposals_enabled, type: :boolean, default: true
     settings.attribute :comments_enabled, type: :boolean, default: true

--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -18,6 +18,7 @@ Decidim.register_feature(:proposals) do |feature|
     settings.attribute :proposal_limit, type: :integer, default: 0
     settings.attribute :proposal_edit_before_minutes, type: :integer, default: 5
     settings.attribute :maximum_votes_per_proposal, type: :integer, default: 0
+    settings.attribute :can_accumulate_more_than_maximum, type: :boolean, default: false
     settings.attribute :proposal_answering_enabled, type: :boolean, default: true
     settings.attribute :official_proposals_enabled, type: :boolean, default: true
     settings.attribute :comments_enabled, type: :boolean, default: true

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -118,6 +118,14 @@ FactoryBot.define do
         }
       end
     end
+
+    trait :with_can_accumulate_more_than_maximum do
+      settings do
+        {
+          can_accumulate_more_than_maximum: true
+        }
+      end
+    end
   end
 
   factory :proposal, class: "Decidim::Proposals::Proposal" do

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -119,10 +119,10 @@ FactoryBot.define do
       end
     end
 
-    trait :with_can_accumulate_more_than_maximum do
+    trait :with_can_accumulate_supports_beyond_threshold do
       settings do
         {
-          can_accumulate_more_than_maximum: true
+          can_accumulate_supports_beyond_threshold: true
         }
       end
     end

--- a/decidim-proposals/spec/commands/decidim/proposals/vote_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/vote_proposal_spec.rb
@@ -49,6 +49,19 @@ module Decidim
             expect { command.call }.to broadcast(:invalid)
           end
         end
+
+        context "when the maximum votes have been reached but proposal can accumulate more votes" do
+          before do
+            expect(proposal).to receive(:maximum_votes_reached?).and_return(true)
+            expect(proposal).to receive(:can_accumulate_more_than_maximum).and_return(true)
+          end
+
+          it "creates a new vote for the proposal" do
+            expect do
+              command.call
+            end.to change { ProposalVote.count }.by(1)
+          end
+        end
       end
     end
   end

--- a/decidim-proposals/spec/commands/decidim/proposals/vote_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/vote_proposal_spec.rb
@@ -53,7 +53,7 @@ module Decidim
         context "when the maximum votes have been reached but proposal can accumulate more votes" do
           before do
             expect(proposal).to receive(:maximum_votes_reached?).and_return(true)
-            expect(proposal).to receive(:can_accumulate_more_than_maximum).and_return(true)
+            expect(proposal).to receive(:can_accumulate_supports_beyond_threshold).and_return(true)
           end
 
           it "creates a new vote for the proposal" do

--- a/decidim-proposals/spec/system/vote_proposal_spec.rb
+++ b/decidim-proposals/spec/system/vote_proposal_spec.rb
@@ -92,7 +92,7 @@ describe "Vote Proposal", type: :system do
           end
 
           within "#proposal-#{proposal.id}-votes-count" do
-            expect(page).to have_content("1 VOTE")
+            expect(page).to have_content("1/0 VOTE")
           end
         end
       end
@@ -110,7 +110,7 @@ describe "Vote Proposal", type: :system do
           end
 
           within "#proposal-#{proposal.id}-votes-count" do
-            expect(page).to have_content("1 VOTE")
+            expect(page).to have_content("1/0 VOTE")
           end
         end
 
@@ -260,7 +260,7 @@ describe "Vote Proposal", type: :system do
             end
 
             it "shows the vote count but not the vote button" do
-              expect(page).to have_css(".card__support__data", text: "1 VOTE")
+              expect(page).to have_css(".card__support__data", text: "1/0 VOTE")
               expect(page).to have_content("Voting disabled")
             end
           end
@@ -319,6 +319,33 @@ describe "Vote Proposal", type: :system do
           within ".card__support", match: :first do
             click_button "Vote"
             expect(page).to have_content("Already voted")
+          end
+        end
+      end
+    end
+    context "when proposals have vote limit but can accumulate more votes" do
+      let!(:feature) do
+        create(:proposal_feature,
+               :with_votes_enabled,
+               :with_maximum_votes_per_proposal,
+               :with_can_accumulate_more_than_maximum,
+               manifest: manifest,
+               participatory_space: participatory_process)
+      end
+
+      before do
+        login_as user, scope: :user
+      end
+
+      it "allows users to vote on proposals over the limit" do
+        create(:proposal_vote, proposal: proposal)
+        visit_feature
+
+        proposal_element = page.find("article", text: proposal.reference)
+
+        within proposal_element do
+          within ".card__support", match: :first do
+            expect(page).to have_content("1/0 VOTE")
           end
         end
       end

--- a/decidim-proposals/spec/system/vote_proposal_spec.rb
+++ b/decidim-proposals/spec/system/vote_proposal_spec.rb
@@ -328,7 +328,7 @@ describe "Vote Proposal", type: :system do
         create(:proposal_feature,
                :with_votes_enabled,
                :with_maximum_votes_per_proposal,
-               :with_can_accumulate_more_than_maximum,
+               :with_can_accumulate_supports_beyond_threshold,
                manifest: manifest,
                participatory_space: participatory_process)
       end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR implements the functionality of threshold absolute for proposals. Proposals can accumulate more than de maximum votes. 

#### :pushpin: Related Issues
- Related to #2276 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add proposal can accumulate more than maximum votes
- [x] User can vote more than the maximum if can accumulate is checked
- [x] Add new design with progress_bar