### PR TITLE
Fix a couple of hidden rubocop offenses

### DIFF
--- a/.rubocop_rails.yml
+++ b/.rubocop_rails.yml
@@ -4,68 +4,227 @@ Rails:
   Enabled: true
 
 Rails/ActionFilter:
+  Description: "Enforces consistent use of action filter methods."
+  Enabled: true
   EnforcedStyle: action
   SupportedStyles:
     - action
     - filter
 
+Rails/ActiveRecordAliases:
+  Description: >-
+                  Avoid Active Record aliases:
+                  Use `update` instead of `update_attributes`.
+                  Use `update!` instead of `update_attributes!`.
+  Enabled: true
+
+Rails/ActiveSupportAliases:
+  Description: >-
+                  Avoid ActiveSupport aliases of standard ruby methods:
+                  `String#starts_with?`, `String#ends_with?`,
+                  `Array#append`, `Array#prepend`.
+  Enabled: true
+
+Rails/ApplicationJob:
+  Description: "Check that jobs subclass ApplicationJob."
+  Enabled: true
+
+Rails/ApplicationRecord:
+  Description: "Check that models subclass ApplicationRecord."
+  Enabled: true
+
+Rails/Blank:
+  Description: "Enforce using `blank?` and `present?`."
+  Enabled: true
+  # Convert checks for `nil` or `empty?` to `blank?`
+  NilOrEmpty: true
+  # Convert usages of not `present?` to `blank?`
+  NotPresent: true
+  # Convert usages of `unless` `present?` to `if` `blank?`
+  UnlessPresent: true
+
+Rails/CreateTableWithTimestamps:
+  Description: >-
+                  Checks the migration for which timestamps are not included
+                  when creating a new table.
+  Enabled: false
+
 Rails/Date:
-  # The value `strict` disallows usage of `Date.today`, `Date.current`,
-  # `Date#to_time` etc.
-  # The value `flexible` allows usage of `Date.current`, `Date.yesterday`, etc
-  # (but not `Date.today`) which are overridden by ActiveSupport to handle current
-  # time zone.
+  Description: >-
+                  Checks the correct usage of date aware methods,
+                  such as Date.today, Date.current etc.
+  Enabled: true
   EnforcedStyle: flexible
   SupportedStyles:
     - strict
     - flexible
 
+Rails/Delegate:
+  Description: "Prefer delegate method for delegations."
+  Enabled: true
+
+Rails/DelegateAllowBlank:
+  Description: "Do not use allow_blank as an option to delegate."
+  Enabled: true
+
+Rails/DynamicFindBy:
+  Description: "Use `find_by` instead of dynamic `find_by_*`."
+  StyleGuide: "https://github.com/bbatsov/rails-style-guide#find_by"
+  Enabled: true
+
+Rails/EnumUniqueness:
+  Description: "Avoid duplicate integers in hash-syntax `enum` declaration."
+  Enabled: true
+
+Rails/EnvironmentComparison:
+  Description: "Favor `Rails.env.production?` over `Rails.env == 'production'`"
+  Enabled: true
+
 Rails/Exit:
+  Description: >-
+                  Favor `fail`, `break`, `return`, etc. over `exit` in
+                  application or library code outside of Rake files to avoid
+                  exits during unit testing or running in production.
+  Enabled: true
   Include:
     - config/**/*.rb
     - lib/**/*.rb
 
-Rails/NotNullColumn:
+Rails/FilePath:
+  Description: "Use `Rails.root.join` for file path joining."
+  Enabled: true
+
+Rails/FindBy:
+  Description: "Prefer find_by over where.first."
+  StyleGuide: "https://github.com/bbatsov/rails-style-guide#find_by"
+  Enabled: true
+
+Rails/FindEach:
+  Description: "Prefer all.find_each over all.find."
+  StyleGuide: "https://github.com/bbatsov/rails-style-guide#find-each"
+  Enabled: true
+
+Rails/HasAndBelongsToMany:
+  Description: "Prefer has_many :through to has_and_belongs_to_many."
+  StyleGuide: "https://github.com/bbatsov/rails-style-guide#has-many-through"
+  Enabled: true
+
+Rails/HasManyOrHasOneDependent:
+  Description: "Define the dependent option to the has_many and has_one associations."
+  StyleGuide: "https://github.com/bbatsov/rails-style-guide#has_many-has_one-dependent-option"
+  Enabled: true
+
+Rails/HttpPositionalArguments:
+  Description: "Use keyword arguments instead of positional arguments in http method calls."
+  Enabled: true
+  Include:
+    - "spec/**/*"
+    - "test/**/*"
+
+Rails/InverseOf:
+  Description: "Checks for associations where the inverse cannot be determined automatically."
   Enabled: false
+
+Rails/LexicallyScopedActionFilter:
+  Description: "Checks that methods specified in the filter's `only` or `except` options are explicitly defined in the controller."
+  StyleGuide: "https://github.com/bbatsov/rails-style-guide#lexically-scoped-action-filter"
+  Enabled: true
+
+Rails/NotNullColumn:
+  Description: "Do not add a NOT NULL column without a default value"
+  Enabled: false
+
+Rails/Output:
+  Description: "Checks for calls to puts, print, etc."
+  Enabled: true
 
 Rails/OutputSafety:
