### PR TITLE
Add missing translation values for datepicker in French

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ controller or added a new module you need to rename `feature` to `component`.
 
 **Fixed**:
 
+- **decidim-core**: Add missing locales in Freanch fot the datepicker [\#3260](https://github.com/decidim/decidim/pull/3260)
 - **decidim-proposals**: Fixes clicking on "see all" should remove the ellipsis sign. \#2894](https://github.com/decidim/decidim/pull/3238)
 - **decidim-proposals**: Restore creation date in proposal detail page. [\#3249](https://github.com/decidim/decidim/pull/3249)
 - **decidim-proposals**: Fix threshold_per_proposal method positive? for nil:NilClass when threshold is null or not defined. [\#3185](https://github.com/decidim/decidim/pull/3185)

--- a/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.fr.js
+++ b/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.fr.js
@@ -9,6 +9,9 @@
 		daysMin: ["D", "L", "Ma", "Me", "J", "V", "S", "D"],
 		months: ["Janvier", "Février", "Mars", "Avril", "Mai", "Juin", "Juillet", "Août", "Septembre", "Octobre", "Novembre", "Décembre"],
 		monthsShort: ["Jan", "Fev", "Mar", "Avr", "Mai", "Jui", "Jul", "Aou", "Sep", "Oct", "Nov", "Dec"],
-		today: "Aujourd'hui"
+		today: "Aujourd'hui",
+		clear: "Effacer",
+		weekStart: 1,
+		format: "dd/mm/yyyy"
 	};
 }(jQuery));


### PR DESCRIPTION
#### :tophat: What? Why?

The datepicker locale file was missing some configuration values for French.

#### :pushpin: Related Issues
- Fixes #3158

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

