### PR TITLE
User must review TOS when updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ must now set a resource name:
 - **decidim-consultations**: Add consultation card [\#3487](https://github.com/decidim/decidim/pull/3487)
 - **decidim-blogs**: Add blog post card [\#3487](https://github.com/decidim/decidim/pull/3487)
 - **decidim-core**: GDPR: Track TOS page version in Organization [\#3491](https://github.com/decidim/decidim/pull/3491)
+- **decidim-core**: GDPR: User must review TOS when updated [\#3494](https://github.com/decidim/decidim/pull/3494)
 
 **Changed**:
 

--- a/decidim-admin/spec/commands/decidim/admin/create_static_page_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/create_static_page_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 module Decidim::Admin
   describe CreateStaticPage do
     describe "call" do
-      let(:organization) { create(:organization) }
+      let(:organization) { create(:organization, :with_tos) }
       let(:user) { create :user, :admin, :confirmed, organization: organization }
       let(:form) do
         StaticPageForm

--- a/decidim-admin/spec/commands/decidim/admin/update_organization_tos_version_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/update_organization_tos_version_spec.rb
@@ -5,8 +5,8 @@ require "spec_helper"
 module Decidim::Admin
   describe UpdateOrganizationTosVersion do
     describe "call" do
-      let(:organization) { create(:organization) }
-      let(:tos_page) { create(:static_page, slug: "terms-and-conditions", organization: organization) }
+      let(:organization) { create(:organization, :with_tos) }
+      let(:tos_page) { Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization: organization) }
       let(:other_page) { create(:static_page, slug: "other-page", organization: organization) }
       let(:user) { create(:user, organization: organization) }
 

--- a/decidim-admin/spec/shared/manage_impersonations_examples.rb
+++ b/decidim-admin/spec/shared/manage_impersonations_examples.rb
@@ -3,7 +3,7 @@
 shared_examples "manage impersonations examples" do
   include ActiveSupport::Testing::TimeHelpers
 
-  let(:organization) { create(:organization, available_authorizations: available_authorizations) }
+  let(:organization) { create(:organization, :with_tos, available_authorizations: available_authorizations) }
   let(:available_authorizations) { ["dummy_authorization_handler"] }
   let(:document_number) { "123456789X" }
 
@@ -243,6 +243,7 @@ shared_examples "manage impersonations examples" do
       within "form.new_user" do
         fill_in :user_password, with: "123456"
         fill_in :user_password_confirmation, with: "123456"
+        check :user_tos_agreement
         find("*[type=submit]").click
       end
 

--- a/decidim-admin/spec/system/admin_invite_spec.rb
+++ b/decidim-admin/spec/system/admin_invite_spec.rb
@@ -41,6 +41,7 @@ describe "Admin invite", type: :system do
         fill_in :user_nickname, with: "caballo_loco"
         fill_in :user_password, with: "123456"
         fill_in :user_password_confirmation, with: "123456"
+        check :user_tos_agreement
         find("*[type=submit]").click
       end
 

--- a/decidim-core/app/cells/decidim/announcement/show.erb
+++ b/decidim-core/app/cells/decidim/announcement/show.erb
@@ -1,0 +1,11 @@
+<div class="row column">
+  <%= content_tag :div, class: "callout announcement mb-sm #{callout_class} cell-announcement" do %>
+    <% if announcement.class == Hash && announcement.key?(:title) %>
+      <h5><%= decidim_sanitize translated_attribute announcement[:title] %></h5>
+
+      <p><%= decidim_sanitize translated_attribute announcement[:body] %></p>
+    <% else %>
+      <%= decidim_sanitize translated_attribute announcement %>
+    <% end %>
+  <% end %>
+</div>

--- a/decidim-core/app/cells/decidim/announcement_cell.rb
+++ b/decidim-core/app/cells/decidim/announcement_cell.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This cell renders an announcement
+  # the `model` is spected to be a Hash with two keys:
+  #  `announcement` is mandatory, its the message to show
+  #  `callout_class` is optional, the css class modifier
+  #
+  # {
+  #   announcement: { ... },
+  #   callout_class: "warning"
+  # }
+  #
+  class AnnouncementCell < Decidim::ViewModel
+    include Decidim::SanitizeHelper
+
+    def show
+      return unless announcement.presence
+      render :show
+    end
+
+    private
+
+    def callout_class
+      model[:callout_class] ||= "secondary"
+    end
+
+    def announcement
+      model[:announcement]
+    end
+  end
+end

--- a/decidim-core/app/cells/decidim/tos_page/announcement.erb
+++ b/decidim-core/app/cells/decidim/tos_page/announcement.erb
@@ -1,0 +1,2 @@
+<%= cell("decidim/announcement", announcement_args) %>
+<%= content_tag :div, nil, id: "sticky-top-stop" %>

--- a/decidim-core/app/cells/decidim/tos_page/refuse_btn_modal.erb
+++ b/decidim-core/app/cells/decidim/tos_page/refuse_btn_modal.erb
@@ -1,0 +1,23 @@
+<button class="clear button secondary button--nomargin small" type="button" data-open="tos-refuse-modal">
+  <%= t("refuse.modal_button", scope: "decidim.pages.terms_and_conditions") %>
+</button>
+
+<div id="tos-refuse-modal" class="reveal" data-reveal aria-labelledby="#{modal_title}" aria-hidden="true" role="dialog">
+  <h2>
+    <%= t("refuse.modal_title", scope: "decidim.pages.terms_and_conditions") %>
+  </h2>
+
+  <p>
+    <%= t("refuse.modal_body", scope: "decidim.pages.terms_and_conditions", data_portability_path: "#", delete_path: decidim.delete_account_path) %>
+  </p>
+
+  <div class="row column flex-center">
+    <%= button_to decidim.destroy_user_session_path, method: :delete, class: "clear button secondary button--nomargin small" do %>
+      <%= t("refuse.modal_btn_exit", scope: "decidim.pages.terms_and_conditions") %>
+    <% end %>
+
+    <%= button_to decidim.accept_tos_path, method: :put, class: "button button--nomargin small" do %>
+      <%= t("refuse.modal_btn_continue", scope: "decidim.pages.terms_and_conditions") %>
+    <% end %>
+  </div>
+</div>

--- a/decidim-core/app/cells/decidim/tos_page/sticky_form.erb
+++ b/decidim-core/app/cells/decidim/tos_page/sticky_form.erb
@@ -1,0 +1,29 @@
+<div data-sticky-container class="cell-sticky">
+  <div class="sticky"
+        data-sticky
+        data-stick-to="bottom"
+        data-margin-bottom="0"
+        data-top-anchor="sticky-top-stop:top"
+        data-btm-anchor="sticky-btm-stop:top"
+        data-sticky-on="small">
+    <article class="card">
+      <div class="card__content">
+        <div class="card__header">
+          <h5 class="card__title text-center">
+            <%= t("form.legend", scope: "decidim.pages.terms_and_conditions") %>
+          </h5>
+        </div>
+
+        <div class="row column flex-center">
+          <%= cell "decidim/tos_page", :refuse_btn_modal %>
+
+          <%= button_to decidim.accept_tos_path, method: :put, class: "button button--nomargin small" do %>
+            <%= t("form.agreement", scope: "decidim.pages.terms_and_conditions") %>
+          <% end %>
+        </div>
+      </div>
+    </article>
+  </div>
+</div>
+
+<div id="sticky-btm-stop"></div>

--- a/decidim-core/app/cells/decidim/tos_page_cell.rb
+++ b/decidim-core/app/cells/decidim/tos_page_cell.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This cell renders specific _partials_ for the `terms_and_conditions` StaticPage
+  # the `model` is the partial to render
+  # - :announcement, the TOS updated announcement when redirected to the TOS page.
+  # - :sticky_form, the Accept updated TOS form in the TOS page.
+  # - :refuse_btn_modal, the Modal with info when refusing the updated TOS.
+  class TosPageCell < Decidim::ViewModel
+    include Decidim::SanitizeHelper
+    include Cell::ViewModel::Partial
+
+    delegate :current_user, to: :controller, prefix: false
+
+    def show
+      return if model.nil?
+      return unless current_user
+      return if current_user.tos_accepted?
+      render model
+    end
+
+    private
+
+    def announcement_args
+      args = {
+        callout_class: "warning",
+        announcement: {
+          title: t("required_review.title", scope: "decidim.pages.terms_and_conditions"),
+          body: t("required_review.body", scope: "decidim.pages.terms_and_conditions")
+        }
+      }
+      args
+    end
+
+    def decidim
+      Decidim::Core::Engine.routes.url_helpers
+    end
+  end
+end

--- a/decidim-core/app/commands/decidim/create_registration.rb
+++ b/decidim-core/app/commands/decidim/create_registration.rb
@@ -41,7 +41,8 @@ module Decidim
                            organization: form.current_organization,
                            tos_agreement: form.tos_agreement,
                            newsletter_notifications: form.newsletter,
-                           email_on_notification: true)
+                           email_on_notification: true,
+                           accepted_tos_version: form.current_organization.tos_version)
     end
 
     def create_user_group

--- a/decidim-core/app/controllers/concerns/decidim/needs_tos_accepted.rb
+++ b/decidim-core/app/controllers/concerns/decidim/needs_tos_accepted.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Decidim
+  # Shared behaviour for signed_in users that require the latest TOS accepted
+  module NeedsTosAccepted
+    def tos_accepted_by_user
+      return true unless current_user
+      return if current_user.tos_accepted?
+      return if permitted_paths?
+
+      redirect_to_tos
+    end
+
+    private
+
+    def permitted_paths?
+      permitted_paths = [tos_path, decidim.delete_account_path, decidim.accept_tos_path]
+      permitted_paths.include?(request.path)
+    end
+
+    def terms_and_conditions_page
+      @terms_and_conditions_page ||= Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization: current_organization)
+    end
+
+    def tos_path
+      decidim.page_path terms_and_conditions_page
+    end
+
+    def redirect_to_tos
+      flash[:notice] = flash[:notice] if flash[:notice]
+      flash[:secondary] = t("required_review.alert", scope: "decidim.pages.terms_and_conditions")
+      redirect_to tos_path
+    end
+  end
+end

