### PR TITLE
Fix notifications styling on (at least) chromium

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_navbar.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_navbar.scss
@@ -263,6 +263,7 @@ $navbar-active-shadow-medium: inset 0 4px 0 0 $primary;
   }
 }
 
+.topbar__notifications,
 .topbar__conversations{
   margin-right: 1rem;
   vertical-align: -4px;
@@ -275,13 +276,6 @@ $navbar-active-shadow-medium: inset 0 4px 0 0 $primary;
   &.is-active .icon{
     fill: $warning;
     opacity: 1;
-  }
-}
-
-.topbar__notifications{
-  .icon{
-    fill: $white;
-    opacity: .3;
   }
 }
 


### PR DESCRIPTION
#### :tophat: What? Why?

Fixes weird top bar icon disposition on (at least) chromium. Introduced in https://github.com/decidim/decidim/pull/3261/commits/01db57ebaf3eb8d8fa6e2a6b169d914eb7548e49.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)

#### Before
![before](https://user-images.githubusercontent.com/2887858/39553218-e53b6b4e-4e42-11e8-8169-42cdb2949183.png)

#### After
![after](https://user-images.githubusercontent.com/2887858/39553163-a95248e6-4e42-11e8-9357-13128ab81988.png)
