### PR TITLE
Add missing i18n in assemblies

### DIFF
--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -3,6 +3,7 @@ en:
   activemodel:
     attributes:
       assembly:
+        area_id: Area
         banner_image: Banner image
         copy_categories: Copy categories
         copy_features: Copy features
@@ -150,6 +151,7 @@ en:
         answers_count: Answers
         assemblies_count: Assemblies
         comments_count: Comments
+        endorsements_count: Endorsements
         headline: Activity
         meetings_count: Meetings
         orders_count: Votes


### PR DESCRIPTION
#### :tophat: What? Why?
Adds missing i18n in assemblies. Solves #2914 and adds more missing i18n related to #2750 

#### :pushpin: Related Issues
- Fixes #2914.

#### :clipboard: Subtasks
None