### PR TITLE
Fix question form errors not being displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,5 +39,6 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-surveys**: Fix errored questions being re-rendered with disabled inputs [\#3014](https://github.com/decidim/decidim/pull/3014)
 - **decidim-surveys**: Fix errored questions rendering answer options as empty fields [\#3014](https://github.com/decidim/decidim/pull/3014)
 - **decidim-surveys**: Fix translated fields of freshly created questions not working after form errors [\#3026](https://github.com/decidim/decidim/pull/3026)
+- **decidim-surveys**: Fix question form errors not being displayed [\#3046](https://github.com/decidim/decidim/pull/3046)
 
 Please check [0.10-stable](https://github.com/decidim/decidim/blob/0.10-stable/CHANGELOG.md) for previous changes.

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
@@ -19,27 +19,21 @@
     }
 
     _enableInterpolation() {
+      $.fn.replaceAttribute = function(attribute, placeholder, value) {
+        $(this).find(`[${attribute}*=${placeholder}]`).each((index, element) => {
+          $(element).attr(attribute, $(element).attr(attribute).replace(placeholder, value));
+        });
+
+        return this;
+      }
+
       $.fn.template = function(placeholder, value) {
-        $(this).find(`[id^=${placeholder}]`).each((index, element) => {
-          $(element).attr("id", $(element).attr("id").replace(placeholder, value));
-        });
-
-        $(this).find(`[data-tabs-content=${placeholder}]`).each((index, element) => {
-          $(element).attr("data-tabs-content", value);
-        });
-
-        $(this).find(`[for^=${placeholder}]`).each((index, element) => {
-          $(element).attr("for", $(element).attr("for").replace(placeholder, value));
-        });
-
-        $(this).find(`[tabs_id=${placeholder}]`).each((index, element) => {
-          $(element).attr("tabs_id", value);
-        });
-
-
-        $(this).find(`[href^='#${placeholder}']`).each((index, element) => {
-          $(element).attr("href", $(element).attr("href").replace(placeholder, value));
-        });
+        $(this).replaceAttribute("id", placeholder, value);
+        $(this).replaceAttribute("name", placeholder, value);
+        $(this).replaceAttribute("data-tabs-content", placeholder, value);
+        $(this).replaceAttribute("for", placeholder, value);
+        $(this).replaceAttribute("tabs_id", placeholder, value);
+        $(this).replaceAttribute("href", placeholder, value);
 
         return this;
       }

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
@@ -29,6 +29,12 @@
       }
 
       $.fn.template = function(placeholder, value) {
+        const $subtemplate = $(this).find("template");
+
+        if ($subtemplate.length > 0) {
+          $subtemplate.html((index, oldHtml) => $(oldHtml).template(placeholder, value)[0].outerHTML);
+        }
+
         $(this).replaceAttribute("id", placeholder, value);
         $(this).replaceAttribute("name", placeholder, value);
         $(this).replaceAttribute("data-tabs-content", placeholder, value);

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
@@ -12,7 +12,7 @@
       this.onRemoveField = options.onRemoveField;
       this.onMoveUpField = options.onMoveUpField;
       this.onMoveDownField = options.onMoveDownField;
-      this.tabsPrefix = options.tabsPrefix;
+      this.placeholderId = options.placeholderId;
       this.elementCounter = 0;
       this._enableInterpolation();
       this._activateFields();
@@ -77,7 +77,7 @@
     _addField() {
       const $container = $(this.wrapperSelector).find(this.containerSelector);
       const $template = $(this.wrapperSelector).children("template");
-      const $newField = $($template.html()).template(this._getPlaceholderTabId(), this._getUniqueTabId());
+      const $newField = $($template.html()).template(this.placeholderId, this._getUID());
 
       $newField.find('ul.tabs').attr('data-tabs', true);
 
@@ -136,18 +136,10 @@
 
     _activateFields() {
       $(this.fieldSelector).each((idx, el) => {
-        $(el).template(this._getPlaceholderTabId(), this._getUniqueTabId());
+        $(el).template(this.placeholderId, this._getUID());
 
         $(el).find('ul.tabs').attr('data-tabs', true);
       })
-    }
-
-    _getPlaceholderTabId() {
-      return `${this.tabsPrefix}-id`;
-    }
-
-    _getUniqueTabId() {
-      return `${this.tabsPrefix}-${this._getUID()}`;
     }
 
     _getUID() {

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
@@ -1,7 +1,6 @@
 ((exports) => {
   class DynamicFieldsComponent {
     constructor(options = {}) {
-      this.templateId = options.templateId;
       this.wrapperSelector = options.wrapperSelector;
       this.containerSelector = options.containerSelector;
       this.fieldSelector = options.fieldSelector;
@@ -82,7 +81,8 @@
 
     _addField() {
       const $container = $(this.wrapperSelector).find(this.containerSelector);
-      const $newField = $($(`#${this.templateId}`).html()).template(this._getPlaceholderTabId(), this._getUniqueTabId());
+      const $template = $(this.wrapperSelector).children("template");
+      const $newField = $($template.html()).template(this._getPlaceholderTabId(), this._getUniqueTabId());
 
       $newField.find('ul.tabs').attr('data-tabs', true);
 

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
@@ -13,6 +13,7 @@
       this.onMoveUpField = options.onMoveUpField;
       this.onMoveDownField = options.onMoveDownField;
       this.tabsPrefix = options.tabsPrefix;
+      this.elementCounter = 0;
       this._enableInterpolation();
       this._activateFields();
       this._bindEvents();
@@ -150,7 +151,9 @@
     }
 
     _getUID() {
-      return `${new Date().getTime()}-${Math.floor(Math.random() * 1000000)}`;
+      this.elementCounter += 1;
+
+      return (new Date().getTime()) + this.elementCounter;
     }
   }
 

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
@@ -35,7 +35,6 @@
 
   const createDynamicFieldsForAnswerOptions = (fieldId) => {
     createDynamicFields({
-      templateId: `survey-question-answer-option-tmpl`,
       tabsPrefix: `survey-question-answer-option`,
       wrapperSelector: `#${fieldId} ${answerOptionsWrapperSelector}`,
       containerSelector: `.survey-question-answer-options-list`,
@@ -57,7 +56,6 @@
   };
 
   createDynamicFields({
-    templateId: 'survey-question-tmpl',
     tabsPrefix: 'survey-question',
     wrapperSelector: wrapperSelector,
     containerSelector: '.survey-questions-list',

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
@@ -7,14 +7,14 @@
 
   const wrapperSelector = '.survey-questions';
   const fieldSelector = '.survey-question';
-  const questionTypeSelector = '[name="survey[questions][][question_type]"]';
+  const questionTypeSelector = 'select[name$=\\[question_type\\]]';
   const answerOptionsWrapperSelector = '.survey-question-answer-options';
 
   const autoLabelByPosition = new AutoLabelByPositionComponent({
     listSelector: '.survey-question:not(.hidden)',
     labelSelector: '.card-title span:first',
     onPositionComputed: (el, idx) => {
-      $(el).find('input[name="survey[questions][][position]"]').val(idx);
+      $(el).find('input[name$=\\[position\\]]').val(idx);
     }
   });
 

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
@@ -35,7 +35,7 @@
 
   const createDynamicFieldsForAnswerOptions = (fieldId) => {
     createDynamicFields({
-      tabsPrefix: `survey-question-answer-option`,
+      placeholderId: `survey-question-answer-option-id`,
       wrapperSelector: `#${fieldId} ${answerOptionsWrapperSelector}`,
       containerSelector: `.survey-question-answer-options-list`,
       fieldSelector: `.survey-question-answer-option`,
@@ -56,7 +56,7 @@
   };
 
   createDynamicFields({
-    tabsPrefix: 'survey-question',
+    placeholderId: 'survey-question-id',
     wrapperSelector: wrapperSelector,
     containerSelector: '.survey-questions-list',
     fieldSelector: fieldSelector,

--- a/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
+++ b/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
@@ -38,7 +38,7 @@ module Decidim
               position: form_question.position,
               mandatory: form_question.mandatory,
               question_type: form_question.question_type,
-              answer_options: form_question.answer_options.map { |answer| { "body" => answer.body } }
+              answer_options: form_question.options.map { |answer| { "body" => answer.body } }
             }
 
             if form_question.id.present?

--- a/decidim-surveys/app/controllers/decidim/surveys/admin/surveys_controller.rb
+++ b/decidim-surveys/app/controllers/decidim/surveys/admin/surveys_controller.rb
@@ -41,7 +41,7 @@ module Decidim
         end
 
         def blank_answer_option
-          @blank_answer_option ||= OpenStruct.new(body: {})
+          @blank_answer_option ||= Admin::SurveyQuestionAnswerOptionForm.new
         end
 
         def question_types

--- a/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_answer_option_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_answer_option_form.rb
@@ -7,7 +7,6 @@ module Decidim
       class SurveyQuestionAnswerOptionForm < Decidim::Form
         include TranslatableAttributes
 
-        attribute :body, String
         translatable_attribute :body, String
       end
     end

--- a/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_answer_option_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_answer_option_form.rb
@@ -8,6 +8,10 @@ module Decidim
         include TranslatableAttributes
 
         translatable_attribute :body, String
+
+        def to_param
+          id || "survey-question-answer-option-id"
+        end
       end
     end
   end

--- a/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_form.rb
@@ -20,13 +20,19 @@ module Decidim
         validates :body, translatable_presence: true, unless: :deleted
 
         def map_model(model)
-          self.options = model.answer_options
+          self.options = model.answer_options.each_with_index.map do |option, id|
+            [id + 1, option]
+          end
         end
 
         def options=(value)
-          @options = value.map do |option|
-            SurveyQuestionAnswerOptionForm.new(option)
+          @options = value.map do |id, option|
+            SurveyQuestionAnswerOptionForm.new(option.merge(id: id.to_s.to_i))
           end
+        end
+
+        def to_param
+          id || "survey-question-id"
         end
       end
     end

--- a/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_form.rb
@@ -7,7 +7,6 @@ module Decidim
       class SurveyQuestionForm < Decidim::Form
         include TranslatableAttributes
 
-        attribute :id, String
         attribute :position, Integer
         attribute :mandatory, Boolean, default: false
         attribute :question_type, String

--- a/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_form.rb
@@ -10,7 +10,7 @@ module Decidim
         attribute :position, Integer
         attribute :mandatory, Boolean, default: false
         attribute :question_type, String
-        attribute :answer_options, Array[SurveyQuestionAnswerOptionForm]
+        attribute :options, Array[SurveyQuestionAnswerOptionForm]
         attribute :deleted, Boolean, default: false
 
         translatable_attribute :body, String
@@ -18,6 +18,16 @@ module Decidim
         validates :position, numericality: { greater_than_or_equal_to: 0 }
         validates :question_type, inclusion: { in: SurveyQuestion::TYPES }
         validates :body, translatable_presence: true, unless: :deleted
+
+        def map_model(model)
+          self.options = model.answer_options
+        end
+
+        def options=(value)
+          @options = value.map do |option|
+            SurveyQuestionAnswerOptionForm.new(option)
+          end
+        end
       end
     end
   end

--- a/decidim-surveys/app/helpers/decidim/surveys/admin/application_helper.rb
+++ b/decidim-surveys/app/helpers/decidim/surveys/admin/application_helper.rb
@@ -7,15 +7,11 @@ module Decidim
       #
       module ApplicationHelper
         def tabs_id_for_question(question)
-          id = question.persisted? ? question.id : "id"
-
-          "survey_question_#{id}"
+          "survey_question_#{question.to_param}"
         end
 
-        def tabs_id_for_question_answer_option(answer_option, idx)
-          id = answer_option.persisted? ? "#{answer_option.question.id}-#{idx}" : "id"
-
-          "survey_question_answer_option_#{id}"
+        def tabs_id_for_question_answer_option(question, answer_option)
+          "survey_question_#{question.to_param}_answer_option_#{answer_option.to_param}"
         end
       end
     end

--- a/decidim-surveys/app/helpers/decidim/surveys/admin/application_helper.rb
+++ b/decidim-surveys/app/helpers/decidim/surveys/admin/application_helper.rb
@@ -9,13 +9,13 @@ module Decidim
         def tabs_id_for_question(question)
           id = question.persisted? ? question.id : "id"
 
-          "survey-question-#{id}"
+          "survey_question_#{id}"
         end
 
         def tabs_id_for_question_answer_option(answer_option, idx)
           id = answer_option.persisted? ? "#{answer_option.question.id}-#{idx}" : "id"
 
-          "survey-question-answer-option-#{id}"
+          "survey_question_answer_option_#{id}"
         end
       end
     end

--- a/decidim-surveys/app/models/decidim/surveys/survey_question.rb
+++ b/decidim-surveys/app/models/decidim/surveys/survey_question.rb
@@ -9,12 +9,6 @@ module Decidim
       belongs_to :survey, class_name: "Survey", foreign_key: "decidim_survey_id"
 
       validates :question_type, inclusion: { in: TYPES }
-
-      # Rectify can't handle a hash when using the from_model method so
-      # the answer options must be converted to struct.
-      def answer_options
-        self[:answer_options].map { |option| OpenStruct.new(option) }
-      end
     end
   end
 end

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
@@ -13,12 +13,10 @@
   <div class="card-section">
     <div class="row column">
       <%=
-        translated_field_tag(
-          :text_field_tag,
-          "survey[questions][][options][]",
-          "body",
-          answer_option.body.with_indifferent_access,
-          tabs_id: tabs_id_for_question_answer_option(answer_option, idx),
+        form.translated(
+          :text_field,
+          :body,
+          tabs_id: tabs_id_for_question_answer_option(question, answer_option),
           label: t(".statement"),
           disabled: !survey.questions_editable?,
           enable_tabs: answer_option.persisted?

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
@@ -15,7 +15,7 @@
       <%=
         translated_field_tag(
           :text_field_tag,
-          "survey[questions][][answer_options][]",
+          "survey[questions][][options][]",
           "body",
           answer_option.body.with_indifferent_access,
           tabs_id: tabs_id_for_question_answer_option(answer_option, idx),

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
@@ -23,7 +23,9 @@
 <div class="survey-questions">
   <% if survey.questions_editable? %>
     <template>
-      <%= render "question", question: blank_question, id: tabs_id_for_question(blank_question) %>
+      <%= fields_for "survey[questions][#{blank_question.to_param}]", blank_question do |question_form| %>
+        <%= render "question", question: blank_question, form: question_form, id: tabs_id_for_question(blank_question) %>
+      <% end %>
     </template>
   <% else %>
     <div class="callout warning">
@@ -33,7 +35,9 @@
 
   <div class="survey-questions-list">
     <% @form.questions.each do |question| %>
-      <%= render "question", question: question, id: tabs_id_for_question(question) %>
+      <%= fields_for "survey[questions][]", question do |question_form| %>
+        <%= render "question", question: question, form: question_form, id: tabs_id_for_question(question) %>
+      <% end %>
     <% end %>
   </div>
 

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
@@ -22,12 +22,8 @@
 
 <div class="survey-questions">
   <% if survey.questions_editable? %>
-    <template id="survey-question-tmpl">
+    <template>
       <%= render "question", question: blank_question, id: tabs_id_for_question(blank_question) %>
-    </template>
-
-    <template id="survey-question-answer-option-tmpl">
-      <%= render "answer_option", answer_option: blank_answer_option, idx: nil %>
     </template>
   <% else %>
     <div class="callout warning">

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
@@ -73,7 +73,7 @@
       </template>
 
       <div class="survey-question-answer-options-list">
-        <% question.answer_options.each_with_index do |answer_option, idx| %>
+        <% question.options.each_with_index do |answer_option, idx| %>
           <%= render "answer_option", answer_option: answer_option, idx: idx %>
         <% end %>
       </div>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
@@ -48,16 +48,16 @@
           "survey[questions][][mandatory]",
           "1",
           question.mandatory,
-          id: "#{id}-mandatory",
+          id: "#{id}_mandatory",
           disabled: !survey.questions_editable?
         )
       %>
-      <%= label_tag "", t("activemodel.attributes.survey_question.mandatory"), for: "#{id}-mandatory" %>
+      <%= label_tag "", t("activemodel.attributes.survey_question.mandatory"), for: "#{id}_mandatory" %>
     </div>
 
     <div class="row column">
-      <%= label_tag "", t("activemodel.attributes.survey_question.question_type"), for: "#{id}-question_type" %>
-      <%= select_tag "survey[questions][][question_type]", options_from_collection_for_select(question_types, :first, :last, question.question_type), id: "#{id}-question_type", disabled: !survey.questions_editable? %>
+      <%= label_tag "", t("activemodel.attributes.survey_question.question_type"), for: "#{id}_question_type" %>
+      <%= select_tag "survey[questions][][question_type]", options_from_collection_for_select(question_types, :first, :last, question.question_type), id: "#{id}_question_type", disabled: !survey.questions_editable? %>
     </div>
 
     <% if question.persisted? %>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
@@ -28,12 +28,9 @@
   <div class="card-section">
     <div class="row column">
       <%=
-        translated_field_tag(
-          :text_field_tag,
-          "survey[questions][]",
-          "body",
-          question.body.with_indifferent_access,
-          object: question,
+        form.translated(
+          :text_field,
+          :body,
           tabs_id: id,
           label: t(".statement"),
           disabled: !survey.questions_editable?,
@@ -44,37 +41,43 @@
 
     <div class="row column">
       <%=
-        check_box_tag(
-          "survey[questions][][mandatory]",
-          "1",
-          question.mandatory,
-          id: "#{id}_mandatory",
-          disabled: !survey.questions_editable?
+        form.check_box(
+          :mandatory,
+          disabled: !survey.questions_editable?,
+          label: t("activemodel.attributes.survey_question.mandatory")
         )
       %>
-      <%= label_tag "", t("activemodel.attributes.survey_question.mandatory"), for: "#{id}_mandatory" %>
     </div>
 
     <div class="row column">
-      <%= label_tag "", t("activemodel.attributes.survey_question.question_type"), for: "#{id}_question_type" %>
-      <%= select_tag "survey[questions][][question_type]", options_from_collection_for_select(question_types, :first, :last, question.question_type), id: "#{id}_question_type", disabled: !survey.questions_editable? %>
+      <%=
+        form.select(
+          :question_type,
+          options_from_collection_for_select(question_types, :first, :last, question.question_type),
+          disabled: !survey.questions_editable?
+        )
+      %>
     </div>
 
     <% if question.persisted? %>
-      <%= hidden_field_tag "survey[questions][][id]", question.id, disabled: !survey.questions_editable? %>
+      <%= form.hidden_field :id, disabled: !survey.questions_editable? %>
     <% end %>
 
-    <%= hidden_field_tag "survey[questions][][position]", question.position || 0, disabled: !survey.questions_editable? %>
-    <%= hidden_field_tag "survey[questions][][deleted]", false, disabled: !survey.questions_editable? %>
+    <%= form.hidden_field :position, value: question.position || 0, disabled: !survey.questions_editable? %>
+    <%= form.hidden_field :deleted, value: false, disabled: !survey.questions_editable? %>
 
     <div class="survey-question-answer-options">
       <template>
-        <%= render "answer_option", answer_option: blank_answer_option, idx: nil %>
+        <%= fields_for "survey[questions][#{question.to_param}][options][]", blank_answer_option do |answer_option_form| %>
+          <%= render "answer_option", answer_option: blank_answer_option, form: answer_option_form, question: question %>
+        <% end %>
       </template>
 
       <div class="survey-question-answer-options-list">
-        <% question.options.each_with_index do |answer_option, idx| %>
-          <%= render "answer_option", answer_option: answer_option, idx: idx %>
+        <% question.options.each do |answer_option| %>
+          <%= fields_for "survey[questions][#{question.to_param}][options][]", answer_option do |answer_option_form| %>
+            <%= render "answer_option", answer_option: answer_option, form: answer_option_form, question: question %>
+          <% end %>
         <% end %>
       </div>
 

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
@@ -68,6 +68,10 @@
     <%= hidden_field_tag "survey[questions][][deleted]", false, disabled: !survey.questions_editable? %>
 
     <div class="survey-question-answer-options">
+      <template>
+        <%= render "answer_option", answer_option: blank_answer_option, idx: nil %>
+      </template>
+
       <div class="survey-question-answer-options-list">
         <% question.answer_options.each_with_index do |answer_option, idx| %>
           <%= render "answer_option", answer_option: answer_option, idx: idx %>

--- a/decidim-surveys/spec/commands/decidim/surveys/admin/update_survey_spec.rb
+++ b/decidim-surveys/spec/commands/decidim/surveys/admin/update_survey_spec.rb
@@ -37,7 +37,7 @@ module Decidim
                 },
                 "position" => "0",
                 "question_type" => "short_answer",
-                "options" => []
+                "options" => {}
               },
               {
                 "body" => {
@@ -48,7 +48,7 @@ module Decidim
                 "position" => "1",
                 "mandatory" => "1",
                 "question_type" => "long_answer",
-                "options" => []
+                "options" => {}
               },
               {
                 "body" => {
@@ -58,22 +58,22 @@ module Decidim
                 },
                 "position" => "2",
                 "question_type" => "single_option",
-                "options" => [
-                  {
+                "options" => {
+                  0 => {
                     "body" => {
                       "en" => "First answer",
                       "ca" => "Primera resposta",
                       "es" => "Primera respuesta"
                     }
                   },
-                  {
+                  1 => {
                     "body" => {
                       "en" => "Second answer",
                       "ca" => "Segona resposta",
                       "es" => "Segunda respuesta"
                     }
                   }
-                ]
+                }
               }
             ],
             "published_at" => published_at

--- a/decidim-surveys/spec/commands/decidim/surveys/admin/update_survey_spec.rb
+++ b/decidim-surveys/spec/commands/decidim/surveys/admin/update_survey_spec.rb
@@ -37,7 +37,7 @@ module Decidim
                 },
                 "position" => "0",
                 "question_type" => "short_answer",
-                "answer_options" => []
+                "options" => []
               },
               {
                 "body" => {
@@ -48,7 +48,7 @@ module Decidim
                 "position" => "1",
                 "mandatory" => "1",
                 "question_type" => "long_answer",
-                "answer_options" => []
+                "options" => []
               },
               {
                 "body" => {
@@ -58,7 +58,7 @@ module Decidim
                 },
                 "position" => "2",
                 "question_type" => "single_option",
-                "answer_options" => [
+                "options" => [
                   {
                     "body" => {
                       "en" => "First answer",
@@ -121,7 +121,7 @@ module Decidim
 
             expect(survey.questions[1]).to be_mandatory
             expect(survey.questions[1].question_type).to eq("long_answer")
-            expect(survey.questions[2].answer_options[1]["body"]["en"]).to eq(form_params["questions"][2]["answer_options"][1]["body"]["en"])
+            expect(survey.questions[2].answer_options[1]["body"]["en"]).to eq(form_params["questions"][2]["options"][1]["body"]["en"])
           end
         end
 

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -56,7 +56,7 @@ shared_examples "edit surveys" do
           questions_body[idx].each do |locale, value|
             within survey_question do
               click_link I18n.with_locale(locale) { t("name", scope: "locale") }
-              fill_in "survey[questions][][body_#{locale}]", with: value
+              fill_in find_nested_form_field_locator("body_#{locale}"), with: value
             end
           end
         end
@@ -102,7 +102,7 @@ shared_examples "edit surveys" do
         within ".survey-question" do
           question_body.each do |locale, value|
             click_link I18n.with_locale(locale) { t("name", scope: "locale") }
-            fill_in "survey[questions][][body_#{locale}]", with: value
+            fill_in find_nested_form_field_locator("body_#{locale}"), with: value
           end
         end
 
@@ -118,7 +118,7 @@ shared_examples "edit surveys" do
           answer_options_body[idx].each do |locale, value|
             within survey_question_answer_option do
               click_link I18n.with_locale(locale) { t("name", scope: "locale") }
-              fill_in "survey[questions][][options][][body_#{locale}]", with: value
+              fill_in find_nested_form_field_locator("body_#{locale}"), with: value
             end
           end
         end
@@ -141,25 +141,25 @@ shared_examples "edit surveys" do
       2.times { click_button "Add answer option" }
 
       within ".survey-question-answer-option:first-of-type" do
-        fill_in "survey[questions][][options][][body_en]", with: "Something"
+        fill_in find_nested_form_field_locator("body_en"), with: "Something"
       end
 
       within ".survey-question-answer-option:last-of-type" do
-        fill_in "survey[questions][][options][][body_en]", with: "Else"
+        fill_in find_nested_form_field_locator("body_en"), with: "Else"
       end
 
       # If JS events for option reordering are incorrectly bound, clicking on
       # the field to gain focus can cause the options to get inverted... :S
       within ".survey-question-answer-option:first-of-type" do
-        find("input[name='survey[questions][][options][][body_en]']").click
+        find_nested_form_field("body_en").click
       end
 
       within ".survey-question-answer-option:first-of-type" do
-        expect(page).to have_field("survey[questions][][options][][body_en]", with: "Something")
+        expect(page).to have_nested_field("body_en", with: "Something")
       end
 
       within ".survey-question-answer-option:last-of-type" do
-        expect(page).to have_field("survey[questions][][options][][body_en]", with: "Else")
+        expect(page).to have_nested_field("body_en", with: "Else")
       end
     end
 
@@ -177,13 +177,13 @@ shared_examples "edit surveys" do
       click_button "Add answer option"
 
       within ".survey-question-answer-option:first-of-type" do
-        fill_in "survey[questions][][options][][body_en]", with: "Something"
+        fill_in find_nested_form_field_locator("body_en"), with: "Something"
       end
 
       click_button "Save"
 
       within ".survey-question-answer-option:first-of-type" do
-        expect(page).to have_field("survey[questions][][options][][body_en]", with: "Something")
+        expect(page).to have_nested_field("body_en", with: "Something")
       end
     end
 
@@ -192,14 +192,14 @@ shared_examples "edit surveys" do
       click_button "Save"
 
       within ".survey-question:first-of-type" do
-        fill_in "survey[questions][][body_en]", with: "Bye"
+        fill_in find_nested_form_field_locator("body_en"), with: "Bye"
         click_link "Català"
 
-        fill_in "survey[questions][][body_ca]", with: "Adeu"
+        fill_in find_nested_form_field_locator("body_ca"), with: "Adeu"
         click_link "English"
 
-        expect(page).to have_field("survey[questions][][body_en]", with: "Bye")
-        expect(page).to have_no_field("survey[questions][][body_ca]", with: "Adeu")
+        expect(page).to have_nested_field("body_en", with: "Bye")
+        expect(page).to have_no_nested_field("body_ca", with: "Adeu")
       end
     end
 
@@ -215,7 +215,7 @@ shared_examples "edit surveys" do
           expect(page).to have_selector(".survey-question", count: 1)
 
           within ".survey-question" do
-            fill_in "survey_question_#{survey_question.id}_body_en", with: "Modified question"
+            fill_in "survey_questions_#{survey_question.id}_body_en", with: "Modified question"
             check "Mandatory"
             select "Long answer", from: "Type"
           end
@@ -229,16 +229,17 @@ shared_examples "edit surveys" do
 
         expect(page).to have_selector("input[value='Modified question']")
         expect(page).to have_no_selector("input[value='This is the first question']")
-        expect(page).to have_selector("input#survey_question_#{survey_question.id}_mandatory[checked]")
-        expect(page).to have_selector("select#survey_question_#{survey_question.id}_question_type option[value='long_answer'][selected]")
+        expect(page).to have_selector("input#survey_questions_#{survey_question.id}_mandatory[checked]")
+        expect(page).to have_selector("select#survey_questions_#{survey_question.id}_question_type option[value='long_answer'][selected]")
       end
 
-      it "re-renders the form when the information is invalid" do
+      it "re-renders the form when the information is invalid and displays errors" do
         within "form.edit_survey" do
           expect(page).to have_selector(".survey-question", count: 1)
 
           within ".survey-question" do
-            fill_in "survey_question_#{survey_question.id}_body_en", with: ""
+            expect(page).to have_content("Statement*")
+            fill_in "survey_questions_#{survey_question.id}_body_en", with: ""
             check "Mandatory"
             select "Multiple option", from: "Type"
           end
@@ -247,11 +248,12 @@ shared_examples "edit surveys" do
         end
 
         expect(page).to have_admin_callout("There's been errors when saving the survey")
+        expect(page).to have_content("can't be blank")
 
         expect(page).to have_selector("input[value='']")
         expect(page).to have_no_selector("input[value='This is the first question']")
-        expect(page).to have_selector("input#survey_question_#{survey_question.id}_mandatory[checked]")
-        expect(page).to have_selector("select#survey_question_#{survey_question.id}_question_type option[value='multiple_option'][selected]")
+        expect(page).to have_selector("input#survey_questions_#{survey_question.id}_mandatory[checked]")
+        expect(page).to have_selector("select#survey_questions_#{survey_question.id}_question_type option[value='multiple_option'][selected]")
       end
 
       it "removes the question" do
@@ -315,12 +317,12 @@ shared_examples "edit surveys" do
       shared_examples_for "switching questions order" do
         it "properly reorders the questions" do
           within ".survey-question:first-of-type" do
-            expect(page).to have_field("survey[questions][][body_en]", with: "Second")
+            expect(page).to have_nested_field("body_en", with: "Second")
             expect(page).to look_like_first_question
           end
 
           within ".survey-question:last-of-type" do
-            expect(page).to have_field("survey[questions][][body_en]", with: "First")
+            expect(page).to have_nested_field("body_en", with: "First")
             expect(page).to look_like_last_question
           end
         end
@@ -388,5 +390,28 @@ shared_examples "edit surveys" do
       expect(page).to have_no_content("Remove")
       expect(page).to have_selector("input[value='This is the first question'][disabled]")
     end
+  end
+
+  private
+
+  def find_nested_form_field_locator(attribute)
+    find_nested_form_field(attribute)["id"]
+  end
+
+  def find_nested_form_field(attribute)
+    current_scope.find(nested_form_field_selector(attribute))
+  end
+
+  def have_nested_field(attribute, with:)
+    have_field find_nested_form_field_locator(attribute), with: with
+  end
+
+  def have_no_nested_field(attribute, with:)
+    have_no_selector(nested_form_field_selector(attribute)) ||
+      have_no_field(find_nested_form_field_locator(attribute), with: with)
+  end
+
+  def nested_form_field_selector(attribute)
+    "[id$=#{attribute}]"
   end
 end

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -118,7 +118,7 @@ shared_examples "edit surveys" do
           answer_options_body[idx].each do |locale, value|
             within survey_question_answer_option do
               click_link I18n.with_locale(locale) { t("name", scope: "locale") }
-              fill_in "survey[questions][][answer_options][][body_#{locale}]", with: value
+              fill_in "survey[questions][][options][][body_#{locale}]", with: value
             end
           end
         end
@@ -141,24 +141,24 @@ shared_examples "edit surveys" do
       2.times { click_button "Add answer option" }
 
       within ".survey-question-answer-option:first-of-type" do
-        fill_in "survey[questions][][answer_options][][body_en]", with: "Something"
+        fill_in "survey[questions][][options][][body_en]", with: "Something"
       end
 
       within ".survey-question-answer-option:last-of-type" do
-        fill_in "survey[questions][][answer_options][][body_en]", with: "Else"
+        fill_in "survey[questions][][options][][body_en]", with: "Else"
       end
 
       # If JS events for option reordering are incorrectly bound, clicking on
       # the field to gain focus can cause the options to get inverted... :S
       within ".survey-question-answer-option:first-of-type" do
-        find("input[name='survey[questions][][answer_options][][body_en]']").click
+        find("input[name='survey[questions][][options][][body_en]']").click
       end
 
       first_answer_option = page.find(".survey-question-answer-option:first-of-type")
-      expect(first_answer_option).to have_field("survey[questions][][answer_options][][body_en]", with: "Something")
+      expect(first_answer_option).to have_field("survey[questions][][options][][body_en]", with: "Something")
 
       second_answer_option = page.find(".survey-question-answer-option:last-of-type")
-      expect(second_answer_option).to have_field("survey[questions][][answer_options][][body_en]", with: "Else")
+      expect(second_answer_option).to have_field("survey[questions][][options][][body_en]", with: "Else")
     end
 
     it "persists question form across submission failures" do
@@ -175,12 +175,12 @@ shared_examples "edit surveys" do
       click_button "Add answer option"
 
       within ".survey-question-answer-option:first-of-type" do
-        fill_in "survey[questions][][answer_options][][body_en]", with: "Something"
+        fill_in "survey[questions][][options][][body_en]", with: "Something"
       end
 
       click_button "Save"
 
-      expect(page).to have_field("survey[questions][][answer_options][][body_en]", with: "Something")
+      expect(page).to have_field("survey[questions][][options][][body_en]", with: "Something")
     end
 
     it "allows switching translated field tabs after form failures" do

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -154,11 +154,13 @@ shared_examples "edit surveys" do
         find("input[name='survey[questions][][options][][body_en]']").click
       end
 
-      first_answer_option = page.find(".survey-question-answer-option:first-of-type")
-      expect(first_answer_option).to have_field("survey[questions][][options][][body_en]", with: "Something")
+      within ".survey-question-answer-option:first-of-type" do
+        expect(page).to have_field("survey[questions][][options][][body_en]", with: "Something")
+      end
 
-      second_answer_option = page.find(".survey-question-answer-option:last-of-type")
-      expect(second_answer_option).to have_field("survey[questions][][options][][body_en]", with: "Else")
+      within ".survey-question-answer-option:last-of-type" do
+        expect(page).to have_field("survey[questions][][options][][body_en]", with: "Else")
+      end
     end
 
     it "persists question form across submission failures" do
@@ -180,7 +182,9 @@ shared_examples "edit surveys" do
 
       click_button "Save"
 
-      expect(page).to have_field("survey[questions][][options][][body_en]", with: "Something")
+      within ".survey-question-answer-option:first-of-type" do
+        expect(page).to have_field("survey[questions][][options][][body_en]", with: "Something")
+      end
     end
 
     it "allows switching translated field tabs after form failures" do
@@ -193,10 +197,10 @@ shared_examples "edit surveys" do
 
         fill_in "survey[questions][][body_ca]", with: "Adeu"
         click_link "English"
-      end
 
-      expect(page).to have_field("survey[questions][][body_en]", with: "Bye")
-      expect(page).to have_no_field("survey[questions][][body_ca]", with: "Adeu")
+        expect(page).to have_field("survey[questions][][body_en]", with: "Bye")
+        expect(page).to have_no_field("survey[questions][][body_ca]", with: "Adeu")
+      end
     end
 
     describe "when a survey has an existing question" do
@@ -310,15 +314,15 @@ shared_examples "edit surveys" do
 
       shared_examples_for "switching questions order" do
         it "properly reorders the questions" do
-          first_question = page.find(".survey-question:first-of-type")
+          within ".survey-question:first-of-type" do
+            expect(page).to have_field("survey[questions][][body_en]", with: "Second")
+            expect(page).to look_like_first_question
+          end
 
-          expect(first_question).to have_field("survey[questions][][body_en]", with: "Second")
-          expect(first_question).to look_like_first_question
-
-          last_question = page.find(".survey-question:last-of-type")
-
-          expect(last_question).to have_field("survey[questions][][body_en]", with: "First")
-          expect(last_question).to look_like_last_question
+          within ".survey-question:last-of-type" do
+            expect(page).to have_field("survey[questions][][body_en]", with: "First")
+            expect(page).to look_like_last_question
+          end
         end
       end
 

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -215,7 +215,7 @@ shared_examples "edit surveys" do
           expect(page).to have_selector(".survey-question", count: 1)
 
           within ".survey-question" do
-            fill_in "survey-question-#{survey_question.id}_body_en", with: "Modified question"
+            fill_in "survey_question_#{survey_question.id}_body_en", with: "Modified question"
             check "Mandatory"
             select "Long answer", from: "Type"
           end
@@ -229,8 +229,8 @@ shared_examples "edit surveys" do
 
         expect(page).to have_selector("input[value='Modified question']")
         expect(page).to have_no_selector("input[value='This is the first question']")
-        expect(page).to have_selector("input#survey-question-#{survey_question.id}-mandatory[checked]")
-        expect(page).to have_selector("select#survey-question-#{survey_question.id}-question_type option[value='long_answer'][selected]")
+        expect(page).to have_selector("input#survey_question_#{survey_question.id}_mandatory[checked]")
+        expect(page).to have_selector("select#survey_question_#{survey_question.id}_question_type option[value='long_answer'][selected]")
       end
 
       it "re-renders the form when the information is invalid" do
@@ -238,7 +238,7 @@ shared_examples "edit surveys" do
           expect(page).to have_selector(".survey-question", count: 1)
 
           within ".survey-question" do
-            fill_in "survey-question-#{survey_question.id}_body_en", with: ""
+            fill_in "survey_question_#{survey_question.id}_body_en", with: ""
             check "Mandatory"
             select "Multiple option", from: "Type"
           end
@@ -250,8 +250,8 @@ shared_examples "edit surveys" do
 
         expect(page).to have_selector("input[value='']")
         expect(page).to have_no_selector("input[value='This is the first question']")
-        expect(page).to have_selector("input#survey-question-#{survey_question.id}-mandatory[checked]")
-        expect(page).to have_selector("select#survey-question-#{survey_question.id}-question_type option[value='multiple_option'][selected]")
+        expect(page).to have_selector("input#survey_question_#{survey_question.id}_mandatory[checked]")
+        expect(page).to have_selector("select#survey_question_#{survey_question.id}_question_type option[value='multiple_option'][selected]")
       end
 
       it "removes the question" do
@@ -328,7 +328,7 @@ shared_examples "edit surveys" do
 
       context "when moving a question up" do
         before do
-          within "#survey-question-#{survey_question_2.id}-field" do
+          within "#survey_question_#{survey_question_2.id}-field" do
             click_button "Up"
           end
 
@@ -338,7 +338,7 @@ shared_examples "edit surveys" do
 
       context "when moving a question down" do
         before do
-          within "#survey-question-#{survey_question_1.id}-field" do
+          within "#survey_question_#{survey_question_1.id}-field" do
             click_button "Down"
           end
         end
@@ -353,7 +353,7 @@ shared_examples "edit surveys" do
         expect(page.find(".survey-question:nth-child(2)")).to look_like_intermediate_question
         expect(page.find(".survey-question:nth-child(3)")).to look_like_last_question
 
-        within "#survey-question-#{survey_question_1.id}-field" do
+        within "#survey_question_#{survey_question_1.id}-field" do
           click_button "Remove"
         end
 

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -99,8 +99,8 @@ shared_examples "edit surveys" do
 
         expect(page).to have_selector(".survey-question", count: 1)
 
-        question_body.each do |locale, value|
-          within ".survey-question" do
+        within ".survey-question" do
+          question_body.each do |locale, value|
             click_link I18n.with_locale(locale) { t("name", scope: "locale") }
             fill_in "survey[questions][][body_#{locale}]", with: value
           end


### PR DESCRIPTION
#### :tophat: What? Why?

The errors happening on a question form where not being properly displayed making it hard to figure out what was wrong. Now we use proper form builder methods that wrap actual models, so we get proper error messages, required attribute detection and so on.

After this PR, `decidim` form helper methods (to build inputs not associated to models) are no longer used anywhere in the code base. It'd be nice to get rid of them since they are quite complex and almost fully duplicate the logic of their form builder counterparts. However, I guess they can be considered public API and might be used by external plugins, so we might want to deprecate them first or not remove them at all... :man_shrugging:

* [editor_field_tag](https://github.com/decidim/decidim/blob/6457a79c2407ae4537a3eaa02adb0db18fbe37bc/decidim-core/app/helpers/decidim/decidim_form_helper.rb#L27-L52). Introduced in #1342, when `surveys` were first implemented. But it was never used.
* [scopes_picker_field_tag](https://github.com/decidim/decidim/blob/master/decidim-core/app/helpers/decidim/decidim_form_helper.rb#L53-L77). I introduced this one [very recently](#2880) and I'm using it in [decidim-module-votings](https://github.com/podemos-info/decidim-module-votings). I guess I could do something similar to what I did in this PR and stop using it.
* [translated_field_tag](https://github.com/decidim/decidim/blob/6457a79c2407ae4537a3eaa02adb0db18fbe37bc/decidim-core/app/helpers/decidim/decidim_form_helper.rb#L78-L105). This PR removed the only usages on this method.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)

#### Before
![before](https://user-images.githubusercontent.com/2887858/37635367-f48ee91c-2bd9-11e8-9cc4-9308d0d824df.png)

#### After
![after](https://user-images.githubusercontent.com/2887858/37635372-f8c42696-2bd9-11e8-9b41-7ffe8712de9f.png)

