### PR TITLE
Fix card image when missing

### DIFF
--- a/decidim-core/app/cells/decidim/card_m/image.erb
+++ b/decidim-core/app/cells/decidim/card_m/image.erb
@@ -1,3 +1,5 @@
-<%= link_to resource_path do %>
-  <%= image_tag resource_image_path, class: "card__image" %>
+<% if resource_image_path.present? %>
+  <%= link_to resource_path do %>
+    <%= image_tag resource_image_path, class: "card__image" %>
+  <% end %>
 <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
This prevents the app from blowing up with cards specifying and image but having no image in the end.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*
