### PR TITLE
[Backport] Add context to content parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 **Added**:
 
+**decidim-core**: Add context to content parsers [\#2751](https://github.com/decidim/decidim/pull/2751)
+
 **Changed**:
 
 **Fixed**:

--- a/decidim-comments/app/commands/decidim/comments/create_comment.rb
+++ b/decidim-comments/app/commands/decidim/comments/create_comment.rb
@@ -35,7 +35,7 @@ module Decidim
       attr_reader :form
 
       def create_comment
-        parsed = Decidim::ContentProcessor.parse(form.body)
+        parsed = Decidim::ContentProcessor.parse(form.body, {})
 
         @comment = Comment.create!(author: @author,
                                    commentable: @commentable,

--- a/decidim-comments/spec/commands/create_comment_spec.rb
+++ b/decidim-comments/spec/commands/create_comment_spec.rb
@@ -117,6 +117,7 @@ module Decidim
 
           context "and comment contains a user mention" do
             let(:mentioned_user) { create(:user, organization: organization) }
+            let(:parser_context) { {} }
             let(:body) { ::Faker::Lorem.paragraph + " @#{mentioned_user.nickname}" }
 
             it "creates a new comment with user mention replaced" do
@@ -124,7 +125,7 @@ module Decidim
                 author: author,
                 commentable: commentable,
                 root_commentable: commentable,
-                body: Decidim::ContentProcessor.parse(body).rewrite,
+                body: Decidim::ContentProcessor.parse(body, parser_context).rewrite,
                 alignment: alignment,
                 decidim_user_group_id: user_group_id
               ).and_call_original

--- a/decidim-core/lib/decidim/content_parsers/base_parser.rb
+++ b/decidim-core/lib/decidim/content_parsers/base_parser.rb
@@ -5,7 +5,7 @@ module Decidim
     # Abstract base class for content parsers, so they have the same contract
     #
     # @example How to use a content parser class
-    #   parser = Decidim::ContentParsers::CustomParser.new(content)
+    #   parser = Decidim::ContentParsers::CustomParser.new(content, context)
     #   parser.rewrite # returns the content rewritten
     #   parser.metadata # returns a Metadata object
     #
@@ -17,11 +17,16 @@ module Decidim
       # @return [String] the content to be rewritten
       attr_reader :content
 
+      # @return [Hash] with context information
+      attr_reader :context
+
       # Gets initialized with the `content` to parse
       #
       # @param content [String] already rewritten content or regular content
-      def initialize(content)
+      # @param context [Hash] arbitrary information to have a context
+      def initialize(content, context)
         @content = content || ""
+        @context = context
       end
 
       # Parse the `content` and return it modified

--- a/decidim-core/lib/decidim/content_processor.rb
+++ b/decidim-core/lib/decidim/content_processor.rb
@@ -22,7 +22,7 @@ module Decidim
   # declare the other side making it "transparent" (declaring the class and leaving it empty).
   #
   # @example How to parse a content
-  #   parsed = Decidim::ContentProcessor.parse(content)
+  #   parsed = Decidim::ContentProcessor.parse(content, context)
   #   parsed.rewrite # contains rewritten content
   #   parsed.metadata # contains the merged metadata of all parsers
   #
@@ -42,10 +42,13 @@ module Decidim
     # This calls all registered processors one after the other and collects the
     # metadata for each one and the resulting modified content
     #
+    # @param content [String] already rewritten content or regular content
+    # @param context [Hash] with information to inject to the parsers as context
+    #
     # @return [Result] a Result object with the content rewritten and the metadata
-    def self.parse(content)
+    def self.parse(content, context)
       parsed = Decidim.content_processors.each_with_object(rewrite: content, metadata: {}) do |type, result|
-        parser = parser_klass(type).constantize.new(result[:rewrite])
+        parser = parser_klass(type).constantize.new(result[:rewrite], context)
         result[:rewrite] = parser.rewrite
         result[:metadata][type] = parser.metadata
       end

--- a/decidim-core/spec/content_parsers/decidim/user_parser_spec.rb
+++ b/decidim-core/spec/content_parsers/decidim/user_parser_spec.rb
@@ -5,7 +5,8 @@ require "spec_helper"
 module Decidim
   describe ContentParsers::UserParser do
     let(:user) { create(:user, :confirmed) }
-    let(:parser) { described_class.new(content) }
+    let(:context) { {} }
+    let(:parser) { described_class.new(content, context) }
 
     context "when mentioning a valid user" do
       let(:content) { "This text contains a valid user mention: @#{user.nickname}" }

--- a/decidim-core/spec/lib/content_processor_spec.rb
+++ b/decidim-core/spec/lib/content_processor_spec.rb
@@ -8,10 +8,11 @@ module Decidim
       allow(Decidim).to receive(:content_processors).and_return([:dummy_foo, :dummy_bar])
     end
 
+    let(:context) { {} }
     let(:processor) { ContentProcessor }
 
     describe "#parse" do
-      subject { processor.parse("This text contains foo and bar and another foo") }
+      subject { processor.parse("This text contains foo and bar and another foo", context) }
 
       it "executes all registered parsers" do
         expect(subject.rewrite).to eq("This text contains *lorem* and *ipsum* and another *lorem*")

--- a/docs/content_processors.md
+++ b/docs/content_processors.md
@@ -41,7 +41,7 @@ end
 ## How to use the content parser class
 
 ```rb
-parser = Decidim::ContentParsers::SpecialWordsParser.new(content)
+parser = Decidim::ContentParsers::SpecialWordsParser.new(content, {})
 parser.rewrite # returns the content rewritten
 parser.metadata # returns a Metadata object
 ```


### PR DESCRIPTION
#### :tophat: What? Why?

We need to pass extra information to content parsers, so they can know the context where they are running. (e.g. to scope a query to the current organization).

We need this into `0.9-stable` to fix the issue with mentions parser not scoping to the current organization.

#### :pushpin: Related Issues

- Related to https://github.com/decidim/decidim/issues/2748

#### :pushpin: Related PR

- Backport off https://github.com/decidim/decidim/pull/2749
- Related to https://github.com/decidim/decidim/pull/2710, https://github.com/decidim/decidim/pull/2711

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
