### PR TITLE
Docker dev setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   docker:
     # This is the sha of the latest `decidim/decidim:latest-test` docker image. You can retrieve the
-    # latest digest by doing `$ docker pull decidim/decidim:latest-dev`.
+    # latest digest by doing `$ docker pull decidim/decidim:latest-test`.
     - image: decidim/decidim@sha256:348fb1faa49cfe76ba7cbeafc67ca09002cf95f0ffa7a76eefa9d5b3774e0ee9
       environment:
         BUNDLE_GEMFILE: /app/Gemfile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ defaults: &defaults
   docker:
     # This is the sha of the latest `decidim/decidim:latest-test` docker image. You can retrieve the
     # latest digest by doing `$ docker pull decidim/decidim:latest-test`.
-    - image: decidim/decidim@sha256:348fb1faa49cfe76ba7cbeafc67ca09002cf95f0ffa7a76eefa9d5b3774e0ee9
+    - image: decidim/decidim@sha256:e2dc624d6a7ca2ee02080d1dcec0ed255a71b7bc4101afb2d2508dbf9568c77e
       environment:
         BUNDLE_GEMFILE: /app/Gemfile
         SIMPLECOV: true

--- a/d/bash
+++ b/d/bash
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker-compose run --rm decidim bash "$@"

--- a/d/bundle
+++ b/d/bundle
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker-compose run --rm decidim bundle "$@"

--- a/d/gem
+++ b/d/gem
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker-compose run --rm decidim gem "$@"

--- a/d/rails
+++ b/d/rails
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker-compose run --service-ports --rm decidim bash -c "cd development_app && bin/rails $*"

--- a/d/rake
+++ b/d/rake
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+fail_fast=${FAIL_FAST:-false}
+
+docker-compose run --rm -e "FAIL_FAST=$fail_fast" decidim bash -c "bundle exec rake $*"

--- a/d/rspec
+++ b/d/rspec
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+gem=${1%%/*}
+spec=${1#*/}
+fail_fast=${FAIL_FAST:-false}
+folder=${gem:-.}
+
+docker-compose run --rm -e "FAIL_FAST=$fail_fast" decidim bash -c "cd $folder && bundle exec rspec $spec"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - 3000:3000
     volumes:
       - .:/code
-      - gems:/gems:delegated
+      - gems:/usr/local/bundle:delegated
     environment:
       - DATABASE_HOST=pg
       - DATABASE_USERNAME=postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,9 @@ services:
     image: decidim/decidim:latest-dev
     entrypoint: /usr/local/bin/entrypoint.sh
     command: decidim
-    working_dir: "/code"
+    working_dir: /code
     ports:
-      - "3000:3000"
+      - 3000:3000
     volumes:
       - .:/code
       - gems:/gems:delegated

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -37,6 +37,15 @@ This will create a `decidim_application` Ruby on Rails app using Decidim in the 
 
 ### C. Step by step
 
+In order to develop on decidim, you'll need:
+
+* **Git** 2.15+
+* **PostgreSQL** 9.4+
+* **Ruby** 2.5.0 (2.3+ should work just fine, but that's the version we test against)
+* **NodeJS** 9.x.x
+* **ImageMagick**
+* **Chrome** browser and [chromedriver](https://sites.google.com/a/chromium.org/chromedriver/).
+
 First of all, you need to install the `decidim` gem:
 
 ```console

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -25,15 +25,34 @@ Read more about the [installation script](https://github.com/alabs/decidim-insta
 
 ### B. Using Docker [experimental]
 
-> *Please note that this is **experimental***
+You can also use [docker v17+] && [docker-compose] to develop decidim. You'll
+need to install those but in exchange you don't need to install any other
+dependency in your computer, not even Ruby!
 
-Make sure you [have Docker v17 at least](https://docs.docker.com/engine/installation/). `cd` to your preferred folder and run this command:
+To get started, first clone the decidim repo
 
 ```console
-docker run --rm -v $(pwd):/tmp codegram/decidim bash -c "bundle exec decidim /tmp/decidim_application"
+git clone https://github.com/decidim/decidim
 ```
 
-This will create a `decidim_application` Ruby on Rails app using Decidim in the current folder. It will install the latest released version of the gem.
+Switch to the cloned folder
+
+```console
+cd decidim
+```
+
+Then create a development application
+
+```console
+d/bundle install
+d/rake development_app
+cd development_app
+bin/rails server
+```
+
+In general, to use the docker development environment, change any instruction in
+the docs to use its equivalent docker binstub.  So for example, instead of
+running `bundle install`, you would run `d/bundle install`.
 
 ### C. Step by step
 
@@ -148,3 +167,6 @@ bin/rails decidim:check_locales
 
 Be aware that this task might not be able to detect everything, so make sure you
 also manually check your application before upgrading.
+
+[docker]: https://docs.docker.com/engine/installation/
+[docker-compose]: https://docs.docker.com/compose/install/


### PR DESCRIPTION
#### :tophat: What? Why?

This PR catches up with decidim/docker#20, but I also take the chance to propose the development setup I've been intermitently using for a while. The idea, as I mentioned in #2755, is to provide docker binstubs for the most usual tools we use for development, and that any instructions for working on a regular development environment can be used "in docker" by replacing the main command with the docker binstub.

#### :pushpin: Related Issues
- Related (fixes?) to #2382.
- Related to #2755.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.