### PR TITLE
Do not require highlighted banner image if already present in organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,5 +88,6 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-surveys**: Max choices selector not disabled when survey has already been answered [\#3133](https://github.com/decidim/decidim/pull/3133)
 - **decidim-surveys**: Translated fields not disabled when survey has already been answered [\#3133](https://github.com/decidim/decidim/pull/3133)
 - **decidim-admin**: Default managed user form displaying two buttons [\#3211](https://github.com/decidim/decidim/pull/3211)
+- **decidim-admin**: Highlighted banner image is not required if already present in the organization [\#3244](https://github.com/decidim/decidim/pull/3244)
 
 Please check [0.10-stable](https://github.com/decidim/decidim/blob/0.10-stable/CHANGELOG.md) for previous changes.

--- a/decidim-admin/app/forms/decidim/admin/organization_appearance_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_appearance_form.rb
@@ -83,8 +83,8 @@ module Decidim
       end
 
       def highlighted_content_banner_image_is_changed?
-        highlighted_content_banner_enabled? && 
-          !current_organization.highlighted_content_banner_image.present?
+        highlighted_content_banner_enabled? &&
+          current_organization.highlighted_content_banner_image.blank?
       end
     end
   end

--- a/decidim-admin/app/forms/decidim/admin/organization_appearance_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_appearance_form.rb
@@ -54,7 +54,7 @@ module Decidim
                 presence: true,
                 file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } },
                 file_content_type: { allow: ["image/jpeg", "image/png"] },
-                if: :highlighted_content_banner_enabled?
+                if: :highlighted_content_banner_image_is_changed?
 
       validates :highlighted_content_banner_title,
                 translatable_presence: true,
@@ -80,6 +80,11 @@ module Decidim
 
       def enable_omnipresent_banner?
         enable_omnipresent_banner
+      end
+
+      def highlighted_content_banner_image_is_changed?
+        highlighted_content_banner_enabled? && 
+          !current_organization.highlighted_content_banner_image.present?
       end
     end
   end

--- a/decidim-admin/spec/forms/organization_appearance_form_spec.rb
+++ b/decidim-admin/spec/forms/organization_appearance_form_spec.rb
@@ -145,6 +145,13 @@ module Decidim
           let(:highlighted_content_banner_image) { "" }
 
           it { is_expected.not_to be_valid }
+
+          context "and the organization already has an image set" do
+            let(:organization) { create :organization, highlighted_content_banner_image: Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
+            let(:highlighted_content_banner_image) { nil }
+
+            it { is_expected.to be_valid }
+          end
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
when the highlighted banner is already enabled and you modify something else from the organization appearance, the form fails because it is expecting to receive the banner image, and forces the user to reupload the image every time.

With this PR, if the banner image is present in the organization then it is not required by the form, so you don't need to reupload it every time.

#### :pushpin: Related Issues
- Fixes #3163

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests