### PR TITLE
Track TOS page version in Organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ must now set a resource name:
 - **decidim-core**: GDPR: Newsletter checkbox unchecked by default [\3316](https://github.com/decidim/decidim/issues/3316)
 - **decidim-consultations**: Add consultation card [\#3487](https://github.com/decidim/decidim/pull/3487)
 - **decidim-blogs**: Add blog post card [\#3487](https://github.com/decidim/decidim/pull/3487)
+- **decidim-core**: GDPR: Track TOS page version in Organization [\#3491](https://github.com/decidim/decidim/pull/3491)
 
 **Changed**:
 

--- a/decidim-admin/app/commands/decidim/admin/create_static_page.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_static_page.rb
@@ -9,6 +9,7 @@ module Decidim
       # form - A form object with the params.
       def initialize(form)
         @form = form
+        @page = nil
       end
 
       # Executes the command. Broadcasts these events:
@@ -21,6 +22,7 @@ module Decidim
         return broadcast(:invalid) if form.invalid?
 
         create_page
+        update_organization_tos_version
         broadcast(:ok)
       end
 
@@ -29,7 +31,7 @@ module Decidim
       attr_reader :form
 
       def create_page
-        Decidim.traceability.create!(
+        @page = Decidim.traceability.create!(
           StaticPage,
           form.current_user,
           title: form.title,
@@ -37,6 +39,10 @@ module Decidim
           content: form.content,
           organization: form.organization
         )
+      end
+
+      def update_organization_tos_version
+        UpdateOrganizationTosVersion.call(@form.organization, @page, @form)
       end
     end
   end

--- a/decidim-admin/app/commands/decidim/admin/update_organization_tos_version.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization_tos_version.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # A command with the business logic for updating the current
+    # organization tos_version attribute.
+    class UpdateOrganizationTosVersion < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # organization - The Organization that will be updated.
+      # page - A static_page instance (slug = "terms-and-conditions").
+      # form - A form object with the params.
+      def initialize(organization, page, form)
+        @organization = organization
+        @page = page
+        @form = form
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid.
+      # - :invalid if the form wasn't valid or not the TOS page.
+      #
+      # Returns nothing.
+      def call
+        return broadcast(:invalid) if @form.nil?
+        return broadcast(:invalid) if @page.nil?
+        return broadcast(:invalid) unless @page.slug == "terms-and-conditions"
+
+        update_organization_tos_version
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :form
+
+      def update_organization_tos_version
+        Decidim.traceability.update!(
+          @organization,
+          @form.current_user,
+          tos_version: @page.updated_at
+        )
+      end
+    end
+  end
+end

--- a/decidim-admin/app/commands/decidim/admin/update_static_page.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_static_page.rb
@@ -23,6 +23,7 @@ module Decidim
         return broadcast(:invalid) if form.invalid?
 
         update_page
+        update_organization_tos_version if form.changed_notably
         broadcast(:ok)
       end
 
@@ -44,6 +45,10 @@ module Decidim
           slug: form.slug,
           content: form.content
         }
+      end
+
+      def update_organization_tos_version
+        UpdateOrganizationTosVersion.call(@form.organization, @page, @form)
       end
     end
   end

--- a/decidim-admin/app/controllers/decidim/admin/static_pages_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/static_pages_controller.rb
@@ -6,6 +6,7 @@ module Decidim
     #
     class StaticPagesController < Decidim::Admin::ApplicationController
       layout "decidim/admin/pages"
+      before_action :tos_version_formatted, only: [:index, :edit]
 
       def index
         enforce_permission_to :read, :static_page
@@ -91,6 +92,14 @@ module Decidim
 
       def collection
         current_organization.static_pages
+      end
+
+      def tos_version
+        current_organization.tos_version
+      end
+
+      def tos_version_formatted
+        @tos_version_formatted ||= l(tos_version, format: :short) if tos_version.present?
       end
     end
   end

--- a/decidim-admin/app/forms/decidim/admin/static_page_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/static_page_form.rb
@@ -9,6 +9,7 @@ module Decidim
       attribute :slug, String
       translatable_attribute :title, String
       translatable_attribute :content, String
+      attribute :changed_notably, Boolean
 
       mimic :static_page
 

--- a/decidim-admin/app/permissions/decidim/admin/permissions.rb
+++ b/decidim-admin/app/permissions/decidim/admin/permissions.rb
@@ -75,6 +75,8 @@ module Decidim
           static_page.present?
         when :update_slug, :destroy
           static_page.present? && !StaticPage.default?(static_page.slug)
+        when :update_notable_changes
+          static_page.slug == "terms-and-conditions" && static_page.persisted?
         else
           true
         end

--- a/decidim-admin/app/views/decidim/admin/static_pages/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_pages/_form.html.erb
@@ -11,3 +11,5 @@
 <div class="row column">
   <%= form.translated :editor, :content, toolbar: :full, lines: 25 %>
 </div>
+
+<%= render partial: "form_notable_changes", locals: { form: form } %>

--- a/decidim-admin/app/views/decidim/admin/static_pages/_form_notable_changes.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_pages/_form_notable_changes.html.erb
@@ -1,0 +1,9 @@
+<% if allowed_to? :update_notable_changes, :static_page, static_page: form.object %>
+  <div class="row column">
+    <%= form.check_box :changed_notably, value: false, help_text: t("changed_notably_help", scope: "decidim.admin.static_pages.edit") %>
+
+    <div class="callout secondary">
+      <%= t("last_notable_change", scope: "decidim.admin.static_pages.index") %>: <%= @tos_version_formatted %>
+    </div>
+  </div>
+<% end %>

--- a/decidim-admin/app/views/decidim/admin/static_pages/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_pages/index.html.erb
@@ -11,6 +11,7 @@
           <tr>
             <th><%= t("models.static_page.fields.title", scope: "decidim.admin") %></th>
             <th><%= t("models.static_page.fields.created_at", scope: "decidim.admin") %></th>
+            <th><%= t("last_notable_change", scope: "decidim.admin.static_pages.index") %></th>
             <th></th>
           </tr>
         </thead>
@@ -22,6 +23,11 @@
               </td>
               <td>
                 <%= l page.created_at, format: :short %>
+              </td>
+              <td>
+                <% if allowed_to? :update_notable_changes, :static_page, static_page: page %>
+                  <%= @tos_version_formatted %>
+                <% end %>
               </td>
               <td class="table-list__actions">
                 <% if allowed_to? :update, :static_page, static_page: page %>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -65,6 +65,7 @@ en:
         omnipresent_banner_url: URL
         reference_prefix: Reference prefix
         show_statistics: Show statistics
+        tos_version: Terms of service version
         twitter_handler: Twitter handler
         welcome_text: Welcome text
         youtube_handler: YouTube handler
@@ -80,6 +81,7 @@ en:
         organization: Organization
         plural: Plural
       static_page:
+        changed_notably: There have been noticeable changes.
         content: Content
         organization: Organization
         slug: URL slug
@@ -575,8 +577,11 @@ en:
         destroy:
           success: Page successfully destroyed
         edit:
+          changed_notably_help: If checked, users will be notified to accept the new terms and conditions.
           title: Edit page
           update: Update
+        index:
+          last_notable_change: Last notable change
         new:
           create: Create
           title: New page

--- a/decidim-admin/spec/commands/decidim/admin/update_organization_tos_version_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/update_organization_tos_version_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Admin
+  describe UpdateOrganizationTosVersion do
+    describe "call" do
+      let(:organization) { create(:organization) }
+      let(:tos_page) { create(:static_page, slug: "terms-and-conditions", organization: organization) }
+      let(:other_page) { create(:static_page, slug: "other-page", organization: organization) }
+      let(:user) { create(:user, organization: organization) }
+
+      describe "when the page is not the terms-and-conditions page" do
+        let(:form) do
+          StaticPageForm.from_params(
+            static_page: other_page.attributes.merge(
+              content_en: Faker::Lorem.paragraph(2),
+              content_es: Faker::Lorem.paragraph(2),
+              content_ca: Faker::Lorem.paragraph(2),
+              changed_notably: true
+            )
+          ).with_context(
+            current_organization: other_page.organization,
+            current_user: user
+          )
+        end
+
+        let(:command) { described_class.new(organization, other_page, form) }
+
+        it "broadcasts invalid" do
+          expect { command.call }.to broadcast(:invalid)
+        end
+
+        it "doesn't update the organization's terms-and-conditions updated at setting" do
+          previous_tos_version = organization.tos_version.strftime("%F %T.%L")
+          command.call
+          organization.reload
+
+          expect(previous_tos_version).to eq(organization.tos_version.strftime("%F %T.%L"))
+        end
+      end
+
+      describe "when the page is the terms-and-conditions page" do
+        let(:form) do
+          StaticPageForm.from_params(
+            static_page: tos_page.attributes.merge(
+              content_en: Faker::Lorem.paragraph(2),
+              content_es: Faker::Lorem.paragraph(2),
+              content_ca: Faker::Lorem.paragraph(2),
+              changed_notably: true
+            )
+          ).with_context(
+            current_organization: tos_page.organization,
+            current_user: user
+          )
+        end
+
+        let(:command) { described_class.new(organization, tos_page, form) }
+
+        it "broadcasts ok" do
+          expect { command.call }.to broadcast(:ok)
+        end
+
+        it "traces the update", versioning: true do
+          expect(Decidim.traceability)
+            .to receive(:update!)
+            .with(organization, user, hash_including(:tos_version))
+            .and_call_original
+
+          expect { command.call }.to change(Decidim::ActionLog, :count)
+
+          action_log = Decidim::ActionLog.last
+          expect(action_log.version).to be_present
+          expect(action_log.action).to eq "update"
+        end
+
+        it "updates the the organization's terms-and-conditions updated at setting" do
+          command.call
+          tos_page.reload
+          organization.reload
+
+          expect(tos_page.updated_at).to eq(organization.tos_version)
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/commands/decidim/admin/update_static_page_changed_notably_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/update_static_page_changed_notably_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Admin
+  describe UpdateStaticPage do
+    describe "call" do
+      let(:organization) { create(:organization) }
+      let(:page) { create(:static_page, organization: organization, slug: "terms-and-conditions") }
+      let(:user) { create :user, :admin, :confirmed, organization: organization }
+      let(:form) do
+        StaticPageForm.from_params(
+          static_page: page.attributes.merge(
+            content_en: Faker::Lorem.paragraph(2),
+            content_es: Faker::Lorem.paragraph(2),
+            content_ca: Faker::Lorem.paragraph(2),
+            changed_notably: true
+          )
+        ).with_context(
+          current_organization: page.organization,
+          current_user: user
+        )
+      end
+      let(:command) { described_class.new(page, form) }
+
+      describe "when the changed_notably is checked" do
+        it "broadcasts ok" do
+          expect { command.call }.to broadcast(:ok)
+        end
+
+        it "traces the update", versioning: true do
+          expect { command.call }.to change(Decidim::ActionLog, :count)
+
+          action_log = Decidim::ActionLog.where(resource_type: "Decidim::Organization").last
+          expect(action_log.version).to be_present
+          expect(action_log.action).to eq "update"
+          expect(action_log.version.item_type).to eq "Decidim::Organization"
+          expect(action_log.version.object_changes).to include "tos_version"
+        end
+
+        it "updates the the organization's terms-and-conditions version setting" do
+          command.call
+          organization.reload
+          page.reload
+
+          expect(page.updated_at).to eq(organization.tos_version)
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/views/decidim/static_pages/_form_notable_changes.html.erb_spec.rb
+++ b/decidim-admin/spec/views/decidim/static_pages/_form_notable_changes.html.erb_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 module Decidim
-  describe "decidim/admin/static_pages/_form" do
+  describe "decidim/admin/static_pages/_form_notable_changes" do
     subject { render }
 
     let(:form) do
@@ -15,7 +15,7 @@ module Decidim
       )
     end
     let(:action) do
-      Decidim::PermissionAction.new(scope: :admin, action: :update, subject: :static_page)
+      Decidim::PermissionAction.new(scope: :admin, action: :update_notable_changes, subject: :static_page)
     end
     let(:permissions_class) do
       Decidim::Admin::Permissions.new(build(:user, :admin), action, static_page: form.object)
@@ -32,21 +32,21 @@ module Decidim
       let(:slug) { Decidim::StaticPage::DEFAULT_PAGES.without("terms-and-conditions").sample }
       let(:allowed?) { false }
 
-      it { is_expected.not_to include("slug") }
+      it { is_expected.to eq("") }
     end
 
     context "with the TOS static page" do
       let(:slug) { "terms-and-conditions" }
-      let(:allowed?) { false }
+      let(:allowed?) { true }
 
-      it { is_expected.not_to include("slug") }
+      it { is_expected.to include("changed_notably") }
     end
 
     context "with a normal static page" do
       let(:slug) { "foo" }
-      let(:allowed?) { true }
+      let(:allowed?) { false }
 
-      it { is_expected.to include("slug") }
+      it { is_expected.to eq("") }
     end
   end
 end

--- a/decidim-core/app/presenters/decidim/admin_log/organization_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/organization_presenter.rb
@@ -30,7 +30,8 @@ module Decidim
           facebook_handler: :string,
           instagram_handler: :string,
           youtube_handler: :string,
-          github_handler: :string
+          github_handler: :string,
+          tos_version: :datetime
         }
       end
 

--- a/decidim-core/db/migrate/20180508111640_add_tos_version_to_organization.rb
+++ b/decidim-core/db/migrate/20180508111640_add_tos_version_to_organization.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddTosVersionToOrganization < ActiveRecord::Migration[5.1]
+  class Organization < ApplicationRecord
+    self.table_name = :decidim_organizations
+  end
+
+  def up
+    add_column :decidim_organizations, :tos_version, :datetime
+    Organization.find_each do |organization|
+      tos_version = Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization: organization).updated_at
+      organization.update(tos_version: tos_version)
+    end
+  end
+
+  def down
+    remove_columns :decidim_organizations, :tos_version
+  end
+end

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -23,7 +23,8 @@ if !Rails.env.production? || ENV["SEED"]
     default_locale: Decidim.default_locale,
     available_locales: Decidim.available_locales,
     reference_prefix: Faker::Name.suffix,
-    available_authorizations: Decidim.authorization_workflows.map(&:name)
+    available_authorizations: Decidim.authorization_workflows.map(&:name),
+    tos_version: Time.current
   )
 
   if organization.top_scopes.none?

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -69,6 +69,7 @@ FactoryBot.define do
     official_url { Faker::Internet.url }
     highlighted_content_banner_enabled false
     enable_omnipresent_banner false
