### PR TITLE
Remove unneeded env vars from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,7 +352,6 @@ jobs:
       - restore_cache:
           keys:
             - bundler-dependencies-{{ checksum "Gemfile.lock" }}
-      - run: export CODECOV_FLAG=verifications
       - run:
           name: Wait for db
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
@@ -372,7 +371,6 @@ jobs:
       - restore_cache:
           keys:
             - bundler-dependencies-{{ checksum "Gemfile.lock" }}
-      - run: export CODECOV_FLAG=debates
       - run:
           name: Wait for db
           command: dockerize -wait tcp://localhost:5432 -timeout 1m


### PR DESCRIPTION
#### :tophat: What? Why?

This PR removes a couple of environment variables we're no longer using from the circleCI configuration.

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/pull/2814#discussion_r170522636.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.