### PR TITLE
Do not run CircleCI on Crowdin PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -412,8 +412,10 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build_design_app
-
+      - build_design_app:
+          filters:
+            branches:
+              ignore: /^l10n_master$/
       - build_test_app:
           filters:
             branches:


### PR DESCRIPTION
#### :tophat: What? Why?
A job on CircleCI was missing the branch filter, which caused some jobs to start running for Crowdin PRs.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None