### PR TITLE
Better survey validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,5 +54,7 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-surveys**: Fix question form errors not being displayed [\#3046](https://github.com/decidim/decidim/pull/3046)
 - **decidim-admin**: Require organization's `reference_prefix` at the form level [\#3056](https://github.com/decidim/decidim/pull/3056)
 - **decidim-core**: Only require caps on the first line with `EtiquetteValidator` [\#3072](https://github.com/decidim/decidim/pull/3072)
+- **decidim-surveys**: Multiple choice questions without answer options can no longer be created [\#3087](https://github.com/decidim/decidim/pull/3087)
+- **decidim-surveys**: Multiple choice questions with empty answer options can no longer be created [\#3087](https://github.com/decidim/decidim/pull/3087)
 
 Please check [0.10-stable](https://github.com/decidim/decidim/blob/0.10-stable/CHANGELOG.md) for previous changes.

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/auto_buttons_by_min_items.component.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/auto_buttons_by_min_items.component.js.es6
@@ -1,0 +1,25 @@
+((exports) => {
+  class AutoButtonsByMinItemsComponent {
+    constructor(options = {}) {
+      this.listSelector = options.listSelector;
+      this.minItems = options.minItems;
+      this.hideOnMinItemsOrLessSelector = options.hideOnMinItemsOrLessSelector;
+
+      this.run();
+    }
+
+    run() {
+      const $list = $(this.listSelector);
+      const $items = $list.find(this.hideOnMinItemsOrLessSelector);
+
+      if ($list.length <= this.minItems) {
+        $items.hide();
+      } else {
+        $items.show();
+      }
+    }
+  }
+
+  exports.DecidimAdmin = exports.DecidimAdmin || {};
+  exports.DecidimAdmin.AutoButtonsByMinItemsComponent = AutoButtonsByMinItemsComponent;
+})(window);

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/auto_buttons_by_position.component.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/auto_buttons_by_position.component.js.es6
@@ -13,24 +13,27 @@
       const hideOnFirst = this.hideOnFirstSelector;
       const hideOnLast = this.hideOnLastSelector;
 
-      $list.each((idx, el) => {
-        if ($list.length === 1) {
-          $(el).find(hideOnFirst).hide();
-          $(el).find(hideOnLast).hide();
-        }
-        else if (el.id === $list.first().attr('id')) {
-          $(el).find(hideOnFirst).hide();
-          $(el).find(hideOnLast).show();
-        }
-        else if (el.id === $list.last().attr('id')) {
-          $(el).find(hideOnLast).hide();
-          $(el).find(hideOnFirst).show();
-        }
-        else {
-          $(el).find(hideOnLast).show();
-          $(el).find(hideOnFirst).show();
-        }
-      });
+      if ($list.length === 1) {
+        const $item = $list.first();
+
+        $item.find(hideOnFirst).hide();
+        $item.find(hideOnLast).hide();
+      } else {
+        $list.each((idx, el) => {
+          if (el.id === $list.first().attr('id')) {
+            $(el).find(hideOnFirst).hide();
+            $(el).find(hideOnLast).show();
+          }
+          else if (el.id === $list.last().attr('id')) {
+            $(el).find(hideOnLast).hide();
+            $(el).find(hideOnFirst).show();
+          }
+          else {
+            $(el).find(hideOnLast).show();
+            $(el).find(hideOnFirst).show();
+          }
+        });
+      }
     }
   }
 

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
@@ -68,10 +68,10 @@
     const $answerOptionsWrapper = $target.parents(fieldSelector).find(answerOptionsWrapperSelector);
     const value = $target.val();
 
-    $answerOptionsWrapper.hide();
-
     if (value === 'single_option' || value === 'multiple_option') {
       $answerOptionsWrapper.show();
+    } else {
+      $answerOptionsWrapper.hide();
     }
   };
 

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
@@ -64,6 +64,8 @@
     });
   };
 
