### PR TITLE
Add label identifier to `card_m`

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
@@ -753,10 +753,10 @@ $datetime-bg: $primary;
     top: $global-margin * .5;
   }
 
-  .success &,
-  .muted &,
-  .warning &,
-  .alert &{
+  .card.success &,
+  .card.muted &,
+  .card.warning &,
+  .card.alert &{
     margin-top: ($global-margin * .95) * -1;
 
     &::before{

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
@@ -736,10 +736,11 @@ $datetime-bg: $primary;
     -1px -1px 0 $card-bg,
     1px -1px 0 $card-bg,
     -1px 1px 0 $card-bg,
-     1px 1px 0 $card-bg;
-  margin-top: ($global-margin * .60) * -1;
+    1px 1px 0 $card-bg;
+  margin-top: ($global-margin * .6) * -1;
   margin-left: $card-padding-small;
   z-index: 0;
+
   &::before{
     content: " ";
     height: $border-width;
@@ -749,16 +750,18 @@ $datetime-bg: $primary;
     left: 0;
     right: 0;
     z-index: -1;
-    top: $global-margin * 0.5;
+    top: $global-margin * .5;
   }
+
   .success &,
   .muted &,
   .warning &,
   .alert & {
     margin-top: ($global-margin * .95) * -1;
+
     &::before{
       height: $card-border-top-width;
-      top: $global-margin * 0.45;
+      top: $global-margin * .45;
     }
   }
 

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
@@ -1,9 +1,10 @@
 /* Variables */
 
-$card-bg: $white;
+$card-bg: $white !default;
 $card-secondary-bg: $light-gray-dark;
 $card-border: $border;
 $card-border-radius: $global-radius;
+$card-border-top-width: 8px !default;
 $card-shadow: 0 2px 7px rgba(black, .1);
 $card-id: $medium-gray;
 
@@ -30,7 +31,7 @@ $datetime-bg: $primary;
   overflow: hidden;
 
   @include modifiers(border-top-color, (muted: rgba($muted, .3))){
-    border-top-width: 8px;
+    border-top-width: $card-border-top-width;
   }
 
   &:hover{
@@ -730,9 +731,36 @@ $datetime-bg: $primary;
   font-size: $small-font-size;
   font-weight: bold;
   position: absolute;
-  background-color: $card-bg;
-  margin-top: -$global-margin * .75;
+  background-color: transparent;
+  text-shadow:
+    -1px -1px 0 $card-bg,
+    1px -1px 0 $card-bg,
+    -1px 1px 0 $card-bg,
+     1px 1px 0 $card-bg;
+  margin-top: ($global-margin * .60) * -1;
   margin-left: $card-padding-small;
+  z-index: 0;
+  &::before{
+    content: " ";
+    height: $border-width;
+    display: inline-block;
+    background: $card-bg;
+    position: absolute;
+    left: 0;
+    right: 0;
+    z-index: -1;
+    top: $global-margin * 0.5;
+  }
+  .success &,
+  .muted &,
+  .warning &,
+  .alert & {
+    margin-top: ($global-margin * .95) * -1;
+    &::before{
+      height: $card-border-top-width;
+      top: $global-margin * 0.45;
+    }
+  }
 
   .icon{
     // Reduces some icon space

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
@@ -756,7 +756,7 @@ $datetime-bg: $primary;
   .success &,
   .muted &,
   .warning &,
-  .alert & {
+  .alert &{
     margin-top: ($global-margin * .95) * -1;
 
     &::before{

--- a/decidim-core/app/assets/stylesheets/decidim/utils/_settings.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/utils/_settings.scss
@@ -101,7 +101,8 @@ $global-button-cursor: auto;
 $global-color-pick-contrast-tolerance: 0;
 $print-transparent-backgrounds: true;
 
-$border: 1px solid $medium-gray !default;
+$border-width: 1px !default;
+$border: $border-width solid $medium-gray !default;
 
 @include add-foundation-colors;
 

--- a/decidim-core/app/cells/decidim/card_m/label.erb
+++ b/decidim-core/app/cells/decidim/card_m/label.erb
@@ -1,0 +1,3 @@
+<div class="card__label <%= card_classes %>">
+  <%= label %>
+</div>

--- a/decidim-core/app/cells/decidim/card_m/show.erb
+++ b/decidim-core/app/cells/decidim/card_m/show.erb
@@ -1,5 +1,7 @@
 <div class="column" id="<%= dom_id(model) %>">
   <article class="card <%= card_classes %>">
+    <%= render :label if has_label? %>
+
     <%= render :image if has_image? %>
 
     <div class="card__content">

--- a/decidim-core/app/cells/decidim/card_m_cell.rb
+++ b/decidim-core/app/cells/decidim/card_m_cell.rb
@@ -33,6 +33,16 @@ module Decidim
       true
     end
 
+    def has_label?
+      context[:label].presence
+    end
+
+    def label
+      return if [false, "false"].include? context[:label]
+      return @label ||= t(model.class.model_name.i18n_key, scope: "activerecord.models", count: 1) if [true, "true"].include? context[:label]
+      context[:label]
+    end
+
     def title
       translated_attribute model.title
     end

--- a/docs/advanced/view_models_aka_cells.md
+++ b/docs/advanced/view_models_aka_cells.md
@@ -17,6 +17,16 @@ If a card for the given resource is not registered, a _basic_ (default) card is 
 
 To render a specified size/variation include the `size` option as a `symbol`: `card_for @instance, size: :m`
 
+### Card M
+
+To render a label to identify the type of component renderized add to the `context` the `label` option.
+
+The `label` option accepts this arguments:
+
+- `false` or `"false"` will not render the label from the locales `t(model.class.model_name.i18n_key, scope: "activerecord.models", count: 1)`
+- `true` or `"true"` will render the translation from
+- `"whathever string"` will render it as String
+
 ## Introducing a Card Cell to a `component`
 
 - add **dependency** to "decidim-*.gemspec"


### PR DESCRIPTION
#### :tophat: What? Why?

`card_m` lack's the label which indentifies which type of card useful in some contexts like search.

This PR doesn't include this option in any view.

#### :pushpin: Related Issues
- Related to #3109
- Related to #3042

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [x] Add documentation regarding the feature 

### :camera: Screenshots (optional)

![screenshot from 2018-05-21 16-40-04](https://user-images.githubusercontent.com/210216/40315614-25b070c4-5d1c-11e8-83af-3b9cf67ed315.png)

![screenshot from 2018-05-21 17-29-31](https://user-images.githubusercontent.com/210216/40315762-93dc9d3e-5d1c-11e8-97c9-9c3dae222e43.png)

