### PR TITLE
Fix duplicated editors in surveys form

### DIFF
--- a/decidim-core/app/assets/javascripts/decidim/editor.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/editor.js.es6
@@ -55,4 +55,5 @@
 
   exports.Decidim = exports.Decidim || {};
   exports.Decidim.quillEditor = quillEditor;
+  exports.Decidim.createQuillEditor = createQuillEditor;
 })(window);

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
@@ -4,7 +4,7 @@
 
 ((exports) => {
   const { AutoLabelByPositionComponent, AutoButtonsByPositionComponent, createDynamicFields, createSortList } = exports.DecidimAdmin;
-  const { quillEditor } = exports.Decidim;
+  const { createQuillEditor } = exports.Decidim;
 
   const wrapperSelector = '.survey-questions';
   const fieldSelector = '.survey-question';
@@ -69,7 +69,11 @@
       const fieldId = $field.attr('id');
 
       createSortableList();
-      quillEditor();
+
+      $field.find(".editor-container").each((idx, el) => {
+        createQuillEditor(el);
+      });
+
       autoLabelByPosition.run();
       autoButtonsByPosition.run();
       createDynamicFieldsForAnswerOptions(fieldId);

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -357,6 +357,10 @@ shared_examples "edit surveys" do
         expect(page.all(".survey-question").last).to look_like_last_question
       end
 
+      it "does not duplicate editors when adding new questions" do
+        expect { click_button "Add question" }.to change { page.all(".ql-toolbar").size }.by(1)
+      end
+
       private
 
       def look_like_first_question


### PR DESCRIPTION
#### :tophat: What? Why?

This fixes a bug I introduced yesterday with #3066 where every time you would click on "Add question", a new editor toolbar would be generated for every editor field in the page... :grimacing:.
 
#### :pushpin: Related Issues
- Related to #3066.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.