### PR TITLE
Rubocop fixes

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -78,7 +78,6 @@ plugins:
 
   rubocop:
     enabled: true
-    channel: rubocop-0-51
 
   stylelint:
     enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1257,27 +1257,7 @@ Rails/HasManyOrHasOneDependent:
     - "**/*/app/models/**/*.rb"
 
 Metrics/BlockLength:
-  Exclude:
-    - 'decidim-admin/app/controllers/decidim/admin/concerns/has_attachments.rb'
-    - 'decidim-admin/app/controllers/decidim/admin/concerns/has_attachment_collections.rb'
-    - 'decidim-*/lib/**/*engine.rb'
-    - 'decidim-api/lib/decidim/api/schema.rb'
-    - 'decidim-core/config/initializers/devise.rb'
-    - 'decidim-core/lib/decidim/core/api/translated_field_type.rb'
-    - 'decidim-core/lib/decidim/resourceable.rb'
-    - 'decidim-comments/lib/decidim/comments/api/comment_type.rb'
-    - 'decidim-*/app/controllers/concerns/**/*'
-    - 'decidim-*/**/routes.rb'
-    - 'decidim-*/db/migrate/*.rb'
-    - 'decidim-*/**/*/types/**/*'
-    - 'decidim-*/lib/**/*/test/**/*'
-    - 'decidim-*/lib/**/*/feature.rb'
-    - 'decidim-*/lib/**/*/participatory_space.rb'
-    - '**/spec/**/*_spec.rb'
-    - '**/spec/shared/**.rb'
-    - '**/spec/**/*_examples.rb'
-    - '**/*.gemspec'
-    - '**/abilities/**/*_ability.rb'
+  Enabled: false
 
 RSpec/BeforeAfterAll:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,9 +3,9 @@ require: rubocop-rspec
 # Common configuration.
 AllCops:
   Exclude:
-    - '**/vendor/**/*'
-    - 'development_app/**/*'
-    - 'spec/decidim_dummy_app/**/*'
+    - "**/vendor/**/*"
+    - "development_app/**/*"
+    - "spec/decidim_dummy_app/**/*"
   # Default formatter will be used if no -f/--format option is given.
   DefaultFormatter: progress
   # Cop names are not displayed in offense messages by default. Change behavior
@@ -78,14 +78,14 @@ Layout/AlignHash:
   # Alignment of entries using hash rocket as separator. Valid values are:
   #
   # key - left alignment of keys
-  #   'a' => 2
-  #   'bb' => 3
+  #   "a" => 2
+  #   "bb" => 3
   # separator - alignment of hash rockets, keys are right aligned
-  #    'a' => 2
-  #   'bb' => 3
+  #    "a" => 2
+  #   "bb" => 3
   # table - left alignment of keys, hash rockets, and values
-  #   'a'  => 2
-  #   'bb' => 3
+  #   "a"  => 2
+  #   "bb" => 3
   EnforcedHashRocketStyle: key
   # Alignment of entries using colon as separator. Valid values are:
   #
@@ -311,11 +311,11 @@ Style/CollectionMethods:
   #   PreferredMethods:
   #     find: detect
   PreferredMethods:
-    collect: 'map'
-    collect!: 'map!'
-    inject: 'reduce'
-    detect: 'find'
-    find_all: 'select'
+    collect: "map"
+    collect!: "map!"
+    inject: "reduce"
+    detect: "find"
+    find_all: "select"
 
 # Use ` or %x around command literals.
 Style/CommandLiteral:
@@ -369,11 +369,11 @@ Style/ConditionalAssignment:
 # Style/Copyright:
 #   Enabled: true
 #   Notice: 'Copyright (\(c\) )?2015 Yahoo! Inc'
-#   AutocorrectNotice: '# Copyright (c) 2015 Yahoo! Inc.'
+#   AutocorrectNotice: "# Copyright (c) 2015 Yahoo! Inc."
 #
 Style/Copyright:
   Notice: '^Copyright (\(c\) )?2[0-9]{3} .+'
-  AutocorrectNotice: ''
+  AutocorrectNotice: ""
 
 Style/DocumentationMethod:
   RequireForNonPublicMethods: false
@@ -608,7 +608,7 @@ Style/LambdaCall:
 Style/Next:
   # With `always` all conditions at the end of an iteration needs to be
   # replaced by next - with `skip_modifier_ifs` the modifier if like this one
-  # are ignored: [1, 2].each { |a| return 'yes' if a == 1 }
+  # are ignored: [1, 2].each { |a| return "yes" if a == 1 }
   EnforcedStyle: skip_modifier_ifs
   # `MinBodyLength` defines the number of lines of the a body of an if / unless
   # needs to have to trigger this cop
