### PR TITLE
Include datepicker locales in front pages too.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ must now set a resource name:
 
 **Fixed**:
 
+- **decidim-core**: Include datepicker locales in front pages too. [\#3448](https://github.com/decidim/decidim/pull/3448)
 - **decidim-core**: Uses current organization scopes in scopes picker. [\#3386](https://github.com/decidim/decidim/pull/3386)
 - **decidim-blog**: Add `params[:id]` when editing/deleting a post from admin site [\#3329](https://github.com/decidim/decidim/pull/3329)
 - **decidim-admin**: Fixes the validation uniqueness name of area, scoped with organization and area_type [\#3336](https://github.com/decidim/decidim/pull/3336) https://github.com/decidim/decidim/pull/3336

--- a/decidim-admin/app/helpers/decidim/admin/application_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/application_helper.rb
@@ -16,10 +16,6 @@ module Decidim
       def title
         current_organization.name
       end
-
-      def foundation_datepicker_locale_tag
-        javascript_include_tag "datepicker-locales/foundation-datepicker.#{I18n.locale}.js" if I18n.locale != :en
-      end
     end
   end
 end

--- a/decidim-core/app/helpers/decidim/decidim_form_helper.rb
+++ b/decidim-core/app/helpers/decidim/decidim_form_helper.rb
@@ -185,5 +185,9 @@ module Decidim
 
       alert_box(record.errors.full_messages_for(:base).join(","), "alert", false)
     end
+
+    def foundation_datepicker_locale_tag
+      javascript_include_tag "datepicker-locales/foundation-datepicker.#{I18n.locale}.js" if I18n.locale != :en
+    end
   end
 end

--- a/decidim-core/app/views/layouts/decidim/_head.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_head.html.erb
@@ -20,6 +20,7 @@
 <%= favicon %>
 <%= stylesheet_link_tag    "application", media: "all" %>
 <%= javascript_include_tag "application" %>
+<%= foundation_datepicker_locale_tag %>
 
 <%= render partial: "layouts/decidim/head_extra" %>
 <%== current_organization.header_snippets if Decidim.enable_html_header_snippets %>


### PR DESCRIPTION
#### :tophat: What? Why?
When adding a date picker to a form in the front, it is rendered always with the english locale. The right locale is only loaded in the admin zone.

This PR includes the picker locale in all of the admin and front pages, even when there is no a page using a datepicker in the front in this repository. We can remove its inclusion from the `_head` template and let the developers to include it only in the pages that uses it, but I think that it would be more error prone. What do you think @decidim/developers?

#### :pushpin: Related Issues
- Related to #1207

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
