### PR TITLE
Prettier markdown

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,22 @@ jobs:
       - run:
           name: Run main folder RSpec
           command: bundle exec rspec
+      - restore_cache:
+          keys:
+            - yarn-dependencies-{{ checksum "yarn.lock" }}
+      - run:
+          name: Install yarn dependencies
+          command: yarn
+      - save_cache:
+          key: yarn-dependencies-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules
+      - run:
+          name: Run es6 lint
+          command: yarn run lint
+      - run:
+          name: Run markdown lint
+          command: yarn run lint:markdown
   core:
     <<: *defaults
     steps:
@@ -222,7 +238,7 @@ jobs:
           paths:
             - node_modules
       - run:
-          name: Run main folder yarn lint & tests
+          name: Run main folder yarn tests
           command: yarn test:ci
       - restore_cache:
           keys:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -64,14 +64,6 @@ plugins:
     exclude_paths:
       - "decidim_app-design/**/*"
 
-  markdownlint:
-    enabled: true
-
-    exclude_paths:
-      - docs/*
-      - .github/*
-      - CHANGELOG.md
-
   rubocop:
     enabled: true
     channel: rubocop-0-51

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,30 +4,30 @@
 
 **Added**:
 
-- **decidim-assemblies**: Assemblies now have a reference [\#2557](https://github.com/decidim/decidim/pull/2557)
-- **decidim-core**: Let participatory spaces have reference [\#2557](https://github.com/decidim/decidim/pull/2557)
-- **decidim-meetings**: Add simple formatting to debates fields to improve readability [\#2670](https://github.com/decidim/decidim/issues/2670)
-- **decidim-meetings**: Notify participatory space followers when a meeting is created. [\#2646](https://github.com/decidim/decidim/pull/2646)
-- **decidim-participatory_processes**: Processes now have a reference [\#2557](https://github.com/decidim/decidim/pull/2557)
-- **decidim-proposals**: Notify participatory space followers when a proposal is created. [\#2646](https://github.com/decidim/decidim/pull/2646)
-- **decidim-proposals**: Copy proposals to another component [\#2619](https://github.com/decidim/decidim/issues/2619).
+* **decidim-assemblies**: Assemblies now have a reference [\#2557](https://github.com/decidim/decidim/pull/2557)
+* **decidim-core**: Let participatory spaces have reference [\#2557](https://github.com/decidim/decidim/pull/2557)
+* **decidim-meetings**: Add simple formatting to debates fields to improve readability [\#2670](https://github.com/decidim/decidim/issues/2670)
+* **decidim-meetings**: Notify participatory space followers when a meeting is created. [\#2646](https://github.com/decidim/decidim/pull/2646)
+* **decidim-participatory_processes**: Processes now have a reference [\#2557](https://github.com/decidim/decidim/pull/2557)
+* **decidim-proposals**: Notify participatory space followers when a proposal is created. [\#2646](https://github.com/decidim/decidim/pull/2646)
+* **decidim-proposals**: Copy proposals to another component [\#2619](https://github.com/decidim/decidim/issues/2619).
 
-- **decidim-participatory_processes**: Ensure only active processes are shown in the highlighted processes section in the homepage[\#2682](https://github.com/decidim/decidim/pull/2682)
+* **decidim-participatory_processes**: Ensure only active processes are shown in the highlighted processes section in the homepage[\#2682](https://github.com/decidim/decidim/pull/2682)
 
 **Changed**:
 
-- **decidim-core**: General improvements on documentation [\#2656](https://github.com/decidim/decidim/pull/2656).
-- **decidim-core**: `FeatureReferenceHelper#feature_reference` has been moved to `ResourceReferenceHelper#resource_reference` to clarify its use. [\#2557](https://github.com/decidim/decidim/pull/2557)
-- **decidim-core**: `Decidim.resource_reference_generator` has been moved to `Decidim.reference_generator` to clarify its use. [\#2557](https://github.com/decidim/decidim/pull/2557)
+* **decidim-core**: General improvements on documentation [\#2656](https://github.com/decidim/decidim/pull/2656).
+* **decidim-core**: `FeatureReferenceHelper#feature_reference` has been moved to `ResourceReferenceHelper#resource_reference` to clarify its use. [\#2557](https://github.com/decidim/decidim/pull/2557)
+* **decidim-core**: `Decidim.resource_reference_generator` has been moved to `Decidim.reference_generator` to clarify its use. [\#2557](https://github.com/decidim/decidim/pull/2557)
 
 **Fixed**:
 
-- **decidim-core**: Fix notifications list when the resource is a User. [\#2687](https://github.com/decidim/decidim/pull/2687)
-- **decidim-participatory_processes**: Fix find a process by its ID.[\#2672](https://github.com/decidim/decidim/pull/2672)
-- **decidim-assemblies**: Fix find an assembly by its ID.[\#2672](https://github.com/decidim/decidim/pull/2672)
-- **decidim-core**: Fix notification mailer when a resource doesn't have an organization. [\#2661](https://github.com/decidim/decidim/pull/2661)
-- **decidim-comments**: Fix comment notifications listing. [\#2652](https://github.com/decidim/decidim/pull/2652)
-- **decidim-participatory_processes**: Fix editing a process after an error.[\#2653](https://github.com/decidim/decidim/pull/2653)
-- **decidim-assemblies**: Fix editing a process after an error.[\#2653](https://github.com/decidim/decidim/pull/2653)
+* **decidim-core**: Fix notifications list when the resource is a User. [\#2687](https://github.com/decidim/decidim/pull/2687)
+* **decidim-participatory_processes**: Fix find a process by its ID.[\#2672](https://github.com/decidim/decidim/pull/2672)
+* **decidim-assemblies**: Fix find an assembly by its ID.[\#2672](https://github.com/decidim/decidim/pull/2672)
+* **decidim-core**: Fix notification mailer when a resource doesn't have an organization. [\#2661](https://github.com/decidim/decidim/pull/2661)
+* **decidim-comments**: Fix comment notifications listing. [\#2652](https://github.com/decidim/decidim/pull/2652)
+* **decidim-participatory_processes**: Fix editing a process after an error.[\#2653](https://github.com/decidim/decidim/pull/2653)
+* **decidim-assemblies**: Fix editing a process after an error.[\#2653](https://github.com/decidim/decidim/pull/2653)
 
 Please check [0.9-stable](https://github.com/decidim/decidim/blob/0.9-stable/CHANGELOG.md) for previous changes.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-<img src="https://cdn.rawgit.com/decidim/decidim/master/logo.svg" alt="Decidim Logo" width="400">
+# Decidim
+
+![Decidim Logo](https://cdn.rawgit.com/decidim/decidim/master/logo.svg)
 
 The participatory democracy framework.
 
@@ -37,8 +39,6 @@ Project management [[See on Waffle.io]](https://waffle.io/decidim/decidim)
 
 ---
 
-# What do you need to do?
-
 * [Get started with Decidim](#getting-started-with-decidim)
 * [Contribute to the project](#how-to-contribute)
 * [Modules](#modules)
@@ -50,9 +50,11 @@ Project management [[See on Waffle.io]](https://waffle.io/decidim/decidim)
 
 TLDR: install gem, generate a Ruby on Rails app, enjoy.
 
-```
-gem install decidim
-decidim decidim_application
+```bash
+$ gem install decidim
+// Install the decidim ruby gem.
+$ decidim decidim_application
+// Generates a new rails application using decidim.
 ```
 
 We've set up a guide on how to install, set up and upgrade Decidim. See the [Getting started guide](https://github.com/decidim/decidim/blob/master/docs/getting_started.md).
@@ -61,14 +63,13 @@ We've set up a guide on how to install, set up and upgrade Decidim. See the [Get
 
 See [Contributing](CONTRIBUTING.md).
 
-
 ### Browse Decidim
 
 After you create a development app (`bundle exec decidim decidim_application`):
 
 * `cd decidim_application`
 * `bundle exec rails s`
-* Go to 'http://localhost:3000'
+* Go to `http://localhost:3000`
 
 Optionally, you can log in as: user@example.org | decidim123456
 
@@ -80,7 +81,7 @@ After you create a development app (`bundle exec rake decidim_application`):
 
 * `cd decidim_application`
 * `bundle exec rails s`
-* Go to 'http://localhost:3000/admin'
+* Go to `http://localhost:3000/admin`
 * Login data: admin@example.org | decidim123456
 
 ## Modules
@@ -106,26 +107,27 @@ After you create a development app (`bundle exec rake decidim_application`):
 
 ### Official (on development)
 
-| Module                                                                                                    | Description                                                                                                                                                  |
-| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [Blogs](https://github.com/decidim/decidim-module-blogs)                                                  |  This component makes possible to add posts ordered by publication time to spaces.                                                                           |
-| [Consultations](https://github.com/decidim/decidim-module-consultations)                                  |  This module creates a new space for decidim to host consultations: debates around critical questions and a proxy for eVoting                                |
-| [Initiatives](https://github.com/decidim/decidim-initiatives)                                             | Initiatives is the place on Decidim's where citizens can promote a civic initiative. Unlike participatory processes that must be created by an administrator, Civic initiatives can be created by any user of the platform.                                                                                             |
-| [Sortitions](https://github.com/decidim/decidim-module-sortitions)                                        |  This component makes possible to select randomly a number of proposals among a set of proposals (or a category of proposals within a set) maximizing guarantees of randomness and avoiding manipulation of results by the administrator.                                                                                               |
+| Module                                                                   | Description                                                                                                                                                                                                                              |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Blogs](https://github.com/decidim/decidim-module-blogs)                 | This component makes possible to add posts ordered by publication time to spaces.                                                                                                                                                        |
+| [Consultations](https://github.com/decidim/decidim-module-consultations) | This module creates a new space for decidim to host consultations: debates around critical questions and a proxy for eVoting                                                                                                             |
+| [Initiatives](https://github.com/decidim/decidim-initiatives)            | Initiatives is the place on Decidim's where citizens can promote a civic initiative. Unlike participatory processes that must be created by an administrator, Civic initiatives can be created by any user of the platform.              |
+| [Sortitions](https://github.com/decidim/decidim-module-sortitions)       | This component makes possible to select randomly a number of proposals among a set of proposals (or a category of proposals within a set) maximizing guarantees of randomness and avoiding manipulation of results by the administrator. |
 
 ### Community
 
-| Module                                                                                                    | Description                                                                                                                                                  |
-| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [Census](https://github.com/diputacioBCN/decidim-diba/tree/master/decidim-census)                         | Allows to upload a census CSV file to perform authorizations against real users parameterised by their age.                                                  |
-| [Crowdfunding](https://github.com/podemos-info/decidim-module-crowdfundings)                              | This rails engine implements a Decidim feature that allows to the administrators to configure crowfunding campaigns for a participatory space.               |
-| [DataViz](https://github.com/AjuntamentdeBarcelona/decidim-barcelona/tree/master/decidim-dataviz)         | The Dataviz module adds the PAM data visualizations to any participatory process but it is intended to be used just for the PAM participatory process.       |
-| [Members](https://github.com/ElectricThings/decidim-members)                                              | Members list and search plugin for Decidim                                                                                                                   |
-| [Pol.is](https://github.com/OpenSourcePolitics/decidim-polis)                                             | Pol.is integration on Decidim                                                                                                                                |
-| [User Export](https://github.com/OpenSourcePolitics/decidim-user-export)                                  | Allow user export                                                                                                                                            |
-| [Verification DIBA Census API](https://github.com/diputacioBCN/decidim-diba/tree/master/decidim-diba_census_api)                                     | A decidim package to provice user authorizations agains the Diputació of Barcelona census API                     |
-| [Verification Podemos Census API](https://github.com/podemos-info/decidim-module-census_connector)        | A decidim package to provice user authorizations against the Podemos census API                                                                              |
-| [Votings](https://github.com/podemos-info/decidim-module-votings)                                         | An administrator can add one or more votings to a participatory process or assambly                                                                          |
+| Module                                                                                                           | Description                                                                                                                                            |
+| ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [Census](https://github.com/diputacioBCN/decidim-diba/tree/master/decidim-census)                                | Allows to upload a census CSV file to perform authorizations against real users parameterised by their age.                                            |
+| [Crowdfunding](https://github.com/podemos-info/decidim-module-crowdfundings)                                     | This rails engine implements a Decidim feature that allows to the administrators to configure crowfunding campaigns for a participatory space.         |
+| [DataViz](https://github.com/AjuntamentdeBarcelona/decidim-barcelona/tree/master/decidim-dataviz)                | The Dataviz module adds the PAM data visualizations to any participatory process but it is intended to be used just for the PAM participatory process. |
+| [Members](https://github.com/ElectricThings/decidim-members)                                                     | Members list and search plugin for Decidim                                                                                                             |
+| [Pol.is](https://github.com/OpenSourcePolitics/decidim-polis)                                                    | Pol.is integration on Decidim                                                                                                                          |
+| [User Export](https://github.com/OpenSourcePolitics/decidim-user-export)                                         | Allow user export                                                                                                                                      |
+| [Verification DIBA Census API](https://github.com/diputacioBCN/decidim-diba/tree/master/decidim-diba_census_api) | A decidim package to provice user authorizations agains the Diputació of Barcelona census API                                                          |
+| [Verification Podemos Census API](https://github.com/podemos-info/decidim-module-census_connector)               | A decidim package to provice user authorizations against the Podemos census API                                                                        |
+| [Votings](https://github.com/podemos-info/decidim-module-votings)                                                | An administrator can add one or more votings to a participatory process or assambly                                                                    |
+
 ## Following our license
 
 If you plan to release your application you'll need to publish it using the same license: GPL Affero 3. We recommend doing that on GitHub before publishing, you can read more on "[Being Open Source From Day One is Especially Important for Government Projects](http://producingoss.com/en/governments-and-open-source.html#starting-open-for-govs)". If you have any trouble you can contact us on [Gitter](https://gitter.im/decidim/decidim).

--- a/docs/advanced/content_processors.md
+++ b/docs/advanced/content_processors.md
@@ -4,11 +4,11 @@ A content processor is a concept to refer to a set of two classes: a content par
 
 The content parser class is used to process the text before it is saved to the database, and the associated renderer class is used to render the saved content.
 
-## How do I add a content processor?
+## How to add a content processor
 
 Register the content processor in an `initializer`:
 
-```
+```ruby
 Decidim.content_processors += [:special_words]
 ```
 

--- a/docs/advanced/features.md
+++ b/docs/advanced/features.md
@@ -2,7 +2,7 @@
 
 Features are the core contract between external modules and the core. They're used to define pieces of functionality that are pluggable to participatory processes and can be enabled or disabled by the administrator.
 
-## How do I create a new feature?
+## How to create a new feature
 
 Features are just gems with one or more Rails engines included in it. You can use as an example [decidim-pages](https://github.com/decidim/decidim/tree/master/decidim-pages).
 

--- a/docs/advanced/followers.md
+++ b/docs/advanced/followers.md
@@ -32,4 +32,3 @@ Decidim.feature_manifests.each do |feature_manifest|
   end
 end; p 1
 ```
-

--- a/docs/advanced/how_to_create_a_module.md
+++ b/docs/advanced/how_to_create_a_module.md
@@ -4,164 +4,163 @@
 
 1. Run the following command:
 
-    ```
-    rails plugin new decidim-<engine_name> --skip-gemfile --skip-test --skip-gemspec
-    ```
+   ```bash
+   $ rails plugin new decidim-<engine_name> --skip-gemfile --skip-test --skip-gemspec
+   # Creates a new plugin inside `decidim-<engine_name>`
+   ```
 
 1. Create a `decidim-<engine_name>.gemspec` file with this content:
 
-    ```ruby
-    # frozen_string_literal: true
+   ```ruby
+   # frozen_string_literal: true
 
-    $LOAD_PATH.push File.expand_path("lib", __dir__)
+   $LOAD_PATH.push File.expand_path("lib", __dir__)
 
-    require "decidim/<engine_name>/version"
+   require "decidim/<engine_name>/version"
 
-    Gem::Specification.new do |s|
-      s.version = Decidim::<EngineName>.version
-      s.authors = ["Your Name"]
-      s.email = ["your_eamail@example.org"]
-      s.license = "AGPL-3.0"
-      s.homepage = "https://github.com/decidim/decidim"
-      s.required_ruby_version = ">= 2.4.2"
+   Gem::Specification.new do |s|
+     s.version = Decidim::<EngineName>.version
+     s.authors = ["Your Name"]
+     s.email = ["your_eamail@example.org"]
+     s.license = "AGPL-3.0"
+     s.homepage = "https://github.com/decidim/decidim"
+     s.required_ruby_version = ">= 2.4.2"
 
-      s.name = "decidim-<engine_name>"
-      s.summary = "<engine_description>"
-      s.description = s.summary
+     s.name = "decidim-<engine_name>"
+     s.summary = "<engine_description>"
+     s.description = s.summary
 
-      s.files = Dir["{app,config,db,lib,vendor}/**/*", "Rakefile", "README.md"]
+     s.files = Dir["{app,config,db,lib,vendor}/**/*", "Rakefile", "README.md"]
 
