### PR TITLE
Simplify rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1232,3 +1232,5 @@ RSpec/NamedSubject:
 
 RSpec/VerifiedDoubles:
   Enabled: false
+
+inherit_from: .rubocop_rails.yml

--- a/.rubocop_rails.yml
+++ b/.rubocop_rails.yml
@@ -4,229 +4,74 @@ Rails:
   Enabled: true
 
 Rails/ActionFilter:
-  Description: "Enforces consistent use of action filter methods."
-  Enabled: true
-  EnforcedStyle: action
-  SupportedStyles:
-    - action
-    - filter
-
-Rails/ActiveRecordAliases:
-  Description: >-
-                  Avoid Active Record aliases:
-                  Use `update` instead of `update_attributes`.
-                  Use `update!` instead of `update_attributes!`.
-  Enabled: true
-
-Rails/ActiveSupportAliases:
-  Description: >-
-                  Avoid ActiveSupport aliases of standard ruby methods:
-                  `String#starts_with?`, `String#ends_with?`,
-                  `Array#append`, `Array#prepend`.
-  Enabled: true
-
-Rails/ApplicationJob:
-  Description: "Check that jobs subclass ApplicationJob."
-  Enabled: true
-
-Rails/ApplicationRecord:
-  Description: "Check that models subclass ApplicationRecord."
-  Enabled: true
-
-Rails/Blank:
-  Description: "Enforce using `blank?` and `present?`."
-  Enabled: true
-  # Convert checks for `nil` or `empty?` to `blank?`
-  NilOrEmpty: true
-  # Convert usages of not `present?` to `blank?`
-  NotPresent: true
-  # Convert usages of `unless` `present?` to `if` `blank?`
-  UnlessPresent: true
+  Include:
+    - decidim-*/app/controllers/**/*.rb
 
 Rails/CreateTableWithTimestamps:
-  Description: >-
-                  Checks the migration for which timestamps are not included
-                  when creating a new table.
   Enabled: false
 
-Rails/Date:
-  Description: >-
-                  Checks the correct usage of date aware methods,
-                  such as Date.today, Date.current etc.
-  Enabled: true
-  EnforcedStyle: flexible
-  SupportedStyles:
-    - strict
-    - flexible
-
-Rails/Delegate:
-  Description: "Prefer delegate method for delegations."
-  Enabled: true
-
-Rails/DelegateAllowBlank:
-  Description: "Do not use allow_blank as an option to delegate."
-  Enabled: true
-
-Rails/DynamicFindBy:
-  Description: "Use `find_by` instead of dynamic `find_by_*`."
-  StyleGuide: "https://github.com/bbatsov/rails-style-guide#find_by"
-  Enabled: true
-
 Rails/EnumUniqueness:
-  Description: "Avoid duplicate integers in hash-syntax `enum` declaration."
-  Enabled: true
-
-Rails/EnvironmentComparison:
-  Description: "Favor `Rails.env.production?` over `Rails.env == 'production'`"
-  Enabled: true
+  Include:
+    - decidim-*/app/models/**/*.rb
 
 Rails/Exit:
-  Description: >-
-                  Favor `fail`, `break`, `return`, etc. over `exit` in
-                  application or library code outside of Rake files to avoid
-                  exits during unit testing or running in production.
-  Enabled: true
   Include:
-    - config/**/*.rb
-    - lib/**/*.rb
-
-Rails/FilePath:
-  Description: "Use `Rails.root.join` for file path joining."
-  Enabled: true
+    - decidim-*/app/**/*.rb
+    - decidim-*/config/**/*.rb
+    - decidim-*/lib/**/*.rb
+  Exclude:
+    - decidim-*/lib/**/*.rake
 
 Rails/FindBy:
-  Description: "Prefer find_by over where.first."
-  StyleGuide: "https://github.com/bbatsov/rails-style-guide#find_by"
-  Enabled: true
   Include:
     - "**/*.rb"
 
 Rails/FindEach:
-  Description: "Prefer all.find_each over all.find."
-  StyleGuide: "https://github.com/bbatsov/rails-style-guide#find-each"
-  Enabled: true
+  Include:
+    - decidim-*/app/models/**/*.rb
 
 Rails/HasAndBelongsToMany:
-  Description: "Prefer has_many :through to has_and_belongs_to_many."
-  StyleGuide: "https://github.com/bbatsov/rails-style-guide#has-many-through"
-  Enabled: true
+  Include:
+    - decidim-*/app/models/**/*.rb
 
 Rails/HasManyOrHasOneDependent:
