### PR TITLE
Add results to process and process group home

### DIFF
--- a/decidim-accountability/app/models/decidim/accountability/result.rb
+++ b/decidim-accountability/app/models/decidim/accountability/result.rb
@@ -25,6 +25,13 @@ module Decidim
 
       after_save :update_parent_progress, if: -> { parent_id.present? }
 
+      def self.order_randomly(seed)
+        transaction do
+          connection.execute("SELECT setseed(#{connection.quote(seed)})")
+          order("RANDOM()").load
+        end
+      end
+
       def update_parent_progress
         return if parent.blank?
 

--- a/decidim-accountability/app/views/decidim/participatory_processes/participatory_process_groups/_highlighted_results.html.erb
+++ b/decidim-accountability/app/views/decidim/participatory_processes/participatory_process_groups/_highlighted_results.html.erb
@@ -1,0 +1,12 @@
+<% if results.any? %>
+    <section class="section row collapse highlighted_results">
+      <h2 class="section-heading"><%= t(".results") %></h2>
+      <div class="row">
+        <div class="columns accountability">
+          <div class="card card--action card--list">
+            <%= render partial: 'decidim/participatory_processes/participatory_process_groups/result', collection: results %>
+          </div>
+        </div>
+      </div>
+    </section>
+<% end %>

--- a/decidim-accountability/app/views/decidim/participatory_processes/participatory_process_groups/_result.html.erb
+++ b/decidim-accountability/app/views/decidim/participatory_processes/participatory_process_groups/_result.html.erb
@@ -1,0 +1,32 @@
+<div class="card--list__item">
+  <%= icon "actions", class: "card--list__icon", remove_icon_class: true %>
+
+  <%= link_to resource_locator(result).path, class: "card--list__text card__link card__link--block" do %>
+      <h5 class="card--list__heading">
+        <%= translated_attribute(result.title) %>
+      </h5>
+
+      <div class="text-small card--meta">
+        <% if result.start_date %>
+            <strong><%= t("models.result.fields.start_date", scope: "decidim.accountability") %></strong>
+            <span><%= result.start_date %></span>
+        <% end %>
+
+        <% if result.end_date %>
+            <strong><%= t("models.result.fields.end_date", scope: "decidim.accountability") %></strong>
+            <span><%= result.end_date %></span>
+        <% end %>
+
+        <% if result.status %>
+            <strong><%= t("models.result.fields.status", scope: "decidim.accountability") %></strong>
+            <span><%= translated_attribute(result.status.name) %></span>
+        <% end %>
+      </div>
+  <% end %>
+
+  <% if result.progress.present? %>
+      <div class="card--list__data">
+        <span class="card--list__data__number"><%= display_percentage result.progress %></span>
+      </div>
+  <% end%>
+</div>

--- a/decidim-accountability/app/views/decidim/participatory_spaces/_highlighted_results.html.erb
+++ b/decidim-accountability/app/views/decidim/participatory_spaces/_highlighted_results.html.erb
@@ -1,0 +1,14 @@
+<% if results.any? %>
+  <section class="section row collapse highlighted_results">
+    <h4 class="section-heading">
+      <%= t(".results") %>  <a href="<%= main_feature_path(results.first.feature) %>" class="text-small"><%= t(".see_all_results") %></a>
+    </h4>
+    <div class="row">
+      <div class="columns accountability">
+        <div class="card card--action card--list">
+          <%= render partial: 'decidim/participatory_spaces/result', collection: results %>
+        </div>
+      </div>
+    </div>
+  </section>
+<% end %>

--- a/decidim-accountability/app/views/decidim/participatory_spaces/_result.html.erb
+++ b/decidim-accountability/app/views/decidim/participatory_spaces/_result.html.erb
@@ -1,0 +1,32 @@
+<div class="card--list__item">
+  <%= icon "actions", class: "card--list__icon", remove_icon_class: true %>
+
+  <%= link_to resource_locator(result).path, class: "card--list__text card__link card__link--block" do %>
+      <h5 class="card--list__heading">
+        <%= translated_attribute(result.title) %>
+      </h5>
+
+      <div class="text-small card--meta">
+        <% if result.start_date %>
+            <strong><%= t("models.result.fields.start_date", scope: "decidim.accountability") %></strong>
+            <span><%= result.start_date %></span>
+        <% end %>
+
+        <% if result.end_date %>
+            <strong><%= t("models.result.fields.end_date", scope: "decidim.accountability") %></strong>
+            <span><%= result.end_date %></span>
+        <% end %>
+
+        <% if result.status %>
+            <strong><%= t("models.result.fields.status", scope: "decidim.accountability") %></strong>
+            <span><%= translated_attribute(result.status.name) %></span>
+        <% end %>
+      </div>
+  <% end %>
+
+  <% if result.progress.present? %>
+      <div class="card--list__data">
+        <span class="card--list__data__number"><%= display_percentage result.progress %></span>
+      </div>
+  <% end%>
+</div>

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -175,6 +175,14 @@ en:
             subcategories_label: Name for "Subcategories"
           step:
             comments_blocked: Comments blocked
