### PR TITLE
Uses current organization scopes in scopes picker.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ end
 
 **Fixed**:
 
+- **decidim-core**: Uses current organization scopes in scopes picker. [\#3386](https://github.com/decidim/decidim/pull/3386)
 - **decidim-blog**: Add `params[:id]` when editing/deleting a post from admin site [\#3329](https://github.com/decidim/decidim/pull/3329)
 - **decidim-admin**: Fixes the validation uniqueness name of area, scoped with organization and area_type [\#3336](https://github.com/decidim/decidim/pull/3336) https://github.com/decidim/decidim/pull/3336
 - **decidim-accountability**: Fixes linking proposals to results for accountability on creation time. [\#3167](https://github.com/decidim/decidim/pull/3262)

--- a/decidim-core/app/controllers/decidim/scopes_controller.rb
+++ b/decidim-core/app/controllers/decidim/scopes_controller.rb
@@ -9,7 +9,7 @@ module Decidim
       enforce_permission_to :pick, :scope
 
       title = params[:title] || t("decidim.scopes.picker.title", field: params[:field]&.downcase)
-      root = Scope.find(params[:root]) if params[:root]
+      root = current_organization.scopes.find(params[:root]) if params[:root]
       context = root ? { root: root.id, title: title } : { title: title }
       required = params[:required] && params[:required] != "false"
       if params[:current]
@@ -18,7 +18,7 @@ module Decidim
         parent_scopes = current.part_of_scopes(root)
       else
         current = root
-        scopes = root&.children || Scope.top_level
+        scopes = root&.children || current_organization.scopes.top_level
         parent_scopes = [root].compact
       end
       render :picker, layout: nil, locals: { required: required, title: title, root: root, current: current, scopes: scopes.order(name: :asc),

--- a/decidim-core/spec/system/scopes_spec.rb
+++ b/decidim-core/spec/system/scopes_spec.rb
@@ -4,8 +4,10 @@ require "spec_helper"
 
 describe "Scopes picker", type: :system do
   let(:organization) { create(:organization) }
+  let(:other_organization) { create(:organization) }
   let!(:scopes) { create_list(:scope, 3, organization: organization) }
   let!(:subscope) { create(:subscope, parent: scopes.first) }
+  let!(:other_scopes) { create_list(:scope, 3, organization: other_organization) }
 
   describe "scope picker page" do
     before do
@@ -25,6 +27,18 @@ describe "Scopes picker", type: :system do
 
       it "does not allow to choose current scope (none)" do
         expect(page).to have_css(".scope-picker.picker-footer .buttons a.button.muted")
+      end
+
+      it "shows organization top scopes in content" do
+        scopes.each do |scope|
+          expect(page).to have_css(".scope-picker.picker-content li a", text: scope.name["en"])
+        end
+      end
+
+      it "does not show other organization top scopes in content" do
+        other_scopes.each do |scope|
+          expect(page).not_to have_css(".scope-picker.picker-content li a", text: scope.name["en"])
+        end
       end
 
       context "when has a current scope" do


### PR DESCRIPTION
#### :tophat: What? Why?
Scopes selector includes scopes from other organizations.

#### :pushpin: Related Issues
- Fixes #3385

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)
