### PR TITLE
BUGFIX Area and AreaType command specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@
 - **decidim-system**: Default pages content are now wrapped in `<p>` HTML tags [\#2754](https://github.com/decidim/decidim/pull/2754)
 
 **Fixed**:
-
+- **decidim-admin**: FIX Area and AreaType command specs [\#2859](https://github.com/decidim/decidim/pull/2859)
 - **decidim-proposals**: Fix wrong message when creating a proposal private note [\#2769](https://github.com/decidim/decidim/pull/2769)
 - **decidim-core**: Fix AuthorEvent when author is missing [\#2777](https://github.com/decidim/decidim/pull/2777)
 - **decidim-system**: Disable recover password for System admins. [\#2752](https://github.com/decidim/decidim/pull/2752)

--- a/decidim-admin/spec/commands/create_area_spec.rb
+++ b/decidim-admin/spec/commands/create_area_spec.rb
@@ -3,21 +3,20 @@
 require "spec_helper"
 
 module Decidim::Admin
-  describe CreateScope do
+  describe CreateArea do
     subject { described_class.new(form) }
 
     let(:organization) { create :organization }
     let(:name) { Decidim::Faker::Localized.literal(Faker::Address.unique.state) }
     let(:code) { Faker::Address.unique.state_abbr }
-    let(:scope_type) { create :scope_type }
+    let(:area_type) { create :area_type }
 
     let(:form) do
       double(
         invalid?: invalid,
         name: name,
         organization: organization,
-        code: code,
-        scope_type: scope_type
+        area_type: area_type
       )
     end
     let(:invalid) { false }
@@ -35,26 +34,8 @@ module Decidim::Admin
         expect { subject.call }.to broadcast(:ok)
       end
 
-      it "creates a new scope for the organization" do
-        expect { subject.call }.to change { organization.scopes.count }.by(1)
-      end
-    end
-
-    context "when its a child scope" do
-      subject { described_class.new(form, parent_scope) }
-
-      let!(:parent_scope) { create :scope, organization: organization }
-
-      it "broadcasts ok" do
-        expect { subject.call }.to broadcast(:ok)
-      end
-
-      it "creates a new scope for the organization" do
-        expect { subject.call }.to change { organization.scopes.count }.by(1)
-      end
-
-      it "creates a child scope for the parent scope" do
-        expect { subject.call }.to change { parent_scope.children.count }.by(1)
+      it "creates a new area for the organization" do
+        expect { subject.call }.to change { organization.areas.count }.by(1)
       end
     end
   end

--- a/decidim-admin/spec/commands/create_area_type_spec.rb
+++ b/decidim-admin/spec/commands/create_area_type_spec.rb
@@ -3,12 +3,12 @@
 require "spec_helper"
 
 module Decidim::Admin
-  describe CreateScopeType do
+  describe CreateAreaType do
     subject { described_class.new(form) }
 
     let(:organization) { create :organization }
-    let(:name) { Decidim::Faker::Localized.literal("province") }
-    let(:plural) { Decidim::Faker::Localized.literal("provinces") }
+    let(:name) { Decidim::Faker::Localized.literal("territorial") }
+    let(:plural) { Decidim::Faker::Localized.literal("territorials") }
 
     let(:form) do
       double(
@@ -34,7 +34,7 @@ module Decidim::Admin
       end
 
       it "creates a new scope type for the organization" do
-        expect { subject.call }.to change { organization.scope_types.count }.by(1)
+        expect { subject.call }.to change { organization.area_types.count }.by(1)
       end
     end
   end

--- a/decidim-admin/spec/commands/update_area_spec.rb
+++ b/decidim-admin/spec/commands/update_area_spec.rb
@@ -3,21 +3,19 @@
 require "spec_helper"
 
 module Decidim::Admin
-  describe UpdateScope do
-    subject { described_class.new(scope, form) }
+  describe UpdateArea do
+    subject { described_class.new(area, form) }
 
     let(:organization) { create :organization }
-    let(:scope) { create :scope, organization: organization }
+    let(:area) { create :area, organization: organization }
     let(:name) { Decidim::Faker::Localized.literal("New name") }
-    let(:code) { "NEWCODE" }
-    let(:scope_type) { create :scope_type, organization: organization }
+    let(:area_type) { create :area_type, organization: organization }
 
     let(:form) do
       double(
         invalid?: invalid,
         name: name,
-        code: code,
-        scope_type: scope_type
+        area_type: area_type
       )
     end
     let(:invalid) { false }
@@ -33,19 +31,15 @@ module Decidim::Admin
     context "when the form is valid" do
       before do
         subject.call
-        scope.reload
+        area.reload
       end
 
-      it "updates the name of the scope" do
-        expect(translated(scope.name)).to eq("New name")
+      it "updates the name of the area" do
+        expect(translated(area.name)).to eq("New name")
       end
 
-      it "updates the code of the scope" do
-        expect(scope.code).to eq("NEWCODE")
-      end
-
-      it "updates the scope type" do
-        expect(scope.scope_type).to eq(scope_type)
+      it "updates the area type" do
+        expect(area.area_type).to eq(area_type)
       end
     end
   end

--- a/decidim-admin/spec/commands/update_area_type_spec.rb
+++ b/decidim-admin/spec/commands/update_area_type_spec.rb
@@ -3,11 +3,11 @@
 require "spec_helper"
 
 module Decidim::Admin
-  describe UpdateScopeType do
-    subject { described_class.new(scope_type, form) }
+  describe UpdateAreaType do
+    subject { described_class.new(area_type, form) }
 
     let(:organization) { create :organization }
-    let(:scope_type) { create :scope_type, organization: organization }
+    let(:area_type) { create :area_type, organization: organization }
     let(:name) { Decidim::Faker::Localized.literal("new name") }
     let(:plural) { Decidim::Faker::Localized.literal("new names") }
 
@@ -31,15 +31,15 @@ module Decidim::Admin
     context "when the form is valid" do
       before do
         subject.call
-        scope_type.reload
+        area_type.reload
       end
 
       it "updates the name of the scope" do
-        expect(translated(scope_type.name)).to eq("new name")
+        expect(translated(area_type.name)).to eq("new name")
       end
 
       it "updates the plural of the scope" do
-        expect(translated(scope_type.plural)).to eq("new names")
+        expect(translated(area_type.plural)).to eq("new names")
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
BUGFIX Area and AreaType command specs was testing scope commands

#### :pushpin: Related Issues
- Related to #2750
- Fixes #2856 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] BUGFIX Area and AreaType command specs

### :camera: Screenshots (optional)
![Description](URL)
