### PR TITLE
Question up and down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-budgets**: Log actions on projects [\#2949](https://github.com/decidim/decidim/pull/2949)
 - **decidim-meetings**: Log meeting registration exports [\#2922](https://github.com/decidim/decidim/pull/2922)
 - **decidim-accountability**: Log results deletion [\#2923](https://github.com/decidim/decidim/pull/2923)
+- **decidim-surveys**: Allow reordering questions via "Up" & "Down" buttons [\#3005](https://github.com/decidim/decidim/pull/3005)
 
 **Changed**:
 

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/auto_buttons_by_position.component.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/auto_buttons_by_position.component.js.es6
@@ -1,0 +1,39 @@
+((exports) => {
+  class AutoButtonsByPositionComponent {
+    constructor(options = {}) {
+      this.listSelector = options.listSelector;
+      this.hideOnFirstSelector = options.hideOnFirstSelector;
+      this.hideOnLastSelector = options.hideOnLastSelector;
+
+      this.run();
+    }
+
+    run() {
+      const $list = $(this.listSelector);
+      const hideOnFirst = this.hideOnFirstSelector;
+      const hideOnLast = this.hideOnLastSelector;
+
+      $list.each((idx, el) => {
+        if ($list.length === 1) {
+          $(el).find(hideOnFirst).hide();
+          $(el).find(hideOnLast).hide();
+        }
+        else if (el.id === $list.first().attr('id')) {
+          $(el).find(hideOnFirst).hide();
+          $(el).find(hideOnLast).show();
+        }
+        else if (el.id === $list.last().attr('id')) {
+          $(el).find(hideOnLast).hide();
+          $(el).find(hideOnFirst).show();
+        }
+        else {
+          $(el).find(hideOnLast).show();
+          $(el).find(hideOnFirst).show();
+        }
+      });
+    }
+  }
+
+  exports.DecidimAdmin = exports.DecidimAdmin || {};
+  exports.DecidimAdmin.AutoButtonsByPositionComponent = AutoButtonsByPositionComponent;
+})(window);

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
@@ -7,8 +7,12 @@
       this.fieldSelector = options.fieldSelector;
       this.addFieldButtonSelector = options.addFieldButtonSelector;
       this.removeFieldButtonSelector = options.removeFieldButtonSelector;
+      this.moveUpFieldButtonSelector = options.moveUpFieldButtonSelector;
+      this.moveDownFieldButtonSelector = options.moveDownFieldButtonSelector;
       this.onAddField = options.onAddField;
       this.onRemoveField = options.onRemoveField;
+      this.onMoveUpField = options.onMoveUpField;
+      this.onMoveDownField = options.onMoveDownField;
       this.tabsPrefix = options.tabsPrefix;
       this._compileTemplate();
       this._bindEvents();
@@ -25,6 +29,14 @@
 
       $(this.wrapperSelector).on('click', this.removeFieldButtonSelector, (event) =>
         this._bindSafeEvent(event, (target) => this._removeField(target))
+      );
+
+      $(this.wrapperSelector).on('click', this.moveUpFieldButtonSelector, (event) =>
+        this._bindSafeEvent(event, (target) => this._moveUpField(target))
+      );
+
+      $(this.wrapperSelector).on('click', this.moveDownFieldButtonSelector, (event) =>
+        this._bindSafeEvent(event, (target) => this._moveDownField(target))
       );
     }
 
@@ -79,6 +91,28 @@
 
       if (this.onRemoveField) {
         this.onRemoveField($removedField);
+      }
+    }
+
+    _moveUpField(target) {
+      const $target = $(target);
+      const $movedUpField = $target.parents(this.fieldSelector);
+
+      $movedUpField.prev().before($movedUpField);
+
+      if (this.onMoveUpField) {
+        this.onMoveUpField($movedUpField);
+      }
+    }
+
+    _moveDownField(target) {
+      const $target = $(target);
+      const $movedDownField = $target.parents(this.fieldSelector);
+
+      $movedDownField.next().after($movedDownField);
+
+      if (this.onMoveDownField) {
+        this.onMoveDownField($movedDownField);
       }
     }
 

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
@@ -1,9 +1,10 @@
 // = require jquery-tmpl
 // = require ./auto_label_by_position.component
+// = require ./auto_buttons_by_position.component
 // = require ./dynamic_fields.component
 
 ((exports) => {
-  const { AutoLabelByPositionComponent, createDynamicFields, createSortList } = exports.DecidimAdmin;
+  const { AutoLabelByPositionComponent, AutoButtonsByPositionComponent, createDynamicFields, createSortList } = exports.DecidimAdmin;
 
   const wrapperSelector = '.survey-questions';
   const fieldSelector = '.survey-question';
@@ -16,6 +17,12 @@
     onPositionComputed: (el, idx) => {
       $(el).find('input[name="survey[questions][][position]"]').val(idx);
     }
+  });
+
+  const autoButtonsByPosition = new AutoButtonsByPositionComponent({
+    listSelector: '.survey-question:not(.hidden)',
+    hideOnFirstSelector: '.move-up-question',
+    hideOnLastSelector: '.move-down-question'
   });
 
   const createSortableList = () => {
@@ -58,16 +65,28 @@
     fieldSelector: fieldSelector,
     addFieldButtonSelector: '.add-question',
     removeFieldButtonSelector: '.remove-question',
+    moveUpFieldButtonSelector: '.move-up-question',
+    moveDownFieldButtonSelector: '.move-down-question',
     onAddField: ($field) => {
       const fieldId = $field.attr('id');
 
       createSortableList();
       autoLabelByPosition.run();
+      autoButtonsByPosition.run();
       createDynamicFieldsForAnswerOptions(fieldId);
       setAnswerOptionsWrapperVisibility($field.find(questionTypeSelector));
     },
     onRemoveField: () => {
       autoLabelByPosition.run();
+      autoButtonsByPosition.run();
+    },
+    onMoveUpField: () => {
+      autoLabelByPosition.run();
+      autoButtonsByPosition.run();
+    },
+    onMoveDownField: () => {
+      autoLabelByPosition.run();
+      autoButtonsByPosition.run();
     }
   });
 

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
@@ -3,7 +3,9 @@
     <h2 class="card-title">
     <span><%= t(".answer_option") %></span>
     <% if survey.questions_editable? %>
-      <button class="button small alert hollow remove-answer-option button--title"><%= t(".remove_answer_option") %></button>
+      <button class="button small alert hollow remove-answer-option button--title">
+        <%= t(".remove") %>
+      </button>
     <% end %>
     </h2>
   </div>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
@@ -10,6 +10,14 @@
     </span>
 
     <% if survey.questions_editable? %>
+      <button class="button small alert hollow move-up-question button--title">
+        <%== "#{icon("arrow-top")} #{t(".up")}" %>
+      </button>
+
+      <button class="button small alert hollow move-down-question button--title">
+        <%== "#{icon("arrow-bottom")} #{t(".down")}" %>
+      </button>
+
       <button class="button small alert hollow remove-question button--title">
         <%= t(".remove") %>
       </button>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
@@ -10,7 +10,9 @@
     </span>
 
     <% if survey.questions_editable? %>
-      <button class="button small alert hollow remove-question button--title"><%= t(".remove_question") %></button>
+      <button class="button small alert hollow remove-question button--title">
+        <%= t(".remove") %>
+      </button>
     <% end %>
     </h2>
   </div>

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -52,9 +52,11 @@ en:
             already_answered_warning: The survey is already answered by some users so you cannot modify its questions.
           question:
             add_answer_option: Add answer option
+            down: Down
             question: Question
             remove: Remove
             statement: Statement
+            up: Up
           update:
             invalid: There's been errors when saving the survey.
             success: Survey saved successfully.

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -42,7 +42,7 @@ en:
         surveys:
           answer_option:
             answer_option: Answer option
-            remove_answer_option: Remove answer option
+            remove: Remove
             statement: Statement
           edit:
             save: Save
@@ -53,7 +53,7 @@ en:
           question:
             add_answer_option: Add answer option
             question: Question
-            remove_question: Remove question
+            remove: Remove
             statement: Statement
           update:
             invalid: There's been errors when saving the survey.

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -170,7 +170,7 @@ shared_examples "edit surveys" do
           expect(page).to have_selector(".survey-question", count: 1)
 
           within ".survey-question" do
-            click_button "Remove question"
+            click_button "Remove"
           end
 
           click_button "Save"
@@ -195,7 +195,7 @@ shared_examples "edit surveys" do
       visit_component_admin
 
       expect(page).to have_no_content("Add question")
-      expect(page).to have_no_content("Remove question")
+      expect(page).to have_no_content("Remove")
       expect(page).to have_selector("input[value='This is the first question'][disabled]")
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds the posibility to surveys to reorder questions via "Up" & "Down" buttons. Drag & drop sometimes is inconvenient, specially when the containers are very big.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![reordering](https://user-images.githubusercontent.com/2887858/37411715-37de8a62-2782-11e8-9992-d9943b2f6b1c.gif)