### PR TITLE
Ignore already imported proposals when importing them

### DIFF
--- a/decidim-proposals/app/commands/decidim/proposals/admin/import_proposals.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/import_proposals.rb
@@ -31,6 +31,8 @@ module Decidim
 
         def import_proposals
           proposals.map do |original_proposal|
+            next if proposal_already_copied?(original_proposal, target_component)
+
             origin_attributes = original_proposal.attributes.except(
               "id",
               "created_at",
@@ -50,7 +52,7 @@ module Decidim
             proposal.save!
 
             proposal.link_resources([original_proposal], "copied_from_component")
-          end
+          end.compact
         end
 
         def proposals
@@ -76,6 +78,12 @@ module Decidim
 
         def target_component
           @form.current_component
+        end
+
+        def proposal_already_copied?(original_proposal, target_component)
+          original_proposal.linked_resources(:proposals, "copied_from_component").any? do |proposal|
+            proposal.component == target_component
+          end
         end
       end
     end

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/import_proposals_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/import_proposals_spec.rb
@@ -53,6 +53,24 @@ module Decidim
               end.to change { Proposal.where(component: current_component).count }.by(1)
             end
 
+            context "when a proposal was already imported" do
+              let(:second_proposal) { create(:proposal, :accepted, component: proposal.component) }
+
+              before do
+                command.call
+                second_proposal
+              end
+
+              it "doesn't import it again" do
+                expect do
+                  command.call
+                end.to change { Proposal.where(component: current_component).count }.by(1)
+
+                titles = Proposal.where(component: current_component).map(&:title)
+                expect(titles).to match_array([proposal.title, second_proposal.title])
+              end
+            end
+
             it "links the proposals" do
               command.call
 


### PR DESCRIPTION
#### :tophat: What? Why?

Ignores already imported proposals by checking if a resource link already exists.

#### :pushpin: Related Issues
- Fixes #3155

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [x] Add tests
