### PR TITLE
Tell dockerize to wait a bit longer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
             - /usr/local/bundle/
       - run:
           name: Wait for db
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+          command: dockerize -wait tcp://localhost:5432 -timeout 2m
       - run:
           name: Generate test app
           command: bundle exec rake test_app
@@ -77,7 +77,7 @@ jobs:
             - /usr/local/bundle/
       - run:
           name: Wait for db
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+          command: dockerize -wait tcp://localhost:5432 -timeout 2m
       - run:
           name: Run main folder RSpec
           command: mkdir ~/rspec && bundle exec rspec --format progress --format RspecJunitFormatter -o ~/rspec/rspec.xml
@@ -99,7 +99,7 @@ jobs:
             - bundler-dependencies-{{ checksum "Gemfile.lock" }}
       - run:
           name: Wait for db
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+          command: dockerize -wait tcp://localhost:5432 -timeout 2m
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rails db:create db:schema:load
@@ -120,7 +120,7 @@ jobs:
             - bundler-dependencies-{{ checksum "Gemfile.lock" }}
       - run:
           name: Wait for db
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+          command: dockerize -wait tcp://localhost:5432 -timeout 2m
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rails db:create db:schema:load
@@ -141,7 +141,7 @@ jobs:
             - bundler-dependencies-{{ checksum "Gemfile.lock" }}
       - run:
           name: Wait for db
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+          command: dockerize -wait tcp://localhost:5432 -timeout 2m
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rails db:create db:schema:load
@@ -162,7 +162,7 @@ jobs:
             - bundler-dependencies-{{ checksum "Gemfile.lock" }}
       - run:
           name: Wait for db
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+          command: dockerize -wait tcp://localhost:5432 -timeout 2m
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rails db:create db:schema:load
@@ -183,7 +183,7 @@ jobs:
             - bundler-dependencies-{{ checksum "Gemfile.lock" }}
       - run:
           name: Wait for db
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+          command: dockerize -wait tcp://localhost:5432 -timeout 2m
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rails db:create db:schema:load
@@ -204,7 +204,7 @@ jobs:
             - bundler-dependencies-{{ checksum "Gemfile.lock" }}
       - run:
           name: Wait for db
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+          command: dockerize -wait tcp://localhost:5432 -timeout 2m
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rails db:create db:schema:load
@@ -225,7 +225,7 @@ jobs:
             - bundler-dependencies-{{ checksum "Gemfile.lock" }}
       - run:
           name: Wait for db
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+          command: dockerize -wait tcp://localhost:5432 -timeout 2m
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rails db:create db:schema:load
@@ -259,7 +259,7 @@ jobs:
             - bundler-dependencies-{{ checksum "Gemfile.lock" }}
       - run:
           name: Wait for db
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+          command: dockerize -wait tcp://localhost:5432 -timeout 2m
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rails db:create db:schema:load
@@ -280,7 +280,7 @@ jobs:
             - bundler-dependencies-{{ checksum "Gemfile.lock" }}
       - run:
           name: Wait for db
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+          command: dockerize -wait tcp://localhost:5432 -timeout 2m
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rails db:create db:schema:load
@@ -301,7 +301,7 @@ jobs:
             - bundler-dependencies-{{ checksum "Gemfile.lock" }}
       - run:
           name: Wait for db
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+          command: dockerize -wait tcp://localhost:5432 -timeout 2m
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rails db:create db:schema:load
@@ -322,7 +322,7 @@ jobs:
             - bundler-dependencies-{{ checksum "Gemfile.lock" }}
       - run:
           name: Wait for db
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+          command: dockerize -wait tcp://localhost:5432 -timeout 2m
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rails db:create db:schema:load
@@ -343,7 +343,7 @@ jobs:
             - bundler-dependencies-{{ checksum "Gemfile.lock" }}
       - run:
           name: Wait for db
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+          command: dockerize -wait tcp://localhost:5432 -timeout 2m
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rails db:create db:schema:load
@@ -364,7 +364,7 @@ jobs:
             - bundler-dependencies-{{ checksum "Gemfile.lock" }}
       - run:
           name: Wait for db
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+          command: dockerize -wait tcp://localhost:5432 -timeout 2m
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rails db:create db:schema:load
@@ -385,7 +385,7 @@ jobs:
             - bundler-dependencies-{{ checksum "Gemfile.lock" }}
       - run:
           name: Wait for db
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+          command: dockerize -wait tcp://localhost:5432 -timeout 2m
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rails db:create db:schema:load
@@ -406,7 +406,7 @@ jobs:
             - bundler-dependencies-{{ checksum "Gemfile.lock" }}
       - run:
           name: Wait for db
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+          command: dockerize -wait tcp://localhost:5432 -timeout 2m
       - run:
           name: Create test DB
           command: cd spec/decidim_dummy_app && RAILS_ENV=test bundle exec rails db:create db:schema:load


### PR DESCRIPTION
#### :tophat: What? Why?

It seems that under some circunstances it takes more than a minute for
the postgreSQL container to become available. Try to give it a bigger
timeout.

See for example https://circleci.com/gh/decidim/decidim/69864?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link.

Maybe this won't actually fix it and once the container takes that long, it means it will actually never properly start. I guess it's worth giving this a try though.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.