### PR TITLE
Don't blow up when terms and conditions are missing

### DIFF
--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -65,9 +65,11 @@
               </div>
             </div>
 
-            <p class="lopd-text">
-              <%= strip_tags(translated_attribute(terms_and_conditions_page.content)) %>
-            </p>
+            <% if terms_and_conditions_page %>
+              <p class="lopd-text">
+                <%= strip_tags(translated_attribute(terms_and_conditions_page.content)) %>
+              </p>
+            <% end %>
 
             <fieldset>
               <div class="field">


### PR DESCRIPTION
#### :tophat: What? Why?
This prevents the app from blowing up when terms and conditions are missing.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*