### PR TITLE
Improve dummies

### DIFF
--- a/decidim-core/spec/lib/global_engines_spec.rb
+++ b/decidim-core/spec/lib/global_engines_spec.rb
@@ -7,7 +7,7 @@ describe "global engines", type: :system do
   let(:mount_at) { nil }
 
   around do |example|
-    Decidim.register_global_engine(:global_engine, Decidim::DummyEngine, at: mount_at)
+    Decidim.register_global_engine(:global_engine, Decidim::DummyResources::DummyEngine, at: mount_at)
     Rails.application.reload_routes!
     switch_to_host(organization.host)
     example.run

--- a/decidim-dev/app/controllers/decidim/dummy_resources/dummy_resources_controller.rb
+++ b/decidim-dev/app/controllers/decidim/dummy_resources/dummy_resources_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Decidim
+  module DummyResources
+    class DummyResourcesController < Decidim::Features::BaseController
+      helper Decidim::Comments::CommentsHelper
+
+      skip_authorization_check
+
+      def show
+        @commentable = DummyResources::DummyResource.find(params[:id])
+      end
+    end
+  end
+end

--- a/decidim-dev/app/views/decidim/dummy_resources/dummy_resources/foo.html.erb
+++ b/decidim-dev/app/views/decidim/dummy_resources/dummy_resources/foo.html.erb
@@ -1,0 +1,1 @@
+Foo stuff

--- a/decidim-dev/app/views/decidim/dummy_resources/dummy_resources/show.html.erb
+++ b/decidim-dev/app/views/decidim/dummy_resources/dummy_resources/show.html.erb
@@ -1,1 +1,5 @@
 <%= inline_comments_for(@commentable) %>
+
+<%= action_authorized_link_to :foo, foo_dummy_resource_path(@commentable) do %>
+  Foo
+<% end %>

--- a/decidim-dev/app/views/decidim/dummy_resources/dummy_resources/show.html.erb
+++ b/decidim-dev/app/views/decidim/dummy_resources/dummy_resources/show.html.erb
@@ -1,0 +1,1 @@
+<%= inline_comments_for(@commentable) %>

--- a/decidim-dev/lib/decidim/dev/test/base_spec_helper.rb
+++ b/decidim-dev/lib/decidim/dev/test/base_spec_helper.rb
@@ -16,8 +16,6 @@ if ENV["SIMPLECOV"]
   SimpleCov.command_name File.basename(Dir.pwd)
 end
 
-require "rails"
-require "active_support/core_ext/string"
 require "decidim/core"
 require "decidim/core/test"
 require "decidim/admin/test"

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
@@ -18,7 +18,9 @@ module Decidim
       routes do
         root to: proc { [200, {}, ["DUMMY ENGINE"]] }
 
-        resources :dummy_resources
+        resources :dummy_resources do
+          get :foo, on: :member
+        end
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR improves the dummy component so that it's easier to extend and behaves more like the real components. Having everything managed in the same file and rendering everything inline was getting out of hand IMO. 

Also (the real point of this PR), I'm adding an authorized link (in the show view) to the `foo` action it declares so that it's easy to test custom verification workflow components against it.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.