### PR TITLE
Free text field for multiple choice answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-proposals**: Add discard draft button in wizard [\#3064](https://github.com/decidim/decidim/pull/3064)
 - **decidim-surveys**: Allow multiple choice questions to specify a maximum number of options to be checked [\#3091](https://github.com/decidim/decidim/pull/3091)
 - **decidim-surveys**: Client side survey errors are now displayed [\#3133](https://github.com/decidim/decidim/pull/3133)
+- **decidim-surveys**: Allow multiple choice questions to have "free text options" where the user can customize the selected answer [\#3134](https://github.com/decidim/decidim/pull/3134)
 
 **Changed**:
 

--- a/decidim-surveys/app/assets/config/decidim_surveys_manifest.js
+++ b/decidim-surveys/app/assets/config/decidim_surveys_manifest.js
@@ -1,0 +1,1 @@
+// = link decidim/surveys/surveys.js

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/option_attached_inputs.component.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/option_attached_inputs.component.js.es6
@@ -1,0 +1,32 @@
+((exports) => {
+  class OptionAttachedInputsComponent {
+    constructor(options = {}) {
+      this.wrapperField = options.wrapperField;
+      this.controllerFieldSelector = options.controllerFieldSelector;
+      this.dependentInputSelector = options.dependentInputSelector;
+      this.controllerSelector = this.wrapperField.find(this.controllerFieldSelector);
+      this._bindEvent();
+      this._run();
+    }
+
+    _run() {
+      this.controllerSelector.each((idx, el) => {
+        const $field = $(el);
+        const enabled = $field.is(":checked");
+
+        $field.parents("label").find(this.dependentInputSelector).prop("disabled", !enabled);
+      });
+    }
+
+    _bindEvent() {
+      this.controllerSelector.on("change", () => {
+        this._run();
+      });
+    }
+  }
+
+  exports.Decidim = exports.Decidim || {};
+  exports.Decidim.createOptionAttachedInputs = (options) => {
+    return new OptionAttachedInputsComponent(options);
+  };
+})(window);

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/surveys.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/surveys.js.es6
@@ -7,7 +7,7 @@
     createOptionAttachedInputs({
       wrapperField: $(el),
       controllerFieldSelector: "input[type=radio], input[type=checkbox]",
-      dependentInputSelector: "input[type=text]"
+      dependentInputSelector: "input[type=text], input[type=hidden]"
     });
   });
 })(window);

--- a/decidim-surveys/app/assets/javascripts/decidim/surveys/surveys.js.es6
+++ b/decidim-surveys/app/assets/javascripts/decidim/surveys/surveys.js.es6
@@ -1,0 +1,13 @@
+// = require ./option_attached_inputs.component
+
+((exports) => {
+  const { createOptionAttachedInputs } = exports.Decidim;
+
+  $(".radio-button-collection, .check-box-collection").each((idx, el) => {
+    createOptionAttachedInputs({
+      wrapperField: $(el),
+      controllerFieldSelector: "input[type=radio], input[type=checkbox]",
+      dependentInputSelector: "input[type=text]"
+    });
+  });
+})(window);

--- a/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
+++ b/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
@@ -43,15 +43,17 @@ module Decidim
               max_choices: form_question.max_choices
             }
 
+            questions = @survey.questions
+
             if form_question.id.present?
-              question = @survey.questions.find_by(id: form_question.id)
+              question = questions.find_by(id: form_question.id)
               if form_question.deleted?
                 question.destroy!
               else
                 question.update!(question_attributes)
               end
             else
-              @survey.questions.create!(question_attributes)
+              questions.create!(question_attributes)
             end
           end
         end

--- a/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
+++ b/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
@@ -45,16 +45,17 @@ module Decidim
 
             questions = @survey.questions
 
-            if form_question.id.present?
-              question = questions.find_by(id: form_question.id)
+            question = questions.find_by(id: form_question.id) || questions.build(question_attributes)
+
+            if question.persisted?
               if form_question.deleted?
                 question.destroy!
               else
-                question.update!(question_attributes)
+                question.assign_attributes(question_attributes)
               end
-            else
-              questions.create!(question_attributes)
             end
+
+            question.save!
           end
         end
 

--- a/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
+++ b/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
@@ -48,19 +48,21 @@ module Decidim
             max_choices: form_question.max_choices
           }
 
-          questions = @survey.questions
+          update_nested_model(form_question, question_attributes, @survey.questions)
+        end
 
-          question = questions.find_by(id: form_question.id) || questions.build(question_attributes)
+        def update_nested_model(form, attributes, parent_association)
+          record = parent_association.find_by(id: form.id) || parent_association.build(attributes)
 
-          if question.persisted?
-            if form_question.deleted?
-              question.destroy!
+          if record.persisted?
+            if form.deleted?
+              record.destroy!
             else
-              question.assign_attributes(question_attributes)
+              record.assign_attributes(attributes)
             end
           end
 
-          question.save!
+          record.save!
         end
 
         def update_survey

--- a/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
+++ b/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
@@ -51,7 +51,7 @@ module Decidim
             form_question.answer_options.each do |form_answer_option|
               answer_option_attributes = {
                 body: form_answer_option.body,
-                free_text_option: form_answer_option.free_text_option
+                free_text: form_answer_option.free_text
               }
 
               update_nested_model(form_answer_option, answer_option_attributes, question.answer_options)

--- a/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
+++ b/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
@@ -33,30 +33,34 @@ module Decidim
 
         def update_survey_questions
           @form.questions.each do |form_question|
-            question_attributes = {
-              body: form_question.body,
-              description: form_question.description,
-              position: form_question.position,
-              mandatory: form_question.mandatory,
-              question_type: form_question.question_type,
-              answer_options: form_question.answer_options_to_persist.map { |option| { "body" => option.body } },
-              max_choices: form_question.max_choices
-            }
-
-            questions = @survey.questions
-
-            question = questions.find_by(id: form_question.id) || questions.build(question_attributes)
-
-            if question.persisted?
-              if form_question.deleted?
-                question.destroy!
-              else
-                question.assign_attributes(question_attributes)
-              end
-            end
-
-            question.save!
+            update_survey_question(form_question)
           end
+        end
+
+        def update_survey_question(form_question)
+          question_attributes = {
+            body: form_question.body,
+            description: form_question.description,
+            position: form_question.position,
+            mandatory: form_question.mandatory,
+            question_type: form_question.question_type,
+            answer_options: form_question.answer_options_to_persist.map { |option| { "body" => option.body } },
+            max_choices: form_question.max_choices
+          }
+
+          questions = @survey.questions
+
+          question = questions.find_by(id: form_question.id) || questions.build(question_attributes)
+
+          if question.persisted?
+            if form_question.deleted?
+              question.destroy!
+            else
+              question.assign_attributes(question_attributes)
+            end
+          end
+
+          question.save!
         end
 
         def update_survey

--- a/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
+++ b/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
@@ -50,7 +50,8 @@ module Decidim
           update_nested_model(form_question, question_attributes, @survey.questions) do |question|
             form_question.answer_options.each do |form_answer_option|
               answer_option_attributes = {
-                body: form_answer_option.body
+                body: form_answer_option.body,
+                free_text_option: form_answer_option.free_text_option
               }
 
               update_nested_model(form_answer_option, answer_option_attributes, question.answer_options)

--- a/decidim-surveys/app/commands/decidim/surveys/answer_survey.rb
+++ b/decidim-surveys/app/commands/decidim/surveys/answer_survey.rb
@@ -40,7 +40,7 @@ module Decidim
               answer.choices.build(
                 body: choice.body,
                 custom_body: choice.custom_body,
-                decidim_survey_answer_option_id: choice.decidim_survey_answer_option_id
+                decidim_survey_answer_option_id: choice.answer_option_id
               )
             end
 

--- a/decidim-surveys/app/commands/decidim/surveys/answer_survey.rb
+++ b/decidim-surveys/app/commands/decidim/surveys/answer_survey.rb
@@ -39,6 +39,7 @@ module Decidim
             form_answer.selected_choices.each do |choice|
               answer.choices.build(
                 body: choice.body,
+                custom_body: choice.custom_body,
                 decidim_survey_answer_option_id: choice.decidim_survey_answer_option_id
               )
             end

