### PR TITLE
Rename migrations to avoid duplicated names

### DIFF
--- a/decidim-initiatives/db/migrate/20171109132011_enable_pg_extensions.rb
+++ b/decidim-initiatives/db/migrate/20171109132011_enable_pg_extensions.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class EnablePgExtensions < ActiveRecord::Migration[5.1]
-  def change
-    enable_extension "pg_trgm"
-  rescue ActiveRecord::CatchAll => e
-    logger.error "Can not deal with pg_trgm extension: #{e}"
-  end
-end

--- a/decidim-initiatives/db/migrate/20171109132011_enable_pg_trgm_extension_for_initiatives.rb
+++ b/decidim-initiatives/db/migrate/20171109132011_enable_pg_trgm_extension_for_initiatives.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class EnablePgExtensions < ActiveRecord::Migration[5.1]
+class EnablePgTrgmExtensionForInitiatives < ActiveRecord::Migration[5.1]
   def change
     return if extension_enabled?("pg_trgm")
 

--- a/decidim-proposals/db/migrate/20171212102250_enable_pg_trgm_extension_for_proposals.rb
+++ b/decidim-proposals/db/migrate/20171212102250_enable_pg_trgm_extension_for_proposals.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class EnablePgTrgmExtensionForProposals < ActiveRecord::Migration[5.1]
+  def change
+    return if extension_enabled?("pg_trgm")
+
+    begin
+      # required so that test suite works in ci env
+      enable_extension "pg_trgm"
+    rescue StandardError
+      raise <<-MSG.squish
+        Decidim requires the pg_trgm extension to be enabled in your PostgreSQL.
+        You can do so by running `CREATE EXTENSION IF NOT EXISTS "pg_trgm";` on the current DB as a PostgreSQL
+        super user.
+      MSG
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This is an attempt to fix #3388. It renames existing migrations and rewrites one of them to make it more developer-friendly.

The downside of this approach is that existing apps will copy these migrations as new ones, as the filenames have changed, but running them will have no effect on your DBs.

#### :pushpin: Related Issues
- Fixes #3388

#### :clipboard: Subtasks
None