-  Description: "Define the dependent option to the has_many and has_one associations."
-  StyleGuide: "https://github.com/bbatsov/rails-style-guide#has_many-has_one-dependent-option"
-  Enabled: true
-
-Rails/HttpPositionalArguments:
-  Description: "Use keyword arguments instead of positional arguments in http method calls."
-  Enabled: true
   Include:
-    - "spec/**/*"
-    - "test/**/*"
+    - decidim-*/app/models/**/*.rb
 
 Rails/InverseOf:
-  Description: "Checks for associations where the inverse cannot be determined automatically."
   Enabled: false
 
 Rails/LexicallyScopedActionFilter:
-  Description: "Checks that methods specified in the filter's `only` or `except` options are explicitly defined in the controller."
-  StyleGuide: "https://github.com/bbatsov/rails-style-guide#lexically-scoped-action-filter"
-  Enabled: true
+  Include:
+    - decidim-*/app/controllers/**/*.rb
 
 Rails/NotNullColumn:
-  Description: "Do not add a NOT NULL column without a default value"
   Enabled: false
 
 Rails/Output:
-  Description: "Checks for calls to puts, print, etc."
-  Enabled: true
+  Include:
+    - decidim-*/app/**/*.rb
+    - decidim-*/config/**/*.rb
+    - decidim-*/db/**/*.rb
+    - decidim-*/lib/**/*.rb
 
 Rails/OutputSafety:
-  Description: "The use of `html_safe` or `raw` may be a security risk."
   Enabled: false
-
-Rails/PluralizationGrammar:
-  Description: "Checks for incorrect grammar when using methods like `3.day.ago`."
-  Enabled: true
-
-Rails/Presence:
-  Description: "Checks code that can be written more easily using `Object#presence` defined by Active Support."
-  Enabled: true
-
-Rails/Present:
-  Description: "Enforce using `blank?` and `present?`."
-  Enabled: true
-  NotNilAndNotEmpty: true
-  # Convert checks for not `nil` and not `empty?` to `present?`
-  NotBlank: true
-  # Convert usages of not `blank?` to `present?`
-  UnlessBlank: true
-  # Convert usages of `unless` `blank?` to `if` `present?`
 
 Rails/ReadWriteAttribute:
-  Description: >-
-                 Checks for read_attribute(:attr) and
-                 write_attribute(:attr, val).
-  StyleGuide: "https://github.com/bbatsov/rails-style-guide#read-attribute"
-  Enabled: true
-
-Rails/RedundantReceiverInWithOptions:
-  Description: "Checks for redundant receiver in `with_options`."
-  Enabled: true
-
-Rails/RelativeDateConstant:
-  Description: "Do not assign relative date to constants."
-  Enabled: true
-
-Rails/RequestReferer:
-  Description: "Use consistent syntax for request.referer."
-  Enabled: true
-  EnforcedStyle: referer
-  SupportedStyles:
-    - referer
-    - referrer
+  Include:
+    - decidim-*/app/models/**/*.rb
 
 Rails/ReversibleMigration:
-  Description: "Checks whether the change method of the migration file is reversible."
-  StyleGuide: "https://github.com/bbatsov/rails-style-guide#reversible-migration"
-  Reference: "http://api.rubyonrails.org/classes/ActiveRecord/Migration/CommandRecorder.html"
   Enabled: false
 
-Rails/SafeNavigation:
-  ConvertTry: false
-  Description: "Use Ruby's safe navigation operator (`&.`) instead of `try!`"
-  Enabled: true
-
 Rails/ScopeArgs:
-  Description: "Checks the arguments of ActiveRecord scopes."
-  Enabled: true
+  Include:
+    - decidim-*/app/models/**/*.rb
 
 Rails/SkipsModelValidations:
-  Description: >-
-                 Use methods that skips model validations with caution.
-                 See reference for more information.
-  Reference: "http://guides.rubyonrails.org/active_record_validations.html#skipping-validations"
-  Enabled: true
-
-Rails/TimeZone:
-  Description: "Checks the correct usage of time zone aware methods."
-  Enabled: true
-  EnforcedStyle: flexible
-  StyleGuide: "https://github.com/bbatsov/rails-style-guide#time"
-  Reference: "http://danilenko.org/2012/7/6/rails_timezones"
-  SupportedStyles:
-    - strict
-    - flexible
-
-Rails/UniqBeforePluck:
-  AutoCorrect: false
-  Description: "Prefer the use of uniq or distinct before pluck."
-  EnforcedStyle: conservative
-  Enabled: true
-
-Rails/UnknownEnv:
-  Description: "Use correct environment name."
   Enabled: true
 
 Rails/Validation:
