### PR TITLE
Preserve deleted status on survey errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,5 +56,6 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-core**: Only require caps on the first line with `EtiquetteValidator` [\#3072](https://github.com/decidim/decidim/pull/3072)
 - **decidim-surveys**: Multiple choice questions without answer options can no longer be created [\#3087](https://github.com/decidim/decidim/pull/3087)
 - **decidim-surveys**: Multiple choice questions with empty answer options can no longer be created [\#3087](https://github.com/decidim/decidim/pull/3087)
+- **decidim-surveys**: Preserve deleted status of questions accross submission failures [\#3089](https://github.com/decidim/decidim/pull/3089)
 
 Please check [0.10-stable](https://github.com/decidim/decidim/blob/0.10-stable/CHANGELOG.md) for previous changes.

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
@@ -163,4 +163,7 @@
     hideDeletedQuestion($target);
     setupInitialQuestionAttributes($target);
   });
+
+  autoLabelByPosition.run();
+  autoButtonsByPosition.run();
 })(window);

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
@@ -108,6 +108,15 @@
     onQuestionTypeChange();
   }
 
+  const hideDeletedQuestion = ($target) => {
+    const inputDeleted = $target.find("input[name$=\\[deleted\\]]").val();
+
+    if (inputDeleted === "true") {
+      $target.addClass('hidden');
+      $target.hide();
+    }
+  }
+
   createDynamicFields({
     placeholderId: 'survey-question-id',
     wrapperSelector: wrapperSelector,
@@ -151,6 +160,7 @@
   $(fieldSelector).each((idx, el) => {
     const $target = $(el);
 
+    hideDeletedQuestion($target);
     setupInitialQuestionAttributes($target);
   });
 })(window);

--- a/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_form.rb
@@ -22,7 +22,7 @@ module Decidim
 
         def map_model(model)
           self.answer_options = model.answer_options.each_with_index.map do |option, id|
-            SurveyQuestionAnswerOptionForm.new(option.merge(id: id + 1))
+            SurveyQuestionAnswerOptionForm.new(option.merge(id: id + 1, deleted: false))
           end
         end
 

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
@@ -76,7 +76,7 @@
     <% end %>
 
     <%= form.hidden_field :position, value: question.position || 0, disabled: !survey.questions_editable? %>
-    <%= form.hidden_field :deleted, value: false, disabled: !survey.questions_editable? %>
+    <%= form.hidden_field :deleted, disabled: !survey.questions_editable? %>
 
     <div class="survey-question-answer-options">
       <template>

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -278,6 +278,20 @@ shared_examples "edit surveys" do
         expect(page).to have_selector("select#survey_questions_#{survey_question.id}_question_type option[value='multiple_option'][selected]")
       end
 
+      it "preserves deleted status across submission failures" do
+        within "form.edit_survey" do
+          within ".survey-question" do
+            click_button "Remove"
+          end
+        end
+
+        click_button "Add question"
+
+        click_button "Save"
+
+        expect(page).to have_selector(".survey-question", count: 1)
+      end
+
       it "removes the question" do
         within "form.edit_survey" do
           within ".survey-question" do

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -170,7 +170,7 @@ shared_examples "edit surveys" do
       end
     end
 
-    it "persists question form across submission failures" do
+    it "preserves question form across submission failures" do
       click_button "Add question"
       select "Long answer", from: "Type"
       click_button "Save"
@@ -178,7 +178,7 @@ shared_examples "edit surveys" do
       expect(page).to have_select("Type", selected: "Long answer")
     end
 
-    it "does not persist spurious answer options from previous type selections" do
+    it "does not preserve spurious answer options from previous type selections" do
       click_button "Add question"
       select "Single option", from: "Type"
 
@@ -197,7 +197,7 @@ shared_examples "edit surveys" do
       end
     end
 
-    it "persists answer options form across submission failures" do
+    it "preserves answer options form across submission failures" do
       click_button "Add question"
       select "Single option", from: "Type"
 

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -97,8 +97,6 @@ shared_examples "edit surveys" do
       within "form.edit_survey" do
         click_button "Add question"
 
-        expect(page).to have_selector(".survey-question", count: 1)
-
         within ".survey-question" do
           fill_in find_nested_form_field_locator("body_en"), with: question_body
         end
@@ -240,8 +238,6 @@ shared_examples "edit surveys" do
 
       it "modifies the question when the information is valid" do
         within "form.edit_survey" do
-          expect(page).to have_selector(".survey-question", count: 1)
-
           within ".survey-question" do
             fill_in "survey_questions_#{survey_question.id}_body_en", with: "Modified question"
             check "Mandatory"
@@ -263,8 +259,6 @@ shared_examples "edit surveys" do
 
       it "re-renders the form when the information is invalid and displays errors" do
         within "form.edit_survey" do
-          expect(page).to have_selector(".survey-question", count: 1)
-
           within ".survey-question" do
             expect(page).to have_content("Statement*")
             fill_in "survey_questions_#{survey_question.id}_body_en", with: ""
@@ -286,8 +280,6 @@ shared_examples "edit surveys" do
 
       it "removes the question" do
         within "form.edit_survey" do
-          expect(page).to have_selector(".survey-question", count: 1)
-
           within ".survey-question" do
             click_button "Remove"
           end

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -290,6 +290,11 @@ shared_examples "edit surveys" do
         click_button "Save"
 
         expect(page).to have_selector(".survey-question", count: 1)
+
+        within ".survey-question" do
+          expect(page).to have_selector(".card-title", text: "#1")
+          expect(page).to have_no_button("Up")
+        end
       end
 
       it "removes the question" do


### PR DESCRIPTION
#### :tophat: What? Why?

I keep on my quest on killing survey usability bugs. Like many of the previous fixes, this is about keeping form information after a submission failure.

Say you're editing a 30 questions survey where you delete 20 questions, and add a new one, but introduce some validation errors on it. Previously you would get the validation error, but the 30 questions back so you would've to delete the 20 extra again. Now you get the form back exactly as you submitted it (but with the errors marked).

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
_None_.
