### PR TITLE
Ci speed up

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,17 +36,6 @@ jobs:
       - run:
           name: Generate test app
           command: bundle exec rake test_app
-      - restore_cache:
-         keys:
-           - assets-{{ .Branch }}
-           - assets-master
-      - run:
-          name: Precompile test app assets
-          command: cd spec/decidim_dummy_app && bundle exec rails assets:precompile
-      - save_cache:
-          key: assets-{{ .Branch }}
-          paths:
-            - spec/decidim_dummy_app/public/assets
       - run:
           name: Install CodeClimate test reporter
           command: /app/.circleci/install_cc_test_reporter.sh

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -19,9 +19,6 @@ module Decidim
 end
 
 Capybara.register_driver :headless_chrome do |app|
-  http_client = Selenium::WebDriver::Remote::Http::Default.new
-  http_client.read_timeout = 120
-
   options = ::Selenium::WebDriver::Chrome::Options.new
   options.args << "--headless"
   options.args << "--no-sandbox"
@@ -30,22 +27,8 @@ Capybara.register_driver :headless_chrome do |app|
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,
-    options: options,
-    http_client: http_client
+    options: options
   )
-end
-
-# Monkeypatch the other place where capybara can timeout. We should contribute
-# the configurability to capybara if this works consistently and proves to be
-# useful
-module Capybara
-  class Server
-    def wait_for_pending_requests
-      Timeout.timeout(120) { sleep(0.01) while pending_requests? }
-    rescue Timeout::Error
-      raise "Requests did not finish in 120 seconds"
-    end
-  end
 end
 
 Capybara.asset_host = "http://localhost:3000"


### PR DESCRIPTION
#### :tophat: What? Why?

Extracted from #3225.

Sometimes we have flakies in the first test of a test run about the server timing out on boot up. Those flakies usually mean that `sprockets-rails` is precompiling the assets on the fly in the first request and that took too long. There's something weird going on in there because I thought by precompiling the assets in the build_test_app job and sharing the precompiled assets with the other jobs we should be avoiding exactly that. But those flakies are there, so assuming they're due to asset precompilation (I've never seen other situation that affects only the first request of a test run), that means something is not happening as we expect.

To fix it, I chose to prevent that on the fly asset precompilation from happening. By doing that, we should fix the flakies but also:

We no longer need the asset precompilation on the build_test_app job. Since that job is the most bottlenecking one of all, that means around 1min savings for every build!
We no longer precompile assets on the development environment either. That means fast page loading on the first request of a freshly created development app!

#### :pushpin: Related Issues
- Related to #3225.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.
