### PR TITLE
Don't try to send notification emails to deleted users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 **Fixed**:
 
+- **decidim-core**: Don't try to send notification emails to deleted users. [\#2743](https://github.com/decidim/decidim/pull/2743)
 - **decidim-core**: Fix notifications list when the resource is a User. [\#2687](https://github.com/decidim/decidim/pull/2687)
 - **decidim-core**: Fix mention rendering when there's more than one mention. [\2690](https://github.com/decidim/decidim/pull/2690)
 - **decidim-participatory_processes**: Fix find a process by its ID.[\#2672](https://github.com/decidim/decidim/pull/2672)

--- a/decidim-core/app/mailers/decidim/notification_mailer.rb
+++ b/decidim-core/app/mailers/decidim/notification_mailer.rb
@@ -7,6 +7,8 @@ module Decidim
     helper Decidim::ResourceHelper
 
     def event_received(event, event_class_name, resource, user, extra)
+      return unless user.email
+
       with_user(user) do
         @organization = user.organization
         event_class = event_class_name.constantize

--- a/decidim-core/spec/mailers/notification_mailer_spec.rb
+++ b/decidim-core/spec/mailers/notification_mailer_spec.rb
@@ -43,6 +43,16 @@ module Decidim
       it "includes the resource url" do
         expect(mail.body).to include(event_instance.resource_url)
       end
+
+      context "when the user doesn't have an email" do
+        before do
+          user.update_attributes(email: nil)
+        end
+
+        it "does nothing" do
+          expect(mail.deliver_now).to be_nil
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

A deleted User doesn't have an email so we shouldn't try to send an email to them.

Should be backported to 0.9

#### :pushpin: Related Issues
- Fixes https://sentry.io/share/issue/2c283714953146ff925748624dd26cb0/

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
