### PR TITLE
Add missing locales in assembly user form

### DIFF
--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -28,6 +28,10 @@ en:
         subtitle: Subtitle
         target: Target
         title: Title
+      assembly_user_role:
+        email: Email
+        name: Name
+        role: Role
   decidim:
     admin:
       assemblies:


### PR DESCRIPTION
#### :tophat: What? Why?
The assembly user form was missing some locales, so it was not being translated. This PR adds the locales so that the form can be translated.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None