@@ -752,15 +752,15 @@ Style/ParenthesesAroundCondition:
 
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
-    '%':  ()
-    '%i': ()
-    '%q': ()
-    '%Q': ()
-    '%r': '{}'
-    '%s': ()
-    '%w': ()
-    '%W': ()
-    '%x': ()
+    "%":  ()
+    "%i": ()
+    "%q": ()
+    "%Q": ()
+    "%r": "{}"
+    "%s": ()
+    "%w": ()
+    "%W": ()
+    "%x": ()
 
 Style/PercentQLiterals:
   EnforcedStyle: lower_case_q
@@ -785,8 +785,8 @@ Naming/PredicateName:
   # Exclude Rspec specs because there is a strong convetion to write spec
   # helpers in the form of `have_something` or `be_something`.
   Exclude:
-    - '**/spec/**/*'
-    - '**/test/**/*'
+    - "**/spec/**/*"
+    - "**/test/**/*"
 
 Style/PreferredHashMethods:
   Enabled: true
@@ -928,7 +928,7 @@ Layout/SpaceInsideHashLiteralBraces:
   SupportedStyles:
     - space
     - no_space
-    # 'compact' normally requires a space inside hash braces, with the exception
+    # "compact" normally requires a space inside hash braces, with the exception
     # that successive left braces or right braces are collapsed together
     - compact
 
@@ -1039,7 +1039,7 @@ Style/WordArray:
   SupportedStyles:
     # percent style: %w(word1 word2)
     - percent
-    # bracket style: ['word1', 'word2']
+    # bracket style: ["word1", "word2"]
     - brackets
   # The MinSize option causes the WordArray rule to be ignored for arrays
   # smaller than a certain size.  The rule is only applied to arrays
@@ -1092,7 +1092,7 @@ Metrics/ParameterLists:
   Max: 5
   CountKeywordArgs: true
   Exclude:
-    - 'decidim-core/lib/decidim/filter_form_builder.rb'
+    - "decidim-core/lib/decidim/filter_form_builder.rb"
 
 Metrics/PerceivedComplexity:
   Max: 10
@@ -1170,7 +1170,7 @@ Rails/ActionFilter:
     - action
     - filter
   Include:
-    - '*/app/controllers/**/*.rb'
+    - "*/app/controllers/**/*.rb"
 
 Rails/Date:
   # The value `strict` disallows usage of `Date.today`, `Date.current`,
@@ -1185,21 +1185,21 @@ Rails/Date:
 
 Rails/Exit:
   Include:
-    - '*/app/**/*.rb'
+    - "*/app/**/*.rb"
     - config/**/*.rb
     - lib/**/*.rb
 
 Rails/FindBy:
   Include:
-    - '*/app/models/**/*.rb'
+    - "*/app/models/**/*.rb"
 
 Rails/FindEach:
   Include:
-    - '*/app/models/**/*.rb'
+    - "*/app/models/**/*.rb"
 
 Rails/HasAndBelongsToMany:
   Include:
-    - '*/app/models/**/*.rb'
+    - "*/app/models/**/*.rb"
 
 Rails/NotNullColumn:
   Include:
@@ -1207,7 +1207,7 @@ Rails/NotNullColumn:
 
 Rails/Output:
   Include:
-    - '*/app/**/*.rb'
+    - "*/app/**/*.rb"
     - config/**/*.rb
     - db/**/*.rb
     - lib/**/*.rb
@@ -1217,7 +1217,7 @@ Rails/OutputSafety:
 
 Rails/ReadWriteAttribute:
   Include:
-    - '*/app/models/**/*.rb'
+    - "*/app/models/**/*.rb"
 
 Rails/RequestReferer:
   EnforcedStyle: referer
@@ -1234,7 +1234,7 @@ Rails/SafeNavigation:
 
 Rails/ScopeArgs:
   Include:
-    - '*/app/models/**/*.rb'
+    - "*/app/models/**/*.rb"
 
 Rails/TimeZone:
   # The value `strict` means that `Time` should be used with `zone`.
@@ -1250,7 +1250,7 @@ Rails/UniqBeforePluck:
 
 Rails/Validation:
   Include:
-    - '*/app/models/**/*.rb'
+    - "*/app/models/**/*.rb"
 
 Rails/HasManyOrHasOneDependent:
   Include:

--- a/decidim-core/lib/decidim/participable.rb
+++ b/decidim-core/lib/decidim/participable.rb
@@ -7,7 +7,6 @@ module Decidim
   module Participable
     extend ActiveSupport::Concern
 
-    # rubocop:disable Metrics/BlockLength
     included do
       def demodulized_name
         self.class.name.demodulize
@@ -66,7 +65,6 @@ module Decidim
         self.class.participatory_space_manifest
       end
     end
-    # rubocop:enable Metrics/BlockLength
 
     class_methods do
       def slug_format


### PR DESCRIPTION
#### :tophat: What? Why?

I propose to disable the `Metrics/BlockLength` rule because we are continuously violating it and just adding exceptions to it. I say let's just keep an eye on increasing complexity in this regard manually. I also updated the rubocop version used in codeclimate and some other consistency changes.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.