### PR TITLE
Fix 0.10's Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 **Fixed**:
 
-## [0.10-pre](https://github.com/decidim/decidim/tree/0.10-stable)
+## [0.10.0](https://github.com/decidim/decidim/tree/v0.9.2)
 
 **Note**: As per [\#2983](https://github.com/decidim/decidim/pull/2983), if you've been using `0.10.pre` version of Decidim for a while you'll need to fix some values in the database. In order to fix them,  run this script in your Rails console:
 
@@ -97,10 +97,7 @@ Decidim::Notification.where(event_class: "Decidim::Proposals::ProposalEndorsedEv
 
 **Fixed**:
 
-- **decidim-proposals**: Fix threshold_per_proposal method positive? for nil:NilClass when threshold is null or not defined. [\#3219](https://github.com/decidim/decidim/pull/3219)
-- **decidim-proposals**: Fix when I create a proposal I see the draft proposal from someone else! [\#3170](https://github.com/decidim/decidim/pull/3083)
- - **decidim-proposals**: Fix view hooks returning proposals that should not be shown [\#3175](https://github.com/decidim/decidim/pull/3175)
-- **decidim-debates**: Fix debates times. [\#3078](https://github.com/decidim/decidim/pull/3078)
+**decidim-debates**: Fix debates times. [\#3078](https://github.com/decidim/decidim/pull/3078)
 - **decidim-proposals**: Fix treshold absolute view and rename the field maximum_votes_per_proposal to threshold_per_proposal. [\#3017](https://github.com/decidim/decidim/pull/3017)
 - **decidim-core**: FIX Mispelling in available_locales initializer: pr-BR should be pt-BR. [\#2883](https://github.com/decidim/decidim/pull/2883)
 - **decidim-admin**: FIX Area and AreaType command specs [\#2859](https://github.com/decidim/decidim/pull/2859)


### PR DESCRIPTION
#### :tophat: What? Why?
The 0.10 version's changelog was broken. This fixes it.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*
