### PR TITLE
Support belongs_to relations in data picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ controller or added a new module you need to rename `feature` to `component`.
 
 **Added**:
 
+- **decidim-core**: Support optional belongs_to relations in data picker [\#3138](https://github.com/decidim/decidim/pull/3138)
 - **decidim-meetings**: Add new fields to meetings registrations [\#3123](https://github.com/decidim/decidim/pull/3123)
 - **decidim-admin**: Decidim as OAuth provider [\#3057](https://github.com/decidim/decidim/pull/3057)
 - **decidim-core**: Decidim as OAuth provider [\#3057](https://github.com/decidim/decidim/pull/3057)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ controller or added a new module you need to rename `feature` to `component`.
 
 **Added**:
 
-- **decidim-core**: Support optional belongs_to relations in data picker [\#3138](https://github.com/decidim/decidim/pull/3138)
+- **decidim-core**: Support belongs_to relations in data picker [\#3138](https://github.com/decidim/decidim/pull/3138)
 - **decidim-meetings**: Add new fields to meetings registrations [\#3123](https://github.com/decidim/decidim/pull/3123)
 - **decidim-admin**: Decidim as OAuth provider [\#3057](https://github.com/decidim/decidim/pull/3057)
 - **decidim-core**: Decidim as OAuth provider [\#3057](https://github.com/decidim/decidim/pull/3057)

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -183,7 +183,11 @@ module Decidim
       }
       picker_options[:class] += " is-invalid-input" if error?(attribute)
 
-      items = object.send(attribute).collect { |item| [item, yield(item)] }
+      items = object.send(attribute) || []
+      items = items.values if items.is_a?(Hash)
+      items = [items] unless items.is_a?(Enumerable)
+      items = items.map { |item| [item, yield(item)] }
+
       template = ""
       template += label(attribute, label_for(attribute) + required_for_attribute(attribute)) unless options[:label] == false
       template += @template.render("decidim/widgets/data_picker", picker_options: picker_options, prompt_params: prompt_params, items: items)


### PR DESCRIPTION
#### :tophat: What? Why?

We need to use the data picker with a `belongs_to` relation type.

I had it done in a PR with another unrelated changes, and @isaacmg410 has pinged me because he also needs this, so I have extracted this in a new PR to not block them.

#### :pushpin: Related Issues

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
