### PR TITLE
Open space hashtags in new tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-participatory_processes**: Render documents in first place (before view hooks). [\#2977](https://github.com/decidim/decidim/pull/2977)
 - **decidim-verifications**: If you're using a custom authorization handler template, make sure it does not include the button. Decidim takes care of that for you so including it will from no now cause duplicated buttons in the form. [\#3211](https://github.com/decidim/decidim/pull/3211)
 - **decidim-accountability**: Include children information in main column [\#3217](https://github.com/decidim/decidim/pull/3217)
+- **decidim-core**: Open space hashtags in new tab [\#3246](https://github.com/decidim/decidim/pull/3246)
 
 **Fixed**:
 

--- a/decidim-assemblies/app/views/layouts/decidim/_assembly_header.html.erb
+++ b/decidim-assemblies/app/views/layouts/decidim/_assembly_header.html.erb
@@ -12,7 +12,7 @@
           <h2 class="text-highlight heading-small">
             <% if current_participatory_space.hashtag.present? %>
               <span class="process-header__hashtag">
-                <%= link_to "##{current_participatory_space.hashtag}", "https://twitter.com/hashtag/#{current_participatory_space.hashtag}" %>
+                <%= link_to "##{current_participatory_space.hashtag}", "https://twitter.com/hashtag/#{current_participatory_space.hashtag}", target: "_blank" %>
               </span>
             <% end %>
             <%= translated_attribute(current_participatory_space.subtitle) %>

--- a/decidim-consultations/app/views/layouts/decidim/_question_header.html.erb
+++ b/decidim-consultations/app/views/layouts/decidim/_question_header.html.erb
@@ -24,7 +24,7 @@
   <h1 class="heading2"><%= decidim_sanitize translated_attribute question.title %></h1>
   <% unless question.hashtag.blank? %>
     <div class="text-center">
-      <%= link_to "##{question.hashtag}", "https://twitter.com/hashtag/#{question.hashtag}" %>
+      <%= link_to "##{question.hashtag}", "https://twitter.com/hashtag/#{question.hashtag}", target: "_blank" %>
     </div>
   <% end %>
 

--- a/decidim-participatory_processes/app/views/layouts/decidim/_process_header.html.erb
+++ b/decidim-participatory_processes/app/views/layouts/decidim/_process_header.html.erb
@@ -12,7 +12,7 @@
           <h2 class="text-highlight heading-small">
             <% if current_participatory_space.hashtag.present? %>
               <span class="process-header__hashtag">
-                <%= link_to "##{current_participatory_space.hashtag}", "https://twitter.com/hashtag/#{current_participatory_space.hashtag}" %>
+                <%= link_to "##{current_participatory_space.hashtag}", "https://twitter.com/hashtag/#{current_participatory_space.hashtag}", target: "_blank" %>
               </span>
             <% end %>
             <%= translated_attribute(current_participatory_space.subtitle) %>


### PR DESCRIPTION
#### :tophat: What? Why?
Opens the space hashtags links in a new tab.

#### :pushpin: Related Issues
- Fixes #3159

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

