### PR TITLE
Keep user group on proposal forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,5 +88,6 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-surveys**: Max choices selector not disabled when survey has already been answered [\#3133](https://github.com/decidim/decidim/pull/3133)
 - **decidim-surveys**: Translated fields not disabled when survey has already been answered [\#3133](https://github.com/decidim/decidim/pull/3133)
 - **decidim-admin**: Default managed user form displaying two buttons [\#3211](https://github.com/decidim/decidim/pull/3211)
+- **decidim-proposals**: Keep the user group (if set) as default value of author field on forms [\#3247](https://github.com/decidim/decidim/pull/3247)
 
 Please check [0.10-stable](https://github.com/decidim/decidim/blob/0.10-stable/CHANGELOG.md) for previous changes.

--- a/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
@@ -29,6 +29,7 @@ module Decidim
       delegate :categories, to: :current_component
 
       def map_model(model)
+        self.user_group_id = model.decidim_user_group_id
         return unless model.categorization
 
         self.category_id = model.categorization.decidim_category_id

--- a/decidim-proposals/spec/forms/decidim/proposals/proposal_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/proposal_form_spec.rb
@@ -11,7 +11,7 @@ module Decidim
         )
       end
 
-      it_behaves_like "a proposal form"
+      it_behaves_like "a proposal form", user_group_check: true
     end
   end
 end

--- a/decidim-proposals/spec/shared/proposal_form_examples.rb
+++ b/decidim-proposals/spec/shared/proposal_form_examples.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-shared_examples "a proposal form" do
+shared_examples "a proposal form" do |options|
   subject { form }
 
   let(:organization) { create(:organization, available_locales: [:en]) }
@@ -9,6 +9,7 @@ shared_examples "a proposal form" do
   let(:title) { "Oriol for president!" }
   let(:body) { "Everything would be better" }
   let(:author) { create(:user, organization: organization) }
+  let(:user_group_id) { create(:user_group, :verified, users: [author], organization: organization).id }
   let(:category) { create(:category, participatory_space: participatory_space) }
   let(:scope) { create(:scope, organization: organization) }
   let(:category_id) { category.try(:id) }
@@ -172,6 +173,14 @@ shared_examples "a proposal form" do
     proposal = create(:proposal, component: component, category: category)
 
     expect(described_class.from_model(proposal).category_id).to eq(category_id)
+  end
+
+  if options && options[:user_group_check]
+    it "properly maps user group id from model" do
+      proposal = create(:proposal, component: component, author: author, decidim_user_group_id: user_group_id)
+
+      expect(described_class.from_model(proposal).user_group_id).to eq(user_group_id)
+    end
   end
 
   context "when the attachment is present" do


### PR DESCRIPTION
#### :tophat: What? Why?
Keeps the user group on proposal forms, so that you don't accidentally change the authorship of a proposal when editing the proposal or proposal draft.

#### :pushpin: Related Issues
- Fixes #3154

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

