### PR TITLE
Add missing locales for another_dummy_authorization_handler

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -122,6 +122,7 @@ en:
         explanation: Get verified by introducing a passport number starting with "A"
         fields:
           passport_number: Passport number
+        name: Another example authorization
       dummy_authorization_handler:
         explanation: Get verified by introducing a document number ending with "X"
         fields:

--- a/decidim-dev/config/locales/en.yml
+++ b/decidim-dev/config/locales/en.yml
@@ -9,9 +9,6 @@ en:
         title: Title
         updated_at: Updated at
   decidim:
-    authorization_handlers:
-      another_dummy_authorization_handler:
-        name: Another example authorization
     dummy:
       admin:
         exports:

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -52,6 +52,7 @@ en:
           success: You've been successfully authorized.
         first_login:
           actions:
+            another_dummy_authorization_handler: Verify against another example of authorization handler
             dummy_authorization_handler: Verify against the example authorization handler
             dummy_authorization_workflow: Verify against the example authorization workflow
             id_documents: Get verified by uploading your identity document


### PR DESCRIPTION
#### :tophat: What? Why?

Add missing locales for `another_dummy_authorization_handler` that raised an error on `development_app`

#### :pushpin: Related Issues
- Related to none
- Fixes none

#### :clipboard: Subtasks


### :camera: Screenshots (optional)
