### PR TITLE
Do not overwrite the parent when updating a scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,5 +79,6 @@
 - **decidim-core**: Fix user invitations by generating their nickname. [\#2783](https://github.com/decidim/decidim/pull/2783)
 - **decidim-core**: Fix authorization modals not reopening [\#2811](https://github.com/decidim/decidim/pull/2811)
 - **decidim-core**: Fix ugly white stripe under flash message on pages with a picture as main background (such as the homepage) [\#2818](https://github.com/decidim/decidim/pull/2818)
+- **decidim-admin**: Fix a bug that lost the scope hierarchy when updating, making the updated scope top-level [\#2853](https://github.com/decidim/decidim/pull/2853)
 
 Please check [0.9-stable](https://github.com/decidim/decidim/blob/0.9-stable/CHANGELOG.md) for previous changes.

--- a/decidim-admin/app/commands/decidim/admin/update_scope.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_scope.rb
@@ -38,8 +38,7 @@ module Decidim
         {
           name: form.name,
           code: form.code,
-          scope_type: form.scope_type,
-          parent: @parent_scope
+          scope_type: form.scope_type
         }
       end
     end

--- a/decidim-admin/spec/commands/update_scope_spec.rb
+++ b/decidim-admin/spec/commands/update_scope_spec.rb
@@ -7,7 +7,8 @@ module Decidim::Admin
     subject { described_class.new(scope, form) }
 
     let(:organization) { create :organization }
-    let(:scope) { create :scope, organization: organization }
+    let(:parent_scope) { create :scope, organization: organization }
+    let(:scope) { create :scope, parent: parent_scope, organization: organization }
     let(:name) { Decidim::Faker::Localized.literal("New name") }
     let(:code) { "NEWCODE" }
     let(:scope_type) { create :scope_type, organization: organization }
@@ -46,6 +47,10 @@ module Decidim::Admin
 
       it "updates the scope type" do
         expect(scope.scope_type).to eq(scope_type)
+      end
+
+      it "keeps the parent scope" do
+        expect(scope.parent).to eq(parent_scope)
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
I found a bug while working on another PR: when you have a child scope and update it, the hierarchy is lost and the scope becomes top-level.

Since we currently have no way to modify the parent of a scope, this is an important bug. I think this should be backported to 0.9.x.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
None