### PR TITLE
Introduce coauthorable concern and coauthorship model.

### DIFF
--- a/decidim-core/app/models/coauthorship.rb
+++ b/decidim-core/app/models/coauthorship.rb
@@ -1,0 +1,5 @@
+class Coauthorship < ApplicationRecord
+  belongs_to :decidim_author
+  belongs_to :decidim_user_group
+  belongs_to :coauthorable
+end

--- a/decidim-core/db/migrate/20180427141253_create_coauthorships.rb
+++ b/decidim-core/db/migrate/20180427141253_create_coauthorships.rb
@@ -1,0 +1,11 @@
+class CreateCoauthorships < ActiveRecord::Migration[5.1]
+  def change
+    create_table :coauthorships do |t|
+      t.references :decidim_author, foreign_key: true, null: false, index: { name: "index_author_on_coauthorsihp" }
+      t.references :decidim_user_group, foreign_key: true, index: { name: "index_user_group_on_coauthorsihp" }
+      t.references :coauthorable,  polymorphic: true, index: { name: "index_coauthorable_on_coauthorship" }
+
+      t.timestamps
+    end
+  end
+end

--- a/decidim-core/lib/decidim/coauthorable.rb
+++ b/decidim-core/lib/decidim/coauthorable.rb
@@ -1,10 +1,16 @@
 # frozen_string_literal: true
 
 module Decidim
-  # This concern contains the logic related to the authorship.
-  # This authorship may belong to a single user or be shared among coauthors, in
-  # this latest case the Coauthorable concern should be also applied.
-  module Authorable
+  # This concern contains the logic related to collective or shared authorship.
+  #
+  # Coauthorable will share the same object interface as Authorable (if it ducks is a duck).
+  #
+  # Coauthorable entities will have an initial author, plus a list of coauthors.
+  # The initial author will be persisted in the entity's table as implemented by Authorable,
+  # and the rest of the coauthors will be persisted in the coauthors table.
+  #
+  # All coauthors, including the initial author, will share the same permissions.
+  module Coauthorable
     extend ActiveSupport::Concern
 
     included do

--- a/decidim-core/lib/decidim/core/test/shared_examples/coauthorable.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/coauthorable.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+shared_examples_for "coauthorable" do
+  describe "validations" do
+    context "when the user group is not verified" do
+      it "is not valid" do
+        user_group = create(:user_group)
+        create(:user_group_membership, user: subject.author, user_group: user_group)
+        subject.user_group = user_group
+        expect(subject).not_to be_valid
+      end
+    end
+
+    context "when the author doesn't have a membership of the user group" do
+      it "is not valid" do
+        user_group = create(:user_group, :verified)
+        subject.user_group = user_group
+        expect(subject).not_to be_valid
+      end
+    end
+
+    context "when the author is from another organization" do
+      before do
+        subject.author = create(:user)
+      end
+
+      it { is_expected.to be_invalid }
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
As CollaborativeDrafts will have collective authorship, Decidim needs a new abstraction to manage this situation. I'm proposing a Coauthorable concern. This concern will be a sibling of Authorable (they will "inherit" the same interface) but with different persistence characteristics.

Coauthorable keep the first author, the creator, in the persistence table of the Coauthorable's model and introduces a new Coauthorship many-to-many relation between Coauthorable and the rest of author Users and/or user_groups.

Coauthorable will also support multiple authorship identities for each User, user and any user_groups.

#### Open discussions
**Is it the best solution to keep the first author in Coauthorable's table?**
This means, for example, having the creator author in collaborative_drafts table, and then having the rest of coauthors in coauthorships table.

#### :pushpin: Related Issues
- Related to #3049 this feature is required by Collaborative Drafts.

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
