### PR TITLE
Show debates statistics on space show and homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-accountability**: Log results deletion [\#2923](https://github.com/decidim/decidim/pull/2923)
 - **decidim-surveys**: Allow reordering questions via "Up" & "Down" buttons [\#3005](https://github.com/decidim/decidim/pull/3005)
 - **decidim-comments**: Add more notification types when a comment is created [\#3004](https://github.com/decidim/decidim/pull/3004)
+- **decidim-debates**: Show debates stats in homepage and space pages [\#3016](https://github.com/decidim/decidim/pull/3016)
 
 **Changed**:
 

--- a/decidim-assemblies/app/views/decidim/assemblies/assemblies/_statistics.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/assemblies/_statistics.html.erb
@@ -1,6 +1,6 @@
 <section class="extended" id="assembly-statistics" class="statistics">
   <div class="row column">
-    <h4 class="section-heading"><%= t("statistics.headline", scope: "decidim.assemblies", assembly: translated_attribute(current_participatory_space.title)) %></h3>
+    <h4 class="section-heading"><%= t("statistics.headline", scope: "decidim.assemblies") %></h3>
   </div>
   <div class="row">
     <div class="columns small-centered mediumlarge-12 large-12 process_stats">

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -162,6 +162,7 @@ en:
         answers_count: Answers
         assemblies_count: Assemblies
         comments_count: Comments
+        debates_count: Debates
         endorsements_count: Endorsements
         headline: Activity
         meetings_count: Meetings

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -509,6 +509,7 @@ en:
         answers_count: Completed Surveys
         assemblies_count: Assemblies
         comments_count: Comments
+        debates_count: Debates
         endorsements_count: Endorsements
         headline: Current state of %{organization}
         meetings_count: Meetings

--- a/decidim-debates/lib/decidim/debates/component.rb
+++ b/decidim-debates/lib/decidim/debates/component.rb
@@ -22,6 +22,10 @@ Decidim.register_component(:debates) do |component|
     settings.attribute :announcement, type: :text, translated: true, editor: true
   end
 
+  component.register_stat :debates_count, primary: true, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |components, _start_at, _end_at|
+    Decidim::Debates::Debate.where(component: components).count
+  end
+
   component.register_resource do |resource|
     resource.model_class_name = "Decidim::Debates::Debate"
   end

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/_statistics.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/_statistics.html.erb
@@ -1,6 +1,6 @@
 <section class="extended" id="participatory_process-statistics" class="statistics">
   <div class="row column">
-    <h4 class="section-heading"><%= t("statistics.headline", scope: "decidim.participatory_processes", participatory_process: translated_attribute(current_participatory_space.title)) %></h3>
+    <h4 class="section-heading"><%= t("statistics.headline", scope: "decidim.participatory_processes") %></h3>
   </div>
   <div class="row">
     <div class="columns small-centered mediumlarge-12 large-12 process_stats">

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -287,6 +287,7 @@ en:
       statistics:
         answers_count: Answers
         comments_count: Comments
+        debates_count: Debates
         endorsements_count: Endorsements
         headline: Activity
         meetings_count: Meetings


### PR DESCRIPTION
#### :tophat: What? Why?
I noticed debates were not exporting their statistics. This PR adds statistics both in the homepage and in the participatory space page. The only thing we can discuss here is wether we want to show debates as a priority statistics, or as a secondary one (this only affects the homepage). In the screenshot, priority stats would be "Participants", "assemblies", etc, while secondary would be "Meetings"

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
Homepage:
![Description](https://i.imgur.com/fQurhSv.png)

Participatory space page:
![](https://i.imgur.com/HkWiw6r.png)