### PR TITLE
Make moderation logs not rely on the reportable

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/hide_resource.rb
+++ b/decidim-admin/app/commands/decidim/admin/hide_resource.rb
@@ -36,7 +36,10 @@ module Decidim
         Decidim.traceability.perform_action!(
           "hide",
           @reportable.moderation,
-          @current_user
+          @current_user,
+          extra: {
+            reportable_type: @reportable.class.name
+          }
         ) do
           @reportable.moderation.update_attributes!(hidden_at: Time.current)
         end

--- a/decidim-admin/app/commands/decidim/admin/unreport_resource.rb
+++ b/decidim-admin/app/commands/decidim/admin/unreport_resource.rb
@@ -32,7 +32,10 @@ module Decidim
         Decidim.traceability.perform_action!(
           "unreport",
           @reportable.moderation,
-          @current_user
+          @current_user,
+          extra: {
+            reportable_type: @reportable.class.name
+          }
         ) do
           @reportable.moderation.update_attributes!(report_count: 0, hidden_at: nil)
         end

--- a/decidim-admin/spec/commands/hide_resource_spec.rb
+++ b/decidim-admin/spec/commands/hide_resource_spec.rb
@@ -23,7 +23,7 @@ module Decidim::Admin
       it "traces the action", versioning: true do
         expect(Decidim.traceability)
           .to receive(:perform_action!)
-          .with("hide", moderation, current_user)
+          .with("hide", moderation, current_user, extra: { reportable_type: "Decidim::DummyResources::DummyResource" })
           .and_call_original
 
         expect { command.call }.to change(Decidim::ActionLog, :count)

--- a/decidim-admin/spec/commands/unreport_resource_spec.rb
+++ b/decidim-admin/spec/commands/unreport_resource_spec.rb
@@ -23,7 +23,7 @@ module Decidim::Admin
       it "traces the action", versioning: true do
         expect(Decidim.traceability)
           .to receive(:perform_action!)
-          .with("unreport", moderation, current_user)
+          .with("unreport", moderation, current_user, extra: { reportable_type: "Decidim::DummyResources::DummyResource" })
           .and_call_original
 
         expect { command.call }.to change(Decidim::ActionLog, :count)

--- a/decidim-core/app/presenters/decidim/admin_log/moderation_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/moderation_presenter.rb
@@ -36,7 +36,7 @@ module Decidim
 
       def i18n_params
         super.merge(
-          resource_type: action_log.resource.try(:decidim_reportable_type).try(:demodulize)
+          resource_type: action_log.extra.dig("extra", "reportable_type").try(:demodulize)
         )
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Moderation logs are calling the log resource to display the text. This could eventually cause errors, so it's better if we remove this dependency and save the value in the log itself.

#### :pushpin: Related Issues
- Related to #2803 

#### :clipboard: Subtasks
None.