### PR TITLE
Fix version format for npm

### DIFF
--- a/lib/decidim/gem_manager.rb
+++ b/lib/decidim/gem_manager.rb
@@ -103,7 +103,7 @@ module Decidim
       end
 
       def version
-        File.read(version_file).strip
+        @version ||= File.read(version_file).strip
       end
 
       def replace_file(name, regexp, replacement)

--- a/lib/decidim/gem_manager.rb
+++ b/lib/decidim/gem_manager.rb
@@ -88,7 +88,7 @@ module Decidim
         replace_file(
           "package.json",
           /^  "version": "[^"]*"/,
-          "  \"version\": \"#{version.gsub(/\.pre/, "-pre")}\""
+          "  \"version\": \"#{semver_friendly_version}\""
         )
 
         all_dirs do |dir|
@@ -123,6 +123,10 @@ module Decidim
       end
 
       private
+
+      def semver_friendly_version
+        version.gsub(/\.pre/, "-pre")
+      end
 
       def version_file
         File.expand_path(File.join("..", "..", ".decidim-version"), __dir__)

--- a/lib/decidim/gem_manager.rb
+++ b/lib/decidim/gem_manager.rb
@@ -106,10 +106,6 @@ module Decidim
         File.read(version_file).strip
       end
 
-      def version_file
-        File.expand_path(File.join("..", "..", ".decidim-version"), __dir__)
-      end
-
       def replace_file(name, regexp, replacement)
         new_content = File.read(name).gsub(regexp, replacement)
 
@@ -124,6 +120,12 @@ module Decidim
         Dir.glob(glob)
            .select { |f| File.directory?(f) }
            .each { |dir| yield(dir) }
+      end
+
+      private
+
+      def version_file
+        File.expand_path(File.join("..", "..", ".decidim-version"), __dir__)
       end
     end
 

--- a/lib/decidim/gem_manager.rb
+++ b/lib/decidim/gem_manager.rb
@@ -125,7 +125,7 @@ module Decidim
       private
 
       def semver_friendly_version
-        version.gsub(/\.pre/, "-pre")
+        version.gsub(/\.pre/, "-pre").gsub(/\.dev/, "-dev")
       end
 
       def version_file

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "decidim",
   "description": "The participatory democracy framework",
-  "version": "0.12.0.dev",
+  "version": "0.12.0-dev",
   "repository": {
     "url": "git@github.com:decidim/decidim.git",
     "type": "git"


### PR DESCRIPTION
#### :tophat: What? Why?

`npm` uses a semver-compatible version format for pre-releases, whereas `rubygems` doesn't. So we need to perform a manual transformation on the version to play nice with `npm`. We were doing that, but the transformation broken when we moved from `.pre` to `.dev` for version specifiers.

These changes should fix that and get `decidim-comments` build green again.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.