--- a/decidim-surveys/app/commands/decidim/surveys/answer_survey.rb
+++ b/decidim-surveys/app/commands/decidim/surveys/answer_survey.rb
@@ -29,13 +29,21 @@ module Decidim
       def answer_survey
         SurveyAnswer.transaction do
           @form.answers.each do |form_answer|
-            SurveyAnswer.create!(
+            answer = SurveyAnswer.new(
               user: @current_user,
               survey: @survey,
               question: form_answer.question,
-              body: form_answer.body,
-              choices: form_answer.choices
+              body: form_answer.body
             )
+
+            form_answer.selected_choices.each do |choice|
+              answer.choices.build(
+                body: choice.body,
+                decidim_survey_answer_option_id: choice.decidim_survey_answer_option_id
+              )
+            end
+
+            answer.save!
           end
         end
       end

--- a/decidim-surveys/app/forms/decidim/surveys/admin/survey_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/admin/survey_form.rb
@@ -15,6 +15,12 @@ module Decidim
         attribute :questions, Array[SurveyQuestionForm]
 
         validates :title, :tos, translatable_presence: true
+
+        def map_model(model)
+          self.questions = model.questions.map do |question|
+            SurveyQuestionForm.from_model(question)
+          end
+        end
       end
     end
   end

--- a/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_answer_option_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_answer_option_form.rb
@@ -8,6 +8,7 @@ module Decidim
         include TranslatableAttributes
 
         attribute :deleted, Boolean, default: false
+        attribute :free_text_option, Boolean
 
         translatable_attribute :body, String
 

--- a/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_answer_option_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_answer_option_form.rb
@@ -7,7 +7,7 @@ module Decidim
       class SurveyQuestionAnswerOptionForm < Decidim::Form
         include TranslatableAttributes
 
-        attribute :deleted, Boolean
+        attribute :deleted, Boolean, default: false
 
         translatable_attribute :body, String
 

--- a/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_answer_option_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_answer_option_form.rb
@@ -8,7 +8,7 @@ module Decidim
         include TranslatableAttributes
 
         attribute :deleted, Boolean, default: false
-        attribute :free_text_option, Boolean
+        attribute :free_text, Boolean
 
         translatable_attribute :body, String
 

--- a/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_form.rb
@@ -22,16 +22,6 @@ module Decidim
         validates :max_choices, numericality: { only_integer: true, greater_than: 1, less_than_or_equal_to: ->(form) { form.number_of_options } }, allow_blank: true
         validates :body, translatable_presence: true, unless: :deleted
 
-        def map_model(model)
-          self.answer_options = model.answer_options.each_with_index.map do |option, id|
-            SurveyQuestionAnswerOptionForm.new(option.merge(id: id + 1, deleted: false))
-          end
-        end
-
-        def answer_options_to_persist
-          answer_options.reject(&:deleted)
-        end
-
         def to_param
           id || "survey-question-id"
         end

--- a/decidim-surveys/app/forms/decidim/surveys/survey_answer_choice_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_answer_choice_form.rb
@@ -6,9 +6,9 @@ module Decidim
     class SurveyAnswerChoiceForm < Decidim::Form
       attribute :body, String
       attribute :custom_body, String
-      attribute :decidim_survey_answer_option_id, Integer
+      attribute :answer_option_id, Integer
 
-      validates :decidim_survey_answer_option_id, presence: true
+      validates :answer_option_id, presence: true
     end
   end
 end

--- a/decidim-surveys/app/forms/decidim/surveys/survey_answer_choice_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_answer_choice_form.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Surveys
+    # This class holds a Form to update survey question answer options
+    class SurveyAnswerChoiceForm < Decidim::Form
+      attribute :body, String
+      attribute :decidim_survey_answer_option_id, Integer
+
+      validates :decidim_survey_answer_option_id, presence: true
+    end
+  end
+end

--- a/decidim-surveys/app/forms/decidim/surveys/survey_answer_choice_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_answer_choice_form.rb
@@ -5,6 +5,7 @@ module Decidim
     # This class holds a Form to update survey question answer options
     class SurveyAnswerChoiceForm < Decidim::Form
       attribute :body, String
+      attribute :custom_body, String
       attribute :decidim_survey_answer_option_id, Integer
 
       validates :decidim_survey_answer_option_id, presence: true

--- a/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
@@ -32,8 +32,7 @@ module Decidim
       #
       # Returns nothing.
       def map_model(model)
-        @question = model.question
-        self.question_id = @question.id
+        self.question_id = model.decidim_survey_question_id
 
         self.choices = model.choices.map do |choice|
           SurveyAnswerChoiceForm.from_model(choice)

--- a/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
@@ -11,7 +11,7 @@ module Decidim
       attribute :choices, Array[SurveyAnswerChoiceForm]
 
       validates :body, presence: true, if: :mandatory_body?
-      validates :choices, presence: true, if: :mandatory_choices?
+      validates :selected_choices, presence: true, if: :mandatory_choices?
 
       validate :max_answers, if: -> { question.max_choices }
 

--- a/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
@@ -8,7 +8,7 @@ module Decidim
 
       attribute :question_id, String
       attribute :body, String
-      attribute :choices, Array[String]
+      attribute :choices, Array[SurveyAnswerChoiceForm]
 
       validates :body, presence: true, if: :mandatory_body?
       validates :choices, presence: true, if: :mandatory_choices?
@@ -32,7 +32,21 @@ module Decidim
       #
       # Returns nothing.
       def map_model(model)
-        self.question_id = model.decidim_survey_question_id
+        @question = model.question
+        self.question_id = @question.id
+
+        self.choices = @question.answer_options.map do |answer_option|
+          existing_choice = model.choices.find_by(decidim_survey_answer_option_id: answer_option.id)
+
+          attributes = { decidim_survey_answer_option_id: answer_option.id }
+          attributes.merge(body: existing_choice.body) if existing_choice
+
+          SurveyAnswerChoiceForm.new(attributes)
+        end
+      end
+
+      def selected_choices
+        choices.select(&:body)
       end
 
       private
@@ -42,7 +56,7 @@ module Decidim
       end
 
       def max_answers
-        errors.add(:choices, :too_many) if choices.size > question.max_choices
+        errors.add(:choices, :too_many) if selected_choices.size > question.max_choices
       end
 
       def mandatory_label

--- a/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
@@ -35,13 +35,8 @@ module Decidim
         @question = model.question
         self.question_id = @question.id
 
-        self.choices = @question.answer_options.map do |answer_option|
-          existing_choice = model.choices.find_by(decidim_survey_answer_option_id: answer_option.id)
-
-          attributes = { decidim_survey_answer_option_id: answer_option.id }
-          attributes.merge(body: existing_choice.body) if existing_choice
-
-          SurveyAnswerChoiceForm.new(attributes)
+        self.choices = model.choices.map do |choice|
+          SurveyAnswerChoiceForm.from_model(choice)
         end
       end
 

--- a/decidim-surveys/app/forms/decidim/surveys/survey_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_form.rb
@@ -14,7 +14,7 @@ module Decidim
       # Returns nothing.
       def map_model(model)
         self.answers = model.questions.each_with_index.map do |question, id|
-          SurveyAnswerForm.new(id: id + 1, question_id: question.id)
+          SurveyAnswerForm.from_model(SurveyAnswer.new(id: id + 1, question: question))
         end
       end
     end

--- a/decidim-surveys/app/models/decidim/surveys/survey_answer.rb
+++ b/decidim-surveys/app/models/decidim/surveys/survey_answer.rb
@@ -8,6 +8,12 @@ module Decidim
       belongs_to :survey, class_name: "Survey", foreign_key: "decidim_survey_id"
       belongs_to :question, class_name: "SurveyQuestion", foreign_key: "decidim_survey_question_id"
 
+      has_many :choices,
+               class_name: "SurveyAnswerChoice",
+               foreign_key: "decidim_survey_answer_id",
+               dependent: :destroy,
+               inverse_of: :answer
+
       validates :body, presence: true, if: -> { question.mandatory_body? }
       validates :options, presence: true, if: -> { question.mandatory_choices? }
 

--- a/decidim-surveys/app/models/decidim/surveys/survey_answer_choice.rb
+++ b/decidim-surveys/app/models/decidim/surveys/survey_answer_choice.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Surveys
+    class SurveyAnswerChoice < Surveys::ApplicationRecord
+      belongs_to :answer,
+                 class_name: "SurveyAnswer",
+                 foreign_key: "decidim_survey_answer_id"
+
+      belongs_to :answer_option,
+                 class_name: "SurveyAnswerOption",
+                 foreign_key: "decidim_survey_answer_option_id"
+    end
+  end
+end

--- a/decidim-surveys/app/models/decidim/surveys/survey_answer_option.rb
+++ b/decidim-surveys/app/models/decidim/surveys/survey_answer_option.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Surveys
+    class SurveyAnswerOption < Surveys::ApplicationRecord
+      belongs_to :question, class_name: "SurveyQuestion", foreign_key: "decidim_survey_question_id"
+    end
+  end
+end

--- a/decidim-surveys/app/models/decidim/surveys/survey_question.rb
+++ b/decidim-surveys/app/models/decidim/surveys/survey_question.rb
@@ -8,6 +8,12 @@ module Decidim
 
       belongs_to :survey, class_name: "Survey", foreign_key: "decidim_survey_id"
 
+      has_many :answer_options,
+               class_name: "SurveyAnswerOption",
+               foreign_key: "decidim_survey_question_id",
+               dependent: :destroy,
+               inverse_of: :question
+
       validates :question_type, inclusion: { in: TYPES }
 
       def multiple_choice?

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
@@ -30,5 +30,5 @@
     <%= form.hidden_field :id, disabled: !editable %>
   <% end %>
 
-  <%= form.hidden_field :deleted, value: false, disabled: !editable %>
+  <%= form.hidden_field :deleted, disabled: !editable %>
 </div>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
@@ -24,6 +24,16 @@
         )
       %>
     </div>
