### PR TITLE
Remove rectify weirdness on surveys

### DIFF
--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -15,7 +15,12 @@ require "foundation-rails"
 require "foundation_rails_helper"
 require "autoprefixer-rails"
 require "active_link_to"
+
+# Until https://github.com/andypike/rectify/pull/45 is attended, we're shipping
+# with a patched version of rectify
 require "rectify"
+require "decidim/rectify_ext"
+
 require "carrierwave"
 require "high_voltage"
 require "rails-i18n"

--- a/decidim-core/lib/decidim/rectify_ext.rb
+++ b/decidim-core/lib/decidim/rectify_ext.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Rectify
+  class FormatAttributesHash
+    private
+
+    def convert_indexed_hashes_to_arrays(attributes_hash)
+      array_attributes.each do |array_attribute|
+        name = array_attribute.name
+        attribute = attributes_hash[name]
+        next unless attribute.is_a?(Hash)
+
+        attributes_hash[name] = transform_values_for_type(
+          attribute.values,
+          array_attribute.member_type.primitive
+        )
+      end
+    end
+
+    def transform_values_for_type(values, element_type)
+      return values unless element_type < Rectify::Form
+
+      values.map do |value|
+        self.class.new(element_type.attribute_set).format(value)
+      end
+    end
+
+    def array_attributes
+      attribute_set.select { |attribute| attribute.primitive == Array }
+    end
+  end
+end

--- a/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
+++ b/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
@@ -38,7 +38,7 @@ module Decidim
               position: form_question.position,
               mandatory: form_question.mandatory,
               question_type: form_question.question_type,
-              answer_options: form_question.options.map { |answer| { "body" => answer.body } }
+              answer_options: form_question.answer_options.map { |answer| { "body" => answer.body } }
             }
 
             if form_question.id.present?

--- a/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_form.rb
@@ -10,7 +10,7 @@ module Decidim
         attribute :position, Integer
         attribute :mandatory, Boolean, default: false
         attribute :question_type, String
-        attribute :options, Array[SurveyQuestionAnswerOptionForm]
+        attribute :answer_options, Array[SurveyQuestionAnswerOptionForm]
         attribute :deleted, Boolean, default: false
 
         translatable_attribute :body, String
@@ -20,7 +20,7 @@ module Decidim
         validates :body, translatable_presence: true, unless: :deleted
 
         def map_model(model)
-          self.options = model.answer_options.each_with_index.map do |option, id|
+          self.answer_options = model.answer_options.each_with_index.map do |option, id|
             SurveyQuestionAnswerOptionForm.new(option.merge(id: id + 1))
           end
         end

--- a/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_form.rb
@@ -21,13 +21,7 @@ module Decidim
 
         def map_model(model)
           self.options = model.answer_options.each_with_index.map do |option, id|
-            [id + 1, option]
-          end
-        end
-
-        def options=(value)
-          @options = value.map do |id, option|
-            SurveyQuestionAnswerOptionForm.new(option.merge(id: id.to_s.to_i))
+            SurveyQuestionAnswerOptionForm.new(option.merge(id: id + 1))
           end
         end
 

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
@@ -68,14 +68,14 @@
 
     <div class="survey-question-answer-options">
       <template>
-        <%= fields_for "survey[questions][#{question.to_param}][options][]", blank_answer_option do |answer_option_form| %>
+        <%= fields_for "survey[questions][#{question.to_param}][answer_options][]", blank_answer_option do |answer_option_form| %>
           <%= render "answer_option", answer_option: blank_answer_option, form: answer_option_form, question: question %>
         <% end %>
       </template>
 
       <div class="survey-question-answer-options-list">
-        <% question.options.each do |answer_option| %>
-          <%= fields_for "survey[questions][#{question.to_param}][options][]", answer_option do |answer_option_form| %>
+        <% question.answer_options.each do |answer_option| %>
+          <%= fields_for "survey[questions][#{question.to_param}][answer_options][]", answer_option do |answer_option_form| %>
             <%= render "answer_option", answer_option: answer_option, form: answer_option_form, question: question %>
           <% end %>
         <% end %>

--- a/decidim-surveys/spec/commands/decidim/surveys/admin/update_survey_spec.rb
+++ b/decidim-surveys/spec/commands/decidim/surveys/admin/update_survey_spec.rb
@@ -28,8 +28,8 @@ module Decidim
               "ca" => "<p>Contingut</p>",
               "es" => "<p>Contenido</p>"
             },
