### PR TITLE
Change broken link on Getting started and add definition on checklist

### DIFF
--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -34,7 +34,7 @@ As a technopolitical project, Decidim needs several things to work. This is a no
 
 1. Ideally you'll have a **Team** formed with experts on IT, Communication, Participation, Design and Law.
 
-1. Texts for at least, **terms of use, privacy policy and frequently asked questions**.
+1. Texts for at least, **terms of use, privacy policy and frequently asked questions**. To show the "Terms and conditions" body text in the "Sign Up Form", it is a requirement that the slug of this page to be equal `terms-and-conditions` 
 
 1. Comply with your current **legal requirements**, like to registrate your privacy policy with the autorities (eg LOPD on Spain).
 

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -34,7 +34,7 @@ As a technopolitical project, Decidim needs several things to work. This is a no
 
 1. Ideally you'll have a **Team** formed with experts on IT, Communication, Participation, Design and Law.
 
-1. Texts for at least, **terms of use, privacy policy and frequently asked questions**. To show the "Terms and conditions" body text in the "Sign Up Form", it is a requirement that the slug of this page to be equal `terms-and-conditions` 
+1. Texts for at least, **terms of use, privacy policy and frequently asked questions**. To show the "Terms and conditions" body text in the "Sign Up Form", it is a requirement that the slug of this page to be equal `terms-and-conditions`.
 
 1. Comply with your current **legal requirements**, like to registrate your privacy policy with the autorities (eg LOPD on Spain).
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -170,7 +170,7 @@ also manually check your application before upgrading.
 
 ## Checklist
 
-There are several things you need to check before making your putting your application on production. See the [checklist](docs/checklist.md).
+There are several things you need to check before making your putting your application on production. See the [checklist](checklist.md).
 
 [docker]: https://docs.docker.com/engine/installation/
 [docker-compose]: https://docs.docker.com/compose/install/


### PR DESCRIPTION
#### :tophat: What? Why?
Fix broken link on Getting Started and add more definition on checklist page for page `terms-and-conditions`

#### :clipboard: Subtasks
- [x] Fix broken link on Getting Started
- [x] Add definition for `terms-and-conditions` 

### :camera: Screenshots (optional)
![Description](URL)
