### PR TITLE
Max choices for multiple choice questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ controller or added a new module you need to rename `feature` to `component`.
   - Add the `card` attribute to the component's manifest `shared/author_reference` partials.
 - **decidim-surveys**: Add rich text description to questions [\#3066](https://github.com/decidim/decidim/pull/3066).
 - **decidim-proposals**: Add discard draft button in wizard [\#3064](https://github.com/decidim/decidim/pull/3064)
+- **decidim-surveys**: Allow multiple choice questions to specify a maximum number of options to be checked [\#3091](https://github.com/decidim/decidim/pull/3091)
 
 **Changed**:
 

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/auto_select_options_by_total_items.component.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/auto_select_options_by_total_items.component.js.es6
@@ -1,0 +1,22 @@
+((exports) => {
+  class AutoSelectOptionsByTotalItemsComponent {
+    constructor(options = {}) {
+      this.selectSelector = options.selectSelector;
+      this.listSelector = options.listSelector;
+    }
+
+    run() {
+      const $list = $(this.listSelector);
+      const selectSelector = this.selectSelector;
+
+      $(selectSelector).empty();
+
+      for (let idx = 2; idx <= $list.length; idx += 1) {
+        $(`<option value="${idx}">${idx}</option>`).appendTo(selectSelector);
+      }
+    }
+  }
+
+  exports.DecidimAdmin = exports.DecidimAdmin || {};
+  exports.DecidimAdmin.AutoSelectOptionsByTotalItemsComponent = AutoSelectOptionsByTotalItemsComponent;
+})(window);

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/auto_select_options_by_total_items.component.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/auto_select_options_by_total_items.component.js.es6
@@ -9,7 +9,7 @@
       const $list = $(this.listSelector);
       const selectSelector = this.selectSelector;
 
-      $(selectSelector).empty();
+      $(`${selectSelector} option`).slice(1).remove();
 
       for (let idx = 2; idx <= $list.length; idx += 1) {
         $(`<option value="${idx}">${idx}</option>`).appendTo(selectSelector);

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/auto_select_options_by_total_items.component.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/auto_select_options_by_total_items.component.js.es6
@@ -1,18 +1,19 @@
 ((exports) => {
   class AutoSelectOptionsByTotalItemsComponent {
     constructor(options = {}) {
+      this.wrapperSelector = options.wrapperSelector;
       this.selectSelector = options.selectSelector;
       this.listSelector = options.listSelector;
     }
 
     run() {
       const $list = $(this.listSelector);
-      const selectSelector = this.selectSelector;
+      const $selectField = $list.parents(this.wrapperSelector).find(this.selectSelector);
 
-      $(`${selectSelector} option`).slice(1).remove();
+      $selectField.find("option").slice(1).remove();
 
       for (let idx = 2; idx <= $list.length; idx += 1) {
-        $(`<option value="${idx}">${idx}</option>`).appendTo(selectSelector);
+        $(`<option value="${idx}">${idx}</option>`).appendTo($selectField);
       }
     }
   }

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/dynamic_fields.component.js.es6
@@ -21,7 +21,7 @@
 
     _enableInterpolation() {
       $.fn.replaceAttribute = function(attribute, placeholder, value) {
-        $(this).find(`[${attribute}*=${placeholder}]`).each((index, element) => {
+        $(this).find(`[${attribute}*=${placeholder}]`).addBack(`[${attribute}*=${placeholder}]`).each((index, element) => {
           $(element).attr(attribute, $(element).attr(attribute).replace(placeholder, value));
         });
 

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/field_dependent_inputs.component.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/field_dependent_inputs.component.js.es6
@@ -1,7 +1,7 @@
 ((exports) => {
-  class SelectFieldDependentInputsComponent {
+  class FieldDependentInputsComponent {
     constructor(options = {}) {
-      this.selectField = options.selectField;
+      this.controllerField = options.controllerField;
       this.wrapperSelector = options.wrapperSelector;
       this.dependentFieldsSelector = options.dependentFieldsSelector;
       this.dependentInputSelector = options.dependentInputSelector;
@@ -9,10 +9,10 @@
     }
 
     run() {
-      const $selectField = this.selectField;
-      const $dependentFields = $selectField.parents(this.wrapperSelector).find(this.dependentFieldsSelector);
+      const $controllerField = this.controllerField;
+      const $dependentFields = $controllerField.parents(this.wrapperSelector).find(this.dependentFieldsSelector);
       const $dependentInputs = $dependentFields.find(this.dependentInputSelector);
-      const value = $selectField.val();
+      const value = $controllerField.val();
 
       if (this.enablingValues.indexOf(value) > -1) {
         $dependentInputs.prop("disabled", false);
@@ -25,5 +25,5 @@
   }
 
   exports.DecidimAdmin = exports.DecidimAdmin || {};
-  exports.DecidimAdmin.SelectFieldDependentInputsComponent = SelectFieldDependentInputsComponent;
+  exports.DecidimAdmin.FieldDependentInputsComponent = FieldDependentInputsComponent;
 })(window);

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/field_dependent_inputs.component.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/field_dependent_inputs.component.js.es6
@@ -6,9 +6,11 @@
       this.dependentFieldsSelector = options.dependentFieldsSelector;
       this.dependentInputSelector = options.dependentInputSelector;
       this.enablingValues = options.enablingValues;
+      this._bindEvent();
+      this._run();
     }
 
-    run() {
+    _run() {
       const $controllerField = this.controllerField;
       const $dependentFields = $controllerField.parents(this.wrapperSelector).find(this.dependentFieldsSelector);
       const $dependentInputs = $dependentFields.find(this.dependentInputSelector);
@@ -22,8 +24,17 @@
         $dependentFields.hide();
       }
     }
+
+    _bindEvent() {
+      this.controllerField.on("change", () => {
+        this._run();
+      });
+    }
   }
 
   exports.DecidimAdmin = exports.DecidimAdmin || {};
   exports.DecidimAdmin.FieldDependentInputsComponent = FieldDependentInputsComponent;
+  exports.DecidimAdmin.createFieldDependentInputs = (options) => {
+    return new FieldDependentInputsComponent(options);
+  };
 })(window);

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/select_field_dependent_inputs.component.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/select_field_dependent_inputs.component.js.es6
@@ -1,0 +1,29 @@
+((exports) => {
+  class SelectFieldDependentInputsComponent {
+    constructor(options = {}) {
+      this.selectField = options.selectField;
+      this.wrapperSelector = options.wrapperSelector;
+      this.dependentFieldsSelector = options.dependentFieldsSelector;
+      this.dependentInputSelector = options.dependentInputSelector;
+      this.enablingValues = options.enablingValues;
+    }
+
+    run() {
+      const $selectField = this.selectField;
+      const $dependentFields = $selectField.parents(this.wrapperSelector).find(this.dependentFieldsSelector);
+      const $dependentInputs = $dependentFields.find(this.dependentInputSelector);
+      const value = $selectField.val();
+
+      if (this.enablingValues.indexOf(value) > -1) {
+        $dependentInputs.prop("disabled", false);
+        $dependentFields.show();
+      } else {
+        $dependentInputs.prop("disabled", true);
+        $dependentFields.hide();
+      }
+    }
+  }
+
+  exports.DecidimAdmin = exports.DecidimAdmin || {};
+  exports.DecidimAdmin.SelectFieldDependentInputsComponent = SelectFieldDependentInputsComponent;
+})(window);

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
@@ -1,11 +1,12 @@
 // = require ./auto_label_by_position.component
 // = require ./auto_buttons_by_position.component
 // = require ./auto_buttons_by_min_items.component
+// = require ./auto_select_options_by_total_items.component
 // = require ./dynamic_fields.component
 // = require ./select_field_dependent_inputs.component
 
 ((exports) => {
-  const { AutoLabelByPositionComponent, AutoButtonsByPositionComponent, AutoButtonsByMinItemsComponent, SelectFieldDependentInputsComponent, createDynamicFields, createSortList } = exports.DecidimAdmin;
+  const { AutoLabelByPositionComponent, AutoButtonsByPositionComponent, AutoButtonsByMinItemsComponent, AutoSelectOptionsByTotalItemsComponent, SelectFieldDependentInputsComponent, createDynamicFields, createSortList } = exports.DecidimAdmin;
   const { createQuillEditor } = exports.Decidim;
 
   const wrapperSelector = ".survey-questions";
@@ -30,6 +31,13 @@
     hideOnLastSelector: ".move-down-question"
   });
 
+  const createAutoMaxChoicesByNumberOfAnswerOptions = (fieldId) => {
+    return new AutoSelectOptionsByTotalItemsComponent({
+      selectSelector: `${maxChoicesWrapperSelector} select`,
+      listSelector: `#${fieldId} ${answerOptionsWrapperSelector} .survey-question-answer-option:not(.hidden)`
+    })
+  };
+
   const createAutoButtonsByMinItemsForAnswerOptions = (fieldId) => {
     return new AutoButtonsByMinItemsComponent({
       listSelector: `#${fieldId} ${answerOptionsWrapperSelector} .survey-question-answer-option:not(.hidden)`,
@@ -49,6 +57,7 @@
 
   const createDynamicFieldsForAnswerOptions = (fieldId) => {
     const autoButtons = createAutoButtonsByMinItemsForAnswerOptions(fieldId);
+    const autoSelectOptions = createAutoMaxChoicesByNumberOfAnswerOptions(fieldId);
 
     return createDynamicFields({
       placeholderId: "survey-question-answer-option-id",
@@ -59,9 +68,11 @@
       removeFieldButtonSelector: answerOptionRemoveFieldButtonSelector,
       onAddField: () => {
         autoButtons.run();
+        autoSelectOptions.run();
       },
       onRemoveField: () => {
         autoButtons.run();
+        autoSelectOptions.run();
       }
     });
   };

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
@@ -13,6 +13,7 @@
   const answerOptionFieldSelector = ".survey-question-answer-option";
   const answerOptionsWrapperSelector = ".survey-question-answer-options";
   const answerOptionRemoveFieldButtonSelector = ".remove-answer-option";
+  const maxChoicesWrapperSelector = ".survey-question-max-choices";
 
   const autoLabelByPosition = new AutoLabelByPositionComponent({
     listSelector: ".survey-question:not(.hidden)",
@@ -80,6 +81,20 @@
     }
   };
 
+  const setMaxChoicesWrapperVisibility = ($target) => {
+    const $maxChoicesWrapper = $target.parents(fieldSelector).find(maxChoicesWrapperSelector);
+    const $maxChoicesSelect = $maxChoicesWrapper.find("select");
+    const value = $target.val();
+
+    if (value === "multiple_option") {
+      $maxChoicesSelect.prop("disabled", false);
+      $maxChoicesWrapper.show();
+    } else {
+      $maxChoicesSelect.prop("disabled", true);
+      $maxChoicesWrapper.hide();
+    }
+  };
+
   const setupInitialQuestionAttributes = ($target) => {
     const fieldId = $target.attr("id");
     const $fieldQuestionTypeSelect = $target.find(questionTypeSelector);
@@ -101,6 +116,7 @@
       }
 
       setAnswerOptionsWrapperVisibility($fieldQuestionTypeSelect);
+      setMaxChoicesWrapperVisibility($fieldQuestionTypeSelect);
     };
 
     $fieldQuestionTypeSelect.on("change", onQuestionTypeChange);

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
@@ -2,9 +2,10 @@
 // = require ./auto_buttons_by_position.component
 // = require ./auto_buttons_by_min_items.component
 // = require ./dynamic_fields.component
+// = require ./select_field_dependent_inputs.component
 
 ((exports) => {
-  const { AutoLabelByPositionComponent, AutoButtonsByPositionComponent, AutoButtonsByMinItemsComponent, createDynamicFields, createSortList } = exports.DecidimAdmin;
+  const { AutoLabelByPositionComponent, AutoButtonsByPositionComponent, AutoButtonsByMinItemsComponent, SelectFieldDependentInputsComponent, createDynamicFields, createSortList } = exports.DecidimAdmin;
   const { createQuillEditor } = exports.Decidim;
 
   const wrapperSelector = ".survey-questions";
@@ -67,37 +68,25 @@
 
   const dynamicFieldsForAnswerOptions = {};
 
-  const setAnswerOptionsWrapperVisibility = ($target) => {
-    const $answerOptionsWrapper = $target.parents(fieldSelector).find(answerOptionsWrapperSelector);
-    const value = $target.val();
-    const $answerOptionsInputs = $answerOptionsWrapper.find(`${answerOptionFieldSelector} input`);
-
-    if (value === "single_option" || value === "multiple_option") {
-      $answerOptionsInputs.prop("disabled", false);
-      $answerOptionsWrapper.show();
-    } else {
-      $answerOptionsInputs.prop("disabled", true);
-      $answerOptionsWrapper.hide();
-    }
-  };
-
-  const setMaxChoicesWrapperVisibility = ($target) => {
-    const $maxChoicesWrapper = $target.parents(fieldSelector).find(maxChoicesWrapperSelector);
-    const $maxChoicesSelect = $maxChoicesWrapper.find("select");
-    const value = $target.val();
-
-    if (value === "multiple_option") {
-      $maxChoicesSelect.prop("disabled", false);
-      $maxChoicesWrapper.show();
-    } else {
-      $maxChoicesSelect.prop("disabled", true);
-      $maxChoicesWrapper.hide();
-    }
-  };
-
   const setupInitialQuestionAttributes = ($target) => {
     const fieldId = $target.attr("id");
     const $fieldQuestionTypeSelect = $target.find(questionTypeSelector);
+
+    const answerOptionsSelectFieldUpdater = new SelectFieldDependentInputsComponent({
+      selectField: $fieldQuestionTypeSelect,
+      wrapperSelector: fieldSelector,
+      dependentFieldsSelector: answerOptionsWrapperSelector,
+      dependentInputSelector: `${answerOptionFieldSelector} input`,
+      enablingValues: ["single_option", "multiple_option"]
+    });
+
+    const maxChoicesSelectFieldUpdater = new SelectFieldDependentInputsComponent({
+      selectField: $fieldQuestionTypeSelect,
+      wrapperSelector: fieldSelector,
+      dependentFieldsSelector: maxChoicesWrapperSelector,
+      dependentInputSelector: "select",
+      enablingValues: ["multiple_option"]
+    });
 
     dynamicFieldsForAnswerOptions[fieldId] = createDynamicFieldsForAnswerOptions(fieldId);
 
@@ -115,8 +104,8 @@
         }
       }
 
-      setAnswerOptionsWrapperVisibility($fieldQuestionTypeSelect);
-      setMaxChoicesWrapperVisibility($fieldQuestionTypeSelect);
+      answerOptionsSelectFieldUpdater.run();
+      maxChoicesSelectFieldUpdater.run();
     };
 
     $fieldQuestionTypeSelect.on("change", onQuestionTypeChange);

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
@@ -6,7 +6,7 @@
 // = require ./field_dependent_inputs.component
 
 ((exports) => {
-  const { AutoLabelByPositionComponent, AutoButtonsByPositionComponent, AutoButtonsByMinItemsComponent, AutoSelectOptionsByTotalItemsComponent, FieldDependentInputsComponent, createDynamicFields, createSortList } = exports.DecidimAdmin;
+  const { AutoLabelByPositionComponent, AutoButtonsByPositionComponent, AutoButtonsByMinItemsComponent, AutoSelectOptionsByTotalItemsComponent, createFieldDependentInputs, createDynamicFields, createSortList } = exports.DecidimAdmin;
   const { createQuillEditor } = exports.Decidim;
 
   const wrapperSelector = ".survey-questions";
@@ -83,7 +83,7 @@
     const fieldId = $target.attr("id");
     const $fieldQuestionTypeSelect = $target.find(questionTypeSelector);
 
-    const answerOptionsSelectFieldUpdater = new FieldDependentInputsComponent({
+    createFieldDependentInputs({
       controllerField: $fieldQuestionTypeSelect,
       wrapperSelector: fieldSelector,
       dependentFieldsSelector: answerOptionsWrapperSelector,
@@ -91,7 +91,7 @@
       enablingValues: ["single_option", "multiple_option"]
     });
 
-    const maxChoicesSelectFieldUpdater = new FieldDependentInputsComponent({
+    createFieldDependentInputs({
       controllerField: $fieldQuestionTypeSelect,
       wrapperSelector: fieldSelector,
       dependentFieldsSelector: maxChoicesWrapperSelector,
@@ -114,9 +114,6 @@
           dynamicFields._addField();
         }
       }
-
-      answerOptionsSelectFieldUpdater.run();
-      maxChoicesSelectFieldUpdater.run();
     };
 
     $fieldQuestionTypeSelect.on("change", onQuestionTypeChange);

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
@@ -3,10 +3,10 @@
 // = require ./auto_buttons_by_min_items.component
 // = require ./auto_select_options_by_total_items.component
 // = require ./dynamic_fields.component
-// = require ./select_field_dependent_inputs.component
+// = require ./field_dependent_inputs.component
 
 ((exports) => {
-  const { AutoLabelByPositionComponent, AutoButtonsByPositionComponent, AutoButtonsByMinItemsComponent, AutoSelectOptionsByTotalItemsComponent, SelectFieldDependentInputsComponent, createDynamicFields, createSortList } = exports.DecidimAdmin;
+  const { AutoLabelByPositionComponent, AutoButtonsByPositionComponent, AutoButtonsByMinItemsComponent, AutoSelectOptionsByTotalItemsComponent, FieldDependentInputsComponent, createDynamicFields, createSortList } = exports.DecidimAdmin;
   const { createQuillEditor } = exports.Decidim;
 
   const wrapperSelector = ".survey-questions";
@@ -83,16 +83,16 @@
     const fieldId = $target.attr("id");
     const $fieldQuestionTypeSelect = $target.find(questionTypeSelector);
 
-    const answerOptionsSelectFieldUpdater = new SelectFieldDependentInputsComponent({
-      selectField: $fieldQuestionTypeSelect,
+    const answerOptionsSelectFieldUpdater = new FieldDependentInputsComponent({
+      controllerField: $fieldQuestionTypeSelect,
       wrapperSelector: fieldSelector,
       dependentFieldsSelector: answerOptionsWrapperSelector,
       dependentInputSelector: `${answerOptionFieldSelector} input`,
       enablingValues: ["single_option", "multiple_option"]
     });
 
-    const maxChoicesSelectFieldUpdater = new SelectFieldDependentInputsComponent({
-      selectField: $fieldQuestionTypeSelect,
+    const maxChoicesSelectFieldUpdater = new FieldDependentInputsComponent({
+      controllerField: $fieldQuestionTypeSelect,
       wrapperSelector: fieldSelector,
       dependentFieldsSelector: maxChoicesWrapperSelector,
       dependentInputSelector: "select",

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
@@ -33,6 +33,7 @@
 
   const createAutoMaxChoicesByNumberOfAnswerOptions = (fieldId) => {
     return new AutoSelectOptionsByTotalItemsComponent({
+      wrapperSelector: fieldSelector,
       selectSelector: `${maxChoicesWrapperSelector} select`,
       listSelector: `#${fieldId} ${answerOptionsWrapperSelector} .survey-question-answer-option:not(.hidden)`
     })
@@ -40,6 +41,7 @@
 
   const createAutoButtonsByMinItemsForAnswerOptions = (fieldId) => {
     return new AutoButtonsByMinItemsComponent({
+      wrapperSelector: fieldSelector,
       listSelector: `#${fieldId} ${answerOptionsWrapperSelector} .survey-question-answer-option:not(.hidden)`,
       minItems: 2,
       hideOnMinItemsOrLessSelector: answerOptionRemoveFieldButtonSelector

--- a/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
+++ b/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
@@ -39,7 +39,8 @@ module Decidim
               position: form_question.position,
               mandatory: form_question.mandatory,
               question_type: form_question.question_type,
-              answer_options: form_question.answer_options_to_persist.map { |answer| { "body" => answer.body } }
+              answer_options: form_question.answer_options_to_persist.map { |answer| { "body" => answer.body } },
+              max_choices: form_question.max_choices
             }
 
             if form_question.id.present?

--- a/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_form.rb
@@ -11,6 +11,7 @@ module Decidim
         attribute :mandatory, Boolean, default: false
         attribute :question_type, String
         attribute :answer_options, Array[SurveyQuestionAnswerOptionForm]
+        attribute :max_choices, Integer
         attribute :deleted, Boolean, default: false
 
         translatable_attribute :body, String
@@ -18,6 +19,7 @@ module Decidim
 
         validates :position, numericality: { greater_than_or_equal_to: 0 }
         validates :question_type, inclusion: { in: SurveyQuestion::TYPES }
+        validates :max_choices, numericality: { only_integer: true, greater_than: 1, less_than_or_equal_to: ->(form) { form.number_of_options } }, allow_blank: true
         validates :body, translatable_presence: true, unless: :deleted
 
         def map_model(model)
@@ -32,6 +34,10 @@ module Decidim
 
         def to_param
           id || "survey-question-id"
+        end
+
+        def number_of_options
+          answer_options.size
         end
       end
     end

--- a/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
@@ -19,6 +19,7 @@ module Decidim
       def label
         base = "#{question.position + 1}. #{translated_attribute(question.body)}"
         base += " #{mandatory_label}" if question.mandatory?
+        base += " (#{max_choices_label})" if question.max_choices
         base
       end
 
@@ -42,6 +43,10 @@ module Decidim
 
       def mandatory_label
         "*"
+      end
+
+      def max_choices_label
+        I18n.t("surveys.question.max_choices", scope: "decidim.surveys", n: question.max_choices)
       end
     end
   end

--- a/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
@@ -10,7 +10,9 @@ module Decidim
       attribute :body, String
 
       validates :body, presence: true, if: -> { question.mandatory? }
+
       validate :body_not_blank, if: -> { question.mandatory? }
+      validate :max_answers, if: -> { question.max_choices }
 
       def question
         @question ||= survey.questions.find(question_id)
@@ -39,6 +41,12 @@ module Decidim
       def body_not_blank
         return if body.nil?
         errors.add("body", :blank) if body.all?(&:blank?)
+      end
+
+      def max_answers
+        return if body.nil?
+
+        errors.add("body", :too_many_choices) if body.size > question.max_choices
       end
 
       def mandatory_label

--- a/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
@@ -4,6 +4,8 @@ module Decidim
   module Surveys
     # This class holds a Form to update survey unswers from Decidim's public page
     class SurveyAnswerForm < Decidim::Form
+      include Decidim::TranslationsHelper
+
       attribute :question_id, String
       attribute :body, String
 
@@ -12,6 +14,12 @@ module Decidim
 
       def question
         @question ||= survey.questions.find(question_id)
+      end
+
+      def label
+        base = "#{question.position + 1}. #{translated_attribute(question.body)}"
+        base += " #{mandatory_label}" if question.mandatory?
+        base
       end
 
       # Public: Map the correct fields.
@@ -30,6 +38,10 @@ module Decidim
       def body_not_blank
         return if body.nil?
         errors.add("body", :blank) if body.all?(&:blank?)
+      end
+
+      def mandatory_label
+        "*"
       end
     end
   end

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
@@ -1,3 +1,5 @@
+<% answer_option = form.object %>
+
 <div class="card survey-question-answer-option">
   <div class="card-divider">
     <h2 class="card-title">

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
@@ -24,7 +24,7 @@
   <% if survey.questions_editable? %>
     <template>
       <%= fields_for "survey[questions][#{blank_question.to_param}]", blank_question do |question_form| %>
-        <%= render "question", question: blank_question, form: question_form, id: tabs_id_for_question(blank_question) %>
+        <%= render "question", form: question_form, id: tabs_id_for_question(blank_question) %>
       <% end %>
     </template>
   <% else %>
@@ -36,7 +36,7 @@
   <div class="survey-questions-list">
     <% @form.questions.each do |question| %>
       <%= fields_for "survey[questions][]", question do |question_form| %>
-        <%= render "question", question: question, form: question_form, id: tabs_id_for_question(question) %>
+        <%= render "question", form: question_form, id: tabs_id_for_question(question) %>
       <% end %>
     <% end %>
   </div>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
@@ -1,3 +1,5 @@
+<% question = form.object %>
+
 <div class="card survey-question" id="<%= id %>-field">
   <div class="card-divider question-divider">
     <h2 class="card-title">
@@ -81,14 +83,14 @@
     <div class="survey-question-answer-options">
       <template>
         <%= fields_for "survey[questions][#{question.to_param}][answer_options][]", blank_answer_option do |answer_option_form| %>
-          <%= render "answer_option", answer_option: blank_answer_option, form: answer_option_form, question: question %>
+          <%= render "answer_option", form: answer_option_form, question: question %>
         <% end %>
       </template>
 
       <div class="survey-question-answer-options-list">
         <% question.answer_options.each do |answer_option| %>
           <%= fields_for "survey[questions][#{question.to_param}][answer_options][]", answer_option do |answer_option_form| %>
-            <%= render "answer_option", answer_option: answer_option, form: answer_option_form, question: question %>
+            <%= render "answer_option", form: answer_option_form, question: question %>
           <% end %>
         <% end %>
       </div>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
@@ -105,6 +105,7 @@
         form.select(
           :max_choices,
           (2..question.number_of_options),
+          prompt: t(".any"),
           disabled: !survey.questions_editable?
         )
       %>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
@@ -97,5 +97,15 @@
         <button class="button add-answer-option"><%= t(".add_answer_option") %></button>
       <% end %>
     </div>
+
+    <div class="row column survey-question-max-choices">
+      <%=
+        form.select(
+          :max_choices,
+          (2..10),
+          disabled: !survey.questions_editable?
+        )
+      %>
+    </div>
   </div>
 </div>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
@@ -104,7 +104,7 @@
       <%=
         form.select(
           :max_choices,
-          (2..10),
+          (2..question.number_of_options),
           disabled: !survey.questions_editable?
         )
       %>

--- a/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
@@ -33,7 +33,7 @@
                   <% @form.answers.each_with_index do |answer, answer_idx| %>
                     <div class="row column">
                       <% field_id = "survey_#{survey.id}_question_#{answer.question.id}_answer_body" %>
-                      <%= label_tag field_id , "#{answer_idx + 1}. #{translated_attribute(answer.question.body)} #{'*' if answer.question.mandatory?}", class: "survey-question" %>
+                      <%= label_tag field_id, answer.label, class: "survey-question" %>
 
                       <% if translated_attribute(answer.question.description).present? %>
                         <div class="help-text">

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -59,6 +59,7 @@ en:
             already_answered_warning: The survey is already answered by some users so you cannot modify its questions.
           question:
             add_answer_option: Add answer option
+            any: Any
             description: Description
             down: Down
             question: Question

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -8,6 +8,12 @@ en:
         mandatory: Mandatory
         max_choices: Maximum number of choices
         question_type: Type
+    errors:
+      models:
+        survey_answer:
+          attributes:
+            body:
+              too_many_choices: has too many options checked
   decidim:
     components:
       surveys:

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -6,6 +6,7 @@ en:
         body: Answer
       survey_question:
         mandatory: Mandatory
+        max_choices: Maximum number of choices
         question_type: Type
   decidim:
     components:

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -71,6 +71,8 @@ en:
         answer:
           invalid: There's been errors when answering the survey.
           success: Survey answered successfully.
+        question:
+          max_choices: 'Max choices: %{n}'
         show:
           answer_survey:
             anonymous_user_message: <a href="%{sign_in_link}">Sign in with your account</a> or <a href="%{sign_up_link}">sign up</a> to answer the survey.

--- a/decidim-surveys/db/migrate/20180314225829_add_max_choices_to_survey_questions.rb
+++ b/decidim-surveys/db/migrate/20180314225829_add_max_choices_to_survey_questions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMaxChoicesToSurveyQuestions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_surveys_survey_questions, :max_choices, :integer
+  end
+end

--- a/decidim-surveys/spec/commands/decidim/surveys/admin/update_survey_spec.rb
+++ b/decidim-surveys/spec/commands/decidim/surveys/admin/update_survey_spec.rb
@@ -75,6 +75,32 @@ module Decidim
                     }
                   }
                 }
+              },
+              "3" => {
+                "body" => {
+                  "en" => "Fourth question",
+                  "ca" => "Cuarta pregunta",
+                  "es" => "Cuarta pregunta"
+                },
+                "position" => "3",
+                "question_type" => "multiple_option",
+                "max_choices" => "2",
+                "answer_options" => {
+                  "0" => {
+                    "body" => {
+                      "en" => "First answer",
+                      "ca" => "Primera resposta",
+                      "es" => "Primera respuesta"
+                    }
+                  },
+                  "1" => {
+                    "body" => {
+                      "en" => "Second answer",
+                      "ca" => "Segona resposta",
+                      "es" => "Segunda respuesta"
+                    }
+                  }
+                }
               }
             },
             "published_at" => published_at
@@ -114,7 +140,7 @@ module Decidim
             survey.reload
 
             expect(survey.description["en"]).to eq("<p>Content</p>")
-            expect(survey.questions.length).to eq(3)
+            expect(survey.questions.length).to eq(4)
 
             survey.questions.each_with_index do |question, idx|
               expect(question.body["en"]).to eq(form_params["questions"][idx.to_s]["body"]["en"])
@@ -124,6 +150,12 @@ module Decidim
             expect(survey.questions[1].description["en"]).to eq(form_params["questions"]["1"]["description"]["en"])
             expect(survey.questions[1].question_type).to eq("long_answer")
             expect(survey.questions[2].answer_options[1]["body"]["en"]).to eq(form_params["questions"]["2"]["answer_options"]["1"]["body"]["en"])
+
+            expect(survey.questions[2].question_type).to eq("single_option")
+            expect(survey.questions[2].max_choices).to be_nil
+
+            expect(survey.questions[3].question_type).to eq("multiple_option")
+            expect(survey.questions[3].max_choices).to eq(2)
           end
         end
 

--- a/decidim-surveys/spec/forms/decidim/surveys/admin/survey_question_form_spec.rb
+++ b/decidim-surveys/spec/forms/decidim/surveys/admin/survey_question_form_spec.rb
@@ -7,7 +7,9 @@ module Decidim
     module Admin
       describe SurveyQuestionForm do
         subject do
-          described_class.from_params(attributes).with_context(current_component: survey.component, current_organization: organization)
+          described_class.from_params(
+            survey_question: attributes
+          ).with_context(current_component: survey.component, current_organization: organization)
         end
 
         let!(:survey) { create(:survey) }
@@ -40,6 +42,40 @@ module Decidim
           let!(:question_type) { "foo" }
 
           it { is_expected.not_to be_valid }
+        end
+
+        context "when the question has no answer options" do
+          it "is invalid if max_choices present" do
+            attributes[:max_choices] = 1
+
+            expect(subject).not_to be_valid
+          end
+        end
+
+        context "when the question has answer options" do
+          let!(:question_type) { "multiple_option" }
+
+          it "is valid when max_choices under the number of options" do
+            attributes[:max_choices] = 3
+            attributes[:answer_options] = {
+              "0" => { "body" => { "en" => "A" } },
+              "1" => { "body" => { "en" => "B" } },
+              "2" => { "body" => { "en" => "C" } }
+            }
+
+            expect(subject).to be_valid
+          end
+
+          it "is invalid when max_choices over the number of options" do
+            attributes[:max_choices] = 4
+            attributes[:answer_options] = {
+              "0" => { "body" => { "en" => "A" } },
+              "1" => { "body" => { "en" => "B" } },
+              "2" => { "body" => { "en" => "C" } }
+            }
+
+            expect(subject).not_to be_valid
+          end
         end
 
         context "when the body is missing a locale translation" do

--- a/decidim-surveys/spec/forms/decidim/surveys/survey_answer_form_spec.rb
+++ b/decidim-surveys/spec/forms/decidim/surveys/survey_answer_form_spec.rb
@@ -31,6 +31,20 @@ module Decidim
           expect(subject).not_to be_valid
         end
       end
+
+      context "when the question has max_choices set" do
+        let!(:survey_question) { create(:survey_question, survey: survey, max_choices: 2) }
+
+        it "is valid if few enough answers checked" do
+          subject.body = %w(foo bar)
+          expect(subject).to be_valid
+        end
+
+        it "is not valid if too many answers checked" do
+          subject.body = %w(foo bar baz)
+          expect(subject).not_to be_valid
+        end
+      end
     end
   end
 end

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -263,19 +263,19 @@ shared_examples "edit surveys" do
 
       it "updates the max choices selector according to the configured options" do
         select "Multiple option", from: "Type"
-        expect(page).to have_select("Maximum number of choices", options: %w(2))
+        expect(page).to have_select("Maximum number of choices", options: %w(Any 2))
 
         click_button "Add answer option"
-        expect(page).to have_select("Maximum number of choices", options: %w(2 3))
+        expect(page).to have_select("Maximum number of choices", options: %w(Any 2 3))
 
         click_button "Add answer option"
-        expect(page).to have_select("Maximum number of choices", options: %w(2 3 4))
+        expect(page).to have_select("Maximum number of choices", options: %w(Any 2 3 4))
 
         within(".survey-question-answer-option:last-of-type") { click_button "Remove" }
-        expect(page).to have_select("Maximum number of choices", options: %w(2 3))
+        expect(page).to have_select("Maximum number of choices", options: %w(Any 2 3))
 
         within(".survey-question-answer-option:last-of-type") { click_button "Remove" }
-        expect(page).to have_select("Maximum number of choices", options: %w(2))
+        expect(page).to have_select("Maximum number of choices", options: %w(Any 2))
 
         select "Single option", from: "Type"
         expect(page).to have_no_select("Maximum number of choices")

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -229,6 +229,35 @@ shared_examples "edit surveys" do
       end
     end
 
+    context "when adding a multiple option question" do
+      before do
+        visit_component_admin
+
+        within "form.edit_survey" do
+          click_button "Add question"
+
+          within ".survey-question" do
+            fill_in find_nested_form_field_locator("body_en"), with: "This is the first question"
+          end
+
+          expect(page).to have_no_content "Add answer option"
+          expect(page).to have_no_select("Maximum number of choices")
+
+          select "Multiple option", from: "Type"
+        end
+      end
+
+      it "shows the max choices selector only in that case" do
+        expect(page).to have_select("Maximum number of choices")
+
+        select "Short answer", from: "Type"
+        expect(page).to have_no_select("Maximum number of choices")
+
+        select "Single option", from: "Type"
+        expect(page).to have_no_select("Maximum number of choices")
+      end
+    end
+
     context "when a survey has an existing question" do
       let!(:survey_question) { create(:survey_question, survey: survey, body: body) }
 
@@ -264,6 +293,7 @@ shared_examples "edit surveys" do
             fill_in "survey_questions_#{survey_question.id}_body_en", with: ""
             check "Mandatory"
             select "Multiple option", from: "Type"
+            select "2", from: "Maximum number of choices"
           end
 
           click_button "Save"
@@ -275,6 +305,7 @@ shared_examples "edit surveys" do
         expect(page).to have_selector("input[value='']")
         expect(page).to have_no_selector("input[value='This is the first question']")
         expect(page).to have_selector("input#survey_questions_#{survey_question.id}_mandatory[checked]")
+        expect(page).to have_select("Maximum number of choices", selected: "2")
         expect(page).to have_selector("select#survey_questions_#{survey_question.id}_question_type option[value='multiple_option'][selected]")
       end
 

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -275,8 +275,15 @@ shared_examples "edit surveys" do
         within(".survey-question-answer-option:last-of-type") { click_button "Remove" }
         expect(page).to have_select("Maximum number of choices", options: %w(Any 2))
 
-        select "Single option", from: "Type"
-        expect(page).to have_no_select("Maximum number of choices")
+        click_button "Add question"
+
+        within(".survey-question:last-of-type") do
+          select "Multiple option", from: "Type"
+          expect(page).to have_select("Maximum number of choices", options: %w(Any 2))
+
+          select "Single option", from: "Type"
+          expect(page).to have_no_select("Maximum number of choices")
+        end
       end
     end
 

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -256,8 +256,6 @@ shared_examples "edit surveys" do
 
           expect(page).to have_no_content "Add answer option"
           expect(page).to have_no_select("Maximum number of choices")
-
-          select "Multiple option", from: "Type"
         end
       end
 

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -486,7 +486,7 @@ shared_examples "edit surveys" do
 
       context "when moving a question up" do
         before do
-          within "#survey_question_#{survey_question_2.id}-field" do
+          within ".survey-question:last-of-type" do
             click_button "Up"
           end
 
@@ -496,7 +496,7 @@ shared_examples "edit surveys" do
 
       context "when moving a question down" do
         before do
-          within "#survey_question_#{survey_question_1.id}-field" do
+          within ".survey-question:first-of-type" do
             click_button "Down"
           end
         end
@@ -511,7 +511,7 @@ shared_examples "edit surveys" do
         expect(page.find(".survey-question:nth-child(2)")).to look_like_intermediate_question
         expect(page.find(".survey-question:nth-child(3)")).to look_like_last_question
 
-        within "#survey_question_#{survey_question_1.id}-field" do
+        within ".survey-question:first-of-type" do
           click_button "Remove"
         end
 

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -140,6 +140,18 @@ describe "Answer a survey", type: :system do
         end
       end
 
+      context "when question type is short answer" do
+        let!(:survey_question_1) { create(:survey_question, survey: survey, question_type: "short_answer") }
+        let!(:survey_question_2) { create(:survey_question, survey: survey, question_type: "short_answer") }
+
+        it "renders the answer as a text field" do
+          visit_component
+
+          expect(page).to have_selector("input[type=text]#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body")
+          expect(page).to have_selector("input[type=text]#survey_#{survey.id}_question_#{survey_question_2.id}_answer_body")
+        end
+      end
+
       context "when question type is single option" do
         let(:answer_options) { Array.new(4) { { "body" => Decidim::Faker::Localized.sentence } } }
         let!(:survey_question_1) { create(:survey_question, survey: survey, question_type: "single_option", answer_options: [answer_options[0], answer_options[1]]) }

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -132,7 +132,7 @@ describe "Answer a survey", type: :system do
         let!(:survey_question_1) { create(:survey_question, survey: survey, question_type: "long_answer") }
         let!(:survey_question_2) { create(:survey_question, survey: survey, question_type: "long_answer") }
 
-        it "the question answer is rendered as a textarea" do
+        it "renders the answer as a textarea" do
           visit_component
 
           expect(page).to have_selector("textarea#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body")
@@ -145,7 +145,7 @@ describe "Answer a survey", type: :system do
         let!(:survey_question_1) { create(:survey_question, survey: survey, question_type: "single_option", answer_options: [answer_options[0], answer_options[1]]) }
         let!(:survey_question_2) { create(:survey_question, survey: survey, question_type: "single_option", answer_options: [answer_options[2], answer_options[3]]) }
 
-        it "the question answers are rendered as a collection of radio buttons" do
+        it "renders answers as a collection of radio buttons" do
           visit_component
 
           expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_answer_options input[type='radio']", count: 2)
@@ -178,7 +178,7 @@ describe "Answer a survey", type: :system do
         let!(:survey_question_1) { create(:survey_question, survey: survey, question_type: "multiple_option", answer_options: [answer_options[0], answer_options[1]]) }
         let!(:survey_question_2) { create(:survey_question, survey: survey, question_type: "multiple_option", answer_options: [answer_options[2], answer_options[3], answer_options[4]]) }
 
-        it "the question answers are rendered as a collection of radio buttons" do
+        it "renders answers as a collection of radio buttons" do
           visit_component
 
           expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_answer_options input[type='checkbox']", count: 2)

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -174,15 +174,16 @@ describe "Answer a survey", type: :system do
       end
 
       context "when question type is multiple option" do
-        let(:answer_options) { Array.new(4) { { "body" => Decidim::Faker::Localized.sentence } } }
+        let(:answer_options) { Array.new(5) { { "body" => Decidim::Faker::Localized.sentence } } }
         let!(:survey_question_1) { create(:survey_question, survey: survey, question_type: "multiple_option", answer_options: [answer_options[0], answer_options[1]]) }
-        let!(:survey_question_2) { create(:survey_question, survey: survey, question_type: "multiple_option", answer_options: [answer_options[2], answer_options[3]]) }
+        let!(:survey_question_2) { create(:survey_question, survey: survey, question_type: "multiple_option", answer_options: [answer_options[2], answer_options[3], answer_options[4]]) }
 
         it "the question answers are rendered as a collection of radio buttons" do
           visit_component
 
           expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_answer_options input[type='checkbox']", count: 2)
-          expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_2.id}_answer_body_answer_options input[type='checkbox']", count: 2)
+          expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_2.id}_answer_body_answer_options input[type='checkbox']", count: 3)
+          expect(page).to have_no_content("Max choices:")
 
           within "#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_answer_options" do
             check answer_options[0]["body"][:en]
@@ -204,6 +205,14 @@ describe "Answer a survey", type: :system do
           expect(page).to have_content("You have already answered this survey.")
           expect(page).to have_no_i18n_content(survey_question_1.body)
           expect(page).to have_no_i18n_content(survey_question_2.body)
+        end
+
+        it "includes the max number of choices in the label when they are set for the question" do
+          survey_question_2.update!(max_choices: 2)
+
+          visit_component
+
+          expect(page).to have_content("Max choices: 2")
         end
       end
 

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -207,12 +207,36 @@ describe "Answer a survey", type: :system do
           expect(page).to have_no_i18n_content(survey_question_2.body)
         end
 
-        it "includes the max number of choices in the label when they are set for the question" do
+        it "respects the max number of choices" do
           survey_question_2.update!(max_choices: 2)
 
           visit_component
 
           expect(page).to have_content("Max choices: 2")
+
+          within "#survey_#{survey.id}_question_#{survey_question_2.id}_answer_body_answer_options" do
+            check answer_options[2]["body"][:en]
+            check answer_options[3]["body"][:en]
+            check answer_options[4]["body"][:en]
+          end
+
+          check "survey_tos_agreement"
+
+          accept_confirm { click_button "Submit" }
+
+          within ".alert.flash" do
+            expect(page).to have_content("There's been errors when answering the survey.")
+          end
+
+          expect(page).to have_content("has too many options checked")
+
+          uncheck answer_options[4]["body"][:en]
+
+          accept_confirm { click_button "Submit" }
+
+          within ".success.flash" do
+            expect(page).to have_content("successfully")
+          end
         end
       end
 

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -92,13 +92,13 @@ describe "Answer a survey", type: :system do
         expect(page).to have_no_i18n_content(survey_question_2.body)
       end
 
-      it "the questions are ordered by position" do
+      it "the questions are ordered by position starting with one" do
         visit_component
 
         form_fields = all(".answer-survey .row")
 
-        expect(form_fields[0]).to have_i18n_content(survey_question_2.body)
-        expect(form_fields[1]).to have_i18n_content(survey_question_1.body)
+        expect(form_fields[0]).to have_i18n_content(survey_question_2.body).and have_content("1. ")
+        expect(form_fields[1]).to have_i18n_content(survey_question_1.body).and have_content("2. ")
       end
 
       context "when a question is mandatory" do


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds the posibilty to specify a maximum number of choices for a multiple choice question. This can be specified through a select box configurable after the answer options which gets prefilled with an adequate range according to the answer options configured for the question.

On further iterations, there's several improvements that could be added, such as disabling the rest of the checkboxes once the maximum number of choices are checked. We can iterate.

This is rebased on top of #3089, review that one first.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![maxchoices](https://user-images.githubusercontent.com/2887858/37830035-085bd6aa-2e80-11e8-8073-bd8a898ab545.gif)
