### PR TITLE
Fix mentions not working properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,5 +23,6 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-accountability**: Fix parent results progress [\#2954](https://github.com/decidim/decidim/pull/2954)
 - **decidim-core**: Fix `Decidim::UserPresenter#nickname` [\#2958](https://github.com/decidim/decidim/pull/2958)
 - **decidim-verifications**: Only show authorizations from current organization [\#2959](https://github.com/decidim/decidim/pull/2959)
+- **decidim-comments**: Fix mentions not working properly.  [\#2947](https://github.com/decidim/decidim/pull/2947)
 
 Please check [0.10-stable](https://github.com/decidim/decidim/blob/0.10-stable/CHANGELOG.md) for previous changes.

--- a/decidim-comments/app/types/decidim/comments/commentable_mutation_type.rb
+++ b/decidim-comments/app/types/decidim/comments/commentable_mutation_type.rb
@@ -17,7 +17,7 @@ module Decidim
 
         resolve lambda { |obj, args, ctx|
           params = { "comment" => { "body" => args[:body], "alignment" => args[:alignment], "user_group_id" => args[:userGroupId] } }
-          form = Decidim::Comments::CommentForm.from_params(params)
+          form = Decidim::Comments::CommentForm.from_params(params).with_context(current_organization: ctx[:current_organization])
           Decidim::Comments::CreateComment.call(form, ctx[:current_user], obj) do
             on(:ok) do |comment|
               return comment

--- a/decidim-comments/spec/types/commentable_mutation_type_spec.rb
+++ b/decidim-comments/spec/types/commentable_mutation_type_spec.rb
@@ -21,7 +21,10 @@ module Decidim
 
         it "calls CreateComment command" do
           params = { "comment" => { "body" => body, "alignment" => alignment, "user_group_id" => nil } }
+          context = { current_organization: current_organization }
           expect(Decidim::Comments::CommentForm).to receive(:from_params).with(params).and_call_original
+          expect_any_instance_of(Decidim::Comments::CommentForm) # rubocop:disable RSpec/AnyInstance
+            .to receive(:with_context).with(context).and_call_original
           expect(Decidim::Comments::CreateComment).to receive(:call).with(
             an_instance_of(Decidim::Comments::CommentForm),
             current_user,


### PR DESCRIPTION
#### :tophat: What? Why?

Mentions in comments are not working properly because the GraphQL mutation was not setting the context correctly.

#### :pushpin: Related Issues

- Fixes #2842

#### :pushpin: Related PR

- Backport to `0.9-stable`: PENDING
- Backport to `0.10-stable`: PENDING

#### :clipboard: Subtasks
- [X] Add `CHANGELOG` entry
- [ ] Backport to `0.9-stable`
- [ ] Backport to `0.10-stable`