-      s.add_dependency "decidim-core", Decidim.version
+     s.add_dependency "decidim-core", Decidim.version
 
-      s.add_development_dependency "decidim-dev", Decidim.version
-    end
-    ```
+     s.add_development_dependency "decidim-dev", Decidim.version
+   end
+   ```
 
 1. Remove `bin/test` and add an executable `bin/rails` with this content:
 
-    ```ruby
-    #!/usr/bin/env ruby
-    # frozen_string_literal: true
+   ```ruby
+   #!/usr/bin/env ruby
+   # frozen_string_literal: true
 
-    # This command will automatically be run when you run "rails" with Rails gems
-    # installed from the root of your application.
+   # This command will automatically be run when you run "rails" with Rails gems
+   # installed from the root of your application.
 
-    ENGINE_ROOT = File.expand_path("..", __dir__)
-    ENGINE_PATH = File.expand_path("../lib/decidim/<engine_name>/engine", __dir__)
+   ENGINE_ROOT = File.expand_path("..", __dir__)
+   ENGINE_PATH = File.expand_path("../lib/decidim/<engine_name>/engine", __dir__)
 
-    # Set up gems listed in the Gemfile.
-    ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
-    require "bundler/setup"
+   # Set up gems listed in the Gemfile.
+   ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __dir__)
+   require "bundler/setup"
 
