### PR TITLE
Use `short_description` on cards

### DIFF
--- a/decidim-core/app/cells/decidim/card_m_cell.rb
+++ b/decidim-core/app/cells/decidim/card_m_cell.rb
@@ -38,7 +38,10 @@ module Decidim
     end
 
     def description
-      decidim_sanitize(html_truncate(translated_attribute(model.description), length: 100))
+      attribute = model.try(:short_description) || model.description
+      text = translated_attribute(attribute)
+
+      decidim_sanitize(html_truncate(text, length: 100))
     end
 
     def decidim


### PR DESCRIPTION
#### :tophat: What? Why?
The `short_description` field is a better fit for those cards that have it, instead of using the `description`. 

#### :pushpin: Related Issues
- Related to #3338

#### :clipboard: Subtasks
None

