### PR TITLE
Remove the link and the path to view single areas on admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 
 **Fixed**:
 
+- **decidim-admin** remove the link and the path to view single areas on admin [\#2945](https://github.com/decidim/decidim/pull/2945)
 - **decidim-core**: FIX Mispelling in available_locales initializer: pr-BR should be pt-BR. [\#2883](https://github.com/decidim/decidim/pull/2883)
 - **decidim-admin**: FIX Area and AreaType command specs [\#2859](https://github.com/decidim/decidim/pull/2859)
 - **decidim-proposals**: Fix wrong message when creating a proposal private note [\#2769](https://github.com/decidim/decidim/pull/2769)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,6 @@
 
 **Fixed**:
 
-- **decidim-admin** remove the link and the path to view single areas on admin [\#2945](https://github.com/decidim/decidim/pull/2945)
 - **decidim-core**: FIX Mispelling in available_locales initializer: pr-BR should be pt-BR. [\#2883](https://github.com/decidim/decidim/pull/2883)
 - **decidim-admin**: FIX Area and AreaType command specs [\#2859](https://github.com/decidim/decidim/pull/2859)
 - **decidim-proposals**: Fix wrong message when creating a proposal private note [\#2769](https://github.com/decidim/decidim/pull/2769)

--- a/decidim-admin/app/views/decidim/admin/areas/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/areas/index.html.erb
@@ -19,7 +19,7 @@
           <% @areas.each do |area| %>
             <tr>
               <td>
-                <%= link_to translated_attribute(area.name), area_path(area) %>
+                <%= translated_attribute(area.name) %>
               </td>
               <td>
                 <%= area.area_type ? translated_attribute(area.area_type.name) : "-" %>


### PR DESCRIPTION
#### :tophat: What? Why?
remove the link and the path to view single areas on admin site.

#### :pushpin: Related Issues
- Related to #2750 
- Fixes #2943 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] remove the link and the path to view single areas.

### :camera: Screenshots (optional)
![Description](URL)