-    require "rails/all"
-    require "rails/engine/commands"
-    ```
+   require "rails/all"
+   require "rails/engine/commands"
+   ```
 
 1. Replace `lib/decidim/<engine_name>.rb` with this:
 
-    ```ruby
-    # frozen_string_literal: true
+   ```ruby
+   # frozen_string_literal: true
 
-    require "decidim/<engine_name>/engine"
-    require "decidim/<engine_name>/feature"
-    ```
+   require "decidim/<engine_name>/engine"
+   require "decidim/<engine_name>/feature"
+   ```
 
 1. Remove `lib/tasks/decidim/<engine_name>_tasks.rb`.
 
 1. Add `lib/decidim/<engine_name>/engine.rb` with this:
 
-    ```ruby
-    # frozen_string_literal: true
+   ```ruby
+   # frozen_string_literal: true
 
-    require "rails"
-    require "active_support/all"
+   require "rails"
+   require "active_support/all"
 
-    require "decidim/core"
+   require "decidim/core"
 
-    module Decidim
-      module <EngineName>
-        # Decidim's <EngineName> Rails Engine.
-        class Engine < ::Rails::Engine
-          isolate_namespace Decidim::<EngineName>
+   module Decidim
+     module <EngineName>
+       # Decidim's <EngineName> Rails Engine.
+       class Engine < ::Rails::Engine
+         isolate_namespace Decidim::<EngineName>
 
-          initializer "decidim_<engine_name>.assets" do |app|
-            app.config.assets.precompile += %w(decidim_<engine_name>_manifest.js)
-          end
-        end
-      end
-    end
-    ```
+         initializer "decidim_<engine_name>.assets" do |app|
+           app.config.assets.precompile += %w(decidim_<engine_name>_manifest.js)
+         end
+       end
+     end
+   end
+   ```
 
 1. Add `lib/decidim/<engine_name>/feature.rb` with this:
 
-    ```ruby
-    # frozen_string_literal: true
+   ```ruby
+   # frozen_string_literal: true
 
-    Decidim.register_feature(:<engine_name>) do |feature|
-      feature.engine = Decidim::<EngineName>::Engine
-      feature.icon = "decidim/<engine_name>/icon.svg"
+   Decidim.register_feature(:<engine_name>) do |feature|
+     feature.engine = Decidim::<EngineName>::Engine
+     feature.icon = "decidim/<engine_name>/icon.svg"
 
-      feature.on(:before_destroy) do |instance|
-        # Code executed before removing the feature
-      end
+     feature.on(:before_destroy) do |instance|
+       # Code executed before removing the feature
+     end
 
-      # These actions permissions can be configured in the admin panel
-      feature.actions = %w()
+     # These actions permissions can be configured in the admin panel
+     feature.actions = %w()
 
-      feature.settings(:global) do |settings|
-        # Add your global settings
-        # Available types: :integer, :boolean
-        # settings.attribute :vote_limit, type: :integer, default: 0
-      end
+     feature.settings(:global) do |settings|
+       # Add your global settings
+       # Available types: :integer, :boolean
+       # settings.attribute :vote_limit, type: :integer, default: 0
+     end
 
-      feature.settings(:step) do |settings|
-        # Add your settings per step
-      end
+     feature.settings(:step) do |settings|
+       # Add your settings per step
+     end
 
