### PR TITLE
Extend OAuth features

### DIFF
--- a/decidim-core/app/commands/decidim/create_omniauth_registration.rb
+++ b/decidim-core/app/commands/decidim/create_omniauth_registration.rb
@@ -55,6 +55,7 @@ module Decidim
         @user.email_on_notification = true
         @user.password = generated_password
         @user.password_confirmation = generated_password
+        @user.remote_avatar_url = form.avatar_url if form.avatar_url.present?
         @user.skip_confirmation! if verified_email
       end
 

--- a/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
@@ -13,6 +13,7 @@ module Decidim
 
       def create
         form_params = user_params_from_oauth_hash || params[:user]
+
         @form = form(OmniauthRegistrationForm).from_params(form_params)
         @form.email ||= verified_email
 
@@ -84,7 +85,8 @@ module Decidim
           uid: oauth_data[:uid],
           name: oauth_data[:info][:name],
           nickname: oauth_data[:info][:nickname],
-          oauth_signature: OmniauthRegistrationForm.create_signature(oauth_data[:provider], oauth_data[:uid])
+          oauth_signature: OmniauthRegistrationForm.create_signature(oauth_data[:provider], oauth_data[:uid]),
+          avatar_url: oauth_data[:info][:image]
         }
       end
 

--- a/decidim-core/app/controllers/decidim/doorkeeper/credentials_controller.rb
+++ b/decidim-core/app/controllers/decidim/doorkeeper/credentials_controller.rb
@@ -18,12 +18,28 @@ module Decidim
         {
           id: current_resource_owner.id,
           email: current_resource_owner.email,
-          nickname: current_resource_owner.nickname
+          name: current_resource_owner.name,
+          nickname: current_resource_owner.nickname,
+          image: avatar_url
         }
       end
 
       def current_resource_owner
         @current_resource_owner ||= Decidim::User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token
+      end
+
+      def avatar_url
+        avatar_url = current_resource_owner.avatar_url
+        return unless avatar_url
+
+        unless avatar_url.match?(%r{/https?://})
+          request_uri = URI.parse(request.url)
+          request_uri.path = avatar_url
+          request_uri.query = nil
+          avatar_url = request_uri.to_s
+        end
+
+        avatar_url
       end
     end
   end

--- a/decidim-core/app/forms/decidim/omniauth_registration_form.rb
+++ b/decidim-core/app/forms/decidim/omniauth_registration_form.rb
@@ -12,6 +12,7 @@ module Decidim
     attribute :uid, String
     attribute :tos_agreement, Boolean
     attribute :oauth_signature, String
+    attribute :avatar_url, String
 
     validates :email, presence: true
     validates :name, presence: true

--- a/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
@@ -21,7 +21,8 @@ module Decidim
               "email_verified" => true,
               "name" => "Facebook User",
               "nickname" => "facebook_user",
-              "oauth_signature" => oauth_signature
+              "oauth_signature" => oauth_signature,
+              "avatar_url" => "http://www.example.com/foo.jpg"
             }
           }
         end
@@ -40,6 +41,11 @@ module Decidim
           it "raises a InvalidOauthSignature exception" do
             expect { command.call }.to raise_error InvalidOauthSignature
           end
+        end
+
+        before do
+          stub_request(:get, "http://www.example.com/foo.jpg")
+            .to_return(status: 200, body: File.read("spec/assets/avatar.jpg"), headers: { "Content-Type" => "image/jpeg" })
         end
 
         context "when the form is not valid" do

--- a/decidim-core/spec/controllers/decidim/doorkeeper/credentials_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/doorkeeper/credentials_controller_spec.rb
@@ -25,10 +25,12 @@ describe Decidim::Doorkeeper::CredentialsController, type: :controller do
 
       credentials = JSON.parse(response.body)
 
-      expect(credentials.keys).to eq(%w(id email nickname))
+      expect(credentials.keys).to eq(%w(id email name nickname image))
       expect(credentials["id"]).to eq(user.id)
       expect(credentials["email"]).to eq(user.email)
+      expect(credentials["name"]).to eq(user.name)
       expect(credentials["nickname"]).to eq(user.nickname)
+      expect(credentials["image"]).to start_with("http")
     end
   end
 end

--- a/decidim-core/spec/forms/omniauth_registration_form_spec.rb
+++ b/decidim-core/spec/forms/omniauth_registration_form_spec.rb
@@ -22,7 +22,8 @@ module Decidim
         name: name,
         provider: provider,
         uid: uid,
-        oauth_signature: oauth_signature
+        oauth_signature: oauth_signature,
+        avatar_url: "http://www.example.org/foo.jpg"
       }
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

When creating an OAuth client for Decidim I realised there was some missing data, this PR adds the name and avatar to it.

#### :pushpin: Related Issues
- Related to #3057 

#### :clipboard: Subtasks
- [ ]  Add `CHANGELOG` entry