### PR TITLE
Fix `gem build` warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,7 +213,7 @@ GEM
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
     bcrypt (3.1.11)
-    better_html (1.0.6)
+    better_html (1.0.7)
       actionview (>= 4.0)
       activesupport (>= 4.0)
       ast (~> 2.0)
@@ -224,7 +224,7 @@ GEM
     bindex (0.5.0)
     builder (3.2.3)
     byebug (10.0.0)
-    cancancan (2.1.3)
+    cancancan (2.1.4)
     capybara (2.18.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -289,16 +289,16 @@ GEM
       devise (>= 4.0.0)
     diff-lcs (1.3)
     docile (1.3.0)
-    doorkeeper (4.3.1)
+    doorkeeper (4.3.2)
       railties (>= 4.2)
     doorkeeper-i18n (4.0.0)
     easy_translate (0.5.1)
       thread
       thread_safe
     equalizer (0.0.11)
-    erb_lint (0.0.22)
+    erb_lint (0.0.23)
       activesupport
-      better_html (~> 1.0.6)
+      better_html (~> 1.0.7)
       colorize
       html_tokenizer
       rubocop (~> 0.51)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ PATH
       paper_trail (~> 8.0)
       pg (>= 0.18, < 2)
       premailer-rails (~> 1.9)
-      rails (~> 5.1.5)
+      rails (~> 5.1, < 5.2)
       rails-i18n (~> 5.0)
       rectify (~> 0.11.0)
       redis (~> 4.0)
@@ -107,7 +107,7 @@ PATH
       i18n-tasks (~> 0.9.18)
       nokogiri (~> 1.8, >= 1.8.2)
       rails-controller-testing (~> 1.0)
-      rspec-cells
+      rspec-cells (~> 0.3.4)
       rspec-html-matchers (~> 0.9.1)
       rspec-rails (~> 3.7)
       rspec_junit_formatter (~> 0.3.0)

--- a/decidim-consultations/decidim-consultations.gemspec
+++ b/decidim-consultations/decidim-consultations.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.3.1"
 
   s.name = "decidim-consultations"
-  s.summary = "Extends Decidim adding a first level public consultation component"
-  s.description = s.summary
+  s.summary = "Decidim consultations module"
+  s.description = "Extends Decidim adding a first level public consultation component"
 
   s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
 

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
   s.add_dependency "paper_trail", "~> 8.0"
   s.add_dependency "pg", ">= 0.18", "< 2"
   s.add_dependency "premailer-rails", "~> 1.9"
-  s.add_dependency "rails", "~> 5.1.5"
+  s.add_dependency "rails", "~> 5.1", "< 5.2"
   s.add_dependency "rails-i18n", "~> 5.0"
   s.add_dependency "rectify", "~> 0.11.0"
   s.add_dependency "redis", "~> 4.0"

--- a/decidim-dev/decidim-dev.gemspec
+++ b/decidim-dev/decidim-dev.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency "i18n-tasks", "~> 0.9.18"
   s.add_dependency "nokogiri", "~> 1.8", ">= 1.8.2"
   s.add_dependency "rails-controller-testing", "~> 1.0"
-  s.add_dependency "rspec-cells"
+  s.add_dependency "rspec-cells", "~> 0.3.4"
   s.add_dependency "rspec-html-matchers", "~> 0.9.1"
   s.add_dependency "rspec-rails", "~> 3.7"
   s.add_dependency "rspec_junit_formatter", "~> 0.3.0"

--- a/decidim-sortitions/decidim-sortitions.gemspec
+++ b/decidim-sortitions/decidim-sortitions.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.version = Decidim::Sortitions.version
   s.authors = ["Juan Salvador Perez Garcia"]
   s.email = ["jsperezg@gmail.com"]
-  s.license = "AGPLv3"
+  s.license = "AGPL-3.0"
   s.homepage = "https://github.com/decidim/decidim"
   s.required_ruby_version = ">= 2.3.1"
 

--- a/decidim-sortitions/decidim-sortitions.gemspec
+++ b/decidim-sortitions/decidim-sortitions.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.3.1"
 
   s.name = "decidim-sortitions"
-  s.summary = "This module makes possible to select amont a set of proposal by sortition"
-  s.description = s.summary
+  s.summary = "Decidim sortitions module"
+  s.description = "This module makes possible to select amont a set of proposal by sortition"
 
   s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md", "LICENSE-AGPLv3.txt"]
 


### PR DESCRIPTION
#### :tophat: What? Why?

Fixes some warnings generator tests spit when building the recently generated components, sortitions and consultations.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.