### PR TITLE
Remove participatory process references from assemblies

### DIFF
--- a/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_copy_form.rb
+++ b/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_copy_form.rb
@@ -17,7 +17,7 @@ module Decidim
         attribute :copy_categories, Boolean
         attribute :copy_features, Boolean
 
-        validates :slug, presence: true, format: { with: Decidim::ParticipatoryProcess.slug_format }
+        validates :slug, presence: true, format: { with: Decidim::Assembly.slug_format }
         validates :title, translatable_presence: true
         validate :slug_uniqueness
 

--- a/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_form.rb
+++ b/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_form.rb
@@ -34,7 +34,7 @@ module Decidim
         attribute :show_statistics, Boolean
         attribute :area_id, Integer
 
-        validates :slug, presence: true, format: { with: Decidim::ParticipatoryProcess.slug_format }
+        validates :slug, presence: true, format: { with: Decidim::Assembly.slug_format }
         validates :title, :subtitle, :description, :short_description, translatable_presence: true
         validates :scope, presence: true, if: proc { |object| object.scope_id.present? }
         validates :area, presence: true, if: proc { |object| object.area_id.present? }

--- a/decidim-assemblies/app/models/decidim/assemblies/abilities/admin/assembly_role_ability.rb
+++ b/decidim-assemblies/app/models/decidim/assemblies/abilities/admin/assembly_role_ability.rb
@@ -29,7 +29,7 @@ module Decidim
           def define_assembly_abilities; end
 
           # Abstract: A subclass must define this method returning a valid role.
-          # See ParticipatoryProcessUserRoles::ROLES for more information.
+          # See AssemblyUserRole::ROLES for more information.
           def role
             raise "Needs implementation"
           end

--- a/decidim-assemblies/app/models/decidim/assemblies/abilities/assembly_role_ability.rb
+++ b/decidim-assemblies/app/models/decidim/assemblies/abilities/assembly_role_ability.rb
@@ -30,7 +30,7 @@ module Decidim
         end
 
         # Abstract: A subclass must define this method returning a valid role.
-        # See ParticipatoryProcessUserRoles::ROLES for more information.
+        # See AssemblyUserRole::ROLES for more information.
         def role
           raise "Needs implementation"
         end

--- a/decidim-core/lib/decidim/abilities/participatory_process_role_ability.rb
+++ b/decidim-core/lib/decidim/abilities/participatory_process_role_ability.rb
@@ -26,7 +26,7 @@ module Decidim
       def define_participatory_process_abilities; end
 
       # Abstract: A subclass must define this method returning a valid role.
-      # See ParticipatoryProcessUserRoles::ROLES for more information.
+      # See ParticipatoryProcessUserRole::ROLES for more information.
       def role
         raise "Needs implementation"
       end


### PR DESCRIPTION
#### :tophat: What? Why?

Just that. Now grepping for `ParticipatoryProcess` in decidim-assemblies produces no results.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.