### PR TITLE
Add missing i18n keys on user profile settings

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -7,11 +7,13 @@ en:
       report:
         details: Additional comments
       user:
+        about: About
         email: Your email
         name: Your name
         nickname: Your short, unique identifier
         password: New password
         password_confirmation: Confirm your new password
+        personal_url: Personal URL
         remove_avatar: Remove avatar
         user_group_document_number: Organization document number
         user_group_name: Organization name


### PR DESCRIPTION
#### :tophat: What? Why?
Adds missing i18n keys on the user profile settings page.

#### :pushpin: Related Issues
- Fixes #3128

#### :clipboard: Subtasks
None
