### PR TITLE
Scope officializations to organization users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,5 +100,6 @@
 - **decidim-core**: Fix ugly white stripe under flash message on pages with a picture as main background (such as the homepage) [\#2818](https://github.com/decidim/decidim/pull/2818)
 - **decidim-admin**: Fix a bug that lost the scope hierarchy when updating, making the updated scope top-level [\#2853](https://github.com/decidim/decidim/pull/2853)
 - **decidim-proposals**: Fix proposals scope not displayed on process group highlighted proposals cards in some cases. [\#2894](https://github.com/decidim/decidim/pull/2894)
+- **decidim-admin**: Fix officializations showing all users in the system instead of only the orgsanization ones [\#2912](https://github.com/decidim/decidim/pull/2912)
 
 Please check [0.9-stable](https://github.com/decidim/decidim/blob/0.9-stable/CHANGELOG.md) for previous changes.

--- a/decidim-admin/app/controllers/decidim/admin/officializations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/officializations_controller.rb
@@ -14,7 +14,7 @@ module Decidim
         @query = params[:q]
         @state = params[:state]
 
-        @users = Decidim::Admin::UsersOfficialization.for(@query, @state)
+        @users = Decidim::Admin::UsersOfficialization.for(current_organization, @query, @state)
                                                      .page(params[:page])
                                                      .per(15)
       end

--- a/decidim-admin/app/queries/decidim/admin/users_officialization.rb
+++ b/decidim-admin/app/queries/decidim/admin/users_officialization.rb
@@ -6,24 +6,27 @@ module Decidim
     class UsersOfficialization < Rectify::Query
       # Syntactic sugar to initialize the class and return the queried objects.
       #
+      # organization - the Decidim::Organization where search will be scoped to
       # q - query to filter user group names
       # state - evaluation state to be used as a filter
-      def self.for(q = nil, state = nil)
-        new(q, state).query
+      def self.for(organization, q = nil, state = nil)
+        new(organization, q, state).query
       end
 
       # Initializes the class.
       #
+      # organization - the Decidim::Organization where search will be scoped to
       # q - query to filter user group names
       # state - officialization state to be used as a filter
-      def initialize(q = nil, state = nil)
+      def initialize(organization, q = nil, state = nil)
+        @organization = organization
         @q = q
         @state = state
       end
 
       # List the User groups by the diferents filters.
       def query
-        users = Decidim::User.all
+        users = Decidim::User.where(organization: organization)
         users = filter_by_search(users)
         users = filter_by_state(users)
         users
@@ -31,7 +34,7 @@ module Decidim
 
       private
 
-      attr_reader :q, :state
+      attr_reader :q, :state, :organization
 
       def filter_by_search(users)
         return users if q.blank?

--- a/decidim-admin/spec/queries/users_officialization_spec.rb
+++ b/decidim-admin/spec/queries/users_officialization_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 module Decidim::Admin
   describe UsersOfficialization do
-    subject { described_class.new(search, filter) }
+    subject { described_class.new(organization, search, filter) }
 
     let(:organization) { create :organization }
     let(:search) { nil }
@@ -12,9 +12,11 @@ module Decidim::Admin
 
     describe "when the list is not filtered" do
       let!(:users) { create_list(:user, 3, organization: organization) }
+      let!(:other_org_users) { create_list(:user, 3) }
 
       it "returns all users" do
         expect(subject.query).to match_array users
+        expect(Decidim::User.count).to eq 6
       end
     end
 

--- a/decidim-admin/spec/system/admin_manages_officializations_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_officializations_spec.rb
@@ -18,6 +18,7 @@ describe "Admin manages officializations", type: :system do
     let!(:officialized) { create(:user, :officialized, organization: organization) }
 
     let!(:not_officialized) { create(:user, organization: organization) }
+    let!(:external_not_officialized) { create(:user) }
 
     before do
       click_link "Officializations"
@@ -26,6 +27,8 @@ describe "Admin manages officializations", type: :system do
     it "shows each user and its officialization status" do
       expect(page).to have_selector("tr[data-user-id=\"#{officialized.id}\"]", text: officialized.name)
       expect(page).to have_selector("tr[data-user-id=\"#{officialized.id}\"]", text: "Officialized")
+
+      expect(page).to have_no_selector("tr[data-user-id=\"#{external_not_officialized.id}\"]", text: not_officialized.name)
 
       expect(page).to have_selector("tr[data-user-id=\"#{not_officialized.id}\"]", text: not_officialized.name)
       expect(page).to have_selector("tr[data-user-id=\"#{not_officialized.id}\"]", text: "Not officialized")


### PR DESCRIPTION
#### :tophat: What? Why?
Currently, organizations lists all users from all organizations in the installation. This PR fixes it so that only the organization users appear.

Reported by @virgile-dev on Gitter:

https://gitter.im/decidim/decidim?at=5a9d54898f1c77ef3a85942c

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
