### PR TITLE
Remove jquery and jquery_ujs from new installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 **Changed**:
 
+- **decidim**: New installs will have the `jquery` and `jquery_ujs` JS dependencies removed, as they are already included by `decidim` and having them duplicated causes JS errors [\#2961](https://github.com/decidim/decidim/pull/2961)
+
 **Fixed**:
 
 - **decidim-accountability**: Fix parent results progress [\#2954](https://github.com/decidim/decidim/pull/2954)

--- a/lib/generators/decidim/install_generator.rb
+++ b/lib/generators/decidim/install_generator.rb
@@ -49,6 +49,8 @@ module Decidim
       def append_assets
         append_file "app/assets/javascripts/application.js", "//= require decidim"
         gsub_file "app/assets/javascripts/application.js", %r{//= require turbolinks\n}, ""
+        gsub_file "app/assets/javascripts/application.js", %r{//= require jquery\n}, ""
+        gsub_file "app/assets/javascripts/application.js", %r{//= require jquery_ujs\n}, ""
         inject_into_file "app/assets/stylesheets/application.css",
                          before: "*= require_tree ." do
           "*= require decidim\n "


### PR DESCRIPTION
#### :tophat: What? Why?
This PR aims to fix #2953 and #2456 by removing `jquery` and `jquery_ujs` from new installs, since `decidim.js` already imports them.

I see, though, that new installs have `rails_ujs`, which is a rewrite of `jquery_ujs` but without the `jquery` dependency:

https://blog.bigbinary.com/2017/06/20/rails-5-1-has-dropped-dependency-on-jquery-from-the-default-stack.html

I'm leaving it as is in the moment, as I don't really know if we should remove it too.

#### :pushpin: Related Issues
- Related to #2456, #2953

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
