### PR TITLE
Allow running `bundle exec rspec --only-failures`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ webpack.report.html
 .graphqlconfig
 schema.json
 .yardoc
+.rspec-failures

--- a/decidim-dev/lib/decidim/dev/test/spec_helper.rb
+++ b/decidim-dev/lib/decidim/dev/test/spec_helper.rb
@@ -24,6 +24,7 @@ RSpec.configure do |config|
   config.mock_with :rspec
   config.order = :random
   config.raise_errors_for_deprecations!
+  config.example_status_persistence_file_path = ".rspec-failures"
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, comment the following line or assign false


### PR DESCRIPTION
#### :tophat: What? Why?

I find this flag handy when you've written some failing specs and you're trying to get them passing.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.