### PR TITLE
Send the endorser ID instead of the whole object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,5 +25,6 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-core**: Fix `Decidim::UserPresenter#nickname` [\#2958](https://github.com/decidim/decidim/pull/2958)
 - **decidim-verifications**: Only show authorizations from current organization [\#2959](https://github.com/decidim/decidim/pull/2959)
 - **decidim-comments**: Fix mentions not working properly.  [\#2947](https://github.com/decidim/decidim/pull/2947)
+- **decidim-proposals**: Fix proposal endorsed event  generation [\#2983](https://github.com/decidim/decidim/pull/2983)
 
 Please check [0.10-stable](https://github.com/decidim/decidim/blob/0.10-stable/CHANGELOG.md) for previous changes.

--- a/decidim-proposals/app/commands/decidim/proposals/endorse_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/endorse_proposal.rb
@@ -47,7 +47,7 @@ module Decidim
           resource: @proposal,
           recipient_ids: recipient_ids.uniq,
           extra: {
-            endorser: @current_user
+            endorser_id: @current_user.id
           }
         )
       end

--- a/decidim-proposals/app/events/decidim/proposals/proposal_endorsed_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/proposal_endorsed_event.rb
@@ -18,7 +18,11 @@ module Decidim
       private
 
       def endorser
-        @endorser ||= Decidim::UserPresenter.new(extra[:endorser])
+        @endorser ||= Decidim::UserPresenter.new(endorser_user)
+      end
+
+      def endorser_user
+        @endorser_user ||= Decidim::User.find_by(id: extra[:endorser_id])
       end
     end
   end

--- a/decidim-proposals/spec/commands/decidim/proposals/endorse_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/endorse_proposal_spec.rb
@@ -36,7 +36,7 @@ module Decidim
                 resource: proposal,
                 recipient_ids: [follower.id],
                 extra: {
-                  endorser: current_user
+                  endorser_id: current_user.id
                 }
               )
 

--- a/decidim-proposals/spec/events/decidim/proposals/proposal_endorsed_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/proposal_endorsed_event_spec.rb
@@ -9,7 +9,7 @@ describe Decidim::Proposals::ProposalEndorsedEvent do
   let(:resource) { proposal }
   let(:author) { create :user, organization: proposal.organization }
 
-  let(:extra) { { endorser: author } }
+  let(:extra) { { endorser_id: author.id } }
   let(:proposal) { create :proposal }
   let(:endorsement) { create :proposal_endorsement, proposal: proposal, author: author }
   let(:resource_path) { resource_locator(proposal).path }


### PR DESCRIPTION
#### :tophat: What? Why?
After merging #2343 we realized the event was sending a whole object instead of an ID, so the presenters were not working properly:

https://sentry.io/share/issue/5e96f9e89a9d408ea6beb3996ff2b60c/

This PR fixes this problem by making the command send an ID to the event. You'll need to run this script in your installation console (`rails console`) if you've been running decidim with `0.10-stable` to make sure the data is in the correct format:

```ruby
Decidim::Notification.where(event_class: "Decidim::Proposals::ProposalEndorsedEvent").find_each{|ev| ev.extra = { endorser_id: ev.extra.dig("endorser", "id") }; ev.save! }
```

#### :pushpin: Related Issues
- Related to #2343

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
