### PR TITLE
Fix question form disabled after submission errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,5 +35,6 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-proposals**: Fix proposal endorsed event  generation [\#2983](https://github.com/decidim/decidim/pull/2983)
 - **decidim-core**: foundation-rails 6.4.3 support [\#2995](https://github.com/decidim/decidim/pull/2995)
 - **decidim-surveys**: Fix errored questions being re-rendered with disabled inputs [\#3014](https://github.com/decidim/decidim/pull/3014)
+- **decidim-surveys**: Fix errored questions rendering answer options as empty fields [\#3014](https://github.com/decidim/decidim/pull/3014)
 
 Please check [0.10-stable](https://github.com/decidim/decidim/blob/0.10-stable/CHANGELOG.md) for previous changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,5 +32,6 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-comments**: Fix mentions not working properly.  [\#2947](https://github.com/decidim/decidim/pull/2947)
 - **decidim-proposals**: Fix proposal endorsed event  generation [\#2983](https://github.com/decidim/decidim/pull/2983)
 - **decidim-core**: foundation-rails 6.4.3 support [\#2995](https://github.com/decidim/decidim/pull/2995)
+- **decidim-surveys**: Fix errored questions being re-rendered with disabled inputs [\#3014](https://github.com/decidim/decidim/pull/3014)
 
 Please check [0.10-stable](https://github.com/decidim/decidim/blob/0.10-stable/CHANGELOG.md) for previous changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and also everything related to it (controllers, views, etc.). If you have custom
 controller or added a new module you need to rename `feature` to `component`.
 
 **Added**:
+
 - **decidim**: Added private_space and participatory space private users. [\#2618](https://github.com/decidim/decidim/pull/2618)
 - **decidim-core**: Add ParticipatorySpaceResourceable between Assemblies and ParticipatoryProcesses [\#2851](https://github.com/decidim/decidim/pull/2851)
 - **decidim**: Rename features to components [\#2913](https://github.com/decidim/decidim/pull/2913)
@@ -24,6 +25,7 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-participatory_processes**: Render documents in first place (before view hooks). [\#2977](https://github.com/decidim/decidim/pull/2977)
 
 **Fixed**:
+
 - **decidim-proposals**: Fix treshold absolute view and rename the field maximum_votes_per_proposal to treshold_per_proposal. [\#2994](https://github.com/decidim/decidim/pull/2994)
 - **decidim-proposals**: Fix proposal endorsed event [\#2970](https://github.com/decidim/decidim/pull/2970)
 - **decidim-accountability**: Fix parent results progress [\#2954](https://github.com/decidim/decidim/pull/2954)

--- a/decidim-surveys/app/helpers/decidim/surveys/admin/application_helper.rb
+++ b/decidim-surveys/app/helpers/decidim/surveys/admin/application_helper.rb
@@ -25,10 +25,6 @@ module Decidim
           return "survey_questions_#{question.id}_question_type" if question.persisted?
           "${tabsId}_question_type"
         end
-
-        def disabled_for_question(survey, question)
-          !question.persisted? || !survey.questions_editable?
-        end
       end
     end
   end

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
@@ -17,7 +17,7 @@
           :text_field_tag,
           "survey[questions][][answer_options][]",
           "body",
-          answer_option.body,
+          answer_option.body.with_indifferent_access,
           tabs_id: tabs_id_for_question_answer_option(question, idx),
           label: t(".statement"),
           disabled: question.nil? || !survey.questions_editable?,

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
@@ -20,7 +20,7 @@
           answer_option.body,
           tabs_id: tabs_id_for_question_answer_option(question, idx),
           label: t(".statement"),
-          disabled: question.nil? || disabled_for_question(survey, question),
+          disabled: question.nil? || !survey.questions_editable?,
           enable_tabs: question.present?
         )
       %>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
@@ -36,7 +36,7 @@
           object: question,
           tabs_id: tabs_id_for_question(question),
           label: t(".statement"),
-          disabled: disabled_for_question(survey, question),
+          disabled: !survey.questions_editable?,
           enable_tabs: question.persisted?
         )
       %>
@@ -49,7 +49,7 @@
           "1",
           question.mandatory,
           id: mandatory_id_for_question(question),
-          disabled: disabled_for_question(survey, question)
+          disabled: !survey.questions_editable?
         )
       %>
       <%= label_tag "", t("activemodel.attributes.survey_question.mandatory"), for: mandatory_id_for_question(question) %>
@@ -57,15 +57,15 @@
 
     <div class="row column">
       <%= label_tag "", t("activemodel.attributes.survey_question.question_type"), for: question_type_id_for_question(question) %>
-      <%= select_tag "survey[questions][][question_type]", options_from_collection_for_select(question_types, :first, :last, question.question_type), id: question_type_id_for_question(question), disabled: disabled_for_question(survey, question) %>
+      <%= select_tag "survey[questions][][question_type]", options_from_collection_for_select(question_types, :first, :last, question.question_type), id: question_type_id_for_question(question), disabled: !survey.questions_editable? %>
     </div>
 
     <% if question.persisted? %>
-      <%= hidden_field_tag "survey[questions][][id]", question.id, disabled: disabled_for_question(survey, question) %>
+      <%= hidden_field_tag "survey[questions][][id]", question.id, disabled: !survey.questions_editable? %>
     <% end %>
 
-    <%= hidden_field_tag "survey[questions][][position]", question.position || 0, disabled: disabled_for_question(survey, question) %>
-    <%= hidden_field_tag "survey[questions][][deleted]", false, disabled: disabled_for_question(survey, question) %>
+    <%= hidden_field_tag "survey[questions][][position]", question.position || 0, disabled: !survey.questions_editable? %>
+    <%= hidden_field_tag "survey[questions][][deleted]", false, disabled: !survey.questions_editable? %>
 
     <div class="survey-question-answer-options">
       <% if survey.questions_editable? %>

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -169,6 +169,20 @@ shared_examples "edit surveys" do
       expect(page).to have_select("Type", selected: "Long answer")
     end
 
+    it "persists answer options form across submission failures" do
+      click_button "Add question"
+      select "Single option", from: "Type"
+      click_button "Add answer option"
+
+      within ".survey-question-answer-option:first-of-type" do
+        fill_in "survey[questions][][answer_options][][body_en]", with: "Something"
+      end
+
+      click_button "Save"
+
+      expect(page).to have_field("survey[questions][][answer_options][][body_en]", with: "Something")
+    end
+
     describe "when a survey has an existing question" do
       let!(:survey_question) { create(:survey_question, survey: survey, body: body) }
 

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -161,6 +161,14 @@ shared_examples "edit surveys" do
       expect(second_answer_option).to have_field("survey[questions][][answer_options][][body_en]", with: "Else")
     end
 
+    it "persists question form across submission failures" do
+      click_button "Add question"
+      select "Long answer", from: "Type"
+      click_button "Save"
+
+      expect(page).to have_select("Type", selected: "Long answer")
+    end
+
     describe "when a survey has an existing question" do
       let!(:survey_question) { create(:survey_question, survey: survey, body: body) }
 


### PR DESCRIPTION
#### :tophat: What? Why?

While investigating #2971, I discovered this bug. After creating a new question and submitting the form with invalid data, the question was rendered with all inputs disabled the second time :grimacing:.

#### :pushpin: Related Issues
- Related to #2971.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
_None_.