### PR TITLE
Sort static pages by title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ must now set a resource name:
 - **decidim-participatory_processes**: Remove duplicated space title on page meta tags [\#3278](https://github.com/decidim/decidim/pull/3278)
 - **decidim-assemblies**: Remove duplicated space title on page meta tags [\#3278](https://github.com/decidim/decidim/pull/3278)
 - **decidim-core**: Add validation to nickname's length. [\#3342](https://github.com/decidim/decidim/pull/3342)
+- **decidim-core**: Sort static pages by title [\#3479](https://github.com/decidim/decidim/pull/3479)
 
 **Removed**:
 

--- a/decidim-core/app/controllers/decidim/pages_controller.rb
+++ b/decidim-core/app/controllers/decidim/pages_controller.rb
@@ -12,9 +12,7 @@ module Decidim
 
     def index
       enforce_permission_to :read, :public_page
-      @pages = current_organization.static_pages.all.to_a.sort do |a, b|
-        a.title[I18n.locale.to_s] <=> b.title[I18n.locale.to_s]
-      end
+      @pages = current_organization.static_pages.sorted_by_i18n_title
     end
 
     def show

--- a/decidim-core/app/models/decidim/static_page.rb
+++ b/decidim-core/app/models/decidim/static_page.rb
@@ -36,6 +36,10 @@ module Decidim
       Decidim::AdminLog::StaticPagePresenter
     end
 
+    def self.sorted_by_i18n_title(locale = I18n.locale)
+      order(["title->? ASC", locale])
+    end
+
     # Whether this is page is a default one or not.
     #
     # Returns Boolean.

--- a/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
@@ -90,7 +90,7 @@
           <div class="medium-8 large-6 large-offset-3 column main__footer__nav">
             <% if current_organization.static_pages.any? %>
               <ul class="footer-nav">
-                <% current_organization.static_pages.each do |page| %>
+                <% current_organization.static_pages.sorted_by_i18n_title.each do |page| %>
                   <li><%= link_to translated_attribute(page.title), decidim.page_path(page) %></li>
                 <% end %>
               </ul>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR sorts static pages by title. this mostly affects the footer, since it showed static pages sorted by creation date.

#### :pushpin: Related Issues
- Fixes #3083 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
Notice how both the pages index and the footer now show the same order:
![Description](https://i.imgur.com/8E0bpk9.png)
