### PR TITLE
Do not force Postgresql user to be admin when enabling trigram extension

### DIFF
--- a/decidim-proposals/db/migrate/20171212102250_enable_pg_extensions.rb
+++ b/decidim-proposals/db/migrate/20171212102250_enable_pg_extensions.rb
@@ -3,11 +3,16 @@
 class EnablePgExtensions < ActiveRecord::Migration[5.1]
   def change
     unless extension_enabled?("pg_trgm")
-      raise <<-MSG.squish
-        Decidim requires the pg_trgm extension to be enabled in your PostgreSQL.
-        You can do so by running `CREATE EXTENSION IF NOT EXISTS "pg_trgm";` on the current DB as a PostgreSQL
-        super user.
-      MSG
+      begin
+        # required so that test suite works in ci env
+        enable_extension "pg_trgm"
+      rescue
+        raise <<-MSG.squish
+          Decidim requires the pg_trgm extension to be enabled in your PostgreSQL.
+          You can do so by running `CREATE EXTENSION IF NOT EXISTS "pg_trgm";` on the current DB as a PostgreSQL
+          super user.
+        MSG
+      end
     end
   end
 end

--- a/decidim-proposals/db/migrate/20171212102250_enable_pg_extensions.rb
+++ b/decidim-proposals/db/migrate/20171212102250_enable_pg_extensions.rb
@@ -2,17 +2,17 @@
 
 class EnablePgExtensions < ActiveRecord::Migration[5.1]
   def change
-    unless extension_enabled?("pg_trgm")
-      begin
-        # required so that test suite works in ci env
-        enable_extension "pg_trgm"
-      rescue
-        raise <<-MSG.squish
-          Decidim requires the pg_trgm extension to be enabled in your PostgreSQL.
-          You can do so by running `CREATE EXTENSION IF NOT EXISTS "pg_trgm";` on the current DB as a PostgreSQL
-          super user.
-        MSG
-      end
+    return unless extension_enabled?("pg_trgm")
+
+    begin
+      # required so that test suite works in ci env
+      enable_extension "pg_trgm"
+    rescue StandardError
+      raise <<-MSG.squish
+        Decidim requires the pg_trgm extension to be enabled in your PostgreSQL.
+        You can do so by running `CREATE EXTENSION IF NOT EXISTS "pg_trgm";` on the current DB as a PostgreSQL
+        super user.
+      MSG
     end
   end
 end

--- a/decidim-proposals/db/migrate/20171212102250_enable_pg_extensions.rb
+++ b/decidim-proposals/db/migrate/20171212102250_enable_pg_extensions.rb
@@ -2,7 +2,7 @@
 
 class EnablePgExtensions < ActiveRecord::Migration[5.1]
   def change
-    return unless extension_enabled?("pg_trgm")
+    return if extension_enabled?("pg_trgm")
 
     begin
       # required so that test suite works in ci env

--- a/decidim-proposals/db/migrate/20171212102250_enable_pg_extensions.rb
+++ b/decidim-proposals/db/migrate/20171212102250_enable_pg_extensions.rb
@@ -2,6 +2,12 @@
 
 class EnablePgExtensions < ActiveRecord::Migration[5.1]
   def change
-    enable_extension "pg_trgm"
+    unless extension_enabled?("pg_trgm")
+      raise <<-MSG.squish
+        Decidim requires the pg_trgm extension to be enabled in your PostgreSQL.
+        You can do so by running `CREATE EXTENSION IF NOT EXISTS "pg_trgm";` on the current DB as a PostgreSQL
+        super user.
+      MSG
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Resolves what is commented in issue #3045 . 

#### :pushpin: Related Issues
- Related to #3045

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [x] Refactor