### PR TITLE
[Design] Fix admin logs with longer dates

### DIFF
--- a/decidim-admin/app/assets/stylesheets/decidim/admin/extra/_logs.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/extra/_logs.scss
@@ -24,15 +24,18 @@ ul.logs{
   }
 
   .logs__log__date{
+    font-family: $font-family-monospace;
+    font-size: 14px;
+    margin-top: 2px;
     color: $muted;
     text-align: right;
     padding-right: rem-calc(10);
-    flex-grow: 4.5;
+    flex-grow: 5;
     flex-basis: 1px;
   }
 
   .logs__log__explanation{
-    flex-grow: 34.5;
+    flex-grow: 34;
     flex-basis: 1px;
 
     span,
@@ -88,14 +91,14 @@ ul.logs{
 
   .logs__log__diff-title{
     padding-right: rem-calc(10);
-    flex-grow: 4.5;
+    flex-grow: 5;
     font-weight: 600;
     text-align: right;
     flex-basis: 1px;
   }
 
   .logs__log__diff-value{
-    flex-grow: 35.5;
+    flex-grow: 35;
     flex-basis: 1px;
   }
 

--- a/decidim-admin/app/assets/stylesheets/decidim/admin/extra/_logs.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/extra/_logs.scss
@@ -27,12 +27,12 @@ ul.logs{
     color: $muted;
     text-align: right;
     padding-right: rem-calc(10);
-    flex-grow: 2;
+    flex-grow: 4.5;
     flex-basis: 1px;
   }
 
   .logs__log__explanation{
-    flex-grow: 17;
+    flex-grow: 34.5;
     flex-basis: 1px;
 
     span,
@@ -88,14 +88,14 @@ ul.logs{
 
   .logs__log__diff-title{
     padding-right: rem-calc(10);
-    flex-grow: 1;
+    flex-grow: 4.5;
     font-weight: 600;
     text-align: right;
     flex-basis: 1px;
   }
 
   .logs__log__diff-value{
-    flex-grow: 9;
+    flex-grow: 35.5;
     flex-basis: 1px;
   }
 

--- a/decidim_app-design/app/views/admin/partials/_logs_list.html.erb
+++ b/decidim_app-design/app/views/admin/partials/_logs_list.html.erb
@@ -7,7 +7,7 @@
       <% 5.times do |index| %>
         <li class="logs__log">
           <div class="logs__log__content">
-            <div class="logs__log__date">10/10/18 08:24</div>
+            <div class="logs__log__date">10/10/2018 08:24</div>
             <div class="logs__log__explanation">
               <a class="logs__log__author has-tip" data-tooltip aria-hashpopup="true" data-disable-hover="false" title="@mmills">Matthew Mills </a>
               created
@@ -22,7 +22,7 @@
 
         <li class="logs__log logs__log--deletion">
           <div class="logs__log__content">
-            <div class="logs__log__date">10/10/18 08:24</div>
+            <div class="logs__log__date">10/10/2018 08:24</div>
             <div class="logs__log__explanation">
               <a class="logs__log__author has-tip" data-tooltip aria-hashpopup="true" data-disable-hover="false" title="@mmills">Matthew Mills </a>
               deleted
@@ -37,7 +37,7 @@
 
         <li class="logs__log" id="log-<%= (index + 1) * 3 %>" data-toggler=".logs__log--expanded">
           <div class="logs__log__content">
-            <div class="logs__log__date">10/10/18 08:24</div>
+            <div class="logs__log__date">10/10/2018 08:24</div>
             <div class="logs__log__explanation">
               <a class="logs__log__author has-tip" data-tooltip aria-hashpopup="true" data-disable-hover="false" title="@mmills">Matthew Mills </a>
               updated


### PR DESCRIPTION
#### :tophat: What? Why?
Builds on top of #2715. 

In reality, dates are longer than what the design suggested, so in order to keep the consistency everywhere I adapted the design to fix with the current dates format.

#### :pushpin: Related Issues
- Related to #2715

### :camera: Screenshots (optional)
Before:
![Description](https://i.imgur.com/yJe0wN8.png)

After:
![](https://i.imgur.com/bg60vLc.png)