+
+    <div class="row column">
+      <%=
+        form.check_box(
+          :free_text_option,
+          label: t(".free_text_option"),
+          disabled: !survey.questions_editable?
+        )
+      %>
+    </div>
   </div>
 
   <% if answer_option.persisted? %>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/_answer_option.html.erb
@@ -28,8 +28,8 @@
     <div class="row column">
       <%=
         form.check_box(
-          :free_text_option,
-          label: t(".free_text_option"),
+          :free_text,
+          label: t(".free_text"),
           disabled: !survey.questions_editable?
         )
       %>

--- a/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
@@ -1,4 +1,4 @@
-<% field_id = "survey_#{survey.id}_question_#{answer.question.id}_answer_body" %>
+<% field_id = "survey_answers_#{answer_idx}" %>
 <%= label_tag field_id, answer.label, class: "survey-question" %>
 
 <% if translated_attribute(answer.question.description).present? %>
@@ -9,37 +9,39 @@
 
 <% case answer.question.question_type %>
   <% when "short_answer" %>
-    <%= answer_form.text_field :body, label: false, id: field_id %>
+    <%= answer_form.text_field :body, label: false, id: "#{field_id}_body" %>
   <% when "long_answer" %>
-    <%= answer_form.text_area :body, label: false, id: field_id, rows: 10 %>
+    <%= answer_form.text_area :body, label: false, id: "#{field_id}_body", rows: 10 %>
   <% when "single_option" %>
-    <div id="<%= field_id %>_answer_options" class="radio-button-collection">
+    <div class="radio-button-collection">
       <% answer.question.answer_options.each_with_index do |answer_option, idx| %>
-        <%= label_tag "#{field_id}_option_#{idx}" do %>
+        <% choice_id = "#{field_id}_choices_#{idx}" %>
+
+        <%= label_tag "#{choice_id}_body" do %>
           <%= radio_button_tag "survey[answers][#{answer_idx}][choices][][body]",
                                translated_attribute(answer_option.body),
                                answer.choices.map(&:body).include?(translated_attribute(answer_option.body)),
-                               id: "#{field_id}_option_#{idx}" %>
+                               id: "#{choice_id}_body" %>
 
           <%= translated_attribute(answer_option.body) %>
 
           <% if answer_option.free_text_option %>
             <%= text_field_tag "survey[answers][#{answer_idx}][choices][][custom_body]",
                                answer.choices.find { |choice| choice.decidim_survey_answer_option_id == answer_option.id }.body,
-                               id: "#{field_id}_custom_body_#{idx}",
+                               id: "#{choice_id}_custom_body",
                                disabled: true %>
           <% end %>
         <% end %>
 
         <%= hidden_field_tag "survey[answers][#{answer_idx}][choices][][decidim_survey_answer_option_id]",
                              answer_option.id,
-                             id: "#{field_id}_answer_option_#{answer_option.id}" %>
+                             id: "#{choice_id}_answer_option" %>
       <% end %>
     </div>
   <% when "multiple_option" %>
-    <div id="<%= field_id %>_answer_options" class="check-box-collection">
+    <div class="check-box-collection">
       <% answer.question.answer_options.each_with_index do |answer_option, idx| %>
-        <%= label_tag "#{field_id}_option_#{idx}" do %>
+        <%= label_tag "#{field_id}_choices_#{idx}" do %>
           <%= check_box_tag "survey[answers][#{answer_idx}][choices][#{idx}][body]",
                             translated_attribute(answer_option.body),
                             answer.choices.map(&:body).include?(translated_attribute(answer_option.body)) %>

--- a/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
@@ -58,9 +58,10 @@
                                choice.try(:custom_body),
                                disabled: true %>
           <% end %>
+
+          <%= hidden_field_tag "survey[answers][#{answer_idx}][choices][#{idx}][decidim_survey_answer_option_id]", answer_option.id %>
         <% end %>
 
-        <%= hidden_field_tag "survey[answers][#{answer_idx}][choices][#{idx}][decidim_survey_answer_option_id]", answer_option.id %>
       <% end %>
     </div>
 <% end %>

--- a/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
@@ -16,8 +16,8 @@
     <div id="<%= field_id %>_answer_options" class="radio-button-collection">
       <% answer.question.answer_options.each_with_index do |answer_option, idx| %>
         <%= label_tag "#{field_id}_option_#{idx}" do %>
-          <%= radio_button_tag "survey[answers][#{answer_idx}][choices][][body]", translated_attribute(answer_option["body"]), answer.choices.map(&:body).include?(translated_attribute(answer_option["body"])), id: "#{field_id}_option_#{idx}" %>
-          <%= translated_attribute(answer_option["body"]) %>
+          <%= radio_button_tag "survey[answers][#{answer_idx}][choices][][body]", translated_attribute(answer_option.body), answer.choices.map(&:body).include?(translated_attribute(answer_option.body)), id: "#{field_id}_option_#{idx}" %>
+          <%= translated_attribute(answer_option.body) %>
         <% end %>
         <%= hidden_field_tag "survey[answers][#{answer_idx}][choices][][decidim_survey_answer_option_id]", answer_option.id %>
       <% end %>
@@ -26,8 +26,8 @@
     <div id="<%= field_id %>_answer_options" class="check-box-collection">
       <% answer.question.answer_options.each_with_index do |answer_option, idx| %>
         <%= label_tag "#{field_id}_option_#{idx}" do %>
-          <%= check_box_tag "survey[answers][#{answer_idx}][choices][#{idx}][body]", translated_attribute(answer_option["body"]), answer.choices.map(&:body).include?(translated_attribute(answer_option["body"])), id: "#{field_id}_option_#{idx}" %>
-          <%= translated_attribute(answer_option["body"]) %>
+          <%= check_box_tag "survey[answers][#{answer_idx}][choices][#{idx}][body]", translated_attribute(answer_option.body), answer.choices.map(&:body).include?(translated_attribute(answer_option.body)), id: "#{field_id}_option_#{idx}" %>
+          <%= translated_attribute(answer_option.body) %>
         <% end %>
         <%= hidden_field_tag "survey[answers][#{answer_idx}][choices][#{idx}][decidim_survey_answer_option_id]", answer_option.id %>
       <% end %>

--- a/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
@@ -16,19 +16,43 @@
     <div id="<%= field_id %>_answer_options" class="radio-button-collection">
       <% answer.question.answer_options.each_with_index do |answer_option, idx| %>
         <%= label_tag "#{field_id}_option_#{idx}" do %>
-          <%= radio_button_tag "survey[answers][#{answer_idx}][choices][][body]", translated_attribute(answer_option.body), answer.choices.map(&:body).include?(translated_attribute(answer_option.body)), id: "#{field_id}_option_#{idx}" %>
+          <%= radio_button_tag "survey[answers][#{answer_idx}][choices][][body]",
+                               translated_attribute(answer_option.body),
+                               answer.choices.map(&:body).include?(translated_attribute(answer_option.body)),
+                               id: "#{field_id}_option_#{idx}" %>
+
           <%= translated_attribute(answer_option.body) %>
+
+          <% if answer_option.free_text_option %>
+            <%= text_field_tag "survey[answers][#{answer_idx}][choices][][custom_body]",
+                               answer.choices.find { |choice| choice.decidim_survey_answer_option_id == answer_option.id }.body,
+                               id: "#{field_id}_custom_body_#{idx}",
+                               disabled: true %>
+          <% end %>
         <% end %>
-        <%= hidden_field_tag "survey[answers][#{answer_idx}][choices][][decidim_survey_answer_option_id]", answer_option.id %>
+
+        <%= hidden_field_tag "survey[answers][#{answer_idx}][choices][][decidim_survey_answer_option_id]",
+                             answer_option.id,
+                             id: "#{field_id}_answer_option_#{answer_option.id}" %>
       <% end %>
     </div>
   <% when "multiple_option" %>
     <div id="<%= field_id %>_answer_options" class="check-box-collection">
       <% answer.question.answer_options.each_with_index do |answer_option, idx| %>
         <%= label_tag "#{field_id}_option_#{idx}" do %>
-          <%= check_box_tag "survey[answers][#{answer_idx}][choices][#{idx}][body]", translated_attribute(answer_option.body), answer.choices.map(&:body).include?(translated_attribute(answer_option.body)), id: "#{field_id}_option_#{idx}" %>
+          <%= check_box_tag "survey[answers][#{answer_idx}][choices][#{idx}][body]",
+                            translated_attribute(answer_option.body),
+                            answer.choices.map(&:body).include?(translated_attribute(answer_option.body)) %>
+
           <%= translated_attribute(answer_option.body) %>
+
+          <% if answer_option.free_text_option %>
+            <%= text_field_tag "survey[answers][#{answer_idx}][choices][#{idx}][custom_body]",
+                               answer.choices.find { |choice| choice.decidim_survey_answer_option_id == answer_option.id }.body,
+                               disabled: true %>
+          <% end %>
         <% end %>
+
         <%= hidden_field_tag "survey[answers][#{answer_idx}][choices][#{idx}][decidim_survey_answer_option_id]", answer_option.id %>
       <% end %>
     </div>

--- a/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
@@ -14,43 +14,48 @@
     <%= answer_form.text_area :body, label: false, id: "#{field_id}_body", rows: 10 %>
   <% when "single_option" %>
     <div class="radio-button-collection">
+      <% choice = answer.choices.first %>
+
       <% answer.question.answer_options.each_with_index do |answer_option, idx| %>
         <% choice_id = "#{field_id}_choices_#{idx}" %>
 
         <%= label_tag "#{choice_id}_body" do %>
           <%= radio_button_tag "survey[answers][#{answer_idx}][choices][][body]",
                                translated_attribute(answer_option.body),
-                               answer.choices.map(&:body).include?(translated_attribute(answer_option.body)),
+                               choice.try(:body),
                                id: "#{choice_id}_body" %>
 
           <%= translated_attribute(answer_option.body) %>
 
           <% if answer_option.free_text_option %>
             <%= text_field_tag "survey[answers][#{answer_idx}][choices][][custom_body]",
-                               answer.choices.find { |choice| choice.decidim_survey_answer_option_id == answer_option.id }.body,
+                               choice.try(:custom_body),
                                id: "#{choice_id}_custom_body",
                                disabled: true %>
           <% end %>
-        <% end %>
 
-        <%= hidden_field_tag "survey[answers][#{answer_idx}][choices][][decidim_survey_answer_option_id]",
-                             answer_option.id,
-                             id: "#{choice_id}_answer_option" %>
+          <%= hidden_field_tag "survey[answers][#{answer_idx}][choices][][decidim_survey_answer_option_id]",
+                               answer_option.id,
+                               id: "#{choice_id}_answer_option",
+                               disabled: true %>
+        <% end %>
       <% end %>
     </div>
   <% when "multiple_option" %>
     <div class="check-box-collection">
       <% answer.question.answer_options.each_with_index do |answer_option, idx| %>
+        <% choice = answer.selected_choices.find { |choice| choice.decidim_survey_answer_option_id == answer_option.id } %>
+
         <%= label_tag "#{field_id}_choices_#{idx}" do %>
           <%= check_box_tag "survey[answers][#{answer_idx}][choices][#{idx}][body]",
                             translated_attribute(answer_option.body),
-                            answer.choices.map(&:body).include?(translated_attribute(answer_option.body)) %>
+                            choice.present? %>
 
           <%= translated_attribute(answer_option.body) %>
 
           <% if answer_option.free_text_option %>
             <%= text_field_tag "survey[answers][#{answer_idx}][choices][#{idx}][custom_body]",
-                               answer.choices.find { |choice| choice.decidim_survey_answer_option_id == answer_option.id }.body,
+                               choice.try(:custom_body),
                                disabled: true %>
           <% end %>
         <% end %>

--- a/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
@@ -34,7 +34,7 @@
                                disabled: true %>
           <% end %>
 
-          <%= hidden_field_tag "survey[answers][#{answer_idx}][choices][][decidim_survey_answer_option_id]",
+          <%= hidden_field_tag "survey[answers][#{answer_idx}][choices][][answer_option_id]",
                                answer_option.id,
                                id: "#{choice_id}_answer_option",
                                disabled: true %>
@@ -44,7 +44,7 @@
   <% when "multiple_option" %>
     <div class="check-box-collection">
       <% answer.question.answer_options.each_with_index do |answer_option, idx| %>
-        <% choice = answer.selected_choices.find { |choice| choice.decidim_survey_answer_option_id == answer_option.id } %>
+        <% choice = answer.selected_choices.find { |choice| choice.answer_option_id == answer_option.id } %>
 
         <%= label_tag "#{field_id}_choices_#{idx}" do %>
           <%= check_box_tag "survey[answers][#{answer_idx}][choices][#{idx}][body]",
@@ -59,7 +59,7 @@
                                disabled: true %>
           <% end %>
 
-          <%= hidden_field_tag "survey[answers][#{answer_idx}][choices][#{idx}][decidim_survey_answer_option_id]", answer_option.id %>
+          <%= hidden_field_tag "survey[answers][#{answer_idx}][choices][#{idx}][answer_option_id]", answer_option.id %>
         <% end %>
 
       <% end %>

--- a/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
@@ -16,18 +16,20 @@
     <div id="<%= field_id %>_answer_options" class="radio-button-collection">
       <% answer.question.answer_options.each_with_index do |answer_option, idx| %>
         <%= label_tag "#{field_id}_option_#{idx}" do %>
-          <%= radio_button_tag "survey[answers][#{answer_idx}][choices][]", translated_attribute(answer_option["body"]), answer.choices.include?(translated_attribute(answer_option["body"])), id: "#{field_id}_option_#{idx}" %>
+          <%= radio_button_tag "survey[answers][#{answer_idx}][choices][][body]", translated_attribute(answer_option["body"]), answer.choices.map(&:body).include?(translated_attribute(answer_option["body"])), id: "#{field_id}_option_#{idx}" %>
           <%= translated_attribute(answer_option["body"]) %>
         <% end %>
+        <%= hidden_field_tag "survey[answers][#{answer_idx}][choices][][decidim_survey_answer_option_id]", answer_option.id %>
       <% end %>
     </div>
   <% when "multiple_option" %>
     <div id="<%= field_id %>_answer_options" class="check-box-collection">
       <% answer.question.answer_options.each_with_index do |answer_option, idx| %>
         <%= label_tag "#{field_id}_option_#{idx}" do %>
