### PR TITLE
Meetings/format closing report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,23 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-admin**: Regular users can now be impersonated [\#3226](https://github.com/decidim/decidim/pull/3226)
 - **decidim-admin**: All available authorization handlers can always be chosen for impersonation even after the first impersonation [\#3226](https://github.com/decidim/decidim/pull/3226)
 - **decidim-generators**: New gem where all of decidim generators live, both to generate final application and decidim components (plugins).
+- **decidim-core**: Add context to content parsers [\#2749](https://github.com/decidim/decidim/pull/2749)
+- **decidim-assemblies**: Assemblies now have a reference [\#2557](https://github.com/decidim/decidim/pull/2557)
+- **decidim-core**: Let participatory spaces have reference [\#2557](https://github.com/decidim/decidim/pull/2557)
+- **decidim-meetings**: Add simple formatting to debates fields to improve readability [\#2670](https://github.com/decidim/decidim/issues/2670)
+- **decidim-meetings**: Notify participatory space followers when a meeting is created. [\#2646](https://github.com/decidim/decidim/pull/2646)
+- **decidim-participatory_processes**: Processes now have a reference [\#2557](https://github.com/decidim/decidim/pull/2557)
+- **decidim-proposals**: Notify participatory space followers when a proposal is created. [\#2646](https://github.com/decidim/decidim/pull/2646)
+- **decidim-proposals**: Copy proposals to another component [\#2619](https://github.com/decidim/decidim/issues/2619).
+- **decidim-proposals**: Users and user_groups can now endorse proposals. [\#2287](https://github.com/decidim/decidim/pull/2287)
+- **decidim-participatory_processes**: Ensure only active processes are shown in the highlighted processes section in the homepage[\#2682](https://github.com/decidim/decidim/pull/2682)
+- **decidim-core**: Add collections to group attachments [\#2394](https://github.com/decidim/decidim/pull/2394).
+- **decidim-admin**: Adds a log of all admin actions, only visible by organization admins [\#2604](https://github.com/decidim/decidim/pull/2604)
+- **decidim-core**: Make static pages traceable [\#2754](https://github.com/decidim/decidim/pull/2754)
+- **decidim-admin**: Log all actions on static pages [\#2754](https://github.com/decidim/decidim/pull/2754)
+- **decidim-admin**: Log all actions on newsletters [\#2763](https://github.com/decidim/decidim/pull/2763)
+- **decidim-meetings**: Add WYSIWYG editor for meeting closing notes [\#2761](https://github.com/decidim/decidim/pull/2779)
+- **decidim-meetings**: Add formatting of the list of organizations attending to a meeting [\#2761](https://github.com/decidim/decidim/pull/2779)
 
 **Changed**:
 

--- a/decidim-meetings/app/views/decidim/meetings/admin/meeting_closes/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meeting_closes/_form.html.erb
@@ -5,7 +5,7 @@
 
   <div class="card-section">
     <div class="row column">
-      <%= form.translated :text_area, :closing_report, autofocus: true, rows: 15 %>
+      <%= form.translated :editor, :closing_report, autofocus: true, rows: 15 %>
     </div>
 
     <div class="row column">

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -51,7 +51,7 @@
           <% end %>
           <div class="definition-data__item">
             <span class="definition-data__title"><%= t(".organizations") %></span>
-            <span class="definition-data__text"><%= meeting.attending_organizations %></span>
+            <span class="definition-data__text"><%= simple_format(meeting.attending_organizations) %></span>
           </div>
         </div>
       <% end %>

--- a/decidim-meetings/spec/shared/manage_meetings_examples.rb
+++ b/decidim-meetings/spec/shared/manage_meetings_examples.rb
@@ -314,7 +314,7 @@ shared_examples "manage meetings" do
       end
 
       within ".edit_close_meeting" do
-        fill_in_i18n(
+        fill_in_i18n_editor(
           :close_meeting_closing_report,
           "#close_meeting-closing_report-tabs",
           en: "The meeting was great!",


### PR DESCRIPTION
#### :tophat: What? Why?
Follows the work by @martinciu on #2779 to fix #2761. 

- adds WYSIWYG editor for meeting closing report
- adds simple formatting of attending organizations  

#### :pushpin: Related Issues
- Related to #2779
- Fixes #2761

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry