### PR TITLE
Added remove_introductory_image to Consultations form & command

### DIFF
--- a/decidim-consultations/app/commands/decidim/consultations/admin/update_consultation.rb
+++ b/decidim-consultations/app/commands/decidim/consultations/admin/update_consultation.rb
@@ -55,7 +55,8 @@ module Decidim
             introductory_video_url: form.introductory_video_url,
             start_voting_date: form.start_voting_date,
             end_voting_date: form.end_voting_date,
-            introductory_image: form.introductory_image
+            introductory_image: form.introductory_image,
+            remove_introductory_image: form.remove_introductory_image
           }
         end
       end

--- a/decidim-consultations/app/forms/decidim/consultations/admin/consultation_form.rb
+++ b/decidim-consultations/app/forms/decidim/consultations/admin/consultation_form.rb
@@ -17,6 +17,7 @@ module Decidim
         attribute :remove_banner_image
         attribute :introductory_video_url, String
         attribute :introductory_image, String
+        attribute :remove_introductory_image
         attribute :decidim_highlighted_scope_id, Integer
         attribute :start_voting_date, Date
         attribute :end_voting_date, Date


### PR DESCRIPTION
#### :tophat: What? Why?
Introductory image in Consultations cannot be removed with checkbox. Added attribute `remove_introductory_image` to Consultations's form and command to perform it

#### :pushpin: Related Issues
- Fixes #3421

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

