### PR TITLE
Show logs diff on resource creation

### DIFF
--- a/decidim-core/app/presenters/decidim/log/base_presenter.rb
+++ b/decidim-core/app/presenters/decidim/log/base_presenter.rb
@@ -134,7 +134,11 @@ module Decidim
       #
       # Returns an object that responds to `present` and `visible?`.
       def diff_presenter
-        @diff_presenter ||= Decidim::Log::DiffPresenter.new(changeset, view_helpers)
+        @diff_presenter ||= Decidim::Log::DiffPresenter.new(
+          changeset,
+          view_helpers,
+          show_previous_value?: action.to_s != "create"
+        )
       end
 
       # Private: Presents the diff of the log, if needed
@@ -188,7 +192,7 @@ module Decidim
       #
       # Returns a Boolean.
       def has_diff?
-        action == "update" && version.present?
+        %w(update create).include?(action.to_s) && version.present?
       end
 
       # Private: Sets a default list of attributes to be rendered in

--- a/decidim-core/app/presenters/decidim/log/diff_presenter.rb
+++ b/decidim-core/app/presenters/decidim/log/diff_presenter.rb
@@ -44,9 +44,7 @@ module Decidim
         h.content_tag(:div, class: "logs__log__diff") do
           changeset.each do |attribute|
             h.concat(present_new_value(attribute[:label], attribute[:new_value], attribute[:type]))
-            if options[:show_previous_value?]
-              h.concat(present_previous_value(attribute[:previous_value], attribute[:type]))
-            end
+            h.concat(present_previous_value(attribute[:previous_value], attribute[:type])) if options[:show_previous_value?]
           end
         end
       end

--- a/decidim-core/app/presenters/decidim/log/diff_presenter.rb
+++ b/decidim-core/app/presenters/decidim/log/diff_presenter.rb
@@ -15,9 +15,11 @@ module Decidim
       # changeset - An array of hashes
       # view_helpers - An object holding the view helpers at the render time.
       #   Most probably should come automatically from the views.
-      def initialize(changeset, view_helpers)
+      # options - a Hash with options
+      def initialize(changeset, view_helpers, options = {})
         @changeset = changeset
         @view_helpers = view_helpers
+        @options = { show_previous_value?: true }.merge(options)
       end
 
       # Public: Renders the given diff.
@@ -29,7 +31,7 @@ module Decidim
 
       private
 
-      attr_reader :changeset, :view_helpers
+      attr_reader :changeset, :view_helpers, :options
       alias h view_helpers
 
       # Private: Presents the diff for this action. If the resource and the
@@ -42,7 +44,9 @@ module Decidim
         h.content_tag(:div, class: "logs__log__diff") do
           changeset.each do |attribute|
             h.concat(present_new_value(attribute[:label], attribute[:new_value], attribute[:type]))
-            h.concat(present_previous_value(attribute[:previous_value], attribute[:type]))
+            if options[:show_previous_value?]
+              h.concat(present_previous_value(attribute[:previous_value], attribute[:type]))
+            end
           end
         end
       end

--- a/decidim-core/spec/presenters/decidim/log/base_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/log/base_presenter_spec.rb
@@ -35,7 +35,6 @@ describe Decidim::Log::BasePresenter, type: :helper do
       expect(subject).to include(participatory_space.title["en"])
     end
 
-
     context "when version exists" do
       let(:version_double) { double(present?: true, changeset: {}) }
 

--- a/decidim-core/spec/presenters/decidim/log/base_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/log/base_presenter_spec.rb
@@ -35,6 +35,25 @@ describe Decidim::Log::BasePresenter, type: :helper do
       expect(subject).to include(participatory_space.title["en"])
     end
 
+
+    context "when version exists" do
+      let(:version_double) { double(present?: true, changeset: {}) }
+
+      it "renders a dropdown" do
+        expect(subject).to include("class=\"logs__log__actions-dropdown\"")
+      end
+
+      it "renders the diff" do
+        allow(Decidim::Log::DiffPresenter)
+          .to receive(:new).and_return(presenter_double)
+
+        expect(presenter_double)
+          .to receive(:present)
+
+        subject
+      end
+    end
+
     context "when the action is update" do
       let(:action) { :update }
 
@@ -44,24 +63,6 @@ describe Decidim::Log::BasePresenter, type: :helper do
         expect(subject).to include(user.nickname)
         expect(subject).to include(resource.title)
         expect(subject).to include(participatory_space.title["en"])
