### PR TITLE
New attributes in Decidim Accountability from Decidim Barcelona

### DIFF
--- a/decidim-accountability/app/commands/decidim/accountability/admin/create_result.rb
+++ b/decidim-accountability/app/commands/decidim/accountability/admin/create_result.rb
@@ -44,7 +44,9 @@ module Decidim
             start_date: @form.start_date,
             end_date: @form.end_date,
             progress: @form.progress,
-            decidim_accountability_status_id: @form.decidim_accountability_status_id
+            decidim_accountability_status_id: @form.decidim_accountability_status_id,
+            external_id: @form.external_id.presence,
+            weight: @form.weight
           )
         end
 

--- a/decidim-accountability/app/commands/decidim/accountability/admin/update_result.rb
+++ b/decidim-accountability/app/commands/decidim/accountability/admin/update_result.rb
@@ -47,7 +47,9 @@ module Decidim
             start_date: @form.start_date,
             end_date: @form.end_date,
             progress: @form.progress,
-            decidim_accountability_status_id: @form.decidim_accountability_status_id
+            decidim_accountability_status_id: @form.decidim_accountability_status_id,
+            external_id: @form.external_id.presence,
+            weight: @form.weight
           )
         end
 

--- a/decidim-accountability/app/forms/decidim/accountability/admin/result_form.rb
+++ b/decidim-accountability/app/forms/decidim/accountability/admin/result_form.rb
@@ -20,9 +20,10 @@ module Decidim
         attribute :progress, Float
         attribute :decidim_accountability_status_id, Integer
         attribute :parent_id, Integer
+        attribute :external_id, String
+        attribute :weight, Float
 
         validates :title, translatable_presence: true
-        validates :description, translatable_presence: true
 
         validates :scope, presence: true, if: ->(form) { form.decidim_scope_id.present? }
         validates :category, presence: true, if: ->(form) { form.decidim_category_id.present? }

--- a/decidim-accountability/app/models/decidim/accountability/result.rb
+++ b/decidim-accountability/app/models/decidim/accountability/result.rb
@@ -43,8 +43,15 @@ module Decidim
         parent.update_progress!
       end
 
+      # Public: There are two ways to update parent's progress:
+      #   - using weights, in which case each progress is multiplied by the weigth and them summed
+      #   - not using weights, and using the average of progress of each children
       def update_progress!
-        self.progress = children.average(:progress)
+        self.progress = if children_use_weighted_progress?
+                          children.sum { |result| (result.progress.presence || 0) * (result.weight.presence || 1) }
+                        else
+                          children.average(:progress)
+                        end
         save!
       end
 
@@ -66,6 +73,13 @@ module Decidim
       # Public: Overrides the `comments_have_votes?` Commentable concern method.
       def comments_have_votes?
         true
+      end
+
+      private
+
+      # Private: When a row uses weight 1 and there's more than one, weight shouldn't be considered
+      def children_use_weighted_progress?
+        children.length == 1 || children.pluck(:weight).none? { |weight| weight == 1.0 }
       end
     end
   end

--- a/decidim-accountability/db/migrate/20180508170210_add_weight_to_results.rb
+++ b/decidim-accountability/db/migrate/20180508170210_add_weight_to_results.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddWeightToResults < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_accountability_results, :weight, :float, default: 1.0
+  end
+end

--- a/decidim-accountability/db/migrate/20180508170647_add_external_id_to_results.rb
+++ b/decidim-accountability/db/migrate/20180508170647_add_external_id_to_results.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddExternalIdToResults < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_accountability_results, :external_id, :string, index: true
+  end
+end

--- a/decidim-accountability/spec/commands/admin/create_result_spec.rb
+++ b/decidim-accountability/spec/commands/admin/create_result_spec.rb
@@ -17,6 +17,8 @@ module Decidim::Accountability
     let(:end_date) { Date.tomorrow }
     let(:status) { create :status, component: current_component, key: "ongoing", name: { en: "Ongoing" } }
     let(:progress) { 89 }
+    let(:external_id) { "external-id" }
+    let(:weight) { 0.3 }
 
     let(:meeting_component) do
       create(:component, manifest_name: "meetings", participatory_space: participatory_process)
@@ -62,7 +64,9 @@ module Decidim::Accountability
         decidim_accountability_status_id: status.id,
         progress: progress,
         current_user: user,
-        parent_id: nil
+        parent_id: nil,
+        external_id: external_id,
+        weight: weight
       )
     end
     let(:invalid) { false }
@@ -167,6 +171,16 @@ module Decidim::Accountability
           )
 
         subject.call
+      end
+
+      it "sets the external_id" do
+        subject.call
+        expect(result.external_id).to eq external_id
+      end
+
+      it "sets the weight" do
+        subject.call
+        expect(result.weight).to eq weight
       end
     end
   end

--- a/decidim-accountability/spec/commands/admin/update_result_spec.rb
+++ b/decidim-accountability/spec/commands/admin/update_result_spec.rb
@@ -20,6 +20,8 @@ module Decidim::Accountability
     let(:end_date) { Date.tomorrow }
     let(:status) { create :status, component: result.component, key: "finished", name: { en: "Finished" } }
     let(:progress) { 95 }
+    let(:external_id) { "external-id" }
+    let(:weight) { 0.3 }
 
     let(:meeting) do
       create(
@@ -61,7 +63,9 @@ module Decidim::Accountability
         decidim_accountability_status_id: status.id,
         progress: progress,
         current_user: user,
-        parent_id: nil
+        parent_id: nil,
+        external_id: external_id,
+        weight: weight
       )
     end
     let(:invalid) { false }
@@ -129,6 +133,16 @@ module Decidim::Accountability
         linked_meetings = result.linked_resources(:meetings, "meetings_through_proposals")
 
         expect(linked_meetings).to eq [meeting]
+      end
+
+      it "sets the external_id" do
+        subject.call
+        expect(result.external_id).to eq external_id
+      end
+
+      it "sets the weight" do
+        subject.call
+        expect(result.weight).to eq weight
       end
     end
   end

--- a/decidim-accountability/spec/forms/admin/result_form_spec.rb
+++ b/decidim-accountability/spec/forms/admin/result_form_spec.rb
@@ -56,12 +56,6 @@ module Decidim::Accountability
       it { is_expected.not_to be_valid }
     end
 
-    describe "when description is missing" do
-      let(:description) { { en: nil } }
-
-      it { is_expected.not_to be_valid }
-    end
-
     describe "when the scope does not exist" do
       let(:scope_id) { scope.id + 10 }
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR introduces the attributes from Decidim Accountability that were custom to the Barcelona fork. 

These attributes are:

- weight
- external_id

Extra thing:

- the validation of presence in the description attribute has been removed

#### :pushpin: Related Issues

- Related to #3190

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
