### PR TITLE
Safer update survey command

### DIFF
--- a/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
+++ b/decidim-surveys/app/commands/decidim/surveys/admin/update_survey.rb
@@ -68,11 +68,11 @@ module Decidim
             if form.deleted?
               record.destroy!
             else
-              record.assign_attributes(attributes)
+              record.update!(attributes)
             end
+          else
+            record.save!
           end
-
-          record.save!
         end
 
         def update_survey


### PR DESCRIPTION

#### :tophat: What? Why?

One of my PRs had a very [weird flaky](https://circleci.com/gh/decidim/decidim/85345) in the survey update command. I think this might help. Previously in the delete case, we were calling calling `destroy!`, and then `save!` on the same record. What does that even mean? This raises in Rails 5.2, which seems reasonable since it's pretty undefined what one means by that, so I've extracted the change from the Rails 5.2 so we can ship this and skip a potential bug.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.
