### PR TITLE
Activate and publish spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-meetings**: Add WYSIWYG editor for meeting closing notes [\#3265](https://github.com/decidim/decidim/pull/3265)
 - **decidim-meetings**: Add formatting of the list of organizations attending to a meeting [\#3265](https://github.com/decidim/decidim/pull/3265)
 - **decidim-core**: Order components by both weight and manifest_name so the order is kept [\#3264](https://github.com/decidim/decidim/pull/3264)
+- **decidim**: Spaces need to be activated and published before they appear publicly [\#3251](https://github.com/decidim/decidim/pull/3251)
 
 **Changed**:
 

--- a/decidim-admin/app/commands/decidim/admin/activate_participatory_space.rb
+++ b/decidim-admin/app/commands/decidim/admin/activate_participatory_space.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # A command with all the business logic to activate a participatory space.
+    class ActivateParticipatorySpace < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # participatory_space - The participatory space to activate
+      # current_user - the user performing the action
+      def initialize(participatory_space, current_user)
+        @participatory_space = participatory_space
+        @current_user = current_user
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid.
+      # - :invalid if the form wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        activate_participatory_space
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :current_user
+
+      def activate_participatory_space
+        Decidim.traceability.perform_action!(
+          "activate",
+          @participatory_space,
+          current_user,
+          manifest_name: @participatory_space.manifest_name
+        ) do
+          @participatory_space.activate!
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/app/commands/decidim/admin/deactivate_participatory_space.rb
+++ b/decidim-admin/app/commands/decidim/admin/deactivate_participatory_space.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # A command with all the business logic to deactivate a participatory space.
+    class DeactivateParticipatorySpace < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # participatory_space - The participatory space to activate
+      # current_user - the user performing the action
+      def initialize(participatory_space, current_user)
+        @participatory_space = participatory_space
+        @current_user = current_user
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid.
+      # - :invalid if the form wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        broadcast(:invalid) unless participatory_space.active?
+        deactivate_participatory_space
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :current_user
+
+      def deactivate_participatory_space
+        Decidim.traceability.perform_action!(
+          "deactivate",
+          @participatory_space,
+          current_user,
+          manifest_name: @participatory_space.manifest_name
+        ) do
+          @participatory_space.deactivate!
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/app/commands/decidim/admin/deactivate_participatory_space.rb
+++ b/decidim-admin/app/commands/decidim/admin/deactivate_participatory_space.rb
@@ -20,7 +20,7 @@ module Decidim
       #
       # Returns nothing.
       def call
-        broadcast(:invalid) unless participatory_space.active?
+        broadcast(:invalid) unless @participatory_space.active?
         deactivate_participatory_space
         broadcast(:ok)
       end

--- a/decidim-admin/app/commands/decidim/admin/publish_participatory_space.rb
+++ b/decidim-admin/app/commands/decidim/admin/publish_participatory_space.rb
@@ -20,7 +20,7 @@ module Decidim
       #
       # Returns nothing.
       def call
-        broadcast(:invalid) unless participatory_space.active?
+        broadcast(:invalid) unless @participatory_space.active?
         publish_participatory_space
         broadcast(:ok)
       end

--- a/decidim-admin/app/commands/decidim/admin/publish_participatory_space.rb
+++ b/decidim-admin/app/commands/decidim/admin/publish_participatory_space.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # A command with all the business logic to publish a participatory space.
+    class PublishParticipatorySpace < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # participatory_space - The participatory space to publish
+      # current_user - the user performing the action
+      def initialize(participatory_space, current_user)
+        @participatory_space = participatory_space
+        @current_user = current_user
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid.
+      # - :invalid if the form wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        broadcast(:invalid) unless participatory_space.active?
+        publish_participatory_space
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :current_user
+
+      def publish_participatory_space
+        Decidim.traceability.perform_action!(
+          "publish",
+          @participatory_space,
+          current_user,
+          manifest_name: @participatory_space.manifest_name
+        ) do
+          @participatory_space.publish!
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/app/commands/decidim/admin/unpublish_participatory_space.rb
+++ b/decidim-admin/app/commands/decidim/admin/unpublish_participatory_space.rb
@@ -20,7 +20,7 @@ module Decidim
       #
       # Returns nothing.
       def call
-        broadcast(:invalid) unless participatory_space.published?
+        broadcast(:invalid) unless @participatory_space.published?
         unpublish_participatory_space
         broadcast(:ok)
       end

--- a/decidim-admin/app/commands/decidim/admin/unpublish_participatory_space.rb
+++ b/decidim-admin/app/commands/decidim/admin/unpublish_participatory_space.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # A command with all the business logic to unpublish a participatory space.
+    class UnpublishParticipatorySpace < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # participatory_space - The participatory space to unpublish
+      # current_user - the user performing the action
+      def initialize(participatory_space, current_user)
+        @participatory_space = participatory_space
+        @current_user = current_user
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid.
+      # - :invalid if the form wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        broadcast(:invalid) unless participatory_space.published?
+        unpublish_participatory_space
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :current_user
+
+      def unpublish_participatory_space
+        Decidim.traceability.perform_action!(
+          "unpublish",
+          @participatory_space,
+          current_user,
+          manifest_name: @participatory_space.manifest_name
+        ) do
+          @participatory_space.unpublish!
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/app/controllers/concerns/decidim/admin/participatory_space_admin_context.rb
+++ b/decidim-admin/app/controllers/concerns/decidim/admin/participatory_space_admin_context.rb
@@ -32,44 +32,44 @@ module Decidim
 
         before_action :space_is_active?
 
+        private
+
         def current_participatory_space_manifest_name
           nil
         end
-      end
 
-      private
+        def current_participatory_space_manifest
+          @current_participatory_space_manifest ||= 
+            Decidim.find_participatory_space_manifest(current_participatory_space_manifest_name)
+        end
 
-      def current_participatory_space_manifest
-        @current_participatory_space_manifest ||= 
-          Decidim.find_participatory_space_manifest(current_participatory_space_manifest_name)
-      end
+        def current_participatory_space_context
+          :admin
+        end
 
-      def current_participatory_space_context
-        :admin
-      end
+        def current_participatory_space
+          raise NotImplementedError
+        end
 
-      def current_participatory_space
-        raise NotImplementedError
-      end
+        def authorize_participatory_space
+          authorize! :read, current_participatory_space
+        end
 
-      def authorize_participatory_space
-        authorize! :read, current_participatory_space
-      end
+        def ability_context
+          super.merge(
+            current_participatory_space: current_participatory_space
+          )
+        end
 
-      def ability_context
-        super.merge(
-          current_participatory_space: current_participatory_space
-        )
-      end
+        def layout
+          current_participatory_space_manifest.context(current_participatory_space_context).layout
+        end
 
-      def layout
-        current_participatory_space_manifest.context(current_participatory_space_context).layout
-      end
+        def space_is_active?
+          return true if current_participatory_space_manifest.space_for(current_organization).active?
 
-      def space_is_active?
-        return true if current_participatory_space_manifest.space_for(current_organization).active?
-
-        raise ActionController::RoutingError.new("Space is not active")
+          raise ActionController::RoutingError.new("Space is not active")
+        end
       end
     end
   end

--- a/decidim-admin/app/controllers/concerns/decidim/admin/participatory_space_admin_context.rb
+++ b/decidim-admin/app/controllers/concerns/decidim/admin/participatory_space_admin_context.rb
@@ -39,7 +39,7 @@ module Decidim
         end
 
         def current_participatory_space_manifest
-          @current_participatory_space_manifest ||= 
+          @current_participatory_space_manifest ||=
             Decidim.find_participatory_space_manifest(current_participatory_space_manifest_name)
         end
 
@@ -68,7 +68,7 @@ module Decidim
         def space_is_active?
           return true if current_participatory_space_manifest.space_for(current_organization).active?
 
-          raise ActionController::RoutingError.new("Space is not active")
+          raise ActionController::RoutingError, "Space is not active"
         end
       end
     end

--- a/decidim-admin/app/controllers/concerns/decidim/admin/participatory_space_admin_context.rb
+++ b/decidim-admin/app/controllers/concerns/decidim/admin/participatory_space_admin_context.rb
@@ -30,10 +30,19 @@ module Decidim
         helper_method :current_participatory_space_manifest
         helper_method :current_participatory_space_context
 
-        delegate :manifest, to: :current_participatory_space, prefix: true
+        before_action :space_is_active?
+
+        def current_participatory_space_manifest_name
+          nil
+        end
       end
 
       private
+
+      def current_participatory_space_manifest
+        @current_participatory_space_manifest ||= 
+          Decidim.find_participatory_space_manifest(current_participatory_space_manifest_name)
+      end
 
       def current_participatory_space_context
         :admin
@@ -55,6 +64,12 @@ module Decidim
 
       def layout
         current_participatory_space_manifest.context(current_participatory_space_context).layout
+      end
+
+      def space_is_active?
+        return true if current_participatory_space_manifest.space_for(current_organization).active?
+
+        raise ActionController::RoutingError.new("Space is not active")
       end
     end
   end

--- a/decidim-admin/app/controllers/decidim/admin/components/base_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/components/base_controller.rb
@@ -19,7 +19,7 @@ module Decidim
         helper_method :current_component,
                       :current_participatory_space,
                       :parent_path
-                      
+
         helper_method :current_participatory_space_manifest
 
         before_action except: [:index, :show] do
@@ -42,9 +42,7 @@ module Decidim
           @parent_path ||= EngineRouter.admin_proxy(current_participatory_space).components_path
         end
 
-        def current_participatory_space_manifest
-          current_participatory_space.manifest
-        end
+        delegate :manifest, to: :current_participatory_space, prefix: true
       end
     end
   end

--- a/decidim-admin/app/controllers/decidim/admin/components/base_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/components/base_controller.rb
@@ -19,6 +19,8 @@ module Decidim
         helper_method :current_component,
                       :current_participatory_space,
                       :parent_path
+                      
+        helper_method :current_participatory_space_manifest
 
         before_action except: [:index, :show] do
           authorize! :manage, current_component
@@ -38,6 +40,10 @@ module Decidim
 
         def parent_path
           @parent_path ||= EngineRouter.admin_proxy(current_participatory_space).components_path
+        end
+
+        def current_participatory_space_manifest
+          current_participatory_space.manifest
         end
       end
     end

--- a/decidim-admin/app/controllers/decidim/admin/participatory_spaces_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/participatory_spaces_controller.rb
@@ -13,7 +13,7 @@ module Decidim
 
       def activate
         authorize! :activate, participatory_space
-        
+
         ActivateParticipatorySpace.call(participatory_space, current_user) do
           on(:ok) do
             flash[:notice] = I18n.t("participatory_spaces.activate.success", scope: "decidim.admin")
@@ -29,7 +29,7 @@ module Decidim
 
       def deactivate
         authorize! :deactivate, participatory_space
-        
+
         DeactivateParticipatorySpace.call(participatory_space, current_user) do
           on(:ok) do
             flash[:notice] = I18n.t("participatory_spaces.deactivate.success", scope: "decidim.admin")
@@ -45,7 +45,7 @@ module Decidim
 
       def publish
         authorize! :publish, participatory_space
-        
+
         PublishParticipatorySpace.call(participatory_space, current_user) do
           on(:ok) do
             flash[:notice] = I18n.t("participatory_spaces.publish.success", scope: "decidim.admin")
@@ -61,7 +61,7 @@ module Decidim
 
       def unpublish
         authorize! :unpublish, participatory_space
-        
+
         UnpublishParticipatorySpace.call(participatory_space, current_user) do
           on(:ok) do
             flash[:notice] = I18n.t("participatory_spaces.unpublish.success", scope: "decidim.admin")
@@ -79,13 +79,13 @@ module Decidim
 
       def participatory_space
         @participatory_space ||= participatory_spaces
-          .find { |space| space.manifest_name == params[:id] }
+                                 .find { |space| space.manifest_name == params[:id] }
       end
 
       def participatory_spaces
         @participatory_spaces ||= Decidim.participatory_space_manifests
-          .map { |manifest| manifest.space_for(current_organization) }
-          .sort_by(&:manifest_name)
+                                         .map { |manifest| manifest.space_for(current_organization) }
+                                         .sort_by(&:manifest_name)
       end
     end
   end

--- a/decidim-admin/app/controllers/decidim/admin/participatory_spaces_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/participatory_spaces_controller.rb
@@ -27,6 +27,54 @@ module Decidim
         end
       end
 
+      def deactivate
+        authorize! :deactivate, participatory_space
+        
+        DeactivateParticipatorySpace.call(participatory_space, current_user) do
+          on(:ok) do
+            flash[:notice] = I18n.t("participatory_spaces.deactivate.success", scope: "decidim.admin")
+            redirect_to participatory_spaces_path
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("participatory_spaces.deactivate.error", scope: "decidim.admin")
+            redirect_to participatory_spaces_path
+          end
+        end
+      end
+
+      def publish
+        authorize! :publish, participatory_space
+        
+        PublishParticipatorySpace.call(participatory_space, current_user) do
+          on(:ok) do
+            flash[:notice] = I18n.t("participatory_spaces.publish.success", scope: "decidim.admin")
+            redirect_to participatory_spaces_path
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("participatory_spaces.publish.error", scope: "decidim.admin")
+            redirect_to participatory_spaces_path
+          end
+        end
+      end
+
+      def unpublish
+        authorize! :unpublish, participatory_space
+        
+        UnpublishParticipatorySpace.call(participatory_space, current_user) do
+          on(:ok) do
+            flash[:notice] = I18n.t("participatory_spaces.unpublish.success", scope: "decidim.admin")
+            redirect_to participatory_spaces_path
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("participatory_spaces.unpublish.error", scope: "decidim.admin")
+            redirect_to participatory_spaces_path
+          end
+        end
+      end
+
       private
 
       def participatory_space

--- a/decidim-admin/app/controllers/decidim/admin/participatory_spaces_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/participatory_spaces_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # Controller that allows managing participatory spaces.
+    class ParticipatorySpacesController < Decidim::Admin::ApplicationController
+      layout "decidim/admin/settings"
+      helper_method :participatory_spaces
+
+      def index
+        authorize! :index, ParticipatorySpace
+      end
+
+      def activate
+        authorize! :activate, participatory_space
+        
+        ActivateParticipatorySpace.call(participatory_space, current_user) do
+          on(:ok) do
+            flash[:notice] = I18n.t("participatory_spaces.activate.success", scope: "decidim.admin")
+            redirect_to participatory_spaces_path
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("participatory_spaces.activate.error", scope: "decidim.admin")
+            redirect_to participatory_spaces_path
+          end
+        end
+      end
+
+      private
+
+      def participatory_space
+        @participatory_space ||= participatory_spaces
+          .find { |space| space.manifest_name == params[:id] }
+      end
+
+      def participatory_spaces
+        @participatory_spaces ||= Decidim.participatory_space_manifests
+          .map { |manifest| manifest.space_for(current_organization) }
+          .sort_by(&:manifest_name)
+      end
+    end
+  end
+end

--- a/decidim-admin/app/models/decidim/admin/abilities/admin_ability.rb
+++ b/decidim-admin/app/models/decidim/admin/abilities/admin_ability.rb
@@ -50,6 +50,7 @@ module Decidim
           can :manage, Newsletter
           can :manage, :oauth_applications
           can :manage, OAuthApplication
+          can :manage, ParticipatorySpace
 
           can [:create, :index, :new, :read, :invite], User
 

--- a/decidim-admin/app/views/decidim/admin/participatory_spaces/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_spaces/index.html.erb
@@ -1,0 +1,39 @@
+<div class="card" id="area-types">
+  <div class="card-divider">
+    <h2 class="card-title"><%= t "decidim.admin.titles.participatory_spaces" %></h2>
+  </div>
+  <div class="card-section">
+    <div class="table-scroll">
+        <table class="table-list">
+        <thead>
+          <tr>
+            <th><%= t("models.participatory_space.fields.manifest_name", scope: "decidim.admin") %></th>
+            <th><%= t("models.participatory_space.fields.state", scope: "decidim.admin") %></th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% participatory_spaces.each do |participatory_space| %>
+            <tr>
+              <td>
+                <%= t(participatory_space.manifest_name, scope: "decidim.admin.menu") %>
+              </td>
+              <td>
+                <%= t(participatory_space.state, scope: "decidim.admin.models.participatory_space.fields.state_values") %>
+              </td>
+              <td class="table-list__actions">
+                <% if participatory_space.published? %>
+                  <span>Unpublish</span>
+                <% elsif participatory_space.active? %>
+                  <span>Deactivate</span> <span>Publish</span>
+                <% else %>
+                  <%= link_to t(".activate"), activate_participatory_space_path(participatory_space.manifest_name), class: "button small", method: :put %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/decidim-admin/app/views/decidim/admin/participatory_spaces/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_spaces/index.html.erb
@@ -23,9 +23,10 @@
               </td>
               <td class="table-list__actions">
                 <% if participatory_space.published? %>
-                  <span>Unpublish</span>
+                  <%= link_to t(".unpublish"), unpublish_participatory_space_path(participatory_space.manifest_name), class: "button small", method: :put %>
                 <% elsif participatory_space.active? %>
-                  <span>Deactivate</span> <span>Publish</span>
+                  <%= link_to t(".deactivate"), deactivate_participatory_space_path(participatory_space.manifest_name), class: "button small", method: :put %>
+                  <%= link_to t(".publish"), publish_participatory_space_path(participatory_space.manifest_name), class: "button small", method: :put %>
                 <% else %>
                   <%= link_to t(".activate"), activate_participatory_space_path(participatory_space.manifest_name), class: "button small", method: :put %>
                 <% end %>

--- a/decidim-admin/app/views/layouts/decidim/admin/settings.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/settings.html.erb
@@ -22,6 +22,9 @@
       <li <% if is_active_link?(decidim_admin.area_types_path) %> class="is-active" <% end %>>
         <%= link_to t("menu.area_types", scope: "decidim.admin"), decidim_admin.area_types_path %>
       </li>
+      <li <% if is_active_link?(decidim_admin.participatory_spaces_path) %> class="is-active" <% end %>>
+        <%= link_to t("menu.participatory_spaces", scope: "decidim.admin"), decidim_admin.participatory_spaces_path %>
+      </li>
     </ul>
   </div>
 <% end %>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -545,8 +545,20 @@ en:
         activate:
           error: There was an error activating this participatory space.
           success: Participatory space activated successfully.
+        deactivate:
+          error: There was an error deactivating this participatory space.
+          success: Participatory space deactivated successfully.
         index:
           activate: Activate
+          deactivate: Deactivate
+          publish: Publish
+          unpublish: Unpublish
+        publish:
+          error: There was an error publishing this participatory space.
+          success: Participatory space published successfully.
+        unpublish:
+          error: There was an error unpublishing this participatory space.
+          success: Participatory space unpublished successfully.
       scope_types:
         create:
           error: There was an error creating a new scope type.

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -332,6 +332,7 @@ en:
         newsletters: Newsletters
         oauth_applications: OAuth applications
         officializations: Officializations
+        participatory_spaces: Participatory spaces
         scope_types: Scope types
         scopes: Scopes
         settings: Settings
@@ -378,6 +379,14 @@ en:
             created_at: Created at
             name: Name
           name: OAuth application
+        participatory_space:
+          fields:
+            manifest_name: Manifest name
+            state: State
+            state_values:
+              active: Active
+              inactive: Inactive
+              published: Published
         participatory_space_private_user:
           name: Participatory space private user
         scope:
@@ -532,6 +541,12 @@ en:
         new:
           create: Create
           title: New Participatory Space private user.
+      participatory_spaces:
+        activate:
+          error: There was an error activating this participatory space.
+          success: Participatory space activated successfully.
+        index:
+          activate: Activate
       scope_types:
         create:
           error: There was an error creating a new scope type.
@@ -589,6 +604,7 @@ en:
         impersonatable_users: Impersonatable users
         impersonations: Impersonations
         officializations: Officializations
+        participatory_spaces: Participatory spaces
         scope_types: Scope types
         scopes: Scopes
         static_pages: Pages

--- a/decidim-admin/config/routes.rb
+++ b/decidim-admin/config/routes.rb
@@ -57,6 +57,15 @@ Decidim::Admin::Engine.routes.draw do
       end
     end
 
+    resources :participatory_spaces, only: [:index] do
+      member do
+        put :activate
+        put :deactivate
+        put :publish
+        put :unpublish
+      end
+    end
+
     resources :oauth_applications
 
     root to: "dashboard#show"

--- a/decidim-admin/spec/commands/decidim/admin/activate_participatory_space_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/activate_participatory_space_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Admin
+  describe ActivateParticipatorySpace do
+    subject { described_class.new(participatory_space, user) }
+
+    let(:organization) { create :organization }
+    let(:user) { create :user, :admin, :confirmed, organization: organization }
+    let(:participatory_space) { create :participatory_space, organization: organization }
+
+    it "activates the area" do
+      subject.call
+      participatory_space.reload
+      expect(participatory_space).to be_active
+    end
+
+    it "broadcasts ok" do
+      expect do
+        subject.call
+      end.to broadcast(:ok)
+    end
+
+    it "traces the action", versioning: true do
+      expect(Decidim.traceability)
+        .to receive(:perform_action!)
+        .with(
+          "activate",
+          participatory_space,
+          user,
+          manifest_name: participatory_space.manifest_name
+        )
+        .and_call_original
+
+      expect { subject.call }.to change(Decidim::ActionLog, :count)
+      action_log = Decidim::ActionLog.last
+      expect(action_log.version).to be_present
+    end
+  end
+end

--- a/decidim-admin/spec/commands/decidim/admin/deactivate_participatory_space_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/deactivate_participatory_space_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Admin
+  describe DeactivateParticipatorySpace do
+    subject { described_class.new(participatory_space, user) }
+
+    let(:organization) { create :organization }
+    let(:user) { create :user, :admin, :confirmed, organization: organization }
+    let(:participatory_space) { create :participatory_space, :active, organization: organization }
+
+    it "activates the area" do
+      subject.call
+      participatory_space.reload
+      expect(participatory_space).not_to be_active
+    end
+
+    it "broadcasts ok" do
+      expect do
+        subject.call
+      end.to broadcast(:ok)
+    end
+
+    it "traces the action", versioning: true do
+      expect(Decidim.traceability)
+        .to receive(:perform_action!)
+        .with(
+          "deactivate",
+          participatory_space,
+          user,
+          manifest_name: participatory_space.manifest_name
+        )
+        .and_call_original
+
+      expect { subject.call }.to change(Decidim::ActionLog, :count)
+      action_log = Decidim::ActionLog.last
+      expect(action_log.version).to be_present
+    end
+  end
+end

--- a/decidim-admin/spec/commands/decidim/admin/publish_participatory_space_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/publish_participatory_space_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Admin
+  describe PublishParticipatorySpace do
+    subject { described_class.new(participatory_space, user) }
+
+    let(:organization) { create :organization }
+    let(:user) { create :user, :admin, :confirmed, organization: organization }
+    let(:participatory_space) { create :participatory_space, :active, organization: organization }
+
+    it "activates the area" do
+      subject.call
+      participatory_space.reload
+      expect(participatory_space).to be_published
+    end
+
+    it "broadcasts ok" do
+      expect do
+        subject.call
+      end.to broadcast(:ok)
+    end
+
+    it "traces the action", versioning: true do
+      expect(Decidim.traceability)
+        .to receive(:perform_action!)
+        .with(
+          "publish",
+          participatory_space,
+          user,
+          manifest_name: participatory_space.manifest_name
+        )
+        .and_call_original
+
+      expect { subject.call }.to change(Decidim::ActionLog, :count)
+      action_log = Decidim::ActionLog.last
+      expect(action_log.version).to be_present
+    end
+  end
+end

--- a/decidim-admin/spec/commands/decidim/admin/unpublish_participatory_space_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/unpublish_participatory_space_spec.rb
@@ -13,7 +13,7 @@ module Decidim::Admin
     it "activates the area" do
       subject.call
       participatory_space.reload
-      expect(participatory_space).to be_published
+      expect(participatory_space).to be_active
     end
 
     it "broadcasts ok" do

--- a/decidim-admin/spec/commands/decidim/admin/unpublish_participatory_space_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/unpublish_participatory_space_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Admin
+  describe UnpublishParticipatorySpace do
+    subject { described_class.new(participatory_space, user) }
+
+    let(:organization) { create :organization }
+    let(:user) { create :user, :admin, :confirmed, organization: organization }
+    let(:participatory_space) { create :participatory_space, :published, organization: organization }
+
+    it "activates the area" do
+      subject.call
+      participatory_space.reload
+      expect(participatory_space).to be_published
+    end
+
+    it "broadcasts ok" do
+      expect do
+        subject.call
+      end.to broadcast(:ok)
+    end
+
+    it "traces the action", versioning: true do
+      expect(Decidim.traceability)
+        .to receive(:perform_action!)
+        .with(
+          "unpublish",
+          participatory_space,
+          user,
+          manifest_name: participatory_space.manifest_name
+        )
+        .and_call_original
+
+      expect { subject.call }.to change(Decidim::ActionLog, :count)
+      action_log = Decidim::ActionLog.last
+      expect(action_log.version).to be_present
+    end
+  end
+end

--- a/decidim-admin/spec/helpers/menu_helper_spec.rb
+++ b/decidim-admin/spec/helpers/menu_helper_spec.rb
@@ -15,20 +15,50 @@ module Decidim
           allow(view).to receive(:can?).and_return(true)
         end
 
-        it "renders the default main menu" do
-          expect(default_main_menu).to \
-            have_selector("li", count: 11) &
-            have_link("Dashboard", href: "/admin/") &
-            have_link("Processes", href: "/admin/participatory_processes") &
-            have_link("Process groups", href: "/admin/participatory_process_groups") &
-            have_link("Assemblies", href: "/admin/assemblies") &
-            have_link("Consultations", href: "/admin/consultations") &
-            have_link("Pages", href: "/admin/static_pages") &
-            have_link("Users", href: "/admin/users") &
-            have_link("Newsletters", href: "/admin/newsletters") &
-            have_link("Settings", href: "/admin/organization/edit") &
-            have_link("Admin activity log", href: "/admin/logs") &
-            have_link("OAuth applications", href: "/admin/oauth_applications")
+        RSpec::Matchers.define_negated_matcher :have_no_link, :have_link
+
+        context "when all spaces are inactive" do
+          it "renders the default main menu" do
+            expect(default_main_menu).to \
+              have_selector("li", count: 7) &
+              have_link("Dashboard", href: "/admin/") &
+              have_link("Pages", href: "/admin/static_pages") &
+              have_link("Users", href: "/admin/users") &
+              have_link("Newsletters", href: "/admin/newsletters") &
+              have_link("Settings", href: "/admin/organization/edit") &
+              have_link("Admin activity log", href: "/admin/logs") &
+              have_link("OAuth applications", href: "/admin/oauth_applications")
+
+            expect(default_main_menu).to \
+              have_no_link("Processes", href: "/admin/participatory_processes") &
+              have_no_link("Process groups", href: "/admin/participatory_process_groups") &
+              have_no_link("Assemblies", href: "/admin/assemblies") &
+              have_no_link("Consultations", href: "/admin/consultations")
+          end
+        end
+
+        context "when all spaces are active" do
+          before do
+            create :participatory_space, :active, organization: current_organization, manifest_name: :participatory_processes
+            create :participatory_space, :active, organization: current_organization, manifest_name: :assemblies
+            create :participatory_space, :active, organization: current_organization, manifest_name: :consultations
+          end
+
+          it "renders the default main menu" do
+            expect(default_main_menu).to \
+              have_selector("li", count: 11) &
+              have_link("Dashboard", href: "/admin/") &
+              have_link("Processes", href: "/admin/participatory_processes") &
+              have_link("Process groups", href: "/admin/participatory_process_groups") &
+              have_link("Assemblies", href: "/admin/assemblies") &
+              have_link("Consultations", href: "/admin/consultations") &
+              have_link("Pages", href: "/admin/static_pages") &
+              have_link("Users", href: "/admin/users") &
+              have_link("Newsletters", href: "/admin/newsletters") &
+              have_link("Settings", href: "/admin/organization/edit") &
+              have_link("Admin activity log", href: "/admin/logs") &
+              have_link("OAuth applications", href: "/admin/oauth_applications")
+          end
         end
 
         it "selects the correct default active option" do

--- a/decidim-admin/spec/system/admin_manages_participatory_spaces_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_participatory_spaces_spec.rb
@@ -5,11 +5,17 @@ require "spec_helper"
 describe "Admin manages participatory spaces", type: :system do
   let(:admin) { create :user, :admin, :confirmed }
   let(:organization) { admin.organization }
+  let(:space) do
+    Decidim
+      .find_participatory_space_manifest(:assemblies)
+      .space_for(organization)
+  end
+  let(:assemblies_row) { ".card table tbody tr:first-child" }
 
   it "can list all spaces" do
     visit_spaces_list
 
-    within ".card table tbody tr:first-child" do
+    within assemblies_row do
       expect(page).to have_content("Assemblies") & have_content("Inactive")
     end
     within ".card table tbody tr:nth-child(2)" do
@@ -24,13 +30,66 @@ describe "Admin manages participatory spaces", type: :system do
     it "activates the space" do
       visit_spaces_list
 
-      within ".card table tbody tr:first-child" do
+      within assemblies_row do
         click_link "Activate"
       end
 
       expect(page).to have_admin_callout("successfully")
 
-      within ".card table tbody tr:first-child" do
+      within assemblies_row do
+        expect(page).to have_content("Assemblies") & have_content("Active")
+      end
+    end
+  end
+
+  context "when deactivating an active space" do
+    it "activates the space" do
+      space.activate!
+      visit_spaces_list
+
+      within assemblies_row do
+        click_link "Deactivate"
+      end
+
+      expect(page).to have_admin_callout("successfully")
+
+      within assemblies_row do
+        expect(page).to have_content("Assemblies") & have_content("Inactive")
+      end
+    end
+  end
+
+  context "when publishing an active space" do
+    it "activates the space" do
+      space.activate!
+      visit_spaces_list
+
+      within assemblies_row do
+        click_link "Publish"
+      end
+
+      expect(page).to have_admin_callout("successfully")
+
+      within assemblies_row do
+        expect(page).to have_content("Assemblies") & have_content("Published")
+      end
+    end
+  end
+
+  context "when unpublishing an active space" do
+    it "activates the space" do
+      space.activate!
+      space.publish!
+
+      visit_spaces_list
+
+      within assemblies_row do
+        click_link "Unpublish"
+      end
+
+      expect(page).to have_admin_callout("successfully")
+
+      within assemblies_row do
         expect(page).to have_content("Assemblies") & have_content("Active")
       end
     end

--- a/decidim-admin/spec/system/admin_manages_participatory_spaces_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_participatory_spaces_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin manages participatory spaces", type: :system do
+  let(:admin) { create :user, :admin, :confirmed }
+  let(:organization) { admin.organization }
+
+  it "can list all spaces" do
+    visit_spaces_list
+
+    within ".card table tbody tr:first-child" do
+      expect(page).to have_content("Assemblies") & have_content("Inactive")
+    end
+    within ".card table tbody tr:nth-child(2)" do
+      expect(page).to have_content("Consultations") & have_content("Inactive")
+    end
+    within ".card table tbody tr:last-child" do
+      expect(page).to have_content("Processes") & have_content("Inactive")
+    end
+  end
+
+  context "when activating an inactive space" do
+    it "activates the space" do
+      visit_spaces_list
+
+      within ".card table tbody tr:first-child" do
+        click_link "Activate"
+      end
+
+      expect(page).to have_admin_callout("successfully")
+
+      within ".card table tbody tr:first-child" do
+        expect(page).to have_content("Assemblies") & have_content("Active")
+      end
+    end
+  end
+
+  def visit_spaces_list
+    switch_to_host(organization.host)
+    login_as admin, scope: :user
+    visit decidim_admin.root_path
+    click_link "Settings"
+    click_link "Participatory spaces"
+  end
+end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/application_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/application_controller.rb
@@ -5,6 +5,9 @@ module Decidim
     module Admin
       # The main admin application controller for assemblies
       class ApplicationController < Decidim::Admin::ApplicationController
+        def current_participatory_space_manifest_name
+          :assemblies
+        end
       end
     end
   end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
@@ -9,6 +9,8 @@ module Decidim
         helper_method :current_assembly, :parent_assembly, :parent_assemblies, :current_participatory_space
         layout "decidim/admin/assemblies"
 
+        include Concerns::AssemblyAdmin
+
         def index
           authorize! :index, Decidim::Assembly
           @assemblies = collection
@@ -110,6 +112,10 @@ module Decidim
             hero_image: current_assembly.hero_image,
             banner_image: current_assembly.banner_image
           }.merge(params[:assembly].to_unsafe_h)
+        end
+
+        def current_participatory_space_manifest_name
+          :assemblies
         end
       end
     end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
@@ -5,11 +5,9 @@ module Decidim
     module Admin
       # Controller that allows managing assemblies.
       #
-      class AssembliesController < Decidim::Admin::ApplicationController
+      class AssembliesController < Decidim::Assemblies::Admin::ApplicationController
         helper_method :current_assembly, :parent_assembly, :parent_assemblies, :current_participatory_space
         layout "decidim/admin/assemblies"
-
-        include Concerns::AssemblyAdmin
 
         def index
           authorize! :index, Decidim::Assembly

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_attachment_collections_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_attachment_collections_controller.rb
@@ -20,6 +20,10 @@ module Decidim
         def authorization_object
           @attachment_collection || AttachmentCollection
         end
+
+        def current_participatory_space_manifest_name
+          :assemblies
+        end
       end
     end
   end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_attachments_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_attachments_controller.rb
@@ -21,6 +21,10 @@ module Decidim
         def authorization_object
           @attachment || Attachment
         end
+
+        def current_participatory_space_manifest_name
+          :assemblies
+        end
       end
     end
   end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_copies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_copies_controller.rb
@@ -29,6 +29,10 @@ module Decidim
             end
           end
         end
+
+        def current_participatory_space_manifest_name
+          :assemblies
+        end
       end
     end
   end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_publications_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_publications_controller.rb
@@ -39,6 +39,10 @@ module Decidim
             redirect_back(fallback_location: assemblies_path)
           end
         end
+
+        def current_participatory_space_manifest_name
+          :assemblies
+        end
       end
     end
   end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_user_roles_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_user_roles_controller.rb
@@ -95,6 +95,10 @@ module Decidim
                           .where(assembly: current_assembly)
                           .order(:role, "decidim_users.name")
         end
+
+        def current_participatory_space_manifest_name
+          :assemblies
+        end
       end
     end
   end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/categories_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/categories_controller.rb
@@ -7,6 +7,10 @@ module Decidim
       #
       class CategoriesController < Decidim::Admin::CategoriesController
         include Concerns::AssemblyAdmin
+
+        def current_participatory_space_manifest_name
+          :assemblies
+        end
       end
     end
   end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/component_permissions_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/component_permissions_controller.rb
@@ -8,6 +8,10 @@ module Decidim
       #
       class ComponentPermissionsController < Decidim::Admin::ComponentPermissionsController
         include Concerns::AssemblyAdmin
+
+        def current_participatory_space_manifest_name
+          :assemblies
+        end
       end
     end
   end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/components_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/components_controller.rb
@@ -8,6 +8,10 @@ module Decidim
       #
       class ComponentsController < Decidim::Admin::ComponentsController
         include Concerns::AssemblyAdmin
+
+        def current_participatory_space_manifest_name
+          :assemblies
+        end
       end
     end
   end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/concerns/assembly_admin.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/concerns/assembly_admin.rb
@@ -29,6 +29,10 @@ module Decidim
           def organization_assemblies
             @organization_assemblies ||= OrganizationAssemblies.new(current_organization).query
           end
+
+          def current_participatory_space_manifest_name
+            :assemblies
+          end
         end
       end
     end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/exports_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/exports_controller.rb
@@ -8,6 +8,10 @@ module Decidim
       # an assembly.
       class ExportsController < Decidim::Admin::ExportsController
         include Concerns::AssemblyAdmin
+
+        def current_participatory_space_manifest_name
+          :assemblies
+        end
       end
     end
   end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/moderations_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/moderations_controller.rb
@@ -6,6 +6,10 @@ module Decidim
       # This controller allows admins to manage moderations in an assembly.
       class ModerationsController < Decidim::Admin::ModerationsController
         include Concerns::AssemblyAdmin
+
+        def current_participatory_space_manifest_name
+          :assemblies
+        end
       end
     end
   end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/participatory_space_private_users_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/participatory_space_private_users_controller.rb
@@ -20,6 +20,10 @@ module Decidim
         def authorization_object
           @participatory_space_private_user || ParticipatorySpacePrivateUser
         end
+
+        def current_participatory_space_manifest_name
+          :assemblies
+        end
       end
     end
   end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/assemblies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/assemblies_controller.rb
@@ -57,6 +57,10 @@ module Decidim
       def assembly_participatory_processes
         @assembly_participatory_processes ||= @current_participatory_space.linked_participatory_space_resources(:participatory_processes, "included_participatory_processes")
       end
+
+      def current_participatory_space_manifest_name
+        :assemblies
+      end
     end
   end
 end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/assembly_widgets_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/assembly_widgets_controller.rb
@@ -18,6 +18,10 @@ module Decidim
       def iframe_url
         @iframe_url ||= assembly_assembly_widget_url(model)
       end
+
+      def current_participatory_space_manifest_name
+        :assemblies
+      end
     end
   end
 end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/categories_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/categories_controller.rb
@@ -7,6 +7,10 @@ module Decidim
       #
       class CategoriesController < Decidim::Admin::CategoriesController
         include Concerns::AssemblyAdmin
+
+        def current_participatory_space_manifest_name
+          :assemblies
+        end
       end
     end
   end

--- a/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
@@ -87,7 +87,8 @@ module Decidim
                     icon_name: "dial",
                     position: 3.5,
                     active: :inclusive,
-                    if: can?(:read, Decidim::Assembly) && Decidim.find_participatory_space_manifest(:assemblies).space_for(current_organization).active?
+                    if: can?(:read, Decidim::Assembly) &&
+                        Decidim.find_participatory_space_manifest(:assemblies).space_for(current_organization).active?
         end
       end
     end

--- a/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
@@ -87,7 +87,7 @@ module Decidim
                     icon_name: "dial",
                     position: 3.5,
                     active: :inclusive,
-                    if: can?(:read, Decidim::Assembly)
+                    if: can?(:read, Decidim::Assembly) && Decidim.find_participatory_space_manifest(:assemblies).space_for(current_organization).active?
         end
       end
     end

--- a/decidim-assemblies/lib/decidim/assemblies/engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/engine.rb
@@ -64,7 +64,7 @@ module Decidim
           menu.item I18n.t("menu.assemblies", scope: "decidim"),
                     decidim_assemblies.assemblies_path,
                     position: 2.5,
-                    if: Decidim::Assembly.where(organization: current_organization).published.any?,
+                    if: Decidim::Assembly.where(organization: current_organization).published.any? && Decidim.find_participatory_space_manifest(:assemblies).space_for(current_organization).published?,
                     active: :inclusive
         end
       end

--- a/decidim-assemblies/lib/decidim/assemblies/engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/engine.rb
@@ -64,7 +64,8 @@ module Decidim
           menu.item I18n.t("menu.assemblies", scope: "decidim"),
                     decidim_assemblies.assemblies_path,
                     position: 2.5,
-                    if: Decidim::Assembly.where(organization: current_organization).published.any? && Decidim.find_participatory_space_manifest(:assemblies).space_for(current_organization).published?,
+                    if: Decidim::Assembly.where(organization: current_organization).published.any? &&
+                        Decidim.find_participatory_space_manifest(:assemblies).space_for(current_organization).published?,
                     active: :inclusive
         end
       end

--- a/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
@@ -48,7 +48,7 @@ FactoryBot.define do
 
     after(:create) do |assembly, _evaluator|
       space = Decidim::ParticipatorySpace
-              .find_or_create_by(organization: assembly.organization, manifest_name: :assemblies)
+              .find_or_initialize_by(organization: assembly.organization, manifest_name: :assemblies)
       space.activate!
       space.publish!
     end

--- a/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
@@ -46,9 +46,9 @@ FactoryBot.define do
     youtube_handler { "others" }
     github_handler { "others" }
 
-    after(:create) do |assembly, evaluator|
+    after(:create) do |assembly, _evaluator|
       space = Decidim::ParticipatorySpace
-        .find_or_create_by(organization: assembly.organization, manifest_name: :assemblies)
+              .find_or_create_by(organization: assembly.organization, manifest_name: :assemblies)
       space.activate!
       space.publish!
     end

--- a/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
@@ -46,6 +46,13 @@ FactoryBot.define do
     youtube_handler { "others" }
     github_handler { "others" }
 
+    after(:create) do |assembly, evaluator|
+      space = Decidim::ParticipatorySpace
+        .find_or_create_by(organization: assembly.organization, manifest_name: :assemblies)
+      space.activate!
+      space.publish!
+    end
+
     trait :promoted do
       promoted true
     end

--- a/decidim-consultations/app/controllers/decidim/consultations/admin/application_controller.rb
+++ b/decidim-consultations/app/controllers/decidim/consultations/admin/application_controller.rb
@@ -8,7 +8,7 @@ module Decidim
         layout "decidim/admin/consultations"
 
         helper Decidim::SanitizeHelper
-        
+
         def current_participatory_space_manifest_name
           :consultations
         end

--- a/decidim-consultations/app/controllers/decidim/consultations/admin/application_controller.rb
+++ b/decidim-consultations/app/controllers/decidim/consultations/admin/application_controller.rb
@@ -8,6 +8,10 @@ module Decidim
         layout "decidim/admin/consultations"
 
         helper Decidim::SanitizeHelper
+        
+        def current_participatory_space_manifest_name
+          :consultations
+        end
       end
     end
   end

--- a/decidim-consultations/app/controllers/decidim/consultations/admin/categories_controller.rb
+++ b/decidim-consultations/app/controllers/decidim/consultations/admin/categories_controller.rb
@@ -7,6 +7,10 @@ module Decidim
       #
       class CategoriesController < Decidim::Admin::CategoriesController
         include QuestionAdmin
+
+        def current_participatory_space_manifest_name
+          :consultations
+        end
       end
     end
   end

--- a/decidim-consultations/app/controllers/decidim/consultations/admin/component_permissions_controller.rb
+++ b/decidim-consultations/app/controllers/decidim/consultations/admin/component_permissions_controller.rb
@@ -7,6 +7,10 @@ module Decidim
       # permissions in the admin panel.
       class ComponentPermissionsController < Decidim::Admin::ComponentPermissionsController
         include QuestionAdmin
+
+        def current_participatory_space_manifest_name
+          :consultations
+        end
       end
     end
   end

--- a/decidim-consultations/app/controllers/decidim/consultations/admin/components_controller.rb
+++ b/decidim-consultations/app/controllers/decidim/consultations/admin/components_controller.rb
@@ -7,6 +7,10 @@ module Decidim
       # admin panel.
       class ComponentsController < Decidim::Admin::ComponentsController
         include QuestionAdmin
+
+        def current_participatory_space_manifest_name
+          :consultations
+        end
       end
     end
   end

--- a/decidim-consultations/app/controllers/decidim/consultations/admin/consultation_publications_controller.rb
+++ b/decidim-consultations/app/controllers/decidim/consultations/admin/consultation_publications_controller.rb
@@ -38,6 +38,10 @@ module Decidim
             redirect_back(fallback_location: consultations_path)
           end
         end
+
+        def current_participatory_space_manifest_name
+          :consultations
+        end
       end
     end
   end

--- a/decidim-consultations/app/controllers/decidim/consultations/admin/consultation_results_publications_controller.rb
+++ b/decidim-consultations/app/controllers/decidim/consultations/admin/consultation_results_publications_controller.rb
@@ -38,6 +38,10 @@ module Decidim
             redirect_back(fallback_location: consultations_path)
           end
         end
+
+        def current_participatory_space_manifest_name
+          :consultations
+        end
       end
     end
   end

--- a/decidim-consultations/app/controllers/decidim/consultations/admin/consultations_controller.rb
+++ b/decidim-consultations/app/controllers/decidim/consultations/admin/consultations_controller.rb
@@ -94,6 +94,10 @@ module Decidim
         def consultation_form
           form(ConsultationForm)
         end
+
+        def current_participatory_space_manifest_name
+          :consultations
+        end
       end
     end
   end

--- a/decidim-consultations/app/controllers/decidim/consultations/admin/question_attachments_controller.rb
+++ b/decidim-consultations/app/controllers/decidim/consultations/admin/question_attachments_controller.rb
@@ -19,6 +19,10 @@ module Decidim
         def authorization_object
           collection.find_by(id: params[:id]) || Decidim::Attachment
         end
+
+        def current_participatory_space_manifest_name
+          :consultations
+        end
       end
     end
   end

--- a/decidim-consultations/app/controllers/decidim/consultations/admin/question_publications_controller.rb
+++ b/decidim-consultations/app/controllers/decidim/consultations/admin/question_publications_controller.rb
@@ -38,6 +38,10 @@ module Decidim
             redirect_back(fallback_location: consultation_questions_path(current_consultation))
           end
         end
+
+        def current_participatory_space_manifest_name
+          :consultations
+        end
       end
     end
   end

--- a/decidim-consultations/app/controllers/decidim/consultations/admin/questions_controller.rb
+++ b/decidim-consultations/app/controllers/decidim/consultations/admin/questions_controller.rb
@@ -82,6 +82,10 @@ module Decidim
         def question_form
           form(QuestionForm)
         end
+
+        def current_participatory_space_manifest_name
+          :consultations
+        end
       end
     end
   end

--- a/decidim-consultations/app/controllers/decidim/consultations/admin/responses_controller.rb
+++ b/decidim-consultations/app/controllers/decidim/consultations/admin/responses_controller.rb
@@ -79,6 +79,10 @@ module Decidim
         def response_form
           form(ResponseForm)
         end
+
+        def current_participatory_space_manifest_name
+          :consultations
+        end
       end
     end
   end

--- a/decidim-consultations/app/controllers/decidim/consultations/consultation_widgets_controller.rb
+++ b/decidim-consultations/app/controllers/decidim/consultations/consultation_widgets_controller.rb
@@ -20,6 +20,10 @@ module Decidim
       def iframe_url
         @iframe_url ||= consultation_consultation_widget_url(model)
       end
+
+      def current_participatory_space_manifest_name
+        :consultations
+      end
     end
   end
 end

--- a/decidim-consultations/app/controllers/decidim/consultations/consultations_controller.rb
+++ b/decidim-consultations/app/controllers/decidim/consultations/consultations_controller.rb
@@ -70,6 +70,10 @@ module Decidim
           current_user: current_user
         }
       end
+
+      def current_participatory_space_manifest_name
+        :consultations
+      end
     end
   end
 end

--- a/decidim-consultations/app/controllers/decidim/consultations/question_votes_controller.rb
+++ b/decidim-consultations/app/controllers/decidim/consultations/question_votes_controller.rb
@@ -35,6 +35,10 @@ module Decidim
           end
         end
       end
+
+      def current_participatory_space_manifest_name
+        :consultations
+      end
     end
   end
 end

--- a/decidim-consultations/app/controllers/decidim/consultations/question_widgets_controller.rb
+++ b/decidim-consultations/app/controllers/decidim/consultations/question_widgets_controller.rb
@@ -21,6 +21,10 @@ module Decidim
       def iframe_url
         @iframe_url ||= question_question_widget_url(model)
       end
+
+      def current_participatory_space_manifest_name
+        :consultations
+      end
     end
   end
 end

--- a/decidim-consultations/app/controllers/decidim/consultations/questions_controller.rb
+++ b/decidim-consultations/app/controllers/decidim/consultations/questions_controller.rb
@@ -18,6 +18,10 @@ module Decidim
       def show
         authorize! :read, current_question
       end
+
+      def current_participatory_space_manifest_name
+        :consultations
+      end
     end
   end
 end

--- a/decidim-consultations/lib/decidim/consultations/admin_engine.rb
+++ b/decidim-consultations/lib/decidim/consultations/admin_engine.rb
@@ -64,7 +64,8 @@ module Decidim
                     icon_name: "comment-square",
                     position: 3.8,
                     active: :inclusive,
-                    if: can?(:index, Decidim::Consultation) && Decidim.find_participatory_space_manifest(:consultations).space_for(current_organization).active?
+                    if: can?(:index, Decidim::Consultation) &&
+                        Decidim.find_participatory_space_manifest(:consultations).space_for(current_organization).active?
         end
       end
     end

--- a/decidim-consultations/lib/decidim/consultations/admin_engine.rb
+++ b/decidim-consultations/lib/decidim/consultations/admin_engine.rb
@@ -64,7 +64,7 @@ module Decidim
                     icon_name: "comment-square",
                     position: 3.8,
                     active: :inclusive,
-                    if: can?(:index, Decidim::Consultation)
+                    if: can?(:index, Decidim::Consultation) && Decidim.find_participatory_space_manifest(:consultations).space_for(current_organization).active?
         end
       end
     end

--- a/decidim-consultations/lib/decidim/consultations/engine.rb
+++ b/decidim-consultations/lib/decidim/consultations/engine.rb
@@ -74,7 +74,8 @@ module Decidim
           menu.item I18n.t("menu.consultations", scope: "decidim"),
                     decidim_consultations.consultations_path,
                     position: 2.7,
-                    if: Decidim::Consultation.where(organization: current_organization).published.any? && Decidim.find_participatory_space_manifest(:consultations).space_for(current_organization).published?,
+                    if: Decidim::Consultation.where(organization: current_organization).published.any? &&
+                        Decidim.find_participatory_space_manifest(:consultations).space_for(current_organization).published?,
                     active: :inclusive
         end
       end

--- a/decidim-consultations/lib/decidim/consultations/engine.rb
+++ b/decidim-consultations/lib/decidim/consultations/engine.rb
@@ -74,7 +74,7 @@ module Decidim
           menu.item I18n.t("menu.consultations", scope: "decidim"),
                     decidim_consultations.consultations_path,
                     position: 2.7,
-                    if: Decidim::Consultation.where(organization: current_organization).published.any?,
+                    if: Decidim::Consultation.where(organization: current_organization).published.any? && Decidim.find_participatory_space_manifest(:consultations).space_for(current_organization).published?,
                     active: :inclusive
         end
       end

--- a/decidim-consultations/lib/decidim/consultations/test/factories.rb
+++ b/decidim-consultations/lib/decidim/consultations/test/factories.rb
@@ -26,9 +26,9 @@ FactoryBot.define do
     decidim_highlighted_scope_id { create(:scope, organization: organization).id }
     results_published_at nil
 
-    after(:create) do |consultation, evaluator|
+    after(:create) do |consultation, _evaluator|
       space = Decidim::ParticipatorySpace
-        .find_or_create_by(organization: consultation.organization, manifest_name: :consultations)
+              .find_or_create_by(organization: consultation.organization, manifest_name: :consultations)
       space.activate!
       space.publish!
     end

--- a/decidim-consultations/lib/decidim/consultations/test/factories.rb
+++ b/decidim-consultations/lib/decidim/consultations/test/factories.rb
@@ -26,6 +26,13 @@ FactoryBot.define do
     decidim_highlighted_scope_id { create(:scope, organization: organization).id }
     results_published_at nil
 
+    after(:create) do |consultation, evaluator|
+      space = Decidim::ParticipatorySpace
+        .find_or_create_by(organization: consultation.organization, manifest_name: :consultations)
+      space.activate!
+      space.publish!
+    end
+
     trait :unpublished do
       published_at nil
     end

--- a/decidim-consultations/lib/decidim/consultations/test/factories.rb
+++ b/decidim-consultations/lib/decidim/consultations/test/factories.rb
@@ -28,7 +28,7 @@ FactoryBot.define do
 
     after(:create) do |consultation, _evaluator|
       space = Decidim::ParticipatorySpace
-              .find_or_create_by(organization: consultation.organization, manifest_name: :consultations)
+              .find_or_initialize_by(organization: consultation.organization, manifest_name: :consultations)
       space.activate!
       space.publish!
     end

--- a/decidim-core/app/controllers/concerns/decidim/participatory_space_context.rb
+++ b/decidim-core/app/controllers/concerns/decidim/participatory_space_context.rb
@@ -30,13 +30,22 @@ module Decidim
       helper_method :current_participatory_space_manifest
       helper_method :current_participatory_space_context
 
-      delegate :manifest, to: :current_participatory_space, prefix: true
+      before_action :space_is_published?
     end
 
     private
 
+    def current_participatory_space_manifest_name
+      nil
+    end
+
     def current_participatory_space_context
       :public
+    end
+
+    def current_participatory_space_manifest
+      @current_participatory_space_manifest ||=
+        Decidim.find_participatory_space_manifest(current_participatory_space_manifest_name)
     end
 
     def current_participatory_space
@@ -70,6 +79,12 @@ module Decidim
       return if current_user_can_visit_space?
       flash[:alert] = I18n.t("participatory_space_private_users.not_allowed", scope: "decidim")
       redirect_to action: "index"
+    end
+
+    def space_is_published?
+      return true if current_participatory_space_manifest.space_for(current_organization).published?
+
+      raise ActionController::RoutingError, "Space is not published"
     end
   end
 end

--- a/decidim-core/app/controllers/decidim/components/base_controller.rb
+++ b/decidim-core/app/controllers/decidim/components/base_controller.rb
@@ -34,6 +34,8 @@ module Decidim
       end
       before_action :redirect_unless_feature_private
 
+      delegate :manifest, to: :current_participatory_space, prefix: true
+
       def current_participatory_space
         request.env["decidim.current_participatory_space"]
       end

--- a/decidim-core/app/models/decidim/participatory_space.rb
+++ b/decidim-core/app/models/decidim/participatory_space.rb
@@ -27,7 +27,7 @@ module Decidim
     def state
       return :published if published?
       return :active if active?
-      return :inactive
+      :inactive
     end
   end
 end

--- a/decidim-core/app/models/decidim/participatory_space.rb
+++ b/decidim-core/app/models/decidim/participatory_space.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Decidim
+  # A ParticipatorySpace resource holds logic related to that space. It's mostly
+  # used to handle whether that space should be active and published. Comparing
+  # it to the `Component` class, multiple components of the same type can exist
+  # per space and per organization, while for `ParticipatorySpace` there can
+  # only be one of each kind per organization. This causes all elements of a
+  # component to be related to that component (eg all `Proposals` belong to
+  # their `component`), while for spaces this is not necessary.
+  class ParticipatorySpace < ApplicationRecord
+    include Publicable
+    include Activable
+
+    belongs_to :organization,
+               foreign_key: "decidim_organization_id",
+               class_name: "Decidim::Organization"
+
+    validates :published_at, absence: true, if: proc { |space| !space.active? }
+  end
+end

--- a/decidim-core/app/models/decidim/participatory_space.rb
+++ b/decidim-core/app/models/decidim/participatory_space.rb
@@ -9,6 +9,8 @@ module Decidim
   # component to be related to that component (eg all `Proposals` belong to
   # their `component`), while for spaces this is not necessary.
   class ParticipatorySpace < ApplicationRecord
+    include Loggable
+    include Traceable
     include Publicable
     include Activable
 
@@ -17,5 +19,15 @@ module Decidim
                class_name: "Decidim::Organization"
 
     validates :published_at, absence: true, if: proc { |space| !space.active? }
+
+    def self.log_presenter_class_for(_log)
+      Decidim::AdminLog::ParticipatorySpacePresenter
+    end
+
+    def state
+      return :published if published?
+      return :active if active?
+      return :inactive
+    end
   end
 end

--- a/decidim-core/app/presenters/decidim/admin_log/participatory_space_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/participatory_space_presenter.rb
@@ -44,7 +44,7 @@ module Decidim
       end
 
       def has_diff?
-        ["activate", "deactivate"].include? action
+        %w(activate deactivate publish unpublish).include? action
       end
     end
   end

--- a/decidim-core/app/presenters/decidim/admin_log/participatory_space_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/participatory_space_presenter.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Decidim
+  module AdminLog
+    # This class holds the logic to present a `Decidim::ParticipatorySpace`
+    # for the `AdminLog` log.
+    #
+    # Usage should be automatic and you shouldn't need to call this class
+    # directly, but here's an example:
+    #
+    #    action_log = Decidim::ActionLog.last
+    #    view_helpers # => this comes from the views
+    #    ParticipatorySpacePresenter.new(action_log, view_helpers).present
+    class ParticipatorySpacePresenter < Decidim::Log::BasePresenter
+      private
+
+      def diff_fields_mapping
+        {
+          activated_at: :date
+        }
+      end
+
+      def action_string
+        case action
+        when "activate"
+          "decidim.admin_log.participatory_space.#{action}"
+        else
+          super
+        end
+      end
+
+      # Private: Caches the object that will be responsible of presenting the participatory space.
+      # Overwrites the method so that we can use a custom presenter to show the correct
+      # path for the space.
+      #
+      # Returns an object that responds to `present`.
+      def resource_presenter
+        @resource_presenter ||= Decidim::AdminLog::ParticipatorySpaceResourcePresenter.new(action_log.resource, h, action_log.extra["resource"])
+      end
+
+      def i18n_labels_scope
+        "activemodel.attributes.participatory_space"
+      end
+
+      def has_diff?
+        ["activate"].include? action
+      end
+    end
+  end
+end

--- a/decidim-core/app/presenters/decidim/admin_log/participatory_space_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/participatory_space_presenter.rb
@@ -16,13 +16,14 @@ module Decidim
 
       def diff_fields_mapping
         {
-          activated_at: :date
+          activated_at: :date,
+          published_at: :date
         }
       end
 
       def action_string
         case action
-        when "activate"
+        when "activate", "deactivate", "publish", "unpublished"
           "decidim.admin_log.participatory_space.#{action}"
         else
           super
@@ -43,7 +44,7 @@ module Decidim
       end
 
       def has_diff?
-        ["activate"].include? action
+        ["activate", "deactivate"].include? action
       end
     end
   end

--- a/decidim-core/app/presenters/decidim/admin_log/participatory_space_resource_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/participatory_space_resource_presenter.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Decidim
+  module AdminLog
+    # This class extends the default resource presenter for logs, so that
+    # it can properly link to the participatory space.
+    class ParticipatorySpaceResourcePresenter < Decidim::Log::ResourcePresenter
+      private
+
+      # Private: Finds the public name for the given participatory space.
+      #
+      # Returns an HTML-safe String.
+      def present_resource_name
+        I18n.t(resource.manifest_name, scope: "decidim.admin.menu")
+      end
+    end
+  end
+end

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -84,6 +84,9 @@ en:
         update: "%{user_name} updated the organization settings"
       participatory_space:
         activate: "%{user_name} activated the %{resource_name} participatory space"
+        deactivate: "%{user_name} deactivated the %{resource_name} participatory space"
+        publish: "%{user_name} published the %{resource_name} participatory space"
+        unpublish: "%{user_name} unpublished the %{resource_name} participatory space"
       scope:
         create: "%{user_name} created the %{resource_name} scope"
         create_with_parent: "%{user_name} created the %{resource_name} scope inside the %{parent_scope} scope"

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -4,6 +4,8 @@ en:
     attributes:
       account:
         delete_reason: Reason to delete your account
+      participatory_space:
+        activated_at: Activated at
       report:
         details: Additional comments
       user:
@@ -80,6 +82,8 @@ en:
         update: "%{user_name} updated the %{resource_name} OAuth application"
       organization:
         update: "%{user_name} updated the organization settings"
+      participatory_space:
+        activate: "%{user_name} activated the %{resource_name} participatory space"
       scope:
         create: "%{user_name} created the %{resource_name} scope"
         create_with_parent: "%{user_name} created the %{resource_name} scope inside the %{parent_scope} scope"

--- a/decidim-core/db/migrate/20180418085313_add_participatory_spaces.rb
+++ b/decidim-core/db/migrate/20180418085313_add_participatory_spaces.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddParticipatorySpaces < ActiveRecord::Migration[5.1]
+  def change
+    create_table :decidim_participatory_spaces do |t|
+      t.integer :decidim_organization_id, null: false
+      t.string :manifest_name, null: false
+      t.datetime :activated_at
+      t.datetime :published_at
+    end
+  end
+end

--- a/decidim-core/db/migrate/20180418085313_add_participatory_spaces.rb
+++ b/decidim-core/db/migrate/20180418085313_add_participatory_spaces.rb
@@ -1,12 +1,35 @@
 # frozen_string_literal: true
 
 class AddParticipatorySpaces < ActiveRecord::Migration[5.1]
-  def change
+  class ParticipatorySpace < ApplicationRecord
+    self.table_name = :decidim_participatory_spaces
+  end
+
+  class Organization < ApplicationRecord
+    self.table_name = :decidim_organizations
+  end
+
+  def up
     create_table :decidim_participatory_spaces do |t|
       t.integer :decidim_organization_id, null: false
       t.string :manifest_name, null: false
       t.datetime :activated_at
       t.datetime :published_at
     end
+
+    %w(participatory_processes assemblies).each do |space_name|
+      Organization.find_each do |organization|
+        space = ParticipatorySpace.find_or_create_by(
+          organization: organization,
+          manifest_name: space_name
+        )
+        space.activate!
+        space.publish!
+      end
+    end
+  end
+
+  def down
+    drop_table :decidim_participatory_spaces
   end
 end

--- a/decidim-core/db/migrate/20180418085313_add_participatory_spaces.rb
+++ b/decidim-core/db/migrate/20180418085313_add_participatory_spaces.rb
@@ -1,35 +1,12 @@
 # frozen_string_literal: true
 
 class AddParticipatorySpaces < ActiveRecord::Migration[5.1]
-  class ParticipatorySpace < ApplicationRecord
-    self.table_name = :decidim_participatory_spaces
-  end
-
-  class Organization < ApplicationRecord
-    self.table_name = :decidim_organizations
-  end
-
-  def up
+  def change
     create_table :decidim_participatory_spaces do |t|
       t.integer :decidim_organization_id, null: false
       t.string :manifest_name, null: false
       t.datetime :activated_at
       t.datetime :published_at
     end
-
-    %w(participatory_processes assemblies).each do |space_name|
-      Organization.find_each do |organization|
-        space = ParticipatorySpace.find_or_create_by(
-          organization: organization,
-          manifest_name: space_name
-        )
-        space.activate!
-        space.publish!
-      end
-    end
-  end
-
-  def down
-    drop_table :decidim_participatory_spaces
   end
 end

--- a/decidim-core/db/migrate/20180420092713_publish_participatory_spaces.rb
+++ b/decidim-core/db/migrate/20180420092713_publish_participatory_spaces.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class PublishParticipatorySpaces < ActiveRecord::Migration[5.1]
+  class ParticipatorySpace < ApplicationRecord
+    self.table_name = :decidim_participatory_spaces
+  end
+
+  class Organization < ApplicationRecord
+    self.table_name = :decidim_organizations
+  end
+
+  def up
+    %w(participatory_processes assemblies).each do |space_name|
+      Organization.find_each do |organization|
+        space = ParticipatorySpace.find_or_create_by(
+          decidim_organization_id: organization.id,
+          manifest_name: space_name
+        )
+        space.update!(activated_at: Time.current, published_at: Time.current)
+      end
+    end
+  end
+
+  def down; end
+end

--- a/decidim-core/db/migrate/20180420092713_publish_participatory_spaces.rb
+++ b/decidim-core/db/migrate/20180420092713_publish_participatory_spaces.rb
@@ -12,7 +12,7 @@ class PublishParticipatorySpaces < ActiveRecord::Migration[5.1]
   def up
     %w(participatory_processes assemblies).each do |space_name|
       Organization.find_each do |organization|
-        space = ParticipatorySpace.find_or_create_by(
+        space = ParticipatorySpace.find_or_initialize_by(
           decidim_organization_id: organization.id,
           manifest_name: space_name
         )

--- a/decidim-core/lib/decidim/activable.rb
+++ b/decidim-core/lib/decidim/activable.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  # This concern contains the logic related to resource activation .
+  module Activable
+    extend ActiveSupport::Concern
+
+    class_methods do
+      # Public: Scope to return only activated records.
+      #
+      # Returns an ActiveRecord::Relation.
+      def active
+        where.not(activated_at: nil)
+      end
+
+      # Public: Scope to return only non-active records.
+      #
+      # Returns an ActiveRecord::Relation.
+      def inactive
+        where(activated_at: nil)
+      end
+    end
+
+    # Public: Checks whether the record has been activated or not.
+    #
+    # Returns true if active, false otherwise.
+    def active?
+      activated_at.present?
+    end
+
+    #
+    # Public: Activates this component
+    #
+    # Returns true if the record was properly saved, false otherwise.
+    def activate!
+      update!(activated_at: Time.current)
+    end
+
+    #
+    # Public: Deactivates this component
+    #
+    # Returns true if the record was properly saved, false otherwise.
+    def deactivate!
+      update!(activated_at: nil)
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -20,6 +20,7 @@ module Decidim
   autoload :Authorable, "decidim/authorable"
   autoload :Participable, "decidim/participable"
   autoload :Publicable, "decidim/publicable"
+  autoload :Activable, "decidim/activable"
   autoload :Scopable, "decidim/scopable"
   autoload :ScopableComponent, "decidim/scopable_component"
   autoload :ContentParsers, "decidim/content_parsers"

--- a/decidim-core/lib/decidim/core/test.rb
+++ b/decidim-core/lib/decidim/core/test.rb
@@ -2,6 +2,7 @@
 
 require "decidim/core/test/shared_examples/authorable"
 require "decidim/core/test/shared_examples/publicable"
+require "decidim/core/test/shared_examples/activable"
 require "decidim/core/test/shared_examples/localised_email"
 require "decidim/core/test/shared_examples/has_attachments"
 require "decidim/core/test/shared_examples/has_attachment_collections"

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -238,6 +238,20 @@ FactoryBot.define do
     end
   end
 
+  factory :participatory_space, class: "Decidim::ParticipatorySpace" do
+    manifest_name { :my_space }
+    organization
+
+    trait :active do
+      activated_at { Time.current }
+    end
+
+    trait :published do
+      activated_at { Time.current }
+      published_at { Time.current }
+    end
+  end
+
   factory :scope_type, class: "Decidim::ScopeType" do
     name { Decidim::Faker::Localized.word }
     plural { Decidim::Faker::Localized.literal(name.values.first.pluralize) }

--- a/decidim-core/lib/decidim/core/test/shared_examples/activable.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/activable.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+shared_examples_for "activable" do
+  let(:factory_name) { described_class.name.demodulize.underscore.to_sym }
+
+  let(:active) do
+    create(factory_name, :active)
+  end
+
+  let(:inactive) do
+    create(factory_name)
+  end
+
+  describe ".active" do
+    let(:scope) { described_class.active }
+
+    before { active && inactive }
+
+    it { expect(scope).to eq([active]) }
+  end
+
+  describe ".inactive" do
+    let(:scope) { described_class.inactive }
+
+    before { active && inactive }
+
+    it { expect(scope).to eq([inactive]) }
+  end
+end

--- a/decidim-core/lib/decidim/core/test/shared_examples/process_announcements_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/process_announcements_examples.rb
@@ -3,7 +3,7 @@
 shared_examples "manage processes announcements" do
   let!(:participatory_process) { create(:participatory_process, organization: organization) }
 
-  it "customize an general announcement for the process" do
+  it "can customize a general announcement for the process" do
     click_link translated(participatory_process.title)
 
     fill_in_i18n_editor(

--- a/decidim-core/lib/decidim/core/test/shared_examples/publicable.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/publicable.rb
@@ -5,22 +5,26 @@ require "spec_helper"
 shared_examples_for "publicable" do
   let(:factory_name) { described_class.name.demodulize.underscore.to_sym }
 
-  let!(:published) do
+  let(:published) do
     create(factory_name, published_at: Time.zone.now)
   end
 
-  let!(:unpublished) do
+  let(:unpublished) do
     create(factory_name, published_at: nil)
   end
 
   describe ".published" do
     let(:scope) { described_class.send(:published) }
 
+    before { published && unpublished }
+
     it { expect(scope).to eq([published]) }
   end
 
   describe ".unpublished" do
     let(:scope) { described_class.send(:unpublished) }
+
+    before { published && unpublished }
 
     it { expect(scope).to eq([unpublished]) }
   end

--- a/decidim-core/lib/decidim/participable.rb
+++ b/decidim-core/lib/decidim/participable.rb
@@ -64,6 +64,10 @@ module Decidim
       def manifest
         self.class.participatory_space_manifest
       end
+
+      def space
+        manifest.space_for(organization)
+      end
     end
 
     class_methods do

--- a/decidim-core/lib/decidim/participatory_space_manifest.rb
+++ b/decidim-core/lib/decidim/participatory_space_manifest.rb
@@ -85,5 +85,15 @@ module Decidim
     def participatory_spaces(&block)
       @participatory_spaces ||= block
     end
+
+    # Public: Finds the space for the current manifest name and the given
+    # organization.
+    #
+    # organization - a Decidim::Organization
+    #
+    # Returns a Decidim::ParticipatorySpace.
+    def space_for(organization)
+      Decidim::ParticipatorySpace.find_or_create_by(organization: organization, manifest_name: name)
+    end
   end
 end

--- a/decidim-core/lib/decidim/participatory_space_manifest.rb
+++ b/decidim-core/lib/decidim/participatory_space_manifest.rb
@@ -93,7 +93,7 @@ module Decidim
     #
     # Returns a Decidim::ParticipatorySpace.
     def space_for(organization)
-      Decidim::ParticipatorySpace.find_or_create_by(organization: organization, manifest_name: name)
+      Decidim::ParticipatorySpace.find_or_initialize_by(organization: organization, manifest_name: name)
     end
   end
 end

--- a/decidim-core/spec/lib/participatory_space_manifest_spec.rb
+++ b/decidim-core/spec/lib/participatory_space_manifest_spec.rb
@@ -4,7 +4,9 @@ require "spec_helper"
 
 module Decidim
   describe ParticipatorySpaceManifest do
-    subject { described_class.new }
+    subject { described_class.new(name: manifest_name) }
+
+    let(:manifest_name) { :my_space }
 
     describe "#context" do
       it "defines and caches contexts" do
@@ -18,6 +20,23 @@ module Decidim
 
         expect(subject.context(:context1).layout).to eq("layouts/context1")
         expect(subject.context(:context2).layout).to eq("layouts/context2")
+      end
+    end
+
+    describe "#space_for(org)" do
+      let(:organization) { create :organization }
+
+      context "when the space does not exist in the DB" do
+        it "creates a new space in the DB" do
+          expect { subject.space_for(organization) }.to change(Decidim::ParticipatorySpace, :count).by(1)
+        end
+      end
+
+      context "when the space already exists in the DB" do
+        it "finds the space" do
+          space = create :participatory_space, organization: organization, manifest_name: manifest_name
+          expect(subject.space_for(organization)).to eq space
+        end
       end
     end
   end

--- a/decidim-core/spec/models/decidim/participatory_space_spec.rb
+++ b/decidim-core/spec/models/decidim/participatory_space_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe ParticipatorySpace do
+    subject { participatory_space }
+
+    let(:participatory_space) { build(:participatory_space, manifest_name: "dummy") }
+
+    it { is_expected.to be_valid }
+
+    include_examples "activable"
+    include_examples "publicable" do
+      let(:published) do
+        create(:participatory_space, :published)
+      end
+    end
+
+    describe "validations" do
+      it "can't be published if it's not active" do
+        expect { subject.publish! }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Published at must be blank")
+      end
+    end
+  end
+end

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/application_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/application_controller.rb
@@ -5,6 +5,9 @@ module Decidim
     module Admin
       # The main admin application controller for participatory processes
       class ApplicationController < Decidim::Admin::ApplicationController
+        def current_participatory_space_manifest_name
+          :participatory_processes
+        end
       end
     end
   end

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/concerns/participatory_process_admin.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/concerns/participatory_process_admin.rb
@@ -26,6 +26,10 @@ module Decidim
                 organization_processes.find_by!(slug: params[:participatory_process_slug] || params[:slug])
             end
 
+            def current_participatory_space_manifest_name
+              :participatory_processes
+            end
+
             alias_method :current_participatory_process, :current_participatory_space
           end
         end

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_processes_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_processes_controller.rb
@@ -5,7 +5,7 @@ module Decidim
     module Admin
       # Controller that allows managing participatory processes.
       #
-      class ParticipatoryProcessesController < Decidim::Admin::ApplicationController
+      class ParticipatoryProcessesController < Decidim::ParticipatoryProcesses::Admin::ApplicationController
         include Decidim::Admin::ParticipatorySpaceAdminContext
         participatory_space_admin_layout only: [:edit]
 
@@ -105,6 +105,10 @@ module Decidim
             hero_image: current_participatory_process.hero_image,
             banner_image: current_participatory_process.banner_image
           }.merge(params[:participatory_process].to_unsafe_h)
+        end
+
+        def current_participatory_space_manifest_name
+          :participatory_processes
         end
       end
     end

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/application_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/application_controller.rb
@@ -6,6 +6,10 @@ module Decidim
     # this engine inherit.
     class ApplicationController < Decidim::ApplicationController
       helper Decidim::ParticipatoryProcesses::ApplicationHelper
+
+      def current_participatory_space_manifest_name
+        :participatory_processes
+      end
     end
   end
 end

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_process_groups_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_process_groups_controller.rb
@@ -28,6 +28,10 @@ module Decidim
       end
 
       attr_reader :group
+
+      def current_participatory_space_manifest_name
+        :participatory_processes
+      end
     end
   end
 end

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_process_steps_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_process_steps_controller.rb
@@ -23,6 +23,10 @@ module Decidim
           organization_participatory_processes.where(id: params[:participatory_process_slug])
         ).first!
       end
+
+      def current_participatory_space_manifest_name
+        :participatory_processes
+      end
     end
   end
 end

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_process_widgets_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_process_widgets_controller.rb
@@ -22,6 +22,10 @@ module Decidim
       def iframe_url
         @iframe_url ||= participatory_process_participatory_process_widget_url(model)
       end
+
+      def current_participatory_space_manifest_name
+        :participatory_processes
+      end
     end
   end
 end

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
@@ -78,6 +78,10 @@ module Decidim
       def default_filter
         "active"
       end
+
+      def current_participatory_space_manifest_name
+        :participatory_processes
+      end
     end
   end
 end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
@@ -89,14 +89,14 @@ module Decidim
                     icon_name: "target",
                     position: 2,
                     active: :inclusive,
-                    if: can?(:read, Decidim::ParticipatoryProcess)
+                    if: can?(:read, Decidim::ParticipatoryProcess) && Decidim.find_participatory_space_manifest(:participatory_processes).space_for(current_organization).active?
 
           menu.item I18n.t("menu.participatory_process_groups", scope: "decidim.admin"),
                     decidim_admin_participatory_processes.participatory_process_groups_path,
                     icon_name: "layers",
                     position: 3,
                     active: :inclusive,
-                    if: can?(:read, Decidim::ParticipatoryProcessGroup)
+                    if: can?(:read, Decidim::ParticipatoryProcessGroup)  && Decidim.find_participatory_space_manifest(:participatory_processes).space_for(current_organization).active?
         end
       end
     end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
@@ -89,14 +89,16 @@ module Decidim
                     icon_name: "target",
                     position: 2,
                     active: :inclusive,
-                    if: can?(:read, Decidim::ParticipatoryProcess) && Decidim.find_participatory_space_manifest(:participatory_processes).space_for(current_organization).active?
+                    if: can?(:read, Decidim::ParticipatoryProcess) &&
+                        Decidim.find_participatory_space_manifest(:participatory_processes).space_for(current_organization).active?
 
           menu.item I18n.t("menu.participatory_process_groups", scope: "decidim.admin"),
                     decidim_admin_participatory_processes.participatory_process_groups_path,
                     icon_name: "layers",
                     position: 3,
                     active: :inclusive,
-                    if: can?(:read, Decidim::ParticipatoryProcessGroup)  && Decidim.find_participatory_space_manifest(:participatory_processes).space_for(current_organization).active?
+                    if: can?(:read, Decidim::ParticipatoryProcessGroup) &&
+                        Decidim.find_participatory_space_manifest(:participatory_processes).space_for(current_organization).active?
         end
       end
     end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
@@ -57,7 +57,8 @@ module Decidim
           menu.item I18n.t("menu.processes", scope: "decidim"),
                     decidim_participatory_processes.participatory_processes_path,
                     position: 2,
-                    if: Decidim::ParticipatoryProcess.where(organization: current_organization).published.any? && Decidim.find_participatory_space_manifest(:participatory_processes).space_for(current_organization).published?,
+                    if: Decidim::ParticipatoryProcess.where(organization: current_organization).published.any? &&
+                        Decidim.find_participatory_space_manifest(:participatory_processes).space_for(current_organization).published?,
                     active: :inclusive
         end
       end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
@@ -57,7 +57,7 @@ module Decidim
           menu.item I18n.t("menu.processes", scope: "decidim"),
                     decidim_participatory_processes.participatory_processes_path,
                     position: 2,
-                    if: Decidim::ParticipatoryProcess.where(organization: current_organization).published.any?,
+                    if: Decidim::ParticipatoryProcess.where(organization: current_organization).published.any? && Decidim.find_participatory_space_manifest(:participatory_processes).space_for(current_organization).published?,
                     active: :inclusive
         end
       end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
@@ -31,6 +31,13 @@ FactoryBot.define do
     start_date { Time.current }
     end_date { 2.months.from_now.at_midnight }
 
+    after(:create) do |participatory_process, evaluator|
+      space = Decidim::ParticipatorySpace
+        .find_or_create_by(organization: participatory_process.organization, manifest_name: :participatory_processes)
+      space.activate!
+      space.publish!
+    end
+
     trait :promoted do
       promoted true
     end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
@@ -31,9 +31,9 @@ FactoryBot.define do
     start_date { Time.current }
     end_date { 2.months.from_now.at_midnight }
 
-    after(:create) do |participatory_process, evaluator|
+    after(:create) do |participatory_process, _evaluator|
       space = Decidim::ParticipatorySpace
-        .find_or_create_by(organization: participatory_process.organization, manifest_name: :participatory_processes)
+              .find_or_create_by(organization: participatory_process.organization, manifest_name: :participatory_processes)
       space.activate!
       space.publish!
     end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
@@ -33,7 +33,7 @@ FactoryBot.define do
 
     after(:create) do |participatory_process, _evaluator|
       space = Decidim::ParticipatorySpace
-              .find_or_create_by(organization: participatory_process.organization, manifest_name: :participatory_processes)
+              .find_or_initialize_by(organization: participatory_process.organization, manifest_name: :participatory_processes)
       space.activate!
       space.publish!
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Lets admins (de)activate and (un)publish participatory spaces. A participatory space cannot be publish unless it's active.

Active spaces appear in the admin dashboard, and published spaces appear in the public section. By default, a space is inactive (and thus unpublished).

#### :pushpin: Related Issues
- Fixes #2979

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Forbid visiting the admin section if the space is not active
- [x] Forbid visiting the public section if the space is not published
- [x] Hide nav link in admin section if space is not active
- [x] Hide nav link in public section if space is not published
- [x] Add admin section to manage participatory spaces
  - [x] Activate
  - [x] Deactivate
  - [x] Publish
  - [x] Unpublish
  - [x] Logs

### :camera: Screenshots (optional)
![Description](URL)
