### PR TITLE
Improve locale normalization

### DIFF
--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -24,7 +24,7 @@ describe "I18n sanity" do
     it "is normalized" do
       error_message = "The following files need to be normalized:\n" \
                       "#{non_normalized_paths.map { |path| "  #{path}" }.join("\n")}\n" \
-                      "Please run `i18n-tasks normalize` to fix them"
+                      "Please run `bundle exec i18n-tasks normalize` to fix them"
 
       expect(non_normalized_paths).to be_empty, error_message
     end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -4,10 +4,10 @@ require "i18n/tasks"
 
 describe "I18n sanity" do
   let(:locales) do
-    ENV["ENFORCED_LOCALES"].present? ? ENV["ENFORCED_LOCALES"].split(",") : [:en]
+    ENV["ENFORCED_LOCALES"].presence || "en"
   end
 
-  let(:i18n) { I18n::Tasks::BaseTask.new(locales: locales) }
+  let(:i18n) { I18n::Tasks::BaseTask.new(locales: locales.split(",")) }
   let(:missing_keys) { i18n.missing_keys }
   let(:unused_keys) { i18n.unused_keys }
   let(:non_normalized_paths) { i18n.non_normalized_paths }
@@ -24,7 +24,7 @@ describe "I18n sanity" do
     it "is normalized" do
       error_message = "The following files need to be normalized:\n" \
                       "#{non_normalized_paths.map { |path| "  #{path}" }.join("\n")}\n" \
-                      "Please run `bundle exec i18n-tasks normalize` to fix them"
+                      "Please run `bundle exec i18n-tasks normalize --locales #{locales}` to fix them"
 
       expect(non_normalized_paths).to be_empty, error_message
     end


### PR DESCRIPTION
#### :tophat: What? Why?

Currently we keep English locale files normalized,  but not the rest since crowdin is in full control of their edition, and it's not too smart regarding style. We a contributor changes an English locale file, and "de-normalizes" it, our linter will catch that but will recommend to run `i18n-tasks normalize` which will cause changes in every locale file (that will later be undone by crowdin). This is not a good contributing experience, so I changed the command suggestion to one that actually does what we expect: `bundle exec i18n-tasks normalize --locales en`.

Another thought is that, given that our current workflow only allows us to keep a single locale "normalized", I wonder if we should drop this lint altogether.

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/pull/2955#issuecomment-371770705, and the following comments.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.