-          <%= check_box_tag "survey[answers][#{answer_idx}][choices][]", translated_attribute(answer_option["body"]), answer.choices.include?(translated_attribute(answer_option["body"])), id: "#{field_id}_option_#{idx}" %>
+          <%= check_box_tag "survey[answers][#{answer_idx}][choices][#{idx}][body]", translated_attribute(answer_option["body"]), answer.choices.map(&:body).include?(translated_attribute(answer_option["body"])), id: "#{field_id}_option_#{idx}" %>
           <%= translated_attribute(answer_option["body"]) %>
         <% end %>
+        <%= hidden_field_tag "survey[answers][#{answer_idx}][choices][#{idx}][decidim_survey_answer_option_id]", answer_option.id %>
       <% end %>
     </div>
 <% end %>

--- a/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
@@ -27,7 +27,7 @@
 
           <%= translated_attribute(answer_option.body) %>
 
-          <% if answer_option.free_text_option %>
+          <% if answer_option.free_text %>
             <%= text_field_tag "survey[answers][#{answer_idx}][choices][][custom_body]",
                                choice.try(:custom_body),
                                id: "#{choice_id}_custom_body",
@@ -53,7 +53,7 @@
 
           <%= translated_attribute(answer_option.body) %>
 
-          <% if answer_option.free_text_option %>
+          <% if answer_option.free_text %>
             <%= text_field_tag "survey[answers][#{answer_idx}][choices][#{idx}][custom_body]",
                                choice.try(:custom_body),
                                disabled: true %>

--- a/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
@@ -70,3 +70,5 @@
     </div>
   </div>
 </div>
+
+<%= javascript_include_tag "decidim/surveys/surveys" %>

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -53,7 +53,7 @@ en:
         surveys:
           answer_option:
             answer_option: Answer option
-            free_text_option: Free text option
+            free_text: Free text
             remove: Remove
             statement: Statement
           edit:

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -53,6 +53,7 @@ en:
         surveys:
           answer_option:
             answer_option: Answer option
+            free_text_option: Free text option
             remove: Remove
             statement: Statement
           edit:

--- a/decidim-surveys/db/migrate/20180405014929_add_choices_to_decidim_survey_answers.rb
+++ b/decidim-surveys/db/migrate/20180405014929_add_choices_to_decidim_survey_answers.rb
@@ -11,7 +11,7 @@ class AddChoicesToDecidimSurveyAnswers < ActiveRecord::Migration[5.1]
 
   def up
     add_column :decidim_surveys_survey_answers, :text_body, :text
-    add_column :decidim_surveys_survey_answers, :choices, :jsonb
+    add_column :decidim_surveys_survey_answers, :choices, :jsonb, default: []
 
     SurveyAnswer.find_each do |answer|
       question = SurveyQuestion.find_by(id: answer.decidim_survey_question_id)

--- a/decidim-surveys/db/migrate/20180405015012_create_decidim_survey_answer_options.rb
+++ b/decidim-surveys/db/migrate/20180405015012_create_decidim_survey_answer_options.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class CreateDecidimSurveyAnswerOptions < ActiveRecord::Migration[5.1]
+  class SurveyQuestion < ApplicationRecord
+    self.table_name = :decidim_surveys_survey_questions
+  end
+
+  class SurveyAnswerOption < ApplicationRecord
+    self.table_name = :decidim_surveys_survey_answer_options
+  end
+
+  def up
+    create_table :decidim_surveys_survey_answer_options do |t|
+      t.references :decidim_survey_question, index: { name: "index_decidim_surveys_answer_options_question_id" }
+      t.jsonb :body
+    end
+
+    SurveyQuestion.find_each do |question|
+      question.answer_options.each do |answer_option|
+        SurveyAnswerOption.create!(
+          decidim_survey_question_id: question.id,
+          body: answer_option["body"]
+        )
+      end
+    end
+
+    remove_column :decidim_surveys_survey_questions, :answer_options
+  end
+
+  def down
+    add_column :decidim_surveys_survey_questions, :answer_options, :jsonb, default: []
+
+    SurveyAnswerOption.find_each do |answer_option|
+      question = SurveyQuestion.find(answer_option.decidim_survey_question_id)
+
+      question.answer_options << { "body" => answer_option.body }
+
+      question.save!
+    end
+
+    drop_table :decidim_surveys_survey_answer_options
+  end
+end

--- a/decidim-surveys/db/migrate/20180405015147_create_decidim_survey_answer_choices.rb
+++ b/decidim-surveys/db/migrate/20180405015147_create_decidim_survey_answer_choices.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class CreateDecidimSurveyAnswerChoices < ActiveRecord::Migration[5.1]
+  class SurveyAnswer < ApplicationRecord
+    self.table_name = :decidim_surveys_survey_answers
+  end
+
+  class SurveyAnswerChoice < ApplicationRecord
+    self.table_name = :decidim_surveys_survey_answer_choices
+  end
+
+  def up
+    create_table :decidim_surveys_survey_answer_choices do |t|
+      t.references :decidim_survey_answer, index: { name: "index_decidim_surveys_answer_choices_answer_id" }
+      t.references :decidim_survey_answer_option, index: { name: "index_decidim_surveys_answer_choices_answer_option_id" }
+      t.jsonb :body
+    end
+
+    SurveyAnswer.find_each do |answer|
+      next if %(short_answer long_answer).include?(answer.question.question_type)
+
+      answer.body.each do |answer_choice|
+        answer_option = answer.question.answer_options.find do |option|
+          option.body.values.include?(answer_choice)
+        end
+
+        SurveyAnswerChoice.create!(
+          decidim_survey_answer_id: answer.id,
+          decidim_survey_answer_option_id: answer_option.id,
+          body: answer_choice
+        )
+      end
+    end
+  end
+
+  def down
+    SurveyAnswerChoice.find_each do |answer_choice|
+      answer = answer_choice.answer
+
+      answer.body << answer_choice.body
+
+      answer.save!
+    end
+
+    drop_table :decidim_surveys_survey_answer_choices
+  end
+end

--- a/decidim-surveys/db/migrate/20180405015258_add_free_text_option_to_survey_answer_options.rb
+++ b/decidim-surveys/db/migrate/20180405015258_add_free_text_option_to_survey_answer_options.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddFreeTextOptionToSurveyAnswerOptions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_surveys_survey_answer_options, :free_text_option, :boolean
+  end
+end

--- a/decidim-surveys/db/migrate/20180405015258_add_free_text_option_to_survey_answer_options.rb
+++ b/decidim-surveys/db/migrate/20180405015258_add_free_text_option_to_survey_answer_options.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class AddFreeTextOptionToSurveyAnswerOptions < ActiveRecord::Migration[5.1]
-  def change
-    add_column :decidim_surveys_survey_answer_options, :free_text_option, :boolean
-  end
-end

--- a/decidim-surveys/db/migrate/20180405015258_add_free_text_to_survey_answer_options.rb
+++ b/decidim-surveys/db/migrate/20180405015258_add_free_text_to_survey_answer_options.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddFreeTextToSurveyAnswerOptions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_surveys_survey_answer_options, :free_text, :boolean
+  end
+end

--- a/decidim-surveys/db/migrate/20180405015314_add_custom_body_to_survey_answer_choices.rb
+++ b/decidim-surveys/db/migrate/20180405015314_add_custom_body_to_survey_answer_choices.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCustomBodyToSurveyAnswerChoices < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_surveys_survey_answer_choices, :custom_body, :text
+  end
+end

--- a/decidim-surveys/lib/decidim/surveys/engine.rb
+++ b/decidim-surveys/lib/decidim/surveys/engine.rb
@@ -15,6 +15,10 @@ module Decidim
         root to: "surveys#show"
       end
 
+      initializer "decidim_surveys.assets" do |app|
+        app.config.assets.precompile += %w(decidim_surveys_manifest.js)
+      end
+
       initializer "decidim_surveys.inject_abilities_to_user" do |_app|
         Decidim.configure do |config|
           config.abilities += ["Decidim::Surveys::Abilities::CurrentUserAbility"]

