### PR TITLE
Fix generated gitignore entry for rspec failures

### DIFF
--- a/decidim-generators/lib/decidim/generators/component_templates/.gitignore
+++ b/decidim-generators/lib/decidim/generators/component_templates/.gitignore
@@ -8,7 +8,7 @@
 /tmp/
 
 # rspec failure tracking
-.rspec_status
+.rspec-failures
 
 # default test application
 spec/decidim_dummy_app


### PR DESCRIPTION
#### :tophat: What? Why?

The one that decidim configures is the one that should be used:

https://github.com/decidim/decidim/blob/cda014e3a41ad7d3b17c7b4dcc457ce4bd215cc0/decidim-dev/lib/decidim/dev/test/spec_helper.rb#L26

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.