### PR TITLE
Better linking back from admin to frontend

### DIFF
--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_secondary-nav.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_secondary-nav.scss
@@ -47,7 +47,8 @@ $process-title-height: 3rem;
   }
 }
 
-.secondary-nav--subnav{
+.secondary-nav--subnav,
+.process-content{
   padding-top: 2rem;
 
   @include breakpoint(large){
@@ -98,7 +99,7 @@ $process-title-height: 3rem;
     left: 120px;
     right: 0;
     top: 0;
-    z-index: -1;
+    z-index: 1;
     background-color: $white;
     padding: 1rem 1.5rem;
     height: $process-title-height;

--- a/decidim-admin/app/views/layouts/decidim/admin/_application.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_application.html.erb
@@ -18,7 +18,6 @@
       <%= yield :secondary_nav if content_for? :secondary_nav %>
     </div>
     <div class="layout-content">
-      <%= render partial: "layouts/decidim/admin/callouts_full" %>
       <div class="container">
         <%= yield %>
       </div>

--- a/decidim-admin/app/views/layouts/decidim/admin/_template_top.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_template_top.html.erb
@@ -1,3 +1,4 @@
 <%= render partial: "layouts/decidim/admin/title_bar" %>
+<%= render partial: "layouts/decidim/admin/callouts_full" %>
 <main class="main">
   <div class="layout-wrapper">

--- a/decidim-assemblies/app/views/layouts/decidim/admin/assemblies.html.erb
+++ b/decidim-assemblies/app/views/layouts/decidim/admin/assemblies.html.erb
@@ -1,14 +1,11 @@
-<% content_for :secondary_nav do %>
-  <div class="secondary-nav">
-    <div class="secondary-nav__title">
-      <%= t "decidim.admin.titles.assemblies" %>
-    </div>
-    <div class="secondary-nav__actions">
-      <%= link_to t("actions.new", scope: "decidim.admin", name: t("models.assembly.name", scope: "decidim.admin")), new_assembly_path(parent_id: parent_assembly&.id), class: "button expanded small" if can? :create, Decidim::Assembly %>
+<%= render "layouts/decidim/admin/application" do %>
+  <div class="process-title">
+    <div class="process-title-content">
+      <%= link_to t("decidim.admin.titles.assemblies"), decidim_assemblies.assemblies_path, target: "_blank" %>
     </div>
   </div>
-<% end %>
 
-<%= render "layouts/decidim/admin/application" do %>
-  <%= yield %>
+  <div class="process-content">
+    <%= yield %>
+  </div>
 <% end %>

--- a/decidim-assemblies/app/views/layouts/decidim/admin/assembly.html.erb
+++ b/decidim-assemblies/app/views/layouts/decidim/admin/assembly.html.erb
@@ -69,8 +69,11 @@
 <%= render "layouts/decidim/admin/application" do %>
   <div class="process-title">
     <div class="process-title-content">
-      <%= translated_attribute(current_participatory_space.title) %>
+      <%= link_to translated_attribute(current_participatory_space.title), decidim_assemblies.assembly_path(current_participatory_space), target: "_blank" %>
     </div>
   </div>
-  <%= yield %>
+
+  <div class="process-content">
+    <%= yield %>
+  </div>
 <% end %>

--- a/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
@@ -13,9 +13,7 @@ describe "Admin manages assemblies", type: :system do
     let(:image2_path) { Decidim::Dev.asset(image2_filename) }
 
     before do
-      within ".secondary-nav__actions" do
-        page.find("a.button").click
-      end
+      click_link "New"
     end
 
     it "creates a new assembly" do

--- a/decidim-consultations/app/views/layouts/decidim/admin/consultation.html.erb
+++ b/decidim-consultations/app/views/layouts/decidim/admin/consultation.html.erb
@@ -21,8 +21,11 @@
 <%= render "layouts/decidim/admin/application" do %>
   <div class="process-title">
     <div class="process-title-content">
-      <%= translated_attribute(current_consultation.title) %>
+      <%= link_to translated_attribute(current_consultation.title), decidim_consultations.consultation_path(current_consultation), target: "_blank" %>
     </div>
   </div>
-  <%= yield %>
+
+  <div class="process-content">
+    <%= yield %>
+  </div>
 <% end %>

--- a/decidim-consultations/app/views/layouts/decidim/admin/consultations.html.erb
+++ b/decidim-consultations/app/views/layouts/decidim/admin/consultations.html.erb
@@ -12,5 +12,13 @@
 <% end %>
 
 <%= render "layouts/decidim/admin/application" do %>
-  <%= yield %>
+  <div class="process-title">
+    <div class="process-title-content">
+      <%= link_to t("decidim.admin.titles.consultations"), decidim_consultations.consultations_path, target: "_blank" %>
+    </div>
+  </div>
+
+  <div class="process-content">
+    <%= yield %>
+  </div>
 <% end %>

--- a/decidim-initiatives/app/views/layouts/decidim/admin/initiative.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/admin/initiative.html.erb
@@ -47,8 +47,11 @@
 <%= render "layouts/decidim/admin/application" do %>
   <div class="process-title">
     <div class="process-title-content">
-      <%= current_initiative.title.try(:[], I18n.locale.to_s) || current_initiative.title.values.compact.first %>
+      <%= link_to translated_attribute(current_initiative.title), decidim_initiatives.initiative_path(current_initiative), target: "_blank" %>
     </div>
   </div>
-  <%= yield %>
+
+  <div class="process-content">
+    <%= yield %>
+  </div>
 <% end %>

--- a/decidim-initiatives/app/views/layouts/decidim/admin/initiatives.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/admin/initiatives.html.erb
@@ -16,5 +16,13 @@
 <% end %>
 
 <%= render "layouts/decidim/admin/application" do %>
-  <%= yield %>
+  <div class="process-title">
+    <div class="process-title-content">
+      <%= link_to t("decidim.admin.titles.initiatives"), decidim_initiatives.initiatives_path, target: "_blank" %>
+    </div>
+  </div>
+
+  <div class="process-content">
+    <%= yield %>
+  </div>
 <% end %>

--- a/decidim-participatory_processes/app/views/layouts/decidim/admin/participatory_process.html.erb
+++ b/decidim-participatory_processes/app/views/layouts/decidim/admin/participatory_process.html.erb
@@ -74,8 +74,11 @@
 <%= render "layouts/decidim/admin/application" do %>
   <div class="process-title">
     <div class="process-title-content">
-      <%= translated_attribute(current_participatory_space.title) %>
+      <%= link_to translated_attribute(current_participatory_space.title), decidim_participatory_processes.participatory_process_path(current_participatory_space), target: "_blank" %>
     </div>
   </div>
-  <%= yield %>
+
+  <div class="process-content">
+    <%= yield %>
+  </div>
 <% end %>

--- a/decidim-participatory_processes/app/views/layouts/decidim/admin/participatory_processes.html.erb
+++ b/decidim-participatory_processes/app/views/layouts/decidim/admin/participatory_processes.html.erb
@@ -1,14 +1,11 @@
-<% content_for :secondary_nav do %>
-  <div class="secondary-nav">
-    <div class="secondary-nav__title">
-      <%= t "decidim.admin.titles.participatory_processes" %>
-    </div>
-    <div class="secondary-nav__actions">
-      <%= link_to t("actions.new", scope: "decidim.admin", name: t("models.participatory_process.name", scope: "decidim.admin")), ["new", "participatory_process"], class: "button expanded small" if can? :create, Decidim::ParticipatoryProcess %>
+<%= render "layouts/decidim/admin/application" do %>
+  <div class="process-title">
+    <div class="process-title-content">
+      <%= link_to t("decidim.admin.titles.participatory_processes"), decidim_participatory_processes.participatory_processes_path, target: "_blank" %>
     </div>
   </div>
-<% end %>
 
-<%= render "layouts/decidim/admin/application" do %>
-  <%= yield %>
+  <div class="process-content">
+    <%= yield %>
+  </div>
 <% end %>

--- a/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_processes_spec.rb
@@ -26,9 +26,7 @@ describe "Admin manages participatory processes", versioning: true, type: :syste
     let(:image2_path) { Decidim::Dev.asset(image2_filename) }
 
     before do
-      within ".secondary-nav__actions" do
-        page.find("a.button").click
-      end
+      click_link "New"
     end
 
     it "creates a new participatory process" do


### PR DESCRIPTION
#### :tophat: What? Why?

I thought of this usability improvement and made these changes quickly. The idea is that it's easier to jump to the frontend from a participatory space administration. Sometimes I make changes in the admin configuration and I want to test the participatory space after that. Previously I had to go back to the index page, remember the name of the space I was editing and click on it. It was quite tedious, although it would be easier if seed names were not written in latin and looked all the same to me :rofl:  

What do you think about this? I'll add a changelog entry and fix tests if the change is approved!

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

#### Before
![old](https://user-images.githubusercontent.com/2887858/39559710-afebc9bc-4e6e-11e8-8b10-4649dc0d3191.gif)

#### After
![after](https://user-images.githubusercontent.com/2887858/39559712-b43c7f84-4e6e-11e8-9dd2-f03555382910.gif)
