### PR TITLE
More survey improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,5 +70,6 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-surveys**: Preserve deleted status of questions accross submission failures [\#3089](https://github.com/decidim/decidim/pull/3089)
 - **decidim-surveys**: Question type selector not disabled when survey has already been answered [\#3133](https://github.com/decidim/decidim/pull/3133)
 - **decidim-surveys**: Max choices selector not disabled when survey has already been answered [\#3133](https://github.com/decidim/decidim/pull/3133)
+- **decidim-surveys**: Translated fields not disabled when survey has already been answered [\#3133](https://github.com/decidim/decidim/pull/3133)
 
 Please check [0.10-stable](https://github.com/decidim/decidim/blob/0.10-stable/CHANGELOG.md) for previous changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,5 +67,6 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-surveys**: Multiple choice questions without answer options can no longer be created [\#3087](https://github.com/decidim/decidim/pull/3087)
 - **decidim-surveys**: Multiple choice questions with empty answer options can no longer be created [\#3087](https://github.com/decidim/decidim/pull/3087)
 - **decidim-surveys**: Preserve deleted status of questions accross submission failures [\#3089](https://github.com/decidim/decidim/pull/3089)
+- **decidim-surveys**: Question type selector not disabled when survey has already been answered [\#3133](https://github.com/decidim/decidim/pull/3133)
 
 Please check [0.10-stable](https://github.com/decidim/decidim/blob/0.10-stable/CHANGELOG.md) for previous changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,5 +69,6 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-surveys**: Multiple choice questions with empty answer options can no longer be created [\#3087](https://github.com/decidim/decidim/pull/3087)
 - **decidim-surveys**: Preserve deleted status of questions accross submission failures [\#3089](https://github.com/decidim/decidim/pull/3089)
 - **decidim-surveys**: Question type selector not disabled when survey has already been answered [\#3133](https://github.com/decidim/decidim/pull/3133)
+- **decidim-surveys**: Max choices selector not disabled when survey has already been answered [\#3133](https://github.com/decidim/decidim/pull/3133)
 
 Please check [0.10-stable](https://github.com/decidim/decidim/blob/0.10-stable/CHANGELOG.md) for previous changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-surveys**: Add rich text description to questions [\#3066](https://github.com/decidim/decidim/pull/3066).
 - **decidim-proposals**: Add discard draft button in wizard [\#3064](https://github.com/decidim/decidim/pull/3064)
 - **decidim-surveys**: Allow multiple choice questions to specify a maximum number of options to be checked [\#3091](https://github.com/decidim/decidim/pull/3091)
+- **decidim-surveys**: Client side survey errors are now displayed [\#3133](https://github.com/decidim/decidim/pull/3133)
 
 **Changed**:
 

--- a/decidim-core/app/assets/javascripts/decidim/editor.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/editor.js.es6
@@ -6,6 +6,7 @@
 
   const createQuillEditor = (container) => {
     const toolbar = $(container).data("toolbar");
+    const disabled = $(container).data("disabled");
 
     let quillToolbar = [
       ["bold", "italic", "underline"],
@@ -34,6 +35,10 @@
       formats: quillFormats,
       theme: "snow"
     });
+
+    if (disabled) {
+      quill.disable();
+    }
 
     quill.on("text-change", () => {
       const text = quill.getText();

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -83,10 +83,10 @@ module Decidim
     #
     # name - The name of the field
     # options - The set of options to send to the field
-    #           :label   - The Boolean value to create or not the input label (optional) (default: true)
+    #           :label - The Boolean value to create or not the input label (optional) (default: true)
     #           :toolbar - The String value to configure WYSIWYG toolbar. It should be 'basic' or
     #                      or 'full' (optional) (default: 'basic')
-    #           :lines   - The Integer to indicate how many lines should editor have (optional) (default: 10)
+    #           :lines - The Integer to indicate how many lines should editor have (optional) (default: 10)
     #
     # Renders a container with both hidden field and editor container
     def editor(name, options = {})

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -87,18 +87,21 @@ module Decidim
     #           :toolbar - The String value to configure WYSIWYG toolbar. It should be 'basic' or
     #                      or 'full' (optional) (default: 'basic')
     #           :lines - The Integer to indicate how many lines should editor have (optional) (default: 10)
+    #           :disabled - Whether the editor should be disabled
     #
     # Renders a container with both hidden field and editor container
     def editor(name, options = {})
       options[:toolbar] ||= "basic"
       options[:lines] ||= 10
+      options[:disabled] ||= false
 
       content_tag(:div, class: "editor") do
         template = ""
         template += label(name, options[:label].to_s || name) if options[:label] != false
         template += hidden_field(name, options)
         template += content_tag(:div, nil, class: "editor-container", data: {
-                                  toolbar: options[:toolbar]
+                                  toolbar: options[:toolbar],
+                                  disabled: options[:disabled]
                                 }, style: "height: #{options[:lines]}rem")
         template += error_for(name, options) if error?(name)
         template.html_safe

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/field_dependent_inputs.component.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/field_dependent_inputs.component.js.es6
@@ -5,7 +5,7 @@
       this.wrapperSelector = options.wrapperSelector;
       this.dependentFieldsSelector = options.dependentFieldsSelector;
       this.dependentInputSelector = options.dependentInputSelector;
-      this.enablingValues = options.enablingValues;
+      this.enablingCondition = options.enablingCondition;
       this._bindEvent();
       this._run();
     }
@@ -14,9 +14,8 @@
       const $controllerField = this.controllerField;
       const $dependentFields = $controllerField.parents(this.wrapperSelector).find(this.dependentFieldsSelector);
       const $dependentInputs = $dependentFields.find(this.dependentInputSelector);
-      const value = $controllerField.val();
 
-      if (this.enablingValues.indexOf(value) > -1) {
+      if (this.enablingCondition($controllerField)) {
         $dependentInputs.prop("disabled", false);
         $dependentFields.show();
       } else {

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
@@ -90,7 +90,9 @@
       wrapperSelector: fieldSelector,
       dependentFieldsSelector: answerOptionsWrapperSelector,
       dependentInputSelector: `${answerOptionFieldSelector} input`,
-      enablingValues: ["single_option", "multiple_option"]
+      enablingCondition: ($field) => {
+        return ["single_option", "multiple_option"].indexOf($field.val()) > -1
+      }
     });
 
     createFieldDependentInputs({
@@ -98,7 +100,9 @@
       wrapperSelector: fieldSelector,
       dependentFieldsSelector: maxChoicesWrapperSelector,
       dependentInputSelector: "select",
-      enablingValues: ["multiple_option"]
+      enablingCondition: ($field) => {
+        return ["multiple_option"].indexOf($field.val()) > -1
+      }
     });
 
     dynamicFieldsForAnswerOptions[fieldId] = createDynamicFieldsForAnswerOptions(fieldId);

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/admin/surveys.js.es6
@@ -81,6 +81,12 @@
 
   const dynamicFieldsForAnswerOptions = {};
 
+  const isMultipleChoiceOption = ($selectField) => {
+    const value = $selectField.val();
+
+    return value === "single_option" || value === "multiple_option"
+  }
+
   const setupInitialQuestionAttributes = ($target) => {
     const fieldId = $target.attr("id");
     const $fieldQuestionTypeSelect = $target.find(questionTypeSelector);
@@ -91,7 +97,7 @@
       dependentFieldsSelector: answerOptionsWrapperSelector,
       dependentInputSelector: `${answerOptionFieldSelector} input`,
       enablingCondition: ($field) => {
-        return ["single_option", "multiple_option"].indexOf($field.val()) > -1
+        return isMultipleChoiceOption($field);
       }
     });
 
@@ -101,7 +107,7 @@
       dependentFieldsSelector: maxChoicesWrapperSelector,
       dependentInputSelector: "select",
       enablingCondition: ($field) => {
-        return ["multiple_option"].indexOf($field.val()) > -1
+        return $field.val() === "multiple_option"
       }
     });
 
@@ -110,9 +116,7 @@
     const dynamicFields = dynamicFieldsForAnswerOptions[fieldId];
 
     const onQuestionTypeChange = () => {
-      const value = $fieldQuestionTypeSelect.val();
-
-      if (value === "single_option" || value === "multiple_option") {
+      if (isMultipleChoiceOption($fieldQuestionTypeSelect)) {
         const nOptions = $fieldQuestionTypeSelect.parents(fieldSelector).find(answerOptionFieldSelector).length;
 
         if (nOptions === 0) {

--- a/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
+++ b/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
@@ -39,7 +39,7 @@ module Decidim
               position: form_question.position,
               mandatory: form_question.mandatory,
               question_type: form_question.question_type,
-              answer_options: form_question.answer_options_to_persist.map { |answer| { "body" => answer.body } },
+              answer_options: form_question.answer_options_to_persist.map { |option| { "body" => option.body } },
               max_choices: form_question.max_choices
             }
 

--- a/decidim-surveys/app/commands/decidim/surveys/answer_survey.rb
+++ b/decidim-surveys/app/commands/decidim/surveys/answer_survey.rb
@@ -33,7 +33,8 @@ module Decidim
               user: @current_user,
               survey: @survey,
               question: form_answer.question,
-              body: form_answer.body
+              body: form_answer.body,
+              choices: form_answer.choices
             )
           end
         end

--- a/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
@@ -40,7 +40,7 @@ module Decidim
       end
 
       def max_answers
-        errors.add("choices", :too_many) if choices.size > question.max_choices
+        errors.add(:choices, :too_many) if choices.size > question.max_choices
       end
 
       def mandatory_label

--- a/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
@@ -22,7 +22,7 @@ module Decidim
       end
 
       def label
-        base = "#{question.position + 1}. #{translated_attribute(question.body)}"
+        base = "#{id}. #{translated_attribute(question.body)}"
         base += " #{mandatory_label}" if question.mandatory?
         base += " (#{max_choices_label})" if question.max_choices
         base

--- a/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
@@ -7,11 +7,12 @@ module Decidim
       include Decidim::TranslationsHelper
 
       attribute :question_id, String
-      attribute :body, Array[String]
+      attribute :body, String
+      attribute :choices, Array[String]
 
-      validates :body, presence: true, if: -> { question.mandatory? }
+      validates :body, presence: true, if: -> { question.mandatory? && !question.multiple_choice? }
+      validates :choices, presence: true, if: -> { question.mandatory? && question.multiple_choice? }
 
-      validate :body_not_blank, if: -> { question.mandatory? }
       validate :max_answers, if: -> { question.max_choices }
 
       def question
@@ -38,12 +39,8 @@ module Decidim
         @survey ||= Survey.where(component: current_component).first
       end
 
-      def body_not_blank
-        errors.add("body", :blank) if body.all?(&:blank?)
-      end
-
       def max_answers
-        errors.add("body", :too_many_choices) if body.size > question.max_choices
+        errors.add("choices", :too_many) if choices.size > question.max_choices
       end
 
       def mandatory_label

--- a/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
@@ -7,7 +7,7 @@ module Decidim
       include Decidim::TranslationsHelper
 
       attribute :question_id, String
-      attribute :body, String
+      attribute :body, Array[String]
 
       validates :body, presence: true, if: -> { question.mandatory? }
 

--- a/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
@@ -10,10 +10,12 @@ module Decidim
       attribute :body, String
       attribute :choices, Array[String]
 
-      validates :body, presence: true, if: -> { question.mandatory? && !question.multiple_choice? }
-      validates :choices, presence: true, if: -> { question.mandatory? && question.multiple_choice? }
+      validates :body, presence: true, if: :mandatory_body?
+      validates :choices, presence: true, if: :mandatory_choices?
 
       validate :max_answers, if: -> { question.max_choices }
+
+      delegate :mandatory_body?, :mandatory_choices?, to: :question
 
       def question
         @question ||= survey.questions.find(question_id)

--- a/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
@@ -39,13 +39,10 @@ module Decidim
       end
 
       def body_not_blank
-        return if body.nil?
         errors.add("body", :blank) if body.all?(&:blank?)
       end
 
       def max_answers
-        return if body.nil?
-
         errors.add("body", :too_many_choices) if body.size > question.max_choices
       end
 

--- a/decidim-surveys/app/forms/decidim/surveys/survey_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_form.rb
@@ -13,8 +13,8 @@ module Decidim
       #
       # Returns nothing.
       def map_model(model)
-        self.answers = model.questions.map do |question|
-          SurveyAnswerForm.from_params(question_id: question.id)
+        self.answers = model.questions.each_with_index.map do |question, id|
+          SurveyAnswerForm.new(id: id + 1, question_id: question.id)
         end
       end
     end

--- a/decidim-surveys/app/models/decidim/surveys/survey_answer.rb
+++ b/decidim-surveys/app/models/decidim/surveys/survey_answer.rb
@@ -8,7 +8,9 @@ module Decidim
       belongs_to :survey, class_name: "Survey", foreign_key: "decidim_survey_id"
       belongs_to :question, class_name: "SurveyQuestion", foreign_key: "decidim_survey_question_id"
 
-      validates :body, presence: true, if: -> { question.mandatory? }
+      validates :body, presence: true, if: -> { question.mandatory_body? }
+      validates :options, presence: true, if: -> { question.mandatory_choices? }
+
       validate :user_survey_same_organization
       validate :question_belongs_to_survey
 

--- a/decidim-surveys/app/models/decidim/surveys/survey_question.rb
+++ b/decidim-surveys/app/models/decidim/surveys/survey_question.rb
@@ -9,6 +9,10 @@ module Decidim
       belongs_to :survey, class_name: "Survey", foreign_key: "decidim_survey_id"
 
       validates :question_type, inclusion: { in: TYPES }
+
+      def multiple_choice?
+        %w(single_option multiple_option).include?(question_type)
+      end
     end
   end
 end

--- a/decidim-surveys/app/models/decidim/surveys/survey_question.rb
+++ b/decidim-surveys/app/models/decidim/surveys/survey_question.rb
@@ -13,6 +13,14 @@ module Decidim
       def multiple_choice?
         %w(single_option multiple_option).include?(question_type)
       end
+
+      def mandatory_body?
+        mandatory? && !multiple_choice?
+      end
+
+      def mandatory_choices?
+        mandatory? && multiple_choice?
+      end
     end
   end
 end

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
@@ -4,7 +4,7 @@
   <div class="card-divider">
     <h2 class="card-title">
     <span><%= t(".answer_option") %></span>
-    <% if survey.questions_editable? %>
+    <% if editable %>
       <button class="button small alert hollow remove-answer-option button--title">
         <%= t(".remove") %>
       </button>
@@ -20,15 +20,15 @@
           :body,
           tabs_id: tabs_id_for_question_answer_option(question, answer_option),
           label: t(".statement"),
-          disabled: !survey.questions_editable?
+          disabled: !editable
         )
       %>
     </div>
   </div>
 
   <% if answer_option.persisted? %>
-    <%= form.hidden_field :id, disabled: !survey.questions_editable? %>
+    <%= form.hidden_field :id, disabled: !editable %>
   <% end %>
 
-  <%= form.hidden_field :deleted, value: false, disabled: !survey.questions_editable? %>
+  <%= form.hidden_field :deleted, value: false, disabled: !editable %>
 </div>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
@@ -46,4 +46,6 @@
   <% end %>
 </div>
 
-<%= javascript_include_tag "decidim/surveys/admin/surveys" %>
+<% if survey.questions_editable? %>
+  <%= javascript_include_tag "decidim/surveys/admin/surveys" %>
+<% end %>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_form.html.erb
@@ -24,7 +24,7 @@
   <% if survey.questions_editable? %>
     <template>
       <%= fields_for "survey[questions][#{blank_question.to_param}]", blank_question do |question_form| %>
-        <%= render "question", form: question_form, id: tabs_id_for_question(blank_question) %>
+        <%= render "question", form: question_form, id: tabs_id_for_question(blank_question), editable: survey.questions_editable? %>
       <% end %>
     </template>
   <% else %>
@@ -36,7 +36,7 @@
   <div class="survey-questions-list">
     <% @form.questions.each do |question| %>
       <%= fields_for "survey[questions][]", question do |question_form| %>
-        <%= render "question", form: question_form, id: tabs_id_for_question(question) %>
+        <%= render "question", form: question_form, id: tabs_id_for_question(question), editable: survey.questions_editable? %>
       <% end %>
     <% end %>
   </div>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
@@ -4,14 +4,14 @@
   <div class="card-divider question-divider">
     <h2 class="card-title">
     <span>
-      <% if survey.questions_editable? %>
+      <% if editable %>
         <%== "#{icon("move")} #{t(".question")}" %>
       <% else %>
         <%= t(".question") %>
       <% end %>
     </span>
 
-    <% if survey.questions_editable? %>
+    <% if editable %>
       <button class="button small alert hollow move-up-question button--title">
         <%== "#{icon("arrow-top")} #{t(".up")}" %>
       </button>
@@ -35,7 +35,7 @@
           :body,
           tabs_id: id,
           label: t(".statement"),
-          disabled: !survey.questions_editable?
+          disabled: !editable
         )
       %>
     </div>
@@ -48,7 +48,7 @@
           toolbar: :full,
           tabs_id: id,
           label: t(".description"),
-          disabled: !survey.questions_editable?
+          disabled: !editable
         )
       %>
     </div>
@@ -57,7 +57,7 @@
       <%=
         form.check_box(
           :mandatory,
-          disabled: !survey.questions_editable?,
+          disabled: !editable,
           label: t("activemodel.attributes.survey_question.mandatory")
         )
       %>
@@ -69,34 +69,34 @@
           :question_type,
           options_from_collection_for_select(question_types, :first, :last, question.question_type),
           {},
-          disabled: !survey.questions_editable?
+          disabled: !editable
         )
       %>
     </div>
 
     <% if question.persisted? %>
-      <%= form.hidden_field :id, disabled: !survey.questions_editable? %>
+      <%= form.hidden_field :id, disabled: !editable %>
     <% end %>
 
-    <%= form.hidden_field :position, value: question.position || 0, disabled: !survey.questions_editable? %>
-    <%= form.hidden_field :deleted, disabled: !survey.questions_editable? %>
+    <%= form.hidden_field :position, value: question.position || 0, disabled: !editable %>
+    <%= form.hidden_field :deleted, disabled: !editable %>
 
     <div class="survey-question-answer-options">
       <template>
         <%= fields_for "survey[questions][#{question.to_param}][answer_options][]", blank_answer_option do |answer_option_form| %>
-          <%= render "answer_option", form: answer_option_form, question: question %>
+          <%= render "answer_option", form: answer_option_form, question: question, editable: editable %>
         <% end %>
       </template>
 
       <div class="survey-question-answer-options-list">
         <% question.answer_options.each do |answer_option| %>
           <%= fields_for "survey[questions][#{question.to_param}][answer_options][]", answer_option do |answer_option_form| %>
-            <%= render "answer_option", form: answer_option_form, question: question %>
+            <%= render "answer_option", form: answer_option_form, question: question, editable: editable %>
           <% end %>
         <% end %>
       </div>
 
-      <% if survey.questions_editable? %>
+      <% if editable %>
         <button class="button add-answer-option"><%= t(".add_answer_option") %></button>
       <% end %>
     </div>
@@ -107,7 +107,7 @@
           :max_choices,
           (2..question.number_of_options),
           prompt: t(".any"),
-          disabled: !survey.questions_editable?
+          disabled: !editable
         )
       %>
     </div>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
@@ -68,6 +68,7 @@
         form.select(
           :question_type,
           options_from_collection_for_select(question_types, :first, :last, question.question_type),
+          {},
           disabled: !survey.questions_editable?
         )
       %>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_question.html.erb
@@ -106,7 +106,7 @@
         form.select(
           :max_choices,
           (2..question.number_of_options),
-          prompt: t(".any"),
+          { prompt: t(".any") },
           disabled: !editable
         )
       %>

--- a/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
@@ -1,0 +1,39 @@
+<% field_id = "survey_#{survey.id}_question_#{answer.question.id}_answer_body" %>
+<%= label_tag field_id, answer.label, class: "survey-question" %>
+
+<% if translated_attribute(answer.question.description).present? %>
+  <div class="help-text">
+    <%= decidim_sanitize translated_attribute(answer.question.description) %>
+  </div>
+<% end %>
+
+<% case answer.question.question_type %>
+  <% when "short_answer" %>
+    <%= text_field_tag "survey[answers][#{answer_idx}][body][]", answer.body.first, id: field_id, class: "#{'is-invalid-input' unless answer.errors.empty?}" %>
+  <% when "long_answer" %>
+    <%= text_area_tag "survey[answers][#{answer_idx}][body][]", answer.body.first, id: field_id, class: "#{'is-invalid-input' unless answer.errors.empty?}", rows: 10 %>
+  <% when "single_option" %>
+    <div id="<%= field_id %>_answer_options" class="radio-button-collection">
+      <% answer.question.answer_options.each_with_index do |answer_option, idx| %>
+        <%= label_tag "#{field_id}_option_#{idx}" do %>
+          <%= radio_button_tag "survey[answers][#{answer_idx}][body][]", translated_attribute(answer_option["body"]), answer.body.include?(translated_attribute(answer_option["body"])), id: "#{field_id}_option_#{idx}" %>
+          <%= translated_attribute(answer_option["body"]) %>
+        <% end %>
+      <% end %>
+    </div>
+  <% when "multiple_option" %>
+    <div id="<%= field_id %>_answer_options" class="check-box-collection">
+      <% answer.question.answer_options.each_with_index do |answer_option, idx| %>
+        <%= label_tag "#{field_id}_option_#{idx}" do %>
+          <%= check_box_tag "survey[answers][#{answer_idx}][body][]", translated_attribute(answer_option["body"]), answer.body.include?(translated_attribute(answer_option["body"])), id: "#{field_id}_option_#{idx}" %>
+          <%= translated_attribute(answer_option["body"]) %>
+        <% end %>
+      <% end %>
+    </div>
+<% end %>
+
+<%= hidden_field_tag "survey[answers][#{answer_idx}][question_id]", answer.question.id %>
+
+<% answer.errors.full_messages.each do |msg| %>
+  <%= content_tag :small, msg, class: "form-error is-visible" %>
+<% end %>

--- a/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
@@ -9,9 +9,9 @@
 
 <% case answer.question.question_type %>
   <% when "short_answer" %>
-    <%= text_field_tag "survey[answers][#{answer_idx}][body]", answer.body, id: field_id, class: "#{'is-invalid-input' unless answer.errors.empty?}" %>
+    <%= answer_form.text_field :body, label: false, id: field_id %>
   <% when "long_answer" %>
-    <%= text_area_tag "survey[answers][#{answer_idx}][body]", answer.body, id: field_id, class: "#{'is-invalid-input' unless answer.errors.empty?}", rows: 10 %>
+    <%= answer_form.text_area :body, label: false, id: field_id, rows: 10 %>
   <% when "single_option" %>
     <div id="<%= field_id %>_answer_options" class="radio-button-collection">
       <% answer.question.answer_options.each_with_index do |answer_option, idx| %>
@@ -32,7 +32,8 @@
     </div>
 <% end %>
 
-<%= hidden_field_tag "survey[answers][#{answer_idx}][question_id]", answer.question.id %>
+<%= answer_form.hidden_field :id %>
+<%= answer_form.hidden_field :question_id %>
 
 <% answer.errors.full_messages.each do |msg| %>
   <%= content_tag :small, msg, class: "form-error is-visible" %>

--- a/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
@@ -9,14 +9,14 @@
 
 <% case answer.question.question_type %>
   <% when "short_answer" %>
-    <%= text_field_tag "survey[answers][#{answer_idx}][body][]", answer.body.first, id: field_id, class: "#{'is-invalid-input' unless answer.errors.empty?}" %>
+    <%= text_field_tag "survey[answers][#{answer_idx}][body]", answer.body, id: field_id, class: "#{'is-invalid-input' unless answer.errors.empty?}" %>
   <% when "long_answer" %>
-    <%= text_area_tag "survey[answers][#{answer_idx}][body][]", answer.body.first, id: field_id, class: "#{'is-invalid-input' unless answer.errors.empty?}", rows: 10 %>
+    <%= text_area_tag "survey[answers][#{answer_idx}][body]", answer.body, id: field_id, class: "#{'is-invalid-input' unless answer.errors.empty?}", rows: 10 %>
   <% when "single_option" %>
     <div id="<%= field_id %>_answer_options" class="radio-button-collection">
       <% answer.question.answer_options.each_with_index do |answer_option, idx| %>
         <%= label_tag "#{field_id}_option_#{idx}" do %>
-          <%= radio_button_tag "survey[answers][#{answer_idx}][body][]", translated_attribute(answer_option["body"]), answer.body.include?(translated_attribute(answer_option["body"])), id: "#{field_id}_option_#{idx}" %>
+          <%= radio_button_tag "survey[answers][#{answer_idx}][choices][]", translated_attribute(answer_option["body"]), answer.choices.include?(translated_attribute(answer_option["body"])), id: "#{field_id}_option_#{idx}" %>
           <%= translated_attribute(answer_option["body"]) %>
         <% end %>
       <% end %>
@@ -25,7 +25,7 @@
     <div id="<%= field_id %>_answer_options" class="check-box-collection">
       <% answer.question.answer_options.each_with_index do |answer_option, idx| %>
         <%= label_tag "#{field_id}_option_#{idx}" do %>
-          <%= check_box_tag "survey[answers][#{answer_idx}][body][]", translated_attribute(answer_option["body"]), answer.body.include?(translated_attribute(answer_option["body"])), id: "#{field_id}_option_#{idx}" %>
+          <%= check_box_tag "survey[answers][#{answer_idx}][choices][]", translated_attribute(answer_option["body"]), answer.choices.include?(translated_attribute(answer_option["body"])), id: "#{field_id}_option_#{idx}" %>
           <%= translated_attribute(answer_option["body"]) %>
         <% end %>
       <% end %>

--- a/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
@@ -32,45 +32,7 @@
                 <%= decidim_form_for(@form, url: answer_survey_path(survey), method: :post, html: { class: "form answer-survey" }) do |form| %>
                   <% @form.answers.each_with_index do |answer, answer_idx| %>
                     <div class="row column">
-                      <% field_id = "survey_#{survey.id}_question_#{answer.question.id}_answer_body" %>
-                      <%= label_tag field_id, answer.label, class: "survey-question" %>
-
-                      <% if translated_attribute(answer.question.description).present? %>
-                        <div class="help-text">
-                          <%= decidim_sanitize translated_attribute(answer.question.description) %>
-                        </div>
-                      <% end %>
-
-                      <% case answer.question.question_type %>
-                        <% when "short_answer" %>
-                          <%= text_field_tag "survey[answers][#{answer_idx}][body][]", answer.body.first, id: field_id, class: "#{'is-invalid-input' unless answer.errors.empty?}" %>
-                        <% when "long_answer" %>
-                          <%= text_area_tag "survey[answers][#{answer_idx}][body][]", answer.body.first, id: field_id, class: "#{'is-invalid-input' unless answer.errors.empty?}", rows: 10 %>
-                        <% when "single_option" %>
-                          <div id="<%= field_id %>_answer_options" class="radio-button-collection">
-                            <% answer.question.answer_options.each_with_index do |answer_option, idx| %>
-                              <%= label_tag "#{field_id}_option_#{idx}" do %>
-                                <%= radio_button_tag "survey[answers][#{answer_idx}][body][]", translated_attribute(answer_option["body"]), answer.body.include?(translated_attribute(answer_option["body"])), id: "#{field_id}_option_#{idx}" %>
-                                <%= translated_attribute(answer_option["body"]) %>
-                              <% end %>
-                            <% end %>
-                          </div>
-                        <% when "multiple_option" %>
-                          <div id="<%= field_id %>_answer_options" class="check-box-collection">
-                            <% answer.question.answer_options.each_with_index do |answer_option, idx| %>
-                              <%= label_tag "#{field_id}_option_#{idx}" do %>
-                                <%= check_box_tag "survey[answers][#{answer_idx}][body][]", translated_attribute(answer_option["body"]), answer.body.include?(translated_attribute(answer_option["body"])), id: "#{field_id}_option_#{idx}" %>
-                                <%= translated_attribute(answer_option["body"]) %>
-                              <% end %>
-                            <% end %>
-                          </div>
-                      <% end %>
-
-                      <%= hidden_field_tag "survey[answers][#{answer_idx}][question_id]", answer.question.id %>
-
-                      <% answer.errors.full_messages.each do |msg| %>
-                        <%= content_tag :small, msg, class: "form-error is-visible" %>
-                      <% end %>
+                      <%= render "answer", answer: answer, answer_idx: answer_idx %>
                     </div>
                   <% end %>
 

--- a/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
@@ -30,9 +30,11 @@
             <% else %>
               <div class="answer-survey">
                 <%= decidim_form_for(@form, url: answer_survey_path(survey), method: :post, html: { class: "form answer-survey" }) do |form| %>
-                  <% @form.answers.each_with_index do |answer, answer_idx| %>
+                  <% @form.answers.each do |answer| %>
                     <div class="row column">
-                      <%= render "answer", answer: answer, answer_idx: answer_idx %>
+                      <%= fields_for "survey[answers][]", answer do |answer_form| %>
+                        <%= render "answer", answer_form: answer_form, answer: answer, answer_idx: answer.id %>
+                      <% end %>
                     </div>
                   <% end %>
 

--- a/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
@@ -43,14 +43,14 @@
 
                       <% case answer.question.question_type %>
                         <% when "short_answer" %>
-                          <%= text_field_tag "survey[answers][#{answer_idx}][body][]", answer.body.try(:first), id: field_id, class: "#{'is-invalid-input' unless answer.errors.empty?}" %>
+                          <%= text_field_tag "survey[answers][#{answer_idx}][body][]", answer.body.first, id: field_id, class: "#{'is-invalid-input' unless answer.errors.empty?}" %>
                         <% when "long_answer" %>
-                          <%= text_area_tag "survey[answers][#{answer_idx}][body][]", answer.body.try(:first), id: field_id, class: "#{'is-invalid-input' unless answer.errors.empty?}", rows: 10 %>
+                          <%= text_area_tag "survey[answers][#{answer_idx}][body][]", answer.body.first, id: field_id, class: "#{'is-invalid-input' unless answer.errors.empty?}", rows: 10 %>
                         <% when "single_option" %>
                           <div id="<%= field_id %>_answer_options" class="radio-button-collection">
                             <% answer.question.answer_options.each_with_index do |answer_option, idx| %>
                               <%= label_tag "#{field_id}_option_#{idx}" do %>
-                                <%= radio_button_tag "survey[answers][#{answer_idx}][body][]", translated_attribute(answer_option["body"]), answer.body.try(:include?, translated_attribute(answer_option["body"])), id: "#{field_id}_option_#{idx}" %>
+                                <%= radio_button_tag "survey[answers][#{answer_idx}][body][]", translated_attribute(answer_option["body"]), answer.body.include?(translated_attribute(answer_option["body"])), id: "#{field_id}_option_#{idx}" %>
                                 <%= translated_attribute(answer_option["body"]) %>
                               <% end %>
                             <% end %>
@@ -59,7 +59,7 @@
                           <div id="<%= field_id %>_answer_options" class="check-box-collection">
                             <% answer.question.answer_options.each_with_index do |answer_option, idx| %>
                               <%= label_tag "#{field_id}_option_#{idx}" do %>
-                                <%= check_box_tag "survey[answers][#{answer_idx}][body][]", translated_attribute(answer_option["body"]), answer.body.try(:include?, translated_attribute(answer_option["body"])), id: "#{field_id}_option_#{idx}" %>
+                                <%= check_box_tag "survey[answers][#{answer_idx}][body][]", translated_attribute(answer_option["body"]), answer.body.include?(translated_attribute(answer_option["body"])), id: "#{field_id}_option_#{idx}" %>
                                 <%= translated_attribute(answer_option["body"]) %>
                               <% end %>
                             <% end %>

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -13,7 +13,7 @@ en:
         survey_answer:
           attributes:
             choices:
-              too_many: has too many options checked
+              too_many: are too many
   decidim:
     components:
       surveys:
@@ -38,6 +38,10 @@ en:
           email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
           email_subject: A new survey in %{participatory_space_title}
           notification_title: The survey <a href="%{resource_path}">%{resource_title}</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a> is now open.
+    forms:
+      errors:
+        survey_answer:
+          body: Body can't be blank
     surveys:
       admin:
         exports:

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -12,8 +12,8 @@ en:
       models:
         survey_answer:
           attributes:
-            body:
-              too_many_choices: has too many options checked
+            choices:
+              too_many: has too many options checked
   decidim:
     components:
       surveys:

--- a/decidim-surveys/db/migrate/20180405014929_add_choices_to_decidim_survey_answers.rb
+++ b/decidim-surveys/db/migrate/20180405014929_add_choices_to_decidim_survey_answers.rb
@@ -10,20 +10,21 @@ class AddChoicesToDecidimSurveyAnswers < ActiveRecord::Migration[5.1]
   end
 
   def up
+    add_column :decidim_surveys_survey_answers, :text_body, :text
     add_column :decidim_surveys_survey_answers, :choices, :jsonb
 
     SurveyAnswer.find_each do |answer|
       question = SurveyQuestion.find_by(id: answer.decidim_survey_question_id)
 
       if %w(single_option multiple_option).include?(question.question_type)
-        answer.update!(choices: answer.body, body: nil)
+        answer.update!(choices: answer.body)
       else
-        answer.update!(body: answer.body.first)
+        answer.update!(text_body: answer.body.first)
       end
     end
 
-    change_column_default :decidim_surveys_survey_answers, :body, nil
-    change_column :decidim_surveys_survey_answers, :body, "text USING CAST(body AS text)"
+    remove_column :decidim_surveys_survey_answers, :body
+    rename_column :decidim_surveys_survey_answers, :text_body, :body
   end
 
   def down
@@ -39,9 +40,9 @@ class AddChoicesToDecidimSurveyAnswers < ActiveRecord::Migration[5.1]
       end
     end
 
-    remove_column :decidim_surveys_survey_answers, :body
     remove_column :decidim_surveys_survey_answers, :choices
 
+    remove_column :decidim_surveys_survey_answers, :body
     rename_column :decidim_surveys_survey_answers, :jsonb_body, :body
   end
 end

--- a/decidim-surveys/db/migrate/20180405014929_add_choices_to_decidim_survey_answers.rb
+++ b/decidim-surveys/db/migrate/20180405014929_add_choices_to_decidim_survey_answers.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class AddChoicesToDecidimSurveyAnswers < ActiveRecord::Migration[5.1]
+  class SurveyAnswer < ApplicationRecord
+    self.table_name = :decidim_surveys_survey_answers
+  end
+
+  def up
+    add_column :decidim_surveys_survey_answers, :choices, :jsonb
+
+    SurveyAnswer.find_each do |answer|
+      if %w(single_option multiple_option).include?(answer.question_type)
+        answer.update!(choices: answer.body, body: nil)
+      else
+        answer.update!(body: answer.body.first)
+      end
+    end
+
+    change_column_default :decidim_surveys_survey_answers, :body, nil
+    change_column :decidim_surveys_survey_answers, :body, "text USING CAST(body AS text)"
+  end
+
+  def down
+    add_column :decidim_surveys_survey_answers, :jsonb_body, :jsonb, default: []
+
+    SurveyAnswer.find_each do |answer|
+      if %w(single_option multiple_option).include?(answer.question_type)
+        answer.update!(jsonb_body: answer.choices)
+      else
+        answer.update!(jsonb_body: [answer.body])
+      end
+    end
+
+    remove_column :decidim_surveys_survey_answers, :body
+    remove_column :decidim_surveys_survey_answers, :choices
+
+    rename_column :decidim_surveys_survey_answers, :jsonb_body, :body
+  end
+end

--- a/decidim-surveys/db/migrate/20180405014929_add_choices_to_decidim_survey_answers.rb
+++ b/decidim-surveys/db/migrate/20180405014929_add_choices_to_decidim_survey_answers.rb
@@ -5,11 +5,17 @@ class AddChoicesToDecidimSurveyAnswers < ActiveRecord::Migration[5.1]
     self.table_name = :decidim_surveys_survey_answers
   end
 
+  class SurveyQuestion < ApplicationRecord
+    self.table_name = :decidim_surveys_survey_questions
+  end
+
   def up
     add_column :decidim_surveys_survey_answers, :choices, :jsonb
 
     SurveyAnswer.find_each do |answer|
-      if %w(single_option multiple_option).include?(answer.question_type)
+      question = SurveyQuestion.find_by(id: answer.decidim_survey_question_id)
+
+      if %w(single_option multiple_option).include?(question.question_type)
         answer.update!(choices: answer.body, body: nil)
       else
         answer.update!(body: answer.body.first)
@@ -24,7 +30,9 @@ class AddChoicesToDecidimSurveyAnswers < ActiveRecord::Migration[5.1]
     add_column :decidim_surveys_survey_answers, :jsonb_body, :jsonb, default: []
 
     SurveyAnswer.find_each do |answer|
-      if %w(single_option multiple_option).include?(answer.question_type)
+      question = SurveyQuestion.find_by(id: answer.decidim_survey_question_id)
+
+      if %w(single_option multiple_option).include?(question.question_type)
         answer.update!(jsonb_body: answer.choices)
       else
         answer.update!(jsonb_body: [answer.body])

--- a/decidim-surveys/spec/commands/decidim/surveys/answer_survey_spec.rb
+++ b/decidim-surveys/spec/commands/decidim/surveys/answer_survey_spec.rb
@@ -20,7 +20,7 @@ module Decidim
               "question_id" => survey_question_1.id
             },
             {
-              "body" => "This is my second answer",
+              "choices" => %w(This is my second answer),
               "question_id" => survey_question_2.id
             }
           ],
@@ -68,8 +68,8 @@ module Decidim
         it "creates answers with the correct information" do
           command.call
 
-          expect(SurveyAnswer.first.body).to eq(["This is my first answer"])
-          expect(SurveyAnswer.second.body).to eq(["This is my second answer"])
+          expect(SurveyAnswer.first.body).to eq("This is my first answer")
+          expect(SurveyAnswer.last.choices).to eq(%w(This is my second answer))
         end
       end
     end

--- a/decidim-surveys/spec/commands/decidim/surveys/answer_survey_spec.rb
+++ b/decidim-surveys/spec/commands/decidim/surveys/answer_survey_spec.rb
@@ -20,7 +20,7 @@ module Decidim
               "question_id" => survey_question_1.id
             },
             {
-              "body" => "This is my first answer",
+              "body" => "This is my second answer",
               "question_id" => survey_question_2.id
             }
           ],
@@ -63,6 +63,13 @@ module Decidim
             command.call
           end.to change(SurveyAnswer, :count).by(2)
           expect(SurveyAnswer.all.map(&:survey)).to eq([survey, survey])
+        end
+
+        it "creates answers with the correct information" do
+          command.call
+
+          expect(SurveyAnswer.first.body).to eq(["This is my first answer"])
+          expect(SurveyAnswer.second.body).to eq(["This is my second answer"])
         end
       end
     end

--- a/decidim-surveys/spec/commands/decidim/surveys/answer_survey_spec.rb
+++ b/decidim-surveys/spec/commands/decidim/surveys/answer_survey_spec.rb
@@ -62,8 +62,7 @@ module Decidim
           expect do
             command.call
           end.to change(SurveyAnswer, :count).by(2)
-          last_answer = SurveyAnswer.last
-          expect(last_answer.survey).to eq(survey)
+          expect(SurveyAnswer.all.map(&:survey)).to eq([survey, survey])
         end
       end
     end

--- a/decidim-surveys/spec/forms/decidim/surveys/survey_answer_form_spec.rb
+++ b/decidim-surveys/spec/forms/decidim/surveys/survey_answer_form_spec.rb
@@ -26,7 +26,7 @@ module Decidim
         )
       end
 
-      let!(:survey_answer) { create(:survey_answer, user: user, survey: survey, question: survey_question) }
+      let!(:survey_answer) { build(:survey_answer, user: user, survey: survey, question: survey_question) }
 
       context "when everything is OK" do
         it { is_expected.to be_valid }
@@ -50,7 +50,7 @@ module Decidim
         context "and question type is multiple choice" do
           let(:question_type) { "multiple_option" }
 
-          it "is not valid if body entries are all blank" do
+          it "is not valid if choices are empty" do
             subject.choices = []
             expect(subject).not_to be_valid
           end

--- a/decidim-surveys/spec/forms/decidim/surveys/survey_answer_form_spec.rb
+++ b/decidim-surveys/spec/forms/decidim/surveys/survey_answer_form_spec.rb
@@ -9,9 +9,23 @@ module Decidim
         described_class.from_model(survey_answer).with_context(current_component: survey.component)
       end
 
+      let(:mandatory) { false }
+      let(:question_type) { "short_answer" }
+      let(:max_choices) { nil }
+
       let!(:survey) { create(:survey) }
       let!(:user) { create(:user, organization: survey.component.participatory_space.organization) }
-      let!(:survey_question) { create(:survey_question, survey: survey) }
+
+      let!(:survey_question) do
+        create(
+          :survey_question,
+          survey: survey,
+          mandatory: mandatory,
+          question_type: question_type,
+          max_choices: max_choices
+        )
+      end
+
       let!(:survey_answer) { create(:survey_answer, user: user, survey: survey, question: survey_question) }
 
       context "when everything is OK" do
@@ -19,14 +33,7 @@ module Decidim
       end
 
       context "when the question is mandatory" do
-        let!(:survey_question) do
-          create(
-            :survey_question,
-            survey: survey,
-            mandatory: true,
-            question_type: question_type
-          )
-        end
+        let(:mandatory) { true }
 
         context "and question type is not multiple choice" do
           let(:question_type) { "long_answer" }
@@ -51,14 +58,9 @@ module Decidim
       end
 
       context "when the question has max_choices set" do
-        let!(:survey_question) do
-          create(
-            :survey_question,
-            survey: survey,
-            max_choices: 2,
-            question_type: "multiple_option"
-          )
-        end
+        let(:question_type) { "multiple_option" }
+
+        let(:max_choices) { 2 }
 
         it "is valid if few enough answers checked" do
           subject.choices = %w(foo bar)

--- a/decidim-surveys/spec/forms/decidim/surveys/survey_answer_form_spec.rb
+++ b/decidim-surveys/spec/forms/decidim/surveys/survey_answer_form_spec.rb
@@ -19,29 +19,54 @@ module Decidim
       end
 
       context "when the question is mandatory" do
-        let!(:survey_question) { create(:survey_question, survey: survey, mandatory: true) }
-
-        it "is not valid if body is not present" do
-          subject.body = nil
-          expect(subject).not_to be_valid
+        let!(:survey_question) do
+          create(
+            :survey_question,
+            survey: survey,
+            mandatory: true,
+            question_type: question_type
+          )
         end
 
-        it "is not valid if body entries are all blank" do
-          subject.body = [""]
-          expect(subject).not_to be_valid
+        context "and question type is not multiple choice" do
+          let(:question_type) { "long_answer" }
+
+          it "is not valid if body is not present" do
+            subject.body = nil
+            expect(subject).not_to be_valid
+
+            subject.body = ""
+            expect(subject).not_to be_valid
+          end
+        end
+
+        context "and question type is multiple choice" do
+          let(:question_type) { "multiple_option" }
+
+          it "is not valid if body entries are all blank" do
+            subject.choices = []
+            expect(subject).not_to be_valid
+          end
         end
       end
 
       context "when the question has max_choices set" do
-        let!(:survey_question) { create(:survey_question, survey: survey, max_choices: 2) }
+        let!(:survey_question) do
+          create(
+            :survey_question,
+            survey: survey,
+            max_choices: 2,
+            question_type: "multiple_option"
+          )
+        end
 
         it "is valid if few enough answers checked" do
-          subject.body = %w(foo bar)
+          subject.choices = %w(foo bar)
           expect(subject).to be_valid
         end
 
         it "is not valid if too many answers checked" do
-          subject.body = %w(foo bar baz)
+          subject.choices = %w(foo bar baz)
           expect(subject).not_to be_valid
         end
       end

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -572,7 +572,7 @@ shared_examples "edit surveys" do
   end
 
   context "when the survey is already answered" do
-    let!(:survey_question) { create(:survey_question, survey: survey, body: body) }
+    let!(:survey_question) { create(:survey_question, survey: survey, body: body, question_type: "multiple_option") }
     let!(:survey_answer) { create(:survey_answer, survey: survey, question: survey_question) }
 
     it "cannot modify survey questions" do
@@ -582,6 +582,7 @@ shared_examples "edit surveys" do
       expect(page).to have_no_content("Remove")
       expect(page).to have_selector("input[value='This is the first question'][disabled]")
       expect(page).to have_selector("select[id$=question_type][disabled]")
+      expect(page).to have_selector("select[id$=max_choices][disabled]")
     end
   end
 

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -581,6 +581,7 @@ shared_examples "edit surveys" do
       expect(page).to have_no_content("Add question")
       expect(page).to have_no_content("Remove")
       expect(page).to have_selector("input[value='This is the first question'][disabled]")
+      expect(page).to have_selector("select[id$=question_type][disabled]")
     end
   end
 

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -583,6 +583,7 @@ shared_examples "edit surveys" do
       expect(page).to have_selector("input[value='This is the first question'][disabled]")
       expect(page).to have_selector("select[id$=question_type][disabled]")
       expect(page).to have_selector("select[id$=max_choices][disabled]")
+      expect(page).to have_selector(".ql-editor[contenteditable=false]")
     end
   end
 

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -92,13 +92,30 @@ describe "Answer a survey", type: :system do
         expect(page).to have_no_i18n_content(survey_question_2.body)
       end
 
-      it "the questions are ordered by position starting with one" do
-        visit_component
+      shared_examples_for "a correctly ordered survey" do
+        it "displays the questions ordered by position starting with one" do
+          form_fields = all(".answer-survey .row")
 
-        form_fields = all(".answer-survey .row")
+          expect(form_fields[0]).to have_i18n_content(survey_question_2.body).and have_content("1. ")
+          expect(form_fields[1]).to have_i18n_content(survey_question_1.body).and have_content("2. ")
+        end
+      end
 
-        expect(form_fields[0]).to have_i18n_content(survey_question_2.body).and have_content("1. ")
-        expect(form_fields[1]).to have_i18n_content(survey_question_1.body).and have_content("2. ")
+      context "and submitting a fresh form" do
+        before do
+          visit_component
+        end
+
+        it_behaves_like "a correctly ordered survey"
+      end
+
+      context "and rendering a form after errors" do
+        before do
+          visit_component
+          accept_confirm { click_button "Submit" }
+        end
+
+        it_behaves_like "a correctly ordered survey"
       end
 
       context "when a question is mandatory" do

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -200,8 +200,8 @@ describe "Answer a survey", type: :system do
         it "renders answers as a collection of radio buttons" do
           visit_component
 
-          expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_answer_options input[type='radio']", count: 2)
-          expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_2.id}_answer_body_answer_options input[type='radio']", count: 2)
+          expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_answer_options input[type=radio]", count: 2)
+          expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_2.id}_answer_body_answer_options input[type=radio]", count: 2)
 
           within "#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_answer_options" do
             choose answer_options[1]["body"][:en]
@@ -233,8 +233,8 @@ describe "Answer a survey", type: :system do
         it "renders answers as a collection of radio buttons" do
           visit_component
 
-          expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_answer_options input[type='checkbox']", count: 2)
-          expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_2.id}_answer_body_answer_options input[type='checkbox']", count: 3)
+          expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_answer_options input[type=checkbox]", count: 2)
+          expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_2.id}_answer_body_answer_options input[type=checkbox]", count: 3)
           expect(page).to have_no_content("Max choices:")
 
           within "#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_answer_options" do
@@ -300,8 +300,8 @@ describe "Answer a survey", type: :system do
         it "the question answers are rendered as a collection of radio buttons" do
           visit_component
 
-          expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_answer_options input[type='checkbox']", count: 2)
-          expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_2.id}_answer_body_answer_options input[type='checkbox']", count: 2)
+          expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_answer_options input[type=checkbox]", count: 2)
+          expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_2.id}_answer_body_answer_options input[type=checkbox]", count: 2)
 
           within "#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_answer_options" do
             check answer_options[0]["body"][:en]


### PR DESCRIPTION
#### :tophat: What? Why?

This PR sits on top of #3091. It keeps refactoring surveys (mainly the frontend), and adds a couple of noticiable changes:

* Question type selector is now correctly disabled once the survey is answered by someone.
* Client side validation errors are now displayed when filling the survey.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
_None_.