--- a/decidim-core/app/controllers/concerns/decidim/needs_tos_accepted.rb
+++ b/decidim-core/app/controllers/concerns/decidim/needs_tos_accepted.rb
@@ -3,6 +3,15 @@
 module Decidim
   # Shared behaviour for signed_in users that require the latest TOS accepted
   module NeedsTosAccepted
+    extend ActiveSupport::Concern
+
+    included do
+      before_action :tos_accepted_by_user
+      helper_method :terms_and_conditions_page
+    end
+
+    private
+
     def tos_accepted_by_user
       return true unless current_user
       return if current_user.tos_accepted?
@@ -11,15 +20,13 @@ module Decidim
       redirect_to_tos
     end
 
-    private
+    def terms_and_conditions_page
+      @terms_and_conditions_page ||= Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization: current_organization)
+    end
 
     def permitted_paths?
       permitted_paths = [tos_path, decidim.delete_account_path, decidim.accept_tos_path]
       permitted_paths.include?(request.path)
-    end
-
-    def terms_and_conditions_page
-      @terms_and_conditions_page ||= Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization: current_organization)
     end
 
     def tos_path

--- a/decidim-core/app/controllers/decidim/application_controller.rb
+++ b/decidim-core/app/controllers/decidim/application_controller.rb
@@ -25,7 +25,6 @@ module Decidim
     # Saves the location before loading each page so we can return to the
     # right page.
     before_action :store_current_location
