### PR TITLE
Scope authorizations to current organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Fixed**:
 
 - **decidim-accountability**: Fix parent results progress [\#2954](https://github.com/decidim/decidim/pull/2954)
-- **decidim-core**: Fix `Decidim::UserPresenter#nickname [\#2958](https://github.com/decidim/decidim/pull/2958)
+- **decidim-core**: Fix `Decidim::UserPresenter#nickname` [\#2958](https://github.com/decidim/decidim/pull/2958)
+- **decidim-verifications**: Only show authorizations from current organization [\#2959](https://github.com/decidim/decidim/pull/2959)
 
 Please check [0.10-stable](https://github.com/decidim/decidim/blob/0.10-stable/CHANGELOG.md) for previous changes.

--- a/decidim-core/app/models/decidim/abilities/base_ability.rb
+++ b/decidim-core/app/models/decidim/abilities/base_ability.rb
@@ -49,7 +49,7 @@ module Decidim
       private
 
       def not_already_active?(user, authorization)
-        Verifications::Authorizations.new(user: user, name: authorization.name).none?
+        Verifications::Authorizations.new(organization: user.organization, user: user, name: authorization.name).none?
       end
     end
   end

--- a/decidim-core/app/models/decidim/authorization.rb
+++ b/decidim-core/app/models/decidim/authorization.rb
@@ -14,6 +14,7 @@ module Decidim
     mount_uploader :verification_attachment, Decidim::Verifications::AttachmentUploader
 
     belongs_to :user, foreign_key: "decidim_user_id", class_name: "Decidim::User"
+    has_one :organization, through: :user, class_name: "Decidim::Organization"
 
     validates :name, uniqueness: { scope: :decidim_user_id }
     validates :verification_metadata, absence: true, if: :granted?

--- a/decidim-core/app/services/decidim/action_authorizer.rb
+++ b/decidim-core/app/services/decidim/action_authorizer.rb
@@ -43,7 +43,7 @@ module Decidim
     def authorization
       return nil unless user && authorization_handler_name
 
-      @authorization ||= Verifications::Authorizations.new(user: user, name: authorization_handler_name).first
+      @authorization ||= Verifications::Authorizations.new(organization: user.organization, user: user, name: authorization_handler_name).first
     end
 
     def authorization_handler

--- a/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
@@ -76,15 +76,15 @@ module Decidim
       end
 
       def active_authorization_methods
-        Authorizations.new(user: current_user).pluck(:name)
+        Authorizations.new(organization: current_organization, user: current_user).pluck(:name)
       end
 
       def granted_authorizations
-        Authorizations.new(user: current_user, granted: true)
+        Authorizations.new(organization: current_organization, user: current_user, granted: true)
       end
 
       def pending_authorizations
-        Authorizations.new(user: current_user, granted: false)
+        Authorizations.new(organization: current_organization, user: current_user, granted: false)
       end
 
       def store_current_location

--- a/decidim-verifications/app/controllers/decidim/verifications/id_documents/admin/pending_authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/id_documents/admin/pending_authorizations_controller.rb
@@ -17,7 +17,7 @@ module Decidim
 
           def pending_authorizations
             Authorizations
-              .new(name: "id_documents", granted: false)
+              .new(organization: current_organization, name: "id_documents", granted: false)
               .query
               .where("verification_metadata->'rejected' IS NULL")
           end

--- a/decidim-verifications/app/controllers/decidim/verifications/postal_letter/admin/pending_authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/postal_letter/admin/pending_authorizations_controller.rb
@@ -18,7 +18,7 @@ module Decidim
           private
 
           def pending_authorizations
-            Authorizations.new(name: "postal_letter", granted: false)
+            Authorizations.new(organization: current_organization, name: "postal_letter", granted: false)
           end
         end
       end

--- a/decidim-verifications/app/queries/decidim/verifications/authorizations.rb
+++ b/decidim-verifications/app/queries/decidim/verifications/authorizations.rb
@@ -6,10 +6,12 @@ module Decidim
     class Authorizations < Rectify::Query
       # Initializes the class.
       #
+      # @param organization [Organization] The organization where this authorization belongs to
       # @param name [String] The name of an authorization method
       # @param user [User] A user to find authorizations for
       # @param granted [Boolean] Whether the authorization is granted or not
-      def initialize(user: nil, name: nil, granted: nil)
+      def initialize(organization:, user: nil, name: nil, granted: nil)
+        @organization = organization
         @user = user
         @name = name
         @granted = granted
@@ -19,7 +21,7 @@ module Decidim
       #
       # Returns an ActiveRecord::Relation.
       def query
-        scope = Decidim::Authorization.where(nil)
+        scope = Decidim::Authorization.left_outer_joins(:organization).where(decidim_organizations: { id: organization.id })
 
         scope = scope.where(name: name) unless name.nil?
         scope = scope.where(user: user) unless user.nil?
@@ -35,7 +37,7 @@ module Decidim
 
       private
 
-      attr_reader :user, :name, :granted
+      attr_reader :user, :name, :granted, :organization
     end
   end
 end

--- a/decidim-verifications/spec/commmands/decidim/verifications/authorize_user_spec.rb
+++ b/decidim-verifications/spec/commmands/decidim/verifications/authorize_user_spec.rb
@@ -15,7 +15,7 @@ module Decidim::Verifications
       )
     end
 
-    let(:authorizations) { Authorizations.new(user: user, granted: true) }
+    let(:authorizations) { Authorizations.new(organization: user.organization, user: user, granted: true) }
 
     context "when the form is not authorized" do
       before do

--- a/decidim-verifications/spec/commmands/decidim/verifications/confirm_user_authorization_spec.rb
+++ b/decidim-verifications/spec/commmands/decidim/verifications/confirm_user_authorization_spec.rb
@@ -35,7 +35,7 @@ describe Decidim::Verifications::ConfirmUserAuthorization do
   let(:form) { form_class.new(secret_code: secret_code) }
 
   let(:authorizations) do
-    Decidim::Verifications::Authorizations.new(user: user, granted: true)
+    Decidim::Verifications::Authorizations.new(organization: user.organization, user: user, granted: true)
   end
 
   let(:user) { authorization.user }

--- a/decidim-verifications/spec/commmands/decidim/verifications/perform_authorization_step_spec.rb
+++ b/decidim-verifications/spec/commmands/decidim/verifications/perform_authorization_step_spec.rb
@@ -28,7 +28,7 @@ describe Decidim::Verifications::PerformAuthorizationStep do
   end
 
   let(:authorizations) do
-    Decidim::Verifications::Authorizations.new(user: user, granted: false)
+    Decidim::Verifications::Authorizations.new(organization: user.organization, user: user, granted: false)
   end
 
   let(:user) { create(:user) }

--- a/decidim-verifications/spec/queries/decidim/verifications/authorizations_spec.rb
+++ b/decidim-verifications/spec/queries/decidim/verifications/authorizations_spec.rb
@@ -4,18 +4,21 @@ require "spec_helper"
 
 describe Decidim::Verifications::Authorizations do
   let(:name) { "some_method" }
-  let(:user) { create(:user) }
+  let(:user) { create(:user, organization: organization) }
+  let(:user2) { create(:user, organization: organization) }
+  let(:user3) { create(:user, organization: organization) }
+  let(:organization) { create :organization }
 
   let!(:granted_for_user_and_method) do
     create(:authorization, :granted, name: name, user: user)
   end
 
   let!(:pending_for_other_user) do
-    create(:authorization, :pending, name: name)
+    create(:authorization, :pending, name: name, user: user2)
   end
 
   let!(:granted_for_other_user) do
-    create(:authorization, :granted, name: name)
+    create(:authorization, :granted, name: name, user: user3)
   end
 
   let!(:pending_for_other_method) do
@@ -27,23 +30,28 @@ describe Decidim::Verifications::Authorizations do
   end
 
   let!(:pending_for_other_user_and_method) do
-    create(:authorization, :pending)
+    create(:authorization, :pending, user: user2)
   end
 
   let!(:granted_for_other_user_and_method) do
-    create(:authorization, :granted)
+    create(:authorization, :granted, user: user3)
+  end
+
+  let!(:external_organization_authorization) do
+    create(:authorization)
   end
 
   shared_examples_for "a correct usage of the query" do
     subject { described_class.new(parameters).query.to_a }
 
     it { is_expected.to match_array(expectation) }
+    it { is_expected.not_to include(external_organization_authorization) }
   end
 
   describe "no filtering" do
     it_behaves_like "a correct usage of the query" do
       let(:parameters) do
-        { user: nil, name: nil, granted: nil }
+        { organization: organization, user: nil, name: nil, granted: nil }
       end
 
       let(:expectation) do
@@ -63,7 +71,7 @@ describe Decidim::Verifications::Authorizations do
   describe "granted only" do
     it_behaves_like "a correct usage of the query" do
       let(:parameters) do
-        { user: nil, name: nil, granted: true }
+        { organization: organization, user: nil, name: nil, granted: true }
       end
 
       let(:expectation) do
@@ -80,7 +88,7 @@ describe Decidim::Verifications::Authorizations do
   describe "pending only" do
     it_behaves_like "a correct usage of the query" do
       let(:parameters) do
-        { user: nil, name: nil, granted: false }
+        { organization: organization, user: nil, name: nil, granted: false }
       end
 
       let(:expectation) do
@@ -96,7 +104,7 @@ describe Decidim::Verifications::Authorizations do
   describe "by method" do
     it_behaves_like "a correct usage of the query" do
       let(:parameters) do
-        { user: nil, name: name, granted: nil }
+        { organization: organization, user: nil, name: name, granted: nil }
       end
 
       let(:expectation) do
@@ -112,7 +120,7 @@ describe Decidim::Verifications::Authorizations do
   describe "granted by method" do
     it_behaves_like "a correct usage of the query" do
       let(:parameters) do
-        { user: nil, name: name, granted: true }
+        { organization: organization, user: nil, name: name, granted: true }
       end
 
       let(:expectation) do
@@ -124,7 +132,7 @@ describe Decidim::Verifications::Authorizations do
   describe "pending by method" do
     it_behaves_like "a correct usage of the query" do
       let(:parameters) do
-        { user: nil, name: name, granted: false }
+        { organization: organization, user: nil, name: name, granted: false }
       end
 
       let(:expectation) do
@@ -136,7 +144,7 @@ describe Decidim::Verifications::Authorizations do
   describe "by user" do
     it_behaves_like "a correct usage of the query" do
       let(:parameters) do
-        { user: user, name: nil, granted: nil }
+        { organization: organization, user: user, name: nil, granted: nil }
       end
 
       let(:expectation) do
@@ -152,7 +160,7 @@ describe Decidim::Verifications::Authorizations do
   describe "granted by user" do
     it_behaves_like "a correct usage of the query" do
       let(:parameters) do
-        { user: user, name: nil, granted: true }
+        { organization: organization, user: user, name: nil, granted: true }
       end
 
       let(:expectation) do
@@ -164,7 +172,7 @@ describe Decidim::Verifications::Authorizations do
   describe "pending by user" do
     it_behaves_like "a correct usage of the query" do
       let(:parameters) do
-        { user: user, name: nil, granted: false }
+        { organization: organization, user: user, name: nil, granted: false }
       end
 
       let(:expectation) { [pending_for_other_method] }
@@ -174,7 +182,7 @@ describe Decidim::Verifications::Authorizations do
   describe "by user and method" do
     it_behaves_like "a correct usage of the query" do
       let(:parameters) do
-        { user: user, name: name, granted: nil }
+        { organization: organization, user: user, name: name, granted: nil }
       end
 
       let(:expectation) { [granted_for_user_and_method] }
@@ -184,7 +192,7 @@ describe Decidim::Verifications::Authorizations do
   describe "granted by user and method" do
     it_behaves_like "a correct usage of the query" do
       let(:parameters) do
-        { user: user, name: name, granted: true }
+        { organization: organization, user: user, name: name, granted: true }
       end
 
       let(:expectation) { [granted_for_user_and_method] }
@@ -194,7 +202,7 @@ describe Decidim::Verifications::Authorizations do
   describe "pending by user and method" do
     it_behaves_like "a correct usage of the query" do
       let(:parameters) do
-        { user: user, name: name, granted: false }
+        { organization: organization, user: user, name: name, granted: false }
       end
 
       let(:expectation) { [] }

--- a/decidim-verifications/spec/system/authorizations_spec.rb
+++ b/decidim-verifications/spec/system/authorizations_spec.rb
@@ -64,7 +64,7 @@ describe "Authorizations", type: :system, with_authorization_workflows: ["dummy_
 
   context "when existing user from her account" do
     let(:organization) { create :organization, available_authorizations: authorizations }
-    let(:user) { create(:user, :confirmed) }
+    let(:user) { create(:user, :confirmed, organization: organization) }
 
     before do
       login_as user, scope: :user

--- a/decidim-verifications/spec/system/postal_letter/postal_letter_admin_spec.rb
+++ b/decidim-verifications/spec/system/postal_letter/postal_letter_admin_spec.rb
@@ -8,11 +8,14 @@ describe "Postal letter management", type: :system do
   end
 
   let(:admin) { create(:user, :confirmed, :admin, organization: organization) }
+  let(:user) { create :user, organization: organization }
+  let(:user2) { create :user, organization: organization }
 
   let!(:letter_not_sent) do
     create(
       :authorization,
       :pending,
+      user: user,
       name: "postal_letter",
       verification_metadata: {
         pending_verification_code: "123456",
@@ -25,6 +28,7 @@ describe "Postal letter management", type: :system do
     create(
       :authorization,
       :pending,
+      user: user2,
       name: "postal_letter",
       verification_metadata: {
         verification_code: "123456",


### PR DESCRIPTION
#### :tophat: What? Why?
Scope authorizations to current organization instead of showing all the authorizations in the system

#### :pushpin: Related Issues
- Fixes #2956

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