-      # # Register an optional resource that can be referenced from other resources.
-      # feature.register_resource do |resource|
-      #   resource.model_class_name = "Decidim::<EngineName>::<ResourceName>"
-      #   resource.template = "decidim/<engine_name>/<resource_view_folder>/linked_<resource_name_plural>"
-      # end
+     # # Register an optional resource that can be referenced from other resources.
+     # feature.register_resource do |resource|
+     #   resource.model_class_name = "Decidim::<EngineName>::<ResourceName>"
+     #   resource.template = "decidim/<engine_name>/<resource_view_folder>/linked_<resource_name_plural>"
+     # end
 
-      feature.register_stat :some_stat do |features, start_at, end_at|
-        # Register some stat number to the application
-      end
+     feature.register_stat :some_stat do |features, start_at, end_at|
+       # Register some stat number to the application
+     end
 
-      feature.seeds do |participatory_space|
-        # Define seeds for a specific participatory_space object
-      end
-    end
-    ```
+     feature.seeds do |participatory_space|
+       # Define seeds for a specific participatory_space object
+     end
+   end
+   ```
 
 1. Replace `Rakefile` with:
 
-    ```ruby
-    # frozen_string_literal: true
+   ```ruby
+   # frozen_string_literal: true
 
-    require "decidim/common_rake"
-    ```
+   require "decidim/common_rake"
+   ```
 
 1. Remove `MIT-LICENSE` and change `README`.
 
 1. Add `spec/spec_helper.rb` with:
 
-    ```ruby
-    # frozen_string_literal: true
+   ```ruby
+   # frozen_string_literal: true
 
-    require "decidim/dev"
+   require "decidim/dev"
 
-    ENV["ENGINE_NAME"] = File.dirname(__dir__).split("/").last
+   ENV["ENGINE_NAME"] = File.dirname(__dir__).split("/").last
 
-    Decidim::Dev.dummy_app_path = File.expand_path(File.join("..", "spec", "decidim_dummy_app"))
+   Decidim::Dev.dummy_app_path = File.expand_path(File.join("..", "spec", "decidim_dummy_app"))
 
