### PR TITLE
[FIX] Consultations question component html error

### DIFF
--- a/decidim-consultations/app/views/layouts/decidim/_question_components.html.erb
+++ b/decidim-consultations/app/views/layouts/decidim/_question_components.html.erb
@@ -14,14 +14,15 @@
     </button>
     <div class="row column process-nav__content is-active" id="process-nav-content" data-toggler=".is-active">
       <ul>
-        <li class="<%= "is-active" if is_active_link?(decidim_consultations.question_path(question), :exclusive) %>"
+        <li class="<%= "is-active" if is_active_link?(decidim_consultations.question_path(question), :exclusive) %>">
           <%= active_link_to decidim_consultations.question_path(question),
                              active: :exclusive,
                              class: "process-nav__link",
                              class_active: "is-active" do %>
             <%= external_icon "decidim/pages/icon.svg" %>
             <%= t ".question_menu_item" %>
-          <% end %>>
+          <% end %>
+        </li>
         <% question.components.each do |component| %>
           <% if component.published? || component == self.try(:current_component) %>
             <li class="<%= "is-active" if is_active_link?(main_component_path(component), :inclusive) %>">


### PR DESCRIPTION
#### :tophat: What? Why?
Consultation question component have an HTML error generation. Browsers fix it, but needs to be corrected

#### :pushpin: Related Issues

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