-    before_action :tos_accepted_by_user
 
     protect_from_forgery with: :exception, prepend: true
     after_action :add_vary_header

--- a/decidim-core/app/controllers/decidim/application_controller.rb
+++ b/decidim-core/app/controllers/decidim/application_controller.rb
@@ -8,6 +8,7 @@ module Decidim
     include NeedsPermission
     include PayloadInfo
     include ImpersonateUsers
+    include NeedsTosAccepted
 
     helper Decidim::MetaTagsHelper
     helper Decidim::DecidimFormHelper
@@ -24,6 +25,7 @@ module Decidim
     # Saves the location before loading each page so we can return to the
     # right page.
     before_action :store_current_location
+    before_action :tos_accepted_by_user
 
     protect_from_forgery with: :exception, prepend: true
     after_action :add_vary_header

--- a/decidim-core/app/controllers/decidim/devise/invitations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/invitations_controller.rb
@@ -8,7 +8,6 @@ module Decidim
       include NeedsTosAccepted
 
       before_action :configure_permitted_parameters
-      helper_method :terms_and_conditions_page
 
       # We don't users to create invitations, so we just redirect them to the
       # homepage.

--- a/decidim-core/app/controllers/decidim/devise/invitations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/invitations_controller.rb
@@ -5,8 +5,10 @@ module Decidim
     # This controller customizes the behaviour of Devise::Invitiable.
     class InvitationsController < ::Devise::InvitationsController
       include Decidim::DeviseControllers
+      include NeedsTosAccepted
 
       before_action :configure_permitted_parameters
+      helper_method :terms_and_conditions_page
 
       # We don't users to create invitations, so we just redirect them to the
       # homepage.
@@ -25,13 +27,14 @@ module Decidim
       def accept_resource
         resource = resource_class.accept_invitation!(update_resource_params)
         resource.update!(managed: false) if resource.managed?
+        resource.update!(accepted_tos_version: resource.organization.tos_version)
         resource
       end
 
       protected
 
       def configure_permitted_parameters
