### PR TITLE
[Backport] Restrict high_voltage version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@ administrators should keep in mind updating the help texts for each step.
 - **decidim-admin**: Ability to select leaf categories from Admin change-category bulk action [\#3243](https://github.com/decidim/decidim/pull/3243)
 - **decidim-admin**: Highlighted banner image is not required if already present in the organization [\#3244](https://github.com/decidim/decidim/pull/3244)
 - **decidim-proposals**: Keep the user group (if set) as default value of author field on forms [\#3247](https://github.com/decidim/decidim/pull/3247)
+- **decidim**: Fix the dependency of `high_voltage` to `v3.0.0` [\#3383](https://github.com/decidim/decidim/pull/3383)
 
 **Removed**:
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,7 @@ PATH
       foundation-rails (~> 6.4, < 6.5)
       foundation_rails_helper (~> 3.0)
       geocoder (~> 1.4)
-      high_voltage (~> 3.0)
+      high_voltage (~> 3.0.0)
       invisible_captcha (~> 0.10.0)
       jquery-rails (~> 4.3)
       loofah (~> 2.0, >= 2.2.1)

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_dependency "foundation-rails", "~> 6.4", "< 6.5"
   s.add_dependency "foundation_rails_helper", "~> 3.0"
   s.add_dependency "geocoder", "~> 1.4"
-  s.add_dependency "high_voltage", "~> 3.0"
+  s.add_dependency "high_voltage", "~> 3.0.0"
   s.add_dependency "invisible_captcha", "~> 0.10.0"
   s.add_dependency "jquery-rails", "~> 4.3"
   s.add_dependency "loofah", "~> 2.0", ">= 2.2.1" # version 2.2.0 has a vulnerability

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -72,7 +72,7 @@ PATH
       foundation-rails (~> 6.4, < 6.5)
       foundation_rails_helper (~> 3.0)
       geocoder (~> 1.4)
-      high_voltage (~> 3.0)
+      high_voltage (~> 3.0.0)
       invisible_captcha (~> 0.10.0)
       jquery-rails (~> 4.3)
       loofah (~> 2.0, >= 2.2.1)

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -92,7 +92,7 @@ PATH
       foundation-rails (~> 6.4, < 6.5)
       foundation_rails_helper (~> 3.0)
       geocoder (~> 1.4)
-      high_voltage (~> 3.0)
+      high_voltage (~> 3.0.0)
       invisible_captcha (~> 0.10.0)
       jquery-rails (~> 4.3)
       loofah (~> 2.0, >= 2.2.1)


### PR DESCRIPTION
#### :tophat: What? Why?
Backports #3375 to 0.11-stable.

#### :pushpin: Related Issues
- Related to #3375, #3374.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry