### PR TITLE
Backport Strange behaviour when creating an area with the same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 **Fixed**:
 
+- **decidim-admin**: Fixes the validation uniqueness name of area, scoped with organization and area_type [\#3350](https://github.com/decidim/decidim/pull/3350)
+
 ## [0.11.0.pre](https://github.com/decidim/decidim/tree/v0.11.0)
 
 **Upgrade notes**:

--- a/decidim-admin/app/forms/decidim/admin/area_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/area_form.rb
@@ -15,6 +15,15 @@ module Decidim
       validates :name, translatable_presence: true
       validates :organization, presence: true
 
+      validate :name_uniqueness
+
+      def name_uniqueness
+        return unless organization
+        return unless organization.areas.where(name: name, area_type: area_type).where.not(id: id).any?
+
+        errors.add(:name, :taken)
+      end
+
       alias organization current_organization
 
       def area_type

--- a/decidim-admin/spec/forms/area_form_spec.rb
+++ b/decidim-admin/spec/forms/area_form_spec.rb
@@ -34,6 +34,17 @@ module Decidim
         it { is_expected.to be_invalid }
       end
 
+      context "when name is not unique" do
+        before do
+          create(:area, organization: organization, name: name)
+        end
+
+        it "is not valid" do
+          expect(subject).not_to be_valid
+          expect(subject.errors[:name]).not_to be_empty
+        end
+      end
+
       context "when the name exists in another organization" do
         before do
           create(:area, name: name)

--- a/decidim-core/app/models/decidim/area.rb
+++ b/decidim-core/app/models/decidim/area.rb
@@ -18,6 +18,7 @@ module Decidim
                inverse_of: :areas,
                optional: true
 
+    validates :name, :organization, presence: true
     validates :name, uniqueness: { scope: [:organization, :area_type] }
 
     def self.log_presenter_class_for(_log)

--- a/decidim-core/app/models/decidim/area.rb
+++ b/decidim-core/app/models/decidim/area.rb
@@ -18,7 +18,7 @@ module Decidim
                inverse_of: :areas,
                optional: true
 
-    validates :name, :organization, presence: true
+    validates :name, uniqueness: { scope: [:organization, :area_type] }
 
     def self.log_presenter_class_for(_log)
       Decidim::AdminLog::AreaPresenter

--- a/decidim-core/spec/models/decidim/area_spec.rb
+++ b/decidim-core/spec/models/decidim/area_spec.rb
@@ -9,8 +9,14 @@ module Decidim
     it { is_expected.to be_valid }
     it { is_expected.to be_versioned }
 
-    context "with two areas with the same name and organization" do
-      let!(:existing_area) { create(:area, name: area.name, organization: area.organization) }
+    context "with two areas with the same name and organization but different area type" do
+      let!(:existing_area) { create(:area, name: area.name, area_type: build(:area_type), organization: area.organization) }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "with two areas with the same name and organization and same area type " do
+      let!(:existing_area) { create(:area, name: area.name, area_type: area.area_type, organization: area.organization) }
 
       it { is_expected.to be_invalid }
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Fix strange behaviour when creating an area with the same name and different area_type than existing other area.
Add validation uniqueness name in area form, scoped with the area_type

#### :pushpin: Related Issues
- Related to #2750 
- Fixes #3333 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add custom validation uniqueness name, areatype, on area form .

### :camera: Screenshots (optional)
![Description](URL)