--- a/decidim-surveys/lib/decidim/surveys/test/factories.rb
+++ b/decidim-surveys/lib/decidim/surveys/test/factories.rb
@@ -36,7 +36,7 @@ FactoryBot.define do
       evaluator.answer_options.each do |answer_option|
         question.answer_options.build(
           body: answer_option["body"],
-          free_text_option: answer_option["free_text_option"]
+          free_text: answer_option["free_text"]
         )
       end
     end

--- a/decidim-surveys/lib/decidim/surveys/test/factories.rb
+++ b/decidim-surveys/lib/decidim/surveys/test/factories.rb
@@ -22,12 +22,21 @@ FactoryBot.define do
   end
 
   factory :survey_question, class: Decidim::Surveys::SurveyQuestion do
+    transient do
+      answer_options []
+    end
+
     body { Decidim::Faker::Localized.sentence }
     mandatory false
     position 0
     question_type { Decidim::Surveys::SurveyQuestion::TYPES.first }
-    answer_options []
     survey
+
+    before(:create) do |question, evaluator|
+      evaluator.answer_options.each do |answer_option|
+        question.answer_options.build(body: answer_option["body"])
+      end
+    end
   end
 
   factory :survey_answer, class: Decidim::Surveys::SurveyAnswer do

--- a/decidim-surveys/lib/decidim/surveys/test/factories.rb
+++ b/decidim-surveys/lib/decidim/surveys/test/factories.rb
@@ -34,7 +34,10 @@ FactoryBot.define do
 
     before(:create) do |question, evaluator|
       evaluator.answer_options.each do |answer_option|
-        question.answer_options.build(body: answer_option["body"])
+        question.answer_options.build(
+          body: answer_option["body"],
+          free_text_option: answer_option["free_text_option"]
+        )
       end
     end
   end

--- a/decidim-surveys/lib/decidim/surveys/test/factories.rb
+++ b/decidim-surveys/lib/decidim/surveys/test/factories.rb
@@ -45,4 +45,8 @@ FactoryBot.define do
     question { create(:survey_question, survey: survey) }
     user { create(:user, organization: survey.organization) }
   end
+
+  factory :survey_answer_option, class: Decidim::Surveys::SurveyAnswerOption do
+    body { Decidim::Faker::Localized.sentence }
+  end
 end

--- a/decidim-surveys/lib/decidim/surveys/test/factories.rb
+++ b/decidim-surveys/lib/decidim/surveys/test/factories.rb
@@ -40,7 +40,7 @@ FactoryBot.define do
   end
 
   factory :survey_answer, class: Decidim::Surveys::SurveyAnswer do
-    body { Decidim::Faker::Localized.sentence }
+    body { "hola" }
     survey
     question { create(:survey_question, survey: survey) }
     user { create(:user, organization: survey.organization) }

--- a/decidim-surveys/spec/commands/decidim/surveys/admin/update_survey_spec.rb
+++ b/decidim-surveys/spec/commands/decidim/surveys/admin/update_survey_spec.rb
@@ -65,7 +65,8 @@ module Decidim
                       "en" => "First answer",
                       "ca" => "Primera resposta",
                       "es" => "Primera respuesta"
