### PR TITLE
Fix double authorization button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ controller or added a new module you need to rename `feature` to `component`.
   - Nested resources (auto_buttons_by_position.component.js.es6, auto_label_by_position.component.js.es6, dynamic_fields.component.js.es6)
   - Dependent inputs (field_dependent_inputs.component.js.es6)
 - **decidim-participatory_processes**: Render documents in first place (before view hooks). [\#2977](https://github.com/decidim/decidim/pull/2977)
+- **decidim-verifications**: If you're using a custom authorization handler template, make sure it does not include the button. Decidim takes care of that for you so including it will from no now cause duplicated buttons in the form. [\#3211](https://github.com/decidim/decidim/pull/3211)
 
 **Fixed**:
 
@@ -83,5 +84,6 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-surveys**: Question type selector not disabled when survey has already been answered [\#3133](https://github.com/decidim/decidim/pull/3133)
 - **decidim-surveys**: Max choices selector not disabled when survey has already been answered [\#3133](https://github.com/decidim/decidim/pull/3133)
 - **decidim-surveys**: Translated fields not disabled when survey has already been answered [\#3133](https://github.com/decidim/decidim/pull/3133)
+- **decidim-admin**: Default managed user form displaying two buttons [\#3211](https://github.com/decidim/decidim/pull/3211)
 
 Please check [0.10-stable](https://github.com/decidim/decidim/blob/0.10-stable/CHANGELOG.md) for previous changes.

--- a/decidim-admin/spec/shared/manage_managed_users_examples.rb
+++ b/decidim-admin/spec/shared/manage_managed_users_examples.rb
@@ -206,6 +206,9 @@ shared_examples "manage managed users examples" do
     end
 
     page.find(".datepicker-dropdown .day", text: "12").click
+
+    expect(page).to have_selector("*[type=submit]", count: 1)
+
     click_button "Create"
   end
 
@@ -217,6 +220,9 @@ shared_examples "manage managed users examples" do
     end
 
     page.find(".datepicker-dropdown .day", text: "12").click
+
+    expect(page).to have_selector("*[type=submit]", count: 1)
+
     click_button "Impersonate"
   end
 

--- a/decidim-verifications/app/views/decidim/verifications/authorizations/new.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/authorizations/new.html.erb
@@ -17,10 +17,11 @@
                 <%= render partial: handler.to_partial_path, locals: { handler: handler, form: form } %>
               <% else %>
                 <%= form.all_fields %>
-                <div class="actions">
-                  <%= form.submit t(".authorize"), class: "button expanded" %>
-                </div>
               <% end %>
+
+              <div class="actions">
+                <%= form.submit t(".authorize"), class: "button expanded" %>
+              </div>
             <% end %>
             <p class="text-center skip">
               <%= t("decidim.verifications.authorizations.skip_verification", link: link_to(t("decidim.verifications.authorizations.start_exploring"), cta_button_path).html_safe).html_safe %>.

--- a/decidim-verifications/app/views/dummy_authorization/_form.html.erb
+++ b/decidim-verifications/app/views/dummy_authorization/_form.html.erb
@@ -2,7 +2,7 @@
   postal_codes = request["postal_codes"].split("-") %>
   <p><%= t("extra_explanation", scope: "decidim.verifications.dummy_authorization", postal_codes: postal_codes.join(", "), count: postal_codes.count) %></p>
 <% end %>
-<%= form.all_fields %>
-<div class="actions partial-demo">
-  <%= form.submit t("decidim.verifications.authorizations.new.authorize"), class: "button expanded" %>
+
+<div class="partial-demo">
+  <%= form.all_fields %>
 </div>

--- a/decidim-verifications/spec/views/decidim/verifications/authorizations/new.html.erb_spec.rb
+++ b/decidim-verifications/spec/views/decidim/verifications/authorizations/new.html.erb_spec.rb
@@ -24,6 +24,10 @@ module Decidim
       expect(render).to include("partial-demo")
     end
 
+    it "renders the button separately" do
+      expect(render).to have_tag("input[type=submit]", count: 1)
+    end
+
     context "when there's not a partial to render the form" do
       before do
         allow(handler).to receive(:to_partial_path).and_return("inexisting_partial")

--- a/decidim-verifications/spec/views/decidim/verifications/authorizations/new.html.erb_spec.rb
+++ b/decidim-verifications/spec/views/decidim/verifications/authorizations/new.html.erb_spec.rb
@@ -20,7 +20,7 @@ module Decidim
       allow(view).to receive(:stored_location).and_return("/processes")
     end
 
-    it "renders the form the partial" do
+    it "renders the form from the partial" do
       expect(render).to include("partial-demo")
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Fixes the default managed user form displaying duplicated buttons. This is a breaking changes for external plugins using custom authorization handler templates that include the button. From now on, these templates should only include the inputs since decidim will take care of rendering the button.
 
#### :pushpin: Related Issues
- Fixes #3161.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
_None_.