### PR TITLE
Move card definition to the ResourceManifest

### DIFF
--- a/decidim-core/app/cells/decidim/card_cell.rb
+++ b/decidim-core/app/cells/decidim/card_cell.rb
@@ -20,8 +20,8 @@ module Decidim
     end
 
     def resource_cell
-      if model.respond_to? :component
-        @resource_cell ||= model.component.manifest.card
+      if model.respond_to?(:resource_manifest) && model.resource_manifest.card.present?
+        @resource_cell ||= model.resource_manifest.card
       elsif model.respond_to? :manifest
         @resource_cell ||= model.manifest.card
       elsif ["Decidim::Proposals::OfficialAuthorPresenter", "Decidim::Debates::OfficialAuthorPresenter"].include? model.class.to_s

--- a/decidim-core/app/cells/decidim/card_cell.rb
+++ b/decidim-core/app/cells/decidim/card_cell.rb
@@ -22,8 +22,6 @@ module Decidim
     def resource_cell
       if model.respond_to?(:resource_manifest) && model.resource_manifest.card.present?
         @resource_cell ||= model.resource_manifest.card
-      elsif model.respond_to? :manifest
-        @resource_cell ||= model.manifest.card
       elsif ["Decidim::Proposals::OfficialAuthorPresenter", "Decidim::Debates::OfficialAuthorPresenter"].include? model.class.to_s
         @resource_cell ||= "decidim/author"
       elsif ["Decidim::User", "Decidim::UserGroup"].include? model.model_name.name

--- a/decidim-core/lib/decidim/component_manifest.rb
+++ b/decidim-core/lib/decidim/component_manifest.rb
@@ -130,7 +130,7 @@ module Decidim
     # defined by `Decidim::ResourceManifest`.
     #
     # Resource manifests are a way to expose a resource from one engine to
-    # the whole system. This was resoruces can be linked between them.
+    # the whole system. This way resources can be linked between them.
     #
     # block - A Block that will be called to set the Resource attributes.
     #

--- a/decidim-core/lib/decidim/component_manifest.rb
+++ b/decidim-core/lib/decidim/component_manifest.rb
@@ -47,9 +47,6 @@ module Decidim
     # as well that allows checking for those permissions.
     attribute :actions, Array[String]
 
-    # The cell path to use to render the card of a resource.
-    attribute :card, String
-
     # The name of the class that handles the permissions for this component. It will
     # probably have the form of `Decidim::<MyComponent>::Permissions`.
     attribute :permissions_class_name, String, default: "Decidim::DefaultPermissions"

--- a/decidim-core/lib/decidim/component_manifest.rb
+++ b/decidim-core/lib/decidim/component_manifest.rb
@@ -10,6 +10,7 @@ module Decidim
   # It's normally not used directly but through the API exposed through
   # `Decidim.register_component`.
   class ComponentManifest
+    include Decidim::HasResourceManifests
     include ActiveModel::Model
     include Virtus.model
 
@@ -126,23 +127,6 @@ module Decidim
       settings
     end
 
-    # Public: Registers a resource inside a component manifest. Exposes a DSL
-    # defined by `Decidim::ResourceManifest`.
-    #
-    # Resource manifests are a way to expose a resource from one engine to
-    # the whole system. This way resources can be linked between them.
-    #
-    # block - A Block that will be called to set the Resource attributes.
-    #
-    # Returns nothing.
-    def register_resource
-      manifest = ResourceManifest.new
-      manifest.component_manifest = self
-      yield(manifest)
-      manifest.validate!
-      resource_manifests << manifest
-    end
-
     # Public: Registers an export artifact with a name and its properties
     # defined in `Decidim::Components::ExportManifest`.
     #
@@ -171,14 +155,6 @@ module Decidim
           block.call(manifest)
         end
       end
