### PR TITLE
Withdrawn proposals are excluded from count limit and stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ controller or added a new module you need to rename `feature` to `component`.
 
 **Changed**:
 
-- **decidim-proposals**: Extract partials in Proposals into helper methors so that they can be reused in collaborative draft. (https://github.com/decidim/decidim/pull/3238)
+- **decidim-proposals**: Extract partials in Proposals into helper methors so that they can be reused in collaborative draft. [\#3238](https://github.com/decidim/decidim/pull/3238)
 - **decidim-admin**: Moved the following reusable javascript components from `decidim-surveys` component [\#3194](https://github.com/decidim/decidim/pull/3194)
   - Nested resources (auto_buttons_by_position.component.js.es6, auto_label_by_position.component.js.es6, dynamic_fields.component.js.es6)
   - Dependent inputs (field_dependent_inputs.component.js.es6)
@@ -71,6 +71,7 @@ controller or added a new module you need to rename `feature` to `component`.
 - **decidim-accountability**: Include children information in main column [\#3217](https://github.com/decidim/decidim/pull/3217)
 - **decidim-core**: Open attachments in new tab [\#3245](https://github.com/decidim/decidim/pull/3245)
 - **decidim-core**: Open space hashtags in new tab [\#3246](https://github.com/decidim/decidim/pull/3246)
+- **decidim-proposals**: Withdrawn proposals are excluded from count limit and stats. [\#3275](https://github.com/decidim/decidim/pull/3238)
 
 **Fixed**:
 

--- a/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
@@ -112,11 +112,11 @@ module Decidim
       end
 
       def current_user_proposals
-        Proposal.where(author: @current_user, component: form.current_component)
+        Proposal.where(author: @current_user, component: form.current_component).except_withdrawn
       end
 
       def user_group_proposals
-        Proposal.where(user_group: @user_group, component: form.current_component)
+        Proposal.where(user_group: @user_group, component: form.current_component).except_withdrawn
       end
     end
   end

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -52,7 +52,7 @@ Decidim.register_component(:proposals) do |component|
   end
 
   component.register_stat :proposals_count, primary: true, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |components, start_at, end_at|
-    Decidim::Proposals::FilteredProposals.for(components, start_at, end_at).published.not_hidden.count
+    Decidim::Proposals::FilteredProposals.for(components, start_at, end_at).published.except_withdrawn.not_hidden.count
   end
 
   component.register_stat :proposals_accepted, primary: true, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |components, start_at, end_at|

--- a/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
@@ -49,6 +49,7 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
     let(:component) { proposal.component }
     let!(:hidden_proposal) { create :proposal, component: component }
     let!(:draft_proposal) { create :proposal, :draft, component: component }
+    let!(:withdrawn_proposal) { create :proposal, :withdrawn, component: component }
     let!(:moderation) { create :moderation, reportable: hidden_proposal, hidden_at: 1.day.ago }
 
     let(:current_stat) { stats.find { |stat| stat[1] == stats_name } }
@@ -56,7 +57,7 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
     describe "proposals_count" do
       let(:stats_name) { :proposals_count }
 
-      it "only counts published and not hidden proposals" do
+      it "only counts published (except withdrawn) and not hidden proposals" do
         expect(Decidim::Proposals::Proposal.where(component: component).count).to eq 3
         expect(subject).to eq 1
       end

--- a/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
@@ -58,7 +58,7 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
       let(:stats_name) { :proposals_count }
 
       it "only counts published (except withdrawn) and not hidden proposals" do
-        expect(Decidim::Proposals::Proposal.where(component: component).count).to eq 3
+        expect(Decidim::Proposals::Proposal.where(component: component).count).to eq 4
         expect(subject).to eq 1
       end
     end

--- a/decidim-proposals/spec/shared/create_proposal_examples.rb
+++ b/decidim-proposals/spec/shared/create_proposal_examples.rb
@@ -134,8 +134,9 @@ shared_examples "create a proposal" do |with_author|
 
           describe "when the author is a user" do
             let(:user_group) { nil }
+
             before do
-              create(:proposal, :withdrawn, author: author, component: component )
+              create(:proposal, :withdrawn, author: author, component: component)
             end
             it "checks the user doesn't exceed the amount of proposals" do
               expect { command.call }.to broadcast(:ok)
@@ -148,7 +149,7 @@ shared_examples "create a proposal" do |with_author|
 
           describe "when the author is a user_group" do
             before do
-              create(:proposal, :withdrawn, author: author, decidim_user_group_id: user_group.id, component: component )
+              create(:proposal, :withdrawn, author: author, decidim_user_group_id: user_group.id, component: component)
             end
             it "checks the user_group doesn't exceed the amount of proposals" do
               expect { command.call }.to broadcast(:ok)

--- a/decidim-proposals/spec/shared/create_proposal_examples.rb
+++ b/decidim-proposals/spec/shared/create_proposal_examples.rb
@@ -126,6 +126,39 @@ shared_examples "create a proposal" do |with_author|
             end
           end
         end
+
+        describe "the proposal limit excludes withdrawn proposals" do
+          let(:component) do
+            create(:proposal_component, settings: { "proposal_limit" => 1 })
+          end
+
+          describe "when the author is a user" do
+            let(:user_group) { nil }
+            before do
+              create(:proposal, :withdrawn, author: author, component: component )
+            end
+            it "checks the user doesn't exceed the amount of proposals" do
+              expect { command.call }.to broadcast(:ok)
+              expect { command.call }.to broadcast(:invalid)
+
+              user_proposal_count = Decidim::Proposals::Proposal.where(author: author).count
+              expect(user_proposal_count).to eq(2)
+            end
+          end
+
+          describe "when the author is a user_group" do
+            before do
+              create(:proposal, :withdrawn, author: author, decidim_user_group_id: user_group.id, component: component )
+            end
+            it "checks the user_group doesn't exceed the amount of proposals" do
+              expect { command.call }.to broadcast(:ok)
+              expect { command.call }.to broadcast(:invalid)
+
+              user_group_proposal_count = Decidim::Proposals::Proposal.where(user_group: user_group).count
+              expect(user_group_proposal_count).to eq(2)
+            end
+          end
+        end
       else
         it "traces the action", versioning: true do
           expect(Decidim.traceability)


### PR DESCRIPTION
#### :tophat: What? Why?

- A withdrawn proposal should not count for the users' creation limit
- A withdrawn proposal should not count in stats

#### :pushpin: Related Issues
- Related to #2492
- Fixes #3160
- [After removing a proposal, it keeps saying I have created one -  Metadecidim](https://meta.decidim.barcelona/processes/bug-report/f/210/proposals/12388)

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Exclude withdrawn proposals to user count limit 
- [x] Exclude withdrawn proposals from stats
- [ ] Add tests

### :camera: Screenshots (optional)
