### PR TITLE
Restore creation date in proposal show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ controller or added a new module you need to rename `feature` to `component`.
 
 **Fixed**:
 
+- **decidim-proposals**: Restore creation date in proposal detail page. [\#3249](https://github.com/decidim/decidim/pull/3249)
 - **decidim-proposals**: Fix threshold_per_proposal method positive? for nil:NilClass when threshold is null or not defined. [\#3185](https://github.com/decidim/decidim/pull/3185)
 - **decidim-proposals**: Fix when I create a proposal I see the draft proposal from someone else! [\#3170](https://github.com/decidim/decidim/pull/3083)
 - **decidim-proposals**: Fix view hooks returning proposals that should not be shown [\#3175](https://github.com/decidim/decidim/pull/3175)

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_author-avatar.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_author-avatar.scss
@@ -88,6 +88,7 @@ $author-data-color: $muted;
   display: inline-block;
 
   > button,
+  > span,
   > a{
     margin-right: 1rem;
   }

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -8,6 +8,7 @@
 <div class="row column view-header">
   <h2 class="heading2"><%= @proposal.title %></h2>
   <%= cell "decidim/author_box", present(@proposal).author, extra: (capture do %>
+      <span><%= l @proposal.created_at, format: :decidim_short %></span>
       <button type="button" data-open="<%= current_user.present? ? "flagModal" : "loginModal" %>" title="<%= t(".report") %>" aria-controls="<%= current_user.present? ? "flagModal" : "loginModal" %>" aria-haspopup="true" tabindex="0">
         <%= icon "flag", aria_label: t(".report"), class: "icon--small" %>
       </button>

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -27,6 +27,11 @@ describe "Proposals", type: :system do
     match_when_negated { |node| node.has_no_selector?(".author-data", text: name) }
   end
 
+  matcher :have_creation_date do |date|
+    match { |node| node.has_selector?(".author-data__extra", text: date) }
+    match_when_negated { |node| node.has_no_selector?(".author-data__extra", text: date) }
+  end
+
   context "when viewing a single proposal" do
     let!(:component) do
       create(:proposal_component,
@@ -47,6 +52,7 @@ describe "Proposals", type: :system do
       expect(page).to have_content(proposal.body)
       expect(page).to have_author(proposal.author.name)
       expect(page).to have_content(proposal.reference)
+      expect(page).to have_creation_date(l(proposal.created_at, format: :decidim_short))
     end
 
     context "when process is not related to any scope" do

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -52,7 +52,7 @@ describe "Proposals", type: :system do
       expect(page).to have_content(proposal.body)
       expect(page).to have_author(proposal.author.name)
       expect(page).to have_content(proposal.reference)
-      expect(page).to have_creation_date(l(proposal.created_at, format: :decidim_short))
+      expect(page).to have_creation_date(I18n.l(proposal.created_at, format: :decidim_short))
     end
 
     context "when process is not related to any scope" do


### PR DESCRIPTION
#### :tophat: What? Why?

Restore the creation date in proposal show view

#### :pushpin: Related Issues

- Fixes #3040

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)

![screen shot 2018-04-18 at 11 49 35](https://user-images.githubusercontent.com/2051199/38925005-b2354b38-42fe-11e8-87ce-de0c1acfe6cc.png)



