### PR TITLE
Validate disposable accounts on form

### DIFF
--- a/decidim-core/app/forms/decidim/registration_form.rb
+++ b/decidim-core/app/forms/decidim/registration_form.rb
@@ -21,7 +21,7 @@ module Decidim
     validates :sign_up_as, inclusion: { in: %w(user user_group) }
     validates :name, presence: true
     validates :nickname, presence: true
-    validates :email, presence: true
+    validates :email, presence: true, 'valid_email_2/email': { disposable: true }
     validates :password, presence: true, confirmation: true, length: { in: Decidim::User.password_length }
     validates :tos_agreement, allow_nil: false, acceptance: true
 

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -30,7 +30,6 @@ module Decidim
     validates :tos_agreement, acceptance: true, allow_nil: false, on: :create
     validates :avatar, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_avatar_size } }
     validates :email, :nickname, uniqueness: { scope: :organization }, unless: -> { deleted? || managed? || nickname.blank? }
-    validates :email, 'valid_email_2/email': { disposable: true }
 
     validate :all_roles_are_valid
 

--- a/decidim-core/spec/forms/registration_form_spec.rb
+++ b/decidim-core/spec/forms/registration_form_spec.rb
@@ -50,6 +50,12 @@ module Decidim
       it { is_expected.to be_valid }
     end
 
+    context "when the email is a disposable account" do
+      let(:email) { "user@mailbox92.biz" }
+
+      it { is_expected.to be_invalid }
+    end
+
     context "when the sign_up_as is different from 'user' and 'user_group'" do
       let(:sign_up_as) { "community" }
 

--- a/decidim-core/spec/models/decidim/user_spec.rb
+++ b/decidim-core/spec/models/decidim/user_spec.rb
@@ -45,17 +45,6 @@ module Decidim
     end
 
     describe "validations", processing_uploads_for: Decidim::AvatarUploader do
-      context "when the email is a disposable account" do
-        before do
-          user.email = "user@mailbox92.biz"
-        end
-
-        it "is not valid" do
-          expect(user).not_to be_valid
-          expect(user.errors[:email].length).to eq(1)
-        end
-      end
-
       context "when the nickname is empty" do
         before do
           user.nickname = ""


### PR DESCRIPTION
#### :tophat: What? Why?
This moves the disposable email account validation in the form. I've been seeing exceptions related to invalid emails and it turns out it was because of this.

This is necessary for two reasons:

* An email might be incorrectly detected as invalid and we don't provide good feedback to the user.
* We only want to apply this protection on public registrations, it's too defensive otherwise.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
- [ ] ~~Add `CHANGELOG` entry~~ Don't think it's necessary for such a small change.

### :camera: Screenshots (optional)
*None*
