### PR TITLE
Add hook on feature permission update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - **decidim-admin**: Log feature creation and deletion [\#2792](https://github.com/decidim/decidim/pull/2792)
 - **decidim-participatory_processes**: Log process users invites (Creation, update and deletion) [\#2793](https://github.com/decidim/decidim/pull/2793)
 - **decidim-admin**: Log actions on moderations [\#2803](https://github.com/decidim/decidim/pull/2803)
+- **decidim-core**: Enable a "permission_update" hook to be run upon feature permissions update [\#2809](https://github.com/decidim/decidim/pull/2809)
 
 **Changed**:
 

--- a/decidim-admin/app/commands/decidim/admin/update_feature_permissions.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_feature_permissions.rb
@@ -22,7 +22,11 @@ module Decidim
       def call
         return broadcast(:invalid) unless @form.valid?
 
-        update_permissions
+        transaction do
+          update_permissions
+          run_hooks
+        end
+
         broadcast(:ok)
       end
 
@@ -41,6 +45,10 @@ module Decidim
         @feature.update_attributes!(
           permissions: permissions
         )
+      end
+
+      def run_hooks
+        @feature.manifest.run_hooks(:permission_update, @feature)
       end
     end
   end

--- a/decidim-admin/spec/commands/update_feature_permissions_spec.rb
+++ b/decidim-admin/spec/commands/update_feature_permissions_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Admin
+  describe UpdateFeaturePermissions do
+    let!(:participatory_process) { create(:participatory_process, :with_steps) }
+
+    let!(:feature) do
+      create(
+        :feature,
+        participatory_space: participatory_process,
+        permissions: {
+          "create" => {
+            "authorization_handler_name" => "dummy_authorization_handler",
+            "options" => { "thelma" => "louise" }
+          }
+        }
+      )
+    end
+
+    let(:manifest) { feature.manifest }
+
+    let(:form) do
+      double(
+        valid?: valid,
+        permissions: {
+          "create" => double(
+            authorization_handler_name: "dummy",
+            options: "{ \"perry\" : \"mason\" }"
+          )
+        }
+      )
+    end
+
+    let(:expected_permissions) do
+      {
+        "create" => {
+          "authorization_handler_name" => "dummy",
+          "options" => { "perry" => "mason" }
+        }
+      }
+    end
+
+    describe "when valid" do
+      let(:valid) { true }
+
+      it "broadcasts :ok and updates the feature" do
+        expect do
+          described_class.call(form, feature)
+        end.to broadcast(:ok)
+
+        expect(feature.permissions).to eq(expected_permissions)
+      end
+    end
+
+    describe "when invalid" do
+      let(:valid) { false }
+
+      it "does not update the permissions" do
+        expect do
+          described_class.call(form, feature)
+        end.to broadcast(:invalid)
+
+        feature.reload
+        expect(feature.permissions).not_to eq(expected_permissions)
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/commands/update_feature_permissions_spec.rb
+++ b/decidim-admin/spec/commands/update_feature_permissions_spec.rb
@@ -52,6 +52,20 @@ module Decidim::Admin
 
         expect(feature.permissions).to eq(expected_permissions)
       end
+
+      it "fires the hooks" do
+        results = {}
+
+        manifest.on(:permission_update) do |feature|
+          results[:feature] = feature
+        end
+
+        described_class.call(form, feature)
+
+        feature = results[:feature]
+
+        expect(feature.permissions).to eq(expected_permissions)
+      end
     end
 
     describe "when invalid" do

--- a/decidim-admin/spec/commands/update_feature_spec.rb
+++ b/decidim-admin/spec/commands/update_feature_spec.rb
@@ -75,7 +75,7 @@ module Decidim::Admin
     describe "when invalid" do
       let(:valid) { false }
 
-      it "creates the feature" do
+      it "does not update the feature" do
         expect do
           described_class.call(form, feature)
         end.to broadcast(:invalid)


### PR DESCRIPTION
#### :tophat: What? Why?

In order to enforce some restrictions on feature permissions, we'd like to enable a hook to be run on feature permissions update. It works just like the other feature hooks we already have.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Another subtask

### :camera: Screenshots (optional)
_None_.
