### PR TITLE
Gem manager tweaks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -60,6 +60,16 @@ Decidim::GemManager.all_dirs(include_root: false) do |dir|
   end
 end
 
+desc "Runs tests for a random participatory space"
+task :test_participatory_space do
+  Decidim::GemManager.test_participatory_space
+end
+
+desc "Runs tests for a random component"
+task :test_component do
+  Decidim::GemManager.test_component
+end
+
 desc "Pushes a new build for each gem."
 task release_all: [:update_versions, :check_locale_completeness, :webpack] do
   Decidim::GemManager.run_all("rake release")

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require "generators/decidim/app_generator"
-require "decidim/component_manager"
+require "decidim/gem_manager"
 
 RSpec::Core::RakeTask.new(:spec)
 
@@ -14,44 +14,44 @@ task test_all: [:test_main, :test_subgems]
 
 desc "Runs all tests in decidim subgems"
 task test_subgems: :test_app do
-  Decidim::ComponentManager.run_all("rake", include_root: false)
+  Decidim::GemManager.run_all("rake", include_root: false)
 end
 
 desc "Runs all tests in the main decidim gem"
 task :test_main do
-  Decidim::ComponentManager.new(__dir__).run("rake")
+  Decidim::GemManager.new(__dir__).run("rake")
 end
 
 desc "Update version in all gems to the one set in the `.decidim-version` file"
 task :update_versions do
-  Decidim::ComponentManager.replace_versions
+  Decidim::GemManager.replace_versions
 end
 
 desc "Installs all gems locally."
 task :install_all do
-  Decidim::ComponentManager.run_all(
+  Decidim::GemManager.run_all(
     "gem build %name && mv %name-%version.gem ..",
     include_root: false
   )
 
-  Decidim::ComponentManager.new(__dir__).run(
+  Decidim::GemManager.new(__dir__).run(
     "gem build %name && gem install *.gem"
   )
 end
 
 desc "Uninstalls all gems locally."
 task :uninstall_all do
-  Decidim::ComponentManager.run_all(
+  Decidim::GemManager.run_all(
     "gem uninstall %name -v %version --executables --force"
   )
 
-  Decidim::ComponentManager.new(__dir__).run(
+  Decidim::GemManager.new(__dir__).run(
     "rm decidim-*.gem"
   )
 end
 
-Decidim::ComponentManager.all_dirs(include_root: false) do |dir|
-  manager = Decidim::ComponentManager.new(dir)
+Decidim::GemManager.all_dirs(include_root: false) do |dir|
+  manager = Decidim::GemManager.new(dir)
   name = manager.short_name
 
   desc "Runs tests on #{name}"
@@ -62,7 +62,7 @@ end
 
 desc "Pushes a new build for each gem."
 task release_all: [:update_versions, :check_locale_completeness, :webpack] do
-  Decidim::ComponentManager.run_all("rake release")
+  Decidim::GemManager.run_all("rake release")
 end
 
 desc "Makes sure all official locales are complete and clean."

--- a/lib/decidim/gem_manager.rb
+++ b/lib/decidim/gem_manager.rb
@@ -16,6 +16,21 @@ module Decidim
   #   of the repository.
   #
   class GemManager
+    PARTICIPATORY_SPACES = %w(
+      participatory_processes
+      assemblies
+    ).freeze
+
+    COMPONENTS = %w(
+      accountability
+      budgets
+      debates
+      meetings
+      pages
+      proposals
+      surveys
+    ).freeze
+
     def initialize(dir)
       @dir = File.expand_path(dir)
     end
@@ -43,6 +58,14 @@ module Decidim
     end
 
     class << self
+      def test_participatory_space
+        new("decidim-#{PARTICIPATORY_SPACES.sample}").run("rake")
+      end
+
+      def test_component
+        new("decidim-#{COMPONENTS.sample}").run("rake")
+      end
+
       def replace_versions
         replace_file(
           "package.json",

--- a/lib/decidim/gem_manager.rb
+++ b/lib/decidim/gem_manager.rb
@@ -15,7 +15,7 @@ module Decidim
   # * Updating version files from the main `.decidim-version` file in the root
   #   of the repository.
   #
-  class ComponentManager
+  class GemManager
     def initialize(dir)
       @dir = File.expand_path(dir)
     end


### PR DESCRIPTION
#### :tophat: What? Why?

Sometimes when applying refactorings to the core of decidim, it's useful to run tests against _a_ participatory space or _a_ component. These changes expose tasks to do that, using a random participatory space or component. Not sure how useful this is in general, but I was experimenting with refactoring core to remove the "step settings" dependency, and I found this handy to check how bad breakage was after making changes.

I also changed the name `ComponentManager` to `GemManager`, since it was a bit confusing, specially since the "feature" to "component" rename.

#### :pushpin: Related Issues 
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.