### PR TITLE
Fix categories select when missing translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 **Fixed**:
 
+- **decidim-core**: Fix categories select when missing translations. [\#2742](https://github.com/decidim/decidim/pull/2742)
 - **decidim-core**: Fix notifications list when the resource is a User. [\#2687](https://github.com/decidim/decidim/pull/2687)
 - **decidim-core**: Fix mention rendering when there's more than one mention. [\2690](https://github.com/decidim/decidim/pull/2690)
 - **decidim-participatory_processes**: Fix find a process by its ID.[\#2672](https://github.com/decidim/decidim/pull/2672)

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -7,6 +7,7 @@ module Decidim
   # following the conventions set on `Decidim::TranslatableAttributes`.
   class FormBuilder < FoundationRailsHelper::FormBuilder
     include ActionView::Context
+    include Decidim::TranslatableAttributes
 
     # Public: generates a check boxes input from a collection and adds help
     # text and errors.
@@ -436,18 +437,18 @@ module Decidim
 
     def categories_for_select(scope)
       sorted_main_categories = scope.first_class.includes(:subcategories).sort_by do |category|
-        category.name[I18n.locale.to_s]
+        translated_attribute(category.name, category.participatory_space.organization)
       end
 
       sorted_main_categories.flat_map do |category|
-        parent = [[category.name[I18n.locale.to_s], category.id]]
+        parent = [[translated_attribute(category.name, category.participatory_space.organization), category.id]]
 
         sorted_subcategories = category.subcategories.sort_by do |subcategory|
-          subcategory.name[I18n.locale.to_s]
+          translated_attribute(subcategory.name, subcategory.participatory_space.organization)
         end
 
         sorted_subcategories.each do |subcategory|
-          parent << ["- #{subcategory.name[I18n.locale.to_s]}", subcategory.id]
+          parent << ["- #{translated_attribute(subcategory.name, subcategory.participatory_space.organization)}", subcategory.id]
         end
 
         parent

--- a/decidim-core/lib/decidim/translatable_attributes.rb
+++ b/decidim-core/lib/decidim/translatable_attributes.rb
@@ -56,15 +56,18 @@ module Decidim
       # attribute - A Hash where keys (strings) are locales, and their values are
       #             the translation for each locale.
       #
+      # organization - An optional Organization to get the default locale from.
+      #
       # Returns a String with the translation.
-      def translated_attribute(attribute)
+      def translated_attribute(attribute, organization = nil)
         return "" if attribute.nil?
         return attribute unless attribute.is_a?(Hash)
 
-        current_organization_locale = try(:current_organization).try(:default_locale)
+        organization ||= try(:current_organization)
+        organization_locale = organization.try(:default_locale)
 
         attribute[I18n.locale.to_s].presence ||
-          attribute[current_organization_locale].presence ||
+          attribute[organization_locale].presence ||
           attribute[attribute.keys.first].presence ||
           ""
       end

--- a/decidim-core/spec/helpers/decidim/translations_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/translations_helper_spec.rb
@@ -41,6 +41,18 @@ module Decidim
           end
         end
       end
+
+      context "when given an organization" do
+        let(:other_organization) { double(default_locale: "ca") }
+
+        it "uses the given organization default locale" do
+          attribute = { "ca" => "Hola", "en" => "Hello" }
+
+          I18n.with_locale(:'zh-CN') do
+            expect(helper.translated_attribute(attribute, other_organization)).to eq("Hola")
+          end
+        end
+      end
     end
 
     describe "#multi_translation" do

--- a/decidim-core/spec/lib/form_builder_spec.rb
+++ b/decidim-core/spec/lib/form_builder_spec.rb
@@ -183,6 +183,22 @@ module Decidim
         expect(subject.css("option")[3].text).to eq("- #{subcategory.name["en"]}")
       end
 
+      context "when a category doesn't have the translation in the current locale" do
+        before do
+          I18n.locale = "zh"
+          create(:category, name: { "en" => "Subcategory 2", "zh" => "Something" }, parent: category, participatory_space: feature.participatory_space)
+        end
+
+        after do
+          I18n.locale = "en"
+        end
+
+        it "uses the organization's default locale" do
+          expect(subject.css("option")[0].text).to eq(other_category.name["en"])
+          expect(subject.css("option")[1].text).to eq(category.name["en"])
+        end
+      end
+
       context "when given a prompt" do
         let(:options) { { prompt: "Select something" } }
 


### PR DESCRIPTION
#### :tophat: What? Why?

When a category is missing a translation in the current locales the app is causing a crash.

Example: https://meta.decidim.barcelona/processes/roadmap/f/219/?locale=en

This should be backported to 0.9

#### :pushpin: Related Issues
- Fixes https://sentry.io/share/issue/df64c7de7cf84b42b3b3124d4256b105/

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry