### PR TITLE
[FIX] Translation missing for withdraw in admin/feature permissions.

### DIFF
--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -53,6 +53,7 @@ en:
           create: Create
           endorse: Endorse
           vote: Vote
+          withdraw: Withdraw
         name: Proposals
         settings:
           global:

--- a/decidim-proposals/spec/shared/manage_proposals_permissions_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_permissions_examples.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+shared_examples "manage proposals permissions" do
+  context "when authorization handler is Everyone" do
+    before do
+      feature = proposal.feature
+      visit ::Decidim::EngineRouter.admin_proxy(feature.participatory_space).edit_feature_permissions_path(feature.id)
+    end
+    it "is possible to select Example authorization handler" do
+      within ".card.withdraw-permission" do
+        expect(page).to have_content("Withdraw")
+        find("#feature_permissions_permissions_withdraw_authorization_handler_name").first("option").click
+      end
+      find("*[type=submit]").click
+
+      expect(page).to have_admin_callout("successfully")
+    end
+  end
+end

--- a/decidim-proposals/spec/system/admin_manages_proposals_spec.rb
+++ b/decidim-proposals/spec/system/admin_manages_proposals_spec.rb
@@ -18,4 +18,5 @@ describe "Admin manages proposals", type: :system do
   it_behaves_like "manage announcements"
   it_behaves_like "manage proposals help texts"
   it_behaves_like "import proposals"
+  it_behaves_like "manage proposals permissions"
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Add missing translation.

#### :pushpin: Related Issues
- Fixes #2732 
