### PR TITLE
Friendlier buttons for dynamic fields

### DIFF
--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
@@ -22,8 +22,6 @@
 
 <div class="survey-questions">
   <% if survey.questions_editable? %>
-    <button class="button add-question"><%= t(".add_question") %></button>
-
     <template id="survey-question-tmpl">
       <%= render "question", question: blank_question %>
     </template>
@@ -42,6 +40,10 @@
       <%= render "question", question: question %>
     <% end %>
   </div>
+
+  <% if survey.questions_editable? %>
+    <button class="button add-question"><%= t(".add_question") %></button>
+  <% end %>
 </div>
 
 <%= javascript_include_tag "decidim/surveys/admin/surveys" %>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
@@ -68,15 +68,15 @@
     <%= hidden_field_tag "survey[questions][][deleted]", false, disabled: !survey.questions_editable? %>
 
     <div class="survey-question-answer-options">
-      <% if survey.questions_editable? %>
-        <button class="button add-answer-option"><%= t(".add_answer_option") %></button>
-      <% end %>
-
       <div class="survey-question-answer-options-list">
         <% question.answer_options.each_with_index do |answer_option, idx| %>
           <%= render "answer_option", question: question, answer_option: answer_option, idx: idx %>
         <% end %>
       </div>
+
+      <% if survey.questions_editable? %>
+        <button class="button add-answer-option"><%= t(".add_answer_option") %></button>
+      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?

While working on surveys I noticed something that it strikes as a bit weird to me. The button to add dynamic fields to a survey is placed on top of all the currently existing dynamic fields, not at the bottom. So if you're adding fields one by one, you have to constantly go back to the top when you want to create more fields.

I guess if you know the exact number of dynamic fields to be added upfront (say 9), you can "fix" the problem by clicking on the button 9 times and forget about it. But I don't think that's the way usually people interact with these forms.

I thought of opening an issue to discuss this (in case it is intentional), but it was easier to open a PR to better explain it. Tagging it as discussion though :)

#### :pushpin: Related Issues

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry

### :camera: Screenshots (optional)

#### Before

![before](https://user-images.githubusercontent.com/2887858/37568896-31d389e8-2aba-11e8-99fc-c75f57db5f87.gif)

#### Before with workaround

![beforewithworkaround](https://user-images.githubusercontent.com/2887858/37568898-385289e0-2aba-11e8-811a-30c953345f61.gif)

#### After

![after](https://user-images.githubusercontent.com/2887858/37568901-3ee711ea-2aba-11e8-8d94-5ff13ff13cfa.gif)