+  Description: "The use of `html_safe` or `raw` may be a security risk."
   Enabled: false
 
+Rails/PluralizationGrammar:
+  Description: "Checks for incorrect grammar when using methods like `3.day.ago`."
+  Enabled: true
+
+Rails/Presence:
+  Description: "Checks code that can be written more easily using `Object#presence` defined by Active Support."
+  Enabled: true
+
+Rails/Present:
+  Description: "Enforce using `blank?` and `present?`."
+  Enabled: true
+  NotNilAndNotEmpty: true
+  # Convert checks for not `nil` and not `empty?` to `present?`
+  NotBlank: true
+  # Convert usages of not `blank?` to `present?`
+  UnlessBlank: true
+  # Convert usages of `unless` `blank?` to `if` `present?`
+
+Rails/ReadWriteAttribute:
+  Description: >-
+                 Checks for read_attribute(:attr) and
+                 write_attribute(:attr, val).
+  StyleGuide: "https://github.com/bbatsov/rails-style-guide#read-attribute"
+  Enabled: true
+
+Rails/RedundantReceiverInWithOptions:
+  Description: "Checks for redundant receiver in `with_options`."
+  Enabled: true
+
+Rails/RelativeDateConstant:
+  Description: "Do not assign relative date to constants."
+  Enabled: true
+
 Rails/RequestReferer:
+  Description: "Use consistent syntax for request.referer."
+  Enabled: true
   EnforcedStyle: referer
   SupportedStyles:
     - referer
     - referrer
 
+Rails/ReversibleMigration:
+  Description: "Checks whether the change method of the migration file is reversible."
+  StyleGuide: "https://github.com/bbatsov/rails-style-guide#reversible-migration"
+  Reference: "http://api.rubyonrails.org/classes/ActiveRecord/Migration/CommandRecorder.html"
+  Enabled: false
+
 Rails/SafeNavigation:
-  # This will convert usages of `try` to use safe navigation as well as `try!`.
-  # `try` and `try!` work slighly differently. `try!` and safe navigation will
-  # both raise a `NoMethodError` if the receiver of the method call does not
-  # implement the intended method. `try` will not raise an exception for this.
   ConvertTry: false
+  Description: "Use Ruby's safe navigation operator (`&.`) instead of `try!`"
+  Enabled: true
+
+Rails/ScopeArgs:
+  Description: "Checks the arguments of ActiveRecord scopes."
+  Enabled: true
+
+Rails/SkipsModelValidations:
+  Description: >-
+                 Use methods that skips model validations with caution.
+                 See reference for more information.
+  Reference: "http://guides.rubyonrails.org/active_record_validations.html#skipping-validations"
+  Enabled: true
 
 Rails/TimeZone:
-  # The value `strict` means that `Time` should be used with `zone`.
-  # The value `flexible` allows usage of `in_time_zone` instead of `zone`.
+  Description: "Checks the correct usage of time zone aware methods."
+  Enabled: true
   EnforcedStyle: flexible
+  StyleGuide: "https://github.com/bbatsov/rails-style-guide#time"
+  Reference: "http://danilenko.org/2012/7/6/rails_timezones"
   SupportedStyles:
     - strict
     - flexible
 
 Rails/UniqBeforePluck:
-  EnforcedStyle: conservative
   AutoCorrect: false
+  Description: "Prefer the use of uniq or distinct before pluck."
+  EnforcedStyle: conservative
+  Enabled: true
 
-Rails/InverseOf:
-  Enabled: false
+Rails/UnknownEnv:
+  Description: "Use correct environment name."
+  Enabled: true
 
-Rails/ReversibleMigration:
-  Enabled: false
-
-Rails/CreateTableWithTimestamps:
-  Enabled: false
-
-# No idea why we need to explicitly set this cop but otherwise we get
-# `Lint/UnneededDisable` false positives for this cop
-Rails/SkipsModelValidations:
+Rails/Validation:
+  Description: "Use validates :attribute, hash of validations."
   Enabled: true

--- a/decidim-debates/spec/system/explore_debates_spec.rb
+++ b/decidim-debates/spec/system/explore_debates_spec.rb
@@ -62,7 +62,7 @@ describe "Explore debates", type: :system do
 
       context "with the component's settings" do
         before do
-          component.update_attributes!(settings: { announcement: announcement })
+          component.update!(settings: { announcement: announcement })
         end
 
         it "shows the announcement" do
@@ -73,7 +73,7 @@ describe "Explore debates", type: :system do
 
       context "with the step's settings" do
         before do
-          component.update_attributes!(
+          component.update!(
             step_settings: {
               component.participatory_space.active_step.id => {
                 announcement: announcement


### PR DESCRIPTION
#### :tophat: What? Why?

I found these two offenses and I'm not sure why they were not being detected.

Switching rubocop Rails config to be fully explicit fixes it, and that's consistent with our main rubocop file, so I made this configuration file fully explicit too (I copied the default config, and changed values to apply our defaults).
 
#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.