### PR TITLE
Fix SimpleEvent shared examples

### DIFF
--- a/decidim-admin/spec/events/decidim/attachment_created_event_spec.rb
+++ b/decidim-admin/spec/events/decidim/attachment_created_event_spec.rb
@@ -15,7 +15,7 @@ describe Decidim::AttachmentCreatedEvent do
     resource.file.class.configure { |config| config.asset_host = "http://example.org" }
   end
 
-  it_behaves_like "an simple event"
+  it_behaves_like "a simple event"
 
   describe "email_subject" do
     it "is generated correctly" do

--- a/decidim-admin/spec/events/decidim/feature_published_event_spec.rb
+++ b/decidim-admin/spec/events/decidim/feature_published_event_spec.rb
@@ -12,7 +12,7 @@ describe Decidim::FeaturePublishedEvent do
   let(:participatory_space) { resource.participatory_space }
   let(:resource_path) { main_feature_path(resource) }
 
-  it_behaves_like "an simple event"
+  it_behaves_like "a simple event"
 
   describe "email_subject" do
     it "is generated correctly" do

--- a/decidim-admin/spec/events/decidim/participatory_process_step_activated_event_spec.rb
+++ b/decidim-admin/spec/events/decidim/participatory_process_step_activated_event_spec.rb
@@ -15,7 +15,7 @@ describe Decidim::ParticipatoryProcessStepActivatedEvent do
       .participatory_process_participatory_process_steps_path(participatory_process)
   end
 
-  it_behaves_like "an simple event"
+  it_behaves_like "a simple event"
 
   describe "email_subject" do
     it "is generated correctly" do

--- a/decidim-comments/spec/events/decidim/comments/comment_created_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/comment_created_event_spec.rb
@@ -11,7 +11,7 @@ describe Decidim::Comments::CommentCreatedEvent do
   let(:event_name) { "decidim.events.comments.comment_created" }
   let(:extra) { { comment_id: comment.id } }
 
-  it_behaves_like "an simple event"
+  it_behaves_like "a simple event"
 
   describe "email_subject" do
     it "is generated correctly" do

--- a/decidim-comments/spec/events/decidim/comments/user_mentioned_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/user_mentioned_event_spec.rb
@@ -11,7 +11,7 @@ describe Decidim::Comments::UserMentionedEvent do
   let(:event_name) { "decidim.events.comments.user_mentioned" }
   let(:extra) { { comment_id: comment.id } }
 
-  it_behaves_like "an simple event"
+  it_behaves_like "a simple event"
 
   describe "email_subject" do
     it "is generated correctly" do

--- a/decidim-core/lib/decidim/core/test/shared_examples/simple_event.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/simple_event.rb
@@ -24,11 +24,13 @@ shared_context "simple event" do
   let(:resource_path) { resource_locator(resource).path }
   let(:resource_url) { resource_locator(resource).url }
   let(:resource_title) { resource.title["en"] }
+  let(:participatory_space) { resource.participatory_space }
+  let(:participatory_space_title) { participatory_space.title["en"] }
   let(:author) { resource.author }
   let(:author_presenter) { Decidim::UserPresenter.new(author) }
 end
 
-shared_examples_for "an simple event" do
+shared_examples_for "a simple event" do
   describe "types" do
     subject { described_class }
 

--- a/decidim-core/lib/decidim/events/base_event.rb
+++ b/decidim-core/lib/decidim/events/base_event.rb
@@ -6,6 +6,8 @@ module Decidim
     # add more logic to a `Decidim::Notification` and are used to render them in the
     # notifications dashboard and to generate other notifications (emails, for example).
     class BaseEvent
+      include Decidim::TranslatableAttributes
+
       class_attribute :types
       self.types = []
 
@@ -88,7 +90,13 @@ module Decidim
       end
 
       def resource_title
-        resource.title.is_a?(Hash) ? resource.title[I18n.locale.to_s] : resource.title
+        return unless resource
+
+        if resource.respond_to?(:title)
+          translated_attribute(resource.title)
+        elsif resource.respond_to?(:name)
+          translated_attribute(resource.name)
+        end
       end
     end
   end

--- a/decidim-core/lib/decidim/events/simple_event.rb
+++ b/decidim-core/lib/decidim/events/simple_event.rb
@@ -71,8 +71,13 @@ module Decidim
           resource_path: resource_path,
           resource_title: resource_title,
           resource_url: resource_url,
+          participatory_space_title: participatory_space_title,
           scope: i18n_scope
         }
+      end
+
+      def participatory_space_title
+        translated_attribute(participatory_space.try(:title))
       end
     end
   end

--- a/decidim-core/spec/events/decidim/profile_updated_event_spec.rb
+++ b/decidim-core/spec/events/decidim/profile_updated_event_spec.rb
@@ -9,7 +9,7 @@ describe Decidim::ProfileUpdatedEvent do
   let(:resource) { create :user }
   let(:author) { resource }
 
-  it_behaves_like "an simple event"
+  it_behaves_like "a simple event"
 
   describe "email_subject" do
     it "is generated correctly" do

--- a/decidim-debates/spec/events/decidim/debates/create_debate_event_spec.rb
+++ b/decidim-debates/spec/events/decidim/debates/create_debate_event_spec.rb
@@ -14,7 +14,7 @@ describe Decidim::Debates::CreateDebateEvent do
   context "when the notification is for user followers" do
     let(:type) { :user }
 
