### PR TITLE
Allow dev & test DB configuration

### DIFF
--- a/lib/generators/decidim/templates/database.yml.erb
+++ b/lib/generators/decidim/templates/database.yml.erb
@@ -28,7 +28,7 @@ default: &default
 
 development:
   <<: *default
-  database: <%%= ENV.fetch("DATABASE_NAME") { "<%= app_name %>_development" } %>
+  database: <%%= ENV.fetch("DEV_DATABASE_NAME") { "<%= app_name %>_development" } %>
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -62,7 +62,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: <%%= ENV.fetch("DATABASE_NAME") { "<%= app_name %>_test" } %>
+  database: <%%= ENV.fetch("TEST_DATABASE_NAME") { "<%= app_name %>_test" } %>
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is


### PR DESCRIPTION
#### :tophat: What? Why?
With the current setup, one can configure a custome DB name, but the same name will be used for both the test & development databases. That seems unuseful and error-prone unless I'm missing something.

I changed the environment variables to have different names. These environment variables are useful when working on both core and external plugins, so that the DB's don't clash with each other.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.