### PR TITLE
Make organization reference_prefix required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,5 +40,6 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-surveys**: Fix errored questions rendering answer options as empty fields [\#3014](https://github.com/decidim/decidim/pull/3014)
 - **decidim-surveys**: Fix translated fields of freshly created questions not working after form errors [\#3026](https://github.com/decidim/decidim/pull/3026)
 - **decidim-surveys**: Fix question form errors not being displayed [\#3046](https://github.com/decidim/decidim/pull/3046)
+- **decidim-admin**: Require organization's `reference_prefix` at the form level [\#3056](https://github.com/decidim/decidim/pull/3056)
 
 Please check [0.10-stable](https://github.com/decidim/decidim/blob/0.10-stable/CHANGELOG.md) for previous changes.

--- a/decidim-admin/app/forms/decidim/admin/organization_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_form.rb
@@ -20,7 +20,7 @@ module Decidim
       attribute :default_locale, String
 
       validates :name, presence: true
-      validates :default_locale, presence: true
+      validates :default_locale, :reference_prefix, presence: true
       validates :default_locale, inclusion: { in: :available_locales }
 
       private

--- a/decidim-admin/spec/forms/organization_form_spec.rb
+++ b/decidim-admin/spec/forms/organization_form_spec.rb
@@ -57,6 +57,12 @@ module Decidim
         it { is_expected.to be_invalid }
       end
 
+      context "when reference_prefix is missing" do
+        let(:reference_prefix) { nil }
+
+        it { is_expected.to be_invalid }
+      end
+
       context "when default_locale is not an available locale" do
         let(:default_locale) { :de }
 


### PR DESCRIPTION
#### :tophat: What? Why?
Organization's `reference_prefix` is required at the model level, but it isn't at the form level, so whenever a user tries to set it blank in the form and submit it, the server raises an error.

This PR validates the presence of this field at the form level, so it appears as required and is correctly validated.

#### :pushpin: Related Issues
- Fixes #3054

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/l8JTS60.png)
