### PR TITLE
Processes: Render documents before view hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ controller or added a new module you need to rename `feature` to `component`.
 
 **Changed**:
 
+- **decidim-participatory_processes**: Render documents in first place (before view hooks). [\#2977](https://github.com/decidim/decidim/pull/2977)
+
 **Fixed**:
 
 - **decidim-proposals**: Fix proposal endorsed event [\#2970](https://github.com/decidim/decidim/pull/2970)

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
@@ -19,8 +19,8 @@
         </div>
         <%= decidim_sanitize translated_attribute(current_participatory_space.description) %>
       </div>
-      <%= render_hook(:participatory_space_highlighted_elements) %>
       <%= attachments_for current_participatory_space %>
+      <%= render_hook(:participatory_space_highlighted_elements) %>
     </div>
     <div class="section columns medium-5 mediumlarge-4 large-3">
       <div class="card extra">


### PR DESCRIPTION
#### :tophat: What? Why?

Documents should be the first element to be rendered as this is the only place where they appear

#### :pushpin: Related Issues

- Fixes #2974 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
