### PR TITLE
Fix AuthorEvent when author is missing backport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 **Fixed**:
 
+* **decidim-core**: Fix AuthorEvent when author is missing [\#2777](https://github.com/decidim/decidim/pull/2777)
 * **decidim-core**: Fix DefaultActionAuthorizer when options is nil [\#2753](https://github.com/decidim/decidim/pull/2753)
+* **decidim-core**: Fix mention parsing to only search users in current organization. [\2711](https://github.com/decidim/decidim/pull/2711)
 * **decidim-system**: Disable recover password for System admins. [\#2752](https://github.com/decidim/decidim/pull/2752)
 * **decidim-core**: Don't render notifications if the resource has been deleted. [\#2746](https://github.com/decidim/decidim/pull/2746)
 * **decidim-core**: Don't try to send notification emails to deleted users. [\#2743](https://github.com/decidim/decidim/pull/2743)

--- a/decidim-core/lib/decidim/events/author_event.rb
+++ b/decidim-core/lib/decidim/events/author_event.rb
@@ -13,22 +13,23 @@ module Decidim
         i18n_attributes :author_name, :author_nickname, :author_path, :author_url
 
         def author_nickname
-          author_presenter.nickname
+          author_presenter&.nickname.to_s
         end
 
         def author_name
-          author_presenter.name
+          author_presenter&.name.to_s
         end
 
         def author_path
-          author_presenter.profile_path
+          author_presenter&.profile_path.to_s
         end
 
         def author_url
-          author_presenter.profile_url
+          author_presenter&.profile_url.to_s
         end
 
         def author_presenter
+          return unless author
           @author ||= Decidim::UserPresenter.new(author)
         end
 

--- a/decidim-core/spec/events/decidim/author_event_spec.rb
+++ b/decidim-core/spec/events/decidim/author_event_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Events
+    describe AuthorEvent do
+      subject { dummy_event }
+
+      let(:dummy_event) do
+        class DummyEvent < Decidim::Events::SimpleEvent
+          include Decidim::Events::AuthorEvent
+
+          def default_i18n_options
+            {}
+          end
+        end
+
+        DummyEvent.new(resource: resource, event_name: "dummy_event", user: user, extra: {})
+      end
+
+      let(:resource) do
+        OpenStruct.new(author: user)
+      end
+
+      let(:user) { create(:user) }
+
+      it "adds author i18n attributes" do
+        expect(subject.i18n_options.keys).to include(:author_name)
+        expect(subject.i18n_options.keys).to include(:author_nickname)
+        expect(subject.i18n_options.keys).to include(:author_path)
+        expect(subject.i18n_options.keys).to include(:author_url)
+      end
+
+      it "delegates the author to the resource" do
+        expect(subject.author).to eq(resource.author)
+      end
+
+      it "has an author nickname" do
+        expect(subject.author_nickname).to be_present
+        expect(subject.author_nickname).to include(user.nickname)
+      end
+
+      it "has an author name" do
+        expect(subject.author_name).to be_present
+        expect(subject.author_name).to include(user.name)
+      end
+
+      it "has an author path" do
+        expect(subject.author_path).to be_present
+        expect(subject.author_path).to start_with("/profile")
+      end
+
+      it "has an author url" do
+        expect(subject.author_url).to be_present
+        expect(subject.author_url).to start_with("http://")
+      end
+
+      context "when the resource is missing its author" do
+        let(:user) { nil }
+
+        it "has an empty author nickname" do
+          expect(subject.author_nickname).to eq("")
+        end
+
+        it "has an empty author name" do
+          expect(subject.author_name).to eq("")
+        end
+
+        it "has an empty author path" do
+          expect(subject.author_path).to eq("")
+        end
+
+        it "has an empty author url" do
+          expect(subject.author_url).to eq("")
+        end
+      end
+
+      context "when the resource doesn't have an author" do
+        let(:resource) { OpenStruct.new }
+
+        it "ignores it" do
+          expect(subject.author).to eq(nil)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Backports #2777 to 0.9 and re-adds a deleted entry to the CHANGELOG.

#### :pushpin: Related Issues
- Related to #2777 
