### PR TITLE
Fix threshold_per_proposal nil values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-proposals**: Fixes clicking on "see all" should remove the ellipsis sign. \#2894](https://github.com/decidim/decidim/pull/3238)
 - **decidim-proposals**: Restore creation date in proposal detail page. [\#3249](https://github.com/decidim/decidim/pull/3249)
 - **decidim-proposals**: Fix threshold_per_proposal method positive? for nil:NilClass when threshold is null or not defined. [\#3185](https://github.com/decidim/decidim/pull/3185)
+- **decidim-proposals**: Make sure threshold per proposal has the right value in existing components [\#3235](https://github.com/decidim/decidim/pull/3235)
 - **decidim-proposals**: Fix when I create a proposal I see the draft proposal from someone else! [\#3170](https://github.com/decidim/decidim/pull/3083)
 - **decidim-proposals**: Fix view hooks returning proposals that should not be shown [\#3175](https://github.com/decidim/decidim/pull/3175)
 - **decidim-debates**: Fix debates times. [\#3071](https://github.com/decidim/decidim/pull/3071)

--- a/decidim-proposals/app/helpers/decidim/proposals/proposal_votes_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/proposal_votes_helper.rb
@@ -50,7 +50,7 @@ module Decidim
       #
       # Returns an Integer with the maximum amount of votes, nil otherwise.
       def threshold_per_proposal
-        return nil unless component_settings.threshold_per_proposal.to_i.positive?
+        return nil unless component_settings.threshold_per_proposal.positive?
         component_settings.threshold_per_proposal
       end
 

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -109,7 +109,7 @@ module Decidim
       #
       # Returns an Integer with the maximum amount of votes, nil otherwise.
       def maximum_votes
-        maximum_votes = component.settings.threshold_per_proposal || 0
+        maximum_votes = component.settings.threshold_per_proposal
         return nil if maximum_votes.zero?
 
         maximum_votes

--- a/decidim-proposals/db/migrate/20180413135249_fix_nil_threshold_per_proposal.rb
+++ b/decidim-proposals/db/migrate/20180413135249_fix_nil_threshold_per_proposal.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class FixNilThresholdPerProposal < ActiveRecord::Migration[5.1]
+  class Component < ApplicationRecord
+    self.table_name = :decidim_components
+  end
+
+  def change
+    proposal_components = Component.where(manifest_name: "proposals")
+
+    proposal_components.each do |component|
+      next unless component.settings.threshold_per_proposal.nil?
+
+      settings = component.attributes["settings"]
+      settings["global"]["threshold_per_proposal"] = 0
+      component.settings = settings
+      component.save
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

As discussed in https://github.com/decidim/decidim/pull/3185#discussion_r181031087 there's a missing migration to make sure `threshold_per_proposal` is correctly set for all components

#### :pushpin: Related Issues
- Related to #3185


#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry