### PR TITLE
Log seeds

### DIFF
--- a/.rubocop_rails.yml
+++ b/.rubocop_rails.yml
@@ -54,6 +54,11 @@ Rails/Output:
     - decidim-*/config/**/*.rb
     - decidim-*/db/**/*.rb
     - decidim-*/lib/**/*.rb
+  Exclude:
+    - decidim-core/db/seeds.rb
+    - decidim-core/lib/decidim/component_manifest.rb
+    - decidim-core/lib/decidim/participatory_space_manifest.rb
+    - decidim-system/db/seeds.rb
 
 Rails/OutputSafety:
   Enabled: false

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 if !Rails.env.production? || ENV["SEED"]
-  print "Creating seeds for decidim-core...\n"
+  print "Creating seeds for decidim-core...\n" unless Rails.env.test?
 
   require "decidim/faker/localized"
 

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 if !Rails.env.production? || ENV["SEED"]
+  print "Creating seeds for decidim-core...\n"
+
   require "decidim/faker/localized"
 
   seeds_root = File.join(__dir__, "seeds")

--- a/decidim-core/lib/decidim/component_manifest.rb
+++ b/decidim-core/lib/decidim/component_manifest.rb
@@ -99,6 +99,7 @@ module Decidim
     #
     # Returns nothing.
     def seed!(participatory_space)
+      print "-- Creating #{name} component seeds for the participatory space with ID: #{participatory_space.id}...\n"
       @seeds&.call(participatory_space)
     end
 

--- a/decidim-core/lib/decidim/component_manifest.rb
+++ b/decidim-core/lib/decidim/component_manifest.rb
@@ -99,7 +99,7 @@ module Decidim
     #
     # Returns nothing.
     def seed!(participatory_space)
-      print "-- Creating #{name} component seeds for the participatory space with ID: #{participatory_space.id}...\n"
+      print "-- Creating #{name} component seeds for the participatory space with ID: #{participatory_space.id}...\n" unless Rails.env.test?
       @seeds&.call(participatory_space)
     end
 

--- a/decidim-core/lib/decidim/participatory_space_manifest.rb
+++ b/decidim-core/lib/decidim/participatory_space_manifest.rb
@@ -74,6 +74,7 @@ module Decidim
     #
     # Returns nothing.
     def seed!
+      print "Creating seeds for the #{name} space...\n"
       @seeds&.call
     end
 

--- a/decidim-core/lib/decidim/participatory_space_manifest.rb
+++ b/decidim-core/lib/decidim/participatory_space_manifest.rb
@@ -74,7 +74,7 @@ module Decidim
     #
     # Returns nothing.
     def seed!
-      print "Creating seeds for the #{name} space...\n"
+      print "Creating seeds for the #{name} space...\n" unless Rails.env.test?
       @seeds&.call
     end
 

--- a/decidim-core/spec/lib/component_manifest_spec.rb
+++ b/decidim-core/spec/lib/component_manifest_spec.rb
@@ -8,12 +8,13 @@ module Decidim
 
     describe "seed" do
       it "registers a block of seeds to be run on development" do
+        space = double(id: 1)
         data = {}
         subject.seeds do |_participatory_space|
           data[:foo] = :bar
         end
 
-        subject.seed!(nil)
+        subject.seed!(space)
 
         expect(data[:foo]).to eq(:bar)
       end

--- a/decidim-system/db/seeds.rb
+++ b/decidim-system/db/seeds.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 if !Rails.env.production? || ENV["SEED"]
-  print "Creating seeds for decidim-system...\n"
+  print "Creating seeds for decidim-system...\n" unless Rails.env.test?
 
   Decidim::System::Admin.find_or_initialize_by(email: "system@example.org").update!(
     password: "decidim123456",

--- a/decidim-system/db/seeds.rb
+++ b/decidim-system/db/seeds.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 if !Rails.env.production? || ENV["SEED"]
+  print "Creating seeds for decidim-system...\n"
+
   Decidim::System::Admin.find_or_initialize_by(email: "system@example.org").update!(
     password: "decidim123456",
     password_confirmation: "decidim123456"


### PR DESCRIPTION
#### :tophat: What? Why?
I've always found it weird that we get no logs when creating the seeds, and it looks like the process got stuck. This PR adds logs to `decidim` seeds, so when you're creating a development app you can know what's going one.

This looks like this in your console (I've cropped it so you get a taste):

```
Creating seeds for decidim-core...
Creating seeds for the participatory_processes space...
-- Creating pages component seeds for the participatory space with ID: 1...
-- Creating meetings component seeds for the participatory space with ID: 1...
-- Creating proposals component seeds for the participatory space with ID: 1...
-- Creating budgets component seeds for the participatory space with ID: 1...
-- Creating surveys component seeds for the participatory space with ID: 1...
-- Creating accountability component seeds for the participatory space with ID: 1...
-- Creating debates component seeds for the participatory space with ID: 1...
-- Creating sortitions component seeds for the participatory space with ID: 1...
-- Creating blogs component seeds for the participatory space with ID: 1...
-- Creating pages component seeds for the participatory space with ID: 2...
```

Etc.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None