### PR TITLE
Fix survey defaults bug

### DIFF
--- a/decidim-surveys/app/controllers/decidim/surveys/admin/surveys_controller.rb
+++ b/decidim-surveys/app/controllers/decidim/surveys/admin/surveys_controller.rb
@@ -41,7 +41,7 @@ module Decidim
         end
 
         def blank_answer_option
-          @blank_answer_option ||= Admin::SurveyQuestionAnswerOptionForm.new
+          @blank_answer_option ||= Admin::SurveyAnswerOptionForm.new
         end
 
         def question_types

--- a/decidim-surveys/app/forms/decidim/surveys/admin/survey_answer_option_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/admin/survey_answer_option_form.rb
@@ -4,7 +4,7 @@ module Decidim
   module Surveys
     module Admin
       # This class holds a Form to update survey question answer options
-      class SurveyQuestionAnswerOptionForm < Decidim::Form
+      class SurveyAnswerOptionForm < Decidim::Form
         include TranslatableAttributes
 
         attribute :deleted, Boolean, default: false

--- a/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/admin/survey_question_form.rb
@@ -10,7 +10,7 @@ module Decidim
         attribute :position, Integer
         attribute :mandatory, Boolean, default: false
         attribute :question_type, String
-        attribute :answer_options, Array[SurveyQuestionAnswerOptionForm]
+        attribute :answer_options, Array[SurveyAnswerOptionForm]
         attribute :max_choices, Integer
         attribute :deleted, Boolean, default: false
 

--- a/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
@@ -21,8 +21,8 @@ module Decidim
         @question ||= survey.questions.find(question_id)
       end
 
-      def label
-        base = "#{id}. #{translated_attribute(question.body)}"
+      def label(idx)
+        base = "#{idx + 1}. #{translated_attribute(question.body)}"
         base += " #{mandatory_label}" if question.mandatory?
         base += " (#{max_choices_label})" if question.max_choices
         base

--- a/decidim-surveys/app/forms/decidim/surveys/survey_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_form.rb
@@ -13,8 +13,8 @@ module Decidim
       #
       # Returns nothing.
       def map_model(model)
-        self.answers = model.questions.each_with_index.map do |question, id|
-          SurveyAnswerForm.from_model(SurveyAnswer.new(id: id + 1, question: question))
+        self.answers = model.questions.map do |question|
+          SurveyAnswerForm.from_model(SurveyAnswer.new(question: question))
         end
       end
     end

--- a/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
@@ -1,5 +1,5 @@
 <% field_id = "survey_answers_#{answer_idx}" %>
-<%= label_tag field_id, answer.label, class: "survey-question" %>
+<%= label_tag field_id, answer.label(answer_idx), class: "survey-question" %>
 
 <% if translated_attribute(answer.question.description).present? %>
   <div class="help-text">
@@ -66,7 +66,6 @@
   </div>
 <% end %>
 
-<%= answer_form.hidden_field :id %>
 <%= answer_form.hidden_field :question_id %>
 
 <% answer.errors.full_messages.each do |msg| %>

--- a/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
@@ -8,62 +8,62 @@
 <% end %>
 
 <% case answer.question.question_type %>
-  <% when "short_answer" %>
-    <%= answer_form.text_field :body, label: false, id: "#{field_id}_body" %>
-  <% when "long_answer" %>
-    <%= answer_form.text_area :body, label: false, id: "#{field_id}_body", rows: 10 %>
-  <% when "single_option" %>
-    <div class="radio-button-collection">
-      <% choice = answer.choices.first %>
+<% when "short_answer" %>
+  <%= answer_form.text_field :body, label: false, id: "#{field_id}_body" %>
+<% when "long_answer" %>
+  <%= answer_form.text_area :body, label: false, id: "#{field_id}_body", rows: 10 %>
+<% when "single_option" %>
+  <div class="radio-button-collection">
+    <% choice = answer.choices.first %>
 
