### PR TITLE
An assembly member can be an existing user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ end
 **Added**:
 
 - **decidim-assemblies**: Add members to assemblies. [\#3008](https://github.com/decidim/decidim/pull/3008)
+- **decidim-assemblies**: An assembly member can be related to an existing user. [\#3302](https://github.com/decidim/decidim/pull/3302)
 - **decidim-meetings**: Add organizer to meeting and meeting types [\#3136](https://github.com/decidim/decidim/pull/3136)
 - **decidim-meetings**: Add Minutes entity to manage Minutes. [\#3213](https://github.com/decidim/decidim/pull/3213)
 - **decidim-admin**: Links to participatory space index & show pages from the admin dashboard. [\#3325](https://github.com/decidim/decidim/pull/3325)

--- a/decidim-admin/lib/decidim/admin/form_builder.rb
+++ b/decidim-admin/lib/decidim/admin/form_builder.rb
@@ -19,7 +19,7 @@ module Decidim
       # @param [Hash] prompt_options
       #   Prompt configuration. A hash with options:
       #   - :url (String) The url where the ajax endpoint to fill the select
-      #   - :text (String) Text to use as placeholder
+      #   - :placeholder (String) Text to use as placeholder
       #   - :no_results (String) (optional) Text to use when there are no matching results (default: No results found)
       #   - :search_prompt (String) (optional) Text to prompt for search input (default: Type at least three characters to search)
       #

--- a/decidim-assemblies/app/assets/javascripts/decidim/assemblies/admin/assembly_members.js.es6
+++ b/decidim-assemblies/app/assets/javascripts/decidim/assemblies/admin/assembly_members.js.es6
@@ -1,6 +1,28 @@
 ((exports) => {
   const { createFieldDependentInputs } = exports.DecidimAdmin;
 
+  const $assemblyMemberType = $("#assembly_member_existing_user");
+
+  createFieldDependentInputs({
+    controllerField: $assemblyMemberType,
+    wrapperSelector: ".user-fields",
+    dependentFieldsSelector: ".user-fields--full-name",
+    dependentInputSelector: "input",
+    enablingCondition: ($field) => {
+      return $field.val() === "false"
+    }
+  });
+
+  createFieldDependentInputs({
+    controllerField: $assemblyMemberType,
+    wrapperSelector: ".user-fields",
+    dependentFieldsSelector: ".user-fields--user-picker",
+    dependentInputSelector: "input",
+    enablingCondition: ($field) => {
+      return $field.val() === "true"
+    }
+  });
+
   const $assemblyMemberPosition = $("#assembly_member_position");
 
   createFieldDependentInputs({

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assembly_member.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assembly_member.rb
@@ -61,7 +61,8 @@ module Decidim
               :position_other,
               :weight
             ).merge(
-              assembly: assembly
+              assembly: assembly,
+              user: form.user
             ),
             log_info
           )

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/update_assembly_member.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/update_assembly_member.rb
@@ -57,6 +57,8 @@ module Decidim
               :position,
               :position_other,
               :weight
+            ).merge(
+              user: form.user
             ),
             log_info
           )

--- a/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_member_form.rb
+++ b/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_member_form.rb
@@ -18,11 +18,24 @@ module Decidim
         attribute :designation_mode, String
         attribute :position, String
         attribute :position_other, String
+        attribute :user_id, Integer
+        attribute :existing_user, Boolean, default: false
 
-        validates :full_name, :designation_date, presence: true
+        validates :designation_date, presence: true
+        validates :full_name, presence: true, unless: proc { |object| object.existing_user }
         validates :position, inclusion: { in: Decidim::AssemblyMember::POSITIONS }
         validates :position_other, presence: true, if: ->(form) { form.position == "other" }
         validates :ceased_date, date: { after: :designation_date, allow_blank: true }
+        validates :user, presence: true, if: proc { |object| object.existing_user }
+
+        def map_model(model)
+          self.user_id = model.decidim_user_id
+          self.existing_user = user_id.present?
+        end
+
+        def user
+          @user ||= current_organization.users.find_by(id: user_id)
+        end
 
         def positions_for_select
           Decidim::AssemblyMember::POSITIONS.map do |position|

--- a/decidim-assemblies/app/models/decidim/assembly_member.rb
+++ b/decidim-assemblies/app/models/decidim/assembly_member.rb
@@ -9,6 +9,7 @@ module Decidim
 
     POSITIONS = %w(president vice_president secretary other).freeze
 
+    belongs_to :user, foreign_key: "decidim_user_id", class_name: "Decidim::User", optional: true
     belongs_to :assembly, foreign_key: "decidim_assembly_id", class_name: "Decidim::Assembly"
     alias participatory_space assembly
 

--- a/decidim-assemblies/app/presenters/decidim/admin/assembly_member_presenter.rb
+++ b/decidim-assemblies/app/presenters/decidim/admin/assembly_member_presenter.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    #
+    # Decorator for assembly members
+    #
+    class AssemblyMemberPresenter < SimpleDelegator
+      def name
+        if user
+          "#{user.name} (#{Decidim::UserPresenter.new(user).nickname})"
+        else
+          full_name
+        end
+      end
+
+      def position
+        return position_other if __getobj__.position == "other"
+
+        I18n.t(__getobj__.position, scope: "decidim.admin.models.assembly_member.positions", default: "")
+      end
+    end
+  end
+end

--- a/decidim-assemblies/app/presenters/decidim/assembly_member_presenter.rb
+++ b/decidim-assemblies/app/presenters/decidim/assembly_member_presenter.rb
@@ -11,6 +11,14 @@ module Decidim
 
     delegate :profile_url, :avatar_url, to: :user, allow_nil: true
 
+    def name
+      user ? user.name : full_name
+    end
+
+    def nickname
+      user.nickname if user
+    end
+
     def personal_information
       [
         gender.presence,
@@ -23,6 +31,16 @@ module Decidim
       return position_other if __getobj__.position == "other"
 
       I18n.t(__getobj__.position, scope: "decidim.admin.models.assembly_member.positions", default: "")
+    end
+
+    private
+
+    def user
+      @user ||= begin
+        if (user = __getobj__.user.presence)
+          Decidim::UserPresenter.new(user)
+        end
+      end
     end
   end
 end

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/_form.html.erb
@@ -6,8 +6,21 @@
   </div>
 
   <div class="card-section">
-    <div class="row column">
-      <%= form.text_field :full_name, autofocus: true %>
+    <div class="user-fields">
+      <div class="row column">
+        <%= form.select :existing_user, [[t(".non_user"), false], [t(".existing_user"), true]], label: t(".user_type") %>
+      </div>
+
+      <div class="row column user-fields--full-name">
+        <%= form.text_field :full_name, autofocus: true %>
+      </div>
+
+      <div class="row column user-fields--user-picker">
+        <% prompt_options = { url: decidim_admin.users_organization_url, placeholder: t(".select_user") } %>
+        <%= form.autocomplete_select(:user_id, form.object.user.presence,  { multiple: false }, prompt_options) do |user|
+          { value: user.id, label: "#{user.name} (@#{user.nickname})" }
+        end %>
+      </div>
     </div>
 
     <div class="position-fields">

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/index.html.erb
@@ -59,12 +59,13 @@
         </thead>
         <tbody>
           <% @assembly_members.each do |member| %>
+            <% member_presenter = Decidim::Admin::AssemblyMemberPresenter.new(member) %>
             <tr>
               <td>
-                <%= member.full_name %>
+                <%= member_presenter.name %>
               </td>
               <td>
-                <%= Decidim::AssemblyMemberPresenter.new(member).position %>
+                <%= member_presenter.position %>
               </td>
               <td>
                 <%= l member.designation_date, format: :datepicker %>

--- a/decidim-assemblies/app/views/decidim/assembly_members/_assembly_member.html.erb
+++ b/decidim-assemblies/app/views/decidim/assembly_members/_assembly_member.html.erb
@@ -7,21 +7,41 @@
         <div class="author-data author-data--big">
           <div class="author-data__main">
             <div class="author author--flex">
-              <span class="author__avatar">
-                <%= image_tag asset_path("decidim/default-avatar.svg") %>
-              </span>
-              <div>
-                <div class="author__name--container">
-                    <%= member_presenter.full_name %>
+              <% if (profile_url = member_presenter.profile_url) %>
+                <a href="<%= profile_url %>" class="author__avatar">
+                  <%= image_tag member_presenter.avatar_url(:big) %>
+                </a>
+                <div>
+                  <div class="author__name--container">
+                    <a href="<%= profile_url %>" class="author__name">
+                      <%= member_presenter.name %>
+                    </a>
+                  </div>
+                  <% if (nickname = member_presenter.nickname) %>
+                    <a href="<%= profile_url %>" class="author__nickname">
+                      <%= nickname %>
+                    </a>
+                  <% end %>
                 </div>
-              </div>
+              <% else %>
+                <span class="author__avatar"><%= image_tag asset_path("decidim/default-avatar.svg") %></span>
+                <div>
+                  <div class="author__name--container"><%= member_presenter.name %></div>
+                  <% if (nickname = member_presenter.nickname) %>
+                    <span class="author__nickname"><%= nickname %></span>
+                  <% end %>
+                </div>
+              <% end %>
             </div>
           </div>
         </div>
       </div>
       <div class="card__text card--picture-offset">
-        <div><small><strong><%= member_presenter.position %></strong></small></div>
-        <div class="text-small"><%= t(".desiganted_on") %> <strong> <%= l assembly_member.designation_date, format: :datepicker %></strong></div>
+        <div>
+          <small><strong><%= member_presenter.position %></strong></small>
+        </div>
+        <div class="text-small"><%= t(".desiganted_on") %>
+          <strong> <%= l assembly_member.designation_date, format: :datepicker %></strong></div>
         <div class="text-small mt-s"><%= member_presenter.personal_information %></div>
       </div>
     </div>

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -208,7 +208,11 @@ en:
             slug_help: 'URL slugs are used to generate the URLs that point to this assembly. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
         assembly_members:
           form:
+            existing_user: Existing user
+            non_user: Non user
             select_a_position: Select a position
+            select_user: Select an user
+            user_type: User type
           index:
             filter:
               all: All

--- a/decidim-assemblies/db/migrate/20180426162405_assembly_member_belongs_to_user.rb
+++ b/decidim-assemblies/db/migrate/20180426162405_assembly_member_belongs_to_user.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AssemblyMemberBelongsToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :decidim_assembly_members, :decidim_user, index: { name: "index_decidim_assembly_members_on_decidim_user_id" }
+  end
+end

--- a/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
@@ -128,5 +128,9 @@ FactoryBot.define do
     trait :ceased do
       ceased_date { Faker::Date.between(1.day.ago, 5.days.ago) }
     end
+
+    trait :with_user do
+      user { create(:user, organization: assembly.organization) }
+    end
   end
 end

--- a/decidim-assemblies/spec/commands/create_assembly_member_spec.rb
+++ b/decidim-assemblies/spec/commands/create_assembly_member_spec.rb
@@ -7,12 +7,14 @@ module Decidim::Assemblies
     subject { described_class.new(form, current_user, assembly) }
 
     let(:assembly) { create(:assembly) }
+    let(:user) { nil }
     let!(:current_user) { create :user, :confirmed, organization: assembly.organization }
     let(:form) do
       instance_double(
         Admin::AssemblyMemberForm,
         invalid?: invalid,
         full_name: "Full name",
+        user: user,
         attributes: {
           weight: 0,
           full_name: "Full name",
@@ -62,6 +64,15 @@ module Decidim::Assemblies
         expect { subject.call }.to change(Decidim::ActionLog, :count)
         action_log = Decidim::ActionLog.last
         expect(action_log.version).to be_present
+      end
+
+      context "with an existing user in the platform" do
+        let!(:user) { create(:user, organization: assembly.organization) }
+
+        it "sets the user" do
+          subject.call
+          expect(assembly_member.user).to eq user
+        end
       end
     end
   end

--- a/decidim-assemblies/spec/forms/assembly_member_form_spec.rb
+++ b/decidim-assemblies/spec/forms/assembly_member_form_spec.rb
@@ -19,6 +19,8 @@ module Decidim
         let(:designation_date) { Time.current }
         let(:gender) { ::Faker::Lorem.word }
         let(:position) { Decidim::AssemblyMember::POSITIONS.first }
+        let(:existing_user) { false }
+        let(:user_id) { nil }
 
         let(:attributes) do
           {
@@ -27,7 +29,9 @@ module Decidim
               "designation_date" => designation_date,
               "gender" => gender,
               "position" => position,
-              "birthday" => Time.current
+              "birthday" => Time.current,
+              "existing_user" => existing_user,
+              "user_id" => user_id
             }
           }
         end
@@ -72,6 +76,26 @@ module Decidim
           end
         end
 
+        context "when existing user is present" do
+          let(:existing_user) { true }
+
+          context "and no user is provided" do
+            it { is_expected.to be_invalid }
+          end
+
+          context "and user exists" do
+            let(:user_id) { create(:user, organization: organization).id }
+
+            it { is_expected.to be_valid }
+          end
+
+          context "and no such user exists" do
+            let(:user_id) { 999_999 }
+
+            it { is_expected.to be_invalid }
+          end
+        end
+
         context "when ceased date is present" do
           context "and is older than designation date" do
             subject(:form) { described_class.from_params(attributes.merge(ceased_date: (designation_date - 1.minute))).with_context(context) }
@@ -89,6 +113,28 @@ module Decidim
             subject(:form) { described_class.from_params(attributes.merge(ceased_date: (designation_date + 1.minute))).with_context(context) }
 
             it { is_expected.to be_valid }
+          end
+        end
+
+        describe "user" do
+          subject { form.user }
+
+          context "when the user exists" do
+            let(:user_id) { create(:user, organization: organization).id }
+
+            it { is_expected.to be_kind_of(Decidim::User) }
+          end
+
+          context "when the user does not exist" do
+            let(:user_id) { 999_999 }
+
+            it { is_expected.to eq(nil) }
+          end
+
+          context "when the user is from another organization" do
+            let(:user_id) { create(:user).id }
+
+            it { is_expected.to eq(nil) }
           end
         end
       end

--- a/decidim-assemblies/spec/presenters/decidim/admin/assembly_member_presenter_spec.rb
+++ b/decidim-assemblies/spec/presenters/decidim/admin/assembly_member_presenter_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe Admin::AssemblyMemberPresenter, type: :helper do
+    let(:assembly_member) do
+      build(:assembly_member, full_name: "Full name")
+    end
+
+    describe "name" do
+      subject { described_class.new(assembly_member).name }
+
+      it { is_expected.to eq "Full name" }
+
+      context "when member is an existing user" do
+        let(:user) { build(:user, name: "Julia G.", nickname: "julia_g") }
+        let(:assembly_member) { build(:assembly_member, full_name: "Full name", user: user) }
+
+        it { is_expected.to eq "Julia G. (@julia_g)" }
+      end
+    end
+
+    describe "position" do
+      subject { described_class.new(assembly_member).position }
+
+      context "when position is predefined" do
+        it { is_expected.to eq t(assembly_member.position, scope: "decidim.admin.models.assembly_member.positions") }
+      end
+
+      context "when position is other" do
+        let(:assembly_member) { build(:assembly_member, position: "other", position_other: "Custom position") }
+
+        it "show the custom position value" do
+          expect(subject).to eq("Custom position")
+        end
+      end
+    end
+  end
+end

--- a/decidim-assemblies/spec/presenters/decidim/assembly_member_presenter_spec.rb
+++ b/decidim-assemblies/spec/presenters/decidim/assembly_member_presenter_spec.rb
@@ -13,6 +13,32 @@ module Decidim
       build(:assembly_member, full_name: "Full name", birthday: birthday)
     end
 
+    describe "name" do
+      subject { described_class.new(assembly_member).name }
+
+      it { is_expected.to eq "Full name" }
+
+      context "when member is an existing user" do
+        let(:user) { build(:user, name: "Julia G.", nickname: "julia_g") }
+        let(:assembly_member) { build(:assembly_member, full_name: "Full name", user: user) }
+
+        it { is_expected.to eq "Julia G." }
+      end
+    end
+
+    describe "nickname" do
+      subject { described_class.new(assembly_member).nickname }
+
+      it { is_expected.to be_nil }
+
+      context "when member is an existing user" do
+        let(:user) { build(:user, name: "Julia G.", nickname: "julia_g") }
+        let(:assembly_member) { build(:assembly_member, full_name: "Full name", user: user) }
+
+        it { is_expected.to eq "@julia_g" }
+      end
+    end
+
     describe "age" do
       subject { described_class.new(assembly_member).age }
 

--- a/decidim-assemblies/spec/shared/manage_assembly_members_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assembly_members_examples.rb
@@ -16,28 +16,57 @@ shared_examples "manage assembly members examples" do
     end
   end
 
-  it "creates a new assembly member" do
-    find(".card-title a.new").click
+  context "without existing user" do
+    it "creates a new assembly member" do
+      find(".card-title a.new").click
 
-    execute_script("$('#date_field_assembly_member_designation_date').focus()")
-    find(".datepicker-days .active").click
+      execute_script("$('#date_field_assembly_member_designation_date').focus()")
+      find(".datepicker-days .active").click
 
-    within ".new_assembly_member" do
-      fill_in(
-        :assembly_member_full_name,
-        with: "Daisy O'connor"
-      )
+      within ".new_assembly_member" do
+        fill_in(
+          :assembly_member_full_name,
+          with: "Daisy O'connor"
+        )
 
-      select "President", from: :assembly_member_position
+        select "President", from: :assembly_member_position
 
-      find("*[type=submit]").click
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_admin_callout("successfully")
+      expect(page).to have_current_path decidim_admin_assemblies.assembly_members_path(assembly)
+
+      within "#assembly_members table" do
+        expect(page).to have_content("Daisy O'connor")
+      end
     end
+  end
 
-    expect(page).to have_admin_callout("successfully")
-    expect(page).to have_current_path decidim_admin_assemblies.assembly_members_path(assembly)
+  context "with existing user" do
+    let!(:member_user) { create :user, organization: assembly.organization }
 
-    within "#assembly_members table" do
-      expect(page).to have_content("Daisy O'connor")
+    it "creates a new assembly member" do
+      find(".card-title a.new").click
+
+      execute_script("$('#date_field_assembly_member_designation_date').focus()")
+      find(".datepicker-days .active").click
+
+      within ".new_assembly_member" do
+        select "Existing user", from: :assembly_member_existing_user
+        autocomplete_select "#{member_user.name} (@#{member_user.nickname})", from: :user_id
+
+        select "President", from: :assembly_member_position
+
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_admin_callout("successfully")
+      expect(page).to have_current_path decidim_admin_assemblies.assembly_members_path(assembly)
+
+      within "#assembly_members table" do
+        expect(page).to have_content("#{member_user.name} (@#{member_user.nickname})")
+      end
     end
   end
 
@@ -68,7 +97,7 @@ shared_examples "manage assembly members examples" do
       end
     end
 
-    it "deletes a assembly_member" do
+    it "deletes the assembly member" do
       within find("#assembly_members tr", text: assembly_member.full_name) do
         accept_confirm { find("a.action-icon--remove").click }
       end

--- a/decidim-assemblies/spec/system/assembly_members_spec.rb
+++ b/decidim-assemblies/spec/system/assembly_members_spec.rb
@@ -81,10 +81,10 @@ describe "Assembly members", type: :system do
         expect(page).to have_selector("article.card--member", count: 2)
 
         assembly_members.each do |assembly_member|
-          expect(page).to have_content(Decidim::AssemblyMemberPresenter.new(assembly_member).full_name)
+          expect(page).to have_content(Decidim::AssemblyMemberPresenter.new(assembly_member).name)
         end
 
-        expect(page).not_to have_content(Decidim::AssemblyMemberPresenter.new(ceased_assembly_member).full_name)
+        expect(page).not_to have_content(Decidim::AssemblyMemberPresenter.new(ceased_assembly_member).name)
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR sits on #3008 and #3301 and add the possibility to link an assembly member to an existing user in the platform.

I'm pointing this PR to the `feature/assembly_members` branch so you can review it faster, once merged, I'll point this to the master branch.

#### :pushpin: Related Issues

- Build on top of #3387
- Related PR's #3008 and #3301

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
