### PR TITLE
Broadcast settings change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 **Added**:
 
+- **decidim-proposals**: Space followers are notified when the proposal can be created, endorsed or voted [\#2794](https://github.com/decidim/decidim/pull/2794)
+- **decidim-debates**: Space followers are notified when the debate creation is enabled or disabled [\#2794](https://github.com/decidim/decidim/pull/2794)
+- **decidim-surveys**: Space followers are notified when a survey is opened or closed [\#2794](https://github.com/decidim/decidim/pull/2794)
+- **decidim-core**: Broadcast feature settings changes [\#2794](https://github.com/decidim/decidim/pull/2794)
 - **decidim-assemblies**: Add a select field for assign an area to assemblies [\#2750](https://github.com/decidim/decidim/pull/2750)
 - **decidim-core**: Add Area and AreaType to Core [\#2750](https://github.com/decidim/decidim/pull/2750)
 - **decidim-proposals**: Proposals can accumulate more votes than the maximum [\#2693](https://github.com/decidim/decidim/pull/2693)

--- a/decidim-admin/app/commands/decidim/admin/update_feature.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_feature.rb
@@ -4,7 +4,7 @@ module Decidim
   module Admin
     # This command gets called when a feature is created from the admin panel.
     class UpdateFeature < Rectify::Command
-      attr_reader :form, :feature
+      attr_reader :form, :feature, :previous_settings
 
       # Public: Initializes the command.
       #
@@ -27,23 +27,35 @@ module Decidim
           run_hooks
         end
 
-        broadcast(:ok)
+        broadcast(:ok, settings_changed?, previous_settings, current_settings)
       end
 
       private
 
       def update_feature
-        @feature.update_attributes!(
-          name: form.name,
-          settings: form.settings,
-          default_step_settings: form.default_step_settings,
-          step_settings: form.step_settings,
-          weight: form.weight
-        )
+        @previous_settings = @feature.attributes["settings"].dup
+
+        @feature.name = form.name
+        @feature.settings = form.settings
+        @feature.default_step_settings = form.default_step_settings
+        @feature.step_settings = form.step_settings
+        @feature.weight = form.weight
+
+        @settings_changed = @feature.settings_changed?
+
+        @feature.save!
       end
 
       def run_hooks
         @manifest.run_hooks(:update, @feature)
+      end
+
+      def settings_changed?
+        @settings_changed
+      end
+
+      def current_settings
+        @feature.attributes["settings"]
       end
     end
   end

--- a/decidim-admin/app/controllers/decidim/admin/features_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/features_controller.rb
@@ -56,7 +56,9 @@ module Decidim
         authorize! :update, @feature
 
         UpdateFeature.call(@form, @feature) do
-          on(:ok) do
+          on(:ok) do |settings_changed, previous_settings, current_settings|
+            handle_feature_settings_change(previous_settings, current_settings) if settings_changed
+
             flash[:notice] = I18n.t("features.update.success", scope: "decidim.admin")
             redirect_to action: :index
           end
@@ -126,6 +128,16 @@ module Decidim
         TranslationsHelper.multi_translation(
           "decidim.features.#{manifest.name}.name",
           current_organization.available_locales
+        )
+      end
+
+      def handle_feature_settings_change(previous_settings, current_settings)
+        return if @feature.participatory_space.allows_steps?
+
+        Decidim::SettingsChange.publish(
+          @feature,
+          previous_settings["default_step"] || {},
+          current_settings["default_step"] || {}
         )
       end
     end

--- a/decidim-admin/app/events/decidim/feature_published_event.rb
+++ b/decidim-admin/app/events/decidim/feature_published_event.rb
@@ -2,14 +2,5 @@
 
 module Decidim
   class FeaturePublishedEvent < Decidim::Events::SimpleEvent
-    include Decidim::FeaturePathHelper
-
-    def resource_path
-      @resource_path ||= main_feature_path(resource)
-    end
-
-    def resource_url
-      @resource_url ||= main_feature_url(resource)
-    end
   end
 end

--- a/decidim-admin/spec/commands/update_feature_spec.rb
+++ b/decidim-admin/spec/commands/update_feature_spec.rb
@@ -70,6 +70,12 @@ module Decidim::Admin
         expect(feature.name["en"]).to eq("My feature")
         expect(feature).to be_persisted
       end
+
+      it "broadcasts the previous and current settings" do
+        expect do
+          described_class.call(form, feature)
+        end.to broadcast(:ok, true, {}, hash_including("global" => kind_of(Hash), "default_step" => kind_of(Hash), "steps" => kind_of(Hash)))
+      end
     end
 
     describe "when invalid" do

--- a/decidim-admin/spec/events/decidim/attachment_created_event_spec.rb
+++ b/decidim-admin/spec/events/decidim/attachment_created_event_spec.rb
@@ -15,7 +15,7 @@ describe Decidim::AttachmentCreatedEvent do
     resource.file.class.configure { |config| config.asset_host = "http://example.org" }
   end
 
-  it_behaves_like "a simple event"
+  it_behaves_like "a simple event", true
 
   describe "email_subject" do
     it "is generated correctly" do

--- a/decidim-assemblies/spec/controllers/admin/features_controller_spec.rb
+++ b/decidim-assemblies/spec/controllers/admin/features_controller_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Assemblies
+    module Admin
+      describe FeaturesController, type: :controller do
+        routes { Decidim::Assemblies::AdminEngine.routes }
+
+        let(:organization) { create(:organization) }
+        let(:current_user) { create(:user, :confirmed, :admin, organization: organization) }
+        let!(:assembly) do
+          create(
+            :assembly,
+            :published,
+            organization: organization
+          )
+        end
+        let(:feature) do
+          create(
+            :feature,
+            manifest_name: :dummy,
+            participatory_space: assembly
+          )
+        end
+
+        before do
+          request.env["decidim.current_organization"] = organization
+          request.env["decidim.current_assembly"] = assembly
+          sign_in current_user
+        end
+
+        describe "PATCH update" do
+          let(:feature_params) do
+            {
+              name_en: "Dummy feature",
+              settings: {
+                comments_enabled: true
+              },
+              default_step_settings: {
+                comments_blocked: true
+              }
+            }
+          end
+
+          it "publishes the default step settings change" do
+            expect(Decidim::SettingsChange).to receive(:publish).with(
+              feature,
+              {},
+              hash_including("comments_blocked" => true)
+            )
+
+            patch :update, params: { assembly_slug: assembly.slug, id: feature.id, feature: feature_params }
+
+            expect(response).to redirect_to features_path
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-comments/spec/events/decidim/comments/comment_created_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/comment_created_event_spec.rb
@@ -10,6 +10,7 @@ describe Decidim::Comments::CommentCreatedEvent do
   let(:comment_author) { comment.author }
   let(:event_name) { "decidim.events.comments.comment_created" }
   let(:extra) { { comment_id: comment.id } }
+  let(:i18n_scope) { "decidim.events.comments.comment_created.comment" }
 
   it_behaves_like "a simple event"
 

--- a/decidim-core/app/services/decidim/settings_change.rb
+++ b/decidim-core/app/services/decidim/settings_change.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This is a helper class in order to publish feature and settings changes
+  # so that components can react to these changes and send notifications to users.
+  class SettingsChange
+    # Publishes a change to ActiveSupport::Notifications.
+    #
+    # feature - The Decidim::Feature where the changes have been applied.
+    # previous_settings - A Hash or a Decidim::SettingsManifest schema with the settings before changing them.
+    # current_settings - A Hash or a Decidim::SettingsManifest schema with the current settings.
+    def self.publish(feature, previous_settings, current_settings)
+      ActiveSupport::Notifications.publish(
+        "decidim.settings_change.#{feature.manifest_name}",
+        feature_id: feature.id,
+        previous_settings: previous_settings.to_h.deep_symbolize_keys,
+        current_settings: current_settings.to_h.deep_symbolize_keys
+      )
+    end
+
+    # Creates a subscription to setting changes.
+    #
+    # scope - The String manifest name of the component so it only receives relevant changes.
+    # block - The block to be executed when an event is received.
+    def self.subscribe(scope, &block)
+      ActiveSupport::Notifications.subscribe(/^decidim\.settings_change\.#{scope}/) do |_event_name, data|
+        block.call(data)
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core/test/shared_examples/simple_event.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/simple_event.rb
@@ -26,11 +26,14 @@ shared_context "simple event" do
   let(:resource_title) { resource.title["en"] }
   let(:participatory_space) { resource.participatory_space }
   let(:participatory_space_title) { participatory_space.title["en"] }
+  let(:participatory_space_path) { Decidim::ResourceLocatorPresenter.new(participatory_space).path }
+  let(:participatory_space_url) { Decidim::ResourceLocatorPresenter.new(participatory_space).url }
   let(:author) { resource.author }
   let(:author_presenter) { Decidim::UserPresenter.new(author) }
+  let(:i18n_scope) { event_name }
 end
 
-shared_examples_for "a simple event" do
+shared_examples_for "a simple event" do |skip_space_checks|
   describe "types" do
     subject { described_class }
 
@@ -83,6 +86,29 @@ shared_examples_for "a simple event" do
     it "is generated correctly" do
       expect(subject.resource_url).to be_kind_of(String)
       expect(subject.resource_url).to start_with("http")
+    end
+  end
+
+  unless skip_space_checks
+    describe "participatory_space_url" do
+      it "is generated correctly" do
+        expect(subject.participatory_space_url).to be_kind_of(String)
+        expect(subject.participatory_space_url).to start_with("http")
+      end
+    end
+  end
+
+  describe "i18n_options" do
+    subject { super().i18n_options }
+
+    it { is_expected.to include(resource_path: satisfy(&:present?)) }
+    it { is_expected.to include(resource_title: satisfy(&:present?)) }
+    it { is_expected.to include(resource_url: start_with("http")) }
+    it { is_expected.to include(scope: i18n_scope) }
+
+    unless skip_space_checks
+      it { is_expected.to include(participatory_space_title: satisfy(&:present?)) }
+      it { is_expected.to include(participatory_space_url: start_with("http")) }
     end
   end
 end

--- a/decidim-core/lib/decidim/events/base_event.rb
+++ b/decidim-core/lib/decidim/events/base_event.rb
@@ -86,7 +86,7 @@ module Decidim
       end
 
       def participatory_space
-        return feature.participatory_space if feature
+        feature&.participatory_space
       end
 
       def resource_title

--- a/decidim-core/lib/decidim/events/simple_event.rb
+++ b/decidim-core/lib/decidim/events/simple_event.rb
@@ -10,6 +10,7 @@ module Decidim
     class SimpleEvent < BaseEvent
       include Decidim::Events::EmailEvent
       include Decidim::Events::NotificationEvent
+      include Decidim::FeaturePathHelper
 
       class_attribute :i18n_interpolations
       self.i18n_interpolations = []
@@ -58,6 +59,25 @@ module Decidim
         default_i18n_options.merge(event_interpolations)
       end
 
+      # Caches the path for the given resource when it's a Decidim::Feature.
+      def resource_path
+        return super unless resource.is_a?(Decidim::Feature)
+        @resource_path ||= main_feature_path(resource)
+      end
+
+      # Caches the URL for the given resource when it's a Decidim::Feature.
+      def resource_url
+        return super unless resource.is_a?(Decidim::Feature)
+        @resource_url ||= main_feature_url(resource)
+      end
+
+      # Caches the URL for the resource's participatory space.
+      def participatory_space_url
+        return unless participatory_space
+
+        @participatory_space_url ||= ResourceLocatorPresenter.new(participatory_space).url
+      end
+
       private
 
       def event_interpolations
@@ -72,6 +92,7 @@ module Decidim
           resource_title: resource_title,
           resource_url: resource_url,
           participatory_space_title: participatory_space_title,
+          participatory_space_url: participatory_space_url,
           scope: i18n_scope
         }
       end

--- a/decidim-core/spec/events/decidim/profile_updated_event_spec.rb
+++ b/decidim-core/spec/events/decidim/profile_updated_event_spec.rb
@@ -9,7 +9,7 @@ describe Decidim::ProfileUpdatedEvent do
   let(:resource) { create :user }
   let(:author) { resource }
 
-  it_behaves_like "a simple event"
+  it_behaves_like "a simple event", true
 
   describe "email_subject" do
     it "is generated correctly" do

--- a/decidim-core/spec/services/decidim/settings_change_spec.rb
+++ b/decidim-core/spec/services/decidim/settings_change_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe SettingsChange do
+    let(:feature) do
+      instance_double(
+        Decidim::Feature,
+        id: 1,
+        manifest_name: "dummy"
+      )
+    end
+    let(:previous_settings) do
+      { "allow_something" => false }
+    end
+    let(:current_settings) do
+      { "allow_something" => true }
+    end
+
+    describe "publish" do
+      it "broadcasts setting changes" do
+        expect(ActiveSupport::Notifications)
+          .to receive(:publish)
+          .with(
+            "decidim.settings_change.dummy",
+            feature_id: 1,
+            previous_settings: { allow_something: false },
+            current_settings: { allow_something: true }
+          )
+
+        described_class.publish(
+          feature,
+          previous_settings,
+          current_settings
+        )
+      end
+    end
+
+    describe "#subscribe" do
+      let(:scope) { "dummy" }
+      let(:block) { proc { |_data| "Hello world" } }
+
+      it "subscribes to setting changes" do
+        expect(ActiveSupport::Notifications)
+          .to receive(:subscribe)
+          .with(/^decidim\.settings_change\.dummy/, &block)
+
+        described_class.subscribe(scope, &block)
+      end
+    end
+  end
+end

--- a/decidim-debates/app/events/decidim/debates/creation_disabled_event.rb
+++ b/decidim-debates/app/events/decidim/debates/creation_disabled_event.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Debates
+    class CreationDisabledEvent < Decidim::Events::SimpleEvent
+    end
+  end
+end

--- a/decidim-debates/app/events/decidim/debates/creation_enabled_event.rb
+++ b/decidim-debates/app/events/decidim/debates/creation_enabled_event.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Debates
+    class CreationEnabledEvent < Decidim::Events::SimpleEvent
+    end
+  end
+end

--- a/decidim-debates/app/jobs/decidim/debates/settings_change_job.rb
+++ b/decidim-debates/app/jobs/decidim/debates/settings_change_job.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Debates
+    class SettingsChangeJob < ApplicationJob
+      def perform(feature_id, previous_settings, current_settings)
+        return if unchanged?(previous_settings, current_settings)
+
+        feature = Decidim::Feature.find(feature_id)
+
+        if debate_creation_enabled?(previous_settings, current_settings)
+          event = "decidim.events.debates.creation_enabled"
+          event_class = Decidim::Debates::CreationEnabledEvent
+        elsif debate_creation_disabled?(previous_settings, current_settings)
+          event = "decidim.events.debates.creation_disabled"
+          event_class = Decidim::Debates::CreationDisabledEvent
+        end
+
+        Decidim::EventsManager.publish(
+          event: event,
+          event_class: event_class,
+          resource: feature,
+          recipient_ids: feature.participatory_space.followers.pluck(:id)
+        )
+      end
+
+      private
+
+      def unchanged?(previous_settings, current_settings)
+        current_settings[:creation_enabled] == previous_settings[:creation_enabled]
+      end
+
+      def debate_creation_enabled?(previous_settings, current_settings)
+        current_settings[:creation_enabled] == true &&
+          previous_settings[:creation_enabled] == false
+      end
+
+      def debate_creation_disabled?(previous_settings, current_settings)
+        current_settings[:creation_enabled] == false &&
+          previous_settings[:creation_enabled] == true
+      end
+    end
+  end
+end

--- a/decidim-debates/config/locales/en.yml
+++ b/decidim-debates/config/locales/en.yml
@@ -104,6 +104,16 @@ en:
             email_outro: You have received this notification because you are following %{author_nickname}. You can stop receiving notifications following the previous link.
             email_subject: New debate by %{author_nickname}
             notification_title: The <a href="%{resource_path}">%{resource_title}</a> debate was created by <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
+        creation_disabled:
+          email_intro: 'Debate creation is no longer active in %{participatory_space_title}. You can still participate in opened debates from this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: Debate creation disabled in %{participatory_space_title}
+          notification_title: Debate creation is now disabled in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+        creation_enabled:
+          email_intro: 'You can now start new debates in %{participatory_space_title}! Start participating in this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: Debates now available in %{participatory_space_title}
+          notification_title: You can now start <a href="%{resource_path}">new debates</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
     features:
       debates:
         actions:

--- a/decidim-debates/lib/decidim/debates/engine.rb
+++ b/decidim-debates/lib/decidim/debates/engine.rb
@@ -21,6 +21,16 @@ module Decidim
           config.abilities += ["Decidim::Debates::Abilities::CurrentUserAbility"]
         end
       end
+
+      initializer "decidim_changes" do
+        Decidim::SettingsChange.subscribe "debates" do |changes|
+          Decidim::Debates::SettingsChangeJob.perform_later(
+            changes[:feature_id],
+            changes[:previous_settings],
+            changes[:current_settings]
+          )
+        end
+      end
     end
   end
 end

--- a/decidim-debates/spec/events/decidim/debates/create_debate_event_spec.rb
+++ b/decidim-debates/spec/events/decidim/debates/create_debate_event_spec.rb
@@ -13,6 +13,7 @@ describe Decidim::Debates::CreateDebateEvent do
 
   context "when the notification is for user followers" do
     let(:type) { :user }
+    let(:i18n_scope) { "decidim.events.debates.create_debate_event.user_followers" }
 
     it_behaves_like "a simple event"
 
@@ -49,6 +50,7 @@ describe Decidim::Debates::CreateDebateEvent do
 
   context "when the notification is for space followers" do
     let(:type) { :space }
+    let(:i18n_scope) { "decidim.events.debates.create_debate_event.space_followers" }
 
     it_behaves_like "a simple event"
 

--- a/decidim-debates/spec/events/decidim/debates/creation_disabled_event_spec.rb
+++ b/decidim-debates/spec/events/decidim/debates/creation_disabled_event_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Debates
+    describe CreationDisabledEvent do
+      include Decidim::FeaturePathHelper
+
+      include_context "simple event"
+
+      let(:event_name) { "decidim.events.debates.creation_disabled" }
+      let(:resource) { create(:debates_feature) }
+      let(:participatory_space) { resource.participatory_space }
+      let(:resource_path) { main_feature_path(resource) }
+
+      it_behaves_like "a simple event"
+
+      describe "email_subject" do
+        it "is generated correctly" do
+          expect(subject.email_subject).to eq("Debate creation disabled in #{participatory_space_title}")
+        end
+      end
+
+      describe "email_intro" do
+        it "is generated correctly" do
+          expect(subject.email_intro)
+            .to eq("Debate creation is no longer active in #{participatory_space_title}. You can still participate in opened debates from this page:")
+        end
+      end
+
+      describe "email_outro" do
+        it "is generated correctly" do
+          expect(subject.email_outro)
+            .to include("You have received this notification because you are following #{participatory_space_title}")
+        end
+      end
+
+      describe "notification_title" do
+        it "is generated correctly" do
+          expect(subject.notification_title)
+            .to eq("Debate creation is now disabled in <a href=\"#{participatory_space_url}\">#{participatory_space_title}</a>")
+        end
+      end
+    end
+  end
+end

--- a/decidim-debates/spec/events/decidim/debates/creation_enabled_event_spec.rb
+++ b/decidim-debates/spec/events/decidim/debates/creation_enabled_event_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Debates
+    describe CreationEnabledEvent do
+      include Decidim::FeaturePathHelper
+
+      include_context "simple event"
+
+      let(:event_name) { "decidim.events.debates.creation_enabled" }
+      let(:resource) { create(:debates_feature) }
+      let(:participatory_space) { resource.participatory_space }
+      let(:resource_path) { main_feature_path(resource) }
+
+      it_behaves_like "a simple event"
+
+      describe "email_subject" do
+        it "is generated correctly" do
+          expect(subject.email_subject).to eq("Debates now available in #{participatory_space.title["en"]}")
+        end
+      end
+
+      describe "email_intro" do
+        it "is generated correctly" do
+          expect(subject.email_intro)
+            .to eq("You can now start new debates in #{participatory_space_title}! Start participating in this page:")
+        end
+      end
+
+      describe "email_outro" do
+        it "is generated correctly" do
+          expect(subject.email_outro)
+            .to include("You have received this notification because you are following #{participatory_space.title["en"]}")
+        end
+      end
+
+      describe "notification_title" do
+        it "is generated correctly" do
+          expect(subject.notification_title)
+            .to eq("You can now start <a href=\"#{resource_path}\">new debates</a> in <a href=\"#{participatory_space_url}\">#{participatory_space.title["en"]}</a>")
+        end
+      end
+    end
+  end
+end

--- a/decidim-participatory_processes/spec/commands/decidim/participatory_processes/admin/activate_participatory_process_step_spec.rb
+++ b/decidim-participatory_processes/spec/commands/decidim/participatory_processes/admin/activate_participatory_process_step_spec.rb
@@ -60,6 +60,22 @@ module Decidim::ParticipatoryProcesses
 
         subject.call
       end
+
+      context "when the process has some features" do
+        let!(:feature) do
+          create(:feature, manifest_name: "dummy", participatory_space: participatory_process)
+        end
+
+        it "publishes the settings change for each feature in the process" do
+          expect(Decidim::SettingsChange).to receive(:publish).with(
+            feature,
+            feature.step_settings[active_step.id.to_s].to_h,
+            feature.step_settings[process_step.id.to_s].to_h
+          )
+
+          subject.call
+        end
+      end
     end
   end
 end

--- a/decidim-participatory_processes/spec/controllers/admin/features_controller_spec.rb
+++ b/decidim-participatory_processes/spec/controllers/admin/features_controller_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module ParticipatoryProcesses
+    module Admin
+      describe FeaturesController, type: :controller do
+        routes { Decidim::ParticipatoryProcesses::AdminEngine.routes }
+
+        let(:organization) { create(:organization) }
+        let(:current_user) { create(:user, :confirmed, :admin, organization: organization) }
+        let!(:participatory_process) do
+          create(
+            :participatory_process,
+            :published,
+            organization: organization
+          )
+        end
+        let(:feature) do
+          create(
+            :feature,
+            manifest_name: :dummy,
+            participatory_space: participatory_process
+          )
+        end
+
+        before do
+          request.env["decidim.current_organization"] = organization
+          request.env["decidim.current_participatory_process"] = participatory_process
+          sign_in current_user
+        end
+
+        describe "PATCH update" do
+          let(:feature_params) do
+            {
+              name_en: "Dummy feature",
+              settings: {
+                comments_enabled: true
+              },
+              default_step_settings: {
+                comments_blocked: true
+              }
+            }
+          end
+
+          it "does not publish the default step settings change" do
+            expect(Decidim::SettingsChange).not_to receive(:publish)
+
+            patch :update, params: { participatory_process_slug: participatory_process.slug, id: feature.id, feature: feature_params }
+
+            expect(response).to redirect_to features_path
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/events/decidim/proposals/creation_enabled_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/creation_enabled_event.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    class CreationEnabledEvent < Decidim::Events::SimpleEvent
+    end
+  end
+end

--- a/decidim-proposals/app/events/decidim/proposals/endorsing_enabled_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/endorsing_enabled_event.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    class EndorsingEnabledEvent < Decidim::Events::SimpleEvent
+    end
+  end
+end

--- a/decidim-proposals/app/events/decidim/proposals/voting_enabled_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/voting_enabled_event.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    class VotingEnabledEvent < Decidim::Events::SimpleEvent
+    end
+  end
+end

--- a/decidim-proposals/app/jobs/decidim/proposals/settings_change_job.rb
+++ b/decidim-proposals/app/jobs/decidim/proposals/settings_change_job.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    class SettingsChangeJob < ApplicationJob
+      def perform(feature_id, previous_settings, current_settings)
+        feature = Decidim::Feature.find(feature_id)
+
+        if creation_enabled?(previous_settings, current_settings)
+          event = "decidim.events.proposals.creation_enabled"
+          event_class = Decidim::Proposals::CreationEnabledEvent
+        elsif voting_enabled?(previous_settings, current_settings)
+          event = "decidim.events.proposals.voting_enabled"
+          event_class = Decidim::Proposals::VotingEnabledEvent
+        elsif endorsing_enabled?(previous_settings, current_settings)
+          event = "decidim.events.proposals.endorsing_enabled"
+          event_class = Decidim::Proposals::EndorsingEnabledEvent
+        end
+
+        return unless event && event_class
+
+        Decidim::EventsManager.publish(
+          event: event,
+          event_class: event_class,
+          resource: feature,
+          recipient_ids: feature.participatory_space.followers.pluck(:id)
+        )
+      end
+
+      private
+
+      def creation_enabled?(previous_settings, current_settings)
+        current_settings[:creation_enabled] == true &&
+          previous_settings[:creation_enabled] == false
+      end
+
+      def voting_enabled?(previous_settings, current_settings)
+        (current_settings[:votes_enabled] == true && current_settings[:votes_blocked] == false) &&
+          (previous_settings[:votes_enabled] == false || previous_settings[:votes_blocked] == true)
+      end
+
+      def endorsing_enabled?(previous_settings, current_settings)
+        (current_settings[:endorsements_enabled] == true && current_settings[:endorsements_blocked] == false) &&
+          (previous_settings[:endorsements_enabled] == false || previous_settings[:endorsements_blocked] == true)
+      end
+    end
+  end
+end

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -17,6 +17,16 @@ en:
   decidim:
     events:
       proposals:
+        creation_enabled:
+          email_intro: 'You can now create new proposals in %{participatory_space_title}! Start participating in this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: Proposals now available in %{participatory_space_title}
+          notification_title: You can now start <a href="%{resource_path}">new proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+        endorsing_enabled:
+          email_intro: 'You can endorse proposals in %{participatory_space_title}! Start participating in this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: Proposals endorsing has started for %{participatory_space_title}
+          notification_title: You can now start <a href="%{resource_path}">endorsing proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
         proposal_accepted:
           email_intro: 'The proposal "%{resource_title}" has been accepted. You can read the answer in this page:'
           email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
@@ -47,6 +57,11 @@ en:
           email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
           email_subject: A proposal you're following has been rejected
           notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal has been rejected.
+        voting_enabled:
+          email_intro: 'You can vote proposals in %{participatory_space_title}! Start participating in this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: Proposals voting has started for %{participatory_space_title}
+          notification_title: You can now start <a href="%{resource_path}">voting proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
     features:
       proposals:
         actions:

--- a/decidim-proposals/lib/decidim/proposals/engine.rb
+++ b/decidim-proposals/lib/decidim/proposals/engine.rb
@@ -42,6 +42,16 @@ module Decidim
           config.abilities += ["Decidim::Proposals::Abilities::CurrentUserAbility"]
         end
       end
+
+      initializer "decidim_changes" do
+        Decidim::SettingsChange.subscribe "surveys" do |changes|
+          Decidim::Proposals::SettingsChangeJob.perform_later(
+            changes[:feature_id],
+            changes[:previous_settings],
+            changes[:current_settings]
+          )
+        end
+      end
     end
   end
 end

--- a/decidim-proposals/spec/events/decidim/proposals/creation_enabled_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/creation_enabled_event_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Proposals
+    describe CreationEnabledEvent do
+      include Decidim::FeaturePathHelper
+
+      include_context "simple event"
+
+      let(:event_name) { "decidim.events.proposals.creation_enabled" }
+      let(:resource) { create(:proposal_feature) }
+      let(:participatory_space) { resource.participatory_space }
+      let(:resource_path) { main_feature_path(resource) }
+
+      it_behaves_like "a simple event"
+
+      describe "email_subject" do
+        it "is generated correctly" do
+          expect(subject.email_subject).to eq("Proposals now available in #{participatory_space.title["en"]}")
+        end
+      end
+
+      describe "email_intro" do
+        it "is generated correctly" do
+          expect(subject.email_intro)
+            .to eq("You can now create new proposals in #{participatory_space_title}! Start participating in this page:")
+        end
+      end
+
+      describe "email_outro" do
+        it "is generated correctly" do
+          expect(subject.email_outro)
+            .to include("You have received this notification because you are following #{participatory_space.title["en"]}")
+        end
+      end
+
+      describe "notification_title" do
+        it "is generated correctly" do
+          expect(subject.notification_title)
+            .to eq("You can now start <a href=\"#{resource_path}\">new proposals</a> in <a href=\"#{participatory_space_url}\">#{participatory_space.title["en"]}</a>")
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/events/decidim/proposals/endorsing_enabled_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/endorsing_enabled_event_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Proposals
+    describe EndorsingEnabledEvent do
+      include Decidim::FeaturePathHelper
+
+      include_context "simple event"
+
+      let(:event_name) { "decidim.events.proposals.endorsing_enabled" }
+      let(:resource) { create(:proposal_feature) }
+      let(:participatory_space) { resource.participatory_space }
+      let(:resource_path) { main_feature_path(resource) }
+
+      it_behaves_like "a simple event"
+
+      describe "email_subject" do
+        it "is generated correctly" do
+          expect(subject.email_subject).to eq("Proposals endorsing has started for #{participatory_space.title["en"]}")
+        end
+      end
+
+      describe "email_intro" do
+        it "is generated correctly" do
+          expect(subject.email_intro)
+            .to eq("You can endorse proposals in #{participatory_space_title}! Start participating in this page:")
+        end
+      end
+
+      describe "email_outro" do
+        it "is generated correctly" do
+          expect(subject.email_outro)
+            .to include("You have received this notification because you are following #{participatory_space.title["en"]}")
+        end
+      end
+
+      describe "notification_title" do
+        it "is generated correctly" do
+          expect(subject.notification_title)
+            .to eq("You can now start <a href=\"#{resource_path}\">endorsing proposals</a> in <a href=\"#{participatory_space_url}\">#{participatory_space.title["en"]}</a>")
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/events/decidim/proposals/voting_enabled_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/voting_enabled_event_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Proposals
+    describe VotingEnabledEvent do
+      include Decidim::FeaturePathHelper
+
+      include_context "simple event"
+
+      let(:event_name) { "decidim.events.proposals.voting_enabled" }
+      let(:resource) { create(:proposal_feature) }
+      let(:participatory_space) { resource.participatory_space }
+      let(:resource_path) { main_feature_path(resource) }
+
+      it_behaves_like "a simple event"
+
+      describe "email_subject" do
+        it "is generated correctly" do
+          expect(subject.email_subject).to eq("Proposals voting has started for #{participatory_space.title["en"]}")
+        end
+      end
+
+      describe "email_intro" do
+        it "is generated correctly" do
+          expect(subject.email_intro)
+            .to eq("You can vote proposals in #{participatory_space_title}! Start participating in this page:")
+        end
+      end
+
+      describe "email_outro" do
+        it "is generated correctly" do
+          expect(subject.email_outro)
+            .to include("You have received this notification because you are following #{participatory_space.title["en"]}")
+        end
+      end
+
+      describe "notification_title" do
+        it "is generated correctly" do
+          expect(subject.notification_title)
+            .to eq("You can now start <a href=\"#{resource_path}\">voting proposals</a> in <a href=\"#{participatory_space_url}\">#{participatory_space.title["en"]}</a>")
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/jobs/decidim/proposals/settings_change_job_spec.rb
+++ b/decidim-proposals/spec/jobs/decidim/proposals/settings_change_job_spec.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Proposals
+    describe SettingsChangeJob do
+      subject { described_class }
+
+      let(:feature) { create(:proposal_feature) }
+      let(:user) { create :user, organization: feature.organization }
+      let!(:follow) { create :follow, followable: feature.participatory_space, user: user }
+
+      describe "creation enabled" do
+        let(:previous_settings) do
+          { creation_enabled: previously_allowing_creation }
+        end
+        let(:current_settings) do
+          { creation_enabled: currently_allowing_creation }
+        end
+
+        context "when creation is enabled" do
+          let(:previously_allowing_creation) { false }
+          let(:currently_allowing_creation) { true }
+
+          it "notifies the space followers about it" do
+            expect(Decidim::EventsManager)
+              .to receive(:publish)
+              .with(
+                event: "decidim.events.proposals.creation_enabled",
+                event_class: Decidim::Proposals::CreationEnabledEvent,
+                resource: feature,
+                recipient_ids: [user.id]
+              )
+
+            subject.perform_now(feature.id, previous_settings, current_settings)
+          end
+        end
+
+        context "when creation is not enabled" do
+          let(:previously_allowing_creation) { false }
+          let(:currently_allowing_creation) { false }
+
+          it "does not notify the space followers about it" do
+            expect(Decidim::EventsManager)
+              .not_to receive(:publish)
+
+            subject.perform_now(feature.id, previous_settings, current_settings)
+          end
+        end
+      end
+
+      describe "voting enabled" do
+        let(:previous_settings) do
+          {
+            votes_enabled: previously_allowing_votes,
+            votes_blocked: previously_blocking_votes
+          }
+        end
+        let(:current_settings) do
+          {
+            votes_enabled: currently_allowing_votes,
+            votes_blocked: currently_blocking_votes
+          }
+        end
+
+        context "when voting is enabled and unlocked" do
+          let(:previously_allowing_votes) { false }
+          let(:previously_blocking_votes) { false }
+          let(:currently_allowing_votes) { true }
+          let(:currently_blocking_votes) { false }
+
+          it "notifies the space followers about it" do
+            expect(Decidim::EventsManager)
+              .to receive(:publish)
+              .with(
+                event: "decidim.events.proposals.voting_enabled",
+                event_class: Decidim::Proposals::VotingEnabledEvent,
+                resource: feature,
+                recipient_ids: [user.id]
+              )
+
+            subject.perform_now(feature.id, previous_settings, current_settings)
+          end
+        end
+
+        context "when votes are not enabled" do
+          let(:previously_allowing_votes) { true }
+          let(:previously_blocking_votes) { false }
+          let(:currently_allowing_votes) { false }
+          let(:currently_blocking_votes) { false }
+
+          it "does not notify the space followers about it" do
+            expect(Decidim::EventsManager)
+              .not_to receive(:publish)
+
+            subject.perform_now(feature.id, previous_settings, current_settings)
+          end
+        end
+
+        context "when votes are blocked" do
+          let(:previously_allowing_votes) { false }
+          let(:previously_blocking_votes) { false }
+          let(:currently_allowing_votes) { true }
+          let(:currently_blocking_votes) { true }
+
+          it "does not notify the space followers about it" do
+            expect(Decidim::EventsManager)
+              .not_to receive(:publish)
+
+            subject.perform_now(feature.id, previous_settings, current_settings)
+          end
+        end
+      end
+
+      describe "endorsing enabled" do
+        let(:previous_settings) do
+          {
+            endorsements_enabled: previously_allowing_endorsements,
+            endorsements_blocked: previously_blocking_endorsements
+          }
+        end
+        let(:current_settings) do
+          {
+            endorsements_enabled: currently_allowing_endorsements,
+            endorsements_blocked: currently_blocking_endorsements
+          }
+        end
+
+        context "when endorsing is enabled and unlocked" do
+          let(:previously_allowing_endorsements) { false }
+          let(:previously_blocking_endorsements) { false }
+          let(:currently_allowing_endorsements) { true }
+          let(:currently_blocking_endorsements) { false }
+
+          it "notifies the space followers about it" do
+            expect(Decidim::EventsManager)
+              .to receive(:publish)
+              .with(
+                event: "decidim.events.proposals.endorsing_enabled",
+                event_class: Decidim::Proposals::EndorsingEnabledEvent,
+                resource: feature,
+                recipient_ids: [user.id]
+              )
+
+            subject.perform_now(feature.id, previous_settings, current_settings)
+          end
+        end
+
+        context "when endorsements are not enabled" do
+          let(:previously_allowing_endorsements) { true }
+          let(:previously_blocking_endorsements) { false }
+          let(:currently_allowing_endorsements) { false }
+          let(:currently_blocking_endorsements) { false }
+
+          it "does not notify the space followers about it" do
+            expect(Decidim::EventsManager)
+              .not_to receive(:publish)
+
+            subject.perform_now(feature.id, previous_settings, current_settings)
+          end
+        end
+
+        context "when endorsements are blocked" do
+          let(:previously_allowing_endorsements) { false }
+          let(:previously_blocking_endorsements) { false }
+          let(:currently_allowing_endorsements) { true }
+          let(:currently_blocking_endorsements) { true }
+
+          it "does not notify the space followers about it" do
+            expect(Decidim::EventsManager)
+              .not_to receive(:publish)
+
+            subject.perform_now(feature.id, previous_settings, current_settings)
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-surveys/app/events/decidim/surveys/closed_survey_event.rb
+++ b/decidim-surveys/app/events/decidim/surveys/closed_survey_event.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Surveys
+    class ClosedSurveyEvent < Decidim::Events::SimpleEvent
+    end
+  end
+end

--- a/decidim-surveys/app/events/decidim/surveys/opened_survey_event.rb
+++ b/decidim-surveys/app/events/decidim/surveys/opened_survey_event.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Surveys
+    class OpenedSurveyEvent < Decidim::Events::SimpleEvent
+    end
+  end
+end

--- a/decidim-surveys/app/jobs/decidim/surveys/settings_change_job.rb
+++ b/decidim-surveys/app/jobs/decidim/surveys/settings_change_job.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Surveys
+    class SettingsChangeJob < ApplicationJob
+      def perform(feature_id, previous_settings, current_settings)
+        return if unchanged?(previous_settings, current_settings)
+
+        feature = Decidim::Feature.find(feature_id)
+
+        if survey_opened?(previous_settings, current_settings)
+          event = "decidim.events.surveys.survey_opened"
+          event_class = Decidim::Surveys::OpenedSurveyEvent
+        elsif survey_closed?(previous_settings, current_settings)
+          event = "decidim.events.surveys.survey_closed"
+          event_class = Decidim::Surveys::ClosedSurveyEvent
+        end
+
+        Decidim::EventsManager.publish(
+          event: event,
+          event_class: event_class,
+          resource: feature,
+          recipient_ids: feature.participatory_space.followers.pluck(:id)
+        )
+      end
+
+      private
+
+      def unchanged?(previous_settings, current_settings)
+        current_settings[:allow_answers] == previous_settings[:allow_answers]
+      end
+
+      def survey_opened?(previous_settings, current_settings)
+        current_settings[:allow_answers] == true &&
+          previous_settings[:allow_answers] == false
+      end
+
+      def survey_closed?(previous_settings, current_settings)
+        current_settings[:allow_answers] == false &&
+          previous_settings[:allow_answers] == true
+      end
+    end
+  end
+end

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -8,6 +8,18 @@ en:
         mandatory: Mandatory
         question_type: Type
   decidim:
+    events:
+      surveys:
+        survey_closed:
+          email_intro: The survey %{resource_title} in %{participatory_space_title} has been closed.
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: A survey has finished in %{participatory_space_title}
+          notification_title: The survey <a href="%{resource_path}">%{resource_title}</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a> has finished.
+        survey_opened:
+          email_intro: 'The survey %{resource_title} in %{participatory_space_title} is now open. You can participate in it from this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: A new survey in %{participatory_space_title}
+          notification_title: The survey <a href="%{resource_path}">%{resource_title}</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a> is now open.
     features:
       surveys:
         actions:

--- a/decidim-surveys/lib/decidim/surveys/engine.rb
+++ b/decidim-surveys/lib/decidim/surveys/engine.rb
@@ -20,6 +20,16 @@ module Decidim
           config.abilities += ["Decidim::Surveys::Abilities::CurrentUserAbility"]
         end
       end
+
+      initializer "decidim_changes" do
+        Decidim::SettingsChange.subscribe "surveys" do |changes|
+          Decidim::Surveys::SettingsChangeJob.perform_later(
+            changes[:feature_id],
+            changes[:previous_settings],
+            changes[:current_settings]
+          )
+        end
+      end
     end
   end
 end

--- a/decidim-surveys/spec/events/decidim/surveys/closed_survey_event_spec.rb
+++ b/decidim-surveys/spec/events/decidim/surveys/closed_survey_event_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Surveys
+    describe ClosedSurveyEvent do
+      include Decidim::FeaturePathHelper
+
+      include_context "simple event"
+
+      let(:event_name) { "decidim.events.surveys.survey_closed" }
+      let(:resource) { create(:surveys_feature) }
+      let(:participatory_space) { resource.participatory_space }
+      let(:resource_path) { main_feature_path(resource) }
+
+      it_behaves_like "a simple event"
+
+      describe "email_subject" do
+        it "is generated correctly" do
+          expect(subject.email_subject).to eq("A survey has finished in #{participatory_space_title}")
+        end
+      end
+
+      describe "email_intro" do
+        it "is generated correctly" do
+          expect(subject.email_intro)
+            .to eq("The survey #{resource.name["en"]} in #{participatory_space_title} has been closed.")
+        end
+      end
+
+      describe "email_outro" do
+        it "is generated correctly" do
+          expect(subject.email_outro)
+            .to include("You have received this notification because you are following #{participatory_space_title}")
+        end
+      end
+
+      describe "notification_title" do
+        it "is generated correctly" do
+          expect(subject.notification_title)
+            .to start_with("The survey <a href=\"#{resource_path}\">#{resource.name["en"]}</a> in")
+          expect(subject.notification_title)
+            .to end_with("<a href=\"#{participatory_space_url}\">#{participatory_space_title}</a> has finished.")
+        end
+      end
+    end
+  end
+end

--- a/decidim-surveys/spec/events/decidim/surveys/opened_survey_event_spec.rb
+++ b/decidim-surveys/spec/events/decidim/surveys/opened_survey_event_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Surveys
+    describe OpenedSurveyEvent do
+      include Decidim::FeaturePathHelper
+
+      include_context "simple event"
+
+      let(:event_name) { "decidim.events.surveys.survey_opened" }
+      let(:resource) { create(:surveys_feature) }
+      let(:participatory_space) { resource.participatory_space }
+      let(:resource_path) { main_feature_path(resource) }
+
+      it_behaves_like "a simple event"
+
+      describe "email_subject" do
+        it "is generated correctly" do
+          expect(subject.email_subject).to eq("A new survey in #{participatory_space_title}")
+        end
+      end
+
+      describe "email_intro" do
+        it "is generated correctly" do
+          expect(subject.email_intro)
+            .to eq("The survey #{resource.name["en"]} in #{participatory_space_title} is now open. You can participate in it from this page:")
+        end
+      end
+
+      describe "email_outro" do
+        it "is generated correctly" do
+          expect(subject.email_outro)
+            .to include("You have received this notification because you are following #{participatory_space_title}")
+        end
+      end
+
+      describe "notification_title" do
+        it "is generated correctly" do
+          expect(subject.notification_title)
+            .to eq("The survey <a href=\"#{resource_path}\">#{resource.name["en"]}</a> in <a href=\"#{participatory_space_url}\">#{participatory_space_title}</a> is now open.")
+        end
+      end
+    end
+  end
+end

--- a/decidim-surveys/spec/jobs/decidim/surveys/settings_change_job_spec.rb
+++ b/decidim-surveys/spec/jobs/decidim/surveys/settings_change_job_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Surveys
+    describe SettingsChangeJob do
+      subject { described_class }
+
+      let(:survey) { create(:survey) }
+      let(:feature) { survey.feature }
+      let(:previous_settings) do
+        { allow_answers: previously_allowing_answers }
+      end
+      let(:current_settings) do
+        { allow_answers: currently_allowing_answers }
+      end
+      let(:user) { create :user, organization: feature.organization }
+      let!(:follow) { create :follow, followable: feature.participatory_space, user: user }
+
+      context "when there are relevant setting changes" do
+        context "when the survey becomes open" do
+          let(:previously_allowing_answers) { false }
+          let(:currently_allowing_answers) { true }
+
+          it "notifies the space followers about it" do
+            expect(Decidim::EventsManager)
+              .to receive(:publish)
+              .with(
+                event: "decidim.events.surveys.survey_opened",
+                event_class: Decidim::Surveys::OpenedSurveyEvent,
+                resource: feature,
+                recipient_ids: [user.id]
+              )
+
+            subject.perform_now(feature.id, previous_settings, current_settings)
+          end
+        end
+
+        context "when the survey becomes closed" do
+          let(:previously_allowing_answers) { true }
+          let(:currently_allowing_answers) { false }
+
+          it "notifies the space followers about it" do
+            expect(Decidim::EventsManager)
+              .to receive(:publish)
+              .with(
+                event: "decidim.events.surveys.survey_closed",
+                event_class: Decidim::Surveys::ClosedSurveyEvent,
+                resource: feature,
+                recipient_ids: [user.id]
+              )
+
+            subject.perform_now(feature.id, previous_settings, current_settings)
+          end
+        end
+      end
+
+      context "when there aren't relevant changes" do
+        let(:previously_allowing_answers) { true }
+        let(:currently_allowing_answers) { true }
+
+        it "doesn't notify the upcoming meeting" do
+          expect(Decidim::EventsManager)
+            .not_to receive(:publish)
+
+          subject.perform_now(feature.id, previous_settings, current_settings)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds a way to track feature settings changes (both for spaces with or without steps) and adds new notifications for surveys, debates and proposals.

#### :pushpin: Related Issues
- Related to #2446

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
