### PR TITLE
Remove unnecessary capybara tweaks

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -48,10 +48,6 @@ module Capybara
   end
 end
 
-Capybara.configure do |config|
-  config.always_include_port = true
-end
-
 Capybara.asset_host = "http://localhost:3000"
 
 RSpec.configure do |config|


### PR DESCRIPTION
#### :tophat: What? Why?

I don't think these divergences from capybara's defaults are needed.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.