-                    }
+                    },
+                    "free_text_option" => "0"
                   },
                   "1" => {
                     "body" => {
@@ -91,7 +92,8 @@ module Decidim
                       "en" => "First answer",
                       "ca" => "Primera resposta",
                       "es" => "Primera respuesta"
-                    }
+                    },
+                    "free_text_option" => "1"
                   },
                   "1" => {
                     "body" => {
@@ -155,6 +157,11 @@ module Decidim
             expect(survey.questions[2].max_choices).to be_nil
 
             expect(survey.questions[3].question_type).to eq("multiple_option")
+            expect(survey.questions[2].answer_options[0].free_text_option).to eq(false)
+            expect(survey.questions[2].max_choices).to be_nil
+
+            expect(survey.questions[3].question_type).to eq("multiple_option")
+            expect(survey.questions[3].answer_options[0].free_text_option).to eq(true)
             expect(survey.questions[3].max_choices).to eq(2)
           end
         end

--- a/decidim-surveys/spec/commands/decidim/surveys/admin/update_survey_spec.rb
+++ b/decidim-surveys/spec/commands/decidim/surveys/admin/update_survey_spec.rb
@@ -66,7 +66,7 @@ module Decidim
                       "ca" => "Primera resposta",
                       "es" => "Primera respuesta"
                     },
-                    "free_text_option" => "0"
+                    "free_text" => "0"
                   },
                   "1" => {
                     "body" => {
@@ -93,7 +93,7 @@ module Decidim
                       "ca" => "Primera resposta",
                       "es" => "Primera respuesta"
                     },
-                    "free_text_option" => "1"
+                    "free_text" => "1"
                   },
                   "1" => {
                     "body" => {
@@ -157,11 +157,11 @@ module Decidim
             expect(survey.questions[2].max_choices).to be_nil
 
             expect(survey.questions[3].question_type).to eq("multiple_option")
-            expect(survey.questions[2].answer_options[0].free_text_option).to eq(false)
+            expect(survey.questions[2].answer_options[0].free_text).to eq(false)
             expect(survey.questions[2].max_choices).to be_nil
 
             expect(survey.questions[3].question_type).to eq("multiple_option")
-            expect(survey.questions[3].answer_options[0].free_text_option).to eq(true)
+            expect(survey.questions[3].answer_options[0].free_text).to eq(true)
             expect(survey.questions[3].max_choices).to eq(2)
           end
         end

--- a/decidim-surveys/spec/commands/decidim/surveys/answer_survey_spec.rb
+++ b/decidim-surveys/spec/commands/decidim/surveys/answer_survey_spec.rb
@@ -23,11 +23,11 @@ module Decidim
             },
             {
               "choices" => [
-                { "decidim_survey_answer_option_id" => answer_option_ids[0], "body" => "This" },
-                { "decidim_survey_answer_option_id" => answer_option_ids[1], "body" => "is" },
-                { "decidim_survey_answer_option_id" => answer_option_ids[2], "body" => "my" },
-                { "decidim_survey_answer_option_id" => answer_option_ids[3], "body" => "second" },
-                { "decidim_survey_answer_option_id" => answer_option_ids[4], "body" => "answer" }
+                { "answer_option_id" => answer_option_ids[0], "body" => "This" },
+                { "answer_option_id" => answer_option_ids[1], "body" => "is" },
+                { "answer_option_id" => answer_option_ids[2], "body" => "my" },
+                { "answer_option_id" => answer_option_ids[3], "body" => "second" },
+                { "answer_option_id" => answer_option_ids[4], "body" => "answer" }
               ],
               "question_id" => survey_question_2.id
             }

--- a/decidim-surveys/spec/commands/decidim/surveys/answer_survey_spec.rb
+++ b/decidim-surveys/spec/commands/decidim/surveys/answer_survey_spec.rb
@@ -12,6 +12,8 @@ module Decidim
       let(:survey) { create(:survey, component: component) }
       let(:survey_question_1) { create(:survey_question, survey: survey) }
       let(:survey_question_2) { create(:survey_question, survey: survey) }
+      let(:answer_options) { create_list(:survey_answer_option, 5, question: survey_question_2) }
+      let(:answer_option_ids) { answer_options.pluck(:id).map(&:to_s) }
       let(:form_params) do
         {
           "answers" => [
@@ -20,7 +22,13 @@ module Decidim
               "question_id" => survey_question_1.id
             },
             {
-              "choices" => %w(This is my second answer),
+              "choices" => [
+                { "decidim_survey_answer_option_id" => answer_option_ids[0], "body" => "This" },
+                { "decidim_survey_answer_option_id" => answer_option_ids[1], "body" => "is" },
+                { "decidim_survey_answer_option_id" => answer_option_ids[2], "body" => "my" },
+                { "decidim_survey_answer_option_id" => answer_option_ids[3], "body" => "second" },
+                { "decidim_survey_answer_option_id" => answer_option_ids[4], "body" => "answer" }
+              ],
               "question_id" => survey_question_2.id
             }
           ],
@@ -69,7 +77,7 @@ module Decidim
           command.call
 
           expect(SurveyAnswer.first.body).to eq("This is my first answer")
-          expect(SurveyAnswer.last.choices).to eq(%w(This is my second answer))
+          expect(SurveyAnswer.last.choices.pluck(:body)).to eq(%w(This is my second answer))
         end
       end
     end

--- a/decidim-surveys/spec/forms/decidim/surveys/admin/survey_question_form_spec.rb
+++ b/decidim-surveys/spec/forms/decidim/surveys/admin/survey_question_form_spec.rb
@@ -76,6 +76,17 @@ module Decidim
 
             expect(subject).not_to be_valid
           end
+
+          it "is valid when max choices under the number of options" do
+            attributes[:max_choices] = 2
+            attributes[:answer_options] = {
+              "0" => { "body" => { "en" => "A" } },
+              "1" => { "body" => { "en" => "B" } },
+              "2" => { "body" => { "en" => "C" } }
+            }
+
+            expect(subject).to be_valid
+          end
         end
 
         context "when the body is missing a locale translation" do

--- a/decidim-surveys/spec/forms/decidim/surveys/survey_answer_form_spec.rb
+++ b/decidim-surveys/spec/forms/decidim/surveys/survey_answer_form_spec.rb
@@ -6,7 +6,7 @@ module Decidim
   module Surveys
     describe SurveyAnswerForm do
       subject do
-        described_class.from_model(survey_answer)
+        described_class.from_model(survey_answer).with_context(current_component: survey.component)
       end
 
       let(:mandatory) { false }

--- a/decidim-surveys/spec/forms/decidim/surveys/survey_answer_form_spec.rb
+++ b/decidim-surveys/spec/forms/decidim/surveys/survey_answer_form_spec.rb
@@ -64,8 +64,8 @@ module Decidim
 
         it "is valid if few enough answers checked" do
           subject.choices = [
-            { "decidim_survey_answer_option_id" => "1", "body" => "foo" },
-            { "decidim_survey_answer_option_id" => "2", "body" => "bar" }
+            { "answer_option_id" => "1", "body" => "foo" },
+            { "answer_option_id" => "2", "body" => "bar" }
           ]
 
           expect(subject).to be_valid
@@ -73,9 +73,9 @@ module Decidim
 
         it "is not valid if too many answers checked" do
           subject.choices = [
-            { "decidim_survey_answer_option_id" => "1", "body" => "foo" },
-            { "decidim_survey_answer_option_id" => "2", "body" => "bar" },
-            { "decidim_survey_answer_option_id" => "3", "body" => "baz" }
+            { "answer_option_id" => "1", "body" => "foo" },
+            { "answer_option_id" => "2", "body" => "bar" },
+            { "answer_option_id" => "3", "body" => "baz" }
           ]
 
           expect(subject).not_to be_valid

--- a/decidim-surveys/spec/forms/decidim/surveys/survey_answer_form_spec.rb
+++ b/decidim-surveys/spec/forms/decidim/surveys/survey_answer_form_spec.rb
@@ -6,7 +6,7 @@ module Decidim
   module Surveys
     describe SurveyAnswerForm do
       subject do
-        described_class.from_model(survey_answer).with_context(current_component: survey.component)
+        described_class.from_model(survey_answer)
       end
 
       let(:mandatory) { false }
@@ -63,12 +63,21 @@ module Decidim
         let(:max_choices) { 2 }
 
         it "is valid if few enough answers checked" do
-          subject.choices = %w(foo bar)
+          subject.choices = [
+            { "decidim_survey_answer_option_id" => "1", "body" => "foo" },
+            { "decidim_survey_answer_option_id" => "2", "body" => "bar" }
+          ]
+
           expect(subject).to be_valid
         end
 
         it "is not valid if too many answers checked" do
-          subject.choices = %w(foo bar baz)
+          subject.choices = [
+            { "decidim_survey_answer_option_id" => "1", "body" => "foo" },
+            { "decidim_survey_answer_option_id" => "2", "body" => "bar" },
+            { "decidim_survey_answer_option_id" => "3", "body" => "baz" }
+          ]
+
           expect(subject).not_to be_valid
         end
       end

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -260,16 +260,16 @@ shared_examples "edit surveys" do
       end
 
       it "updates the free text option selector according to the selected question type" do
-        expect(page).to have_no_selector("input[type=checkbox][id$=_free_text_option]")
+        expect(page).to have_no_selector("input[type=checkbox][id$=_free_text]")
 
         select "Multiple option", from: "Type"
-        expect(page).to have_selector("input[type=checkbox][id$=_free_text_option]")
+        expect(page).to have_selector("input[type=checkbox][id$=_free_text]")
 
         select "Short answer", from: "Type"
-        expect(page).to have_no_selector("input[type=checkbox][id$=_free_text_option]")
+        expect(page).to have_no_selector("input[type=checkbox][id$=_free_text]")
 
         select "Single option", from: "Type"
-        expect(page).to have_selector("input[type=checkbox][id$=_free_text_option]")
+        expect(page).to have_selector("input[type=checkbox][id$=_free_text]")
       end
 
       it "updates the max choices selector according to the configured options" do

--- a/decidim-surveys/spec/shared/edit_survey_examples.rb
+++ b/decidim-surveys/spec/shared/edit_survey_examples.rb
@@ -259,7 +259,22 @@ shared_examples "edit surveys" do
         end
       end
 
+      it "updates the free text option selector according to the selected question type" do
+        expect(page).to have_no_selector("input[type=checkbox][id$=_free_text_option]")
+
+        select "Multiple option", from: "Type"
+        expect(page).to have_selector("input[type=checkbox][id$=_free_text_option]")
+
+        select "Short answer", from: "Type"
+        expect(page).to have_no_selector("input[type=checkbox][id$=_free_text_option]")
+
+        select "Single option", from: "Type"
+        expect(page).to have_selector("input[type=checkbox][id$=_free_text_option]")
+      end
+
       it "updates the max choices selector according to the configured options" do
+        expect(page).to have_no_select("Maximum number of choices")
+
         select "Multiple option", from: "Type"
         expect(page).to have_select("Maximum number of choices", options: %w(Any 2))
 

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -200,6 +200,20 @@ describe "Answer a survey", type: :system do
 
             expect(page).to have_field("survey_answers_1_choices_2_custom_body", disabled: false, count: 1)
           end
+
+          it "saves the free text in a separate field" do
+            choose answer_option_bodies[2]["en"]
+            fill_in "survey_answers_1_choices_2_custom_body", with: "Cacatua"
+
+            check "survey_tos_agreement"
+            accept_confirm { click_button "Submit" }
+
+            within ".success.flash" do
+              expect(page).to have_content("successfully")
+            end
+
+            expect(Decidim::Surveys::SurveyAnswer.first.choices.first.custom_body).to eq("Cacatua")
+          end
         end
 
         context "when question is multiple_option type" do

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -268,6 +268,20 @@ describe "Answer a survey", type: :system do
 
             expect(page).to have_field("survey_answers_1_choices_2_custom_body", disabled: false, count: 1)
           end
+
+          it "saves the free text in a separate field if submission correct" do
+            check answer_option_bodies[2]["en"]
+            fill_in "survey_answers_1_choices_2_custom_body", with: "Cacatua"
+
+            check "survey_tos_agreement"
+            accept_confirm { click_button "Submit" }
+
+            within ".success.flash" do
+              expect(page).to have_content("successfully")
+            end
+
+            expect(Decidim::Surveys::SurveyAnswer.first.choices.first.custom_body).to eq("Cacatua")
+          end
         end
       end
 

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -219,7 +219,7 @@ describe "Answer a survey", type: :system do
             answer_options: [
               { "body" => answer_option_bodies[0] },
               { "body" => answer_option_bodies[1] },
-              { "body" => answer_option_bodies[2], "free_text_option" => true }
+              { "body" => answer_option_bodies[2], "free_text" => true }
             ]
           )
         end

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -76,8 +76,8 @@ describe "Answer a survey", type: :system do
         expect(page).to have_i18n_content(survey.title, upcase: true)
         expect(page).to have_i18n_content(survey.description)
 
