### PR TITLE
Add puma as a dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,7 @@ PATH
       factory_bot_rails (~> 4.8)
       i18n-tasks (~> 0.9.18)
       nokogiri (~> 1.8, >= 1.8.2)
+      puma (~> 3.11)
       rails-controller-testing (~> 1.0)
       rspec-html-matchers (~> 0.9.1)
       rspec-rails (~> 3.7)

--- a/decidim-dev/decidim-dev.gemspec
+++ b/decidim-dev/decidim-dev.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency "db-query-matchers", "~> 0.9.0"
   s.add_dependency "i18n-tasks", "~> 0.9.18"
   s.add_dependency "nokogiri", "~> 1.8", ">= 1.8.2"
+  s.add_dependency "puma", "~> 3.11"
   s.add_dependency "rails-controller-testing", "~> 1.0"
   s.add_dependency "rspec-html-matchers", "~> 0.9.1"
   s.add_dependency "rspec-rails", "~> 3.7"


### PR DESCRIPTION
#### :tophat: What? Why?
Puma is a dependency when running system tests. I just stumbled upon this when configuring `decidim-initiatives` - the issue is reported here: https://github.com/rspec/rspec-rails/issues/1930#issue-282898679 .

This warning seems to have appeared in the latest rails versions.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*
