### PR TITLE
Add configurable proposal body length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **decidim-proposals**: Notify participatory space followers when a proposal is created. [\#2646](https://github.com/decidim/decidim/pull/2646)
 - **decidim-proposals**: Copy proposals to another component [\#2619](https://github.com/decidim/decidim/issues/2619).
 - **decidim-proposals**: Users and user_groups can now endorse proposals. [\#2287](https://github.com/decidim/decidim/pull/2287)
+- **decidim-proposals**: Add configurable proposal body length. [\#2639](https://github.com/decidim/decidim/pull/2639)
 - **decidim-participatory_processes**: Ensure only active processes are shown in the highlighted processes section in the homepage[\#2682](https://github.com/decidim/decidim/pull/2682)
 - **decidim-core**: Add collections to group attachments [\#2394](https://github.com/decidim/decidim/pull/2394).
 - **decidim-admin**: Adds a log of all admin actions, only visible by organization admins [\#2604](https://github.com/decidim/decidim/pull/2604)

--- a/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
@@ -60,6 +60,7 @@ module Decidim
       end
 
       def proposal_length
+        return unless body.presence
         length = current_feature.settings.proposal_length
         errors.add(:body, :too_long, count: length) if body.length > length
       end

--- a/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
@@ -18,12 +18,12 @@ module Decidim
       attribute :attachment, AttachmentForm
       validates :title, :body, presence: true, etiquette: true
       validates :title, length: { maximum: 150 }
-      validate :proposal_length
       validates :address, geocoding: true, if: ->(form) { Decidim.geocoder.present? && form.has_address? }
       validates :address, presence: true, if: ->(form) { form.has_address? }
       validates :category, presence: true, if: ->(form) { form.category_id.present? }
       validates :scope, presence: true, if: ->(form) { form.scope_id.present? }
       validate { errors.add(:scope_id, :invalid) if current_participatory_space&.scope && !current_participatory_space&.scope&.ancestor_of?(scope) }
+      validate :proposal_length
 
       delegate :categories, to: :current_feature
 

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -66,12 +66,12 @@ en:
             official_proposals_enabled: Official proposals enabled
             proposal_answering_enabled: Proposal answering enabled
             proposal_edit_before_minutes: Proposals can be edited by authors before this many minutes passes
+            proposal_length: Maximum proposal body length
             proposal_limit: Proposal limit per user
             proposal_wizard_step_1_help_text: Proposal wizard "Create" step help text
             proposal_wizard_step_2_help_text: Proposal wizard "Compare" step help text
             proposal_wizard_step_3_help_text: Proposal wizard "Publish" step help text
             vote_limit: Vote limit per user
-            proposal_length: Maximum proposal body length
           step:
             announcement: Announcement
             comments_blocked: Comments blocked

--- a/decidim-proposals/config/locales/es.yml
+++ b/decidim-proposals/config/locales/es.yml
@@ -60,7 +60,6 @@ es:
             proposal_edit_before_minutes: Las propuestas pueden ser editadas por los autores antes de que pasen estos minutos
             proposal_limit: Límite de propuestas por usuario
             vote_limit: Límite de votos por usuario
-            proposal_length: Tamaño máximo del cuerpo de la propuesta
           step:
             announcement: Aviso
             comments_blocked: Comentarios bloqueados

--- a/decidim-proposals/spec/system/edit_proposal_spec.rb
+++ b/decidim-proposals/spec/system/edit_proposal_spec.rb
@@ -52,7 +52,7 @@ describe "Edit proposals", type: :system do
         fill_in "Body", with: "A"
         click_button "Send"
 
-        expect(page).to have_content("Is using too much caps, Is too short, Is using too much caps, Is too short")
+        expect(page).to have_content("Is using too much caps, Is too short")
       end
     end
   end


### PR DESCRIPTION
*This actually comes from #2639 - made by @mijailr, reviewed by @mrcasals*  

#### :tophat: What? Why?
Many users want to have more length in the body of a proposal, so i enable the posibility to handle a configurable body length from the feature settings, so if you want to define the proposal body of a specific participatory process you can easily configure that.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)

![Configure proposal body length](https://user-images.githubusercontent.com/1911813/35747026-d4b1669c-0816-11e8-868f-cef23b5e20f2.png)

![Check proposal body length](https://user-images.githubusercontent.com/1911813/35747060-ed94ee9a-0816-11e8-92c6-eacd289769f2.png)

