### PR TITLE
Fix design app

### DIFF
--- a/decidim_app-design/Gemfile
+++ b/decidim_app-design/Gemfile
@@ -6,10 +6,10 @@ source "https://rubygems.org"
 gem "decidim", path: ".."
 gem "puma", "~> 3.7"
 gem "uglifier", ">= 1.3.0"
+gem "faker"
 
 group :development do
   gem "decidim-dev", path: ".."
-  gem "faker"
   gem "listen", ">= 3.0.5", "< 3.2"
   gem "spring-watcher-listen", "~> 2.0.0"
 end

--- a/decidim_app-design/Gemfile
+++ b/decidim_app-design/Gemfile
@@ -4,9 +4,9 @@ source "https://rubygems.org"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem "decidim", path: ".."
+gem "faker"
 gem "puma", "~> 3.7"
 gem "uglifier", ">= 1.3.0"
-gem "faker"
 
 group :development do
   gem "decidim-dev", path: ".."


### PR DESCRIPTION
#### :tophat: What? Why?
After waaaaaaay more debugging that it would reasonably be for a bug like this, I found out that `faker` was missing on the production dependencies, and thus some pages failed to render on the `design-app`. Since errors are being rescued by zombie `decidim` (which silently roams on the back of the design app), it tried to redirect to `root_path`, but since no organization was found zombie `decidim` tried to redirect to `/system`, which triggered again the `pages#show` controller again and blew up 💥 .

@Crashillo 😭 

#### :pushpin: Related Issues
- Fixes #3172

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*
