### PR TITLE
Eval Gemfile to sync decidim_app-design with the main repo

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1197,6 +1197,7 @@ RSpec/ContextWording:
 
 RSpec/DescribeClass:
   Exclude:
+    - spec/bundle_spec.rb
     - spec/i18n_spec.rb
     - spec/generator_spec.rb
     - decidim-comments/spec/bundle_spec.rb

--- a/decidim_app-design/Gemfile
+++ b/decidim_app-design/Gemfile
@@ -2,16 +2,4 @@
 
 source "https://rubygems.org"
 
-# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem "decidim", path: ".."
-gem "faker"
-gem "puma", "~> 3.7"
-gem "uglifier", ">= 1.3.0"
-
-group :development do
-  gem "decidim-dev", path: ".."
-  gem "listen", ">= 3.0.5", "< 3.2"
-  gem "spring-watcher-listen", "~> 2.0.0"
-end
-
-gem "byebug"
+eval_gemfile "../Gemfile"

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -1,4 +1,12 @@
 PATH
+  remote: ../decidim-consultations
+  specs:
+    decidim-consultations (0.11.0.pre)
+      decidim-admin (= 0.11.0.pre)
+      decidim-comments (= 0.11.0.pre)
+      decidim-core (= 0.11.0.pre)
+
+PATH
   remote: ..
   specs:
     decidim (0.11.0.pre)
@@ -148,14 +156,6 @@ PATH
       jquery-rails (~> 4.3)
       sassc-rails (~> 1.3)
     decidim-verifications (0.11.0.pre)
-      decidim-core (= 0.11.0.pre)
-
-PATH
-  remote: ../decidim-consultations
-  specs:
-    decidim-consultations (0.11.0.pre)
-      decidim-admin (= 0.11.0.pre)
-      decidim-comments (= 0.11.0.pre)
       decidim-core (= 0.11.0.pre)
 
 GEM

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -8,7 +8,6 @@ PATH
       decidim-assemblies (= 0.11.0.pre)
       decidim-budgets (= 0.11.0.pre)
       decidim-comments (= 0.11.0.pre)
-      decidim-consultations (= 0.11.0.pre)
       decidim-core (= 0.11.0.pre)
       decidim-debates (= 0.11.0.pre)
       decidim-meetings (= 0.11.0.pre)
@@ -47,10 +46,6 @@ PATH
     decidim-comments (0.11.0.pre)
       decidim-core (= 0.11.0.pre)
       jquery-rails (~> 4.0)
-    decidim-consultations (0.11.0.pre)
-      decidim-admin (= 0.11.0.pre)
-      decidim-comments (= 0.11.0.pre)
-      decidim-core (= 0.11.0.pre)
     decidim-core (0.11.0.pre)
       active_link_to (~> 1.0)
       autoprefixer-rails (~> 8.0)
@@ -155,6 +150,14 @@ PATH
     decidim-verifications (0.11.0.pre)
       decidim-core (= 0.11.0.pre)
 
+PATH
+  remote: ../decidim-consultations
+  specs:
+    decidim-consultations (0.11.0.pre)
+      decidim-admin (= 0.11.0.pre)
+      decidim-comments (= 0.11.0.pre)
+      decidim-core (= 0.11.0.pre)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -202,7 +205,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     ast (2.4.0)
-    autoprefixer-rails (8.2.0)
+    autoprefixer-rails (8.3.0)
       execjs
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -221,9 +224,10 @@ GEM
       html_tokenizer (~> 0.0.6)
       parser (>= 2.4)
       smart_properties
+    bindex (0.5.0)
     builder (3.2.3)
     byebug (10.0.0)
-    cancancan (2.1.4)
+    cancancan (2.2.0)
     capybara (2.18.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -281,7 +285,7 @@ GEM
       railties (>= 4.1.0, < 6.0)
       responders
       warden (~> 1.2.3)
-    devise-i18n (1.6.1)
+    devise-i18n (1.6.2)
       devise (>= 4.4)
     devise_invitable (1.7.4)
       actionmailer (>= 4.1.0)
@@ -380,6 +384,14 @@ GEM
       activerecord
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    letter_opener (1.6.0)
+      launchy (~> 2.2)
+    letter_opener_web (1.3.4)
+      actionmailer (>= 3.2)
+      letter_opener (~> 1.0)
+      railties (>= 3.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -606,7 +618,7 @@ GEM
     uglifier (4.1.7)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.3.0)
-    valid_email2 (2.2.2)
+    valid_email2 (2.2.3)
       activemodel (>= 3.2)
       mail (~> 2.5)
     virtus (1.0.5)
@@ -616,6 +628,11 @@ GEM
       equalizer (~> 0.0, >= 0.0.9)
     warden (1.2.7)
       rack (>= 1.0)
+    web-console (3.6.0)
+      actionview (>= 5.0)
+      activemodel (>= 5.0)
+      bindex (>= 0.4.0)
+      railties (>= 5.0)
     webmock (3.3.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -632,14 +649,21 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  byebug
+  byebug (~> 10.0)
   decidim!
+  decidim-consultations!
   decidim-dev!
-  faker
-  listen (>= 3.0.5, < 3.2)
-  puma (~> 3.7)
-  spring-watcher-listen (~> 2.0.0)
-  uglifier (>= 1.3.0)
+  faker (~> 1.8)
+  letter_opener_web (~> 1.3)
+  listen (~> 3.1)
+  puma (~> 3.0)
+  spring (~> 2.0)
+  spring-watcher-listen (~> 2.0)
+  uglifier (~> 4.1)
+  web-console (~> 3.5)
+
+RUBY VERSION
+   ruby 2.5.0p0
 
 BUNDLED WITH
    1.16.1

--- a/spec/bundle_spec.rb
+++ b/spec/bundle_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "digest"
+
+describe "Bundle sanity" do
+  it "is up to date" do
+    Dir.chdir("decidim_app-design") do
+      previous_content = File.read("Gemfile.lock")
+
+      new_content = Bundler.with_original_env do
+        `BUNDLE_GEMFILE=./Gemfile bundle lock --print`
+      end
+
+      msg = "Please update the design_app lock file with `bundle install` from the `decidim_app-design folder"
+
+      expect(new_content).to eq(previous_content), msg
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This is another take on what @deivid-rodriguez did in on https://github.com/decidim/decidim/pull/3234 - it ensures the design app's `Gemfile` stays in sync with the main one. It's also a nice way to :trollface: him.

#### :pushpin: Related Issues
- Related to #3234 

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*
