### PR TITLE
[Backport] Send the endorser ID instead of the whole object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@
 
 **Fixed**:
 
-- **decidim-comments**: Fix mentions not working properly. [\#2972](https://github.com/decidim/decidim/pull/2972)
-
 ## [0.10-pre](https://github.com/decidim/decidim/tree/0.10-stable)
+
+**Note**: As per [\#2983](https://github.com/decidim/decidim/pull/2983), if you've been using `0.10.pre` version of Decidim for a while you'll need to fix some values in the database. In order to fix them,  run this script in your Rails console:
+
+```ruby
+Decidim::Notification.where(event_class: "Decidim::Proposals::ProposalEndorsedEvent").find_each{|ev| ev.extra = { endorser_id: ev.extra.dig("endorser", "id") }; ev.save! }
+```
 
 **Added**:
 
@@ -122,5 +126,7 @@
 - **decidim-core**: Fix `Decidim::UserPresenter#nickname` [\#2958](https://github.com/decidim/decidim/pull/2958)
 - **decidim-verifications**: Only show authorizations from current organization [\#2959](https://github.com/decidim/decidim/pull/2959)
 - **decidim-proposals**: Fix proposal endorsed event [\#2970](https://github.com/decidim/decidim/pull/2970)
+- **decidim-comments**: Fix mentions not working properly. [\#2972](https://github.com/decidim/decidim/pull/2972)
+- **decidim-proposals**: Fix proposal endorsed event  generation [\#2983](https://github.com/decidim/decidim/pull/2983)
 
 Please check [0.9-stable](https://github.com/decidim/decidim/blob/0.9-stable/CHANGELOG.md) for previous changes.

--- a/decidim-proposals/app/commands/decidim/proposals/endorse_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/endorse_proposal.rb
@@ -47,7 +47,7 @@ module Decidim
           resource: @proposal,
           recipient_ids: recipient_ids.uniq,
           extra: {
-            endorser: @current_user
+            endorser_id: @current_user.id
           }
         )
       end

--- a/decidim-proposals/app/events/decidim/proposals/proposal_endorsed_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/proposal_endorsed_event.rb
@@ -18,7 +18,11 @@ module Decidim
       private
 
       def endorser
-        @endorser ||= Decidim::UserPresenter.new(extra[:endorser])
+        @endorser ||= Decidim::UserPresenter.new(endorser_user)
+      end
+
+      def endorser_user
+        @endorser_user ||= Decidim::User.find_by(id: extra[:endorser_id])
       end
     end
   end

--- a/decidim-proposals/spec/commands/decidim/proposals/endorse_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/endorse_proposal_spec.rb
@@ -36,7 +36,7 @@ module Decidim
                 resource: proposal,
                 recipient_ids: [follower.id],
                 extra: {
-                  endorser: current_user
+                  endorser_id: current_user.id
                 }
               )
 

--- a/decidim-proposals/spec/events/decidim/proposals/proposal_endorsed_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/proposal_endorsed_event_spec.rb
@@ -9,7 +9,7 @@ describe Decidim::Proposals::ProposalEndorsedEvent do
   let(:resource) { proposal }
   let(:author) { create :user, organization: proposal.organization }
 
-  let(:extra) { { endorser: author } }
+  let(:extra) { { endorser_id: author.id } }
   let(:proposal) { create :proposal }
   let(:endorsement) { create :proposal_endorsement, proposal: proposal, author: author }
   let(:resource_path) { resource_locator(proposal).path }


### PR DESCRIPTION
#### :tophat: What? Why?
Backports #2983 to `0.10-stable`.

#### :pushpin: Related Issues
- Related to #2983

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
