### PR TITLE
Fix UserPresenter#nickname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@
 **Fixed**:
 
 - **decidim-accountability**: Fix parent results progress [\#2954](https://github.com/decidim/decidim/pull/2954)
+- **decidim-core**: Fix `Decidim::UserPresenter#nickname [\#2958](https://github.com/decidim/decidim/pull/2958)
 
 Please check [0.10-stable](https://github.com/decidim/decidim/blob/0.10-stable/CHANGELOG.md) for previous changes.

--- a/decidim-core/app/presenters/decidim/user_presenter.rb
+++ b/decidim-core/app/presenters/decidim/user_presenter.rb
@@ -12,7 +12,7 @@ module Decidim
     # nickname presented in a twitter-like style
     #
     def nickname
-      "@#{super}"
+      "@#{__getobj__.nickname}"
     end
 
     def badge


### PR DESCRIPTION
#### :tophat: What? Why?
For some reason, `Decidim::UserPresenter` does not know how to call `super` on the `nickname` method:

https://sentry.io/share/issue/87ac924348b546e59632228a03f65ab5/

I feel like `super` should be working there, but I couldn't make it work. What's event weirder is that tests pass anyway, but if I try it from the console then I get the error reported in Sentry:

```ruby
proposal = Decidim::Proposals::Proposal.first
user = Decidim::User.first
event = Decidim::Proposals::ProposalEndorsedEvent.new(resource: proposal, event_name: "blah", user: user, extra: {endorser: user})
event.notification_title
```

Without this PR, the last line of the example code fails on my console. With this PR, it works as expected.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
