### PR TITLE
Backport Fix issue editing and deleting a specific post

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **Fixed**:
 
+- **decidim-blog**: Add `params[:id]` when editing/deleting a post from admin site [\#3360](https://github.com/decidim/decidim/pull/3360)
 ## [0.11.0.pre](https://github.com/decidim/decidim/tree/v0.11.0)
 
 **Upgrade notes**:

--- a/decidim-blogs/app/controllers/decidim/blogs/admin/posts_controller.rb
+++ b/decidim-blogs/app/controllers/decidim/blogs/admin/posts_controller.rb
@@ -56,7 +56,7 @@ module Decidim
         private
 
         def post
-          @post ||= Blogs::Post.find_by(component: current_component)
+          @post ||= Blogs::Post.find_by(component: current_component, id: params[:id])
         end
       end
     end

--- a/decidim-blogs/spec/shared/manage_posts_examples.rb
+++ b/decidim-blogs/spec/shared/manage_posts_examples.rb
@@ -2,7 +2,7 @@
 
 shared_examples "manage posts" do
   it "updates a post" do
-    within find("tr", text: translated(post.title)) do
+    within find("tr", text: translated(post1.title)) do
       click_link "Edit"
     end
 
@@ -29,6 +29,7 @@ shared_examples "manage posts" do
 
     within "table" do
       expect(page).to have_content("My new title")
+      expect(page).to have_content("Post title 2")
     end
   end
 
@@ -59,31 +60,26 @@ shared_examples "manage posts" do
 
     within "table" do
       expect(page).to have_content("My post")
+      expect(page).to have_content("Post title 1")
+      expect(page).to have_content("Post title 2")
     end
   end
 
   describe "deleting a post" do
-    let(:title) do
-      {
-        en: "This is the title of deleted post",
-        es: "Este es el título del post eliminado",
-        ca: "Aquest és el títol del post eliminat"
-      }
-    end
-
     before do
       visit current_path
     end
 
     it "deletes a post" do
-      within find("tr", text: translated(post.title)) do
+      within find("tr", text: translated(post1.title)) do
         accept_confirm { click_link "Delete" }
       end
 
       expect(page).to have_admin_callout("successfully")
 
       within "table" do
-        expect(page).to have_no_content(translated(post.title))
+        expect(page).to have_no_content(translated(post1.title))
+        expect(page).to have_content(translated(post2.title))
       end
     end
   end

--- a/decidim-blogs/spec/system/admin_manages_posts_spec.rb
+++ b/decidim-blogs/spec/system/admin_manages_posts_spec.rb
@@ -4,7 +4,8 @@ require "spec_helper"
 
 describe "Admin manages posts", type: :system do
   let(:manifest_name) { "blogs" }
-  let!(:post) { create :post, component: current_component }
+  let!(:post1) { create :post, component: current_component, title: { en: "Post title 1" } }
+  let!(:post2) { create :post, component: current_component, title: { en: "Post title 2" } }
 
   include_context "when managing a component as an admin"
 

--- a/decidim-blogs/spec/system/process_admin_manages_post_spec.rb
+++ b/decidim-blogs/spec/system/process_admin_manages_post_spec.rb
@@ -4,7 +4,8 @@ require "spec_helper"
 
 describe "Process admin manages post", type: :system do
   let(:manifest_name) { "blogs" }
-  let!(:post) { create :post, component: current_component }
+  let!(:post1) { create :post, component: current_component, title: { en: "Post title 1" } }
+  let!(:post2) { create :post, component: current_component, title: { en: "Post title 2" } }
 
   include_context "when managing a component as a process admin"
 

--- a/decidim-core/app/models/decidim/area.rb
+++ b/decidim-core/app/models/decidim/area.rb
@@ -19,7 +19,8 @@ module Decidim
                optional: true
 
     validates :name, :organization, presence: true
-
+    validates :name, uniqueness: { scope: :organization }
+    
     def self.log_presenter_class_for(_log)
       Decidim::AdminLog::AreaPresenter
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Fix when and admin try to edit a old post in the admin view he can edit only the last one.
Also, occurse the same with delete option.

#### :pushpin: Related Issues
- Related to #3230 
- Fixes #3327 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x]  Add params[:id] when searching post.
- [x] Add tests

### :camera: Screenshots (optional)
![Description](URL)