-    require "decidim/dev/test/base_spec_helper"
+   require "decidim/dev/test/base_spec_helper"
+   ```
 
-    ```
-
-1. Upload to GitHub with the naming *decidim-module-<engine_name>*, so it's easier to find on
-the [dependency graph](https://github.com/decidim/decidim/network/dependents).
-
+1. Upload to GitHub with the naming _decidim-module-<engine_name>_, so it's easier to find on
+   the [dependency graph](https://github.com/decidim/decidim/network/dependents).
 
 ## Experimental way
 

--- a/docs/advanced/managing_translations_i18n.md
+++ b/docs/advanced/managing_translations_i18n.md
@@ -4,21 +4,21 @@
 
 Decidim uses [Crowdin](https://crowdin.com/) to manage the translations.
 
-- Whenever someone [adds a new translation key](https://github.com/decidim/decidim/pull/1814/files#diff-c78c80097da59920d55b3f462ca21afaR177) to _Decidim_, _Crowdin_ gets notified and the new content is available to be translated from [Crowdin's Decidim dashboard](https://crowdin.com/project/decidim).
-- When a translator translates any key from Crowdin, it automatically creates a [PR in Github](https://github.com/decidim/decidim/pulls?utf8=%E2%9C%93&q=is%3Apr%20author%3Adecidim-bot%20Crowdin), adding the keys in the corresponding _yaml_ files.
-- 🌈
+* Whenever someone [adds a new translation key](https://github.com/decidim/decidim/pull/1814/files#diff-c78c80097da59920d55b3f462ca21afaR177) to _Decidim_, _Crowdin_ gets notified and the new content is available to be translated from [Crowdin's Decidim dashboard](https://crowdin.com/project/decidim).
+* When a translator translates any key from Crowdin, it automatically creates a [PR in Github](https://github.com/decidim/decidim/pulls?utf8=%E2%9C%93&q=is%3Apr%20author%3Adecidim-bot%20Crowdin), adding the keys in the corresponding _yaml_ files.
+* 🌈
 
 ## Adding a new language
 
-- Setup the new language in [_Crowdin's Decidim project_](https://crowdin.com/project/decidim) (or open an issue on Github asking an admin to do that).
-- Add the locale mapping in the `crowdin.yml` file
-- Translate at least one key from every engine, so, your _yaml_ files are not empty. The easiest way to do this is to automatically translate and sync all the content. Later you'll be able to fix the content that wasn't properly translated.
-- Add [Foundation Datepicker](https://github.com/najlepsiwebdesigner/foundation-datepicker/tree/master/js/locales)'s translations ([PR](https://github.com/decidim/decidim/pull/2039)).
-- Add the new language to `available_locales` ([PR](https://github.com/decidim/decidim/pull/1991)).
-- Announce the new language in the Readme ([PR](https://github.com/decidim/decidim/pull/2125)).
+* Setup the new language in [_Crowdin's Decidim project_](https://crowdin.com/project/decidim) (or open an issue on Github asking an admin to do that).
+* Add the locale mapping in the `crowdin.yml` file
+* Translate at least one key from every engine, so, your _yaml_ files are not empty. The easiest way to do this is to automatically translate and sync all the content. Later you'll be able to fix the content that wasn't properly translated.
+* Add [Foundation Datepicker](https://github.com/najlepsiwebdesigner/foundation-datepicker/tree/master/js/locales)'s translations ([PR](https://github.com/decidim/decidim/pull/2039)).
+* Add the new language to `available_locales` ([PR](https://github.com/decidim/decidim/pull/1991)).
+* Announce the new language in the Readme ([PR](https://github.com/decidim/decidim/pull/2125)).
 
 ## Test the new language
 
-- Generate the development app and `cd` into it.
-- Change the `config/initializer/decidim.rb` file and add your locale to `Decidim.available_locales`.
-- `rake db:drop db:setup` to drop, create, load schema and seed the DB.
+* Generate the development app and `cd` into it.
+* Change the `config/initializer/decidim.rb` file and add your locale to `Decidim.available_locales`.
+* `rake db:drop db:setup` to drop, create, load schema and seed the DB.

--- a/docs/advanced/migrate_to_0.8.0.md
+++ b/docs/advanced/migrate_to_0.8.0.md
@@ -1,27 +1,25 @@
 # Migration from 0.7.0 to 0.8.0
 
-## Note about this guide.
+## Note about this guide
 
 This is a work-in-progress guide for all those people that needs to adapt his existing source code from Decidim
-0.7.0 to Decidim 0.8.0. If you find a mistake or missing parts in this  document do not hesitate to make a pull request
+0.7.0 to Decidim 0.8.0. If you find a mistake or missing parts in this document do not hesitate to make a pull request
 and add your discoveries.
 
-
-## Upgrading the gem.
+## Upgrading the gem
 
 You need to alter the following files:
 
-### Gemspec file.
+### Gemspec file
 
 You must set the decidim version to 0.8.0 or higher in your gemspec.
 
 ```ruby
-...
 s.add-dependency "decidim-core", "~> 0.8.0"
-...
 ```
 
 ### Gemfile
+
 You must adjust the decidim version in your gem file as well. You also need to add the new engine 'decidim-verifications':
 
 ```ruby
@@ -30,17 +28,21 @@ gem "decidim", "~> 0.8.0"
 gem "decidim-verifications"
 ...
 ```
+
 ### bundle update
-Finally run *bundle update* to get the required gems updated.
+
+Finally run _bundle update_ to get the required gems updated.
 
 ```bash
 $ bundle update --full-index
+# Will update all gems and dependencies to the latest versions.
 ```
 
-## Updating your sources.
+## Updating your sources
 
 ### Factories
-Decidim 0.8.0 has migratied from FactoryGirl gem to FactoryBot. Cause this you need to update your factories. Usually the *factories.rb* file looks like this:
+
+Decidim 0.8.0 has migratied from FactoryGirl gem to FactoryBot. Cause this you need to update your factories. Usually the _factories.rb_ file looks like this:
 
 ```ruby
 # frozen_string_literal: true
@@ -51,7 +53,6 @@ require 'decidim/dev'
 FactoryGirl.define do
   ...
 end
-
 ```
 
 You must replace FactoryGirl by FactoryBot. After the change it should look like this:
@@ -65,16 +66,15 @@ require 'decidim/dev'
 FactoryBot.define do
   ...
 end
-
 ```
 
-### Spec tests examples.
+### Spec tests examples
 
 Some examples have changed its name to be more descriptive. In order to have your tests up and running again you must perform the following substitions in the specs folder:
 
-* *include_context "feature"* now is *include_context "with a feature"*
+* _include_context "feature"_ now is _include_context "with a feature"_
 
-* *include_context "feature admin"* now is *include_context "when managing a feature as an admin"*
+* _include_context "feature admin"_ now is _include_context "when managing a feature as an admin"_
 
 ### Capybara
 
@@ -91,15 +91,17 @@ where the dialog was supposed to be accepted:
 accept_confirm { click_button "Submit" }
 ```
 
-## Steps to do after migrating your source code.
+## Steps to do after migrating your source code
 
-### Adapting code for an existing engine:
+### Adapting code for an existing engine
 
 You must remove the external test app and regenerate it:
 
 ```bash
 $ rm -Rf spec/decidim_dummy_app
+# Erases the dummy app.
 $ bundle exec rails decidim:generate_external_test_app
+# Generates a new test app, applying the migrations from scratch.
 ```
 
 After regenerating the test app you should recreate the test database as well:
@@ -107,23 +109,25 @@ After regenerating the test app you should recreate the test database as well:
 ```bash
 $ cd spec/decidim_dummy_app
 $ bundle exec rails db:drop
-$ bundle exec rails db:create
-$ bundle exec rails db:migrate
-$ bundle exec rails db:migrate RAILS_ENV=test
-$ bundle exec rails db:seed
+# Drops the current databases
+$ bundle exec rails db:setup
+# Re-creates the databases and seeds them.
 ```
-### Adapting code for an existing Decidim implementation.
+
+### Adapting code for an existing Decidim implementation
 
 After updating the decidim gems you should import the new migrations and execute them:
 
 ```bash
-$ rails decidim:upgraded
+$ rails decidim:upgrade
+# Copies the latest migrations
 $ rails db:migrate
+# Applies the latest migrations
 ```
 
 Additionally you should change the way uglifier is used in your app:
 
-Edit the file *config/environments/production.rb* and make the following changes:
+Edit the file _config/environments/production.rb_ and make the following changes:
 
 ```ruby
 # Original value
@@ -132,6 +136,7 @@ Edit the file *config/environments/production.rb* and make the following changes
 # Enable ES6 support
 config.assets.js_compressor = Uglifier.new(harmony: true)
 ```
-# To sum it up.
+
+## To sum it up
 
 Take a cold beer and enjoy democracy.

--- a/docs/advanced/migrate_to_0.8.0.md
+++ b/docs/advanced/migrate_to_0.8.0.md
@@ -31,7 +31,7 @@ gem "decidim-verifications"
 
 ### bundle update
 
-Finally run _bundle update_ to get the required gems updated.
+Finally run `bundle update` to get the required gems updated.
 
 ```bash
 $ bundle update --full-index
@@ -42,7 +42,7 @@ $ bundle update --full-index
 
 ### Factories
 
-Decidim 0.8.0 has migratied from FactoryGirl gem to FactoryBot. Cause this you need to update your factories. Usually the _factories.rb_ file looks like this:
+Decidim 0.8.0 has migratied from FactoryGirl gem to FactoryBot. Cause this you need to update your factories. Usually the `factories.rb` file looks like this:
 
 ```ruby
 # frozen_string_literal: true
@@ -72,9 +72,9 @@ end
 
 Some examples have changed its name to be more descriptive. In order to have your tests up and running again you must perform the following substitions in the specs folder:
 
-* _include_context "feature"_ now is _include_context "with a feature"_
+* `include_context "feature"` now is `include_context "with a feature"`
 
-* _include_context "feature admin"_ now is _include_context "when managing a feature as an admin"_
+* `include_context "feature admin"` now is `include_context "when managing a feature as an admin"`
 
 ### Capybara
 

--- a/docs/advanced/tradeoffs.md
+++ b/docs/advanced/tradeoffs.md
@@ -11,4 +11,3 @@ Decidim doesn't support `turbolinks` so it isn't included on our generated apps 
 The main reason is we are injecting some scripts into the body for some individual pages and Turbolinks loads the scripts in parallel. For some libraries like [leaflet](http://leafletjs.com/) it's very inconvenient because its plugins extend an existing global object.
 
 The support of Turbolinks was dropped in [d8c7d9f](https://github.com/decidim/decidim/commit/d8c7d9f63e4d75307e8f7a0360bef977fab209b6). If you're interested in bringing turbolinks back, further discussion is welcome.
-

--- a/docs/advanced/view_hooks.md
+++ b/docs/advanced/view_hooks.md
@@ -6,7 +6,7 @@ All engines can define their own view hooks, and register to other engines' ones
 
 Take the homepage, for example. It is rendered by the `decidim-core`. We want to show there a list of highlighted participatory spaces (processes and assemblies). We cannot be sure the final app has these engines, so we need to check they exist:
 
-```
+```erb
 <% if defined? Decidim::Processes %>
   <% # iterate through the most important ones %>
 <% end %>
@@ -24,7 +24,7 @@ This raises two important issues:
 
 Instead of the previous example, we created the concept of "view hooks". Think of them as a registry of views which can be defined by a given engine and extended by others. To follow the previous example, we would register a view hook in `decidim-core`:
 
-```
+```erb
 <%= Decidim.view_hooks.render(:highlighted_elements, self) %>
 ```
 
@@ -69,6 +69,6 @@ end
 
 Ideally, each engine should hold their own instance of `Decidim::ViewHooks`. This means that if `decidim-participatory_processes` wants to allow part of its views to be extended by other engines, it should define `Decidim::ParticipatoryProcesses.view_hooks`, and other engines should register to this instance.
 
-## The engine I want to extend does not support view hooks, what can I do?
+## The engine I want to extend does not support view hooks - what to do
 
-First of all, send a PR to the engine to add the view hook you need. Expose your needs, so the developers can assess a view hook is the best solution. Sometimes a view hook can be replaced with another abstraction, or another UI. Meanwhile, you can use [`deface`](https://github.com/spree/deface) to extend a view file without replacing it. Be careful, since `deface` is *very* powerful and can be a double-edged sword. We considered adding `deface` to `decidim`, but found that it opened to a code that would be much harder to maintain.
+First of all, send a PR to the engine to add the view hook you need. Expose your needs, so the developers can assess a view hook is the best solution. Sometimes a view hook can be replaced with another abstraction, or another UI. Meanwhile, you can use [`deface`](https://github.com/spree/deface) to extend a view file without replacing it. Be careful, since `deface` is _very_ powerful and can be a double-edged sword. We considered adding `deface` to `decidim`, but found that it opened to a code that would be much harder to maintain.

--- a/docs/customization/code.md
+++ b/docs/customization/code.md
@@ -7,8 +7,9 @@ Decidim is multiple things:
 
 Most of the time, you should work with the generated application. That application (development_app on this docs) should be named as your project, for instance for Barcelona City Council is `DecidimBarcelona`, so for creating it should be:
 
-```
-decidim DecidimBarcelona
+```bash
+$ decidim decidim_barcelona
+# Creates a news application inside a `decidim_barcelona/` folder.
 ```
 
 If you want to override/change anything (for instance the homepage), you can just do it with the same name of the file, through Monkey Patching.
@@ -16,12 +17,14 @@ If you want to override/change anything (for instance the homepage), you can jus
 If you want to extend Decidim, the prefered way should be by having a Module. This is a Ruby on Rails Engine which provides ruby code (models, views, controllers, assets, etc). You can use it through multiple ways:
 
 * Putting it on the same directory as your app and pointing on the Gemfile. [See example on GitHub](https://github.com/AjuntamentdeBarcelona/decidim-barcelona/tree/c210b5338d7ba1338c9879627e081da1441f1946). For instance:
-```
+
+```ruby
 gem "decidim-debates", path: "decidim-debates"
 ```
 
 * Publishing on a git reposotory and pointing in on the Gemfile. For instance:
-```
+
+```ruby
 gem "decidim-consultations", git: "https://github.com/decidim/decidim-module-consultations"
 ```
 

--- a/docs/customization/gemfile.md
+++ b/docs/customization/gemfile.md
@@ -1,8 +1,8 @@
 # Gemfile
 
-You can add and change your Gemfile as you want, this is a classic Ruby on Rails application. For example to add[ rails-footnotes](https://github.com/josevalim/rails-footnotes) gem you would just add:
+You can add and change your Gemfile as you want, this is a classic Ruby on Rails application. For example to add [rails-footnotes](https://github.com/josevalim/rails-footnotes) gem you would just add:
 
-```
+```ruby
 gem 'rails-footnotes', '~> 4.0'
 ```
 

--- a/docs/customization/javascript.md
+++ b/docs/customization/javascript.md
@@ -2,8 +2,8 @@
 
 If you want to add some custom Javascript code, just add it to app/assets/javascripts/application.js. For example to create a new alert just add:
 
-```
-$(function(){
-  alert('foobar');
+```javascript
+$(function() {
+  alert("foobar");
 });
 ```

--- a/docs/customization/styles.md
+++ b/docs/customization/styles.md
@@ -6,10 +6,11 @@ We use [SASS, with SCSS syntax](http://sass-lang.com/guide) as CSS preprocessor.
 
 Also you can check your scss files syntax with
 
-```
-scss-lint
+```bash
+$ scss-lint
+# Will show a report of scss code violations.
 ```
 
 ## **Accesibility**
 
-To maintain accesibility level, if you add new colors use a[ Color contrast checker](http://webaim.org/resources/contrastchecker/) (WCAG AA is mandatory, WCAG AAA is recommended)
+To maintain accesibility level, if you add new colors use a [Color contrast checker](http://webaim.org/resources/contrastchecker/) (WCAG AA is mandatory, WCAG AAA is recommended)

--- a/docs/customization/texts.md
+++ b/docs/customization/texts.md
@@ -2,7 +2,7 @@
 
 You can change most of the texts through the Administration panel.
 
-If you want to change a given text that isn’t on the Administration panel, and belongs on Decidim code, you should first find out which key is being used. For instance, we want to change the home page text where it says "Let's build a more open, transparent and collaborative society.", we would search the text (using [github](https://github.com/decidim/decidim/search?utf8=%E2%9C%93&q=%22Let%27s+build+a+more+open%2C+transparent+and+collaborative+society.%22&type= ) or grep) and then I’d extract that key and their parents. On this case it’d be:
+If you want to change a given text that isn’t on the Administration panel, and belongs on Decidim code, you should first find out which key is being used. For instance, we want to change the home page text where it says "Let's build a more open, transparent and collaborative society.", we would search the text (using [github](https://github.com/decidim/decidim/search?utf8=%E2%9C%93&q=%22Let%27s+build+a+more+open%2C+transparent+and+collaborative+society.%22&type=) or grep) and then I’d extract that key and their parents. On this case it’d be:
 
 ```yml
 en:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,6 +1,6 @@
 # Getting started with Decidim
 
-## What is and what isn't Decidim?
+## What is and what isn't Decidim
 
 Decidim is a set of Ruby on Rails engines to create a participatory democracy framework on top of a Ruby on Rails app. This system allows having Decidim code separated from custom code for each installation and still enabling easy updates.
 
@@ -12,11 +12,11 @@ If you want to start your own installation of Decidim, you don't need to clone t
 
 ### A. Using installation script [experimental]
 
-> *Please note that this is **experimental***
+> \*Please note that this is **experimental\***
 
 We've made an script for Ubuntu 16.04 LTS and macos sierra 10.2. It's a BETA and as such you should be aware that this could break your environment (if you have any). It'll install rbenv, postgresql, nodejs and install decidim on this directory. It should take 15 minutes depending on your network connection.
 
-```
+```bash
 wget http://get.decidim.org -O install_decidim.bash
 bash install_decidim.bash
 ```
@@ -25,28 +25,27 @@ Read more about the [installation script](https://github.com/alabs/decidim-insta
 
 ### B. Using Docker [experimental]
 
-> *Please note that this is **experimental***
+> \*Please note that this is **experimental\***
 
 Make sure you [have Docker v17 at least](https://docs.docker.com/engine/installation/). `cd` to your preferred folder and run this command:
 
-```
+```bash
 docker run --rm -v $(pwd):/tmp codegram/decidim bash -c "bundle exec decidim /tmp/decidim_application"
 ```
 
 This will create a `decidim_application` Ruby on Rails app using Decidim in the current folder. It will install the latest released version of the gem.
 
-
 ### C. Step by step
 
 First of all, you need to install the `decidim` gem:
 
-```
+```bash
 gem install decidim
 ```
 
 afterwards, you can create an application with the nice `decidim` executable:
 
-```
+```bash
 decidim decidim_application
 cd decidim_application
 bundle install
@@ -57,8 +56,9 @@ rails server
 
 You should now setup your database:
 
-```
+```bash
 $ bin/rails db:create db:migrate db:seed
+# Creates the database and example data.
 ```
 
 This will also create some default data so you can start testing the app:
@@ -67,12 +67,21 @@ This will also create some default data so you can start testing the app:
 * A `Decidim::Organization` named `Decidim Staging`. You probably want to change its name and hostname to match your needs.
 * A `Decidim::User` acting as an admin for the organization, with email `admin@example.org` and password `decidim123456`.
 * A `Decidim::User` that also belongs to the organization but it's a regular user, with email `user@example.org` and password `decidim123456`.
-This data won't be created in production environments, if you still want to do it, run: ``` $ SEED=true rails db:setup ```
+  This data won't be created in production environments, if you still want to do it, run: `$ SEED=true rails db:setup`
 
 You can now start your server!
 
-```
+```bash
 $ bin/rails s
+=> Booting Puma
+=> Rails 5.1.4 application starting in development
+=> Run `rails server -h` for more startup options
+Puma starting in single mode...
+* Version 3.11.2 (ruby 2.5.0-p0), codename: Love Song
+* Min threads: 0, max threads: 16
+* Environment: development
+* Listening on tcp://localhost:3000
+Use Ctrl-C to stop
 ```
 
 Visit [http://localhost:3000](http://localhost:3000) to see your app running.
@@ -83,9 +92,9 @@ Decidim comes pre-configured with some safe defaults, but can be changed through
 
 We also have other guides on how to configure some extra features:
 
-- [Social providers integration](https://github.com/decidim/decidim/blob/master/docs/services/social_providers.md): Enable sign up from social networks.
-- [Analytics](https://github.com/decidim/decidim/blob/master/docs/services/analytics.md): How to enable analytics
-- [Geocoding](https://github.com/decidim/decidim/blob/master/docs/services/geocoding.md): How to enable geocoding for proposals and meetings
+* [Social providers integration](https://github.com/decidim/decidim/blob/master/docs/services/social_providers.md): Enable sign up from social networks.
+* [Analytics](https://github.com/decidim/decidim/blob/master/docs/services/analytics.md): How to enable analytics
+* [Geocoding](https://github.com/decidim/decidim/blob/master/docs/services/geocoding.md): How to enable geocoding for proposals and meetings
 
 ## Deploy
 
@@ -108,8 +117,9 @@ You can check the [`decidim-system` README file](https://github.com/decidim/deci
 
 If you want, you can create seed data in production. Run this command in your production console:
 
-```
+```bash
 $ SEED=true rails db:seed
+# Creates example data on production. Dangerous!
 ```
 
 You'll need to login as system user and edit the host for the organization. Set it to you production host, without the protocol and the port (so if your host is `https://my.host:3001`, you need to write `my.host`).
@@ -118,22 +128,26 @@ You'll need to login as system user and edit the host for the organization. Set 
 
 We keep releasing new versions of Decidim. In order to get the latest one, update your dependencies:
 
-```
+```bash
 $ bundle update decidim
+# Updates all dependencies. You should do that to be sure to get the latest bugfixes & security fixes.
 ```
 
 And make sure you get all the latest migrations:
 
-```
+```bash
 $ bin/rails decidim:upgrade
+# Copies new migrations.
 $ bin/rails db:migrate
+# Applies the migrations to the database and updates the schema.
 ```
 
 You can also make sure new translations are complete for all languages in your
 application with:
 
-```
+```bash
 $ bin/rails decidim:check_locales
+# Makes sure locales are present in all languages.
 ```
 
 Be aware that this task might not be able to detect everything, so make sure you

--- a/docs/services/analytics.md
+++ b/docs/services/analytics.md
@@ -6,7 +6,7 @@ Adding analytics is quite easy. We've set up a partial in place for that. Just c
 
 Here's an example for Piwik:
 
-```
+```html
 <script type="text/javascript">
   var _paq = _paq || [];
   // tracker methods like "setCustomDimension" should be called before "trackPageView"

--- a/docs/services/social_providers.md
+++ b/docs/services/social_providers.md
@@ -5,37 +5,37 @@ If you want to enable sign up through social providers like Facebook you will ne
 ## Facebook
 
 1. Navigate to [Facebook Developers Page](https://developers.facebook.com/)
-2. Follow the "Add a New App" link.
-3. Click the "Website" option.
-4. Fill in your application name and click "Create New Facebook App ID" button.
-5. Fill in the contact email info and category.
-6. Validate the captcha.
-7. Ignore the source code and fill in the URL field.
-8. Navigate to the application dashboard and copy the APP_ID and APP_SECRET
-9. Paste credentials in `config/secrets.yml`. Ensure the `enabled` attribute is `true`.
+1. Follow the "Add a New App" link.
+1. Click the "Website" option.
+1. Fill in your application name and click "Create New Facebook App ID" button.
+1. Fill in the contact email info and category.
+1. Validate the captcha.
+1. Ignore the source code and fill in the URL field.
+1. Navigate to the application dashboard and copy the APP_ID and APP_SECRET
+1. Paste credentials in `config/secrets.yml`. Ensure the `enabled` attribute is `true`.
 
 ## Twitter
 
 1. Navigate to [Twitter Developers Page](https://dev.twitter.com/)
-2. Follow the "My apps" link.
-3. Click the "Create New App" button.
-4. Fill in the `Name`, `Description` fields.
-5. Fill in the `Website` and `Callback URL` fields with the same value. If you are working on a development app you need to use `http://127.0.0.1:3000/` instead of `http://localhost:3000/`.
-6. Check the 'Developer Agreement' checkbox and click the 'Create your Twitter application' button.
-7. Navigate to the "Keys and Access Tokens" tab and copy the API_KEY and API_SECRET.
-8. (Optional) Navigate to the "Permissions" tab and check the "Request email addresses from users" checkbox.
-9. Paste credentials in `config/secrets.yml`. Ensure the `enabled` attribute is `true`.
+1. Follow the "My apps" link.
+1. Click the "Create New App" button.
+1. Fill in the `Name`, `Description` fields.
+1. Fill in the `Website` and `Callback URL` fields with the same value. If you are working on a development app you need to use `http://1.1.0.0.1.1.00/` instead of `http://localhost:1.00/`.
+1. Check the 'Developer Agreement' checkbox and click the 'Create your Twitter application' button.
+1. Navigate to the "Keys and Access Tokens" tab and copy the API_KEY and API_SECRET.
+1. (Optional) Navigate to the "Permissions" tab and check the "Request email addresses from users" checkbox.
+1. Paste credentials in `config/secrets.yml`. Ensure the `enabled` attribute is `true`.
 
 ## Google
 
 1. Navigate to [Google Developers Page](https://console.developers.google.com)
-2. Follow the 'Create projecte' link.
-3. Fill in the name of your app.
-4. Navigate to the projecte dashboard and click on "Enable API"
-5. Click on `Google+ API` and then "Enable"
-6. Navigate to the project credentials page and click on `OAuth consent screen`.
-7. Fill in the `Product name` field
-8. Click on `Credentials` tab and click on "Create credentials" button. Select `OAuth client ID`.
-9. Select `Web applications`. Fill in the `Authorized Javascript origins` with your url. Then fill in the `Authorized redirect URIs` with your url and append the path `/users/auth/google_oauth2/callback`.
-10. Copy the CLIENT_ID AND CLIENT_SECRET
-11. Paste credentials in `config/secrets.yml`. Ensure the `enabled` attribute is `true`.
+1. Follow the 'Create projecte' link.
+1. Fill in the name of your app.
+1. Navigate to the projecte dashboard and click on "Enable API"
+1. Click on `Google+ API` and then "Enable"
+1. Navigate to the project credentials page and click on `OAuth consent screen`.
+1. Fill in the `Product name` field
+1. Click on `Credentials` tab and click on "Create credentials" button. Select `OAuth client ID`.
+1. Select `Web applications`. Fill in the `Authorized Javascript origins` with your url. Then fill in the `Authorized redirect URIs` with your url and append the path `/users/auth/google_oauth1.callback`.
+1. Copy the CLIENT_ID AND CLIENT_SECRET
+1. Paste credentials in `config/secrets.yml`. Ensure the `enabled` attribute is `true`.

--- a/docs/services/social_providers.md
+++ b/docs/services/social_providers.md
@@ -21,8 +21,8 @@ If you want to enable sign up through social providers like Facebook you will ne
 3. Click the "Create New App" button.
 4. Fill in the `Name`, `Description` fields.
 5. Fill in the `Website` and `Callback URL` fields with the same value. If you are working on a development app you need to use `http://127.0.0.1:3000/` instead of `http://localhost:3000/`.
-5. Check the 'Developer Agreement' checkbox and click the 'Create your Twitter application' button.
-6. Navigate to the "Keys and Access Tokens" tab and copy the API_KEY and API_SECRET.
+6. Check the 'Developer Agreement' checkbox and click the 'Create your Twitter application' button.
+7. Navigate to the "Keys and Access Tokens" tab and copy the API_KEY and API_SECRET.
 8. (Optional) Navigate to the "Permissions" tab and check the "Request email addresses from users" checkbox.
 9. Paste credentials in `config/secrets.yml`. Ensure the `enabled` attribute is `true`.
 

--- a/package.json
+++ b/package.json
@@ -15,25 +15,29 @@
   "scripts": {
     "build": "webpack --env.dev",
     "build:prod": "NODE_ENV=production webpack -p --env.prod",
-    "start": "webpack --env.dev --watch --progress --color --display-error-details",
+    "start":
+      "webpack --env.dev --watch --progress --color --display-error-details",
     "prelint": "tslint decidim-*/**/*.ts decidim-*/**/*.tsx",
     "lint": "eslint -c .eslintrc.json --ext .js,.js.es6,.jsx .",
+    "postlint": "prettier *.md doc/**/*.md --list-different",
     "test": "jest",
     "test:watch": "yarn test -- --watch",
-    "test:ci": "yarn run lint && yarn test",
-    "graphql:download_schema": "apollo-codegen download-schema http://${DECIDIM_HOST:-localhost:3000}/api --output schema.json",
+    "test:ci": "yarn test",
+    "graphql:download_schema":
+      "apollo-codegen download-schema http://${DECIDIM_HOST:-localhost:3000}/api --output schema.json",
     "pregraphql:generate_schema_types": "yarn run graphql:download_schema",
-    "graphql:generate_schema_types": "apollo-codegen generate decidim-comments/**/*.graphql --schema schema.json --target typescript --output decidim-comments/app/frontend/support/schema.ts"
+    "graphql:generate_schema_types":
+      "apollo-codegen generate decidim-comments/**/*.graphql --schema schema.json --target typescript --output decidim-comments/app/frontend/support/schema.ts"
   },
   "stylelint": {
     "rules": {
-      "at-rule-empty-line-before": [ "always", {
-        "except": [
-          "blockless-after-same-name-blockless",
-          "first-nested"
-        ],
-        "ignore": ["after-comment"]
-      } ],
+      "at-rule-empty-line-before": [
+        "always",
+        {
+          "except": ["blockless-after-same-name-blockless", "first-nested"],
+          "ignore": ["after-comment"]
+        }
+      ],
       "at-rule-name-case": "lower",
       "at-rule-semicolon-newline-after": "always",
       "block-closing-brace-empty-line-before": "never",
@@ -47,27 +51,30 @@
       "color-hex-case": "lower",
       "color-hex-length": "short",
       "color-no-invalid-hex": true,
-      "comment-empty-line-before": [ "always", {
-        "except": ["first-nested"],
-        "ignore": ["stylelint-commands"]
-      } ],
+      "comment-empty-line-before": [
+        "always",
+        {
+          "except": ["first-nested"],
+          "ignore": ["stylelint-commands"]
+        }
+      ],
       "comment-no-empty": true,
       "comment-whitespace-inside": "always",
-      "custom-property-empty-line-before": [ "always", {
-        "except": [
-          "after-custom-property",
-          "first-nested"
-        ],
-        "ignore": [
-          "after-comment",
-          "inside-single-line-block"
-        ]
-      } ],
+      "custom-property-empty-line-before": [
+        "always",
+        {
+          "except": ["after-custom-property", "first-nested"],
+          "ignore": ["after-comment", "inside-single-line-block"]
+        }
+      ],
       "declaration-bang-space-after": "never",
       "declaration-bang-space-before": "always",
-      "declaration-block-no-duplicate-properties": [ true, {
-        "ignore": ["consecutive-duplicates-with-different-values"]
-      } ],
+      "declaration-block-no-duplicate-properties": [
+        true,
+        {
+          "ignore": ["consecutive-duplicates-with-different-values"]
+        }
+      ],
       "declaration-block-no-redundant-longhand-properties": true,
       "declaration-block-no-shorthand-property-overrides": true,
       "declaration-block-semicolon-newline-after": "always-multi-line",
@@ -78,16 +85,13 @@
       "declaration-colon-newline-after": "always-multi-line",
       "declaration-colon-space-after": "always-single-line",
       "declaration-colon-space-before": "never",
-      "declaration-empty-line-before": [ "always", {
-        "except": [
-          "after-declaration",
-          "first-nested"
-        ],
-        "ignore": [
-          "after-comment",
-          "inside-single-line-block"
-        ]
-      } ],
+      "declaration-empty-line-before": [
+        "always",
+        {
+          "except": ["after-declaration", "first-nested"],
+          "ignore": ["after-comment", "inside-single-line-block"]
+        }
+      ],
       "function-calc-no-unspaced-operator": true,
       "function-comma-newline-after": "always-multi-line",
       "function-comma-space-after": "always-single-line",
@@ -121,10 +125,13 @@
       "number-no-trailing-zeros": true,
       "property-case": "lower",
       "property-no-unknown": true,
-      "rule-empty-line-before": [ "always-multi-line", {
-        "except": ["first-nested"],
-        "ignore": ["after-comment"]
-      } ],
+      "rule-empty-line-before": [
+        "always-multi-line",
+        {
+          "except": ["first-nested"],
+          "ignore": ["after-comment"]
+        }
+      ],
       "selector-attribute-brackets-space-inside": "never",
       "selector-attribute-operator-space-after": "never",
       "selector-attribute-operator-space-before": "never",
@@ -185,6 +192,7 @@
     "faker": "^4.1.0",
     "jest": "^21.2.1",
     "json-loader": "~0.5.7",
+    "prettier": "^1.10.2",
     "progress-bar-webpack-plugin": "^1.10.0",
     "raf": "^3.4.0",
     "source-map-loader": "^0.2.3",
@@ -222,15 +230,12 @@
       "raf/polyfill",
       "<rootDir>/decidim-comments/app/frontend/entry_test.ts"
     ],
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js"
-    ],
+    "moduleFileExtensions": ["ts", "tsx", "js"],
     "transform": {
       "^.+\\.(ts|tsx)$": "typescript-babel-jest",
       "\\.yml$": "yaml-jest",
-      "\\.(gql|graphql)$": "<rootDir>/decidim-comments/app/frontend/support/graphql_transformer.js",
+      "\\.(gql|graphql)$":
+        "<rootDir>/decidim-comments/app/frontend/support/graphql_transformer.js",
       ".*": "babel-jest"
     },
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4730,6 +4730,10 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.10.2.tgz#1af8356d1842276a99a5b5529c82dd9e9ad3cc93"
+
 pretty-format@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-21.2.1.tgz#ae5407f3cf21066cd011aa1ba5fce7b6a2eddb36"


### PR DESCRIPTION
#### :tophat: What? Why?
This prettifies our markdown files using `prettier`, which is a de-facto standard, instead of using ruby's `mdl` (supported by codeclimate but way older and less strict).

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*
