### PR TITLE
Update PostgreSQL minimum version to v9.5 in docs

### DIFF
--- a/decidim-generators/lib/decidim/generators/app_templates/database.yml.erb
+++ b/decidim-generators/lib/decidim/generators/app_templates/database.yml.erb
@@ -1,4 +1,4 @@
-# PostgreSQL. Versions 9.1 and up are supported.
+# PostgreSQL. Versions 9.5 and up are supported.
 #
 # Install the pg driver:
 #   gem install pg

--- a/docs/manual-installation.md
+++ b/docs/manual-installation.md
@@ -5,7 +5,7 @@
 In order to develop on decidim, you'll need:
 
 * **Git** 2.15+
-* **PostgreSQL** 9.4+
+* **PostgreSQL** 9.5+
 * **Ruby** 2.5.0 (2.3+ should work just fine, but that's the version we test against)
 * **NodeJS** 9.x.x
 * **ImageMagick**


### PR DESCRIPTION
#### :tophat: What? Why?
I was receiving an error when trying to update my app with the last migrations.

The received error message was:
```
Caused by:
ActiveRecord::StatementInvalid: PG::UndefinedFunction: ERROR:  operator does not exist: jsonb - unknown
LINE 5:   (settings->'global')::jsonb - 'maximum_votes_per_proposal'...
                                      ^
HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
: UPDATE decidim_components
SET settings = jsonb_set(
  settings::jsonb,
  array['global'],
  (settings->'global')::jsonb - 'maximum_votes_per_proposal' || jsonb_build_object('threshold_per_proposal', settings->'global'->'maximum_votes_per_proposal')
  )
WHERE manifest_name = 'proposals'
```

I was using PostgreSQL v9.4, and I checked that the support for `-` operator for JSONB type was added to PostgreSQL v9.5:
- https://www.postgresql.org/docs/9.4/static/functions-json.html
- https://www.postgresql.org/docs/9.5/static/functions-json.html

I've updated my PostgreSQL to v9.5 and now is working, so I think we should update docs to warn about this.

#### :pushpin: Related Issues
- Related to #3017

#### :clipboard: Subtasks

### :camera: Screenshots (optional)
