### PR TITLE
Backport PR - Wrong message creating proposal note to stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 **Changed**:
 
 **Fixed**:
-
+* **decidim-proposals**: Fix wrong message when creating a proposal private note [\#2796](https://github.com/decidim/decidim/pull/2796)
 * **decidim-core**: Fix AuthorEvent when author is missing [\#2777](https://github.com/decidim/decidim/pull/2777)
 * **decidim-core**: Fix DefaultActionAuthorizer when options is nil [\#2753](https://github.com/decidim/decidim/pull/2753)
 * **decidim-core**: Fix mention parsing to only search users in current organization. [\2711](https://github.com/decidim/decidim/pull/2711)

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposal_notes_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposal_notes_controller.rb
@@ -18,12 +18,12 @@ module Decidim
 
           CreateProposalNote.call(@form, proposal, current_user) do
             on(:ok) do
-              flash[:notice] = I18n.t("proposals.create.success", scope: "decidim")
+              flash[:notice] = I18n.t("proposal_notes.create.success", scope: "decidim.proposals.admin")
               redirect_to proposal_proposal_notes_path(proposal_id: proposal.id)
             end
 
             on(:invalid) do
-              flash.now[:alert] = I18n.t("proposals.create.error", scope: "decidim")
+              flash.now[:alert] = I18n.t("proposal_notes.create.error", scope: "decidim.proposals.admin")
               render :index
             end
           end

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -84,6 +84,9 @@ en:
             rejected: Rejected
             title: Answer for proposal %{title}
         proposal_notes:
+          create:
+            invalid: There's been a problem creating this proposal note
+            success: Proposal note successfully created
           form:
             note: Note
             submit: Submit

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -85,7 +85,7 @@ en:
             title: Answer for proposal %{title}
         proposal_notes:
           create:
-            invalid: There's been a problem creating this proposal note
+            error: There's been a problem creating this proposal note
             success: Proposal note successfully created
           form:
             note: Note

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -416,6 +416,27 @@ shared_examples "manage proposals" do
     end
   end
 
+  context "when admin can create proposal notes" do
+    it "can create proposal note" do
+      within find("tr", text: proposal.title) do
+        click_link "Private notes"
+      end
+
+      expect(page).to have_selector(".new_proposal_note")
+
+      within ".new_proposal_note" do
+        fill_in :proposal_note_body, with: "Lorem ipsum dolor sit amet consectetur"
+        click_button "Submit"
+      end
+
+      expect(page).to have_admin_callout("Proposal note successfully created")
+
+      within find(".comments") do
+        expect(page).to have_content("Lorem ipsum dolor sit amet consectetur")
+      end
+    end
+  end
+
   def go_to_edit_answer(proposal)
     within find("tr", text: proposal.title) do
       click_link "Answer"

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -416,27 +416,6 @@ shared_examples "manage proposals" do
     end
   end
 
-  context "when admin can create proposal notes" do
-    it "can create proposal note" do
-      within find("tr", text: proposal.title) do
-        click_link "Private notes"
-      end
-
-      expect(page).to have_selector(".new_proposal_note")
-
-      within ".new_proposal_note" do
-        fill_in :proposal_note_body, with: "Lorem ipsum dolor sit amet consectetur"
-        click_button "Submit"
-      end
-
-      expect(page).to have_admin_callout("Proposal note successfully created")
-
-      within find(".comments") do
-        expect(page).to have_content("Lorem ipsum dolor sit amet consectetur")
-      end
-    end
-  end
-
   def go_to_edit_answer(proposal)
     within find("tr", text: proposal.title) do
       click_link "Answer"

--- a/decidim-proposals/spec/system/index_proposal_notes_spec.rb
+++ b/decidim-proposals/spec/system/index_proposal_notes_spec.rb
@@ -27,7 +27,7 @@ describe "Index Proposal Notes", type: :system do
     visit current_path + "proposals/#{proposal.id}/proposal_notes"
   end
 
-  it "shows all proposal notes for the given proposal" do
+  it "shows proposal notes for the current proposal" do
     proposal_notes.each do |proposal_note|
       expect(page).to have_content(proposal_note.author.name)
       expect(page).to have_content(proposal_note.body)
@@ -35,8 +35,8 @@ describe "Index Proposal Notes", type: :system do
     expect(page).to have_selector("form")
   end
 
-  context "when the form is valid" do
-    it "creates a new proposal note ", :slow do
+  context "when the form has a text inside body" do
+    it "creates a proposal note ", :slow do
       within ".new_proposal_note" do
         fill_in :proposal_note_body, with: body
 
@@ -51,10 +51,10 @@ describe "Index Proposal Notes", type: :system do
     end
   end
 
-  context "when the form is not valid" do
+  context "when the form hasn't text inside body" do
     let(:body) { nil }
 
-    it "not creates a new proposal note", :slow do
+    it "don't create a proposal note", :slow do
       within ".new_proposal_note" do
         fill_in :proposal_note_body, with: body
 


### PR DESCRIPTION
#### :tophat: What? Why?
Add correct locales when creating admin proposal notes to 0.9-stable.

#### :pushpin: Related Issues
- Related to #?
- Fixes #2769 to branch 0.9-stable

#### :clipboard: Subtasks
- [x] fix locales when creating admin proposal notes

