### PR TITLE
Always show footer on the meeting card

### DIFF
--- a/decidim-meetings/app/cells/decidim/meetings/meeting_m/footer.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_m/footer.erb
@@ -1,7 +1,9 @@
-<% if shows_footer? %>
-  <div class="card__footer">
-    <div class="card__support">
+<div class="card__footer">
+  <div class="card__support">
+    <% if can_join? %>
       <%= cell "decidim/meetings/join_meeting_button", model %>
-    </div>
+    <% else %>
+      <%= link_to t("view", scope: "decidim.meetings.meetings.show"), resource_path, class: "card__button button secondary button--sc small light" %>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_m_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_m_cell.rb
@@ -42,7 +42,7 @@ module Decidim
         model.end_time.to_date
       end
 
-      def shows_footer?
+      def can_join?
         model.can_be_joined_by?(current_user)
       end
     end

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -254,6 +254,7 @@ en:
             one: 1 slot remaining
             other: "%{count} slots remaining"
             zero: No slots remaining
+          view: View
       models:
         meeting:
           fields:


### PR DESCRIPTION
#### :tophat: What? Why?
This PR makes the `MeetingMCard` always show a footer, to fix the visual discrepancy shown at #3502.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None.