-        devise_parameter_sanitizer.permit(:accept_invitation, keys: [:nickname])
+        devise_parameter_sanitizer.permit(:accept_invitation, keys: [:nickname, :tos_agreement, :newsletter_notifications])
       end
     end
   end

--- a/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
@@ -7,9 +7,9 @@ module Decidim
     class RegistrationsController < ::Devise::RegistrationsController
       include FormFactory
       include Decidim::DeviseControllers
+      include NeedsTosAccepted
 
       before_action :configure_permitted_parameters
-      helper_method :terms_and_conditions_page
 
       invisible_captcha
 
@@ -41,12 +41,6 @@ module Decidim
             render :new
           end
         end
-      end
-
-      private
-
-      def terms_and_conditions_page
-        @terms_and_conditions_page ||= Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization: current_organization)
       end
 
       protected

--- a/decidim-core/app/controllers/decidim/tos_controller.rb
+++ b/decidim-core/app/controllers/decidim/tos_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Decidim
+  # The controller to handle the current user's
+  # Terms and Conditions agreement.
+  class TosController < Decidim::ApplicationController
+    skip_before_action :store_current_location
+
+    def accept_tos
+      current_user.accepted_tos_version = Time.current
+      if current_user.save!
+        flash[:notice] = t("accept.success", scope: "decidim.pages.terms_and_conditions")
+        redirect_to after_sign_in_path_for current_user
+      else
+        flash[:alert] = t("accept.error", scope: "decidim.pages.terms_and_conditions")
+        redirect_to decidim.page_path tos_page
+      end
+    end
+  end
+end

--- a/decidim-core/app/views/decidim/devise/invitations/edit.html.erb
+++ b/decidim-core/app/views/decidim/devise/invitations/edit.html.erb
@@ -3,28 +3,74 @@
   <div class="row collapse">
     <div class="columns large-8 large-centered text-center page-title">
       <h1><%= t "devise.invitations.edit.header" %></h1>
+
+      <p><%= t("devise.invitations.edit.subtitle").html_safe %></p>
     </div>
   </div>
 
   <div class="row">
-    <div class="columns medium-7 large-5 medium-centered">
-      <div class="card">
-        <div class="card__content">
-          <%= decidim_form_for resource, as: resource_name, url: invitation_path(resource_name, invite_redirect: params[:invite_redirect]), html: { method: :put, class: "register-form new_user" } do |f| %>
+    <div class="columns large-6 medium-10 medium-centered">
+      <%= decidim_form_for resource, as: resource_name, url: invitation_path(resource_name, invite_redirect: params[:invite_redirect]), html: { method: :put, class: "register-form new_user" } do |f| %>
+        <div class="card">
+          <div class="card__content">
+            <legend><%= t("sign_up_as.legend", scope: "decidim.devise.registrations.new") %></legend>
+
             <%= f.hidden_field :invitation_token %>
 
-            <%= f.text_field :nickname, help_text: t("devise.invitations.edit.nickname_help", organization: current_organization.name) %>
+            <div class="field">
+              <%= f.text_field :nickname, help_text: t("devise.invitations.edit.nickname_help", organization: current_organization.name), required: "required" %>
+            </div>
 
             <% if f.object.class.require_password_on_accepting %>
-              <%= f.password_field :password %></p>
+              <div class="field">
+                <%= f.password_field :password, required: "required" %></p>
+              </div>
 
-              <%= f.password_field :password_confirmation %></p>
+              <div class="field">
+                <%= f.password_field :password_confirmation, required: "required" %></p>
+              </div>
             <% end %>
-
-            <p><%= f.submit t("devise.invitations.edit.submit_button", class: "button expanded") %></p>
-          <% end %>
+          </div>
         </div>
-      </div>
+
+        <div class="card" id="card__tos">
+          <div class="card__content">
+            <legend>
+              <%= t("tos_title", scope: "decidim.devise.registrations.new") %>
+            </legend>
+
+            <p class="tos-text">
+              <%= strip_tags(translated_attribute(terms_and_conditions_page.content)) %>
+            </p>
+
+            <div class="field">
+              <% link = link_to t("terms", scope: "decidim.devise.registrations.new"), page_path("terms-and-conditions"), target: "_blank" %>
+              <% label = t("tos_agreement", scope: "decidim.devise.registrations.new", link: link) %>
+              <%= f.check_box :tos_agreement, label: label, required: "required" %>
+            </div>
+          </div>
+        </div>
+
+        <div class="card" id="card__newsletter">
+          <div class="card__content">
+            <legend><%= t("newsletter_title", scope: "decidim.devise.registrations.new") %></legend>
+            <fieldset>
+              <div class="field">
+                <%= f.check_box :newsletter_notifications, label: t("newsletter", scope: "decidim.devise.registrations.new") %>
+              </div>
+            </fieldset>
+          </div>
+        </div>
+
+        <div class="card">
+          <div class="card__content">
+            <div class="actions">
+              <%= f.submit t("devise.invitations.edit.submit_button"), class: "button expanded" %>
+            </div>
+          </div>
+        </div>
+
+      <% end %>
     </div>
   </div>
 </div>

