### PR TITLE
Use optional gems in development app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ source "https://rubygems.org"
 ruby RUBY_VERSION
 
 gem "decidim", path: "."
-gem "decidim-consultations", path: "decidim-consultations"
-gem "decidim-initiatives", path: "decidim-initiatives"
+gem "decidim-consultations", path: "."
+gem "decidim-initiatives", path: "."
 
 gem "puma", "~> 3.0"
 gem "uglifier", "~> 4.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,10 @@ PATH
     decidim-comments (0.12.0.dev)
       decidim-core (= 0.12.0.dev)
       jquery-rails (~> 4.0)
+    decidim-consultations (0.12.0.dev)
+      decidim-admin (= 0.12.0.dev)
+      decidim-comments (= 0.12.0.dev)
+      decidim-core (= 0.12.0.dev)
     decidim-core (0.12.0.dev)
       active_link_to (~> 1.0)
       autoprefixer-rails (~> 8.0)
@@ -122,6 +126,14 @@ PATH
       wisper-rspec (~> 1.0)
     decidim-generators (0.12.0.dev)
       decidim-core (= 0.12.0.dev)
+    decidim-initiatives (0.12.0.dev)
+      decidim-admin (= 0.12.0.dev)
+      decidim-comments (= 0.12.0.dev)
+      decidim-core (= 0.12.0.dev)
+      decidim-verifications (= 0.12.0.dev)
+      kaminari (~> 1.0)
+      social-share-button (~> 1.0)
+      wicked (~> 1.3)
     decidim-meetings (0.12.0.dev)
       cells-erb (~> 0.1.0)
       cells-rails (~> 0.0.9)
@@ -161,26 +173,6 @@ PATH
       sassc-rails (~> 1.3)
     decidim-verifications (0.12.0.dev)
       decidim-core (= 0.12.0.dev)
-
-PATH
-  remote: decidim-consultations
-  specs:
-    decidim-consultations (0.12.0.dev)
-      decidim-admin (= 0.12.0.dev)
-      decidim-comments (= 0.12.0.dev)
-      decidim-core (= 0.12.0.dev)
-
-PATH
-  remote: decidim-initiatives
-  specs:
-    decidim-initiatives (0.12.0.dev)
-      decidim-admin (= 0.12.0.dev)
-      decidim-comments (= 0.12.0.dev)
-      decidim-core (= 0.12.0.dev)
-      decidim-verifications (= 0.12.0.dev)
-      kaminari (~> 1.0)
-      social-share-button (~> 1.0)
-      wicked (~> 1.3)
 
 GEM
   remote: https://rubygems.org/
@@ -229,7 +221,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     ast (2.4.0)
-    autoprefixer-rails (8.3.0.1)
+    autoprefixer-rails (8.4.1)
       execjs
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -435,7 +427,7 @@ GEM
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
-    nio4r (2.3.0)
+    nio4r (2.3.1)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     oauth (0.5.4)
@@ -596,7 +588,7 @@ GEM
       sprockets-rails
       tilt
     searchlight (4.1.0)
