### PR TITLE
Fix `past?` on `participatory_processes`

### DIFF
--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_m/data.erb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_m/data.erb
@@ -6,13 +6,15 @@
     <li class="card-data__item">
       <div class="card-data__item--centerblock">
         <strong><%= t("activemodel.attributes.participatory_process.start_date") %></strong>
-        <%= l start_date, format: :decidim_short %>
+        <br />
+        <%= start_date ? l(start_date, format: :decidim_short) : t("decidim.participatory_processes.show.unspecified") %>
       </div>
     </li>
     <li class="card-data__item">
       <div class="card-data__item--centerblock">
         <strong><%= t("activemodel.attributes.participatory_process.end_date") %></strong>
-        <%= l end_date, format: :decidim_short %>
+        <br />
+        <%= end_date ? l(end_date, format: :decidim_short) : t("decidim.participatory_processes.show.unspecified") %>
       </div>
     </li>
   </ul>

--- a/decidim-participatory_processes/app/models/decidim/participatory_process.rb
+++ b/decidim-participatory_processes/app/models/decidim/participatory_process.rb
@@ -71,6 +71,7 @@ module Decidim
     end
 
     def past?
+      return false if end_date.blank?
       end_date < Time.current
     end
 

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -284,6 +284,7 @@ en:
         scope: Scope
         start_date: Start date
         target: Who participates
+        unspecified: Not specified
       statistics:
         answers_count: Answers
         comments_count: Comments

--- a/decidim-participatory_processes/spec/models/decidim/participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/models/decidim/participatory_process_spec.rb
@@ -33,5 +33,28 @@ module Decidim
 
       it { is_expected.to be_valid }
     end
+
+    describe "#past?" do
+      context "when it ends in the past" do
+        it "returns true" do
+          participatory_process.end_date = 1.day.ago
+          expect(participatory_process).to be_past
+        end
+      end
+
+      context "when it ends in the future" do
+        it "returns false" do
+          participatory_process.end_date = 1.day.from_now
+          expect(participatory_process).not_to be_past
+        end
+      end
+
+      context "when it doesn't have an end date" do
+        it "returns false" do
+          participatory_process.end_date = nil
+          expect(participatory_process).not_to be_past
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
`end_date` is optional on `participatory_processes`, so its `past?` method sometimes failed.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*
