### PR TITLE
Ignore builds for any branch starting with `l10n_`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -619,15 +619,15 @@ workflows:
       - build_design_app:
           filters:
             branches:
-              ignore: /^l10n_master$/
+              ignore: /^l10n_/
       - build_test_app:
           filters:
             branches:
-              ignore: /^l10n_master$/
+              ignore: /^l10n_/
       - main:
           filters:
             branches:
-              ignore: /^l10n_master$/
+              ignore: /^l10n_/
       - core:
           requires:
             - build_test_app


### PR DESCRIPTION
#### :tophat: What? Why?
Ignore builds for any branch starting with `l10n_`. This is to avoid builds on branched Crowdin integrations.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None