### PR TITLE
Fix uniqueness problem in seeds

### DIFF
--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -87,7 +87,7 @@ if !Rails.env.production? || ENV["SEED"]
 
   admin.update!(
     name: Faker::Name.name,
-    nickname: Faker::Lorem.unique.characters(rand(1..20)),
+    nickname: Faker::Twitter.unique.screen_name,
     password: "decidim123456",
     password_confirmation: "decidim123456",
     organization: organization,
@@ -103,7 +103,7 @@ if !Rails.env.production? || ENV["SEED"]
 
   regular_user.update!(
     name: Faker::Name.name,
-    nickname: Faker::Lorem.unique.characters(rand(1..20)),
+    nickname: Faker::Twitter.unique.screen_name,
     password: "decidim123456",
     password_confirmation: "decidim123456",
     confirmed_at: Time.current,


### PR DESCRIPTION

#### :tophat: What? Why?

Fixes this [test flaky](https://circleci.com/gh/decidim/decidim/86625?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) mentioned [here](https://github.com/decidim/decidim/pull/3238#issuecomment-382340858).

The `nickname` of these two users was generated based on a non necessarily unique username, so later nicknames for other seed users could conflict with the ones that were generated here.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.
