### PR TITLE
Relax etiquette validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,5 +53,6 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-surveys**: Fix translated fields of freshly created questions not working after form errors [\#3026](https://github.com/decidim/decidim/pull/3026)
 - **decidim-surveys**: Fix question form errors not being displayed [\#3046](https://github.com/decidim/decidim/pull/3046)
 - **decidim-admin**: Require organization's `reference_prefix` at the form level [\#3056](https://github.com/decidim/decidim/pull/3056)
+- **decidim-core**: Only require caps on the first line with `EtiquetteValidator` [\#3072](https://github.com/decidim/decidim/pull/3072)
 
 Please check [0.10-stable](https://github.com/decidim/decidim/blob/0.10-stable/CHANGELOG.md) for previous changes.

--- a/decidim-core/app/validators/etiquette_validator.rb
+++ b/decidim-core/app/validators/etiquette_validator.rb
@@ -31,7 +31,7 @@ class EtiquetteValidator < ActiveModel::EachValidator
   end
 
   def validate_caps_first(record, attribute, value)
-    return if value.scan(/^[a-z]{1}/).empty?
+    return if value.scan(/\A[a-z]{1}/).empty?
     record.errors.add(attribute, options[:message] || :must_start_with_caps)
   end
 

--- a/decidim-core/spec/validators/etiquette_validator_spec.rb
+++ b/decidim-core/spec/validators/etiquette_validator_spec.rb
@@ -55,9 +55,17 @@ describe EtiquetteValidator do
   end
 
   context "when the text is written starting in downcase" do
-    let(:body) { "i no care about grammer" }
+    context "with a single line body" do
+      let(:body) { "i no care about grammer" }
 
-    it { is_expected.to be_invalid }
+      it { is_expected.to be_invalid }
+    end
+
+    context "with a multiple line body with the second line starting in downcase" do
+      let(:body) { "This is a multiline body\nwith a line starting with downcase." }
+
+      it { is_expected.to be_valid }
+    end
   end
 
   context "when the body is too short" do


### PR DESCRIPTION
#### :tophat: What? Why?
This relaxes the `start with caps` validation on `EtiquetteValidator` so it only applies to the *first* line of a multi-line body.

**Needs to be backported**.

#### :pushpin: Related Issues
- Related to #3043 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
*None*
