### PR TITLE
Fix proposal endorsed event

### DIFF
--- a/decidim-proposals/app/commands/decidim/proposals/endorse_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/endorse_proposal.rb
@@ -40,7 +40,7 @@ module Decidim
       end
 
       def notify_endorser_followers
-        recipient_ids = @proposal.author.followers.pluck(:id)
+        recipient_ids = @current_user.followers.pluck(:id)
         Decidim::EventsManager.publish(
           event: "decidim.events.proposals.proposal_endorsed",
           event_class: Decidim::Proposals::ProposalEndorsedEvent,

--- a/decidim-proposals/app/events/decidim/proposals/proposal_endorsed_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/proposal_endorsed_event.rb
@@ -3,42 +3,16 @@
 module Decidim
   module Proposals
     class ProposalEndorsedEvent < Decidim::Events::SimpleEvent
-      i18n_attributes :endorser_nickname, :endorser_name, :endorser_path
+      i18n_attributes :endorser_nickname, :endorser_name, :endorser_path, :nickname
 
       delegate :nickname, :name, to: :endorser, prefix: true
 
+      def nickname
+        endorser_nickname
+      end
+
       def endorser_path
         endorser.profile_path
-      end
-
-      def email_subject
-        I18n.t(
-          "decidim.events.proposals.proposal_endorsed.email_subject",
-          endorser_nickname: endorser.nickname
-        )
-      end
-
-      def email_intro
-        I18n.t(
-          "decidim.events.proposals.proposal_endorsed.email_intro",
-          endorser_nickname: endorser.nickname,
-          endorser_name: endorser.name
-        )
-      end
-
-      def notification_title
-        I18n.t(
-          "decidim.events.proposals.proposal_endorsed.notification_title",
-          resource_title: resource_title,
-          resource_path: resource_path,
-          endorser_nickname: endorser.nickname,
-          endorser_name: endorser.name,
-          endorser_path: endorser.profile_path
-        ).html_safe
-      end
-
-      def i18n_options
-        super().merge(nickname: endorser_nickname)
       end
 
       private

--- a/decidim-proposals/spec/commands/decidim/proposals/endorse_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/endorse_proposal_spec.rb
@@ -8,10 +8,6 @@ module Decidim
       let(:proposal) { create(:proposal) }
       let(:current_user) { create(:user, organization: proposal.component.organization) }
 
-      before do
-        proposal.update author: current_user
-      end
-
       describe "User endorses Proposal" do
         let(:command) { described_class.new(proposal, current_user) }
 
@@ -29,6 +25,8 @@ module Decidim
           it "notifies all followers of the endorser that the proposal has been endorsed" do
             follower = create(:user, organization: proposal.organization)
             create(:follow, followable: current_user, user: follower)
+            author_follower = create(:user, organization: proposal.organization)
+            create(:follow, followable: proposal.author, user: author_follower)
 
             expect(Decidim::EventsManager)
               .to receive(:publish)

--- a/decidim-proposals/spec/events/decidim/proposals/proposal_endorsed_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/proposal_endorsed_event_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe Decidim::Proposals::ProposalEndorsedEvent do
   include_context "simple event"
 
-  let(:event_name) { "decidim.events.users.profile_updated" }
+  let(:event_name) { "decidim.events.proposals.proposal_endorsed" }
   let(:resource) { proposal }
   let(:author) { create :user, organization: proposal.organization }
 


### PR DESCRIPTION
#### :tophat: What? Why?

Endorser followers should receive the notification, not the proposal author's followers.

#### :pushpin: Related Issues
- Related to #2287 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
