### PR TITLE
Remove unnecessary `allow_nil`'s

### DIFF
--- a/decidim-budgets/app/models/decidim/budgets/order.rb
+++ b/decidim-budgets/app/models/decidim/budgets/order.rb
@@ -63,6 +63,8 @@ module Decidim
       private
 
       def user_belongs_to_organization
+        organization = feature&.organization
+
         return if !user || !organization
         errors.add(:user, :invalid) unless user.organization == organization
       end

--- a/decidim-core/lib/decidim/authorable.rb
+++ b/decidim-core/lib/decidim/authorable.rb
@@ -33,6 +33,8 @@ module Decidim
       end
 
       def author_belongs_to_organization
+        organization = feature&.organization
+
         return if !author || !organization
         errors.add(:author, :invalid) unless author.organization == organization
       end

--- a/decidim-core/lib/decidim/has_feature.rb
+++ b/decidim-core/lib/decidim/has_feature.rb
@@ -10,8 +10,8 @@ module Decidim
 
     included do
       belongs_to :feature, foreign_key: "decidim_feature_id", class_name: "Decidim::Feature"
-      delegate :organization, to: :feature, allow_nil: true
-      delegate :participatory_space, to: :feature, allow_nil: true
+      delegate :organization, to: :feature
+      delegate :participatory_space, to: :feature
     end
 
     class_methods do


### PR DESCRIPTION
#### :tophat: What? Why?

All featurables (as in "models including the `HasFeature` module") should have a compulsory `feature` since the `belongs_to :feature` association is required. Thus, `allow_nil` when delegating is unnecessary.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.
