### PR TITLE
(Backport 0.10) Ability to select leaf categories from Admin change-category bulk action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - **decidim-proposals**: Fix threshold_per_proposal method positive? for nil:NilClass when threshold is null or not defined. [\#3219](https://github.com/decidim/decidim/pull/3219)
 - **decidim-proposals**: Fix when I create a proposal I see the draft proposal from someone else! [\#3170](https://github.com/decidim/decidim/pull/3083)
 - **decidim-proposals**: Fix view hooks returning proposals that should not be shown [\#3199](https://github.com/decidim/decidim/pull/3199)
+- **decidim-admin**: Ability to select leaf categories from Admin change-category bulk action [\#3253](https://github.com/decidim/decidim/pull/3253)
 
 ## [0.10.0](https://github.com/decidim/decidim/tree/v0.10.0)
 

--- a/decidim-admin/app/helpers/decidim/admin/bulk_actions_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/bulk_actions_helper.rb
@@ -21,6 +21,42 @@ module Decidim
       def proposal_find(id)
         Decidim::Proposals::Proposal.find(id)
       end
+
+      # Public: Generates a select field with the categories. Only leaf categories can be set as selected.
+      #
+      # categories - A collection of categories.
+      #
+      # Returns a String.
+      def bulk_categories_select(collection)
+        categories = bulk_categories_for_select collection
+        disabled = bulk_disabled_categories_for collection
+        prompt = t("decidim.proposals.admin.proposals.index.change_category")
+        select(:category, :id, options_for_select(categories, selected: [], disabled: disabled), prompt: prompt)
+      end
+
+      def bulk_categories_for_select(scope)
+        sorted_main_categories = scope.first_class.includes(:subcategories).sort_by do |category|
+          translated_attribute(category.name, category.participatory_space.organization)
+        end
+
+        sorted_main_categories.flat_map do |category|
+          parent = [[translated_attribute(category.name, category.participatory_space.organization), category.id]]
+
+          sorted_subcategories = category.subcategories.sort_by do |subcategory|
+            translated_attribute(subcategory.name, subcategory.participatory_space.organization)
+          end
+
+          sorted_subcategories.each do |subcategory|
+            parent << ["- #{translated_attribute(subcategory.name, subcategory.participatory_space.organization)}", subcategory.id]
+          end
+
+          parent
+        end
+      end
+
+      def bulk_disabled_categories_for(scope)
+        scope.first_class.joins(:subcategories).pluck(:id)
+      end
     end
   end
 end

--- a/decidim-admin/app/views/decidim/admin/bulk_actions/_recategorize.html.erb
+++ b/decidim-admin/app/views/decidim/admin/bulk_actions/_recategorize.html.erb
@@ -6,7 +6,7 @@
       <% end %>
     </div>
 
-    <%= grouped_collection_select(:category, :id, current_feature.categories.first_class, :descendants, :translated_name, :id, :translated_name, prompt: t("decidim.proposals.admin.proposals.index.change_category")) %>
+    <%= bulk_categories_select current_feature.categories %>
 
     <%= submit_tag(t("decidim.proposals.admin.proposals.index.update"), id: "js-submit-edit-category", class: "button small button--simple float-left") %>
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport to `0.10-stable` 
Adds the ability to select leaf categories (not only child) from the bulk actions in the Admin.

#### :pushpin: Related Issues
- Related to #2291
- Related to #3243
- Fixes #3229
- [Unable to change Categories on proposals - Metadecidim](https://meta.decidim.barcelona/processes/bug-report/f/210/proposals/12410)


#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)

![screenshot from 2018-04-18 15-03-41](https://user-images.githubusercontent.com/210216/38933830-622c77d0-431a-11e8-995f-9edfdfe15eec.png)
