### PR TITLE
Notify process followers when there's a change in a step's dates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1084,6 +1084,8 @@ Metrics/LineLength:
   URISchemes:
     - http
     - https
+  Exclude:
+    - "**/spec/**/*"
 
 Metrics/MethodLength:
   CountComments: false  # count full line comments?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Added**:
 
+- **decidim-core**: Space followers are notified when a step changes its dates [\#2833](https://github.com/decidim/decidim/pull/2833)
 - **decidim-proposals**: Space followers are notified when the proposal can be created, endorsed or voted [\#2794](https://github.com/decidim/decidim/pull/2794)
 - **decidim-debates**: Space followers are notified when the debate creation is enabled or disabled [\#2794](https://github.com/decidim/decidim/pull/2794)
 - **decidim-surveys**: Space followers are notified when a survey is opened or closed [\#2794](https://github.com/decidim/decidim/pull/2794)

--- a/decidim-admin/app/events/decidim/participatory_process_step_changed_event.rb
+++ b/decidim-admin/app/events/decidim/participatory_process_step_changed_event.rb
@@ -1,0 +1,23 @@
+# frozen-string_literal: true
+
+module Decidim
+  class ParticipatoryProcessStepChangedEvent < Decidim::Events::SimpleEvent
+    include Rails.application.routes.mounted_helpers
+
+    def resource_path
+      @resource_path ||= decidim_participatory_processes.participatory_process_participatory_process_steps_path(participatory_process_slug: participatory_space.slug)
+    end
+
+    def resource_url
+      @resource_url ||= decidim_participatory_processes
+                        .participatory_process_participatory_process_steps_url(
+                          participatory_process_slug: participatory_space.slug,
+                          host: participatory_space.organization.host
+                        )
+    end
+
+    def participatory_space
+      resource.participatory_process
+    end
+  end
+end

--- a/decidim-admin/spec/events/decidim/participatory_process_step_changed_event_spec.rb
+++ b/decidim-admin/spec/events/decidim/participatory_process_step_changed_event_spec.rb
@@ -2,12 +2,12 @@
 
 require "spec_helper"
 
-describe Decidim::ParticipatoryProcessStepActivatedEvent do
+describe Decidim::ParticipatoryProcessStepChangedEvent do
   include Rails.application.routes.mounted_helpers
 
   include_context "simple event"
 
-  let(:event_name) { "decidim.events.participatory_process.step_activated" }
+  let(:event_name) { "decidim.events.participatory_process.step_changed" }
   let(:participatory_process) { resource.participatory_process }
   let(:participatory_space) { resource.participatory_process }
   let(:resource) { create :participatory_process_step }
@@ -34,7 +34,7 @@ describe Decidim::ParticipatoryProcessStepActivatedEvent do
   describe "email_intro" do
     it "is generated correctly" do
       expect(subject.email_intro)
-        .to eq("The #{resource_title} step is now active for #{participatory_space_title}. You can see it from this page:")
+        .to eq("The dates for the #{resource_title} step at #{participatory_space_title} have been updated. You can see it from this page:")
     end
   end
 
@@ -48,7 +48,7 @@ describe Decidim::ParticipatoryProcessStepActivatedEvent do
   describe "notification_title" do
     it "is generated correctly" do
       expect(subject.notification_title)
-        .to eq("The #{resource_title} step is now active for <a href=\"#{resource_path}\">#{participatory_space_title}</a>")
+        .to eq("The dates for the <a href=\"#{resource_path}\">#{resource_title}</a> step at <a href=\"#{participatory_space_url}\">#{participatory_space_title}</a> have been updated.")
     end
   end
 end

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -174,11 +174,6 @@ en:
           notification_title: The %{resource_title} component is now active for <a href="%{resource_path}">%{participatory_space_title}</a>
       notification_event:
         notification_title: An event occured to <a href="%{resource_path}">%{resource_title}</a>.
-      participatory_process_step_activated_event:
-        email_intro: 'The %{resource_title} step is now active for %{participatory_space_title}. You can see it from this page:'
-        email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
-        email_subject: An update to %{participatory_space_title}
-        notification_title: The %{resource_title} step is now active for <a href="%{resource_path}">%{participatory_space_title}</a>
       users:
         profile_updated:
           email_intro: The <a href="%{resource_url}">profile page</a> of %{name} (%{nickname}), who you are following, has been updated.

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/update_participatory_process_step.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/update_participatory_process_step.rb
@@ -6,13 +6,13 @@ module Decidim
       # A command with all the business logic when creating a new participatory
       # process in the system.
       class UpdateParticipatoryProcessStep < Rectify::Command
-        attr_reader :participatory_process_step
+        attr_reader :step
         # Public: Initializes the command.
         #
-        # participatory_process_step - the ParticipatoryProcessStep to update
+        # step - the ParticipatoryProcessStep to update
         # form - A form object with the params.
-        def initialize(participatory_process_step, form)
-          @participatory_process_step = participatory_process_step
+        def initialize(step, form)
+          @step = step
           @form = form
         end
 
@@ -25,7 +25,8 @@ module Decidim
         def call
           return broadcast(:invalid) if form.invalid?
 
-          update_participatory_process_step
+          update_step
+          notify_followers
           broadcast(:ok)
         end
 
@@ -33,8 +34,8 @@ module Decidim
 
         attr_reader :form
 
-        def update_participatory_process_step
-          participatory_process_step.update_attributes!(attributes)
+        def update_step
+          step.update_attributes!(attributes)
         end
 
         def attributes
@@ -44,6 +45,17 @@ module Decidim
             end_date: form.end_date,
             description: form.description
           }
+        end
+
+        def notify_followers
+          return unless step.saved_change_to_start_date || step.saved_change_to_end_date
+
+          Decidim::EventsManager.publish(
+            event: "decidim.events.participatory_process.step_changed",
+            event_class: Decidim::ParticipatoryProcessStepChangedEvent,
+            resource: step,
+            recipient_ids: step.participatory_process.followers.pluck(:id)
+          )
         end
       end
     end

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -215,6 +215,18 @@ en:
         create: "%{user_name} invited the user %{resource_name} to the %{space_name} participatory process"
         delete: "%{user_name} removed the user %{resource_name} from the %{space_name} participatory process"
         update: "%{user_name} changed the role of the user %{resource_name} in the %{space_name} participatory process"
+    events:
+      participatory_process:
+        step_activated:
+          email_intro: 'The %{resource_title} step is now active for %{participatory_space_title}. You can see it from this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: An update to %{participatory_space_title}
+          notification_title: The %{resource_title} step is now active for <a href="%{resource_path}">%{participatory_space_title}</a>
+        step_changed:
+          email_intro: 'The dates for the %{resource_title} step at %{participatory_space_title} have been updated. You can see it from this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: An update to %{participatory_space_title}
+          notification_title: The dates for the <a href="%{resource_path}">%{resource_title}</a> step at <a href="%{participatory_space_url}">%{participatory_space_title}</a> have been updated.
     menu:
       processes: Processes
     participatory_process_groups:

--- a/decidim-participatory_processes/spec/commands/update_participatory_process_step_spec.rb
+++ b/decidim-participatory_processes/spec/commands/update_participatory_process_step_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::ParticipatoryProcesses
+  describe Admin::UpdateParticipatoryProcessStep do
+    subject { described_class.new(step, form) }
+
+    let(:step) { create :participatory_process_step }
+    let(:participatory_process) { step.participatory_process }
+    let(:form) do
+      instance_double(
+        Admin::ParticipatoryProcessStepForm,
+        title: { en: "new title" },
+        description: { en: "new description" },
+        start_date: start_date,
+        end_date: end_date,
+        invalid?: invalid
+      )
+    end
+
+    context "when the form is not valid" do
+      let(:invalid) { true }
+      let(:start_date) { nil }
+      let(:end_date) { nil }
+
+      it "broadcasts invalid" do
+        expect { subject.call }.to broadcast(:invalid)
+      end
+    end
+
+    context "when everything is ok" do
+      let(:invalid) { false }
+      let(:start_date) { step.start_date }
+      let(:end_date) { step.end_date }
+
+      it "updates a participatory process step" do
+        subject.call
+        step.reload
+
+        expect(step.title["en"]).to eq("new title")
+        expect(step.description["en"]).to eq("new description")
+      end
+
+      it "broadcasts ok" do
+        expect { subject.call }.to broadcast(:ok)
+      end
+
+      it "doesn't notify followers" do
+        expect(Decidim::EventsManager).not_to receive(:publish)
+
+        subject.call
+      end
+
+      context "when the dates are updated" do
+        let(:start_date) { Time.zone.now }
+        let(:end_date) { 1.week.from_now }
+
+        it "notifies the process followers" do
+          follower = create(:user, organization: participatory_process.organization)
+          create(:follow, followable: participatory_process, user: follower)
+
+          expect(Decidim::EventsManager)
+            .to receive(:publish)
+            .with(
+              event: "decidim.events.participatory_process.step_changed",
+              event_class: Decidim::ParticipatoryProcessStepChangedEvent,
+              resource: step,
+              recipient_ids: [follower.id]
+            )
+
+          subject.call
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

When there's a change in the start or end date of a step the process followers will be notified about it.

I've also updated and fixed the other event related to steps.

#### :pushpin: Related Issues
- Related to #2446

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
