### PR TITLE
Fix DefaultActionAuthorizer when options is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 **Fixed**:
 
+- **decidim-core**: Fix DefaultActionAuthorizer when options is nil [\#2753](https://github.com/decidim/decidim/pull/2753)
 - **decidim-core**: Don't render notifications if the resource has been deleted. [\#2746](https://github.com/decidim/decidim/pull/2746)
 - **decidim-core**: Fix categories select when missing translations. [\#2742](https://github.com/decidim/decidim/pull/2742)
 - **decidim-core**: Don't try to send notification emails to deleted users. [\#2743](https://github.com/decidim/decidim/pull/2743)

--- a/decidim-verifications/lib/decidim/verifications/default_action_authorizer.rb
+++ b/decidim-verifications/lib/decidim/verifications/default_action_authorizer.rb
@@ -11,7 +11,7 @@ module Decidim
       #
       def initialize(authorization, options)
         @authorization = authorization
-        @options = options.deep_dup # options hash is cloned to allow changes applied to it without risks
+        @options = options.deep_dup || {} # options hash is cloned to allow changes applied to it without risks
       end
 
       #


### PR DESCRIPTION
#### :tophat: What? Why?

I can't seem to find a way to add a regression test for this.

#### :pushpin: Related Issues
- Fixes https://sentry.io/share/issue/6186537079b14d678c4aa63e78fc0af0/

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
