### PR TITLE
Introduce a flag to display the progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - **decidim-participatory_processes**: Adds a basic API including steps and components. [\#2787](https://github.com/decidim/decidim/pull/2787)
 - **decidim-core**: Adds a statistics API to `Organization` and `ParticipatorySpace`. [\#2843](https://github.com/decidim/decidim/pull/2843)
 - **decidim-proposals**: Log proposal answers [\#2848](https://github.com/decidim/decidim/pull/2848)
+- **decidim-accountability**: Adds flag to control if the visualization of progress is visible [\#2847](https://github.com/decidim/decidim/pull/2847)
 
 **Changed**:
 

--- a/decidim-accountability/app/views/decidim/accountability/results/_home_categories.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_home_categories.html.erb
@@ -28,14 +28,14 @@
                 <p class="heading3">
                 <%= link_to translated_attribute(category.name),results_path(filter: { category_id: category, scope_id: current_scope }) %></p>
 
-                <% if progress_calculator(current_scope, category.id).present? %>
+                <% if feature_settings.display_progress_enabled? && progress_calculator(current_scope, category.id).present? %>
                   <div class="progress">
                     <div class="progress-meter" style="width:<%= progress_calculator(current_scope, category.id) %>%"></div>
                   </div>
                 <% end %>
 
                 <div class="progress-info">
-                  <% if progress_calculator(current_scope, category.id).present? %>
+                  <% if feature_settings.display_progress_enabled? && progress_calculator(current_scope, category.id).present? %>
                     <div class="progress-figure heading3">
                       <%= display_percentage progress_calculator(current_scope, category.id) %>
                     </div>
@@ -55,7 +55,7 @@
                       <div class="category--line">
                         <strong><%= translated_attribute(subcategory.name) %></strong>
 
-                        <% if progress_calculator(current_scope, subcategory.id).present? %>
+                        <% if feature_settings.display_progress_enabled? && progress_calculator(current_scope, subcategory.id).present? %>
                           <div class="progress-figure heading3">
                             <%= display_percentage progress_calculator(current_scope, subcategory.id) %>
                           </div>

--- a/decidim-accountability/app/views/decidim/accountability/results/_home_header.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_home_header.html.erb
@@ -4,7 +4,7 @@
       <%== translated_attribute feature_settings.intro %>
     </div>
 
-    <% if progress_calculator(current_scope, nil).present? %>
+    <% if feature_settings.display_progress_enabled? && progress_calculator(current_scope, nil).present? %>
       <div class="small-12 medium-5 columns">
         <div class="progress-level">
           <p><%= t(".global_status") %></p>

--- a/decidim-accountability/app/views/decidim/accountability/results/_nav_breadcrumb.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_nav_breadcrumb.html.erb
@@ -1,12 +1,16 @@
 <div class="lines-breadcrumb">
   <%= link_to t(".global"), root_path %>
-  <span class="percentage"><%= display_percentage progress_calculator(current_scope, nil) %></span>
+  <% if feature_settings.display_progress_enabled? %>
+    <span class="percentage"><%= display_percentage progress_calculator(current_scope, nil) %></span>
+  <% end %>
 
   <% if category.present? && category.parent.present? %>
     <span class="breadcrumb--separator">></span>
     <div>
       <%= link_to translated_attribute(category.parent.name), results_path(filter: { category_id: category.parent_id, scope_id: current_scope }) %>
-      <span class="percentage"><%= display_percentage progress_calculator(current_scope, category.parent_id) %></span>
+      <% if feature_settings.display_progress_enabled? %>
+        <span class="percentage"><%= display_percentage progress_calculator(current_scope, category.parent_id) %></span>
+      <% end %>
     </div>
   <% end %>
 
@@ -14,7 +18,9 @@
     <span class="breadcrumb--separator">></span>
     <div>
       <%= link_to translated_attribute(category.name), results_path(filter: { category_id: category.id, scope_id: current_scope }) %>
-      <span class="percentage"><%= display_percentage progress_calculator(current_scope, category.id) %></span>
+      <% if feature_settings.display_progress_enabled? %>
+        <span class="percentage"><%= display_percentage progress_calculator(current_scope, category.id) %></span>
+      <% end %>
     </div>
   <% end %>
 
@@ -22,7 +28,9 @@
     <span class="breadcrumb--separator">></span>
     <div>
       <%= link_to translated_attribute(result.parent.title), result_path(result.parent, filter: { scope_id: current_scope }) %>
-      <span class="percentage"><%= display_percentage result.parent.progress %></span>
+      <% if feature_settings.display_progress_enabled? %>
+        <span class="percentage"><%= display_percentage result.parent.progress %></span>
+      <% end %>
     </div>
   <% end %>
 

--- a/decidim-accountability/app/views/decidim/accountability/results/_results_leaf.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_results_leaf.html.erb
@@ -34,7 +34,7 @@
             </div>
           <% end %>
 
-          <% if result.progress.present? %>
+          <% if feature_settings.display_progress_enabled? && result.progress.present? %>
             <div class="card--list__data">
               <span class="card--list__data__number"><%= display_percentage result.progress %></span>
             </div>

--- a/decidim-accountability/app/views/decidim/accountability/results/_results_parent.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_results_parent.html.erb
@@ -19,7 +19,7 @@
             <span class="text-small"><%= heading_leaf_level_results(result.children.count) %></span>
           <% end %>
 
-          <% if result.progress.present? %>
+          <% if feature_settings.display_progress_enabled? && result.progress.present? %>
             <div class="card--list__data">
               <span class="card--list__data__number"><%= display_percentage result.progress %></span>
             </div>

--- a/decidim-accountability/app/views/decidim/accountability/results/_show_leaf.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_show_leaf.html.erb
@@ -14,14 +14,18 @@
           <div class="progress-level">
             <div class="progress-label">
               <span class="progress-text"><%= t("models.result.fields.progress", scope: "decidim.accountability") %>:</span>
-              <span class="progress-figure">
-                <%= display_percentage result.progress %>
-              </span>
+              <% if feature_settings.display_progress_enabled? %>
+                <span class="progress-figure">
+                  <%= display_percentage result.progress %>
+                </span>
+              <% end %>
             </div>
 
-            <div class="progress">
-              <div class="progress-meter" style="width:<%= result.progress %>%"></div>
-            </div>
+            <% if feature_settings.display_progress_enabled? %>
+              <div class="progress">
+                <div class="progress-meter" style="width:<%= result.progress %>%"></div>
+              </div>
+            <% end %>
           </div>
         </div>
       <% end %>

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -169,6 +169,7 @@ en:
           global:
             categories_label: Name for "Categories"
             comments_enabled: Comments enabled
+            display_progress_enabled: Display progress
             heading_leaf_level_results: Name for "Projects"
             heading_parent_level_results: Name for "Results"
             intro: Intro

--- a/decidim-accountability/lib/decidim/accountability/feature.rb
+++ b/decidim-accountability/lib/decidim/accountability/feature.rb
@@ -24,6 +24,7 @@ Decidim.register_feature(:accountability) do |feature|
     settings.attribute :subcategories_label, type: :string, translated: true, editor: true
     settings.attribute :heading_parent_level_results, type: :string, translated: true, editor: true
     settings.attribute :heading_leaf_level_results, type: :string, translated: true, editor: true
+    settings.attribute :display_progress_enabled, type: :boolean, default: true
   end
 
   feature.register_stat :results_count, primary: true, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |features, _start_at, _end_at|

--- a/decidim-accountability/spec/system/explore_results_spec.rb
+++ b/decidim-accountability/spec/system/explore_results_spec.rb
@@ -29,6 +29,24 @@ describe "Explore results", versioning: true, type: :system do
         expect(page).to have_content(translated(category.name)) if !category.subcategories.empty? || results_count.positive?
       end
     end
+
+    it "shows progress" do
+      expect(page).to have_content("GLOBAL EXECUTION STATUS")
+      expect(page).to have_selector(".progress-figure")
+    end
+
+    context "with progress disabled" do
+      before do
+        feature.update_attributes!(settings: { display_progress_enabled: false })
+      end
+
+      it "doesn't show progress" do
+        visit path
+
+        expect(page).to have_no_content("Global execution status")
+        expect(page).to have_no_selector(".progress-figure")
+      end
+    end
   end
 
   describe "index" do


### PR DESCRIPTION
#### :tophat: What? Why?

This PR introduces a flag to enable/disable progress display in the accountability module. This is useful when there's no progress data uploaded, to avoid all the percentages to be 0% and the progress bar be empty.

#### :pushpin: Related Issues

- Implements #2737

#### :clipboard: Subtasks

- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)

New setting:

![screen shot 2018-02-27 at 15 24 40](https://user-images.githubusercontent.com/17616/36733916-5a11a4a4-1bd2-11e8-92a1-a913ad507a1f.png)

UI with the setting enabled:

![screen shot 2018-02-27 at 15 26 34](https://user-images.githubusercontent.com/17616/36734039-a6dfd9e0-1bd2-11e8-8b0a-d38175c2c6e2.png)

UI with the setting disabled:

![screen shot 2018-02-27 at 15 24 58](https://user-images.githubusercontent.com/17616/36733940-69b8356c-1bd2-11e8-8ebc-18eb517afa6b.png)




