### PR TITLE
Use decidim video for seed data on consultations

### DIFF
--- a/decidim-consultations/lib/decidim/consultations/participatory_space.rb
+++ b/decidim-consultations/lib/decidim/consultations/participatory_space.rb
@@ -35,7 +35,7 @@ Decidim.register_participatory_space(:consultations) do |participatory_space|
       start_voting_date: Time.zone.today,
       end_voting_date: Time.zone.today + 1.month,
       banner_image: File.new(File.join(seeds_root, "city2.jpeg")),
-      introductory_video_url: "https://www.youtube.com/embed/LakKJZjKkRM",
+      introductory_video_url: "https://www.youtube.com/embed/zhMMW0TENNA",
       decidim_highlighted_scope_id: Decidim::Scope.reorder("RANDOM()").first.id,
       organization: organization
     )
@@ -98,7 +98,7 @@ Decidim.register_participatory_space(:consultations) do |participatory_space|
       start_voting_date: Time.zone.today - 2.months,
       end_voting_date: Time.zone.today - 1.month,
       banner_image: File.new(File.join(seeds_root, "city2.jpeg")),
-      introductory_video_url: "https://www.youtube.com/embed/LakKJZjKkRM",
+      introductory_video_url: "https://www.youtube.com/embed/zhMMW0TENNA",
       decidim_highlighted_scope_id: Decidim::Scope.reorder("RANDOM()").first.id,
       organization: organization
     )

--- a/decidim-consultations/lib/decidim/consultations/test/factories.rb
+++ b/decidim-consultations/lib/decidim/consultations/test/factories.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
     published_at { Time.current }
     start_voting_date { Time.zone.today }
     end_voting_date { Time.zone.today + 1.month }
-    introductory_video_url "https://www.youtube.com/embed/LakKJZjKkRM"
+    introductory_video_url "https://www.youtube.com/embed/zhMMW0TENNA"
     decidim_highlighted_scope_id { create(:scope, organization: organization).id }
     results_published_at nil
 


### PR DESCRIPTION
#### :tophat: What? Why?
The seed data for consultations uses a corporate video unrelated to Decidim. This PR replaces that video with this one, which is about Decidim:

https://www.youtube.com/watch?v=zhMMW0TENNA

#### :pushpin: Related Issues
- Related to #3106 

#### :clipboard: Subtasks
None