### PR TITLE
Code Climate configuration: removes execution for documentation files

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -118,3 +118,4 @@ exclude_patterns:
   - "spec/decidim_dummy_app/"
   - "coverage/"
   - "webpack.report.html"
+  - "**/*.md"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -119,3 +119,6 @@ exclude_patterns:
   - "coverage/"
   - "webpack.report.html"
   - "**/*.md"
+  - "docs/*"
+  - "**/docs/*"
+


### PR DESCRIPTION
#### :tophat: What? Why?
This disables the execution on Code Climate for Markdown files and everything inside `doc/` folders. They only are for documentation purposes so we don't need tests for that, most of the time they get cancelled. 

#### :pushpin: Related Issues
- Related to #3218 #2887 