+  const dynamicFieldsForAnswerOptions = {};
+
   const setAnswerOptionsWrapperVisibility = ($target) => {
     const $answerOptionsWrapper = $target.parents(fieldSelector).find(answerOptionsWrapperSelector);
     const value = $target.val();
@@ -81,7 +83,10 @@
   const setupInitialQuestionAttributes = ($target) => {
     const fieldId = $target.attr('id');
     const $fieldQuestionTypeSelect = $target.find(questionTypeSelector);
-    const dynamicFields = createDynamicFieldsForAnswerOptions(fieldId);
+
+    dynamicFieldsForAnswerOptions[fieldId] = createDynamicFieldsForAnswerOptions(fieldId);
+
+    const dynamicFields = dynamicFieldsForAnswerOptions[fieldId];
 
     const onQuestionTypeChange = () => {
       const value = $fieldQuestionTypeSelect.val();
@@ -123,9 +128,13 @@
       autoLabelByPosition.run();
       autoButtonsByPosition.run();
     },
-    onRemoveField: () => {
+    onRemoveField: ($field) => {
       autoLabelByPosition.run();
       autoButtonsByPosition.run();
+
+      $field.find(answerOptionRemoveFieldButtonSelector).each((idx, el) => {
+        dynamicFieldsForAnswerOptions[$field.attr("id")]._removeField(el);
+      });
     },
     onMoveUpField: () => {
       autoLabelByPosition.run();

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
@@ -1,9 +1,10 @@
 // = require ./auto_label_by_position.component
 // = require ./auto_buttons_by_position.component
+// = require ./auto_buttons_by_min_items.component
 // = require ./dynamic_fields.component
 
 ((exports) => {
-  const { AutoLabelByPositionComponent, AutoButtonsByPositionComponent, createDynamicFields, createSortList } = exports.DecidimAdmin;
+  const { AutoLabelByPositionComponent, AutoButtonsByPositionComponent, AutoButtonsByMinItemsComponent, createDynamicFields, createSortList } = exports.DecidimAdmin;
   const { createQuillEditor } = exports.Decidim;
 
   const wrapperSelector = '.survey-questions';
@@ -11,6 +12,7 @@
   const questionTypeSelector = 'select[name$=\\[question_type\\]]';
   const answerOptionFieldSelector = '.survey-question-answer-option';
   const answerOptionsWrapperSelector = '.survey-question-answer-options';
+  const answerOptionRemoveFieldButtonSelector = `.remove-answer-option`;
 
   const autoLabelByPosition = new AutoLabelByPositionComponent({
     listSelector: '.survey-question:not(.hidden)',
@@ -26,6 +28,14 @@
     hideOnLastSelector: '.move-down-question'
   });
 
+  const createAutoButtonsByMinItemsForAnswerOptions = (fieldId) => {
+    return new AutoButtonsByMinItemsComponent({
+      listSelector: `#${fieldId} ${answerOptionsWrapperSelector} .survey-question-answer-option:not(.hidden)`,
+      minItems: 2,
+      hideOnMinItemsOrLessSelector: answerOptionRemoveFieldButtonSelector
+    })
+  };
+
   const createSortableList = () => {
     createSortList('.survey-questions-list:not(.published)', {
       handle: '.question-divider',
@@ -36,13 +46,21 @@
   };
 
   const createDynamicFieldsForAnswerOptions = (fieldId) => {
+    const autoButtons = createAutoButtonsByMinItemsForAnswerOptions(fieldId);
+
     return createDynamicFields({
       placeholderId: `survey-question-answer-option-id`,
       wrapperSelector: `#${fieldId} ${answerOptionsWrapperSelector}`,
       containerSelector: `.survey-question-answer-options-list`,
       fieldSelector: answerOptionFieldSelector,
       addFieldButtonSelector: `.add-answer-option`,
-      removeFieldButtonSelector: `.remove-answer-option`
+      removeFieldButtonSelector: answerOptionRemoveFieldButtonSelector,
+      onAddField: () => {
+        autoButtons.run();
+      },
+      onRemoveField: () => {
+        autoButtons.run();
+      }
     });
   };
 

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
@@ -67,10 +67,13 @@
   const setAnswerOptionsWrapperVisibility = ($target) => {
     const $answerOptionsWrapper = $target.parents(fieldSelector).find(answerOptionsWrapperSelector);
     const value = $target.val();
+    const $answerOptionsInputs = $answerOptionsWrapper.find(`${answerOptionFieldSelector} input`);
 
     if (value === 'single_option' || value === 'multiple_option') {
+      $answerOptionsInputs.prop('disabled', false);
       $answerOptionsWrapper.show();
     } else {
+      $answerOptionsInputs.prop('disabled', true);
       $answerOptionsWrapper.hide();
     }
   };

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
@@ -56,6 +56,21 @@
     }
   };
 
+  const setupInitialQuestionAttributes = ($target) => {
+    const fieldId = $target.attr('id');
+    const $fieldQuestionTypeSelect = $target.find(questionTypeSelector);
+
+    createDynamicFieldsForAnswerOptions(fieldId);
+
+    const onQuestionTypeChange = () => {
+      setAnswerOptionsWrapperVisibility($fieldQuestionTypeSelect);
+    };
+
+    $fieldQuestionTypeSelect.on('change', onQuestionTypeChange);
+
+    onQuestionTypeChange();
+  }
+
   createDynamicFields({
     placeholderId: 'survey-question-id',
     wrapperSelector: wrapperSelector,
@@ -66,8 +81,7 @@
     moveUpFieldButtonSelector: '.move-up-question',
     moveDownFieldButtonSelector: '.move-down-question',
     onAddField: ($field) => {
-      const fieldId = $field.attr('id');
-
+      setupInitialQuestionAttributes($field);
       createSortableList();
 
       $field.find(".editor-container").each((idx, el) => {
@@ -76,8 +90,6 @@
 
       autoLabelByPosition.run();
       autoButtonsByPosition.run();
-      createDynamicFieldsForAnswerOptions(fieldId);
-      setAnswerOptionsWrapperVisibility($field.find(questionTypeSelector));
     },
     onRemoveField: () => {
       autoLabelByPosition.run();
@@ -96,12 +108,8 @@
   createSortableList();
 
   $(fieldSelector).each((idx, el) => {
-    createDynamicFieldsForAnswerOptions($(el).attr('id'));
-    setAnswerOptionsWrapperVisibility($(el).find(questionTypeSelector));
-  });
+    const $target = $(el);
 
-  $(wrapperSelector).on('change', questionTypeSelector, (ev) => {
-    const $target = $(ev.target);
-    setAnswerOptionsWrapperVisibility($target);
+    setupInitialQuestionAttributes($target);
   });
 })(window);

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
@@ -9,6 +9,7 @@
   const wrapperSelector = '.survey-questions';
   const fieldSelector = '.survey-question';
   const questionTypeSelector = 'select[name$=\\[question_type\\]]';
+  const answerOptionFieldSelector = '.survey-question-answer-option';
   const answerOptionsWrapperSelector = '.survey-question-answer-options';
 
   const autoLabelByPosition = new AutoLabelByPositionComponent({
@@ -35,11 +36,11 @@
   };
 
   const createDynamicFieldsForAnswerOptions = (fieldId) => {
-    createDynamicFields({
+    return createDynamicFields({
       placeholderId: `survey-question-answer-option-id`,
       wrapperSelector: `#${fieldId} ${answerOptionsWrapperSelector}`,
       containerSelector: `.survey-question-answer-options-list`,
-      fieldSelector: `.survey-question-answer-option`,
+      fieldSelector: answerOptionFieldSelector,
       addFieldButtonSelector: `.add-answer-option`,
       removeFieldButtonSelector: `.remove-answer-option`
     });
@@ -59,10 +60,20 @@
   const setupInitialQuestionAttributes = ($target) => {
     const fieldId = $target.attr('id');
     const $fieldQuestionTypeSelect = $target.find(questionTypeSelector);
-
-    createDynamicFieldsForAnswerOptions(fieldId);
+    const dynamicFields = createDynamicFieldsForAnswerOptions(fieldId);
 
     const onQuestionTypeChange = () => {
+      const value = $fieldQuestionTypeSelect.val();
+
+      if (value === 'single_option' || value === 'multiple_option') {
+        const nOptions = $fieldQuestionTypeSelect.parents(fieldSelector).find(answerOptionFieldSelector).length;
+
+        if (nOptions === 0) {
+          dynamicFields._addField();
+          dynamicFields._addField();
+        }
+      }
+
       setAnswerOptionsWrapperVisibility($fieldQuestionTypeSelect);
     };
 

--- a/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
+++ b/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
@@ -39,7 +39,7 @@ module Decidim
               position: form_question.position,
               mandatory: form_question.mandatory,
               question_type: form_question.question_type,
-              answer_options: form_question.answer_options.map { |answer| { "body" => answer.body } }
+              answer_options: form_question.answer_options_to_persist.map { |answer| { "body" => answer.body } }
             }
 
             if form_question.id.present?

--- a/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_answer_option_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_answer_option_form.rb
@@ -7,9 +7,11 @@ module Decidim
       class SurveyQuestionAnswerOptionForm < Decidim::Form
         include TranslatableAttributes
 
+        attribute :deleted, Boolean
+
         translatable_attribute :body, String
 
-        validates :body, translatable_presence: true
+        validates :body, translatable_presence: true, unless: :deleted
 
         def to_param
           id || "survey-question-answer-option-id"

--- a/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_answer_option_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_answer_option_form.rb
@@ -9,6 +9,8 @@ module Decidim
 
         translatable_attribute :body, String
 
+        validates :body, translatable_presence: true
+
         def to_param
           id || "survey-question-answer-option-id"
         end

--- a/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_form.rb
@@ -26,6 +26,10 @@ module Decidim
           end
         end
 
+        def answer_options_to_persist
+          answer_options.reject(&:deleted)
+        end
+
         def to_param
           id || "survey-question-id"
         end

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
@@ -23,4 +23,10 @@
       %>
     </div>
   </div>
+
+  <% if answer_option.persisted? %>
+    <%= form.hidden_field :id, disabled: !survey.questions_editable? %>
+  <% end %>
+
+  <%= form.hidden_field :deleted, value: false, disabled: !survey.questions_editable? %>
 </div>

--- a/decidim-surveys/spec/forms/decidim/surveys/admin/survey_question_answer_option_form_spec.rb
+++ b/decidim-surveys/spec/forms/decidim/surveys/admin/survey_question_answer_option_form_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Surveys
+    module Admin
+      describe SurveyQuestionAnswerOptionForm do
+        subject do
+          described_class.from_params(
+            survey_question_answer_option: attributes
+          ).with_context(current_organization: organization)
+        end
+
+        let(:organization) { create :organization }
+
+        let(:attributes) do
+          {
+            body_en: "Body en",
+            body_ca: "Body ca",
+            body_es: "Body es"
+          }
+        end
+
+        context "when everything is OK" do
+          it { is_expected.to be_valid }
+        end
+
+        context "when the main body is not present" do
+          before { attributes[:body_en] = "" }
+
+          it { is_expected.not_to be_valid }
+        end
+      end
+    end
+  end
+end

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -231,7 +231,7 @@ shared_examples "edit surveys" do
       end
     end
 
-    describe "when a survey has an existing question" do
+    context "when a survey has an existing question" do
       let!(:survey_question) { create(:survey_question, survey: survey, body: body) }
 
       before do

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -321,6 +321,39 @@ shared_examples "edit surveys" do
       end
     end
 
+    context "when a survey has an existing question with answer options" do
+      let!(:survey_question) do
+        create(
+          :survey_question,
+          survey: survey,
+          body: body,
+          question_type: "single_option",
+          answer_options: [
+            { "body" => { "en" => "cacarua" } },
+            { "body" => { "en" => "cat" } },
+            { "body" => { "en" => "dog" } }
+
+          ]
+        )
+      end
+
+      before do
+        visit_component_admin
+      end
+
+      it "allows deleting answer options" do
+        within ".survey-question-answer-option:last-of-type" do
+          click_button "Remove"
+        end
+
+        click_button "Save"
+
+        visit_component_admin
+
+        expect(page).to have_selector(".survey-question-answer-option", count: 2)
+      end
+    end
+
     context "when a survey has multiple existing questions" do
       let!(:survey_question_1) do
         create(:survey_question, survey: survey, body: first_body, position: 0)

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -352,6 +352,30 @@ shared_examples "edit surveys" do
 
         expect(page).to have_selector(".survey-question-answer-option", count: 2)
       end
+
+      it "still removes the question even if previous editions rendered the options invalid" do
+        within "form.edit_survey" do
+          expect(page).to have_selector(".survey-question", count: 1)
+
+          within ".survey-question-answer-option:first-of-type" do
+            fill_in find_nested_form_field_locator("body_en"), with: ""
+          end
+
+          within ".survey-question" do
+            click_button "Remove", match: :first
+          end
+
+          click_button "Save"
+        end
+
+        expect(page).to have_admin_callout("successfully")
+
+        visit_component_admin
+
+        within "form.edit_survey" do
+          expect(page).to have_selector(".survey-question", count: 0)
+        end
+      end
     end
 
     context "when a survey has multiple existing questions" do

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -180,6 +180,25 @@ shared_examples "edit surveys" do
       expect(page).to have_select("Type", selected: "Long answer")
     end
 
+    it "does not persist spurious answer options from previous type selections" do
+      click_button "Add question"
+      select "Single option", from: "Type"
+
+      within ".survey-question-answer-option:first-of-type" do
+        fill_in find_nested_form_field_locator("body_en"), with: "Something"
+      end
+
+      select "Long answer", from: "Type"
+
+      click_button "Save"
+
+      select "Single option", from: "Type"
+
+      within ".survey-question-answer-option:first-of-type" do
+        expect(page).to have_no_nested_field("body_en", with: "Something")
+      end
+    end
+
     it "persists answer options form across submission failures" do
       click_button "Add question"
       select "Single option", from: "Type"
@@ -207,7 +226,8 @@ shared_examples "edit surveys" do
         click_link "English", match: :first
 
         expect(page).to have_nested_field("body_en", with: "Bye")
-        expect(page).to have_no_nested_field("body_ca", with: "Adeu")
+        expect(page).to have_no_selector(nested_form_field_selector("body_ca"))
+        expect(page).to have_no_content("Adeu")
       end
     end
 
@@ -451,8 +471,7 @@ shared_examples "edit surveys" do
   end
 
   def have_no_nested_field(attribute, with:)
-    have_no_selector(nested_form_field_selector(attribute)) ||
-      have_no_field(find_nested_form_field_locator(attribute), with: with)
+    have_no_field(find_nested_form_field_locator(attribute), with: with)
   end
 
   def nested_form_field_selector(attribute)

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -107,10 +107,6 @@ shared_examples "edit surveys" do
 
         select "Single option", from: "Type"
 
-        expect(page).to have_content "Add answer option"
-
-        2.times { click_button "Add answer option" }
-
         page.all(".survey-question-answer-option").each_with_index do |survey_question_answer_option, idx|
           within survey_question_answer_option do
             fill_in find_nested_form_field_locator("body_en"), with: answer_options_body[idx]
@@ -127,6 +123,25 @@ shared_examples "edit surveys" do
       expect(page).to have_selector("input[value='This is the first question']")
       expect(page).to have_selector("input[value='This is the first option']")
       expect(page).to have_selector("input[value='This is the second option']")
+    end
+
+    it "adds a sane number of options for each attribute type" do
+      click_button "Add question"
+
+      select "Long answer", from: "Type"
+      expect(page).to have_no_selector(".survey-question-answer-option")
+
+      select "Single option", from: "Type"
+      expect(page).to have_selector(".survey-question-answer-option", count: 2)
+
+      select "Multiple option", from: "Type"
+      expect(page).to have_selector(".survey-question-answer-option", count: 2)
+
+      select "Single option", from: "Type"
+      expect(page).to have_selector(".survey-question-answer-option", count: 2)
+
+      select "Short answer", from: "Type"
+      expect(page).to have_no_selector(".survey-question-answer-option")
     end
 
     it "does not incorrectly reorder when clicking answer options" do
@@ -168,7 +183,6 @@ shared_examples "edit surveys" do
     it "persists answer options form across submission failures" do
       click_button "Add question"
       select "Single option", from: "Type"
-      click_button "Add answer option"
 
       within ".survey-question-answer-option:first-of-type" do
         fill_in find_nested_form_field_locator("body_en"), with: "Something"

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -375,6 +375,38 @@ shared_examples "edit surveys" do
         expect { click_button "Add question" }.to change { page.all(".ql-toolbar").size }.by(1)
       end
 
+      it "properly decides which button to show after adding/removing answer options" do
+        click_button "Add question"
+
+        within ".survey-question:last-of-type" do
+          select "Single option", from: "Type"
+
+          within ".survey-question-answer-options-list" do
+            expect(page).to have_no_button("Remove")
+          end
+
+          click_button "Add answer option"
+
+          expect(page.all(".survey-question-answer-option")).to all(have_button("Remove"))
+
+          within ".survey-question-answer-option:first-of-type" do
+            click_button "Remove"
+          end
+
+          within ".survey-question-answer-options-list" do
+            expect(page).to have_no_button("Remove")
+          end
+        end
+
+        click_button "Save"
+
+        within ".survey-question:last-of-type" do
+          within ".survey-question-answer-options-list" do
+            expect(page).to have_no_button("Remove")
+          end
+        end
+      end
+
       private
 
       def look_like_first_question

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -276,7 +276,7 @@ shared_examples "edit surveys" do
         end
 
         expect(page).to have_admin_callout("There's been errors when saving the survey")
-        expect(page).to have_content("can't be blank")
+        expect(page).to have_content("can't be blank", count: 3) # emtpy question, 2 empty default answer options
 
         expect(page).to have_selector("input[value='']")
         expect(page).to have_no_selector("input[value='This is the first question']")


### PR DESCRIPTION
#### :tophat: What? Why?

This PR improves validations in the surveys form and makes it more user friendly by:

* Ensure multiple choice questions without answer options cannot be created. To do this, with auto-generate two empty answer options when the user changes the type to a multiple choice question.

* Ensure multiple choice questions with empty answer options cannot be created. To do this, we add presence validation answer options.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)

#### Before (creating multiple choices questions without answer options and with empty answer options)
![multiplechoicequestionswithoutansweroptionsorwithemptyansweroptions](https://user-images.githubusercontent.com/2887858/37789756-7cd19602-2de3-11e8-9601-ae9db81f7878.gif)

#### After (autocreation of empty default answer options and validation on them)
![defaultansweroptionsandvalidationsonthem](https://user-images.githubusercontent.com/2887858/37789774-8274c700-2de3-11e8-88b9-91dceed61a0a.gif)