### PR TITLE
Admins auto follows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 **Added**:
 
+- **decidim-assemblies**: Make admins auto follow assemblies [\#2855](https://github.com/decidim/decidim/pull/2855)
+- **decidim-participatory_processes**: Make admins auto follow participatory processes [\#2855](https://github.com/decidim/decidim/pull/2855)
 - **decidim-accountability**: Proposal followers are notified when a proposal is included in a result [\#2836](https://github.com/decidim/decidim/pull/2836)
 - **decidim-core**: Space followers are notified when a step changes its dates [\#2833](https://github.com/decidim/decidim/pull/2833)
 - **decidim-proposals**: Space followers are notified when the proposal can be created, endorsed or voted [\#2794](https://github.com/decidim/decidim/pull/2794)

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assembly.rb
@@ -24,6 +24,7 @@ module Decidim
           assembly = create_assembly
 
           if assembly.persisted?
+            add_admins_as_followers(assembly)
             broadcast(:ok, assembly)
           else
             form.errors.add(:hero_image, assembly.errors[:hero_image]) if assembly.errors.include? :hero_image
@@ -62,6 +63,19 @@ module Decidim
           return assembly unless assembly.valid?
           assembly.save!
           assembly
+        end
+
+        def add_admins_as_followers(assembly)
+          assembly.organization.admins.each do |admin|
+            form = Decidim::FollowForm
+                   .from_params(followable_gid: assembly.to_signed_global_id.to_s)
+                   .with_context(
+                     current_organization: assembly.organization,
+                     current_user: admin
+                   )
+
+            Decidim::CreateFollow.new(form, admin).call
+          end
         end
       end
     end

--- a/decidim-assemblies/spec/commands/create_assembly_admin_spec.rb
+++ b/decidim-assemblies/spec/commands/create_assembly_admin_spec.rb
@@ -39,9 +39,18 @@ module Decidim::Assemblies
         expect(roles.first.role).to eq "admin"
       end
 
-      it "creates a new user with no application admin privileges" do
+      it "doesn't add admin privileges to the user" do
         subject.call
-        expect(Decidim::User.last).not_to be_admin
+        user.reload
+
+        expect(user).not_to be_admin
+      end
+
+      it "makes the new admin follow the process" do
+        subject.call
+        user.reload
+
+        expect(user.follows?(my_assembly)).to be true
       end
 
       context "when there is no user with the given email" do

--- a/decidim-assemblies/spec/commands/create_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/create_assembly_spec.rb
@@ -82,6 +82,14 @@ module Decidim::Assemblies
       it "broadcasts ok" do
         expect { subject.call }.to broadcast(:ok)
       end
+
+      it "adds the admins as followers" do
+        subject.call do
+          on(:ok) do |assembly|
+            expect(current_user.follows?(assembly)).to be_true
+          end
+        end
+      end
     end
   end
 end

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process.rb
@@ -24,6 +24,7 @@ module Decidim
           process = create_participatory_process
 
           if process.persisted?
+            add_admins_as_followers(process)
             broadcast(:ok, process)
           else
             form.errors.add(:hero_image, process.errors[:hero_image]) if process.errors.include? :hero_image
@@ -86,6 +87,19 @@ module Decidim
             process,
             process.versions.last.id
           )
+        end
+
+        def add_admins_as_followers(process)
+          process.organization.admins.each do |admin|
+            form = Decidim::FollowForm
+                   .from_params(followable_gid: process.to_signed_global_id.to_s)
+                   .with_context(
+                     current_organization: process.organization,
+                     current_user: admin
+                   )
+
+            Decidim::CreateFollow.new(form, admin).call
+          end
         end
       end
     end

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process_admin.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process_admin.rb
@@ -30,6 +30,7 @@ module Decidim
           ActiveRecord::Base.transaction do
             create_or_invite_user
             existing_role || create_role
+            add_admin_as_follower
           end
 
           broadcast(:ok)
@@ -107,6 +108,19 @@ module Decidim
         def invitation_instructions
           return "invite_admin" if form.role == "admin"
           "invite_collaborator"
+        end
+
+        def add_admin_as_follower
+          return if user.follows?(participatory_process)
+
+          form = Decidim::FollowForm
+                 .from_params(followable_gid: participatory_process.to_signed_global_id.to_s)
+                 .with_context(
+                   current_organization: participatory_process.organization,
+                   current_user: user
+                 )
+
+          Decidim::CreateFollow.new(form, user).call
         end
       end
     end

--- a/decidim-participatory_processes/spec/commands/create_participatory_process_admin_spec.rb
+++ b/decidim-participatory_processes/spec/commands/create_participatory_process_admin_spec.rb
@@ -67,9 +67,18 @@ module Decidim::ParticipatoryProcesses
         expect(action_log.version.event).to eq "create"
       end
 
-      it "creates a new user with no application admin privileges" do
+      it "doesn't add admin privileges to the user" do
         subject.call
-        expect(Decidim::User.last).not_to be_admin
+        user.reload
+
+        expect(user).not_to be_admin
+      end
+
+      it "makes the new admin follow the process" do
+        subject.call
+        user.reload
+
+        expect(user.follows?(my_process)).to be true
       end
 
       context "when there is no user with the given email" do

--- a/decidim-participatory_processes/spec/commands/create_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/commands/create_participatory_process_spec.rb
@@ -9,7 +9,7 @@ module Decidim::ParticipatoryProcesses
     let(:organization) { create :organization }
     let(:participatory_process_group) { create :participatory_process_group, organization: organization }
     let(:scope) { create :scope, organization: organization }
-    let(:current_user) { create :user, organization: organization }
+    let(:current_user) { create :user, :admin, organization: organization }
     let(:errors) { double.as_null_object }
     let(:form) do
       instance_double(
@@ -105,6 +105,14 @@ module Decidim::ParticipatoryProcesses
           on(:ok) do |process|
             expect(process.steps.count).to eq(1)
             expect(process.steps.first).to be_active
+          end
+        end
+      end
+
+      it "adds the admins as followers" do
+        subject.call do
+          on(:ok) do |process|
+            expect(current_user.follows?(process)).to be_true
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

Makes admins and space admin follow processes and assemblies.

#### :pushpin: Related Issues
- Related to #2334

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
