### PR TITLE
Data picker improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@
 - **decidim-proposals**: Log proposal answers [\#2848](https://github.com/decidim/decidim/pull/2848)
 - **decidim-accountability**: Adds flag to control if the visualization of progress is visible [\#2847](https://github.com/decidim/decidim/pull/2847)
 - **decidim-proposals**: Adds a basic API that lists proposals. [\#2788](https://github.com/decidim/decidim/pull/2788)
+- **decidim-core**: `scopes_picker_field` can now receive options such as `label: false` [\#2867](https://github.com/decidim/decidim/pull/2847)
+- **decidim-core**: `theDataPicker.activate("#my_data_picker_element")` can now be used to bind dinamically created inputs to a data picker [\#2867](https://github.com/decidim/decidim/pull/2847)
 
 **Changed**:
 

--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_forms.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_forms.scss
@@ -20,7 +20,8 @@ textarea{
   select,
   textarea,
   .check-radio,
-  .input-field{
+  .input-field,
+  .data-picker{
     margin-bottom: $input-margin;
   }
 

--- a/decidim-core/app/assets/javascripts/decidim/data_picker.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/data_picker.js.es6
@@ -9,32 +9,36 @@
       this.current = null;
 
       elements.each((_index, element) => {
-        let $element = $(element);
-        let input    = "hidden",
-            name     = $element.data('picker-name'),
-            values   = $(".picker-values", $element);
+        this.activate(element);
+      });
+    }
 
-        if ($element.hasClass("picker-multiple")) {
-          input = "checkbox";
-          name += "[]";
+    activate(picker) {
+      let $element = $(picker);
+      let input    = "hidden",
+          name     = $element.data('picker-name'),
+          values   = $(".picker-values", $element);
+
+      if ($element.hasClass("picker-multiple")) {
+        input = "checkbox";
+        name += "[]";
+      }
+
+      $("div", values).each((_index2, div) => {
+        let value = $("a", div).data("picker-value");
+        $(div).prepend($(`<input type="${input}" checked name="${name}" value="${value}"/>`));
+      });
+
+      $element.on("click", "a", (event) => {
+        event.preventDefault();
+        if ($element.hasClass('disabled')) {
+          return;
         }
+        this._openPicker($element, event.target.parentNode);
+      });
 
-        $("div", values).each((_index2, div) => {
-          let value = $("a", div).data("picker-value");
-          $(div).prepend($(`<input type="${input}" checked name="${name}" value="${value}"/>`));
-        });
-
-        $element.on("click", "a", (event) => {
-          event.preventDefault();
-          if ($element.hasClass('disabled')) {
-            return;
-          }
-          this._openPicker($element, event.target.parentNode);
-        });
-
-        $element.on("click", "input", (event) => {
-          this._removeValue($element, event.target.parentNode);
-        });
+      $element.on("click", "input", (event) => {
+        this._removeValue($element, event.target.parentNode);
       });
     }
 

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_data-picker.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_data-picker.scss
@@ -6,7 +6,6 @@
     cursor: pointer;
     display: block;
     width: 100%;
-    margin-bottom: 1rem;
     padding: .4rem .7rem;
     border: 1px solid #e8e8e8;
     border-radius: 4px;

--- a/decidim-core/app/helpers/decidim/scopes_helper.rb
+++ b/decidim-core/app/helpers/decidim/scopes_helper.rb
@@ -33,9 +33,9 @@ module Decidim
     # name - attribute name
     #
     # Returns nothing.
-    def scopes_picker_field(form, name, root: false)
+    def scopes_picker_field(form, name, root: false, options: {})
       root = try(:current_participatory_space)&.scope if root == false
-      form.scopes_picker name do |scope|
+      form.scopes_picker name, options do |scope|
         { url: decidim.scopes_picker_path(root: root, current: scope&.id, field: form.label_for(name)),
           text: scope_name_for_picker(scope, I18n.t("decidim.scopes.global")) }
       end


### PR DESCRIPTION
#### :tophat: What? Why?
These are some features for the data picker that I'd like to have:

* Expose an `activate` JS method to bind a data-picker element. This is just a little refactoring but it's useful for me since I'm adding data_pickers dinamically, so I need a way to bind the newly created elements to the data picker events.

* Allow `scopes_picker_field` to receive options. In particular I'm using this to pass `label: false` and generate a data picker input without a label.

* A small tweak to make data picker have the same bottom margin as all the other inputs.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
_None_.
