### PR TITLE
Remove coupling with feature

### DIFF
--- a/decidim-core/lib/decidim/authorable.rb
+++ b/decidim-core/lib/decidim/authorable.rb
@@ -33,8 +33,6 @@ module Decidim
       end
 
       def author_belongs_to_organization
-        organization = feature&.organization
-
         return if !author || !organization
         errors.add(:author, :invalid) unless author.organization == organization
       end

--- a/decidim-core/lib/decidim/has_feature.rb
+++ b/decidim-core/lib/decidim/has_feature.rb
@@ -10,8 +10,8 @@ module Decidim
 
     included do
       belongs_to :feature, foreign_key: "decidim_feature_id", class_name: "Decidim::Feature"
-      delegate :organization, to: :feature
-      delegate :participatory_space, to: :feature
+      delegate :organization, to: :feature, allow_nil: true
+      delegate :participatory_space, to: :feature, allow_nil: true
     end
 
     class_methods do


### PR DESCRIPTION
#### :tophat: What? Why?
This removes authorable's coupling with `feature`. `organization` must be implemented by other mixins (or explicitly) by the implementor - in general, `HasFeature` provides it.

This needed to be done due to incompatibilities with external modules, which were using `Authorable` in other context (`decidim-initiatives` defines an `Initiative`, which is a participatory space, as `Authorable`)

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*
