### PR TITLE
Fix meeting update and creation when its participatory space has a scope without subscopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 **Fixed**:
 
+* **decidim-meetings**: Fix meeting update and creation when its participatory space has a scope without subscopes. [\#2720](https://github.com/decidim/decidim/pull/2720)
+
 ## [v0.9.2](https://github.com/decidim/decidim/tree/v0.9.2) (2018-2-9)
 
 **Fixed**:

--- a/decidim-meetings/spec/forms/admin/meeting_form_spec.rb
+++ b/decidim-meetings/spec/forms/admin/meeting_form_spec.rb
@@ -170,10 +170,25 @@ module Decidim::Meetings
       context "when the participatory space has a scope" do
         let(:parent_scope) { create(:scope, organization: organization) }
         let(:participatory_process) { create(:participatory_process, organization: organization, scope: parent_scope) }
-        let(:scope) { create(:scope, organization: organization, parent: parent_scope) }
 
         context "when the scope is descendant from participatory space scope" do
+          let(:scope) { create(:scope, organization: organization, parent: parent_scope) }
+
           it { is_expected.to eq(scope) }
+
+          it "makes the form valid" do
+            expect(form).to be_valid
+          end
+        end
+
+        context "when the scope is the same scope of the participatory space scope" do
+          let(:scope) { parent_scope }
+
+          it { is_expected.to eq(scope) }
+
+          it "makes the form valid" do
+            expect(form).to be_valid
+          end
         end
 
         context "when the scope is not descendant from participatory space scope" do


### PR DESCRIPTION
#### :tophat: What? Why?
This fixes meetings when trying to be update in processes with a single scope. Before this patch, only descendants of a scope are allowed, but not the *scope* itself which is implicit when there's no subscopes.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*