### PR TITLE
Let foundation style tooltips

### DIFF
--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_action-icon.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_action-icon.scss
@@ -11,12 +11,6 @@ $action-icon-width: $icon-size;
   margin-right: 1rem;
 }
 
-.action-icon.has-tip,
-.simple-has-tip.has-tip{
-  border-bottom: 0;
-  cursor: pointer;
-}
-
 .action-icon.action-icon--remove{
   color: $alert-color;
 }

--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_table-list.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_table-list.scss
@@ -86,7 +86,3 @@
 .table-list__state{
   text-align: center;
 }
-
-.icon-state.has-tip{
-  border-bottom: 0;
-}

--- a/decidim-admin/app/assets/stylesheets/decidim/admin/utils/_settings.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/utils/_settings.scss
@@ -829,9 +829,9 @@ $titlebar-icon-spacing: .25rem;
 // 54. Tooltip
 // -----------
 
-$has-tip-cursor: help;
+$has-tip-cursor: pointer;
 $has-tip-font-weight: $global-weight-bold;
-$has-tip-border-bottom: dotted 1px $dark-gray;
+$has-tip-border-bottom: 0;
 $tooltip-background-color: $black;
 $tooltip-color: $white;
 $tooltip-padding: .3rem 1rem;

--- a/decidim-admin/app/helpers/decidim/admin/icon_link_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/icon_link_helper.rb
@@ -21,8 +21,7 @@ module Decidim
                 data: options[:data] || {},
                 title: title,
                 target: options[:target]) do
-          content_tag(:span, class: "simple-has-tip",
-                             data: { tooltip: true, disable_hover: false, click_open: false },
+          content_tag(:span, data: { tooltip: true, disable_hover: false, click_open: false },
                              title: title) do
             icon(icon_name)
           end

--- a/decidim-admin/app/views/decidim/admin/moderations/_report.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/_report.html.erb
@@ -4,7 +4,6 @@
   <span
     data-tooltip
     aria-haspopup="true"
-    class="has-tip"
     title="<%= report.details %>">
       <%= t(".reasons.#{report.reason}") %>
   </span>

--- a/decidim-core/app/assets/stylesheets/decidim/utils/_settings.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/utils/_settings.scss
@@ -829,9 +829,9 @@ $titlebar-icon-spacing: .25rem;
 // 54. Tooltip
 // -----------
 
-$has-tip-cursor: help;
+$has-tip-cursor: pointer;
 $has-tip-font-weight: $global-weight-bold;
-$has-tip-border-bottom: dotted 1px $dark-gray;
+$has-tip-border-bottom: 0;
 $tooltip-background-color: $black;
 $tooltip-color: $white;
 $tooltip-padding: .75rem;

--- a/decidim-core/app/presenters/decidim/log/user_presenter.rb
+++ b/decidim-core/app/presenters/decidim/log/user_presenter.rb
@@ -50,7 +50,7 @@ module Decidim
         h.link_to(
           present_user_name,
           user_path,
-          class: "logs__log__author has-tip",
+          class: "logs__log__author",
           title: "@" + user.nickname,
           data: {
             tooltip: true,

--- a/decidim_app-design/app/views/admin/partials/_logs_list.html.erb
+++ b/decidim_app-design/app/views/admin/partials/_logs_list.html.erb
@@ -9,7 +9,7 @@
           <div class="logs__log__content">
             <div class="logs__log__date">10/10/2018 08:24</div>
             <div class="logs__log__explanation">
-              <a class="logs__log__author has-tip" data-tooltip aria-hashpopup="true" data-disable-hover="false" title="@mmills">Matthew Mills </a>
+              <a class="logs__log__author" data-tooltip aria-hashpopup="true" data-disable-hover="false" title="@mmills">Matthew Mills </a>
               created
               <a class="logs__log__resource">Regular meetup</a>
               in
@@ -43,7 +43,7 @@
           <div class="logs__log__content">
             <div class="logs__log__date">10/10/2018 08:24</div>
             <div class="logs__log__explanation">
-              <a class="logs__log__author has-tip" data-tooltip aria-hashpopup="true" data-disable-hover="false" title="@mmills">Matthew Mills </a>
+              <a class="logs__log__author" data-tooltip aria-hashpopup="true" data-disable-hover="false" title="@mmills">Matthew Mills </a>
               deleted
               <span class="logs__log__resource">Regular meetup with a really, reeeeeaaaallyyyyy loooooooooong name because why not</span>
               in
@@ -58,7 +58,7 @@
           <div class="logs__log__content">
             <div class="logs__log__date">10/10/2018 08:24</div>
             <div class="logs__log__explanation">
-              <a class="logs__log__author has-tip" data-tooltip aria-hashpopup="true" data-disable-hover="false" title="@mmills">Matthew Mills </a>
+              <a class="logs__log__author" data-tooltip aria-hashpopup="true" data-disable-hover="false" title="@mmills">Matthew Mills </a>
               updated
               <a class="logs__log__resource">Regular meetup</a>
               in

--- a/decidim_app-design/app/views/admin/process-steps.html.erb
+++ b/decidim_app-design/app/views/admin/process-steps.html.erb
@@ -39,13 +39,13 @@
                   15/01/17
                 </td>
                 <td class="table-list__actions">
-                  <a href="#"  data-tooltip aria-haspopup="true"  data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true"  data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
+                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
+                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
                 </td>
               </tr>
               <tr>
                 <td>
-                  <span  data-tooltip aria-haspopup="true"  data-disable-hover="false" title="Fase activa">
+                  <span data-tooltip aria-haspopup="true" data-disable-hover="false" title="Fase activa">
                     <span class="icon-active"></span>
                   </span>
                   <a href="#">Fase 2: Recogida de propuestas</a>
@@ -57,8 +57,8 @@
                   08/06/17
                 </td>
                 <td class="table-list__actions">
-                  <a href="#"  data-tooltip aria-haspopup="true"  data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true"  data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
+                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
+                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
                 </td>
               </tr>
               <tr>
@@ -72,8 +72,8 @@
                   12/09/17
                 </td>
                 <td class="table-list__actions">
-                  <a href="#"  data-tooltip aria-haspopup="true"  data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true"  data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
+                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
+                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
                 </td>
               </tr>
             </tbody>

--- a/decidim_app-design/app/views/admin/process-steps.html.erb
+++ b/decidim_app-design/app/views/admin/process-steps.html.erb
@@ -45,7 +45,7 @@
               </tr>
               <tr>
                 <td>
-                  <span  data-tooltip aria-haspopup="true"  data-disable-hover="false" title="Fase activa" class="simple-has-tip">
+                  <span  data-tooltip aria-haspopup="true"  data-disable-hover="false" title="Fase activa">
                     <span class="icon-active"></span>
                   </span>
                   <a href="#">Fase 2: Recogida de propuestas</a>


### PR DESCRIPTION
#### :tophat: What? Why?

In this PR I'm letting foundation properly style tooltips instead of doing it ourselves. Who knows if this could help with #2790?

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.