### PR TITLE
Fix surveys n+1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ administrators should keep in mind updating the help texts for each step.
 - **decidim**: Fix the dependency of `high_voltage` to `v3.0.0` [\#3383](https://github.com/decidim/decidim/pull/3383)
 - **decidim-blog**: Add `params[:id]` when editing/deleting a post from admin site [\#3360](https://github.com/decidim/decidim/pull/3360)
 - **decidim-admin**: Fixes the validation uniqueness name of area, scoped with organization and area_type [\#3350](https://github.com/decidim/decidim/pull/3350)
+- **decidim-surveys**: Fix a N+1 in surveys [\#333493](https://github.com/decidim/decidim/pull/3493)
 
 **Removed**:
 

--- a/decidim-surveys/app/commands/decidim/surveys/answer_survey.rb
+++ b/decidim-surveys/app/commands/decidim/surveys/answer_survey.rb
@@ -28,7 +28,7 @@ module Decidim
 
       def answer_survey
         SurveyAnswer.transaction do
-          @form.answers.each do |form_answer|
+          @form.survey_answers.each do |form_answer|
             answer = SurveyAnswer.new(
               user: @current_user,
               survey: @survey,

--- a/decidim-surveys/app/controllers/decidim/surveys/surveys_controller.rb
+++ b/decidim-surveys/app/controllers/decidim/surveys/surveys_controller.rb
@@ -32,7 +32,7 @@ module Decidim
       private
 
       def survey
-        @survey ||= Survey.find_by(component: current_component)
+        @survey ||= Survey.includes(questions: :answer_options).find_by(component: current_component)
       end
     end
   end

--- a/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
@@ -18,7 +18,11 @@ module Decidim
 
       delegate :mandatory_body?, :mandatory_choices?, to: :question
 
-      attr_reader :question
+      attr_accessor :question
+
+      def question
+        @question ||= Decidim::Surveys::SurveyQuestion.find(question_id)
+      end
 
       def label(idx)
         base = "#{idx + 1}. #{translated_attribute(question.body)}"
@@ -32,7 +36,7 @@ module Decidim
       # Returns nothing.
       def map_model(model)
         self.question_id = model.decidim_survey_question_id
-        @question = model.question
+        self.question = model.question
 
         self.choices = model.choices.map do |choice|
           SurveyAnswerChoiceForm.from_model(choice)

--- a/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
@@ -18,7 +18,7 @@ module Decidim
 
       delegate :mandatory_body?, :mandatory_choices?, to: :question
 
-      attr_accessor :question
+      attr_writer :question
 
       def question
         @question ||= Decidim::Surveys::SurveyQuestion.find(question_id)

--- a/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_answer_form.rb
@@ -18,9 +18,7 @@ module Decidim
 
       delegate :mandatory_body?, :mandatory_choices?, to: :question
 
-      def question
-        @question ||= survey.questions.find(question_id)
-      end
+      attr_reader :question
 
       def label(idx)
         base = "#{idx + 1}. #{translated_attribute(question.body)}"
@@ -34,6 +32,7 @@ module Decidim
       # Returns nothing.
       def map_model(model)
         self.question_id = model.decidim_survey_question_id
+        @question = model.question
 
         self.choices = model.choices.map do |choice|
           SurveyAnswerChoiceForm.from_model(choice)
@@ -45,10 +44,6 @@ module Decidim
       end
 
       private
-
-      def survey
-        @survey ||= Survey.find_by(component: current_component)
-      end
 
       def max_choices
         errors.add(:choices, :too_many) if selected_choices.size > question.max_choices

--- a/decidim-surveys/app/forms/decidim/surveys/survey_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/survey_form.rb
@@ -4,7 +4,7 @@ module Decidim
   module Surveys
     # This class holds a Form to answer a surveys from Decidim's public page.
     class SurveyForm < Decidim::Form
-      attribute :answers, Array[SurveyAnswerForm]
+      attribute :survey_answers, Array[SurveyAnswerForm]
 
       attribute :tos_agreement, Boolean
       validates :tos_agreement, allow_nil: false, acceptance: true
@@ -13,7 +13,7 @@ module Decidim
       #
       # Returns nothing.
       def map_model(model)
-        self.answers = model.questions.map do |question|
+        self.survey_answers = model.questions.map do |question|
           SurveyAnswerForm.from_model(SurveyAnswer.new(question: question))
         end
       end

--- a/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/_answer.html.erb
@@ -20,7 +20,7 @@
       <% choice_id = "#{field_id}_choices_#{idx}" %>
 
       <%= label_tag "#{choice_id}_body" do %>
-        <%= radio_button_tag "survey[answers][#{answer_idx}][choices][][body]",
+        <%= radio_button_tag "survey[survey_answers][#{answer_idx}][choices][][body]",
                              translated_attribute(answer_option.body),
                              choice.try(:body),
                              id: "#{choice_id}_body" %>
@@ -28,13 +28,13 @@
         <%= translated_attribute(answer_option.body) %>
 
         <% if answer_option.free_text %>
-          <%= text_field_tag "survey[answers][#{answer_idx}][choices][][custom_body]",
+          <%= text_field_tag "survey[survey_answers][#{answer_idx}][choices][][custom_body]",
                              choice.try(:custom_body),
                              id: "#{choice_id}_custom_body",
                              disabled: true %>
         <% end %>
 
-        <%= hidden_field_tag "survey[answers][#{answer_idx}][choices][][answer_option_id]",
+        <%= hidden_field_tag "survey[survey_answers][#{answer_idx}][choices][][answer_option_id]",
                              answer_option.id,
                              id: "#{choice_id}_answer_option",
                              disabled: true %>
@@ -47,19 +47,19 @@
       <% choice = answer.selected_choices.find { |choice| choice.answer_option_id == answer_option.id } %>
 
       <%= label_tag do %>
-        <%= check_box_tag "survey[answers][#{answer_idx}][choices][#{idx}][body]",
+        <%= check_box_tag "survey[survey_answers][#{answer_idx}][choices][#{idx}][body]",
                           translated_attribute(answer_option.body),
                           choice.present? %>
 
         <%= translated_attribute(answer_option.body) %>
 
         <% if answer_option.free_text %>
-          <%= text_field_tag "survey[answers][#{answer_idx}][choices][#{idx}][custom_body]",
+          <%= text_field_tag "survey[survey_answers][#{answer_idx}][choices][#{idx}][custom_body]",
                              choice.try(:custom_body),
                              disabled: true %>
         <% end %>
 
-        <%= hidden_field_tag "survey[answers][#{answer_idx}][choices][#{idx}][answer_option_id]", answer_option.id %>
+        <%= hidden_field_tag "survey[survey_answers][#{answer_idx}][choices][#{idx}][answer_option_id]", answer_option.id %>
       <% end %>
     <% end %>
   </div>
@@ -69,7 +69,7 @@
       <% choice = answer.selected_choices.find { |choice| choice.answer_option_id == answer_option.id } %>
 
       <%= label_tag do %>
-        <%= check_box_tag "survey[answers][#{answer_idx}][choices][#{idx}][body]",
+        <%= check_box_tag "survey[survey_answers][#{answer_idx}][choices][#{idx}][body]",
                           translated_attribute(answer_option.body),
                           choice.present? %>
 
@@ -77,11 +77,11 @@
 
         <%= translated_attribute(answer_option.body) %>
 
-        <%= hidden_field_tag "survey[answers][#{answer_idx}][choices][#{idx}][position]",
+        <%= hidden_field_tag "survey[survey_answers][#{answer_idx}][choices][#{idx}][position]",
                              choice.try(:position),
                              disabled: true %>
 
-        <%= hidden_field_tag "survey[answers][#{answer_idx}][choices][#{idx}][answer_option_id]", answer_option.id %>
+        <%= hidden_field_tag "survey[survey_answers][#{answer_idx}][choices][#{idx}][answer_option_id]", answer_option.id %>
       <% end %>
     <% end %>
   </div>

--- a/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
@@ -32,7 +32,7 @@
                 <%= decidim_form_for(@form, url: answer_survey_path(survey), method: :post, html: { class: "form answer-survey" }) do |form| %>
                   <% @form.survey_answers.each_with_index do |answer, answer_idx| %>
                     <div class="row column">
-                      <%= fields_for "survey[answers][#{answer_idx}]", answer do |answer_form| %>
+                      <%= fields_for "survey[survey_answers][#{answer_idx}]", answer do |answer_form| %>
                         <%= render "answer", answer_form: answer_form, answer: answer, answer_idx: answer_idx %>
                       <% end %>
                     </div>

--- a/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/show.html.erb
@@ -30,7 +30,7 @@
             <% else %>
               <div class="answer-survey">
                 <%= decidim_form_for(@form, url: answer_survey_path(survey), method: :post, html: { class: "form answer-survey" }) do |form| %>
-                  <% @form.answers.each_with_index do |answer, answer_idx| %>
+                  <% @form.survey_answers.each_with_index do |answer, answer_idx| %>
                     <div class="row column">
                       <%= fields_for "survey[answers][#{answer_idx}]", answer do |answer_form| %>
                         <%= render "answer", answer_form: answer_form, answer: answer, answer_idx: answer_idx %>

--- a/decidim-surveys/spec/commands/decidim/surveys/answer_survey_spec.rb
+++ b/decidim-surveys/spec/commands/decidim/surveys/answer_survey_spec.rb
@@ -17,7 +17,7 @@ module Decidim
       let(:answer_option_ids) { answer_options.pluck(:id).map(&:to_s) }
       let(:form_params) do
         {
-          "answers" => [
+          "survey_answers" => [
             {
               "body" => "This is my first answer",
               "question_id" => survey_question_1.id

--- a/decidim-surveys/spec/forms/decidim/surveys/survey_form_spec.rb
+++ b/decidim-surveys/spec/forms/decidim/surveys/survey_form_spec.rb
@@ -13,7 +13,7 @@ module Decidim
       let!(:survey_question) { create(:survey_question, survey: survey) }
 
       it "builds empty answers for each question" do
-        expect(subject.answers.length).to eq(1)
+        expect(subject.survey_answers.length).to eq(1)
       end
 
       context "when tos_agreement is not accepted" do

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -323,16 +323,16 @@ describe "Answer a survey", type: :system do
           it "renders them as check boxes with attached text fields disabled by default" do
             expect(page.first(".check-box-collection")).to have_selector("input[type=checkbox]", count: 3)
 
-            expect(page).to have_field("survey_answers_0_choices_2_custom_body", disabled: true, count: 1)
+            expect(page).to have_field("survey_survey_answers_0_choices_2_custom_body", disabled: true, count: 1)
 
             check answer_option_bodies[2]["en"]
 
-            expect(page).to have_field("survey_answers_0_choices_2_custom_body", disabled: false, count: 1)
+            expect(page).to have_field("survey_survey_answers_0_choices_2_custom_body", disabled: false, count: 1)
           end
 
           it "saves the free text in a separate field if submission correct" do
             check answer_option_bodies[2]["en"]
-            fill_in "survey_answers_0_choices_2_custom_body", with: "Cacatua"
+            fill_in "survey_survey_answers_0_choices_2_custom_body", with: "Cacatua"
 
             check "survey_tos_agreement"
             accept_confirm { click_button "Submit" }
@@ -345,12 +345,12 @@ describe "Answer a survey", type: :system do
           end
 
           it "preserves the previous custom body if submission not correct" do
-            check "survey_answers_1_choices_0_body"
-            check "survey_answers_1_choices_1_body"
-            check "survey_answers_1_choices_2_body"
+            check "survey_survey_answers_1_choices_0_body"
+            check "survey_survey_answers_1_choices_1_body"
+            check "survey_survey_answers_1_choices_2_body"
 
             check answer_option_bodies[2]["en"]
-            fill_in "survey_answers_0_choices_2_custom_body", with: "Cacatua"
+            fill_in "survey_survey_answers_0_choices_2_custom_body", with: "Cacatua"
 
             check "survey_tos_agreement"
             accept_confirm { click_button "Submit" }
@@ -359,7 +359,7 @@ describe "Answer a survey", type: :system do
               expect(page).to have_content("There's been errors when answering the survey.")
             end
 
-            expect(page).to have_field("survey_answers_0_choices_2_custom_body", with: "Cacatua")
+            expect(page).to have_field("survey_survey_answers_0_choices_2_custom_body", with: "Cacatua")
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
We found a N+1 in surveys, where it was loading all the survey answers when rendering the survey form. This is due to how `rectify` forms work: if you have an attribute to the form, and its `model` responds to that attribute, the form will automatically call . this method. 

This meant that if a form had an attribute called `:answers`, it automatically calls `model.answers`. In our case, it was causing the app to load all the answers for the given survey, which caused memory problems.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
