### PR TITLE
Comment out optional gems

### DIFF
--- a/lib/generators/decidim/app_generator.rb
+++ b/lib/generators/decidim/app_generator.rb
@@ -95,7 +95,8 @@ module Decidim
                        end
 
         gsub_file "Gemfile", /gem "#{current_gem}".*/, "gem \"#{current_gem}\", #{gem_modifier}"
-        gsub_file "Gemfile", /gem "decidim-dev".*/, "gem \"decidim-dev\", #{gem_modifier}" if current_gem == "decidim"
+        gsub_file "Gemfile", /gem "decidim-([A-z]+)".*/, "# gem \"decidim-\\1\", #{gem_modifier}"
+        gsub_file "Gemfile", /(# )?gem "decidim-dev".*/, "gem \"decidim-dev\", #{gem_modifier}" if current_gem == "decidim"
 
         Bundler.with_original_env { run "bundle install" }
       end


### PR DESCRIPTION
#### :tophat: What? Why?
This will comment out optional gems found on the project's `Gemfile`, in order to indicate to the user they are available, but optional.

So this will generate this gemfile:

```ruby
source "https://rubygems.org"

ruby RUBY_VERSION

gem "decidim", "0.11.0.pre"
# gem "decidim-consultations", "0.11.0.pre"

gem "puma", "~> 3.0"
gem "uglifier", "~> 4.1"

gem "faker", "~> 1.8"

group :development, :test do
  gem "byebug", "~> 10.0", platform: :mri

  gem "decidim-dev", "0.11.0.pre"
end

group :development do
  gem "letter_opener_web", "~> 1.3"
  gem "listen", "~> 3.1"
  gem "spring", "~> 2.0"
  gem "spring-watcher-listen", "~> 2.0"
  gem "web-console", "~> 3.5"
end
```

When given a gemfile like this:

```ruby
source "https://rubygems.org"

ruby RUBY_VERSION

gem "decidim", path: "."
gem "decidim-consultations", path: "decidim-consultations"

gem "puma", "~> 3.0"
gem "uglifier", "~> 4.1"

gem "faker", "~> 1.8"

group :development, :test do
  gem "byebug", "~> 10.0", platform: :mri

  gem "decidim-dev", path: "."
end

group :development do
  gem "letter_opener_web", "~> 1.3"
  gem "listen", "~> 3.1"
  gem "spring", "~> 2.0"
  gem "spring-watcher-listen", "~> 2.0"
  gem "web-console", "~> 3.5"
end
```

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*