-        fill_in "survey_#{survey.id}_question_#{survey_question_1.id}_answer_body", with: "My first answer"
-        fill_in "survey_#{survey.id}_question_#{survey_question_2.id}_answer_body", with: "My second answer"
+        fill_in "survey_answers_1_body", with: "My first answer"
+        fill_in "survey_answers_2_body", with: "My second answer"
 
         check "survey_tos_agreement"
 
@@ -192,13 +192,13 @@ describe "Answer a survey", type: :system do
           let(:question_type) { "single_option" }
 
           it "renders them as radio buttons with attached text fields disabled by default" do
-            expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_answer_options input[type=radio]", count: 3)
+            expect(page).to have_selector(".radio-button-collection input[type=radio]", count: 3)
 
-            expect(page).to have_field("survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_custom_body_2", disabled: true, count: 1)
+            expect(page).to have_field("survey_answers_1_choices_2_custom_body", disabled: true, count: 1)
 
             choose answer_option_bodies[2]["en"]
 
-            expect(page).to have_field("survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_custom_body_2", disabled: false, count: 1)
+            expect(page).to have_field("survey_answers_1_choices_2_custom_body", disabled: false, count: 1)
           end
         end
 
@@ -206,7 +206,7 @@ describe "Answer a survey", type: :system do
           let(:question_type) { "multiple_option" }
 
           it "renders them as check boxes with attached text fields disabled by default" do
-            expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_answer_options input[type=checkbox]", count: 3)
+            expect(page).to have_selector(".check-box-collection input[type=checkbox]", count: 3)
 
             expect(page).to have_field("survey_answers_1_choices_2_custom_body", disabled: true, count: 1)
 
@@ -224,8 +224,8 @@ describe "Answer a survey", type: :system do
         it "renders the answer as a textarea" do
           visit_component
 
-          expect(page).to have_selector("textarea#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body")
-          expect(page).to have_selector("textarea#survey_#{survey.id}_question_#{survey_question_2.id}_answer_body")
+          expect(page).to have_selector("textarea#survey_answers_1_body")
+          expect(page).to have_selector("textarea#survey_answers_2_body")
         end
       end
 
@@ -236,8 +236,8 @@ describe "Answer a survey", type: :system do
         it "renders the answer as a text field" do
           visit_component
 
-          expect(page).to have_selector("input[type=text]#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body")
-          expect(page).to have_selector("input[type=text]#survey_#{survey.id}_question_#{survey_question_2.id}_answer_body")
+          expect(page).to have_selector("input[type=text]#survey_answers_1_body")
+          expect(page).to have_selector("input[type=text]#survey_answers_2_body")
         end
       end
 
@@ -249,14 +249,16 @@ describe "Answer a survey", type: :system do
         it "renders answers as a collection of radio buttons" do
           visit_component
 
-          expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_answer_options input[type=radio]", count: 2)
-          expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_2.id}_answer_body_answer_options input[type=radio]", count: 2)
+          collections = page.all(".radio-button-collection")
 
-          within "#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_answer_options" do
+          expect(collections.first).to have_selector("input[type=radio]", count: 2)
+          expect(collections.last).to have_selector("input[type=radio]", count: 2)
+
+          within collections.first do
             choose answer_options[1]["body"][:en]
           end
 
-          within "#survey_#{survey.id}_question_#{survey_question_2.id}_answer_body_answer_options" do
+          within collections.last do
             choose answer_options[2]["body"][:en]
           end
 
@@ -282,16 +284,22 @@ describe "Answer a survey", type: :system do
         it "renders answers as a collection of radio buttons" do
           visit_component
 
-          expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_answer_options input[type=checkbox]", count: 2)
-          expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_2.id}_answer_body_answer_options input[type=checkbox]", count: 3)
+          collections = page.all(".check-box-collection")
+
+          first_choice = collections.first
+          last_choice = collections.last
+
+          expect(first_choice).to have_selector("input[type=checkbox]", count: 2)
+          expect(last_choice).to have_selector("input[type=checkbox]", count: 3)
+
           expect(page).to have_no_content("Max choices:")
 
-          within "#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_answer_options" do
+          within first_choice do
             check answer_options[0]["body"][:en]
             check answer_options[1]["body"][:en]
           end
 
-          within "#survey_#{survey.id}_question_#{survey_question_2.id}_answer_body_answer_options" do
+          within last_choice do
             check answer_options[2]["body"][:en]
           end
 
@@ -315,7 +323,7 @@ describe "Answer a survey", type: :system do
 
           expect(page).to have_content("Max choices: 2")
 
-          within "#survey_#{survey.id}_question_#{survey_question_2.id}_answer_body_answer_options" do
+          within page.all(".check-box-collection").last do
             check answer_options[2]["body"][:en]
             check answer_options[3]["body"][:en]
             check answer_options[4]["body"][:en]
@@ -349,15 +357,20 @@ describe "Answer a survey", type: :system do
         it "the question answers are rendered as a collection of radio buttons" do
           visit_component
 
-          expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_answer_options input[type=checkbox]", count: 2)
-          expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_2.id}_answer_body_answer_options input[type=checkbox]", count: 2)
+          collections = page.all(".check-box-collection")
 
-          within "#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_answer_options" do
+          first_choice = collections.first
+          last_choice = collections.last
+
+          expect(first_choice).to have_selector("input[type=checkbox]", count: 2)
+          expect(last_choice).to have_selector("input[type=checkbox]", count: 2)
+
+          within first_choice do
             check answer_options[0]["body"][:en]
             check answer_options[1]["body"][:en]
           end
 
-          within "#survey_#{survey.id}_question_#{survey_question_2.id}_answer_body_answer_options" do
+          within last_choice do
             check answer_options[2]["body"][:en]
           end
 

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -168,6 +168,55 @@ describe "Answer a survey", type: :system do
         end
       end
 
+      describe "free text options" do
+        let(:answer_option_bodies) { Array.new(3) { Decidim::Faker::Localized.sentence } }
+
+        let!(:survey_question_1) do
+          create(
+            :survey_question,
+            survey: survey,
+            question_type: question_type,
+            answer_options: [
+              { "body" => answer_option_bodies[0] },
+              { "body" => answer_option_bodies[1] },
+              { "body" => answer_option_bodies[2], "free_text_option" => true }
+            ]
+          )
+        end
+
+        before do
+          visit_component
+        end
+
+        context "when question is single_option type" do
+          let(:question_type) { "single_option" }
+
+          it "renders them as radio buttons with attached text fields disabled by default" do
+            expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_answer_options input[type=radio]", count: 3)
+
+            expect(page).to have_field("survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_custom_body_2", disabled: true, count: 1)
+
+            choose answer_option_bodies[2]["en"]
+
+            expect(page).to have_field("survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_custom_body_2", disabled: false, count: 1)
+          end
+        end
+
+        context "when question is multiple_option type" do
+          let(:question_type) { "multiple_option" }
+
+          it "renders them as check boxes with attached text fields disabled by default" do
+            expect(page).to have_selector("#survey_#{survey.id}_question_#{survey_question_1.id}_answer_body_answer_options input[type=checkbox]", count: 3)
+
+            expect(page).to have_field("survey_answers_1_choices_2_custom_body", disabled: true, count: 1)
+
+            check answer_option_bodies[2]["en"]
+
+            expect(page).to have_field("survey_answers_1_choices_2_custom_body", disabled: false, count: 1)
+          end
+        end
+      end
+
       context "when question type is long answer" do
         let!(:survey_question_1) { create(:survey_question, survey: survey, question_type: "long_answer") }
         let!(:survey_question_2) { create(:survey_question, survey: survey, question_type: "long_answer") }


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds a new feature to multiple choice questions. It allows any option to be configured as a "free text" option, meaning that the user can enter a custom value when selecting the option.

Previously both the available answers for a question and the options the user selected on each answer were stored in jsonb hashes in single DB columns. I found it really hard and prone to errors and bad user experience to implement this feature on top of that, so I upgraded both to fully fledged models.

This PR sits on top of #3133 , so that one should be reviewed first. I splitted it to make reviewing easier and minify the diff.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![customoptions](https://user-images.githubusercontent.com/2887858/38349598-2d3a4aa8-387e-11e8-82f9-220ecb3d99e0.gif)