### PR TITLE
Show the assemblies that a user belongs in their profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ end
 
 - **decidim-assemblies**: Add members to assemblies. [\#3008](https://github.com/decidim/decidim/pull/3008)
 - **decidim-assemblies**: An assembly member can be related to an existing user. [\#3302](https://github.com/decidim/decidim/pull/3302)
+- **decidim-assemblies**: Show the assemblies that a user belongs in their profile. [\#3410](https://github.com/decidim/decidim/pull/3410)
+- **decidim-core**: Added the user_profile_bottom view hook to the public profiel page. [\#3410](https://github.com/decidim/decidim/pull/3410)
 - **decidim-meetings**: Add organizer to meeting and meeting types [\#3136](https://github.com/decidim/decidim/pull/3136)
 - **decidim-meetings**: Add Minutes entity to manage Minutes. [\#3213](https://github.com/decidim/decidim/pull/3213)
 - **decidim-admin**: Links to participatory space index & show pages from the admin dashboard. [\#3325](https://github.com/decidim/decidim/pull/3325)

--- a/decidim-assemblies/app/views/decidim/assemblies/pages/user_profile/_member_of.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/pages/user_profile/_member_of.html.erb
@@ -1,0 +1,8 @@
+<div class="row" id="member-of-assemblies">
+  <strong><%= t(".member_of") %></strong>
+  <div class="card__text--separated-mid-dot">
+    <% assemblies.each do |assembly| %>
+      <%= link_to translated_attribute(assembly.title), decidim_assemblies.assembly_path(assembly) %>
+    <% end %>
+  </div>
+</div>

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -242,6 +242,9 @@ en:
           highlighted_assemblies:
             active_assemblies: Active assemblies
             see_all_assemblies: See all assemblies
+        user_profile:
+          member_of:
+            member_of: Member of
       show:
         area: Area
         assembly_type: Assembly type

--- a/decidim-assemblies/lib/decidim/assemblies/engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/engine.rb
@@ -71,6 +71,23 @@ module Decidim
             }
           )
         end
+
+        Decidim.view_hooks.register(:user_profile_bottom, priority: Decidim::ViewHooks::MEDIUM_PRIORITY) do |view_context|
+          assemblies = OrganizationPublishedAssemblies.new(view_context.current_organization, view_context.current_user)
+                                                      .query.distinct
+                                                      .joins(:members)
+                                                      .merge(Decidim::AssemblyMember.where(user: view_context.user))
+                                                      .reorder(title: :asc)
+
+          next unless assemblies.any?
+
+          view_context.render(
+            partial: "decidim/assemblies/pages/user_profile/member_of",
+            locals: {
+              assemblies: assemblies
+            }
+          )
+        end
       end
     end
   end

--- a/decidim-assemblies/spec/system/user_profile_view_hooks_spec.rb
+++ b/decidim-assemblies/spec/system/user_profile_view_hooks_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Member of assemblies", type: :system do
+  let(:organization) { create(:organization) }
+  let!(:assembly) { create(:assembly, organization: organization) }
+  let!(:assembly_member) { create(:assembly_member, :with_user, assembly: assembly) }
+
+  before do
+    switch_to_host(organization.host)
+  end
+
+  it "includes active assemblies to the homepage" do
+    visit decidim.profile_path(assembly_member.user.nickname)
+
+    within "#member-of-assemblies" do
+      expect(page).to have_i18n_content(assembly.title)
+    end
+  end
+end

--- a/decidim-core/app/views/decidim/profiles/show.html.erb
+++ b/decidim-core/app/views/decidim/profiles/show.html.erb
@@ -60,5 +60,7 @@
         </div>
       </div>
     <% end %>
+
+    <%= render_hook(:user_profile_bottom) %>
   <% end %>
 </main>

--- a/decidim-core/spec/system/profile_spec.rb
+++ b/decidim-core/spec/system/profile_spec.rb
@@ -58,4 +58,24 @@ describe "Profile", type: :system do
       end
     end
   end
+
+  describe "view hooks" do
+    before do
+      allow(Decidim.view_hooks)
+        .to receive(:render)
+        .with(a_kind_of(Symbol), a_kind_of(ActionView::Base))
+        .and_return("Rendered from #{view_hook} view hook")
+
+      visit decidim.profile_path(user.nickname)
+    end
+
+    context "with user_profile_bottom view hook" do
+      let(:view_hook) { :user_profile_bottom }
+
+      it "renders the view hook" do
+        expect(Decidim.view_hooks).to have_received(:render).with(:user_profile_bottom, a_kind_of(ActionView::Base))
+        expect(page).to have_content("Rendered from user_profile_bottom view hook")
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

It must be possible to show links on the participant’s public profile on Decidim to the assemblies of which they are members.

#### :pushpin: Related Issues

- Related to #2832

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)

![screencapture-decidim-localhost-profiles-blaise_kulas-2018-05-14-12_34_42](https://user-images.githubusercontent.com/2051199/39992901-76f3bfac-5774-11e8-8ffd-cdb28d81023d.png)

