### PR TITLE
Restrict high_voltage version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,7 @@ PATH
       foundation-rails (~> 6.4, < 6.5)
       foundation_rails_helper (~> 3.0)
       geocoder (~> 1.4)
-      high_voltage (~> 3.0)
+      high_voltage (~> 3.0.0)
       invisible_captcha (~> 0.10.0)
       jquery-rails (~> 4.3)
       loofah (~> 2.0, >= 2.2.1)

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency "foundation-rails", "~> 6.4", "< 6.5"
   s.add_dependency "foundation_rails_helper", "~> 3.0"
   s.add_dependency "geocoder", "~> 1.4"
-  s.add_dependency "high_voltage", "~> 3.0"
+  s.add_dependency "high_voltage", "~> 3.0.0"
   s.add_dependency "invisible_captcha", "~> 0.10.0"
   s.add_dependency "jquery-rails", "~> 4.3"
   s.add_dependency "loofah", "~> 2.0", ">= 2.2.1" # version 2.2.0 has a vulnerability

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -71,7 +71,7 @@ PATH
       foundation-rails (~> 6.4, < 6.5)
       foundation_rails_helper (~> 3.0)
       geocoder (~> 1.4)
-      high_voltage (~> 3.0)
+      high_voltage (~> 3.0.0)
       invisible_captcha (~> 0.10.0)
       jquery-rails (~> 4.3)
       loofah (~> 2.0, >= 2.2.1)

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -136,7 +136,7 @@ PATH
       foundation-rails (~> 6.4, < 6.5)
       foundation_rails_helper (~> 3.0)
       geocoder (~> 1.4)
-      high_voltage (~> 3.0)
+      high_voltage (~> 3.0.0)
       invisible_captcha (~> 0.10.0)
       jquery-rails (~> 4.3)
       loofah (~> 2.0, >= 2.2.1)


### PR DESCRIPTION
#### :tophat: What? Why?
Limits the `high_voltage` version to 3.0.0, as per #3374.

#### :pushpin: Related Issues
- Related to #3374

#### :clipboard: Subtasks
None