-    end
-
-    # Public: Finds all the registered resource manifest's via the
-    # `register_resource` method.
-    #
-    # Returns an Array[ResourceManifest].
-    def resource_manifests
-      @resource_manifests ||= []
     end
 
     # Public: Stores an instance of StatsRegistry

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -53,6 +53,7 @@ module Decidim
   autoload :ParticipatorySpaceResourceable, "decidim/participatory_space_resourceable"
   autoload :HasPrivateUsers, "decidim/has_private_users"
   autoload :ViewModel, "decidim/view_model"
+  autoload :HasResourceManifests, "decidim/has_resource_manifests"
 
   include ActiveSupport::Configurable
 
@@ -286,7 +287,8 @@ module Decidim
   #
   # Returns a ResourceManifest if found, nil otherwise.
   def self.find_resource_manifest(resource_name_or_klass)
-    component_registry.find_resource_manifest(resource_name_or_klass)
+    component_registry.find_resource_manifest(resource_name_or_klass) ||
+      participatory_space_registry.find_resource_manifest(resource_name_or_klass)
   end
 
   # Public: Stores the registry of components

--- a/decidim-core/lib/decidim/has_resource_manifests.rb
+++ b/decidim-core/lib/decidim/has_resource_manifests.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  # A concern with the logic needed to hold and register resource manifests.
+  # Intended to be used internally by the ComponentManifest and the
+  # ParticipatorySpaceManifest.
+  module HasResourceManifests
+    extend ActiveSupport::Concern
+
+    included do
+      # Public: Finds all the registered resource manifest's via the
+      # `register_resource` method.
+      #
+      # Returns an Array[ResourceManifest].
+      def resource_manifests
+        @resource_manifests ||= []
+      end
+
+      # Public: Registers a resource inside a component manifest. Exposes a DSL
+      # defined by `Decidim::ResourceManifest`.
+      #
+      # Resource manifests are a way to expose a resource from one engine to
+      # the whole system. This way resources can be linked between them.
+      #
+      # block - A Block that will be called to set the Resource attributes.
+      #
+      # Returns nothing.
+      def register_resource
+        manifest = ResourceManifest.new
+        manifest.component_manifest = self
+        yield(manifest)
+        manifest.validate!
+        resource_manifests << manifest
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/participatory_space_manifest.rb
+++ b/decidim-core/lib/decidim/participatory_space_manifest.rb
@@ -10,6 +10,7 @@ module Decidim
   # It's normally not used directly but through the API exposed through
   # `Decidim.register_participatory_space`.
   class ParticipatorySpaceManifest
+    include Decidim::HasResourceManifests
     include ActiveModel::Model
     include Virtus.model
 

--- a/decidim-core/lib/decidim/participatory_space_resourceable.rb
+++ b/decidim-core/lib/decidim/participatory_space_resourceable.rb
@@ -26,6 +26,8 @@ module Decidim
       # An association with all the links that are originated from this model.
       has_many :participatory_space_resource_links_from, as: :from, class_name: "Decidim::ParticipatorySpaceLink"
 
+      delegate :resource_manifest, to: :class
+
       # Finds all the linked resources to or from this model for a given resource
       # name and link name.
       #
@@ -74,6 +76,15 @@ module Decidim
             )
           end
         end
+      end
+    end
+
+    class_methods do
+      # Finds the resource manifest for the model.
+      #
+      # Returns a Decidim::ResourceManifest
+      def resource_manifest
+        Decidim.find_resource_manifest(self)
       end
     end
   end

--- a/decidim-core/lib/decidim/resource_manifest.rb
+++ b/decidim-core/lib/decidim/resource_manifest.rb
@@ -30,8 +30,11 @@ module Decidim
     # When not explicitly set, it will use the model name.
     attribute :route_name, String
 
-    # The template to use to render the collection of a resource.
+    # The template to use to render the collection of the resource.
     attribute :template, String
+
+    # The main card to render an instance of the resource.
+    attribute :card, String
 
     validates :component_manifest, :model_class_name, :route_name, presence: true
 

--- a/decidim-core/lib/decidim/resourceable.rb
+++ b/decidim-core/lib/decidim/resourceable.rb
@@ -81,6 +81,8 @@ module Decidim
           end
         end
       end
+
+      delegate :resource_manifest, to: :class
     end
 
     class_methods do

--- a/decidim-debates/lib/decidim/debates/component.rb
+++ b/decidim-debates/lib/decidim/debates/component.rb
@@ -7,7 +7,6 @@ Decidim.register_component(:debates) do |component|
   component.admin_engine = Decidim::Debates::AdminEngine
   component.icon = "decidim/debates/icon.svg"
   component.permissions_class_name = "Decidim::Debates::Permissions"
-  component.card = "decidim/debates/debate"
 
   component.on(:before_destroy) do |instance|
     raise StandardError, "Can't remove this component" if Decidim::Debates::Debate.where(component: instance).any?
@@ -30,6 +29,7 @@ Decidim.register_component(:debates) do |component|
 
   component.register_resource do |resource|
     resource.model_class_name = "Decidim::Debates::Debate"
+    resource.card = "decidim/debates/debate"
   end
 
   component.actions = %w(create)

--- a/decidim-meetings/lib/decidim/meetings/component.rb
+++ b/decidim-meetings/lib/decidim/meetings/component.rb
@@ -6,7 +6,6 @@ Decidim.register_component(:meetings) do |component|
   component.engine = Decidim::Meetings::Engine
   component.admin_engine = Decidim::Meetings::AdminEngine
   component.icon = "decidim/meetings/icon.svg"
-  component.card = "decidim/meetings/meeting"
   component.permissions_class_name = "Decidim::Meetings::Permissions"
 
   component.query_type = "Decidim::Meetings::MeetingsType"
@@ -18,6 +17,7 @@ Decidim.register_component(:meetings) do |component|
   component.register_resource do |resource|
     resource.model_class_name = "Decidim::Meetings::Meeting"
     resource.template = "decidim/meetings/meetings/linked_meetings"
+    resource.card = "decidim/meetings/meeting"
   end
 
   component.register_stat :meetings_count, primary: true, priority: Decidim::StatsRegistry::MEDIUM_PRIORITY do |components, start_at, end_at|

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
@@ -2,7 +2,6 @@
 
 Decidim.register_participatory_space(:participatory_processes) do |participatory_space|
   participatory_space.icon = "decidim/participatory_processes/icon.svg"
-  participatory_space.card = "decidim/participatory_processes/process"
   participatory_space.model_class_name = "Decidim::ParticipatoryProcess"
 
   participatory_space.participatory_spaces do |organization|
@@ -12,6 +11,11 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
   participatory_space.query_type = "Decidim::ParticipatoryProcesses::ParticipatoryProcessType"
 
   participatory_space.permissions_class_name = "Decidim::ParticipatoryProcesses::Permissions"
+
+  participatory_space.register_resource do |resource|
+    resource.model_class_name = "Decidim::ParticipatoryProcess"
+    resource.card = "decidim/participatory_processes/process"
+  end
 
   participatory_space.context(:public) do |context|
     context.engine = Decidim::ParticipatoryProcesses::Engine

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -6,7 +6,6 @@ Decidim.register_component(:proposals) do |component|
   component.engine = Decidim::Proposals::Engine
   component.admin_engine = Decidim::Proposals::AdminEngine
   component.icon = "decidim/proposals/icon.svg"
-  component.card = "decidim/proposals/proposal"
 
   component.on(:before_destroy) do |instance|
     raise "Can't destroy this component when there are proposals" if Decidim::Proposals::Proposal.where(component: instance).any?
@@ -53,6 +52,7 @@ Decidim.register_component(:proposals) do |component|
   component.register_resource do |resource|
     resource.model_class_name = "Decidim::Proposals::Proposal"
     resource.template = "decidim/proposals/proposals/linked_proposals"
+    resource.card = "decidim/proposals/proposal"
   end
 
   component.register_stat :proposals_count, primary: true, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |components, start_at, end_at|

--- a/docs/advanced/view_models_aka_cells.md
+++ b/docs/advanced/view_models_aka_cells.md
@@ -13,7 +13,7 @@ Think of cells, or view models, as small Rails controllers, but without any HTTP
 ## Decidim Cards
 
 `card_for @instance` will render the corresponding default card for each component instance.
-If a `component.card` is not registered a _basic_ (deafult) card is shown.
+If a card for the given resource is not registered, a _basic_ (default) card is shown.
 
 To render a specified size/variation include the `size` option as a `symbol`: `card_for @instance, size: :m`
 
@@ -44,34 +44,37 @@ To render a specified size/variation include the `size` option as a `symbol`: `c
   end
   ```
 
-- The attribute `card` of the Components is defined in `decidim-core/lib/decidim/component_manifest.rb`:
+- The attribute `card` of the resource is defined in `decidim-core/lib/decidim/resource_manifest.rb`:
 
   ```rb
   # The cell to use to render the card of a resource.
   attribute :card, String
   ```
 
-  In your `decidim-<component>/lib/decidim/<component>/component.rb` register the cell value:
+  In your `decidim-<component>/lib/decidim/<component>/component.rb` register the resource and set the card value:
 
   ```rb
-  component.card = "decidim/<component>s/<component>"
+  component.register_resource do |resource|
+    resource.class = "Decidim::<Component>/<MyResource>" # eg. "Decidim::Proposals::ProposalDraft
+    resource.card = "decidim/<component>/<my_resource>" # eg. "decidim/proposals/proposal_draft"
+  end
   ```
 
-- The **Cell Class**, following the convention will reside in `decidim-<component>s/app/cells/decidim/<component>s/<component>_cell.rb`:
+- The **Cell Class**, following the convention, will reside in `decidim-<component>/app/cells/decidim/<component>/<my_resource>_cell.rb`:
 
   ```rb
   module Decidim
     module <Component>s
-      class <Component>Cell < Decidim::ViewModel
+      class <MyResource>Cell < Decidim::ViewModel
         def show
-          render # renders decidim-<component>s/app/cells/decidim/<component>s/<component>
+          render # renders decidim-<component>/app/cells/decidim/<component>/<my_resource>
         end
       end
     end
   end
   ```
 
-- The **Cell Views** will be in the `decidim-<component>s/app/cells/decidim/<component>s/<component>` and defaults to `show.erb`
+- The **Cell Views** will be in the `decidim-<component>/app/cells/decidim/<component>/<my_resource>` and defaults to `show.erb`
 
 ## More Info
 


### PR DESCRIPTION
#### :tophat: What? Why?
During the work on #3338, I found myself with the need to have different cards for a single component, as that component has different resources. Specifically, I'm talking about the `decidim-participatory_processes` component, which has different cards for processes and process groups.

The current code on `master` only allows to define a single card per component, and then I'd need to make that card redirect to other cards depending on the type of the resource I'm sending it. While it's true this is a nice hack and it would certainly work, I find it sub-perfect, or not nice enough. I'd use this method if I didn't have access to the main code, but as I do have access, I think it's better refactoring a little bit. So here's what I've done.

As per https://github.com/decidim/decidim/issues/2872#issuecomment-387736252, I think the card definition should be done at the `ResourceManifest` level. Luckily, component manifests can already define their own resource manifests, so the change here was quick. Participatory space manifests didn't, so I had to add the logic to let them register resources, and then I needed to change the code to find the resource manifest to include those registered under a participatory space. This means the internal changes are minimal.

I've dropped some PAI, though: components can no longer define their own cards, as that no longer makes sense. So if your PR uses `component.card = "decidim/my/card"` in your `component.rb` file, you'll need to move this line to the `register_resource` block. For an example check the `component.rb` file in `decidim-debates` in this PR.

Current cards should not be affected by this change.

#### :pushpin: Related Issues
- Related to #3338, #2872.

#### :clipboard: Subtasks
None.