--- a/decidim-core/app/views/decidim/pages/decidim_page.html.erb
+++ b/decidim-core/app/views/decidim/pages/decidim_page.html.erb
@@ -4,9 +4,12 @@
 ) %>
 
 <main class="wrapper">
+  <%= cell "decidim/tos_page", :announcement %>
+
   <div class="row column">
     <h1 class="heading1 page-title"><%= translated_attribute page.title %></h1>
   </div>
+
   <div class="row">
     <div class="columns large-8">
       <div class="static__content">
@@ -14,4 +17,6 @@
       </div>
     </div>
   </div>
+
+  <%= cell "decidim/tos_page", :sticky_form %>
 </main>

--- a/decidim-core/app/views/decidim/shared/_announcement.html.erb
+++ b/decidim-core/app/views/decidim/shared/_announcement.html.erb
@@ -1,6 +1,1 @@
-<div class="row column">
-  <% callout_class ||= "secondary" %>
-  <%= content_tag :div, class: "callout announcement mb-sm #{callout_class}" do %>
-    <%= decidim_sanitize translated_attribute announcement %>
-  <% end %>
-</div>
+<%= cell("decidim/announcement", local_assigns) %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -424,6 +424,23 @@ en:
           register: Register
       index:
         title: More information
+      terms_and_conditions:
+        accept:
+          error: There's been an error while accepting the terms and conditions.
+          success: Great! You have accepted the terms and conditions.
+        form:
+          agreement: I agree this terms
+          legend: Agree to the terms and conditions of use
+        refuse:
+          modal_body: If you refuse, you won't be able to use the platform, you can <a href="%{data_portability_path}">download your data</a> and/or <a href="%{delete_path}">delete your account</a>.
+          modal_btn_continue: Accept terms and continue
+          modal_btn_exit: I'll review it later
+          modal_button: Refuse the terms
+          modal_title: Do you really refuse the updated Terms and Conditions?
+        required_review:
+          alert: We've updated our Terms of Service, please review them.
+          body: Please take a moment to review updates to our Terms of Services. Otherwise you won't be able to use the platform.
+          title: 'Required: Review updates to our terms of service'
     participatory_space_private_users:
       not_allowed: You are not allowed to view this content
     profile:
@@ -516,9 +533,10 @@ en:
   devise:
     invitations:
       edit:
-        header: Set your password
+        header: Finish creating your account
         nickname_help: Your unique identifier in %{organization}.
         submit_button: Save
+        subtitle: If you accept the invitation please set your nickname and password.
     mailer:
       invitation_instructions:
         accept: Accept invitation
@@ -526,7 +544,7 @@ en:
         hello: Hello %{email},
         ignore: |-
           If you don't want to accept the invitation, please ignore this email.<br />
-          Your account won't be created until you access the link above and set your password.
+          Your account won't be created until you access the link above and set your nickname and password.
         invited_you_as_admin: "%{invited_by} has invited you as an admin of %{application}. You can accept it through the link below."
         invited_you_as_private_user: "%{invited_by} has invited you as a private user of %{application}. You can accept it through the link below."
         someone_invited_you: Someone has invited you to %{application}. You can accept it through the link below.

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -61,6 +61,7 @@ Decidim::Core::Engine.routes.draw do
 
   get "/static_map", to: "static_map#show", as: :static_map
   get "/cookies/accept", to: "cookie_policy#accept", as: :accept_cookies
+  put "/pages/terms-and-conditions/accept", to: "tos#accept_tos", as: :accept_tos
 
   match "/404", to: "errors#not_found", via: :all
   match "/500", to: "errors#internal_server_error", via: :all

