### PR TITLE
Include children information in main column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ controller or added a new module you need to rename `feature` to `component`.
   - Dependent inputs (field_dependent_inputs.component.js.es6)
 - **decidim-participatory_processes**: Render documents in first place (before view hooks). [\#2977](https://github.com/decidim/decidim/pull/2977)
 - **decidim-verifications**: If you're using a custom authorization handler template, make sure it does not include the button. Decidim takes care of that for you so including it will from no now cause duplicated buttons in the form. [\#3211](https://github.com/decidim/decidim/pull/3211)
+- **decidim-accountability**: Include children information in main column [\#3217](https://github.com/decidim/decidim/pull/3217)
 
 **Fixed**:
 

--- a/decidim-accountability/app/views/decidim/accountability/results/_show_parent.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_show_parent.html.erb
@@ -13,12 +13,12 @@
             <%== translated_attribute result.description %>
           </div>
           <%= render partial: "decidim/shared/tags", locals: { resource: result, tags_class_extra: "tags--result" } %>
+
+          <%= render partial: "results_leaf", locals: { results: result.children.page(1).per(result.children_count), total_count: result.children_count } %>
         </div>
       </div>
       <%= render partial: "stats_box" %>
     </div>
-
-    <%= render partial: "results_leaf", locals: { results: result.children.page(1).per(result.children_count), total_count: result.children_count } %>
 
   </div>
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adapts the parent results page to the new design and includes the list of children results in the main column.

#### :pushpin: Related Issues

- Fixes #3188

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots 

**Before**

![screen shot 2018-04-13 at 07 53 26](https://user-images.githubusercontent.com/17616/38719102-7e076934-3ef0-11e8-8dcc-dd97efb23d91.png)

**After**

![screen shot 2018-04-13 at 07 58 17](https://user-images.githubusercontent.com/17616/38719105-82ba5202-3ef0-11e8-9d19-ee76cfb889de.png)