### PR TITLE
Fix markdownlint severity level on CodeClimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -101,6 +101,9 @@ plugins:
     exclude_patterns:
       - .github/*
 
+    issue_override:
+      severity: minor
+
   stylelint:
     enabled: true
     exclude_patterns:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,14 +26,14 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-comments**: Add more notification types when a comment is created [\#3004](https://github.com/decidim/decidim/pull/3004)
 - **decidim-debates**: Show debates stats in homepage and space pages [\#3016](https://github.com/decidim/decidim/pull/3016)
 - **decidim-core**: [\#3022](https://github.com/decidim/decidim/pull/3022)
-  + Introduce `ViewModel` and `Cells` to make it possible to add cards to resources.
-  + Add `CardHelper` with `card_for` that returns a card given an instance of a the Component attribute `card` from the ComponentManifest.
-  + Add `AuthorBoxCell` and `ProfileCell`; Remove `shared/author_reference` partials.
+  - Introduce `ViewModel` and `Cells` to make it possible to add cards to resources.
+  - Add `CardHelper` with `card_for` that returns a card given an instance of a the Component attribute `card` from the ComponentManifest.
+  - Add `AuthorBoxCell` and `ProfileCell`; Remove `shared/author_reference` partials.
 - **decidim**: Add documentation for `ViewModel` and `CardCells` `docs/advanced/view_models_aka_cells.md` [\#3022](https://github.com/decidim/decidim/pull/3022)
 - **decidim-dev**: Add `rspec-cells` for testing `Cells` [\#3022](https://github.com/decidim/decidim/pull/3022)
 - **decidim-meetings**: [\#3022](https://github.com/decidim/decidim/pull/3022)
-  + Introduce `ViewModel` and `Cells`. Add `MeetingCell` with two variations: `MeetingMCell` and `MeetingListItemCell`.
-  + Add the `card` attribute to the component's manifest `shared/author_reference` partials.
+  - Introduce `ViewModel` and `Cells`. Add `MeetingCell` with two variations: `MeetingMCell` and `MeetingListItemCell`.
+  - Add the `card` attribute to the component's manifest `shared/author_reference` partials.
 - **decidim-surveys**: Add rich text description to questions [\#3066](https://github.com/decidim/decidim/pull/3066).
 - **decidim-proposals**: Add discard draft button in wizard [\#3064](https://github.com/decidim/decidim/pull/3064)
 

--- a/docs/advanced/content_processors.md
+++ b/docs/advanced/content_processors.md
@@ -13,10 +13,12 @@ Decidim.content_processors += [:special_words]
 ```
 
 This symbol will be used to instantiate parsers and processors using the following convention:
+
 - "Decidim::ContentParsers::#{type.to_s.camelize}Parser"
 - "Decidim::ContentRenderers::#{type.to_s.camelize}Renderer"
 
 Autoload parser and renderer if in the lib/ dir. For example if in proposals module edit `lib/decidim/proposals.rb`:
+
 ```rb
 module Decidim
   ...

--- a/docs/advanced/view_models_aka_cells.md
+++ b/docs/advanced/view_models_aka_cells.md
@@ -10,27 +10,30 @@ Cells are faster than ActionView. While exposing a better performance, you step-
 
 Think of cells, or view models, as small Rails controllers, but without any HTTP coupling. Cells embrace all presentation and rendering logic to present a fragment of the UI.
 
-
-# Decidim Cards
+## Decidim Cards
 
 `card_for @instance` will render the corresponding default card for each component instance.
 If a `component.card` is not registered a _basic_ (deafult) card is shown.
 
 To render a specified size/variation include the `size` option as a `symbol`: `card_for @instance, size: :m`
 
-
-## Introduce a Card Cell to a `component`.
+## Introducing a Card Cell to a `component`
 
 - add **dependency** to "decidim-*.gemspec"
+
   ```rb
   s.add_dependency "cells-erb", "~> 0.1.0"
   s.add_dependency "cells-rails", "~> 0.0.8"
   ```
+
 - **autoload** view_model to module `decidim-<module>/lib/decidim/<module>.rb`
+
   ```rb
   autoload :ViewModel, "decidim/<module>/view_model"
   ```
+
 - **require** cells in `decidim-<module>/lib/decidim/<module>/engine.rb`
+
   ```rb
   require "cells/rails"
   require "cells-erb"
@@ -40,7 +43,9 @@ To render a specified size/variation include the `size` option as a `symbol`: `c
     Cell::ViewModel.view_paths << File.expand_path("#{Decidim::<Module>::Engine.root}/app/views") # for partials
   end
   ```
+
 - add the *ViewModel* `decidim-<module>/lib/decidim/<module>/view_model.rb`
+
   ```rb
   module Decidim
     module <Module>
@@ -51,16 +56,20 @@ To render a specified size/variation include the `size` option as a `symbol`: `c
   ```
 
 - The attribute `card` of the Components is defined in `decidim-core/lib/decidim/component_manifest.rb`:
+
   ```rb
   # The cell to use to render the card of a resource.
   attribute :card, String
   ```
+
   In your `decidim-<component>/lib/decidim/<component>/component.rb` register the cell value:
+
   ```rb
   component.card = "decidim/<component>s/<component>"
   ```
 
 - The **Cell Class**, following the convention will reside in `decidim-<component>s/app/cells/decidim/<component>s/<component>_cell.rb`:
+
   ```rb
   module Decidim
     module <Component>s
@@ -77,6 +86,6 @@ To render a specified size/variation include the `size` option as a `symbol`: `c
 
 ## More Info
 
-+ [cells/README.md at master · trailblazer/cells](https://github.com/trailblazer/cells/blob/master/README.md)
-+ [Trailblazer: Cells](http://trailblazer.to/gems/cells/) / [Trailblazer: Cells API](http://trailblazer.to/gems/cells/api.html)
-+ [Introduction to Cells: A Better View Layer for Rails — SitePoint](https://www.sitepoint.com/introduction-to-cells-a-better-view-layer-for-rails/)
+- [cells/README.md at master · trailblazer/cells](https://github.com/trailblazer/cells/blob/master/README.md)
+- [Trailblazer: Cells](http://trailblazer.to/gems/cells/) / [Trailblazer: Cells API](http://trailblazer.to/gems/cells/api.html)
+- [Introduction to Cells: A Better View Layer for Rails — SitePoint](https://www.sitepoint.com/introduction-to-cells-a-better-view-layer-for-rails/)


### PR DESCRIPTION
#### :tophat: What? Why?
This PR increases the severity level of markdownlint checks so that PRs fail. Also fixes the issues found.

#### :pushpin: Related Issues
- Related to #3068

#### :clipboard: Subtasks
None