### PR TITLE
Projects per page setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-surveys**: Client side survey errors are now displayed [\#3133](https://github.com/decidim/decidim/pull/3133)
 - **decidim-surveys**: Allow multiple choice questions to have "free text options" where the user can customize the selected answer [\#3134](https://github.com/decidim/decidim/pull/3134)
 - **decidim-surveys**: New question type to sort different options [\#3148](https://github.com/decidim/decidim/pull/3148)
+- **decidim-budgets**: Setting to control the number of projects per page to be listed [\#3239](https://github.com/decidim/decidim/pull/3239)
 
 **Changed**:
 

--- a/decidim-budgets/app/controllers/decidim/budgets/projects_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/projects_controller.rb
@@ -12,7 +12,7 @@ module Decidim
       private
 
       def projects
-        @projects ||= search.results.page(params[:page]).per(12)
+        @projects ||= search.results.page(params[:page]).per(current_component.settings.projects_per_page)
       end
 
       def random_seed

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -115,6 +115,7 @@ en:
           global:
             announcement: Announcement
             comments_enabled: Comments enabled
+            projects_per_page: Projects per page
             total_budget: Total budget
             vote_threshold_percent: Vote threshold percent
           step:

--- a/decidim-budgets/lib/decidim/budgets/component.rb
+++ b/decidim-budgets/lib/decidim/budgets/component.rb
@@ -36,6 +36,7 @@ Decidim.register_component(:budgets) do |component|
   end
 
   component.settings(:global) do |settings|
+    settings.attribute :projects_per_page, type: :integer, default: 12
     settings.attribute :total_budget, type: :integer, default: 100_000_000
     settings.attribute :vote_threshold_percent, type: :integer, default: 70
     settings.attribute :comments_enabled, type: :boolean, default: true

--- a/decidim-budgets/spec/system/orders_spec.rb
+++ b/decidim-budgets/spec/system/orders_spec.rb
@@ -222,6 +222,38 @@ describe "Orders", type: :system do
     end
   end
 
+  describe "index" do
+    it "respects the projects_per_page setting when under total projects" do
+      component.update!(settings: { projects_per_page: 1 })
+
+      create_list(:project, 2, component: component)
+
+      visit_component
+
+      expect(page).to have_selector("[id^=project-]", count: 1)
+    end
+
+    it "respects the projects_per_page setting when it matches total projects" do
+      component.update!(settings: { projects_per_page: 2 })
+
+      create_list(:project, 2, component: component)
+
+      visit_component
+
+      expect(page).to have_selector("[id^=project-]", count: 2)
+    end
+
+    it "respects the projects_per_page setting when over total projects" do
+      component.update!(settings: { projects_per_page: 3 })
+
+      create_list(:project, 2, component: component)
+
+      visit_component
+
+      expect(page).to have_selector("[id^=project-]", count: 2)
+    end
+  end
+
   describe "show" do
     let!(:project) { create(:project, component: component, budget: 25_000_000) }
 

--- a/decidim-budgets/spec/system/orders_spec.rb
+++ b/decidim-budgets/spec/system/orders_spec.rb
@@ -7,7 +7,6 @@ describe "Orders", type: :system do
   let(:manifest_name) { "budgets" }
 
   let!(:user) { create :user, :confirmed, organization: organization }
-  let!(:projects) { create_list(:project, 3, component: component, budget: 25_000_000) }
   let(:project) { projects.first }
 
   let!(:component) do
@@ -18,6 +17,8 @@ describe "Orders", type: :system do
   end
 
   context "when the user is not logged in" do
+    let!(:projects) { create_list(:project, 1, component: component, budget: 25_000_000) }
+
     it "is given the option to sign in" do
       visit_component
 
@@ -30,6 +31,8 @@ describe "Orders", type: :system do
   end
 
   context "when the user is logged in" do
+    let!(:projects) { create_list(:project, 3, component: component, budget: 25_000_000) }
+
     before do
       login_as user, scope: :user
     end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds a setting to control the number of projects to be listed per page in `decidim-budgets`, which was previously hard-coded to 12.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
_None_.