-      <% answer.question.answer_options.each_with_index do |answer_option, idx| %>
-        <% choice_id = "#{field_id}_choices_#{idx}" %>
+    <% answer.question.answer_options.each_with_index do |answer_option, idx| %>
+      <% choice_id = "#{field_id}_choices_#{idx}" %>
 
-        <%= label_tag "#{choice_id}_body" do %>
-          <%= radio_button_tag "survey[answers][#{answer_idx}][choices][][body]",
-                               translated_attribute(answer_option.body),
-                               choice.try(:body),
-                               id: "#{choice_id}_body" %>
+      <%= label_tag "#{choice_id}_body" do %>
+        <%= radio_button_tag "survey[answers][#{answer_idx}][choices][][body]",
+                             translated_attribute(answer_option.body),
+                             choice.try(:body),
+                             id: "#{choice_id}_body" %>
 
-          <%= translated_attribute(answer_option.body) %>
+        <%= translated_attribute(answer_option.body) %>
 
-          <% if answer_option.free_text %>
-            <%= text_field_tag "survey[answers][#{answer_idx}][choices][][custom_body]",
-                               choice.try(:custom_body),
-                               id: "#{choice_id}_custom_body",
-                               disabled: true %>
-          <% end %>
-
-          <%= hidden_field_tag "survey[answers][#{answer_idx}][choices][][answer_option_id]",
-                               answer_option.id,
-                               id: "#{choice_id}_answer_option",
-                               disabled: true %>
-        <% end %>
-      <% end %>
-    </div>
-  <% when "multiple_option" %>
-    <div class="check-box-collection">
-      <% answer.question.answer_options.each_with_index do |answer_option, idx| %>
-        <% choice = answer.selected_choices.find { |choice| choice.answer_option_id == answer_option.id } %>
-
-        <%= label_tag "#{field_id}_choices_#{idx}" do %>
-          <%= check_box_tag "survey[answers][#{answer_idx}][choices][#{idx}][body]",
-                            translated_attribute(answer_option.body),
-                            choice.present? %>
-
-          <%= translated_attribute(answer_option.body) %>
-
-          <% if answer_option.free_text %>
-            <%= text_field_tag "survey[answers][#{answer_idx}][choices][#{idx}][custom_body]",
-                               choice.try(:custom_body),
-                               disabled: true %>
-          <% end %>
-
-          <%= hidden_field_tag "survey[answers][#{answer_idx}][choices][#{idx}][answer_option_id]", answer_option.id %>
+        <% if answer_option.free_text %>
+          <%= text_field_tag "survey[answers][#{answer_idx}][choices][][custom_body]",
+                             choice.try(:custom_body),
+                             id: "#{choice_id}_custom_body",
+                             disabled: true %>
         <% end %>
 
+        <%= hidden_field_tag "survey[answers][#{answer_idx}][choices][][answer_option_id]",
+                             answer_option.id,
+                             id: "#{choice_id}_answer_option",
+                             disabled: true %>
       <% end %>
-    </div>
+    <% end %>
+  </div>
+<% when "multiple_option" %>
+  <div class="check-box-collection">
+    <% answer.question.answer_options.each_with_index do |answer_option, idx| %>
+      <% choice = answer.selected_choices.find { |choice| choice.answer_option_id == answer_option.id } %>
+
+      <%= label_tag "#{field_id}_choices_#{idx}" do %>
+        <%= check_box_tag "survey[answers][#{answer_idx}][choices][#{idx}][body]",
+                          translated_attribute(answer_option.body),
+                          choice.present? %>
+
+        <%= translated_attribute(answer_option.body) %>
+
+        <% if answer_option.free_text %>
+          <%= text_field_tag "survey[answers][#{answer_idx}][choices][#{idx}][custom_body]",
+                             choice.try(:custom_body),
+                             disabled: true %>
+        <% end %>
+
+        <%= hidden_field_tag "survey[answers][#{answer_idx}][choices][#{idx}][answer_option_id]", answer_option.id %>
+      <% end %>
+
+    <% end %>
+  </div>
 <% end %>
 
 <%= answer_form.hidden_field :id %>

