### PR TITLE
Fix broken translated field after form errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,5 +37,6 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-core**: foundation-rails 6.4.3 support [\#2995](https://github.com/decidim/decidim/pull/2995)
 - **decidim-surveys**: Fix errored questions being re-rendered with disabled inputs [\#3014](https://github.com/decidim/decidim/pull/3014)
 - **decidim-surveys**: Fix errored questions rendering answer options as empty fields [\#3014](https://github.com/decidim/decidim/pull/3014)
+- **decidim-surveys**: Fix translated fields of freshly created questions not working after form errors [\#3026](https://github.com/decidim/decidim/pull/3026)
 
 Please check [0.10-stable](https://github.com/decidim/decidim/blob/0.10-stable/CHANGELOG.md) for previous changes.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,6 @@ PATH
       social-share-button (~> 1.0)
     decidim-surveys (0.11.0.pre)
       decidim-core (= 0.11.0.pre)
-      jquery-tmpl-rails (~> 1.1)
     decidim-system (0.11.0.pre)
       active_link_to (~> 1.0)
       decidim-core (= 0.11.0.pre)

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
@@ -21,7 +21,28 @@
 
     _enableInterpolation() {
       $.fn.template = function(placeholder, value) {
-        return $(this).html((id, oldHtml) => oldHtml.replace(new RegExp(placeholder, "g"), value));
+        $(this).find(`[id^=${placeholder}]`).each((index, element) => {
+          $(element).attr("id", $(element).attr("id").replace(placeholder, value));
+        });
+
+        $(this).find(`[data-tabs-content=${placeholder}]`).each((index, element) => {
+          $(element).attr("data-tabs-content", value);
+        });
+
+        $(this).find(`[for^=${placeholder}]`).each((index, element) => {
+          $(element).attr("for", $(element).attr("for").replace(placeholder, value));
+        });
+
+        $(this).find(`[tabs_id=${placeholder}]`).each((index, element) => {
+          $(element).attr("tabs_id", value);
+        });
+
+
+        $(this).find(`[href^='#${placeholder}']`).each((index, element) => {
+          $(element).attr("href", $(element).attr("href").replace(placeholder, value));
+        });
+
+        return this;
       }
     }
 

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
@@ -63,7 +63,6 @@
       const $container = $(this.wrapperSelector).find(this.containerSelector);
       const $newField = $($(`#${this.templateId}`).html()).template(this._getPlaceholderTabId(), this._getUniqueTabId());
 
-      $newField.find('[disabled]').attr('disabled', false);
       $newField.find('ul.tabs').attr('data-tabs', true);
 
       $newField.appendTo($container);

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
@@ -14,12 +14,14 @@
       this.onMoveUpField = options.onMoveUpField;
       this.onMoveDownField = options.onMoveDownField;
       this.tabsPrefix = options.tabsPrefix;
-      this._compileTemplate();
+      this._enableInterpolation();
       this._bindEvents();
     }
 
-    _compileTemplate() {
-      $.template(this.templateId, $(`#${this.templateId}`).html());
+    _enableInterpolation() {
+      $.fn.template = function(placeholder, value) {
+        return $($(this).html().replace(new RegExp(placeholder, "g"), value));
+      }
     }
 
     _bindEvents() {
@@ -60,8 +62,9 @@
       const $container = $(this.wrapperSelector).find(this.containerSelector);
       const uid = this._getUID();
       const tabsId = `${this.tabsPrefix}-${uid}`;
+      const oldTabsId = `${this.tabsPrefix}-id`;
 
-      const $newField = $.tmpl(this.templateId, { tabsId });
+      const $newField = $(`#${this.templateId}`).template(oldTabsId, tabsId);
 
       $newField.find('[disabled]').attr('disabled', false);
       $newField.find('ul.tabs').attr('data-tabs', true);

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
@@ -15,12 +15,13 @@
       this.onMoveDownField = options.onMoveDownField;
       this.tabsPrefix = options.tabsPrefix;
       this._enableInterpolation();
+      this._activateFields();
       this._bindEvents();
     }
 
     _enableInterpolation() {
       $.fn.template = function(placeholder, value) {
-        return $($(this).html().replace(new RegExp(placeholder, "g"), value));
+        return $(this).html((id, oldHtml) => oldHtml.replace(new RegExp(placeholder, "g"), value));
       }
     }
 
@@ -60,7 +61,7 @@
 
     _addField() {
       const $container = $(this.wrapperSelector).find(this.containerSelector);
-      const $newField = $(`#${this.templateId}`).template(this._getPlaceholderTabId(), this._getUniqueTabId());
+      const $newField = $($(`#${this.templateId}`).html()).template(this._getPlaceholderTabId(), this._getUniqueTabId());
 
       $newField.find('[disabled]').attr('disabled', false);
       $newField.find('ul.tabs').attr('data-tabs', true);
@@ -116,6 +117,14 @@
       if (this.onMoveDownField) {
         this.onMoveDownField($movedDownField);
       }
+    }
+
+    _activateFields() {
+      $(this.fieldSelector).each((idx, el) => {
+        $(el).template(this._getPlaceholderTabId(), this._getUniqueTabId());
+
+        $(el).find('ul.tabs').attr('data-tabs', true);
+      })
     }
 
     _getPlaceholderTabId() {

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
@@ -63,7 +63,6 @@
 
       const $newField = $.tmpl(this.templateId, { tabsId });
 
-      $newField.attr('id', `${tabsId}-field`);
       $newField.find('[disabled]').attr('disabled', false);
       $newField.find('ul.tabs').attr('data-tabs', true);
 

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
@@ -60,11 +60,7 @@
 
     _addField() {
       const $container = $(this.wrapperSelector).find(this.containerSelector);
-      const uid = this._getUID();
-      const tabsId = `${this.tabsPrefix}-${uid}`;
-      const oldTabsId = `${this.tabsPrefix}-id`;
-
-      const $newField = $(`#${this.templateId}`).template(oldTabsId, tabsId);
+      const $newField = $(`#${this.templateId}`).template(this._getPlaceholderTabId(), this._getUniqueTabId());
 
       $newField.find('[disabled]').attr('disabled', false);
       $newField.find('ul.tabs').attr('data-tabs', true);
@@ -120,6 +116,14 @@
       if (this.onMoveDownField) {
         this.onMoveDownField($movedDownField);
       }
+    }
+
+    _getPlaceholderTabId() {
+      return `${this.tabsPrefix}-id`;
+    }
+
+    _getUniqueTabId() {
+      return `${this.tabsPrefix}-${this._getUID()}`;
     }
 
     _getUID() {

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
@@ -1,4 +1,3 @@
-// = require jquery-tmpl
 // = require ./auto_label_by_position.component
 // = require ./auto_buttons_by_position.component
 // = require ./dynamic_fields.component

--- a/decidim-surveys/app/controllers/decidim/surveys/admin/surveys_controller.rb
+++ b/decidim-surveys/app/controllers/decidim/surveys/admin/surveys_controller.rb
@@ -37,7 +37,7 @@ module Decidim
         end
 
         def blank_question
-          @blank_question ||= survey.questions.build(body: {}, answer_options: [])
+          @blank_question ||= Admin::SurveyQuestionForm.new
         end
 
         def blank_answer_option

--- a/decidim-surveys/app/helpers/decidim/surveys/admin/application_helper.rb
+++ b/decidim-surveys/app/helpers/decidim/surveys/admin/application_helper.rb
@@ -15,20 +15,6 @@ module Decidim
           return "survey-question-answer-option-#{question.id}-#{idx}" if question.present?
           "${tabsId}"
         end
-
-        def mandatory_id_for_question(question)
-          question_attribute_id(question, "mandatory")
-        end
-
-        def question_type_id_for_question(question)
-          question_attribute_id(question, "question_type")
-        end
-
-        private
-
-        def question_attribute_id(question, attribute)
-          "#{tabs_id_for_question(question)}-#{attribute}"
-        end
       end
     end
   end

--- a/decidim-surveys/app/helpers/decidim/surveys/admin/application_helper.rb
+++ b/decidim-surveys/app/helpers/decidim/surveys/admin/application_helper.rb
@@ -11,8 +11,8 @@ module Decidim
           "${tabsId}"
         end
 
-        def tabs_id_for_question_answer_option(question, idx)
-          return "survey-question-answer-option-#{question.id}-#{idx}" if question.persisted?
+        def tabs_id_for_question_answer_option(answer_option, idx)
+          return "survey-question-answer-option-#{answer_option.question.id}-#{idx}" if answer_option.persisted?
           "${tabsId}"
         end
       end

--- a/decidim-surveys/app/helpers/decidim/surveys/admin/application_helper.rb
+++ b/decidim-surveys/app/helpers/decidim/surveys/admin/application_helper.rb
@@ -17,13 +17,18 @@ module Decidim
         end
 
         def mandatory_id_for_question(question)
-          return "survey_questions_#{question.id}_mandatory" if question.persisted?
-          "${tabsId}_mandatory"
+          question_attribute_id(question, "mandatory")
         end
 
         def question_type_id_for_question(question)
-          return "survey_questions_#{question.id}_question_type" if question.persisted?
-          "${tabsId}_question_type"
+          question_attribute_id(question, "question_type")
+        end
+
+        private
+
+        def question_attribute_id(question, attribute)
+          return "survey_questions_#{question.id}_#{attribute}" if question.persisted?
+          "${tabsId}_#{attribute}"
         end
       end
     end

--- a/decidim-surveys/app/helpers/decidim/surveys/admin/application_helper.rb
+++ b/decidim-surveys/app/helpers/decidim/surveys/admin/application_helper.rb
@@ -7,13 +7,15 @@ module Decidim
       #
       module ApplicationHelper
         def tabs_id_for_question(question)
-          return "survey-question-#{question.id}" if question.persisted?
-          "${tabsId}"
+          id = question.persisted? ? question.id : "id"
+
+          "survey-question-#{id}"
         end
 
         def tabs_id_for_question_answer_option(answer_option, idx)
-          return "survey-question-answer-option-#{answer_option.question.id}-#{idx}" if answer_option.persisted?
-          "${tabsId}"
+          id = answer_option.persisted? ? "#{answer_option.question.id}-#{idx}" : "id"
+
+          "survey-question-answer-option-#{id}"
         end
       end
     end

--- a/decidim-surveys/app/helpers/decidim/surveys/admin/application_helper.rb
+++ b/decidim-surveys/app/helpers/decidim/surveys/admin/application_helper.rb
@@ -27,8 +27,8 @@ module Decidim
         private
 
         def question_attribute_id(question, attribute)
-          return "survey_questions_#{question.id}_#{attribute}" if question.persisted?
-          "${tabsId}_#{attribute}"
+          return "survey-question-#{question.id}-#{attribute}" if question.persisted?
+          "${tabsId}-#{attribute}"
         end
       end
     end

--- a/decidim-surveys/app/helpers/decidim/surveys/admin/application_helper.rb
+++ b/decidim-surveys/app/helpers/decidim/surveys/admin/application_helper.rb
@@ -27,8 +27,7 @@ module Decidim
         private
 
         def question_attribute_id(question, attribute)
-          return "survey-question-#{question.id}-#{attribute}" if question.persisted?
-          "${tabsId}-#{attribute}"
+          "#{tabs_id_for_question(question)}-#{attribute}"
         end
       end
     end

--- a/decidim-surveys/app/helpers/decidim/surveys/admin/application_helper.rb
+++ b/decidim-surveys/app/helpers/decidim/surveys/admin/application_helper.rb
@@ -12,7 +12,7 @@ module Decidim
         end
 
         def tabs_id_for_question_answer_option(question, idx)
-          return "survey-question-answer-option-#{question.id}-#{idx}" if question.present?
+          return "survey-question-answer-option-#{question.id}-#{idx}" if question.persisted?
           "${tabsId}"
         end
       end

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
@@ -20,7 +20,7 @@
           answer_option.body.with_indifferent_access,
           tabs_id: tabs_id_for_question_answer_option(question, idx),
           label: t(".statement"),
-          disabled: question.nil? || !survey.questions_editable?,
+          disabled: !survey.questions_editable?,
           enable_tabs: question.present?
         )
       %>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
@@ -18,7 +18,7 @@
           "survey[questions][][answer_options][]",
           "body",
           answer_option.body.with_indifferent_access,
-          tabs_id: tabs_id_for_question_answer_option(question, idx),
+          tabs_id: tabs_id_for_question_answer_option(answer_option, idx),
           label: t(".statement"),
           disabled: !survey.questions_editable?,
           enable_tabs: answer_option.persisted?

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
@@ -21,7 +21,7 @@
           tabs_id: tabs_id_for_question_answer_option(question, idx),
           label: t(".statement"),
           disabled: !survey.questions_editable?,
-          enable_tabs: question.present?
+          enable_tabs: question.persisted?
         )
       %>
     </div>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
@@ -21,7 +21,7 @@
           tabs_id: tabs_id_for_question_answer_option(question, idx),
           label: t(".statement"),
           disabled: !survey.questions_editable?,
-          enable_tabs: question.persisted?
+          enable_tabs: answer_option.persisted?
         )
       %>
     </div>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
@@ -29,7 +29,7 @@
     </template>
 
     <template id="survey-question-answer-option-tmpl">
-      <%= render "answer_option", answer_option: blank_answer_option, question: blank_question, idx: nil %>
+      <%= render "answer_option", answer_option: blank_answer_option, idx: nil %>
     </template>
   <% else %>
     <div class="callout warning">

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
@@ -29,7 +29,7 @@
     </template>
 
     <template id="survey-question-answer-option-tmpl">
-      <%= render "answer_option", answer_option: blank_answer_option, question: nil, idx: nil %>
+      <%= render "answer_option", answer_option: blank_answer_option, question: blank_question, idx: nil %>
     </template>
   <% else %>
     <div class="callout warning">

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
@@ -38,7 +38,7 @@
   <% end %>
 
   <div class="survey-questions-list">
-    <% @form.questions.each_with_index do |question, idx| %>
+    <% @form.questions.each do |question| %>
       <%= render "question", question: question, id: tabs_id_for_question(question) %>
     <% end %>
   </div>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
@@ -25,7 +25,7 @@
     <button class="button add-question"><%= t(".add_question") %></button>
 
     <template id="survey-question-tmpl">
-      <%= render "question", question: blank_question %>
+      <%= render "question", question: blank_question, id: tabs_id_for_question(blank_question) %>
     </template>
 
     <template id="survey-question-answer-option-tmpl">
@@ -39,7 +39,7 @@
 
   <div class="survey-questions-list">
     <% @form.questions.each_with_index do |question, idx| %>
-      <%= render "question", question: question %>
+      <%= render "question", question: question, id: tabs_id_for_question(question) %>
     <% end %>
   </div>
 </div>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
@@ -74,7 +74,7 @@
 
       <div class="survey-question-answer-options-list">
         <% question.answer_options.each_with_index do |answer_option, idx| %>
-          <%= render "answer_option", question: question, answer_option: answer_option, idx: idx %>
+          <%= render "answer_option", answer_option: answer_option, idx: idx %>
         <% end %>
       </div>
     </div>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
@@ -34,7 +34,7 @@
           "body",
           question.body.with_indifferent_access,
           object: question,
-          tabs_id: tabs_id_for_question(question),
+          tabs_id: id,
           label: t(".statement"),
           disabled: !survey.questions_editable?,
           enable_tabs: question.persisted?
@@ -48,16 +48,16 @@
           "survey[questions][][mandatory]",
           "1",
           question.mandatory,
-          id: mandatory_id_for_question(question),
+          id: "#{id}-mandatory",
           disabled: !survey.questions_editable?
         )
       %>
-      <%= label_tag "", t("activemodel.attributes.survey_question.mandatory"), for: mandatory_id_for_question(question) %>
+      <%= label_tag "", t("activemodel.attributes.survey_question.mandatory"), for: "#{id}-mandatory" %>
     </div>
 
     <div class="row column">
-      <%= label_tag "", t("activemodel.attributes.survey_question.question_type"), for: question_type_id_for_question(question) %>
-      <%= select_tag "survey[questions][][question_type]", options_from_collection_for_select(question_types, :first, :last, question.question_type), id: question_type_id_for_question(question), disabled: !survey.questions_editable? %>
+      <%= label_tag "", t("activemodel.attributes.survey_question.question_type"), for: "#{id}-question_type" %>
+      <%= select_tag "survey[questions][][question_type]", options_from_collection_for_select(question_types, :first, :last, question.question_type), id: "#{id}-question_type", disabled: !survey.questions_editable? %>
     </div>
 
     <% if question.persisted? %>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
@@ -1,4 +1,4 @@
-<div class="card survey-question" id="survey-question-<%= question.id %>-field">
+<div class="card survey-question" id="<%= id %>-field">
   <div class="card-divider question-divider">
     <h2 class="card-title">
     <span>

--- a/decidim-surveys/decidim-surveys.gemspec
+++ b/decidim-surveys/decidim-surveys.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
 
   s.add_dependency "decidim-core", Decidim::Surveys.version
-  s.add_dependency "jquery-tmpl-rails", "~> 1.1"
 
   s.add_development_dependency "decidim-admin", Decidim::Surveys.version
   s.add_development_dependency "decidim-dev", Decidim::Surveys.version

--- a/decidim-surveys/lib/decidim/surveys/admin_engine.rb
+++ b/decidim-surveys/lib/decidim/surveys/admin_engine.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "jquery-tmpl-rails"
-
 module Decidim
   module Surveys
     # This is the engine that runs on the public interface of `Surveys`.

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -209,8 +209,8 @@ shared_examples "edit surveys" do
 
         expect(page).to have_selector("input[value='Modified question']")
         expect(page).to have_no_selector("input[value='This is the first question']")
-        expect(page).to have_selector("input#survey_questions_#{survey_question.id}_mandatory[checked]")
-        expect(page).to have_selector("select#survey_questions_#{survey_question.id}_question_type option[value='long_answer'][selected]")
+        expect(page).to have_selector("input#survey-question-#{survey_question.id}-mandatory[checked]")
+        expect(page).to have_selector("select#survey-question-#{survey_question.id}-question_type option[value='long_answer'][selected]")
       end
 
       it "re-renders the form when the information is invalid" do
@@ -230,8 +230,8 @@ shared_examples "edit surveys" do
 
         expect(page).to have_selector("input[value='']")
         expect(page).to have_no_selector("input[value='This is the first question']")
-        expect(page).to have_selector("input#survey_questions_#{survey_question.id}_mandatory[checked]")
-        expect(page).to have_selector("select#survey_questions_#{survey_question.id}_question_type option[value='multiple_option'][selected]")
+        expect(page).to have_selector("input#survey-question-#{survey_question.id}-mandatory[checked]")
+        expect(page).to have_selector("select#survey-question-#{survey_question.id}-question_type option[value='multiple_option'][selected]")
       end
 
       it "removes the question" do

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -183,6 +183,22 @@ shared_examples "edit surveys" do
       expect(page).to have_field("survey[questions][][answer_options][][body_en]", with: "Something")
     end
 
+    it "allows switching translated field tabs after form failures" do
+      click_button "Add question"
+      click_button "Save"
+
+      within ".survey-question:first-of-type" do
+        fill_in "survey[questions][][body_en]", with: "Bye"
+        click_link "Català"
+
+        fill_in "survey[questions][][body_ca]", with: "Adeu"
+        click_link "English"
+      end
+
+      expect(page).to have_field("survey[questions][][body_en]", with: "Bye")
+      expect(page).to have_no_field("survey[questions][][body_ca]", with: "Adeu")
+    end
+
     describe "when a survey has an existing question" do
       let!(:survey_question) { create(:survey_question, survey: survey, body: body) }
 

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -190,7 +190,7 @@ shared_examples "edit surveys" do
         visit_component_admin
       end
 
-      it "modifies the question" do
+      it "modifies the question when the information is valid" do
         within "form.edit_survey" do
           expect(page).to have_selector(".survey-question", count: 1)
 
@@ -211,6 +211,27 @@ shared_examples "edit surveys" do
         expect(page).to have_no_selector("input[value='This is the first question']")
         expect(page).to have_selector("input#survey_questions_#{survey_question.id}_mandatory[checked]")
         expect(page).to have_selector("select#survey_questions_#{survey_question.id}_question_type option[value='long_answer'][selected]")
+      end
+
+      it "re-renders the form when the information is invalid" do
+        within "form.edit_survey" do
+          expect(page).to have_selector(".survey-question", count: 1)
+
+          within ".survey-question" do
+            fill_in "survey-question-#{survey_question.id}_body_en", with: ""
+            check "Mandatory"
+            select "Multiple option", from: "Type"
+          end
+
+          click_button "Save"
+        end
+
+        expect(page).to have_admin_callout("There's been errors when saving the survey")
+
+        expect(page).to have_selector("input[value='']")
+        expect(page).to have_no_selector("input[value='This is the first question']")
+        expect(page).to have_selector("input#survey_questions_#{survey_question.id}_mandatory[checked]")
+        expect(page).to have_selector("select#survey_questions_#{survey_question.id}_question_type option[value='multiple_option'][selected]")
       end
 
       it "removes the question" do

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -186,9 +186,11 @@ shared_examples "edit surveys" do
     describe "when a survey has an existing question" do
       let!(:survey_question) { create(:survey_question, survey: survey, body: body) }
 
-      it "modifies the question" do
+      before do
         visit_component_admin
+      end
 
+      it "modifies the question" do
         within "form.edit_survey" do
           expect(page).to have_selector(".survey-question", count: 1)
 
@@ -212,8 +214,6 @@ shared_examples "edit surveys" do
       end
 
       it "removes the question" do
-        visit_component_admin
-
         within "form.edit_survey" do
           expect(page).to have_selector(".survey-question", count: 1)
 
@@ -234,8 +234,6 @@ shared_examples "edit surveys" do
       end
 
       it "cannot be moved up" do
-        visit_component_admin
-
         within "form.edit_survey" do
           within ".survey-question" do
             expect(page).to have_no_button("Up")
@@ -244,8 +242,6 @@ shared_examples "edit surveys" do
       end
 
       it "cannot be moved down" do
-        visit_component_admin
-
         within "form.edit_survey" do
           within ".survey-question" do
             expect(page).to have_no_button("Down")


### PR DESCRIPTION
#### :tophat: What? Why?

When working on some features for surveys, I noticed a small bug:

* :bug: When a freshly created question has errors, the question will be re-rendered but the translated field tabs for the statement won't work.

I started fixing it, but the `jquery-tmpl` library was giving me some trouble:

* :bomb: The interpolation variable (`${tabsId}`) that it uses was being included in the href of the translated field tabs, and that was making `foundation-tabs` crash and preventing the tabs from being enabled.

I couldn't really figure out an easy way to fix that other that not using those interpolation placeholders at all. `jquery-tmpl` was not really doing much and it seems like an abandoned library that hasn't been updated for 4 years. So I removed its usage and replaced it with some similar custom code.

I'm not sure about [the last commit](https://github.com/decidim/decidim/commit/1a85e4ab53cfe0b736a94d2e003394fd74afae5c), initially I was globally replacing the "placeholder string" with a unique value, but I was paranoid about someone creating a question like this:

```
Which string would you like to use as a placeholder?
* survey-question-id
* survey-question-placeholder-id
```
and unintentionally replacing actual content that I don't want to replace...

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)

#### Before
![before](https://user-images.githubusercontent.com/2887858/37568691-8fa1f04e-2ab7-11e8-8b65-266e97a96009.gif)

#### After
![after](https://user-images.githubusercontent.com/2887858/37568692-8fccb702-2ab7-11e8-8fcf-8624175fdae4.gif)

