### PR TITLE
Fix dev app's gemfile for external plugins

### DIFF
--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -139,7 +139,7 @@ module Decidim
       def current_gem
         return "decidim" unless options[:path]
 
-        File.read(gemspec).match(/name\s*=\s*['"](?<name>.*)["']/)[:name]
+        @current_gem ||= File.read(gemspec).match(/name\s*=\s*['"](?<name>.*)["']/)[:name]
       end
 
       def gemspec

--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -95,9 +95,12 @@ module Decidim
                        end
 
         gsub_file "Gemfile", /gem "#{current_gem}".*/, "gem \"#{current_gem}\", #{gem_modifier}"
-        gsub_file "Gemfile", /gem "decidim-dev".*/, "gem \"decidim-dev\", #{gem_modifier}" if current_gem == "decidim"
-        gsub_file "Gemfile", /gem "decidim-([A-z]+)".*/, "# gem \"decidim-\\1\", #{gem_modifier}"
-        gsub_file "Gemfile", /(# )?gem "decidim-dev".*/, "gem \"decidim-dev\", #{gem_modifier}" if current_gem == "decidim"
+
+        if current_gem == "decidim"
+          gsub_file "Gemfile", /gem "decidim-dev".*/, "gem \"decidim-dev\", #{gem_modifier}"
+          gsub_file "Gemfile", /gem "decidim-consultations".*/, "# gem \"decidim-consultations\", #{gem_modifier}"
+          gsub_file "Gemfile", /gem "decidim-initiatives".*/, "# gem \"decidim-initiatives\", #{gem_modifier}"
+        end
 
         Bundler.with_original_env { run "bundle install" }
       end


### PR DESCRIPTION
#### :tophat: What? Why?

We want to skip commenting out optional gems if we're in the context of developing a decidim plugin.

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/pull/3224#issuecomment-381610862 and the subsequent discussion.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.