### PR TITLE
Fix permissions for space areas

### DIFF
--- a/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
+++ b/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
@@ -4,6 +4,8 @@ module Decidim
   module Assemblies
     class Permissions < Decidim::DefaultPermissions
       def permissions
+        user_can_enter_space_area?
+
         return permission_action if assembly && !assembly.is_a?(Decidim::Assembly)
 
         if permission_action.scope == :public
@@ -20,8 +22,6 @@ module Decidim
           return permission_action
         end
         return permission_action unless permission_action.scope == :admin
-
-        user_can_enter_space_area?
 
         if read_admin_dashboard_action?
           user_can_read_admin_dashboard?
@@ -107,6 +107,7 @@ module Decidim
       # not the assembly groups one.
       def user_can_enter_space_area?
         return unless permission_action.action == :enter &&
+                      permission_action.scope == :admin &&
                       permission_action.subject == :space_area &&
                       context.fetch(:space_name, nil) == :assemblies
 

--- a/decidim-initiatives/app/permissions/decidim/initiatives/admin/permissions.rb
+++ b/decidim-initiatives/app/permissions/decidim/initiatives/admin/permissions.rb
@@ -8,9 +8,10 @@ module Decidim
           # The public part needs to be implemented yet
           return permission_action if permission_action.scope != :admin
           return permission_action unless user
-          return permission_action if initiative && !initiative.is_a?(Decidim::Initiative)
 
           user_can_enter_space_area?
+
+          return permission_action if initiative && !initiative.is_a?(Decidim::Initiative)
 
           user_can_read_participatory_space?
 

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
@@ -88,7 +88,7 @@ module Decidim
                     icon_name: "layers",
                     position: 3,
                     active: :inclusive,
-                    if: allowed_to?(:enter, :space_area, space_name: :processes) && allowed_to?(:manage, :process_group, {}, [Decidim::ParticipatoryProcesses::Permissions])
+                    if: allowed_to?(:enter, :space_area, space_name: :process_groups)
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Once you entered a space area and selected a space instance (ie you
start managing a single initiative), the `current_participatory_space`
helper method is set to that initiative. This caused all the space
permissions to fail the check to enter the space area, as it's using
that value to check for the space type. Since, in those permissions
classes, the check of the participatory space is done before checking
the access to the space area, this caused the permission check to fail.

The solution was to move the space area check before the participatory
space type check.

#### :pushpin: Related Issues
- Fixes #3396

#### :clipboard: Subtasks
No need for changelog entry since this has not yet been released.

### :camera: Screenshots (optional)
Compare with the screenshot in the original issue:
![Description](https://i.imgur.com/9cMrKhG.png)
