### PR TITLE
Add margin to .data-picker

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_data-picker.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_data-picker.scss
@@ -1,6 +1,7 @@
 
 .data-picker{
-  margin: 0 0 $form-spacing;
+  margin: 0 0 $global-margin;
+
   &.picker-single .picker-values div a,
   .picker-prompt a{
     background: white;

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_data-picker.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_data-picker.scss
@@ -1,5 +1,6 @@
 
 .data-picker{
+  margin: 0 0 $form-spacing;
   &.picker-single .picker-values div a,
   .picker-prompt a{
     background: white;


### PR DESCRIPTION
#### :tophat: What? Why?

In the creation forms, the scope `data-picker` appears with **no** `margin-bottom` wich results with the form fields stuck together. This PR adds a margin to the `.data-picker` using the `$form-spacing` variable from `foundation`.

#### :pushpin: Related Issues
- Related to none

#### :clipboard: Subtasks

### :camera: Screenshots (optional)

+ **Before** (no margin below scope picker):
  ![screenshot from 2018-05-21 14-48-05](https://user-images.githubusercontent.com/210216/40308514-d1584a84-5d06-11e8-83f1-44333ea525c0.png)

+ **After** (with margin):
  ![screenshot from 2018-05-21 14-48-31](https://user-images.githubusercontent.com/210216/40308543-df1694fa-5d06-11e8-8df4-e81052eeba2a.png)

 
