### PR TITLE
Show next upcoming meeting in assembly card

### DIFF
--- a/decidim-meetings/lib/decidim/meetings/engine.rb
+++ b/decidim-meetings/lib/decidim/meetings/engine.rb
@@ -80,7 +80,7 @@ module Decidim
         # meeting for the given participatory space.
         Decidim.view_hooks.register(:upcoming_meeting_for_card, priority: Decidim::ViewHooks::LOW_PRIORITY) do |view_context|
           published_components = Decidim::Component.where(participatory_space: view_context.current_participatory_space).published
-          upcoming_meeting = Decidim::Meetings::Meeting.where(component: published_components).order(:start_time, :end_time).first
+          upcoming_meeting = Decidim::Meetings::Meeting.where(component: published_components).upcoming.order(:start_time, :end_time).first
 
           next unless upcoming_meeting
 

--- a/decidim-meetings/spec/system/upcoming_meeting_for_card_view_hooks_spec.rb
+++ b/decidim-meetings/spec/system/upcoming_meeting_for_card_view_hooks_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Upcoming meeting for card view hook", type: :system do
+  let(:assembly) { create :assembly, organization: organization }
+
+  include_context "with a component" do
+    let(:participatory_space) { assembly }
+  end
+
+  let(:manifest_name) { "meetings" }
+
+  let!(:past_meeting) do
+    create(:meeting, :past, component: component)
+  end
+
+  context "when there are only past meetings" do
+    it "doesn't show any meeting" do
+      visit decidim_assemblies.assemblies_path
+
+      within "#assembly_#{assembly.id}" do
+        expect(page).to have_no_selector(".card__icondata")
+      end
+    end
+  end
+
+  context "when there are some upcoming meetings" do
+    let(:start_time) { Time.zone.local(2099, 5, 31, 12, 34) }
+    let!(:upcoming_meeting1) do
+      create(:meeting, :upcoming, start_time: start_time, end_time: start_time + 1.hour, component: component)
+    end
+    let!(:upcoming_meeting2) do
+      create(:meeting, :upcoming, start_time: start_time + 1.year, end_time: start_time + 1.year + 1.hour, component: component)
+    end
+
+    it "shows the next upcoming meeting" do
+      visit decidim_assemblies.assemblies_path
+
+      within "#assembly_#{assembly.id}" do
+        expect(page).to have_selector(".card__icondata")
+
+        within ".card__icondata" do
+          expect(page).to have_text("31 MAY 2099")
+          expect(page).to have_text("12:34")
+          expect(page).to have_text("13:34")
+        end
+      end
+    end
+  end
+end

--- a/decidim-meetings/spec/system/upcoming_meeting_for_card_view_hooks_spec.rb
+++ b/decidim-meetings/spec/system/upcoming_meeting_for_card_view_hooks_spec.rb
@@ -3,14 +3,12 @@
 require "spec_helper"
 
 describe "Upcoming meeting for card view hook", type: :system do
-  let(:assembly) { create :assembly, organization: organization }
-
   include_context "with a component" do
     let(:participatory_space) { assembly }
   end
 
+  let(:assembly) { create :assembly, organization: organization }
   let(:manifest_name) { "meetings" }
-
   let!(:past_meeting) do
     create(:meeting, :past, component: component)
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes the code to render the next upcoming meeting date that is included in the assembly cards. Also adds tests to ensure this works as expected.

#### :pushpin: Related Issues
- Fixes #3427

#### :clipboard: Subtasks
None