-      end
-
-      context "when version exists" do
-        let(:version_double) { double(present?: true, changeset: {}) }
-
-        it "renders a dropdown" do
-          expect(subject).to include("class=\"logs__log__actions-dropdown\"")
-        end
-
-        it "renders the diff" do
-          allow(Decidim::Log::DiffPresenter)
-            .to receive(:new).and_return(presenter_double)
-
-          expect(presenter_double)
-            .to receive(:present)
-
-          subject
-        end
       end
     end
 

--- a/decidim-core/spec/presenters/decidim/log/diff_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/log/diff_presenter_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe Decidim::Log::DiffPresenter, type: :helper do
-  subject { described_class.new(changeset, helper).present }
+  subject { described_class.new(changeset, helper, options).present }
 
   let(:user) { create :user }
   let(:type) { nil }
@@ -19,6 +19,7 @@ describe Decidim::Log::DiffPresenter, type: :helper do
     ]
   end
   let(:presenter_double) { double(present: true) }
+  let(:options) { {} }
 
   describe "#present" do
     context "when no changeset is present" do
@@ -39,6 +40,16 @@ describe Decidim::Log::DiffPresenter, type: :helper do
 
     it "shows the previous value" do
       expect(subject).to include("Previous value")
+    end
+
+    describe "options" do
+      context "when `show_previous_value?` is false" do
+        let(:options) { { show_previous_value?: false } }
+
+        it "does not show the previous value" do
+          expect(subject).not_to include("Previous value")
+        end
+      end
     end
 
     describe "value types presenters" do

--- a/decidim_app-design/app/views/admin/partials/_logs_list.html.erb
+++ b/decidim_app-design/app/views/admin/partials/_logs_list.html.erb
@@ -5,7 +5,7 @@
   <div class="table-scroll">
     <ul class="logs table">
       <% 5.times do |index| %>
-        <li class="logs__log">
+        <li class="logs__log" id="log-<%= (index + 1) * 3 - 2 %>" data-toggler=".logs__log--expanded">
           <div class="logs__log__content">
             <div class="logs__log__date">10/10/2018 08:24</div>
             <div class="logs__log__explanation">
@@ -16,6 +16,25 @@
               <a class="logs__log__space">Book Cycle</a>
             </div>
             <div class="logs__log__actions">
+              <a class="logs__log__actions-dropdown" data-toggle="log-<%= (index + 1) * 3 - 2 %>"></a>
+            </div>
+          </div>
+          <div class="logs__log__diff">
+            <div class="logs__log__diff-row logs__log__diff-row--new-value">
+              <div class="logs__log__diff-title">
+                Title
+              </div>
+              <div class="logs__log__diff-value">
+                My new title is uber-awesome
+              </div>
+            </div>
+            <div class="logs__log__diff-row logs__log__diff-row--new-value">
+              <div class="logs__log__diff-title">
+                Description
+              </div>
+              <div class="logs__log__diff-value">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras vulputate mi eu enim vulputate, et dignissim justo ultrices. Aliquam sodales scelerisque tincidunt. Praesent gravida iaculis iaculis. Curabitur arcu libero, hendrerit eu mi id, aliquet aliquam nisl. Etiam ullamcorper, metus non mollis egestas, massa sapien dictum magna, quis venenatis eros leo sit amet arcu. Fusce at accumsan nisi, ut cursus velit. Quisque urna tellus, rhoncus vitae ex ut, dictum eleifend nibh. Pellentesque ut blandit purus, id feugiat lectus. Fusce vehicula nisi odio. In vel laoreet lorem. Maecenas sed iaculis nibh, a semper eros. Aliquam a congue lacus. Donec maximus tincidunt purus, sed sagittis felis porttitor eu. Maecenas finibus, mi quis lacinia gravida, metus eros sagittis ligula, commodo ultricies neque libero sed sapien.
+              </div>
             </div>
           </div>
         </li>


### PR DESCRIPTION
#### :tophat: What? Why?
As per https://github.com/decidim/decidim/issues/2603#issuecomment-366622179, we decided that creation actions show render the diff in the logs, too. This PR adds it.

#### :pushpin: Related Issues
- Related to #2603.

#### :clipboard: Subtasks
- [x] Update design app

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/SFAC7vr.png)