--- a/decidim-core/db/migrate/20180508111710_add_accepted_tos_version_field_to_users.rb
+++ b/decidim-core/db/migrate/20180508111710_add_accepted_tos_version_field_to_users.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class AddAcceptedTosVersionFieldToUsers < ActiveRecord::Migration[5.1]
+  class Organization < ApplicationRecord
+    self.table_name = :decidim_organizations
+    has_many :users, foreign_key: "decidim_organization_id", class_name: "Decidim::User", dependent: :destroy
+  end
+  class User < ApplicationRecord
+    self.table_name = :decidim_users
+    belongs_to :organization, foreign_key: "decidim_organization_id", class_name: "Decidim::Organization"
+  end
+
+  def up
+    add_column :decidim_users, :accepted_tos_version, :datetime
+    Organization.find_each do |organization|
+      # rubocop:disable Rails/SkipsModelValidations
+      organization.users.update_all(accepted_tos_version: organization.tos_version)
+      # rubocop:enable Rails/SkipsModelValidations
+    end
+  end
+
+  def down
+    remove_columns :decidim_users, :accepted_tos_version
+  end
+end

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -101,8 +101,8 @@ if !Rails.env.production? || ENV["SEED"]
     admin: true,
     tos_agreement: true,
     personal_url: Faker::Internet.url,
-    about: Faker::Lorem.paragraph(2)
-    # accepted_tos_version: Time.current
+    about: Faker::Lorem.paragraph(2),
+    accepted_tos_version: organization.tos_version
   )
 
   regular_user = Decidim::User.find_or_initialize_by(email: "user@example.org")
@@ -117,8 +117,8 @@ if !Rails.env.production? || ENV["SEED"]
     organization: organization,
     tos_agreement: true,
     personal_url: Faker::Internet.url,
-    about: Faker::Lorem.paragraph(2)
-    # accepted_tos_version: Time.current
+    about: Faker::Lorem.paragraph(2),
+    accepted_tos_version: organization.tos_version
   )
 
   Decidim::Messaging::Conversation.start!(

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -102,6 +102,7 @@ if !Rails.env.production? || ENV["SEED"]
     tos_agreement: true,
     personal_url: Faker::Internet.url,
     about: Faker::Lorem.paragraph(2)
+    # accepted_tos_version: Time.current
   )
 
   regular_user = Decidim::User.find_or_initialize_by(email: "user@example.org")
@@ -117,6 +118,7 @@ if !Rails.env.production? || ENV["SEED"]
     tos_agreement: true,
     personal_url: Faker::Internet.url,
     about: Faker::Lorem.paragraph(2)
+    # accepted_tos_version: Time.current
   )
 
   Decidim::Messaging::Conversation.start!(

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -70,6 +70,13 @@ FactoryBot.define do
     highlighted_content_banner_enabled false
     enable_omnipresent_banner false
     tos_version { Time.current }
+
+    trait :with_tos do
+      after(:create) do |organization|
+        tos_page = Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization: organization)
+        create(:static_page, :tos, organization: organization) if tos_page.nil?
+      end
+    end
   end
 
   factory :user, class: "Decidim::User" do
@@ -84,6 +91,13 @@ FactoryBot.define do
     avatar { Decidim::Dev.test_file("avatar.jpg", "image/jpeg") }
     personal_url { Faker::Internet.url }
     about { Faker::Lorem.paragraph(2) }
+
+    after(:create) do |user|
+      tos_page = Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization: user.organization)
+      create(:static_page, :tos, organization: user.organization) if tos_page.nil?
+      user.accepted_tos_version = user.organization.tos_version
+      user.save
+    end
 
     trait :confirmed do
       confirmed_at { Time.current }
@@ -190,6 +204,10 @@ FactoryBot.define do
     trait :default do
       slug { Decidim::StaticPage::DEFAULT_PAGES.sample }
     end
+
+    trait :tos do
+      slug { "terms-and-conditions" }
+    end
   end
 
   factory :attachment_collection, class: "Decidim::AttachmentCollection" do
@@ -287,10 +305,8 @@ FactoryBot.define do
     author { build(:user, :confirmed, organization: organization) }
     organization
 
-    # rubocop:disable RSpec/EmptyLineAfterSubject
-    # Bug in rubocop-rspec
     subject { Decidim::Faker::Localized.sentence(3) }
-    # rubocop:enable RSpec/EmptyLineAfterSubject
+
     body { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
 
     trait :sent do

--- a/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
@@ -6,7 +6,7 @@ module Decidim
   module Comments
     describe CreateOmniauthRegistration do
       describe "call" do
-        let(:organization) { create(:organization) }
+        let(:organization) { create(:organization, :with_tos) }
         let(:email) { "user@from-facebook.com" }
         let(:provider) { "facebook" }
         let(:uid) { "12345" }

--- a/decidim-core/spec/commands/decidim/create_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_registration_spec.rb
@@ -6,7 +6,7 @@ module Decidim
   module Comments
     describe CreateRegistration do
       describe "call" do
-        let(:organization) { create(:organization) }
+        let(:organization) { create(:organization, :with_tos) }
 
         let(:sign_up_as) { "user" }
         let(:name) { "Username" }
@@ -78,7 +78,8 @@ module Decidim
               tos_agreement: form.tos_agreement,
               newsletter_notifications: form.newsletter,
               email_on_notification: true,
-              organization: organization
+              organization: organization,
+              accepted_tos_version: organization.tos_version
             ).and_call_original
 
             expect { command.call }.to change(User, :count).by(1)

