### PR TITLE
Truncate cell description to 100 characters

### DIFF
--- a/decidim-core/app/cells/decidim/card_m_cell.rb
+++ b/decidim-core/app/cells/decidim/card_m_cell.rb
@@ -34,7 +34,7 @@ module Decidim
     end
 
     def description
-      decidim_sanitize(translated_attribute(model.description))
+      decidim_sanitize(html_truncate(translated_attribute(model.description), length: 100))
     end
 
     def decidim

--- a/decidim-sortitions/app/cells/decidim/sortitions/sortition_m_cell.rb
+++ b/decidim-sortitions/app/cells/decidim/sortitions/sortition_m_cell.rb
@@ -46,6 +46,7 @@ module Decidim
       def description
         text = decidim_sanitize(translated_attribute(model.additional_info))
         text.gsub(/^<p>/, "<p>#{render :badge}")
+        html_truncate(text, length: 100)
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Truncates the description on cells, taking the HTML into account.

#### :pushpin: Related Issues
- Related to #3338
- Fixes #3424 
- Fixes #3425.

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/xHFXWEW.png)
