### PR TITLE
delete ellipsis control from css

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
@@ -66,8 +66,6 @@ $datetime-bg: $primary;
 }
 
 .card__title{
-  @include ellipsis(2);
-
   @extend .heading5;
 }
 
@@ -107,10 +105,6 @@ $datetime-bg: $primary;
 }
 
 .card__text{
-  .card__text--paragraph{
-    @include ellipsis();
-  }
-
   .card__text--status{
     font-weight: bold;
     text-transform: uppercase;

--- a/decidim-core/app/assets/stylesheets/decidim/utils/_mixins.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/utils/_mixins.scss
@@ -90,13 +90,3 @@ $palette: $foundation-palette;
   }
 }
 
-@mixin ellipsis($lines: 3){
-  display: block; /* Fallback for non-webkit */
-  display: -webkit-box;
-  max-height: ($global-lineheight * $lines) * 1rem; /* Fallback for non-webkit */
-  -webkit-line-clamp: $lines;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-


### PR DESCRIPTION
#### :tophat: What? Why?
Removes the CSS `ellipsis` mixin in order to avoid conflicts with text lengths.
It leaves that property to be handled straight from rails.

#### :pushpin: Related Issues
- Fixes #2891 