### PR TITLE
Order components by weight and manifest_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-admin**: Regular users can now be impersonated [\#3226](https://github.com/decidim/decidim/pull/3226)
 - **decidim-admin**: All available authorization handlers can always be chosen for impersonation even after the first impersonation [\#3226](https://github.com/decidim/decidim/pull/3226)
 - **decidim-generators**: New gem where all of decidim generators live, both to generate final application and decidim components (plugins).
+- **decidim-core**: Order components by both weight and manifest_name so the order is kept [\#3264](https://github.com/decidim/decidim/pull/3264)
 
 **Changed**:
 

--- a/decidim-core/app/models/decidim/component.rb
+++ b/decidim-core/app/models/decidim/component.rb
@@ -12,7 +12,7 @@ module Decidim
 
     belongs_to :participatory_space, polymorphic: true
 
-    default_scope { order(arel_table[:weight].asc) }
+    default_scope { order(arel_table[:weight].asc, arel_table[:manifest_name].asc) }
 
     delegate :organization, :categories, to: :participatory_space
 

--- a/decidim-core/spec/models/decidim/component_spec.rb
+++ b/decidim-core/spec/models/decidim/component_spec.rb
@@ -17,5 +17,19 @@ module Decidim
       expect(described_class.log_presenter_class_for(:foo))
         .to eq Decidim::AdminLog::ComponentPresenter
     end
+
+    describe "default scope" do
+      subject { described_class.all }
+
+      it "orders the components by wieght and by manifest name" do
+        described_class.destroy_all
+
+        component_b = create :component, manifest_name: :b, weight: 0
+        component_c = create :component, manifest_name: :c, weight: 2
+        component_a = create :component, manifest_name: :a, weight: 0
+
+        expect(subject).to eq [component_a, component_b, component_c]
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Orders the components by both weight and manifest name. It currently only orders by weight, so components with the same weight are ordered by the `updated_at` attribute, which causes the list to change every time a component is modified.

#### :pushpin: Related Issues
- Fixes #3144

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