+    participatory_processes:
+      participatory_process_groups:
+        highlighted_results:
+          results: Results
+    participatory_spaces:
+      highlighted_results:
+        results: Results
+        see_all_results: See all results
     resource_links:
       included_projects:
         result_projects: Projects included in this result

--- a/decidim-accountability/lib/decidim/accountability/engine.rb
+++ b/decidim-accountability/lib/decidim/accountability/engine.rb
@@ -22,6 +22,40 @@ module Decidim
       initializer "decidim_accountability.assets" do |app|
         app.config.assets.precompile += %w(decidim_accountability_manifest.js)
       end
+
+      initializer "decidim_accountability.view_hooks" do
+        Decidim.view_hooks.register(:participatory_space_highlighted_elements, priority: Decidim::ViewHooks::LOW_PRIORITY) do |view_context|
+          published_features = Decidim::Feature.where(participatory_space: view_context.current_participatory_space).published
+          results = Decidim::Accountability::Result.where(feature: published_features).order_randomly(rand * 2 - 1).limit(4)
+
+          next unless results.any?
+
+          view_context.extend Decidim::Accountability::ApplicationHelper
+          view_context.render(
+            partial: "decidim/participatory_spaces/highlighted_results",
+            locals: {
+              results: results
+            }
+          )
+        end
+
+        if defined? Decidim::ParticipatoryProcesses
+          Decidim::ParticipatoryProcesses.view_hooks.register(:process_group_highlighted_elements, priority: Decidim::ViewHooks::LOW_PRIORITY) do |view_context|
+            published_features = Decidim::Feature.where(participatory_space: view_context.participatory_processes).published
+            results = Decidim::Accountability::Result.where(feature: published_features).order_randomly(rand * 2 - 1).limit(4)
+
+            next unless results.any?
+
+            view_context.extend Decidim::Accountability::ApplicationHelper
+            view_context.render(
+              partial: "decidim/participatory_processes/participatory_process_groups/highlighted_results",
+              locals: {
+                results: results
+              }
+            )
+          end
+        end
+      end
     end
   end
 end

--- a/decidim-accountability/spec/system/participatory_process_groups_view_hooks_spec.rb
+++ b/decidim-accountability/spec/system/participatory_process_groups_view_hooks_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Results in process group home", type: :system do
+  include_context "with a feature"
+  let(:manifest_name) { "accountability" }
+  let(:results_count) { 5 }
+
+  let!(:participatory_process_group) do
+    create(
+      :participatory_process_group,
+      participatory_processes: [participatory_process],
+      organization: organization,
+      name: { en: "Name", ca: "Nom", es: "Nombre" }
+    )
+  end
+
+  context "when there are no results" do
+    it "does not show the highlighted results section" do
+      visit decidim_participatory_processes.participatory_process_group_path(participatory_process_group)
+      expect(page).not_to have_css(".highlighted_results")
+    end
+  end
+
+  context "when there are results" do
+    let!(:results) do
+      create_list(:result, results_count, feature: feature)
+    end
+
+    it "shows the highlighted results section" do
+      visit decidim_participatory_processes.participatory_process_group_path(participatory_process_group)
+
+      within ".highlighted_results" do
+        expect(page).to have_css(".card--list__item", count: 4)
+
+        results_titles = results.map { |r| translated(r.title) }
+        highlighted_results = page.all(".card--list__item .card--list__heading").map(&:text)
+        expect(results_titles).to include(*highlighted_results)
+      end
+    end
+  end
+end

--- a/decidim-accountability/spec/system/participatory_processes_view_hooks_spec.rb
+++ b/decidim-accountability/spec/system/participatory_processes_view_hooks_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Results in process home", type: :system do
+  include_context "with a feature"
+  let(:manifest_name) { "accountability" }
+  let(:results_count) { 5 }
+
+  context "when there are no results" do
+    it "does not show the highlighted results section" do
+      visit resource_locator(participatory_process).path
+      expect(page).not_to have_css(".highlighted_results")
+    end
+  end
+
+  context "when there are results" do
+    let!(:results) do
+      create_list(:result, results_count, feature: feature)
+    end
+
+    it "shows the highlighted results section" do
+      visit resource_locator(participatory_process).path
+
+      within ".highlighted_results" do
+        expect(page).to have_css(".card--list__item", count: 4)
+
+        results_titles = results.map { |r| translated(r.title) }
+        highlighted_results = page.all(".card--list__item .card--list__heading").map(&:text)
+        expect(results_titles).to include(*highlighted_results)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Show random results in process/process group home

#### :pushpin: Related Issues

- Related to #2273 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry

### :camera: Screenshots

- Process home

![screencapture-decidim-localhost-processes-beatae-inventore-1519635722403](https://user-images.githubusercontent.com/2051199/36662530-f89979ac-1ade-11e8-9c9a-77b47fbf4d49.png)

- Process group home

![screencapture-decidim-localhost-processes_groups-1-1519635706077](https://user-images.githubusercontent.com/2051199/36662542-00cd99c8-1adf-11e8-8756-cd91bc6c90c3.png)