-  Description: "Use validates :attribute, hash of validations."
-  Enabled: true
+  Include:
+    - decidim-*/app/models/**/*.rb

--- a/decidim-accountability/.rubocop.yml
+++ b/decidim-accountability/.rubocop.yml
@@ -1,5 +1,0 @@
----
-
-inherit_from:
-  - ../.rubocop.yml
-  - .rubocop_rails.yml

--- a/decidim-accountability/.rubocop_rails.yml
+++ b/decidim-accountability/.rubocop_rails.yml
@@ -1,1 +1,0 @@
-../.rubocop_rails.yml

--- a/decidim-admin/.rubocop.yml
+++ b/decidim-admin/.rubocop.yml
@@ -1,5 +1,0 @@
----
-
-inherit_from:
-  - ../.rubocop.yml
-  - .rubocop_rails.yml

--- a/decidim-admin/.rubocop_rails.yml
+++ b/decidim-admin/.rubocop_rails.yml
@@ -1,1 +1,0 @@
-../.rubocop_rails.yml

--- a/decidim-api/.rubocop.yml
+++ b/decidim-api/.rubocop.yml
@@ -1,5 +1,0 @@
----
-
-inherit_from:
-  - ../.rubocop.yml
-  - .rubocop_rails.yml

--- a/decidim-api/.rubocop_rails.yml
+++ b/decidim-api/.rubocop_rails.yml
@@ -1,1 +1,0 @@
-../.rubocop_rails.yml

--- a/decidim-assemblies/.rubocop.yml
+++ b/decidim-assemblies/.rubocop.yml
@@ -1,5 +1,0 @@
----
-
-inherit_from:
-  - ../.rubocop.yml
-  - .rubocop_rails.yml

--- a/decidim-assemblies/.rubocop_rails.yml
+++ b/decidim-assemblies/.rubocop_rails.yml
@@ -1,1 +1,0 @@
-../.rubocop_rails.yml

--- a/decidim-budgets/.rubocop.yml
+++ b/decidim-budgets/.rubocop.yml
@@ -1,5 +1,0 @@
----
-
-inherit_from:
-  - ../.rubocop.yml
-  - .rubocop_rails.yml

--- a/decidim-budgets/.rubocop_rails.yml
+++ b/decidim-budgets/.rubocop_rails.yml
@@ -1,1 +1,0 @@
-../.rubocop_rails.yml

--- a/decidim-comments/.rubocop.yml
+++ b/decidim-comments/.rubocop.yml
@@ -1,5 +1,0 @@
----
-
-inherit_from:
-  - ../.rubocop.yml
-  - .rubocop_rails.yml

--- a/decidim-comments/.rubocop_rails.yml
+++ b/decidim-comments/.rubocop_rails.yml
@@ -1,1 +1,0 @@
-../.rubocop_rails.yml

--- a/decidim-consultations/.rubocop.yml
+++ b/decidim-consultations/.rubocop.yml
@@ -1,5 +1,0 @@
----
-
-inherit_from:
-  - ../.rubocop.yml
-  - .rubocop_rails.yml

--- a/decidim-consultations/.rubocop_rails.yml
+++ b/decidim-consultations/.rubocop_rails.yml
@@ -1,1 +1,0 @@
-../.rubocop_rails.yml

--- a/decidim-core/.rubocop.yml
+++ b/decidim-core/.rubocop.yml
@@ -1,5 +1,0 @@
----
-
-inherit_from:
-  - ../.rubocop.yml
-  - .rubocop_rails.yml

--- a/decidim-core/.rubocop_rails.yml
+++ b/decidim-core/.rubocop_rails.yml
@@ -1,1 +1,0 @@
-../.rubocop_rails.yml

--- a/decidim-debates/.rubocop.yml
+++ b/decidim-debates/.rubocop.yml
@@ -1,5 +1,0 @@
----
-
-inherit_from:
-  - ../.rubocop.yml
-  - .rubocop_rails.yml

--- a/decidim-debates/.rubocop_rails.yml
+++ b/decidim-debates/.rubocop_rails.yml
@@ -1,1 +1,0 @@
-../.rubocop_rails.yml

