### PR TITLE
Build using the latest docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,9 @@ version: 2
 
 defaults: &defaults
   docker:
-    # This is the sha of the latest `decidim/decidim:latest-dev` docker image. You can retrieve the
+    # This is the sha of the latest `decidim/decidim:latest-test` docker image. You can retrieve the
     # latest digest by doing `$ docker pull decidim/decidim:latest-dev`.
-    - image: decidim/decidim@sha256:a5fb460b462338ea018ef3ad30c8910f1ed7203a776d410603b9fc79ba3856ce
+    - image: decidim/decidim@sha256:348fb1faa49cfe76ba7cbeafc67ca09002cf95f0ffa7a76eefa9d5b3774e0ee9
       environment:
         BUNDLE_GEMFILE: /app/Gemfile
         SIMPLECOV: true


### PR DESCRIPTION
#### :tophat: What? Why?
Build using the latest docker image to ensure we're using the latest chrome version, as well as potentially other updated dependencies.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*