### PR TITLE
Prevent autoloading issues with GraphQL interfaces

### DIFF
--- a/decidim-core/app/types/decidim/core/component_type.rb
+++ b/decidim-core/app/types/decidim/core/component_type.rb
@@ -3,7 +3,7 @@
 module Decidim
   module Core
     ComponentType = GraphQL::ObjectType.define do
-      interfaces [ComponentInterface]
+      interfaces [-> { ComponentInterface }]
 
       name "Component"
       description "A base component with no particular specificities."

--- a/decidim-proposals/app/types/decidim/proposals/proposals_type.rb
+++ b/decidim-proposals/app/types/decidim/proposals/proposals_type.rb
@@ -3,7 +3,7 @@
 module Decidim
   module Proposals
     ProposalsType = GraphQL::ObjectType.define do
-      interfaces [Decidim::Core::ComponentInterface]
+      interfaces [-> { Decidim::Core::ComponentInterface }]
 
       name "Proposals"
       description "A proposals component of a participatory space."


### PR DESCRIPTION
#### :tophat: What? Why?

Rails' autoload causes issues with graphql-ruby's current interface.
They suggest using procs as a workaround: https://github.com/rmosolgo/graphql-ruby/issues/935

#### :pushpin: Related Issues
- Related to #3058
- Fixes #3058

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*