--- a/decidim-dev/.rubocop.yml
+++ b/decidim-dev/.rubocop.yml
@@ -1,5 +1,0 @@
----
-
-inherit_from:
-  - ../.rubocop.yml
-  - .rubocop_rails.yml

--- a/decidim-dev/.rubocop_rails.yml
+++ b/decidim-dev/.rubocop_rails.yml
@@ -1,1 +1,0 @@
-../.rubocop_rails.yml

--- a/decidim-meetings/.rubocop.yml
+++ b/decidim-meetings/.rubocop.yml
@@ -1,5 +1,0 @@
----
-
-inherit_from:
-  - ../.rubocop.yml
-  - .rubocop_rails.yml

--- a/decidim-meetings/.rubocop_rails.yml
+++ b/decidim-meetings/.rubocop_rails.yml
@@ -1,1 +1,0 @@
-../.rubocop_rails.yml

--- a/decidim-pages/.rubocop.yml
+++ b/decidim-pages/.rubocop.yml
@@ -1,5 +1,0 @@
----
-
-inherit_from:
-  - ../.rubocop.yml
-  - .rubocop_rails.yml

--- a/decidim-pages/.rubocop_rails.yml
+++ b/decidim-pages/.rubocop_rails.yml
@@ -1,1 +1,0 @@
-../.rubocop_rails.yml

--- a/decidim-participatory_processes/.rubocop.yml
+++ b/decidim-participatory_processes/.rubocop.yml
@@ -1,5 +1,0 @@
----
-
-inherit_from:
-  - ../.rubocop.yml
-  - .rubocop_rails.yml

--- a/decidim-participatory_processes/.rubocop_rails.yml
+++ b/decidim-participatory_processes/.rubocop_rails.yml
@@ -1,1 +1,0 @@
-../.rubocop_rails.yml

--- a/decidim-proposals/.rubocop.yml
+++ b/decidim-proposals/.rubocop.yml
@@ -1,5 +1,0 @@
----
-
-inherit_from:
-  - ../.rubocop.yml
-  - .rubocop_rails.yml

--- a/decidim-proposals/.rubocop_rails.yml
+++ b/decidim-proposals/.rubocop_rails.yml
@@ -1,1 +1,0 @@
-../.rubocop_rails.yml

--- a/decidim-sortitions/.rubocop.yml
+++ b/decidim-sortitions/.rubocop.yml
@@ -1,5 +1,0 @@
----
-
-inherit_from:
-  - ../.rubocop.yml
-  - .rubocop_rails.yml

--- a/decidim-sortitions/.rubocop_rails.yml
+++ b/decidim-sortitions/.rubocop_rails.yml
@@ -1,1 +1,0 @@
-../.rubocop_rails.yml

--- a/decidim-surveys/.rubocop.yml
+++ b/decidim-surveys/.rubocop.yml
@@ -1,5 +1,0 @@
----
-
-inherit_from:
-  - ../.rubocop.yml
-  - .rubocop_rails.yml

--- a/decidim-surveys/.rubocop_rails.yml
+++ b/decidim-surveys/.rubocop_rails.yml
@@ -1,1 +1,0 @@
-../.rubocop_rails.yml

--- a/decidim-system/.rubocop.yml
+++ b/decidim-system/.rubocop.yml
@@ -1,5 +1,0 @@
----
-
-inherit_from:
-  - ../.rubocop.yml
-  - .rubocop_rails.yml

--- a/decidim-system/.rubocop_rails.yml
+++ b/decidim-system/.rubocop_rails.yml
@@ -1,1 +1,0 @@
-../.rubocop_rails.yml

--- a/decidim-verifications/.rubocop.yml
+++ b/decidim-verifications/.rubocop.yml
@@ -1,5 +1,0 @@
----
-
-inherit_from:
-  - ../.rubocop.yml
-  - .rubocop_rails.yml

--- a/decidim-verifications/.rubocop_rails.yml
+++ b/decidim-verifications/.rubocop_rails.yml
@@ -1,1 +1,0 @@
-../.rubocop_rails.yml


### PR DESCRIPTION
#### :tophat: What? Why?

I'm tweaking our rubocop config for rails cops to be simpler, since the previous version, while a potentially good idea, seems to not properly work in some cases, and it's way harder to understand. Whenever rubocop provides cops with `Include` directives that don't match our folder structure, we'll need to tweak the config for those cops.

Also, fixing some offenses that sneaked in with a recent PR.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.