### PR TITLE
External contribution friendly design app job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -425,21 +425,14 @@ jobs:
       - checkout
       - setup_remote_docker
       - run:
-          name: Login to docker
-          command: |
-            docker login --username=_ --password=$HEROKU_AUTH_TOKEN registry.heroku.com
-      - run:
-          name: Pulling docker image
-          command: |
-            docker pull registry.heroku.com/decidim-design/web || true
-      - run:
           name: Build image
           command: |
-            docker build -t registry.heroku.com/decidim-design/web --cache-from registry.heroku.com/decidim-design/web -f Dockerfile.design .
+            docker build -t registry.heroku.com/decidim-design/web -f Dockerfile.design .
       - run:
           name: Push deployment image
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              docker login --username=_ --password=$HEROKU_AUTH_TOKEN registry.heroku.com
               docker push registry.heroku.com/decidim-design/web
             fi
 


### PR DESCRIPTION
#### :tophat: What? Why?

I was about to merge a [typo fixing PR](https://github.com/decidim/decidim/pull/3088)  but found out that the design app check was failing. I tried building the design app locally, and it doesn't take very long. So maybe we can remove the caching, so we don't need to connect to dockerhub, so external PR's will get that check green (if it passes, of course).

@josepjaume & circleCI, does this make sense?

#### :pushpin: Related Issues
- Related to #3088.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.