### PR TITLE
Fix showing not visible proposals in process home page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ controller or added a new module you need to rename `feature` to `component`.
 
 **Added**:
 
-- **decidim-proposals**: Fix view hooks returning proposals that should not be shown [\#3175](https://github.com/decidim/decidim/pull/3175)
 - **decidim-proposals**: Add configuration for set the number of proposals to be highlighted [\#3175](https://github.com/decidim/decidim/pull/3175)
 - **decidim-meetings**: Add new fields to meetings registrations [\#3123](https://github.com/decidim/decidim/pull/3123)
 - **decidim-admin**: Decidim as OAuth provider [\#3057](https://github.com/decidim/decidim/pull/3057)
@@ -51,6 +50,7 @@ controller or added a new module you need to rename `feature` to `component`.
 
 **Fixed**:
 
+- **decidim-proposals**: Fix view hooks returning proposals that should not be shown [\#3175](https://github.com/decidim/decidim/pull/3175)
 - **decidim-debates**: Fix debates times. [\#3071](https://github.com/decidim/decidim/pull/3071)
 - **decidim-proposals**: Fix Feedback needed after Endorsing when user has no user_groups [\#2968](https://github.com/decidim/decidim/pull/2998)
 - **decidim-proposals**: Fix threshold absolute view and rename the field maximum_votes_per_proposal to threshold_per_proposal. [\#2994](https://github.com/decidim/decidim/pull/2994)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ controller or added a new module you need to rename `feature` to `component`.
 
 **Added**:
 
+- **decidim-proposals**: Fix view hooks returning proposals that should not be shown [\#3175](https://github.com/decidim/decidim/pull/3175)
+- **decidim-proposals**: Add configuration for set the number of proposals to be highlighted [\#3175](https://github.com/decidim/decidim/pull/3175)
 - **decidim-meetings**: Add new fields to meetings registrations [\#3123](https://github.com/decidim/decidim/pull/3123)
 - **decidim-admin**: Decidim as OAuth provider [\#3057](https://github.com/decidim/decidim/pull/3057)
 - **decidim-core**: Decidim as OAuth provider [\#3057](https://github.com/decidim/decidim/pull/3057)

--- a/decidim-proposals/lib/decidim/proposals.rb
+++ b/decidim-proposals/lib/decidim/proposals.rb
@@ -25,6 +25,18 @@ module Decidim
     config_accessor :similarity_limit do
       10
     end
+
+    # Public Setting that defines how many proposals will be shown in the
+    # participatory_space_highlighted_elements view hook
+    config_accessor :participatory_space_highlighted_proposals_limit do
+      4
+    end
+
+    # Public Setting that defines how many proposals will be shown in the
+    # process_group_highlighted_elements view hook
+    config_accessor :process_group_highlighted_proposals_limit do
+      3
+    end
   end
 
   module ContentParsers

--- a/decidim-proposals/lib/decidim/proposals/engine.rb
+++ b/decidim-proposals/lib/decidim/proposals/engine.rb
@@ -53,7 +53,10 @@ module Decidim
       initializer "decidim_proposals.view_hooks" do
         Decidim.view_hooks.register(:participatory_space_highlighted_elements, priority: Decidim::ViewHooks::MEDIUM_PRIORITY) do |view_context|
           published_components = Decidim::Component.where(participatory_space: view_context.current_participatory_space).published
-          proposals = Decidim::Proposals::Proposal.published.not_hidden.except_withdrawn.where(component: published_components).order_randomly(rand * 2 - 1).limit(4)
+          proposals = Decidim::Proposals::Proposal.published.not_hidden.except_withdrawn
+                                                  .where(component: published_components)
+                                                  .order_randomly(rand * 2 - 1)
+                                                  .limit(Decidim::Proposals.config.participatory_space_highlighted_proposals_limit)
 
           next unless proposals.any?
 
@@ -69,7 +72,10 @@ module Decidim
         if defined? Decidim::ParticipatoryProcesses
           Decidim::ParticipatoryProcesses.view_hooks.register(:process_group_highlighted_elements, priority: Decidim::ViewHooks::MEDIUM_PRIORITY) do |view_context|
             published_components = Decidim::Component.where(participatory_space: view_context.participatory_processes).published
-            proposals = Decidim::Proposals::Proposal.published.not_hidden.except_withdrawn.where(component: published_components).order_randomly(rand * 2 - 1).limit(3)
+            proposals = Decidim::Proposals::Proposal.published.not_hidden.except_withdrawn
+                                                    .where(component: published_components)
+                                                    .order_randomly(rand * 2 - 1)
+                                                    .limit(Decidim::Proposals.config.process_group_highlighted_proposals_limit)
 
             next unless proposals.any?
 

--- a/decidim-proposals/lib/decidim/proposals/engine.rb
+++ b/decidim-proposals/lib/decidim/proposals/engine.rb
@@ -53,7 +53,7 @@ module Decidim
       initializer "decidim_proposals.view_hooks" do
         Decidim.view_hooks.register(:participatory_space_highlighted_elements, priority: Decidim::ViewHooks::MEDIUM_PRIORITY) do |view_context|
           published_components = Decidim::Component.where(participatory_space: view_context.current_participatory_space).published
-          proposals = Decidim::Proposals::Proposal.where(component: published_components).order_randomly(rand * 2 - 1).limit(4)
+          proposals = Decidim::Proposals::Proposal.published.not_hidden.except_withdrawn.where(component: published_components).order_randomly(rand * 2 - 1).limit(4)
 
           next unless proposals.any?
 
@@ -69,7 +69,7 @@ module Decidim
         if defined? Decidim::ParticipatoryProcesses
           Decidim::ParticipatoryProcesses.view_hooks.register(:process_group_highlighted_elements, priority: Decidim::ViewHooks::MEDIUM_PRIORITY) do |view_context|
             published_components = Decidim::Component.where(participatory_space: view_context.participatory_processes).published
-            proposals = Decidim::Proposals::Proposal.where(component: published_components).order_randomly(rand * 2 - 1).limit(3)
+            proposals = Decidim::Proposals::Proposal.published.not_hidden.except_withdrawn.where(component: published_components).order_randomly(rand * 2 - 1).limit(3)
 
             next unless proposals.any?
 

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -179,6 +179,12 @@ FactoryBot.define do
       published_at nil
     end
 
+    trait :hidden do
+      moderation do
+        create(:moderation, hidden_at: Time.current)
+      end
+    end
+
     trait :with_votes do
       after :create do |proposal|
         create_list(:proposal_vote, 5, proposal: proposal)

--- a/decidim-proposals/spec/system/participatory_process_groups_view_hooks_spec.rb
+++ b/decidim-proposals/spec/system/participatory_process_groups_view_hooks_spec.rb
@@ -5,10 +5,8 @@ require "spec_helper"
 describe "Proposals in process group home", type: :system do
   include_context "with a component"
   let(:manifest_name) { "proposals" }
-  # The proposals count has to be less than the number of proposals
-  # returned in the view hook. Otherwise the spec is not reliable
-  # to check that only the visible proposals are shown
   let(:proposals_count) { 2 }
+  let(:highlighted_proposals) { proposals_count * 2 }
 
   let!(:participatory_process_group) do
     create(
@@ -17,6 +15,12 @@ describe "Proposals in process group home", type: :system do
       organization: organization,
       name: { en: "Name", ca: "Nom", es: "Nombre" }
     )
+  end
+
+  before do
+    allow(Decidim::Proposals.config)
+      .to receive(:process_group_highlighted_proposals_limit)
+      .and_return(highlighted_proposals)
   end
 
   context "when there are no proposals" do
@@ -36,7 +40,7 @@ describe "Proposals in process group home", type: :system do
       visit decidim_participatory_processes.participatory_process_group_path(participatory_process_group)
 
       within ".highlighted_proposals" do
-        expect(page).to have_css(".card--proposal", count: 2)
+        expect(page).to have_css(".card--proposal", count: proposals_count)
 
         proposals_titles = proposals.map(&:title)
         drafted_proposals_titles = drafted_proposals.map(&:title)
@@ -48,6 +52,22 @@ describe "Proposals in process group home", type: :system do
         expect(drafted_proposals_titles).not_to include(*highlighted_proposals)
         expect(hidden_proposals_titles).not_to include(*highlighted_proposals)
         expect(withdrawn_proposals_titles).not_to include(*highlighted_proposals)
+      end
+    end
+
+    context "and there are more proposals than those that can be shown" do
+      let!(:proposals) { create_list(:proposal, highlighted_proposals + 2, component: component) }
+
+      it "shows the amount of proposals configured" do
+        visit resource_locator(participatory_process).path
+
+        within ".highlighted_proposals" do
+          expect(page).to have_css(".card--proposal", count: highlighted_proposals)
+
+          proposals_titles = proposals.map(&:title)
+          highlighted_proposals = page.all(".card--proposal .card__title").map(&:text)
+          expect(proposals_titles).to include(*highlighted_proposals)
+        end
       end
     end
 
@@ -63,7 +83,7 @@ describe "Proposals in process group home", type: :system do
       it "shows a tag with the proposals scope" do
         visit decidim_participatory_processes.participatory_process_group_path(participatory_process_group)
 
-        expect(page).to have_selector(".tags", text: child_scope.name["en"], count: 2)
+        expect(page).to have_selector(".tags", text: child_scope.name["en"], count: proposals_count)
       end
     end
   end

--- a/decidim-proposals/spec/system/participatory_process_groups_view_hooks_spec.rb
+++ b/decidim-proposals/spec/system/participatory_process_groups_view_hooks_spec.rb
@@ -59,7 +59,7 @@ describe "Proposals in process group home", type: :system do
       let!(:proposals) { create_list(:proposal, highlighted_proposals + 2, component: component) }
 
       it "shows the amount of proposals configured" do
-        visit resource_locator(participatory_process).path
+        visit decidim_participatory_processes.participatory_process_group_path(participatory_process_group)
 
         within ".highlighted_proposals" do
           expect(page).to have_css(".card--proposal", count: highlighted_proposals)

--- a/decidim-proposals/spec/system/participatory_process_groups_view_hooks_spec.rb
+++ b/decidim-proposals/spec/system/participatory_process_groups_view_hooks_spec.rb
@@ -5,7 +5,10 @@ require "spec_helper"
 describe "Proposals in process group home", type: :system do
   include_context "with a component"
   let(:manifest_name) { "proposals" }
-  let(:proposals_count) { 5 }
+  # The proposals count has to be less than the number of proposals
+  # returned in the view hook. Otherwise the spec is not reliable
+  # to check that only the visible proposals are shown
+  let(:proposals_count) { 2 }
 
   let!(:participatory_process_group) do
     create(
@@ -24,19 +27,27 @@ describe "Proposals in process group home", type: :system do
   end
 
   context "when there are proposals" do
-    let!(:proposals) do
-      create_list(:proposal, proposals_count, component: component)
-    end
+    let!(:proposals) { create_list(:proposal, proposals_count, component: component) }
+    let!(:drafted_proposals) { create_list(:proposal, proposals_count, :draft, component: component) }
+    let!(:hidden_proposals) { create_list(:proposal, proposals_count, :hidden, component: component) }
+    let!(:withdrawn_proposals) { create_list(:proposal, proposals_count, :withdrawn, component: component) }
 
     it "shows the highlighted proposals section" do
       visit decidim_participatory_processes.participatory_process_group_path(participatory_process_group)
 
       within ".highlighted_proposals" do
-        expect(page).to have_css(".card--proposal", count: 3)
+        expect(page).to have_css(".card--proposal", count: 2)
 
         proposals_titles = proposals.map(&:title)
+        drafted_proposals_titles = drafted_proposals.map(&:title)
+        hidden_proposals_titles = hidden_proposals.map(&:title)
+        withdrawn_proposals_titles = withdrawn_proposals.map(&:title)
+
         highlighted_proposals = page.all(".card--proposal .card__title").map(&:text)
         expect(proposals_titles).to include(*highlighted_proposals)
+        expect(drafted_proposals_titles).not_to include(*highlighted_proposals)
+        expect(hidden_proposals_titles).not_to include(*highlighted_proposals)
+        expect(withdrawn_proposals_titles).not_to include(*highlighted_proposals)
       end
     end
 
@@ -52,7 +63,7 @@ describe "Proposals in process group home", type: :system do
       it "shows a tag with the proposals scope" do
         visit decidim_participatory_processes.participatory_process_group_path(participatory_process_group)
 
-        expect(page).to have_selector(".tags", text: child_scope.name["en"], count: 3)
+        expect(page).to have_selector(".tags", text: child_scope.name["en"], count: 2)
       end
     end
   end

--- a/decidim-proposals/spec/system/participatory_processes_view_hooks_spec.rb
+++ b/decidim-proposals/spec/system/participatory_processes_view_hooks_spec.rb
@@ -5,7 +5,10 @@ require "spec_helper"
 describe "Proposals in process home", type: :system do
   include_context "with a component"
   let(:manifest_name) { "proposals" }
-  let(:proposals_count) { 5 }
+  # The proposals count has to be less than the number of proposals
+  # returned in the view hook. Otherwise the spec is not reliable
+  # to check that only the visible proposals are shown
+  let(:proposals_count) { 2 }
 
   context "when there are no proposals" do
     it "does not show the highlighted proposals section" do
@@ -15,19 +18,27 @@ describe "Proposals in process home", type: :system do
   end
 
   context "when there are proposals" do
-    let!(:proposals) do
-      create_list(:proposal, proposals_count, component: component)
-    end
+    let!(:proposals) { create_list(:proposal, proposals_count, component: component) }
+    let!(:drafted_proposals) { create_list(:proposal, proposals_count, :draft, component: component) }
+    let!(:hidden_proposals) { create_list(:proposal, proposals_count, :hidden, component: component) }
+    let!(:withdrawn_proposals) { create_list(:proposal, proposals_count, :withdrawn, component: component) }
 
     it "shows the highlighted proposals section" do
       visit resource_locator(participatory_process).path
 
       within ".highlighted_proposals" do
-        expect(page).to have_css(".card--proposal", count: 4)
+        expect(page).to have_css(".card--proposal", count: 2)
 
         proposals_titles = proposals.map(&:title)
+        drafted_proposals_titles = drafted_proposals.map(&:title)
+        hidden_proposals_titles = hidden_proposals.map(&:title)
+        withdrawn_proposals_titles = withdrawn_proposals.map(&:title)
+
         highlighted_proposals = page.all(".card--proposal .card__title").map(&:text)
         expect(proposals_titles).to include(*highlighted_proposals)
+        expect(drafted_proposals_titles).not_to include(*highlighted_proposals)
+        expect(hidden_proposals_titles).not_to include(*highlighted_proposals)
+        expect(withdrawn_proposals_titles).not_to include(*highlighted_proposals)
       end
     end
   end

--- a/decidim-proposals/spec/system/participatory_processes_view_hooks_spec.rb
+++ b/decidim-proposals/spec/system/participatory_processes_view_hooks_spec.rb
@@ -5,10 +5,14 @@ require "spec_helper"
 describe "Proposals in process home", type: :system do
   include_context "with a component"
   let(:manifest_name) { "proposals" }
-  # The proposals count has to be less than the number of proposals
-  # returned in the view hook. Otherwise the spec is not reliable
-  # to check that only the visible proposals are shown
   let(:proposals_count) { 2 }
+  let(:highlighted_proposals) { proposals_count * 2 }
+
+  before do
+    allow(Decidim::Proposals.config)
+      .to receive(:participatory_space_highlighted_proposals_limit)
+      .and_return(highlighted_proposals)
+  end
 
   context "when there are no proposals" do
     it "does not show the highlighted proposals section" do
@@ -27,7 +31,7 @@ describe "Proposals in process home", type: :system do
       visit resource_locator(participatory_process).path
 
       within ".highlighted_proposals" do
-        expect(page).to have_css(".card--proposal", count: 2)
+        expect(page).to have_css(".card--proposal", count: proposals_count)
 
         proposals_titles = proposals.map(&:title)
         drafted_proposals_titles = drafted_proposals.map(&:title)
@@ -39,6 +43,22 @@ describe "Proposals in process home", type: :system do
         expect(drafted_proposals_titles).not_to include(*highlighted_proposals)
         expect(hidden_proposals_titles).not_to include(*highlighted_proposals)
         expect(withdrawn_proposals_titles).not_to include(*highlighted_proposals)
+      end
+    end
+
+    context "and there are more proposals than those that can be shown" do
+      let!(:proposals) { create_list(:proposal, highlighted_proposals + 2, component: component) }
+
+      it "shows the amount of proposals configured" do
+        visit resource_locator(participatory_process).path
+
+        within ".highlighted_proposals" do
+          expect(page).to have_css(".card--proposal", count: highlighted_proposals)
+
+          proposals_titles = proposals.map(&:title)
+          highlighted_proposals = page.all(".card--proposal .card__title").map(&:text)
+          expect(proposals_titles).to include(*highlighted_proposals)
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

The detail of the process shows all the proposals of that process. It doesn't filter if the proposals are draft, moderated or withdrawn.

#### :pushpin: Related Issues

- Fixes #3141

#### :pushpin: Related PR

- Backport to `0.10-stable`: PENDING

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)

