### PR TITLE
Make sure capybara does not swallow syntax errors

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -50,6 +50,8 @@ end
 
 Capybara.asset_host = "http://localhost:3000"
 
+Capybara.server_errors = [SyntaxError, StandardError]
+
 RSpec.configure do |config|
   config.before :each, type: :system do
     driven_by(:headless_chrome)


### PR DESCRIPTION
#### :tophat: What? Why?

Sometimes when you're doing TDD and introduce a syntax error on a template, `capybara` will give a very obscure message since it swallows the syntax error. Now it no longer does that. For example (after introducing a duplicated `<% end %>` on a random template):

##### Before

```
  1) Answer a survey when the survey doesn't allow answers the survey cannot be answered
     Failure/Error: expect(page).to have_i18n_content(survey.title, upcase: true)
       expected to find text "SURVEY'S TITLE" in ""
```

##### After

```
  1) Answer a survey when the survey doesn't allow answers the survey cannot be answered
     Failure/Error: mod.module_eval(source, identifier, 0)
     
     SyntaxError:
       /home/deivid/Code/decidim/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb:112: syntax error, unexpected keyword_ensure, expecting end-of-input
                 ensure
                 ^~~~~~
```
#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.