### PR TITLE
Fix controller name in admin routes

### DIFF
--- a/decidim-admin/config/routes.rb
+++ b/decidim-admin/config/routes.rb
@@ -36,7 +36,7 @@ Decidim::Admin::Engine.routes.draw do
     resources :impersonatable_users, only: [:index] do
       resources :promotions, controller: "managed_users/promotions", only: [:new, :create]
       resources :impersonation_logs, controller: "managed_users/impersonation_logs", only: [:index]
-      resources :impersonations, controller: "managed_users/impersonations", only: [:new, :create] do
+      resources :impersonations, controller: "impersonations", only: [:new, :create] do
         collection do
           post :close_session
         end


### PR DESCRIPTION
#### :tophat: What? Why?
Seems to be an inconsistency from #3226 by @deivid-rodriguez. 

While working on #3029 and rebasing it against `master`, I started seeing some weird errors:

```
            ActionController::RoutingError:
              uninitialized constant Decidim::Admin::ManagedUsers::ImpersonationsController
```

After merging #3226, the `routes/rb` file for `decidim-admin` looks like this:

https://github.com/decidim/decidim/blob/103b9f34836124308ce603efc1bdbe57f3ae4436/decidim-admin/config/routes.rb#L36-L44

Note line 39, it's setting the controller to `managed_users/impersonations`, which should translate to `Decidim::Admin::ManagedUsers::ImpersonationsController`, but this constant does not exist. Instead, it's loading `Decidim::Admin::ImpersonationsController` (note the missing `ManagedUsers::` scope).

The weird part is that this does not fail on `master`, but it does fail on #3029 😕 

This PR ~moves the controller to the correct folder, and all its related resources (views and locales) too~ fixes the name of the controller in the routes, as discussed in this very same PR.

#### :pushpin: Related Issues
- Related to #3226

#### :clipboard: Subtasks
None