-            "questions" => [
-              {
+            "questions" => {
+              0 => {
                 "body" => {
                   "en" => "First question",
                   "ca" => "Primera pregunta",
@@ -39,7 +39,7 @@ module Decidim
                 "question_type" => "short_answer",
                 "options" => {}
               },
-              {
+              1 => {
                 "body" => {
                   "en" => "Second question",
                   "ca" => "Segona pregunta",
@@ -50,7 +50,7 @@ module Decidim
                 "question_type" => "long_answer",
                 "options" => {}
               },
-              {
+              2 => {
                 "body" => {
                   "en" => "Third question",
                   "ca" => "Tercera pregunta",
@@ -75,13 +75,13 @@ module Decidim
                   }
                 }
               }
-            ],
+            },
             "published_at" => published_at
           }
         end
         let(:form) do
           SurveyForm.from_params(
-            form_params
+            survey: form_params
           ).with_context(
             current_organization: current_organization
           )

--- a/decidim-surveys/spec/commands/decidim/surveys/admin/update_survey_spec.rb
+++ b/decidim-surveys/spec/commands/decidim/surveys/admin/update_survey_spec.rb
@@ -29,7 +29,7 @@ module Decidim
               "es" => "<p>Contenido</p>"
             },
             "questions" => {
-              0 => {
+              "0" => {
                 "body" => {
                   "en" => "First question",
                   "ca" => "Primera pregunta",
@@ -39,7 +39,7 @@ module Decidim
                 "question_type" => "short_answer",
                 "options" => {}
               },
-              1 => {
+              "1" => {
                 "body" => {
                   "en" => "Second question",
                   "ca" => "Segona pregunta",
@@ -50,7 +50,7 @@ module Decidim
                 "question_type" => "long_answer",
                 "options" => {}
               },
-              2 => {
+              "2" => {
                 "body" => {
                   "en" => "Third question",
                   "ca" => "Tercera pregunta",
@@ -59,14 +59,14 @@ module Decidim
                 "position" => "2",
                 "question_type" => "single_option",
                 "options" => {
-                  0 => {
+                  "0" => {
                     "body" => {
                       "en" => "First answer",
                       "ca" => "Primera resposta",
                       "es" => "Primera respuesta"
                     }
                   },
-                  1 => {
+                  "1" => {
                     "body" => {
                       "en" => "Second answer",
                       "ca" => "Segona resposta",
@@ -116,12 +116,12 @@ module Decidim
             expect(survey.questions.length).to eq(3)
 
             survey.questions.each_with_index do |question, idx|
-              expect(question.body["en"]).to eq(form_params["questions"][idx]["body"]["en"])
+              expect(question.body["en"]).to eq(form_params["questions"][idx.to_s]["body"]["en"])
             end
 
             expect(survey.questions[1]).to be_mandatory
             expect(survey.questions[1].question_type).to eq("long_answer")
-            expect(survey.questions[2].answer_options[1]["body"]["en"]).to eq(form_params["questions"][2]["options"][1]["body"]["en"])
+            expect(survey.questions[2].answer_options[1]["body"]["en"]).to eq(form_params["questions"]["2"]["options"]["1"]["body"]["en"])
           end
         end
 

--- a/decidim-surveys/spec/commands/decidim/surveys/admin/update_survey_spec.rb
+++ b/decidim-surveys/spec/commands/decidim/surveys/admin/update_survey_spec.rb
@@ -37,7 +37,7 @@ module Decidim
                 },
                 "position" => "0",
                 "question_type" => "short_answer",
-                "options" => {}
+                "answer_options" => {}
               },
               "1" => {
                 "body" => {
@@ -48,7 +48,7 @@ module Decidim
                 "position" => "1",
                 "mandatory" => "1",
                 "question_type" => "long_answer",
-                "options" => {}
+                "answer_options" => {}
               },
               "2" => {
                 "body" => {
@@ -58,7 +58,7 @@ module Decidim
                 },
                 "position" => "2",
                 "question_type" => "single_option",
-                "options" => {
+                "answer_options" => {
                   "0" => {
                     "body" => {
                       "en" => "First answer",
@@ -121,7 +121,7 @@ module Decidim
 
             expect(survey.questions[1]).to be_mandatory
             expect(survey.questions[1].question_type).to eq("long_answer")
-            expect(survey.questions[2].answer_options[1]["body"]["en"]).to eq(form_params["questions"]["2"]["options"]["1"]["body"]["en"])
+            expect(survey.questions[2].answer_options[1]["body"]["en"]).to eq(form_params["questions"]["2"]["answer_options"]["1"]["body"]["en"])
           end
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Yesterday I almost went crazy figuring out why things were not working for our nested survey forms. I ended up adding two hacks to the answer form model to make it work:
* Override the setter for the answer options.
* Renaming the answer_options attribute to something that doesn't match attributes in the underlying model, so that rectify magic does not get in the middle.

However, these hacks are biting me now since I'm adding more attributes to this form, and I cannot easily unit test them, because the form is now instantiated wierdly.

I digged in a little deeper and it seems like a bug / missing feature in `rectify` to me: it only supports one-level nested forms. I added a fix for it in https://github.com/andypike/rectify/pull/45, but I'm opening this PR monkeypatching it to see how the patch plays against the whole of decidim's test suite.

With this, I can remove both hacks mentioned before.

#### :pushpin: Related Issues
- Related to #3046.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.