### PR TITLE
Fix SCSS warnings

### DIFF
--- a/decidim-admin/app/assets/stylesheets/decidim/admin/utils/_flex.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/utils/_flex.scss
@@ -45,16 +45,16 @@ $spaces: $space ($space * 2);
 
 // flex--cc:
 // justify-content: center;
-// align-items: center;
+// align-items: middle;
 .flex--cc{
   @include flex;
-  @include flex-align($x: center, $y: center);
+  @include flex-align($x: center, $y: middle);
 }
 
 // flex--cc:
 // justify-content: space-between;
-// align-items: center;
+// align-items: middle;
 .flex--sbc{
   @include flex;
-  @include flex-align($x: space-between, $y: center);
+  @include flex-align($x: space-between, $y: middle);
 }


### PR DESCRIPTION
#### :tophat: What? Why?
After #2585 I'm getting these warnings:

```
WARNING: flex-grid-row-align(): center is not a valid value for vertical alignment. Use top, bottom, middle, or stretch.
Backtrace:
	../../../.gem/ruby/2.5.0/gems/foundation-rails-6.4.1.3/vendor/assets/scss/util/_flex.scss:47, in mixin `flex-align`
	../decidim-admin/app/assets/stylesheets/decidim/admin/utils/_flex.scss:51

WARNING: flex-grid-row-align(): space-between is not a valid value for horizontal alignment. Use left, right, center, justify, or spaced.
Backtrace:
	../../../.gem/ruby/2.5.0/gems/foundation-rails-6.4.1.3/vendor/assets/scss/util/_flex.scss:38, in mixin `flex-align`
	../decidim-admin/app/assets/stylesheets/decidim/admin/utils/_flex.scss:59
```

This PR fixes it by setting the value to `middle` instead of `center`

#### :pushpin: Related Issues
- Related to #2585

#### :clipboard: Subtasks
None