--- a/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
@@ -30,10 +30,10 @@
             <% else %>
               <div class="answer-survey">
                 <%= decidim_form_for(@form, url: answer_survey_path(survey), method: :post, html: { class: "form answer-survey" }) do |form| %>
-                  <% @form.answers.each do |answer| %>
+                  <% @form.answers.each_with_index do |answer, answer_idx| %>
                     <div class="row column">
-                      <%= fields_for "survey[answers][]", answer do |answer_form| %>
-                        <%= render "answer", answer_form: answer_form, answer: answer, answer_idx: answer.id %>
+                      <%= fields_for "survey[answers][#{answer_idx}]", answer do |answer_form| %>
+                        <%= render "answer", answer_form: answer_form, answer: answer, answer_idx: answer_idx %>
                       <% end %>
                     </div>
                   <% end %>

--- a/decidim-surveys/spec/forms/decidim/surveys/admin/survey_answer_option_form_spec.rb
+++ b/decidim-surveys/spec/forms/decidim/surveys/admin/survey_answer_option_form_spec.rb
@@ -5,10 +5,10 @@ require "spec_helper"
 module Decidim
   module Surveys
     module Admin
-      describe SurveyQuestionAnswerOptionForm do
+      describe SurveyAnswerOptionForm do
         subject do
           described_class.from_params(
-            survey_question_answer_option: attributes
+            survey_answer_option: attributes
           ).with_context(current_organization: organization)
         end
 

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -21,7 +21,7 @@ describe "Answer a survey", type: :system do
   end
   let(:user) { create(:user, :confirmed, organization: component.organization) }
   let!(:survey) { create(:survey, component: component, title: title, description: description) }
-  let!(:survey_question_1) { create(:survey_question, survey: survey, position: 0) }
+  let!(:survey_question) { create(:survey_question, survey: survey, position: 0) }
 
   include_context "with a component"
 
@@ -32,7 +32,7 @@ describe "Answer a survey", type: :system do
       expect(page).to have_i18n_content(survey.title, upcase: true)
       expect(page).to have_i18n_content(survey.description)
 
-      expect(page).to have_no_i18n_content(survey_question_1.body)
+      expect(page).to have_no_i18n_content(survey_question.body)
 
       expect(page).to have_content("The survey is closed and cannot be answered.")
     end
@@ -56,7 +56,7 @@ describe "Answer a survey", type: :system do
         expect(page).to have_i18n_content(survey.title, upcase: true)
         expect(page).to have_i18n_content(survey.description)
 
-        expect(page).to have_no_i18n_content(survey_question_1.body)
+        expect(page).to have_no_i18n_content(survey_question.body)
 
         expect(page).to have_content("Sign in with your account or sign up to answer the survey.")
       end
@@ -84,20 +84,20 @@ describe "Answer a survey", type: :system do
         end
 
         expect(page).to have_content("You have already answered this survey.")
-        expect(page).to have_no_i18n_content(survey_question_1.body)
+        expect(page).to have_no_i18n_content(survey_question.body)
       end
 
       shared_examples_for "a correctly ordered survey" do
         it "displays the questions ordered by position starting with one" do
           form_fields = all(".answer-survey .row")
 
-          expect(form_fields[0]).to have_i18n_content(survey_question_1.body).and have_content("1. ")
-          expect(form_fields[1]).to have_i18n_content(survey_question_2.body).and have_content("2. ")
+          expect(form_fields[0]).to have_i18n_content(survey_question.body).and have_content("1. ")
+          expect(form_fields[1]).to have_i18n_content(other_survey_question.body).and have_content("2. ")
         end
       end
 
       context "and submitting a fresh form" do
-        let!(:survey_question_2) { create(:survey_question, survey: survey, position: 1) }
+        let!(:other_survey_question) { create(:survey_question, survey: survey, position: 1) }
 
         before do
           visit_component
@@ -107,7 +107,7 @@ describe "Answer a survey", type: :system do
       end
 
       context "and rendering a form after errors" do
