### PR TITLE
Fix/2761 format of the meeting closing report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 - **decidim-core**: Make static pages traceable [\#2754](https://github.com/decidim/decidim/pull/2754)
 - **decidim-admin**: Log all actions on static pages [\#2754](https://github.com/decidim/decidim/pull/2754)
 - **decidim-admin**: Log all actions on newsletters [\#2763](https://github.com/decidim/decidim/pull/2763)
+- **decidim-meetings**: Add WYSIWYG editor for meeting closing notes [\#2761](https://github.com/decidim/decidim/pull/2779)
+- **decidim-meetings**: Add formatting of the list of organizations attending to a meeting [\#2761](https://github.com/decidim/decidim/pull/2779)
 
 **Changed**:
 

--- a/decidim-meetings/app/views/decidim/meetings/admin/meeting_closes/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meeting_closes/_form.html.erb
@@ -5,7 +5,7 @@
 
   <div class="card-section">
     <div class="row column">
-      <%= form.translated :text_area, :closing_report, autofocus: true, rows: 15 %>
+      <%= form.translated :editor, :closing_report, autofocus: true, rows: 15 %>
     </div>
 
     <div class="row column">

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -51,7 +51,7 @@
           <% end %>
           <div class="definition-data__item">
             <span class="definition-data__title"><%= t(".organizations") %></span>
-            <span class="definition-data__text"><%= meeting.attending_organizations %></span>
+            <span class="definition-data__text"><%= simple_format(meeting.attending_organizations) %></span>
           </div>
         </div>
       <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
- adds WYSIWYG editor for meeting closing report
- adds simple formatting of attending organizations  

#### :pushpin: Related Issues
- Fixes #2761

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
<img width="1189" alt="screenshot 2018-02-20 23 41 39" src="https://user-images.githubusercontent.com/34633/36453807-bd0f7010-1699-11e8-8058-72dd421f8272.png">