--- a/decidim-core/spec/controllers/registrations_controller_spec.rb
+++ b/decidim-core/spec/controllers/registrations_controller_spec.rb
@@ -6,7 +6,7 @@ module Decidim
   describe Decidim::Devise::RegistrationsController, type: :controller do
     routes { Decidim::Core::Engine.routes }
 
-    let(:organization) { create(:organization) }
+    let(:organization) { create(:organization, :with_tos) }
 
     before do
       request.env["devise.mapping"] = ::Devise.mappings[:user]

--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -3,12 +3,11 @@
 require "spec_helper"
 
 describe "Authentication", type: :system do
-  let(:organization) { create(:organization) }
+  let(:organization) { create(:organization, :with_tos) }
   let(:last_user) { Decidim::User.last }
 
   before do
     switch_to_host(organization.host)
-    create(:static_page, slug: "terms-and-conditions", organization: organization)
     visit decidim.root_path
   end
 

--- a/decidim-core/spec/system/locales_spec.rb
+++ b/decidim-core/spec/system/locales_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe "Locales", type: :system do
   describe "switching locales" do
-    let(:organization) { create(:organization, available_locales: %w(en ca)) }
+    let(:organization) { create(:organization, :with_tos, available_locales: %w(en ca)) }
 
     before do
       switch_to_host(organization.host)

--- a/decidim-core/spec/system/user_tos_acceptance_spec.rb
+++ b/decidim-core/spec/system/user_tos_acceptance_spec.rb
@@ -13,9 +13,9 @@ describe "UserTosAcceptance", type: :system do
     switch_to_host(organization.host)
   end
 
-  describe "When TOS are updated" do
+  describe "When the Organization TOS version is updated" do
     before do
-      tos_page.update!(title: { en: "Terms of service" }, content: { en: "Updated terms of services" })
+      organization.update!(tos_version: Time.current)
       login_as user, scope: :user
       visit decidim.root_path
     end
@@ -24,7 +24,7 @@ describe "UserTosAcceptance", type: :system do
       it "redirects to the TOS page" do
         expect(page).to have_current_path(decidim.page_path(tos_page))
         expect(page).to have_content translated(tos_page.title)
-        expect(page).to have_content translated(tos_page.content)
+        expect(page).to have_content strip_tags(translated(tos_page.content))
       end
 
       it "renders an announcement requiring to review the TOS" do

--- a/decidim-core/spec/system/user_tos_acceptance_spec.rb
+++ b/decidim-core/spec/system/user_tos_acceptance_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "UserTosAcceptance", type: :system do
+  let!(:organization) { create(:organization, :with_tos) }
+  let!(:user) { create(:user, :confirmed, organization: organization) }
+  let!(:tos_page) { Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization: organization) }
+  let(:btn_accept) { "I agree this terms" }
+  let(:btn_refuse) { "Refuse the terms" }
+
+  before do
+    switch_to_host(organization.host)
+  end
+
+  describe "When TOS are updated" do
+    before do
+      tos_page.update!(title: { en: "Terms of service" }, content: { en: "Updated terms of services" })
+      login_as user, scope: :user
+      visit decidim.root_path
+    end
+
+    context "when a user starts a session, has to accept review them" do
+      it "redirects to the TOS page" do
+        expect(page).to have_current_path(decidim.page_path(tos_page))
+        expect(page).to have_content translated(tos_page.title)
+        expect(page).to have_content translated(tos_page.content)
+      end
+
+      it "renders an announcement requiring to review the TOS" do
+        expect(page).to have_content("Required: Review updates to our terms of service")
+      end
+
+      it "renders an announcement advising that TOS has been updated" do
+        expect(page).to have_content("We've updated our Terms of Service, please review them.")
+      end
+
+      it "shows a button to Agree the updated Terms" do
+        expect(page).to have_button btn_accept
+      end
+
+      it "shows a button to Refuse Terms" do
+        expect(page).to have_button btn_refuse
+      end
+    end
+
+    context "and the user accepts the updated TOS" do
+      before do
+        click_button btn_accept
+      end
+
+      it "renders a success announcement" do
+        expect(page).to have_content("Great! You have accepted the terms and conditions.")
+        expect(page).to have_css(".flash.success")
+      end
+    end
+
+    context "and the user refuses the updated TOS" do
+      before do
+        click_button btn_refuse
+      end
+
+      it "renders a modal" do
+        expect(page).to have_css("#tos-refuse-modal")
+        expect(page).to have_content("Do you really refuse the updated Terms and Conditions?")
+      end
+
+      context "with the refuse modal has different options" do
+        it "shows an option to accept the TOS" do
+          within "#tos-refuse-modal" do
+            expect(page).to have_button("Accept terms and continue")
+          end
+        end
+
+        it "shows an option to download the users data" do
+          within "#tos-refuse-modal" do
+            expect(page).to have_link("download your data")
+          end
+        end
+
+        it "shows an option to logout" do
+          within "#tos-refuse-modal" do
+            expect(page).to have_button("I'll review it later")
+          end
+        end
+
+        it "shows an option delete the account" do
+          within "#tos-refuse-modal" do
+            expect(page).to have_link("delete your account")
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/initiative_votes_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/initiative_votes_controller_spec.rb
@@ -7,7 +7,7 @@ module Decidim
     describe InitiativeVotesController, type: :controller do
       routes { Decidim::Initiatives::Engine.routes }
 
