### PR TITLE
Do not wrap static pages default content in `<p>` tags

### DIFF
--- a/decidim-system/app/commands/decidim/system/create_default_pages.rb
+++ b/decidim-system/app/commands/decidim/system/create_default_pages.rb
@@ -33,7 +33,7 @@ module Decidim
       def localized_attribute(slug, attribute)
         Decidim.available_locales.inject({}) do |result, locale|
           text = I18n.with_locale(locale) do
-            "<p>#{I18n.t(attribute, scope: "decidim.system.default_pages.placeholders", page: slug)}</p>"
+            I18n.t(attribute, scope: "decidim.system.default_pages.placeholders", page: slug)
           end
 
           result.update(locale => text)


### PR DESCRIPTION
#### :tophat: What? Why?
Removes `<p>` wrapping for default content in static pages.

#### :pushpin: Related Issues
- Fixes #2798

#### :clipboard: Subtasks
None. No changelog entry needed since this hasn't been released yet.
