### PR TITLE
[Backport] Fix mentions not working properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## Unreleased
+
+**Added**:
+
+**Changed**:
+
+**Fixed**:
+
+- **decidim-comments**: Fix mentions not working properly. [\#2972](https://github.com/decidim/decidim/pull/2972)
+
 ## [0.10-pre](https://github.com/decidim/decidim/tree/0.10-stable)
 
 **Added**:

--- a/decidim-comments/app/types/decidim/comments/commentable_mutation_type.rb
+++ b/decidim-comments/app/types/decidim/comments/commentable_mutation_type.rb
@@ -17,7 +17,7 @@ module Decidim
 
         resolve lambda { |obj, args, ctx|
           params = { "comment" => { "body" => args[:body], "alignment" => args[:alignment], "user_group_id" => args[:userGroupId] } }
-          form = Decidim::Comments::CommentForm.from_params(params)
+          form = Decidim::Comments::CommentForm.from_params(params).with_context(current_organization: ctx[:current_organization])
           Decidim::Comments::CreateComment.call(form, ctx[:current_user], obj) do
             on(:ok) do |comment|
               return comment

--- a/decidim-comments/spec/types/commentable_mutation_type_spec.rb
+++ b/decidim-comments/spec/types/commentable_mutation_type_spec.rb
@@ -21,7 +21,10 @@ module Decidim
 
         it "calls CreateComment command" do
           params = { "comment" => { "body" => body, "alignment" => alignment, "user_group_id" => nil } }
+          context = { current_organization: current_organization }
           expect(Decidim::Comments::CommentForm).to receive(:from_params).with(params).and_call_original
+          expect_any_instance_of(Decidim::Comments::CommentForm) # rubocop:disable RSpec/AnyInstance
+            .to receive(:with_context).with(context).and_call_original
           expect(Decidim::Comments::CreateComment).to receive(:call).with(
             an_instance_of(Decidim::Comments::CommentForm),
             current_user,


### PR DESCRIPTION
#### :tophat: What? Why?

Mentions in comments are not working properly because the GraphQL mutation was not setting the context correctly.

#### :pushpin: Related Issues

- Related to https://github.com/decidim/decidim/issues/2842

#### :pushpin: Related PR

- Backport of https://github.com/decidim/decidim/pull/2947

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