-      let(:organization) { create(:organization) }
+      let(:organization) { create(:organization, :with_tos) }
       let(:initiative) { create(:initiative, organization: organization) }
 
       before do

--- a/decidim-meetings/spec/shared/manage_registrations_examples.rb
+++ b/decidim-meetings/spec/shared/manage_registrations_examples.rb
@@ -73,6 +73,7 @@ shared_examples "manage registrations" do
           fill_in :user_nickname, with: "caballo_loco"
           fill_in :user_password, with: "123456"
           fill_in :user_password_confirmation, with: "123456"
+          check :user_tos_agreement
           find("*[type=submit]").click
         end
 

--- a/decidim-participatory_processes/spec/system/admin/invite_process_admin_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/invite_process_admin_spec.rb
@@ -23,6 +23,7 @@ describe "Invite process administrator", type: :system do
         fill_in :user_nickname, with: "caballo_loco"
         fill_in :user_password, with: "123456"
         fill_in :user_password_confirmation, with: "123456"
+        check :user_tos_agreement
         find("*[type=submit]").click
       end
 

--- a/decidim-participatory_processes/spec/system/admin/invite_process_collaborator_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/invite_process_collaborator_spec.rb
@@ -22,6 +22,7 @@ describe "Invite process collaborator", type: :system do
         fill_in :user_nickname, with: "caballo_loco"
         fill_in :user_password, with: "123456"
         fill_in :user_password_confirmation, with: "123456"
+        check :user_tos_agreement
         find("*[type=submit]").click
       end
 

--- a/decidim-participatory_processes/spec/system/admin/invite_process_moderator_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/invite_process_moderator_spec.rb
@@ -21,6 +21,7 @@ describe "Invite process moderator", type: :system do
         fill_in :user_nickname, with: "caballo_loco"
         fill_in :user_password, with: "123456"
         fill_in :user_password_confirmation, with: "123456"
+        check :user_tos_agreement
         find("*[type=submit]").click
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

When a user has accepted the TOS (Term Of Service), if it gets updated the user must review and accept again. Or an option to refuse.
Invited users must also accept the TOS.

#### :pushpin: Related Issues
- Related to Epic #3320
- Fixes #3318
- Relates to issue #3317, PR #3491

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add/modify seeds
- [x] Add tests
- [x] Add field `accepted_tos_version` to user
- [x] Added form to accept new TOS
- [x] Added option to refuse terms
- [x] signed_in user must accept to continue
- [x] fixed bug with `high_voltage` gem version
- [x] invited users must also accept TOS

### :camera: Screenshots (optional)

+ Redirected to tos page:
  ![screenshot from 2018-05-09 17-55-22](https://user-images.githubusercontent.com/210216/39825580-6626392c-53b2-11e8-9818-362a3405026b.png)

+ If TOS are accepted:
  ![screenshot from 2018-05-09 17-55-59](https://user-images.githubusercontent.com/210216/39825608-753f81c0-53b2-11e8-8b82-644ba31fbcd3.png)

+ If the Refuse option is clicked a modal is shown with options:
  ![screenshot from 2018-05-16 16-49-05](https://user-images.githubusercontent.com/210216/40124546-19228d16-5929-11e8-8707-6940564b5387.png)


+ Accept Invitation screen with TOS checkbox and text:
  ![screenshot from 2018-05-16 16-45-32](https://user-images.githubusercontent.com/210216/40124416-d37f9038-5928-11e8-8ca2-82ffcdc92f7d.png)


