### PR TITLE
Scope `terms_and_conditions_page` helper method to `organization`

### DIFF
--- a/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
@@ -8,8 +8,6 @@ module Decidim
       include FormFactory
       include Decidim::DeviseControllers
 
-      helper_method :terms_and_conditions_page
-
       before_action :configure_permitted_parameters
       helper_method :terms_and_conditions_page
 
@@ -48,7 +46,7 @@ module Decidim
       private
 
       def terms_and_conditions_page
-        @terms_and_conditions_page ||= Decidim::StaticPage.find_by(slug: "terms-and-conditions")
+        @terms_and_conditions_page ||= Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization: current_organization)
       end
 
       protected


### PR DESCRIPTION
#### :tophat: What? Why?

On a multitenant installation **with more than one Organization**, in the registration page (`users/sign_up`), the information regarding the _terms and conditions_ is not scoped to the `current organization`, this PR solves this issue by searching the `terms-and-conditions` slug page within the `current_organization`.

It also removes a duplicate call of `helper_method :terms_and_conditions_page`


#### :pushpin: Related Issues
- Related to none

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add tests

### :camera: Screenshots (optional)
