### PR TITLE
Use autocomplete field when selecting the meeting organizer

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/organization_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/organization_controller.rb
@@ -40,7 +40,7 @@ module Decidim
                         query.where("name ILIKE ?", "%#{term}%")
                       end
 
-              render json: query.pluck(:id, :name, :nickname)
+              render json: query.all.collect { |u| { value: u.id, label: "#{u.name} (@#{u.nickname})" } }
             else
               render json: []
             end

--- a/decidim-admin/lib/decidim/admin/form_builder.rb
+++ b/decidim-admin/lib/decidim/admin/form_builder.rb
@@ -53,6 +53,7 @@ module Decidim
                                     searchPromptText: options[:search_prompt] || I18n.t("autocomplete.search_prompt", scope: "decidim.admin"),
                                     noResultsText: options[:no_results] || I18n.t("autocomplete.no_results", scope: "decidim.admin")
                                   },
+                                  autocomplete_for: attribute,
                                   plugin: "autocomplete"
                                 })
         template += error_for(attribute, options) if error?(attribute)

--- a/decidim-admin/spec/controllers/organizations_contoller_spec.rb
+++ b/decidim-admin/spec/controllers/organizations_contoller_spec.rb
@@ -19,7 +19,7 @@ module Decidim
         let!(:user) { create(:user, name: "Daisy Miller", nickname: "daisy_m", organization: organization) }
         let!(:other_user) { create(:user, name: "Daisy O'connor", nickname: "daisy_o") }
 
-        let(:parsed_response) { JSON.parse(response.body) }
+        let(:parsed_response) { JSON.parse(response.body).map(&:symbolize_keys) }
 
         context "when no search term is provided" do
           it "returns an empty result set" do
@@ -38,14 +38,14 @@ module Decidim
         context "when searching by name" do
           it "returns the id, name and nickname for filtered users" do
             get :users, format: :json, params: { term: "daisy" }
-            expect(parsed_response).to eq([[user.id, user.name, user.nickname]])
+            expect(parsed_response).to eq([{ value: user.id, label: "#{user.name} (@#{user.nickname})" }])
           end
         end
 
         context "when searching by nickname" do
           it "returns the id, name and nickname for filtered users" do
             get :users, format: :json, params: { term: "@daisy" }
-            expect(parsed_response).to eq([[user.id, user.name, user.nickname]])
+            expect(parsed_response).to eq([{ value: user.id, label: "#{user.name} (@#{user.nickname})" }])
           end
         end
       end

--- a/decidim-admin/spec/lib/admin/form_builder_spec.rb
+++ b/decidim-admin/spec/lib/admin/form_builder_spec.rb
@@ -39,11 +39,15 @@ module Decidim
       let(:autocomplete_data) { JSON.parse(subject.xpath("//div[@data-autocomplete]/@data-autocomplete").first.value) }
 
       it "sets the plugin data attribute" do
-        expect(subject.css("div.autocomplete-field [data-plugin='autocomplete']")).not_to be_nil
+        expect(subject.css("div[data-plugin='autocomplete']")).not_to be_empty
       end
 
       it "sets the autocomplete data attribute" do
-        expect(subject.css("div.autocomplete-field [data-autocomplete]")).not_to be_nil
+        expect(subject.css("div[data-autocomplete]")).not_to be_empty
+      end
+
+      it "sets the autocomplete_for data attribute" do
+        expect(subject.css("div[data-autocomplete-for='category_id']")).not_to be_empty
       end
 
       context "without selected value" do

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/react_select.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/react_select.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Adapted from https://github.com/JedWatson/react-select/issues/832#issuecomment-276441836
+
+module Capybara
+  module ReactSelect
+    def autocomplete_select(value, from:)
+      within("div[data-autocomplete-for='#{from}']") do
+        find(".Select-control").click
+
+        find(".Select .Select-input input").native.send_keys(value[0..4])
+        expect(page).to have_css(".Select-menu-outer") # select should be open now
+
+        # This is a little funky because when the entered text forces the select to
+        # wrap, it causes React to re-render.  We need to get it to re-render
+        # (if needed) by hovering.
+        expect(page).to have_css(".Select-option", text: value)
+        find(".Select-option", text: value).hover
+        expect(page).to have_css(".Select-option", text: value)
+        find(".Select-option", text: value).click
+        expect(page).to have_css(".Select-value-label", text: value)
+      end
+    end
+  end
+end

--- a/decidim-dev/lib/decidim/dev/test/spec_helper.rb
+++ b/decidim-dev/lib/decidim/dev/test/spec_helper.rb
@@ -35,5 +35,6 @@ RSpec.configure do |config|
   config.include Rectify::RSpec::Helpers
   config.include ActionView::Helpers::SanitizeHelper
   config.include ERB::Util
+  config.include Capybara::ReactSelect, type: :system
   config.include Decidim::ScreenshotHelperExt, type: :system
 end

