### PR TITLE
Destroy user's authorizations when they delete their account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Added**:
 
+- **decidim-core**: Destroy user's authorizations when they delete their account [\#2937](https://github.com/decidim/decidim/pull/2937)
 - **decidim-accountability**: Proposal selection from accountability with autoComplete [\#2348](https://github.com/decidim/decidim/pull/2584)
 - **decidim-assemblies**: Make admins auto follow assemblies [\#2855](https://github.com/decidim/decidim/pull/2855)
 - **decidim-participatory_processes**: Make admins auto follow participatory processes [\#2855](https://github.com/decidim/decidim/pull/2855)

--- a/decidim-core/app/commands/decidim/destroy_account.rb
+++ b/decidim-core/app/commands/decidim/destroy_account.rb
@@ -19,6 +19,7 @@ module Decidim
         destroy_user_account!
         destroy_user_identities
         destroy_user_group_memberships
+        destroy_user_authorizations
       end
 
       broadcast(:ok)
@@ -43,6 +44,10 @@ module Decidim
 
     def destroy_user_group_memberships
       Decidim::UserGroupMembership.where(user: @user).destroy_all
+    end
+
+    def destroy_user_authorizations
+      Decidim::Authorization.where(user: @user).destroy_all
     end
   end
 end

--- a/decidim-core/spec/commands/decidim/destroy_account_spec.rb
+++ b/decidim-core/spec/commands/decidim/destroy_account_spec.rb
@@ -70,6 +70,14 @@ module Decidim
           command.call
         end.to change(UserGroupMembership, :count).by(-1)
       end
+
+      it "deletes user's authorizations" do
+        create(:authorization, user: user)
+
+        expect do
+          command.call
+        end.to change(Authorization, :count).by(-1)
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

When a user deletes their account their authorizations should also be deleted, otherwise if they create a new account they won't be able to be verified again.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