-    it_behaves_like "an simple event"
+    it_behaves_like "a simple event"
 
     describe "email_subject" do
       it "is generated correctly" do
@@ -50,7 +50,7 @@ describe Decidim::Debates::CreateDebateEvent do
   context "when the notification is for space followers" do
     let(:type) { :space }
 
-    it_behaves_like "an simple event"
+    it_behaves_like "a simple event"
 
     describe "email_subject" do
       it "is generated correctly" do

--- a/decidim-meetings/spec/events/decidim/meetings/close_meeting_event_spec.rb
+++ b/decidim-meetings/spec/events/decidim/meetings/close_meeting_event_spec.rb
@@ -7,5 +7,5 @@ describe Decidim::Meetings::CloseMeetingEvent do
   let(:event_name) { "decidim.events.meetings.meeting_closed" }
 
   include_context "simple event"
-  it_behaves_like "an simple event"
+  it_behaves_like "a simple event"
 end

--- a/decidim-meetings/spec/events/decidim/meetings/meeting_registrations_enabled_event_spec.rb
+++ b/decidim-meetings/spec/events/decidim/meetings/meeting_registrations_enabled_event_spec.rb
@@ -7,5 +7,5 @@ describe Decidim::Meetings::MeetingRegistrationsEnabledEvent do
   let(:event_name) { "decidim.events.meetings.registrations_enabled" }
 
   include_context "simple event"
-  it_behaves_like "an simple event"
+  it_behaves_like "a simple event"
 end

--- a/decidim-meetings/spec/events/decidim/meetings/meeting_registrations_over_percentage_event_spec.rb
+++ b/decidim-meetings/spec/events/decidim/meetings/meeting_registrations_over_percentage_event_spec.rb
@@ -9,5 +9,5 @@ describe Decidim::Meetings::MeetingRegistrationsOverPercentageEvent do
   let(:event_name) { "decidim.events.meetings.meeting_registrations_over_percentage" }
   let(:extra) { { percentage: 1.1 } }
 
-  it_behaves_like "an simple event"
+  it_behaves_like "a simple event"
 end

--- a/decidim-meetings/spec/events/decidim/meetings/upcoming_meeting_event_spec.rb
+++ b/decidim-meetings/spec/events/decidim/meetings/upcoming_meeting_event_spec.rb
@@ -7,5 +7,5 @@ describe Decidim::Meetings::UpcomingMeetingEvent do
   let(:event_name) { "decidim.events.meetings.upcoming_meeting" }
 
   include_context "simple event"
-  it_behaves_like "an simple event"
+  it_behaves_like "a simple event"
 end

--- a/decidim-meetings/spec/events/decidim/meetings/update_meeting_event_spec.rb
+++ b/decidim-meetings/spec/events/decidim/meetings/update_meeting_event_spec.rb
@@ -7,5 +7,5 @@ describe Decidim::Meetings::UpdateMeetingEvent do
   let(:event_name) { "decidim.events.meetings.meeting_updated" }
 
   include_context "simple event"
-  it_behaves_like "an simple event"
+  it_behaves_like "a simple event"
 end

--- a/decidim-proposals/spec/events/decidim/proposals/accepted_proposal_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/accepted_proposal_event_spec.rb
@@ -7,7 +7,7 @@ describe Decidim::Proposals::AcceptedProposalEvent do
   let(:event_name) { "decidim.events.proposals.proposal_accepted" }
 
   include_context "simple event"
-  it_behaves_like "an simple event"
+  it_behaves_like "a simple event"
 
   describe "email_subject" do
     it "is generated correctly" do

--- a/decidim-proposals/spec/events/decidim/proposals/create_proposal_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/create_proposal_event_spec.rb
@@ -9,7 +9,7 @@ module Decidim
       let(:event_name) { "decidim.events.proposals.proposal_created" }
 
       include_context "simple event"
-      it_behaves_like "an simple event"
+      it_behaves_like "a simple event"
 
       describe "email_subject" do
         it "is generated correctly" do

--- a/decidim-proposals/spec/events/decidim/proposals/evaluating_proposal_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/evaluating_proposal_event_spec.rb
@@ -7,7 +7,7 @@ describe Decidim::Proposals::EvaluatingProposalEvent do
   let(:event_name) { "decidim.events.proposals.proposal_evaluating" }
 
   include_context "simple event"
-  it_behaves_like "an simple event"
+  it_behaves_like "a simple event"
 
   describe "email_subject" do
     it "is generated correctly" do

--- a/decidim-proposals/spec/events/decidim/proposals/rejected_proposal_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/rejected_proposal_event_spec.rb
@@ -7,7 +7,7 @@ describe Decidim::Proposals::RejectedProposalEvent do
   let(:event_name) { "decidim.events.proposals.proposal_rejected" }
 
   include_context "simple event"
-  it_behaves_like "an simple event"
+  it_behaves_like "a simple event"
 
   describe "email_subject" do
     it "is generated correctly" do


### PR DESCRIPTION
#### :tophat: What? Why?

The shared examples at `0.9-stable` for SimpleEvent have a typo and can't be used by other modules that depend on this version.