+    tos_version { Time.current }
   end
 
   factory :user, class: "Decidim::User" do


### PR DESCRIPTION
#### :tophat: What? Why?

[decidim-admin] Adds the option to mark as _Notable changes_ in the TOS edit page, The Organization has a new setting `tos_version` that is updated when the `notable_changes` checkbox is `true`.

This PR is related to the PR _User must review TOS when updated_ (comming soon) to solve issue #3318.

#### :pushpin: Related Issues
- Related to Epic #3320
- Fixes #3317
- Related to issue #3318, PR #3494

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add/modify seeds
- [x] Add tests
- [x] option to mark as notable changes in TOS page
- [x] migration to add organization setting tos_version 
- [x] traces updates

### :camera: Screenshots (optional)

+ Last notable change shown in index: 
  ![screenshot from 2018-05-09 12-53-45](https://user-images.githubusercontent.com/210216/39811280-79bac6d0-5388-11e8-927e-4fb6b092d946.png)

+ Edit Page with noticeable changes `check_box` : 
   ![screenshot from 2018-05-09 12-54-10](https://user-images.githubusercontent.com/210216/39811339-a2523d9e-5388-11e8-8452-0830f114b0a8.png)

+ Version changes in Admin Dashboard:
   ![screenshot from 2018-05-23 11-26-35](https://user-images.githubusercontent.com/210216/40415916-559b667a-5e7c-11e8-8d7b-20e01295eae4.png)

