### PR TITLE
Don't seed with random scopes if the existing organization already have.

### DIFF
--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -24,34 +24,36 @@ if !Rails.env.production? || ENV["SEED"]
     available_authorizations: Decidim.authorization_workflows.map(&:name)
   )
 
-  province = Decidim::ScopeType.create!(
-    name: Decidim::Faker::Localized.literal("province"),
-    plural: Decidim::Faker::Localized.literal("provinces"),
-    organization: organization
-  )
-
-  municipality = Decidim::ScopeType.create!(
-    name: Decidim::Faker::Localized.literal("municipality"),
-    plural: Decidim::Faker::Localized.literal("municipalities"),
-    organization: organization
-  )
-
-  3.times do
-    parent = Decidim::Scope.create!(
-      name: Decidim::Faker::Localized.literal(Faker::Address.unique.state),
-      code: Faker::Address.unique.country_code,
-      scope_type: province,
+  if organization.top_scopes.none?
+    province = Decidim::ScopeType.create!(
+      name: Decidim::Faker::Localized.literal("province"),
+      plural: Decidim::Faker::Localized.literal("provinces"),
       organization: organization
     )
 
-    5.times do
-      Decidim::Scope.create!(
-        name: Decidim::Faker::Localized.literal(Faker::Address.unique.city),
-        code: parent.code + "-" + Faker::Address.unique.state_abbr,
-        scope_type: municipality,
-        organization: organization,
-        parent: parent
+    municipality = Decidim::ScopeType.create!(
+      name: Decidim::Faker::Localized.literal("municipality"),
+      plural: Decidim::Faker::Localized.literal("municipalities"),
+      organization: organization
+    )
+
+    3.times do
+      parent = Decidim::Scope.create!(
+        name: Decidim::Faker::Localized.literal(Faker::Address.unique.state),
+        code: Faker::Address.unique.country_code,
+        scope_type: province,
+        organization: organization
       )
+
+      5.times do
+        Decidim::Scope.create!(
+          name: Decidim::Faker::Localized.literal(Faker::Address.unique.city),
+          code: parent.code + "-" + Faker::Address.unique.state_abbr,
+          scope_type: municipality,
+          organization: organization,
+          parent: parent
+        )
+      end
     end
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?
I'd like to seed my test app with random data, but I need to have an specific set of scopes instead of random scopes. This change would simplify very much my seed process, and avoid me to do nasty things like [this](https://github.com/podemos-info/participa2/blob/459cdfef5e6eaef6d584fecdb2245c134bc3405f/db/seeds.rb#L26). :laughing:

Also, this change only modifies the random seed process, do you think it needs a `CHANGELOG` entry?

#### :pushpin: Related Issues

#### :clipboard: Subtasks

### :camera: Screenshots (optional)
