### PR TITLE
Don't render notifications if the resource has been deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 **Fixed**:
 
+- **decidim-core**: Don't render notifications if the resource has been deleted. [\#2746](https://github.com/decidim/decidim/pull/2746)
 - **decidim-core**: Fix categories select when missing translations. [\#2742](https://github.com/decidim/decidim/pull/2742)
 - **decidim-core**: Don't try to send notification emails to deleted users. [\#2743](https://github.com/decidim/decidim/pull/2743)
 - **decidim-core**: Fix notifications list when the resource is a User. [\#2687](https://github.com/decidim/decidim/pull/2687)

--- a/decidim-core/app/views/decidim/notifications/_notification.html.erb
+++ b/decidim-core/app/views/decidim/notifications/_notification.html.erb
@@ -1,18 +1,20 @@
-<div class="card--list__item">
-  <div class="card--list__text">
-    <%= link_to notification.event_class_instance.resource_path do %>
-      <%= resource_icon notification.resource, class: "icon--chat card--list__icon" %>
-    <% end %>
-    <div>
-      <h5 class="card--list__heading">
-        <%= notification.event_class_instance.notification_title %>
-      </h5>
-      <span class="text-small"><%= l notification.created_at.to_date, format: :long %></span>
+<% if notification.resource %>
+  <div class="card--list__item">
+    <div class="card--list__text">
+      <%= link_to notification.event_class_instance.resource_path do %>
+        <%= resource_icon notification.resource, class: "icon--chat card--list__icon" %>
+      <% end %>
+      <div>
+        <h5 class="card--list__heading">
+          <%= notification.event_class_instance.notification_title %>
+        </h5>
+        <span class="text-small"><%= l notification.created_at.to_date, format: :long %></span>
+      </div>
+    </div>
+    <div class="card--list__data">
+      <%= link_to notification, class: "mark-as-read-button card--list__data__icon", remote: true, method: :delete do %>
+        <%= icon "check", class: "icon icon--chevron-right" %>
+      <% end %>
     </div>
   </div>
-  <div class="card--list__data">
-    <%= link_to notification, class: "mark-as-read-button card--list__data__icon", remote: true, method: :delete do %>
-      <%= icon "check", class: "icon icon--chevron-right" %>
-    <% end %>
-  </div>
-</div>
+<% end %>

--- a/decidim-core/spec/system/notifications_spec.rb
+++ b/decidim-core/spec/system/notifications_spec.rb
@@ -22,7 +22,26 @@ describe "Notifications", type: :system do
     it "has a button on the topbar nav that links to the notifications page" do
       within ".topbar__user__logged" do
         find("a.topbar__notifications").click
+      end
+
+      expect(page).to have_current_path decidim.notifications_path
+      expect(page).to have_no_content("No notifications yet")
+      expect(page).to have_content("An event occured")
+    end
+
+    context "when the resource has been deleted" do
+      before do
+        resource.destroy!
+        page.visit decidim.root_path
+      end
+
+      it "displays nothing" do
+        within ".topbar__user__logged" do
+          find("a.topbar__notifications").click
+        end
+
         expect(page).to have_current_path decidim.notifications_path
+        expect(page).to have_content("No notifications yet")
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

When a resource from a notification has been deleted the app is crashing. We can't use `join` since `resource` is polymorphic so we need to check before rendering.

Should be backported to 0.9

#### :pushpin: Related Issues
- Fixes https://sentry.io/share/issue/fd527456c0804853934ffa3ffa42a0ed/

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