--- a/decidim-meetings/app/assets/javascripts/decidim/meetings/admin/meetings_form.js.es6
+++ b/decidim-meetings/app/assets/javascripts/decidim/meetings/admin/meetings_form.js.es6
@@ -93,37 +93,5 @@
 
     $privateMeeting.on("change", toggleDisabledHiddenFields);
     toggleDisabledHiddenFields();
-
-    let xhr = null;
-
-    $(".user-autocomplete").autoComplete({
-      minChars: 2,
-      source: function(term, response) {
-        try {
-          xhr.abort();
-        } catch (exception) { xhr = null }
-
-        xhr = $.getJSON(
-          $(".user-autocomplete").data("url"),
-          { term: term },
-          function(data) { response(data); }
-        );
-      },
-      renderItem: function (item, search) {
-        let re = new RegExp(`(${search.split(" ").join("|")})`, "gi");
-
-        let modelId = item[0];
-        let name = item[1];
-        let nickname = item[2];
-        let val = `${name} (@${nickname})`;
-        return `<div class="autocomplete-suggestion" data-model-id="${modelId}" data-val="${val}">${val.replace(re, "<b>$1</b>")}</div>`;
-      },
-      onSelect: function(event, term, item) {
-        let modelId = item.data("modelId");
-        let val = `${item.data("val")}`;
-        $("#meeting_organizer_id").val(modelId);
-        $(".user-autocomplete").val(val);
-      }
-    });
   }
 })(window);

--- a/decidim-meetings/app/views/decidim/meetings/admin/meeting_copies/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meeting_copies/_form.html.erb
@@ -35,9 +35,10 @@
     </div>
 
     <div class="row column">
-      <%= form.text_field :organizer_picker, value: meeting_organizer_picker_text(form), class: "user-autocomplete", placeholder: t(".select_organizer"),
-                          data: { url: decidim_admin.users_organization_url } %>
-      <%= form.hidden_field :organizer_id %>
+      <% prompt_options = { url: decidim_admin.users_organization_url, text: t(".select_organizer") } %>
+      <%= form.autocomplete_select(:organizer_id, form.object.organizer.presence, { multiple: false }, prompt_options) do |user|
+        { value: user.id, label: "#{user.name} (@#{user.nickname})" }
+      end %>
     </div>
 
     <div class="row column" id="private_meeting">

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
@@ -46,9 +46,10 @@
     </div>
 
     <div class="row column">
-      <%= form.text_field :organizer_picker, value: meeting_organizer_picker_text(form), class: "user-autocomplete", placeholder: t(".select_organizer"),
-                          data: { url: decidim_admin.users_organization_url } %>
-      <%= form.hidden_field :organizer_id %>
+      <% prompt_options = { url: decidim_admin.users_organization_url, text: t(".select_organizer") } %>
+      <%= form.autocomplete_select(:organizer_id, form.object.organizer.presence, { multiple: false }, prompt_options) do |user|
+        { value: user.id, label: "#{user.name} (@#{user.nickname})" }
+      end %>
     </div>
 
     <div class="row column" id="private_meeting">

--- a/decidim-meetings/spec/shared/manage_meetings_examples.rb
+++ b/decidim-meetings/spec/shared/manage_meetings_examples.rb
@@ -5,6 +5,7 @@ shared_examples "manage meetings" do
   let(:latitude) { 40.1234 }
   let(:longitude) { 2.1234 }
 
+  let(:organizer) { create(:user, :confirmed, organization: organization) }
   let(:service_titles) { ["This is the first service", "This is the second service"] }
 
   before do
@@ -124,6 +125,8 @@ shared_examples "manage meetings" do
     scope_pick select_data_picker(:meeting_decidim_scope_id), scope
     select translated(category.name), from: :meeting_decidim_category_id
 
+    autocomplete_select "#{organizer.name} (@#{organizer.nickname})", from: :organizer_id
+
     within ".new_meeting" do
       find("*[type=submit]").click
     end
@@ -181,6 +184,8 @@ shared_examples "manage meetings" do
       page.find(".datepicker-dropdown .day", text: "12").click
       page.find(".datepicker-dropdown .hour", text: "12:00").click
       page.find(".datepicker-dropdown .minute", text: "12:50").click
+
+      autocomplete_select "#{organizer.name} (@#{organizer.nickname})", from: :organizer_id
 
       within ".copy_meetings" do
         find("*[type=submit]").click
@@ -289,6 +294,8 @@ shared_examples "manage meetings" do
 
       scope_pick select_data_picker(:meeting_decidim_scope_id), scope
       select translated(category.name), from: :meeting_decidim_category_id
+
+      autocomplete_select "#{organizer.name} (@#{organizer.nickname})", from: :organizer_id
 
       within ".new_meeting" do
         find("*[type=submit]").click


### PR DESCRIPTION
#### :tophat: What? Why?

Use the new autocomplete field component when selecting the meeting organizer. We need this change, because we are reusing the users endpoint here and in the assembly members feature.

I don't add a change log entry, because the PR adding the meetings organizers was merged yesterday and not released yet, so this is a "internal" change.

#### :pushpin: Related Issues
- Build on top of #3381

#### :clipboard: Subtasks
- ~[ ] Add `CHANGELOG` entry~
