### PR TITLE
Fix nickname uniqueness validation & generate when inviting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,5 +48,6 @@
 - **decidim-participatory_processes**: Fix editing a process after an error.[\#2653](https://github.com/decidim/decidim/pull/2653)
 - **decidim-assemblies**: Fix editing a process after an error.[\#2653](https://github.com/decidim/decidim/pull/2653)
 - **decidim-core**: Fix missing i18n strings for "Feature published" events. [\#2729](https://github.com/decidim/decidim/pull/2729)
+- **decidim-core**: Fix user invitations by generating their nickname. [\#2783](https://github.com/decidim/decidim/pull/2783)
 
 Please check [0.9-stable](https://github.com/decidim/decidim/blob/0.9-stable/CHANGELOG.md) for previous changes.

--- a/decidim-admin/app/commands/decidim/admin/invite_admin.rb
+++ b/decidim-admin/app/commands/decidim/admin/invite_admin.rb
@@ -16,7 +16,6 @@ module Decidim
 
         transaction do
           invite_user
-          generate_nickname
           log_action
         end
 
@@ -33,10 +32,6 @@ module Decidim
             save_user(user)
           end
         end
-      end
-
-      def generate_nickname
-        user.update_attributes(nickname: User.nicknamize(user.name))
       end
 
       # Ugly fix to get the user from the block inside the

--- a/decidim-core/app/commands/decidim/invite_user.rb
+++ b/decidim-core/app/commands/decidim/invite_user.rb
@@ -41,6 +41,7 @@ module Decidim
       @user = Decidim::User.new(
         name: form.name,
         email: form.email.downcase,
+        nickname: User.nicknamize(form.name),
         organization: form.organization,
         admin: form.role == "admin",
         roles: form.role == "admin" ? [] : [form.role].compact

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -28,7 +28,7 @@ module Decidim
     validates :locale, inclusion: { in: :available_locales }, allow_blank: true
     validates :tos_agreement, acceptance: true, allow_nil: false, on: :create
     validates :avatar, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_avatar_size } }
-    validates :email, :nickname, uniqueness: { scope: :organization }, unless: -> { deleted? || managed? }
+    validates :email, :nickname, uniqueness: { scope: :organization }, unless: -> { deleted? || managed? || nickname.blank? }
     validates :email, 'valid_email_2/email': { disposable: true }
 
     validate :all_roles_are_valid

--- a/decidim-core/db/migrate/20180221101934_fix_nickname_index.rb
+++ b/decidim-core/db/migrate/20180221101934_fix_nickname_index.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class FixNicknameIndex < ActiveRecord::Migration[5.1]
+  class User < ApplicationRecord
+    self.table_name = :decidim_users
+  end
+
+  def change
+    Decidim::User.where(nickname: nil)
+                 .where(deleted_at: nil)
+                 .where(managed: false)
+                 .find_each { |u| u.update_attributes(nickname: Decidim::User.nicknamize(u.name)) }
+
+    # rubocop:disable Rails/SkipsModelValidations
+    Decidim::User.where(nickname: nil)
+                 .update_all("nickname = ''")
+    # rubocop:enable Rails/SkipsModelValidations
+
+    change_column_default :decidim_users, :nickname, ""
+    change_column_null(:decidim_users, :nickname, false)
+  end
+end

--- a/decidim-core/lib/decidim/nicknamizable.rb
+++ b/decidim-core/lib/decidim/nicknamizable.rb
@@ -42,7 +42,7 @@ module Decidim
         2.step do |n|
           return candidate unless exists?(nickname: candidate)
 
-          candidate = numbered_variation_of(candidate, n)
+          candidate = numbered_variation_of(name, n)
         end
       end
 

--- a/decidim-core/spec/lib/nicknamizable_spec.rb
+++ b/decidim-core/spec/lib/nicknamizable_spec.rb
@@ -43,6 +43,14 @@ module Decidim
 
         expect(subject.nicknamize("Felipe Rocks So Much")).to eq("felipe_rocks_so_mu_2")
       end
+
+      it "resolves conflicts with other existing nicknames" do
+        create(:user, nickname: "existing")
+        create(:user, nickname: "existing_1")
+        create(:user, nickname: "existing_2")
+
+        expect(subject.nicknamize("existing")).to eq("existing_3")
+      end
     end
   end
 end

--- a/decidim-core/spec/models/decidim/user_spec.rb
+++ b/decidim-core/spec/models/decidim/user_spec.rb
@@ -60,6 +60,77 @@ module Decidim
           expect(user).not_to be_valid
           expect(user.errors[:nickname].length).to eq(1)
         end
+
+        it "can't be empty backed by an index" do
+          expect { user.save(validate: false) }.not_to raise_error
+        end
+
+        context "when managed" do
+          before do
+            user.managed = true
+          end
+
+          it "is valid" do
+            expect(user).to be_valid
+          end
+
+          it "can be saved" do
+            expect(user.save).to be true
+          end
+
+          it "can have duplicates" do
+            user.save!
+
+            expect do
+              create(:user, organization: user.organization,
+                            nickname: user.nickname,
+                            managed: true)
+            end.not_to raise_error
+          end
+        end
+
+        context "when deleted" do
+          before do
+            user.deleted_at = Time.zone.now
+          end
+
+          it "is valid" do
+            expect(user).to be_valid
+          end
+
+          it "can be saved" do
+            expect(user.save).to be true
+          end
+
+          it "can have duplicates" do
+            user.save!
+
+            expect do
+              create(:user, organization: user.organization,
+                            nickname: user.nickname,
+                            deleted_at: Time.zone.now)
+            end.not_to raise_error
+          end
+        end
+      end
+
+      context "when the nickname is not empty" do
+        before do
+          user.nickname = "a-nickname"
+        end
+
+        it "can be created" do
+          expect(user.save).to eq(true)
+        end
+
+        it "can't have duplicates even when skipping validations" do
+          user.save!
+
+          expect do
+            build(:user, organization: user.organization,
+                         nickname: user.nickname).save(validate: false)
+          end.to raise_error(ActiveRecord::RecordNotUnique)
+        end
       end
 
       context "when the file is too big" do

--- a/decidim-meetings/app/commands/decidim/meetings/admin/invite_user_to_join_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/invite_user_to_join_meeting.rb
@@ -40,6 +40,7 @@ module Decidim
             InviteJoinMeetingMailer.invite(user, meeting, invited_by).deliver_later
           else
             user.name = form.name
+            user.nickname = User.nicknamize(user.name)
             user.skip_reconfirmation!
             user.invite!(invited_by, invitation_instructions: "join_meeting", meeting: meeting)
           end

--- a/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
@@ -47,6 +47,7 @@ module Decidim
             expect(admin.organization.name).to eq("Gotham City")
             expect(admin).to be_admin
             expect(admin).to be_created_by_invite
+            expect(admin).to be_valid
           end
 
           it "sends a custom email" do

--- a/lib/generators/decidim/install_generator.rb
+++ b/lib/generators/decidim/install_generator.rb
@@ -108,13 +108,8 @@ module Decidim
       def recreate_db
         soft_rails "db:environment:set", "db:drop"
         rails "db:create"
-
-        if options[:seed_db]
-          rails "db:migrate", "db:seed"
-        else
-          rails "db:migrate"
-        end
-
+        rails "db:migrate"
+        rails "db:seed" if options[:seed_db]
         rails "db:test:prepare"
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
This fixes the nickname uniqueness index. The story behind this is funny: Invited users without a nickname were being created, and the index wasn't preventing that.

It turns out that in PostgreSQL, `NULL != NULL` because `NULL` is an undetermined value - that's why you have to write `IS NULL` instead of simply `NULL = NULL`. Funny enough, that's not the case in MySQL.

A solution could be to create two different indexes (one when nickname is not null and the other when it is) and coalesce `NULL` to another valid value, say `""` (empty string). While this is a good approach, this thing (`coalesce(is_null(nickname), "")`) can't be expressed in rails with a ruby `schema.rb` file.

So in the end I ended up with another solution: Using `""` as a default value. It's less `correct`, but it works in this case.

**Must be backported to 0.9**

#### :pushpin: Related Issues
- Fixes #2757

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
*None*
