### PR TITLE
[FIX] backport fix maximum votes to threshold proposals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ Decidim::Notification.where(event_class: "Decidim::Proposals::ProposalEndorsedEv
 
 **Fixed**:
 
+- **decidim-proposals**: Fix treshold absolute view and rename the field maximum_votes_per_proposal to threshold_per_proposal. [\#3017](https://github.com/decidim/decidim/pull/3017)
 - **decidim-core**: FIX Mispelling in available_locales initializer: pr-BR should be pt-BR. [\#2883](https://github.com/decidim/decidim/pull/2883)
 - **decidim-admin**: FIX Area and AreaType command specs [\#2859](https://github.com/decidim/decidim/pull/2859)
 - **decidim-proposals**: Fix wrong message when creating a proposal private note [\#2769](https://github.com/decidim/decidim/pull/2769)

--- a/decidim-core/db/migrate/20180314085339_rename_maximum_votes_per_proposal_to_threshold_per_proposal.rb
+++ b/decidim-core/db/migrate/20180314085339_rename_maximum_votes_per_proposal_to_threshold_per_proposal.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class RenameMaximumVotesPerProposalToThresholdPerProposal < ActiveRecord::Migration[5.1]
+  def up
+    execute <<~SQL
+      UPDATE decidim_features
+      SET settings = jsonb_set(
+        settings::jsonb,
+        array['global'],
+        (settings->'global')::jsonb - 'maximum_votes_per_proposal' || jsonb_build_object('threshold_per_proposal', settings->'global'->'maximum_votes_per_proposal')
+        )
+      WHERE manifest_name = 'proposals'
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      UPDATE decidim_features
+      SET settings = jsonb_set(
+        settings::jsonb,
+        array['global'],
+        (settings->'global')::jsonb - 'threshold_per_proposal' || jsonb_build_object('maximum_votes_per_proposal', settings->'global'->'threshold_per_proposal')
+        )
+      WHERE manifest_name = 'proposals'
+    SQL
+  end
+end

--- a/decidim-proposals/app/helpers/decidim/proposals/proposal_votes_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/proposal_votes_helper.rb
@@ -39,19 +39,19 @@ module Decidim
         vote_limit.present?
       end
 
-      # Public: Checks if maximum votes per proposal are set.
+      # Public: Checks if threshold per proposal are set.
       #
       # Returns true if set, false otherwise.
-      def maximum_votes_per_proposal_enabled?
-        maximum_votes_per_proposal.present?
+      def threshold_per_proposal_enabled?
+        threshold_per_proposal.present?
       end
 
       # Public: Fetches the maximum amount of votes per proposal.
       #
       # Returns an Integer with the maximum amount of votes, nil otherwise.
-      def maximum_votes_per_proposal
-        return nil unless feature_settings.maximum_votes_per_proposal.positive?
-        feature_settings.maximum_votes_per_proposal
+      def threshold_per_proposal
+        return nil unless feature_settings.threshold_per_proposal.positive?
+        feature_settings.threshold_per_proposal
       end
 
       # Public: Checks if can accumulate more than maxium is enabled

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -109,7 +109,7 @@ module Decidim
       #
       # Returns an Integer with the maximum amount of votes, nil otherwise.
       def maximum_votes
-        maximum_votes = feature.settings.maximum_votes_per_proposal
+        maximum_votes = feature.settings.threshold_per_proposal
         return nil if maximum_votes.zero?
 
         maximum_votes

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_votes_count.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_votes_count.html.erb
@@ -6,21 +6,22 @@
     <% vertical ||= from_proposals_list %>
     <div class="progress__bar<%= (!vertical) ? ' progress__bar--vertical' : '' %>">
       <div class="progress__bar__title">
-        <span class="progress__bar__number"><%= progress %></span>/<%= total %>
+        <span class="progress__bar__number"><%= progress %></span><%= "/#{total}" if total != 0 %>
         <span class="progress__bar__text"><%= t('.count', count: proposal.proposal_votes_count) %></span>
       </div>
-      <div class="progress progress__bar__bar" role="progressbar" tabindex="0" aria-valuenow="<%= percent %>" aria-valuemin="0" aria-valuetext="<%= percent %> percent" aria-valuemax="100">
-        <div class="progress-meter progress__bar__bar--complete" style="width: <%= percent %>%"></div>
-        <div class="progress__bar__bar--incomplete" style="width:calc(100% - <%= percent %>%);"></div>
-      </div>
-      <div class="progress__bar__subtitle">
-        <% if progress >= total %>
-          <%= t('.most_popular_proposal') %>
-        <% else %>
-          <%= t('.need_more_votes') %>
-        <% end %>
-      </div>
+      <% if total != 0 %>
+        <div class="progress progress__bar__bar" role="progressbar" tabindex="0" aria-valuenow="<%= percent %>" aria-valuemin="0" aria-valuetext="<%= percent %> percent" aria-valuemax="100">
+          <div class="progress-meter progress__bar__bar--complete" style="width: <%= percent %>%"></div>
+          <div class="progress__bar__bar--incomplete" style="width:calc(100% - <%= percent %>%);"></div>
+        </div>
+        <div class="progress__bar__subtitle">
+          <% if progress >= total %>
+            <%= t('.most_popular_proposal') %>
+          <% else %>
+            <%= t('.need_more_votes') %>
+          <% end %>
+        </div>
+      <% end %>
     </div>
-
   <% end %>
 </div>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_voting_rules.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_voting_rules.html.erb
@@ -1,4 +1,4 @@
-<% if votes_enabled? && (vote_limit_enabled? || maximum_votes_per_proposal_enabled? || proposal_limit_enabled? || can_accumulate_supports_beyond_threshold?) %>
+<% if votes_enabled? && (vote_limit_enabled? || threshold_per_proposal_enabled? || proposal_limit_enabled? || can_accumulate_supports_beyond_threshold?) %>
   <div class="row column">
     <div class="callout secondary voting-rules">
       <div class="row">
@@ -13,8 +13,8 @@
               <li><%= t('.proposal_limit.description', limit: proposal_limit) %></li>
             <% end %>
 
-            <% if maximum_votes_per_proposal_enabled? %>
-              <li><%= t('.maximum_votes_per_proposal.description', limit: maximum_votes_per_proposal) %></li>
+            <% if threshold_per_proposal_enabled? %>
+              <li><%= t('.threshold_per_proposal.description', limit: threshold_per_proposal) %></li>
             <% end %>
 
             <% if can_accumulate_supports_beyond_threshold? %>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -85,7 +85,6 @@ en:
             can_accumulate_supports_beyond_threshold: Can accumulate supports beyond threshold
             comments_enabled: Comments enabled
             geocoding_enabled: Geocoding enabled
-            maximum_votes_per_proposal: Maximum votes per proposal
             new_proposal_help_text: New proposal help text
             official_proposals_enabled: Official proposals enabled
             proposal_answering_enabled: Proposal answering enabled
@@ -95,6 +94,7 @@ en:
             proposal_wizard_step_1_help_text: Proposal wizard "Create" step help text
             proposal_wizard_step_2_help_text: Proposal wizard "Compare" step help text
             proposal_wizard_step_3_help_text: Proposal wizard "Publish" step help text
+            threshold_per_proposal: Threshold per proposal
             vote_limit: Vote limit per user
           step:
             announcement: Announcement
@@ -338,11 +338,11 @@ en:
           need_more_votes: Need more votes
         voting_rules:
           can_accumulate_supports_beyond_threshold:
-            description: Each proposal can accumulate more than maximum votes
-          maximum_votes_per_proposal:
-            description: Each proposal can receive a maximum of %{limit} votes.
+            description: Each proposal can accumulate more than %{limit} supports
           proposal_limit:
             description: You can create up to %{limit} proposals.
+          threshold_per_proposal:
+            description: In order to be accepted proposals need to reach %{limit} supports
           title: 'Voting is subject to the following rules:'
           vote_limit:
             description: You can vote up to %{limit} proposals.

--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -20,7 +20,7 @@ Decidim.register_feature(:proposals) do |feature|
     settings.attribute :proposal_limit, type: :integer, default: 0
     settings.attribute :proposal_length, type: :integer, default: 500
     settings.attribute :proposal_edit_before_minutes, type: :integer, default: 5
-    settings.attribute :maximum_votes_per_proposal, type: :integer, default: 0
+    settings.attribute :threshold_per_proposal, type: :integer, default: 0
     settings.attribute :can_accumulate_supports_beyond_threshold, type: :boolean, default: false
     settings.attribute :proposal_answering_enabled, type: :boolean, default: true
     settings.attribute :official_proposals_enabled, type: :boolean, default: true

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -119,10 +119,10 @@ FactoryBot.define do
       end
     end
 
-    trait :with_maximum_votes_per_proposal do
+    trait :with_threshold_per_proposal do
       settings do
         {
-          maximum_votes_per_proposal: 1
+          threshold_per_proposal: 1
         }
       end
     end

--- a/decidim-proposals/spec/commands/decidim/proposals/vote_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/vote_proposal_spec.rb
@@ -40,7 +40,7 @@ module Decidim
           end
         end
 
-        context "when the maximum votes have been reached" do
+        context "when the threshold have been reached" do
           before do
             expect(proposal).to receive(:maximum_votes_reached?).and_return(true)
           end
@@ -50,7 +50,7 @@ module Decidim
           end
         end
 
-        context "when the maximum votes have been reached but proposal can accumulate more votes" do
+        context "when the threshold have been reached but proposal can accumulate more votes" do
           before do
             expect(proposal).to receive(:maximum_votes_reached?).and_return(true)
             expect(proposal).to receive(:can_accumulate_supports_beyond_threshold).and_return(true)

--- a/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
@@ -110,7 +110,7 @@ module Decidim
 
         context "when the feature's settings are set to an integer bigger than 0" do
           before do
-            feature[:settings]["global"] = { maximum_votes_per_proposal: 10 }
+            feature[:settings]["global"] = { threshold_per_proposal: 10 }
             feature.save!
           end
 
@@ -121,7 +121,7 @@ module Decidim
 
         context "when the feature's settings are set to 0" do
           before do
-            feature[:settings]["global"] = { maximum_votes_per_proposal: 0 }
+            feature[:settings]["global"] = { threshold_per_proposal: 0 }
             feature.save!
           end
 

--- a/decidim-proposals/spec/system/vote_proposal_spec.rb
+++ b/decidim-proposals/spec/system/vote_proposal_spec.rb
@@ -92,7 +92,7 @@ describe "Vote Proposal", type: :system do
           end
 
           within "#proposal-#{proposal.id}-votes-count" do
-            expect(page).to have_content("1/0 VOTE")
+            expect(page).to have_content("1 VOTE")
           end
         end
       end
@@ -110,7 +110,7 @@ describe "Vote Proposal", type: :system do
           end
 
           within "#proposal-#{proposal.id}-votes-count" do
-            expect(page).to have_content("1/0 VOTE")
+            expect(page).to have_content("1 VOTE")
           end
         end
 
@@ -260,7 +260,7 @@ describe "Vote Proposal", type: :system do
             end
 
             it "shows the vote count but not the vote button" do
-              expect(page).to have_css(".card__support__data", text: "1/0 VOTE")
+              expect(page).to have_css(".card__support__data", text: "1 VOTE")
               expect(page).to have_content("Voting disabled")
             end
           end
@@ -288,7 +288,7 @@ describe "Vote Proposal", type: :system do
       let!(:feature) do
         create(:proposal_feature,
                :with_votes_enabled,
-               :with_maximum_votes_per_proposal,
+               :with_threshold_per_proposal,
                manifest: manifest,
                participatory_space: participatory_process)
       end
@@ -327,7 +327,7 @@ describe "Vote Proposal", type: :system do
       let!(:feature) do
         create(:proposal_feature,
                :with_votes_enabled,
-               :with_maximum_votes_per_proposal,
+               :with_threshold_per_proposal,
                :with_can_accumulate_supports_beyond_threshold,
                manifest: manifest,
                participatory_space: participatory_process)
@@ -345,7 +345,7 @@ describe "Vote Proposal", type: :system do
 
         within proposal_element do
           within ".card__support", match: :first do
-            expect(page).to have_content("1/0 VOTE")
+            expect(page).to have_content("1 VOTE")
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR is a backport  solving the treshold absolute on view and rename the field maximum votes per proposal to threshold per proposal

#### :pushpin: Related Issues
- Related to #2276 
- Fixes #2969 #2965

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] When maximum supports is 0 it shouldn't be shown the threshold 
- [x] Change field "Maximum Number of votes" to "Threshold per proposal" 
- [x] Change translation " Each proposal can receive a maximum of 5 votes." to "In order to be accepted proposals need to reach X supports." 
- [x] Change translation "Each proposal can accumulate more than maximum votes" to " Each proposal can accumulate more than X supports"


