### PR TITLE
Fix foundation-rails warning after the upgrade

### DIFF
--- a/decidim-admin/app/assets/stylesheets/decidim/admin/utils/_settings.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/utils/_settings.scss
@@ -498,7 +498,10 @@ $meter-fill-bad: $alert-color;
 // 25. Off-canvas
 // --------------
 
-$offcanvas-size: 250px;
+$offcanvas-sizes: (
+  small: 250px
+);
+
 $offcanvas-background: $light-gray;
 $offcanvas-shadow: 0 0 10px rgba($black, .7);
 $offcanvas-inner-shadow-size: 20px;

--- a/decidim-core/app/assets/stylesheets/decidim/utils/_settings.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/utils/_settings.scss
@@ -497,7 +497,10 @@ $meter-fill-bad: $alert-color;
 // 25. Off-canvas
 // --------------
 
-$offcanvas-size: 250px;
+$offcanvas-sizes: (
+  small: 250px
+);
+
 $offcanvas-background: $light-gray;
 $offcanvas-shadow: 0 0 10px rgba($black, .7);
 $offcanvas-inner-shadow-size: 20px;

--- a/decidim-system/app/assets/stylesheets/decidim/system/_settings.scss
+++ b/decidim-system/app/assets/stylesheets/decidim/system/_settings.scss
@@ -396,7 +396,10 @@ $button-margin: 0;
 // 24. Off-canvas
 // --------------
 
-// $offcanvas-size: 250px;
+// $offcanvas-sizes: (
+//   small: 250px
+// );
+//
 $offcanvas-background: $black;
 // $offcanvas-zindex: -1;
 // $offcanvas-transition-length: 0.5s;


### PR DESCRIPTION
#### :tophat: What? Why?
Some `foundation-rails` warnings appeared after the upgrade (it seems like they do care about backwards compatibility :smiley:)

```
WARNING: $offcanvas-size is deprecated and not used anymore! Please update your settings and use the map $offcanvas-sizes instead
Backtrace:
.../foundation-rails-6.4.3.0/vendor/assets/scss/components/_off-canvas.scss:78, in mixin `off-canvas-basics`
.../foundation-rails-6.4.3.0/vendor/assets/scss/components/_off-canvas.scss:439, in mixin `foundation-off-canvas`
.../foundation-rails-6.4.3.0/vendor/assets/scss/foundation.scss:109, in mixin `foundation-everything`
.../decidim-core/app/assets/stylesheets/decidim/_decidim.scss:5
```

This PR fixes them.

#### :pushpin: Related Issues
- Related to #2995.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.