-    selenium-webdriver (3.11.0)
+    selenium-webdriver (3.12.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
     simplecov (0.16.1)
@@ -656,7 +648,7 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
-    webmock (3.3.0)
+    webmock (3.4.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff

--- a/Rakefile
+++ b/Rakefile
@@ -68,3 +68,12 @@ desc "Build webpack bundle files"
 task :webpack do
   sh "npm install && npm run build:prod"
 end
+
+desc "Bundle all Gemfiles"
+task :bundle do
+  [".", "decidim-generators", "decidim_app-design"].each do |dir|
+    Bundler.with_original_env do
+      Dir.chdir(dir) { sh "bundle install" }
+    end
+  end
+end

--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -133,6 +133,7 @@ module Decidim
           [
             "--recreate_db=#{options[:recreate_db]}",
             "--seed_db=#{options[:seed_db]}",
+            "--skip_gemfile=#{options[:skip_gemfile]}",
             "--app_name=#{app_name}"
           ]
         )

--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -102,8 +102,14 @@ module Decidim
 
         if current_gem == "decidim"
           gsub_file "Gemfile", /gem "decidim-dev".*/, "gem \"decidim-dev\", #{gem_modifier}"
-          gsub_file "Gemfile", /gem "decidim-consultations".*/, "# gem \"decidim-consultations\", #{gem_modifier}"
-          gsub_file "Gemfile", /gem "decidim-initiatives".*/, "# gem \"decidim-initiatives\", #{gem_modifier}"
+
+          if options[:demo]
+            gsub_file "Gemfile", /gem "decidim-consultations".*/, "gem \"decidim-consultations\", #{gem_modifier}"
+            gsub_file "Gemfile", /gem "decidim-initiatives".*/, "gem \"decidim-initiatives\", #{gem_modifier}"
+          else
+            gsub_file "Gemfile", /gem "decidim-consultations".*/, "# gem \"decidim-consultations\", #{gem_modifier}"
+            gsub_file "Gemfile", /gem "decidim-initiatives".*/, "# gem \"decidim-initiatives\", #{gem_modifier}"
+          end
         end
 
         Bundler.with_original_env { run "bundle install" }

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -1,24 +1,4 @@
 PATH
-  remote: ../decidim-consultations
-  specs:
-    decidim-consultations (0.12.0.dev)
-      decidim-admin (= 0.12.0.dev)
-      decidim-comments (= 0.12.0.dev)
-      decidim-core (= 0.12.0.dev)
-
-PATH
-  remote: ../decidim-initiatives
-  specs:
-    decidim-initiatives (0.12.0.dev)
-      decidim-admin (= 0.12.0.dev)
-      decidim-comments (= 0.12.0.dev)
-      decidim-core (= 0.12.0.dev)
-      decidim-verifications (= 0.12.0.dev)
-      kaminari (~> 1.0)
-      social-share-button (~> 1.0)
-      wicked (~> 1.3)
-
-PATH
   remote: ..
   specs:
     decidim (0.12.0.dev)
@@ -75,6 +55,10 @@ PATH
     decidim-comments (0.12.0.dev)
       decidim-core (= 0.12.0.dev)
       jquery-rails (~> 4.0)
+    decidim-consultations (0.12.0.dev)
+      decidim-admin (= 0.12.0.dev)
+      decidim-comments (= 0.12.0.dev)
+      decidim-core (= 0.12.0.dev)
     decidim-core (0.12.0.dev)
       active_link_to (~> 1.0)
       autoprefixer-rails (~> 8.0)
@@ -142,6 +126,14 @@ PATH
       wisper-rspec (~> 1.0)
     decidim-generators (0.12.0.dev)
       decidim-core (= 0.12.0.dev)
+    decidim-initiatives (0.12.0.dev)
+      decidim-admin (= 0.12.0.dev)
+      decidim-comments (= 0.12.0.dev)
+      decidim-core (= 0.12.0.dev)
+      decidim-verifications (= 0.12.0.dev)
+      kaminari (~> 1.0)
+      social-share-button (~> 1.0)
+      wicked (~> 1.3)
     decidim-meetings (0.12.0.dev)
       cells-erb (~> 0.1.0)
       cells-rails (~> 0.0.9)
@@ -229,7 +221,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     ast (2.4.0)
-    autoprefixer-rails (8.3.0.1)
+    autoprefixer-rails (8.4.1)
       execjs
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -435,7 +427,7 @@ GEM
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
-    nio4r (2.3.0)
+    nio4r (2.3.1)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     oauth (0.5.4)
@@ -596,7 +588,7 @@ GEM
       sprockets-rails
       tilt
     searchlight (4.1.0)
-    selenium-webdriver (3.11.0)
+    selenium-webdriver (3.12.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
     simplecov (0.16.1)
@@ -656,7 +648,7 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
-    webmock (3.3.0)
+    webmock (3.4.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff


### PR DESCRIPTION
#### :tophat: What? Why?

Currently optional gems (consultations & initiatives) are not used when generating a development app. I think we should probably use them in development?

@mrcasals @oriolgual This _might_ be relevant for your demo.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.