### PR TITLE
Fix unintentional answer options reordering

### DIFF
--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
@@ -31,13 +31,17 @@
         this._bindSafeEvent(event, (target) => this._removeField(target))
       );
 
-      $(this.wrapperSelector).on('click', this.moveUpFieldButtonSelector, (event) =>
-        this._bindSafeEvent(event, (target) => this._moveUpField(target))
-      );
+      if (this.moveUpFieldButtonSelector) {
+        $(this.wrapperSelector).on('click', this.moveUpFieldButtonSelector, (event) =>
+          this._bindSafeEvent(event, (target) => this._moveUpField(target))
+        );
+      }
 
-      $(this.wrapperSelector).on('click', this.moveDownFieldButtonSelector, (event) =>
-        this._bindSafeEvent(event, (target) => this._moveDownField(target))
-      );
+      if (this.moveDownFieldButtonSelector) {
+        $(this.wrapperSelector).on('click', this.moveDownFieldButtonSelector, (event) =>
+          this._bindSafeEvent(event, (target) => this._moveDownField(target))
+        );
+      }
     }
 
     _bindSafeEvent(event, cb) {

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -56,7 +56,7 @@ shared_examples "edit surveys" do
           questions_body[idx].each do |locale, value|
             within survey_question do
               click_link I18n.with_locale(locale) { t("name", scope: "locale") }
-              find("input[name='survey[questions][][body_#{locale}]']").send_keys value
+              fill_in "survey[questions][][body_#{locale}]", with: value
             end
           end
         end
@@ -102,7 +102,7 @@ shared_examples "edit surveys" do
         question_body.each do |locale, value|
           within ".survey-question" do
             click_link I18n.with_locale(locale) { t("name", scope: "locale") }
-            find("input[name='survey[questions][][body_#{locale}]']").send_keys value
+            fill_in "survey[questions][][body_#{locale}]", with: value
           end
         end
 
@@ -118,7 +118,7 @@ shared_examples "edit surveys" do
           answer_options_body[idx].each do |locale, value|
             within survey_question_answer_option do
               click_link I18n.with_locale(locale) { t("name", scope: "locale") }
-              find("input[name='survey[questions][][answer_options][][body_#{locale}]']").send_keys value
+              fill_in "survey[questions][][answer_options][][body_#{locale}]", with: value
             end
           end
         end

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -135,6 +135,32 @@ shared_examples "edit surveys" do
       expect(page).to have_selector("input[value='This is the second option']")
     end
 
+    it "does not incorrectly reorder when clicking answer options" do
+      click_button "Add question"
+      select "Single option", from: "Type"
+      2.times { click_button "Add answer option" }
+
+      within ".survey-question-answer-option:first-of-type" do
+        fill_in "survey[questions][][answer_options][][body_en]", with: "Something"
+      end
+
+      within ".survey-question-answer-option:last-of-type" do
+        fill_in "survey[questions][][answer_options][][body_en]", with: "Else"
+      end
+
+      # If JS events for option reordering are incorrectly bound, clicking on
+      # the field to gain focus can cause the options to get inverted... :S
+      within ".survey-question-answer-option:first-of-type" do
+        find("input[name='survey[questions][][answer_options][][body_en]']").click
+      end
+
+      first_answer_option = page.find(".survey-question-answer-option:first-of-type")
+      expect(first_answer_option).to have_field("survey[questions][][answer_options][][body_en]", with: "Something")
+
+      second_answer_option = page.find(".survey-question-answer-option:last-of-type")
+      expect(second_answer_option).to have_field("survey[questions][][answer_options][][body_en]", with: "Else")
+    end
+
     describe "when a survey has an existing question" do
       let!(:survey_question) { create(:survey_question, survey: survey, body: body) }
 


### PR DESCRIPTION
#### :tophat: What? Why?

As soon as I started having a look at #2971, I was stumped by this bug that I introduced yesterday in #3005. Fixing it here!

#### :pushpin: Related Issues
- Related to #3005.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.