-        let!(:survey_question_2) { create(:survey_question, survey: survey, position: 1) }
+        let!(:other_survey_question) { create(:survey_question, survey: survey, position: 1) }
 
         before do
           visit_component
@@ -118,7 +118,7 @@ describe "Answer a survey", type: :system do
       end
 
       shared_context "when a non multiple choice question is mandatory" do
-        let!(:survey_question_1) do
+        let!(:survey_question) do
           create(
             :survey_question,
             survey: survey,
@@ -166,7 +166,7 @@ describe "Answer a survey", type: :system do
       end
 
       describe "leaving a blank multiple choice question" do
-        let!(:survey_question_1) do
+        let!(:survey_question) do
           create(
             :survey_question,
             survey: survey,
@@ -198,7 +198,7 @@ describe "Answer a survey", type: :system do
       end
 
       context "when a question has a rich text description" do
-        let!(:survey_question_1) { create(:survey_question, survey: survey, position: 0, description: "<b>This question is important</b>") }
+        let!(:survey_question) { create(:survey_question, survey: survey, position: 0, description: "<b>This question is important</b>") }
 
         it "properly interprets HTML descriptions" do
           visit_component
@@ -210,7 +210,7 @@ describe "Answer a survey", type: :system do
       describe "free text options" do
         let(:answer_option_bodies) { Array.new(3) { Decidim::Faker::Localized.sentence } }
 
-        let!(:survey_question_1) do
+        let!(:survey_question) do
           create(
             :survey_question,
             survey: survey,
@@ -223,7 +223,7 @@ describe "Answer a survey", type: :system do
           )
         end
 
-        let!(:survey_question_2) do
+        let!(:other_survey_question) do
           create(
             :survey_question,
             survey: survey,
@@ -335,7 +335,7 @@ describe "Answer a survey", type: :system do
       end
 
       context "when question type is long answer" do
-        let!(:survey_question_1) { create(:survey_question, survey: survey, question_type: "long_answer") }
+        let!(:survey_question) { create(:survey_question, survey: survey, question_type: "long_answer") }
 
         it "renders the answer as a textarea" do
           visit_component
@@ -345,7 +345,7 @@ describe "Answer a survey", type: :system do
       end
 
       context "when question type is short answer" do
-        let!(:survey_question_1) { create(:survey_question, survey: survey, question_type: "short_answer") }
+        let!(:survey_question) { create(:survey_question, survey: survey, question_type: "short_answer") }
 
         it "renders the answer as a text field" do
           visit_component
@@ -356,7 +356,7 @@ describe "Answer a survey", type: :system do
 
       context "when question type is single option" do
         let(:answer_options) { Array.new(2) { { "body" => Decidim::Faker::Localized.sentence } } }
-        let!(:survey_question_1) { create(:survey_question, survey: survey, question_type: "single_option", answer_options: [answer_options[0], answer_options[1]]) }
+        let!(:survey_question) { create(:survey_question, survey: survey, question_type: "single_option", answer_options: [answer_options[0], answer_options[1]]) }
 
         it "renders answers as a collection of radio buttons" do
           visit_component
@@ -374,13 +374,13 @@ describe "Answer a survey", type: :system do
           end
 
           expect(page).to have_content("You have already answered this survey.")
-          expect(page).to have_no_i18n_content(survey_question_1.body)
+          expect(page).to have_no_i18n_content(survey_question.body)
         end
       end
 
       context "when question type is multiple option" do
         let(:answer_options) { Array.new(3) { { "body" => Decidim::Faker::Localized.sentence } } }
-        let!(:survey_question_1) { create(:survey_question, survey: survey, question_type: "multiple_option", answer_options: [answer_options[0], answer_options[1], answer_options[2]]) }
+        let!(:survey_question) { create(:survey_question, survey: survey, question_type: "multiple_option", answer_options: [answer_options[0], answer_options[1], answer_options[2]]) }
 
         it "renders answers as a collection of radio buttons" do
           visit_component
@@ -401,11 +401,11 @@ describe "Answer a survey", type: :system do
           end
 
           expect(page).to have_content("You have already answered this survey.")
-          expect(page).to have_no_i18n_content(survey_question_1.body)
+          expect(page).to have_no_i18n_content(survey_question.body)
         end
 
         it "respects the max number of choices" do
-          survey_question_1.update!(max_choices: 2)
+          survey_question.update!(max_choices: 2)
 
           visit_component
 
@@ -437,7 +437,7 @@ describe "Answer a survey", type: :system do
 
       context "when question type is multiple option" do
         let(:answer_options) { Array.new(2) { { "body" => Decidim::Faker::Localized.sentence } } }
-        let!(:survey_question_1) { create(:survey_question, survey: survey, question_type: "multiple_option", answer_options: [answer_options[0], answer_options[1]]) }
+        let!(:survey_question) { create(:survey_question, survey: survey, question_type: "multiple_option", answer_options: [answer_options[0], answer_options[1]]) }
 
         it "the question answers are rendered as a collection of radio buttons" do
           visit_component
@@ -456,7 +456,7 @@ describe "Answer a survey", type: :system do
           end
 
           expect(page).to have_content("You have already answered this survey.")
-          expect(page).to have_no_i18n_content(survey_question_1.body)
+          expect(page).to have_no_i18n_content(survey_question.body)
         end
       end
     end

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -21,8 +21,7 @@ describe "Answer a survey", type: :system do
   end
   let(:user) { create(:user, :confirmed, organization: component.organization) }
   let!(:survey) { create(:survey, component: component, title: title, description: description) }
-  let!(:survey_question_1) { create(:survey_question, survey: survey, position: 1) }
-  let!(:survey_question_2) { create(:survey_question, survey: survey, position: 0) }
+  let!(:survey_question_1) { create(:survey_question, survey: survey, position: 0) }
 
   include_context "with a component"
 
@@ -34,7 +33,6 @@ describe "Answer a survey", type: :system do
       expect(page).to have_i18n_content(survey.description)
 
       expect(page).to have_no_i18n_content(survey_question_1.body)
-      expect(page).to have_no_i18n_content(survey_question_2.body)
 
       expect(page).to have_content("The survey is closed and cannot be answered.")
     end
@@ -59,7 +57,6 @@ describe "Answer a survey", type: :system do
         expect(page).to have_i18n_content(survey.description)
 
         expect(page).to have_no_i18n_content(survey_question_1.body)
-        expect(page).to have_no_i18n_content(survey_question_2.body)
 
         expect(page).to have_content("Sign in with your account or sign up to answer the survey.")
       end
@@ -77,7 +74,6 @@ describe "Answer a survey", type: :system do
         expect(page).to have_i18n_content(survey.description)
 
         fill_in "survey_answers_1_body", with: "My first answer"
-        fill_in "survey_answers_2_body", with: "My second answer"
 
         check "survey_tos_agreement"
 
@@ -89,19 +85,20 @@ describe "Answer a survey", type: :system do
 
         expect(page).to have_content("You have already answered this survey.")
         expect(page).to have_no_i18n_content(survey_question_1.body)
-        expect(page).to have_no_i18n_content(survey_question_2.body)
       end
 
       shared_examples_for "a correctly ordered survey" do
         it "displays the questions ordered by position starting with one" do
           form_fields = all(".answer-survey .row")
 
-          expect(form_fields[0]).to have_i18n_content(survey_question_2.body).and have_content("1. ")
-          expect(form_fields[1]).to have_i18n_content(survey_question_1.body).and have_content("2. ")
+          expect(form_fields[0]).to have_i18n_content(survey_question_1.body).and have_content("1. ")
+          expect(form_fields[1]).to have_i18n_content(survey_question_2.body).and have_content("2. ")
         end
       end
 
       context "and submitting a fresh form" do
+        let!(:survey_question_2) { create(:survey_question, survey: survey, position: 1) }
+
         before do
           visit_component
         end
@@ -110,6 +107,8 @@ describe "Answer a survey", type: :system do
       end
 
       context "and rendering a form after errors" do
+        let!(:survey_question_2) { create(:survey_question, survey: survey, position: 1) }
+
         before do
           visit_component
           accept_confirm { click_button "Submit" }
@@ -119,7 +118,7 @@ describe "Answer a survey", type: :system do
       end
 
       shared_context "when a non multiple choice question is mandatory" do
-        let!(:survey_question_2) do
+        let!(:survey_question_1) do
           create(
             :survey_question,
             survey: survey,
@@ -167,7 +166,7 @@ describe "Answer a survey", type: :system do
       end
 
       describe "leaving a blank multiple choice question" do
-        let!(:survey_question_2) do
+        let!(:survey_question_1) do
           create(
             :survey_question,
             survey: survey,
@@ -199,7 +198,7 @@ describe "Answer a survey", type: :system do
       end
 
       context "when a question has a rich text description" do
-        let!(:survey_question_2) { create(:survey_question, survey: survey, position: 0, description: "<b>This question is important</b>") }
+        let!(:survey_question_1) { create(:survey_question, survey: survey, position: 0, description: "<b>This question is important</b>") }
 
         it "properly interprets HTML descriptions" do
           visit_component
@@ -337,48 +336,34 @@ describe "Answer a survey", type: :system do
 
       context "when question type is long answer" do
         let!(:survey_question_1) { create(:survey_question, survey: survey, question_type: "long_answer") }
-        let!(:survey_question_2) { create(:survey_question, survey: survey, question_type: "long_answer") }
 
         it "renders the answer as a textarea" do
           visit_component
 
           expect(page).to have_selector("textarea#survey_answers_1_body")
-          expect(page).to have_selector("textarea#survey_answers_2_body")
         end
       end
 
       context "when question type is short answer" do
         let!(:survey_question_1) { create(:survey_question, survey: survey, question_type: "short_answer") }
-        let!(:survey_question_2) { create(:survey_question, survey: survey, question_type: "short_answer") }
 
         it "renders the answer as a text field" do
           visit_component
 
           expect(page).to have_selector("input[type=text]#survey_answers_1_body")
-          expect(page).to have_selector("input[type=text]#survey_answers_2_body")
         end
       end
 
       context "when question type is single option" do
-        let(:answer_options) { Array.new(4) { { "body" => Decidim::Faker::Localized.sentence } } }
+        let(:answer_options) { Array.new(2) { { "body" => Decidim::Faker::Localized.sentence } } }
         let!(:survey_question_1) { create(:survey_question, survey: survey, question_type: "single_option", answer_options: [answer_options[0], answer_options[1]]) }
-        let!(:survey_question_2) { create(:survey_question, survey: survey, question_type: "single_option", answer_options: [answer_options[2], answer_options[3]]) }
 
         it "renders answers as a collection of radio buttons" do
           visit_component
 
-          collections = page.all(".radio-button-collection")
+          expect(page).to have_selector(".radio-button-collection input[type=radio]", count: 2)
 
-          expect(collections.first).to have_selector("input[type=radio]", count: 2)
-          expect(collections.last).to have_selector("input[type=radio]", count: 2)
-
-          within collections.first do
-            choose answer_options[1]["body"][:en]
-          end
-
-          within collections.last do
-            choose answer_options[2]["body"][:en]
-          end
+          choose answer_options[0]["body"][:en]
 
           check "survey_tos_agreement"
 
@@ -390,36 +375,22 @@ describe "Answer a survey", type: :system do
 
           expect(page).to have_content("You have already answered this survey.")
           expect(page).to have_no_i18n_content(survey_question_1.body)
-          expect(page).to have_no_i18n_content(survey_question_2.body)
         end
       end
 
       context "when question type is multiple option" do
-        let(:answer_options) { Array.new(5) { { "body" => Decidim::Faker::Localized.sentence } } }
-        let!(:survey_question_1) { create(:survey_question, survey: survey, question_type: "multiple_option", answer_options: [answer_options[0], answer_options[1]]) }
-        let!(:survey_question_2) { create(:survey_question, survey: survey, question_type: "multiple_option", answer_options: [answer_options[2], answer_options[3], answer_options[4]]) }
+        let(:answer_options) { Array.new(3) { { "body" => Decidim::Faker::Localized.sentence } } }
+        let!(:survey_question_1) { create(:survey_question, survey: survey, question_type: "multiple_option", answer_options: [answer_options[0], answer_options[1], answer_options[2]]) }
 
         it "renders answers as a collection of radio buttons" do
           visit_component
 
-          collections = page.all(".check-box-collection")
-
-          first_choice = collections.first
-          last_choice = collections.last
-
-          expect(first_choice).to have_selector("input[type=checkbox]", count: 2)
-          expect(last_choice).to have_selector("input[type=checkbox]", count: 3)
+          expect(page).to have_selector(".check-box-collection input[type=checkbox]", count: 3)
 
           expect(page).to have_no_content("Max choices:")
 
-          within first_choice do
-            check answer_options[0]["body"][:en]
-            check answer_options[1]["body"][:en]
-          end
-
-          within last_choice do
-            check answer_options[2]["body"][:en]
-          end
+          check answer_options[0]["body"][:en]
+          check answer_options[1]["body"][:en]
 
           check "survey_tos_agreement"
 
@@ -431,21 +402,18 @@ describe "Answer a survey", type: :system do
 
           expect(page).to have_content("You have already answered this survey.")
           expect(page).to have_no_i18n_content(survey_question_1.body)
-          expect(page).to have_no_i18n_content(survey_question_2.body)
         end
 
         it "respects the max number of choices" do
-          survey_question_2.update!(max_choices: 2)
+          survey_question_1.update!(max_choices: 2)
 
           visit_component
 
           expect(page).to have_content("Max choices: 2")
 
-          within page.all(".check-box-collection").last do
-            check answer_options[2]["body"][:en]
-            check answer_options[3]["body"][:en]
-            check answer_options[4]["body"][:en]
-          end
+          check answer_options[0]["body"][:en]
+          check answer_options[1]["body"][:en]
+          check answer_options[2]["body"][:en]
 
           check "survey_tos_agreement"
 
@@ -457,7 +425,7 @@ describe "Answer a survey", type: :system do
 
           expect(page).to have_content("are too many")
 
-          uncheck answer_options[4]["body"][:en]
+          uncheck answer_options[2]["body"][:en]
 
           accept_confirm { click_button "Submit" }
 
@@ -468,29 +436,16 @@ describe "Answer a survey", type: :system do
       end
 
       context "when question type is multiple option" do
-        let(:answer_options) { Array.new(4) { { "body" => Decidim::Faker::Localized.sentence } } }
+        let(:answer_options) { Array.new(2) { { "body" => Decidim::Faker::Localized.sentence } } }
         let!(:survey_question_1) { create(:survey_question, survey: survey, question_type: "multiple_option", answer_options: [answer_options[0], answer_options[1]]) }
-        let!(:survey_question_2) { create(:survey_question, survey: survey, question_type: "multiple_option", answer_options: [answer_options[2], answer_options[3]]) }
 
         it "the question answers are rendered as a collection of radio buttons" do
           visit_component
 
-          collections = page.all(".check-box-collection")
+          expect(page).to have_selector(".check-box-collection input[type=checkbox]", count: 2)
 
-          first_choice = collections.first
-          last_choice = collections.last
-
-          expect(first_choice).to have_selector("input[type=checkbox]", count: 2)
-          expect(last_choice).to have_selector("input[type=checkbox]", count: 2)
-
-          within first_choice do
-            check answer_options[0]["body"][:en]
-            check answer_options[1]["body"][:en]
-          end
-
-          within last_choice do
-            check answer_options[2]["body"][:en]
-          end
+          check answer_options[0]["body"][:en]
+          check answer_options[1]["body"][:en]
 
           check "survey_tos_agreement"
 
@@ -502,7 +457,6 @@ describe "Answer a survey", type: :system do
 
           expect(page).to have_content("You have already answered this survey.")
           expect(page).to have_no_i18n_content(survey_question_1.body)
-          expect(page).to have_no_i18n_content(survey_question_2.body)
         end
       end
     end

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -26,7 +26,7 @@ describe "Answer a survey", type: :system do
   include_context "with a component"
 
   context "when the survey doesn't allow answers" do
-    it "the survey cannot be answered" do
+    it "does not allow answering the survey" do
       visit_component
 
       expect(page).to have_i18n_content(survey.title, upcase: true)
@@ -50,7 +50,7 @@ describe "Answer a survey", type: :system do
     end
 
     context "when the user is not logged in" do
-      it "the survey cannot be answered" do
+      it "does not allow answering the survey" do
         visit_component
 
         expect(page).to have_i18n_content(survey.title, upcase: true)
@@ -67,7 +67,7 @@ describe "Answer a survey", type: :system do
         login_as user, scope: :user
       end
 
-      it "the survey can be answered" do
+      it "allows answering the survey" do
         visit_component
 
         expect(page).to have_i18n_content(survey.title, upcase: true)
@@ -439,7 +439,7 @@ describe "Answer a survey", type: :system do
         let(:answer_options) { Array.new(2) { { "body" => Decidim::Faker::Localized.sentence } } }
         let!(:survey_question) { create(:survey_question, survey: survey, question_type: "multiple_option", answer_options: answer_options) }
 
-        it "the question answers are rendered as a collection of radio buttons" do
+        it "renders the question answers as a collection of radio buttons" do
           visit_component
 
           expect(page).to have_selector(".check-box-collection input[type=checkbox]", count: 2)

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -356,7 +356,7 @@ describe "Answer a survey", type: :system do
 
       context "when question type is single option" do
         let(:answer_options) { Array.new(2) { { "body" => Decidim::Faker::Localized.sentence } } }
-        let!(:survey_question) { create(:survey_question, survey: survey, question_type: "single_option", answer_options: [answer_options[0], answer_options[1]]) }
+        let!(:survey_question) { create(:survey_question, survey: survey, question_type: "single_option", answer_options: answer_options) }
 
         it "renders answers as a collection of radio buttons" do
           visit_component
@@ -380,7 +380,7 @@ describe "Answer a survey", type: :system do
 
       context "when question type is multiple option" do
         let(:answer_options) { Array.new(3) { { "body" => Decidim::Faker::Localized.sentence } } }
-        let!(:survey_question) { create(:survey_question, survey: survey, question_type: "multiple_option", answer_options: [answer_options[0], answer_options[1], answer_options[2]]) }
+        let!(:survey_question) { create(:survey_question, survey: survey, question_type: "multiple_option", answer_options: answer_options) }
 
         it "renders answers as a collection of radio buttons" do
           visit_component
@@ -437,7 +437,7 @@ describe "Answer a survey", type: :system do
 
       context "when question type is multiple option" do
         let(:answer_options) { Array.new(2) { { "body" => Decidim::Faker::Localized.sentence } } }
-        let!(:survey_question) { create(:survey_question, survey: survey, question_type: "multiple_option", answer_options: [answer_options[0], answer_options[1]]) }
+        let!(:survey_question) { create(:survey_question, survey: survey, question_type: "multiple_option", answer_options: answer_options) }
 
         it "the question answers are rendered as a collection of radio buttons" do
           visit_component


### PR DESCRIPTION
#### :tophat: What? Why?

I found a pretty nasty bug where multiple choice questions in a survey would appear with preselected options once another user has already answer the survey. Pretty bad things I was doing in there (manually assigning the id of a DB backed model... :S).

Also took the chance the simplify the specs which had gotten too complex.

#### :pushpin: Related Issues
- Sits on top of #3134. Review and merge that one first, and I'll rebase this one after that.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.
