### PR TITLE
Fix authorization modal not reopening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,5 +60,6 @@
 - **decidim-assemblies**: Fix editing a process after an error.[\#2653](https://github.com/decidim/decidim/pull/2653)
 - **decidim-core**: Fix missing i18n strings for "Feature published" events. [\#2729](https://github.com/decidim/decidim/pull/2729)
 - **decidim-core**: Fix user invitations by generating their nickname. [\#2783](https://github.com/decidim/decidim/pull/2783)
+- **decidim-core**: Fix authorization modals not reopening [\#2811](https://github.com/decidim/decidim/pull/2811)
 
 Please check [0.9-stable](https://github.com/decidim/decidim/blob/0.9-stable/CHANGELOG.md) for previous changes.

--- a/decidim-core/app/assets/javascripts/decidim/append_redirect_url_to_modals.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/append_redirect_url_to_modals.js.es6
@@ -36,7 +36,7 @@ $(() => {
       const parts = queryString.split(/[&;]/g);
 
       // Reverse iteration as may be destructive
-      for (let index = parts.length; index > 0; index -= 1) {
+      for (let index = parts.length - 1; index >= 0; index -= 1) {
         // Idiom for string.startsWith
         if (parts[index].lastIndexOf(prefix, 0) !== -1) {
           parts.splice(index, 1);

--- a/decidim-core/spec/system/menu_spec.rb
+++ b/decidim-core/spec/system/menu_spec.rb
@@ -69,6 +69,12 @@ describe "Menu", type: :system do
       end
     end
 
+    after do
+      within_language_menu do
+        click_link "English"
+      end
+    end
+
     it "works with multiple languages" do
       visit decidim.root_path
 

--- a/decidim-verifications/spec/system/action_authorization_spec.rb
+++ b/decidim-verifications/spec/system/action_authorization_spec.rb
@@ -46,6 +46,14 @@ describe "Action Authorization", type: :system do
         expect(page).to have_content("In order to perform this action, you need to be authorized with \"Example authorization\"")
       end
 
+      it "prompts the user to authorize again after modal reopening" do
+        click_button "×"
+        click_link "New proposal"
+
+        expect(page).to have_content("Authorization required")
+        expect(page).to have_content("In order to perform this action, you need to be authorized with \"Example authorization\"")
+      end
+
       it "redirects to authorization when modal clicked" do
         click_link "Authorize with \"Example authorization\""
 


### PR DESCRIPTION
#### :tophat: What? Why?

When closing an authorization modal, I was not able to open it again. Aparently the JS taking care of appending the redirect_url to the modal destination was crashing. I checked and it seemed to me that an array was being accessed out of bounds?

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
_None_.
