### PR TITLE
Notify proposal followers when it's included in a Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Added**:
 
+- **decidim-accountability**: Proposal followers are notified when a proposal is included in a result [\#2836](https://github.com/decidim/decidim/pull/2836)
 - **decidim-core**: Space followers are notified when a step changes its dates [\#2833](https://github.com/decidim/decidim/pull/2833)
 - **decidim-proposals**: Space followers are notified when the proposal can be created, endorsed or voted [\#2794](https://github.com/decidim/decidim/pull/2794)
 - **decidim-debates**: Space followers are notified when the debate creation is enabled or disabled [\#2794](https://github.com/decidim/decidim/pull/2794)

--- a/decidim-accountability/app/events/decidim/accountability/proposal_linked_event.rb
+++ b/decidim-accountability/app/events/decidim/accountability/proposal_linked_event.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Accountability
+    class ProposalLinkedEvent < Decidim::Events::SimpleEvent
+      i18n_attributes :proposal_title, :proposal_path
+
+      def proposal_path
+        @proposal_path ||= Decidim::ResourceLocatorPresenter.new(proposal).path
+      end
+
+      def proposal_title
+        @proposal_title ||= proposal.title
+      end
+
+      def proposal
+        @proposal ||= resource.linked_resources(:proposals, "included_proposals").where(id: extra[:proposal_id]).first
+      end
+    end
+  end
+end

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -162,6 +162,13 @@ en:
           changes_at_title: Changes at "%{title}"
         version:
           version_index: Version %{index}
+    events:
+      accountability:
+        proposal_linked:
+          email_intro: 'The proposal "%{proposal_title}" has been included in a result. You can see it from this page:'
+          email_outro: You have received this notification because you are following "%{proposal_title}". You can stop receiving notifications following the previous link.
+          email_subject: An update to %{proposal_title}
+          notification_title: The proposal <a href="%{proposal_path}">%{proposal_title}</a> has been included in the <a href="%{resource_path}">%{resource_title}</a> result.
     features:
       accountability:
         name: Accountability

--- a/decidim-accountability/spec/commands/admin/create_result_spec.rb
+++ b/decidim-accountability/spec/commands/admin/create_result_spec.rb
@@ -125,6 +125,49 @@ module Decidim::Accountability
 
         expect(linked_meetings).to eq [meeting]
       end
+
+      it "notifies the process followers" do
+        follower = create(:user, organization: organization)
+        create(:follow, followable: proposals.first, user: follower)
+
+        expect(Decidim::EventsManager)
+          .to receive(:publish)
+          .with(
+            event: "decidim.events.accountability.proposal_linked",
+            event_class: Decidim::Accountability::ProposalLinkedEvent,
+            resource: kind_of(Result),
+            recipient_ids: [proposals.first.author.id, follower.id],
+            extra: {
+              proposal_id: proposals.first.id
+            }
+          )
+
+        expect(Decidim::EventsManager)
+          .to receive(:publish)
+          .with(
+            event: "decidim.events.accountability.proposal_linked",
+            event_class: Decidim::Accountability::ProposalLinkedEvent,
+            resource: kind_of(Result),
+            recipient_ids: [proposals.second.author.id],
+            extra: {
+              proposal_id: proposals.second.id
+            }
+          )
+
+        expect(Decidim::EventsManager)
+          .to receive(:publish)
+          .with(
+            event: "decidim.events.accountability.proposal_linked",
+            event_class: Decidim::Accountability::ProposalLinkedEvent,
+            resource: kind_of(Result),
+            recipient_ids: [proposals.third.author.id],
+            extra: {
+              proposal_id: proposals.third.id
+            }
+          )
+
+        subject.call
+      end
     end
   end
 end

--- a/decidim-accountability/spec/events/decidim/accountability/proposal_linked_event_spec.rb
+++ b/decidim-accountability/spec/events/decidim/accountability/proposal_linked_event_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Accountability::ProposalLinkedEvent do
+  include_context "simple event"
+
+  let(:event_name) { "decidim.events.accountability.proposal_linked" }
+  let(:resource) { create(:result) }
+  let(:proposal_feature) do
+    create(:feature, manifest_name: "proposals", participatory_space: resource.feature.participatory_space)
+  end
+  let(:proposal) { create :proposal, feature: proposal_feature }
+  let(:extra) { { proposal_id: proposal.id } }
+  let(:proposal_path) { resource_locator(proposal).path }
+  let(:proposal_title) { proposal.title }
+
+  before do
+    resource.link_resources([proposal], "included_proposals")
+  end
+
+  it_behaves_like "a simple event"
+
+  describe "proposal" do
+    it "finds the linked proposal" do
+      expect(subject.proposal).to eq(proposal)
+    end
+  end
+
+  describe "types" do
+    subject { described_class }
+
+    it "supports notifications" do
+      expect(subject.types).to include :notification
+    end
+
+    it "supports emails" do
+      expect(subject.types).to include :email
+    end
+  end
+
+  describe "email_subject" do
+    it "is generated correctly" do
+      expect(subject.email_subject).to eq("An update to #{proposal_title}")
+    end
+  end
+
+  describe "email_outro" do
+    it "is generated correctly" do
+      expect(subject.email_outro).to eq("You have received this notification because you are following \"#{proposal_title}\". You can stop receiving notifications following the previous link.")
+    end
+  end
+
+  describe "email_intro" do
+    it "is generated correctly" do
+      expect(subject.email_intro).to eq("The proposal \"#{proposal_title}\" has been included in a result. You can see it from this page:")
+    end
+  end
+
+  describe "notification_title" do
+    it "is generated correctly" do
+      expect(subject.notification_title).to eq("The proposal <a href=\"#{proposal_path}\">#{proposal_title}</a> has been included in the <a href=\"#{resource_path}\">#{resource_title}</a> result.")
+    end
+  end
+end

--- a/decidim-core/app/services/decidim/events_manager.rb
+++ b/decidim-core/app/services/decidim/events_manager.rb
@@ -23,7 +23,7 @@ module Decidim
         event,
         event_class: event_class.name,
         resource: resource,
-        recipient_ids: recipient_ids,
+        recipient_ids: recipient_ids.compact.uniq,
         extra: extra
       )
     end

--- a/decidim-core/spec/services/decidim/events_manager_spec.rb
+++ b/decidim-core/spec/services/decidim/events_manager_spec.rb
@@ -23,6 +23,24 @@ describe Decidim::EventsManager do
         extra: extra
       )
     end
+
+    context "when there are invalid values as the recipient ids" do
+      let(:recipient_ids) { [1, nil, 2, 3, 2] }
+
+      it "sanitizes the recipients" do
+        expect(ActiveSupport::Notifications)
+          .to receive(:publish)
+          .with(event, hash_including(recipient_ids: [1, 2, 3]))
+
+        described_class.publish(
+          event: event,
+          event_class: event_class,
+          resource: resource,
+          recipient_ids: recipient_ids,
+          extra: extra
+        )
+      end
+    end
   end
 
   describe "#subscribe" do


### PR DESCRIPTION
#### :tophat: What? Why?

When a proposal is included in a result its author and followers are notified about it.

#### :pushpin: Related Issues
- Related to #2334
- Fixes #2825

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
