### PR TITLE
Check admin permissions on components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ must now set a resource name:
 - **decidim-participatory_processes**: Remove duplicated space title on page meta tags [\#3278](https://github.com/decidim/decidim/pull/3278)
 - **decidim-assemblies**: Remove duplicated space title on page meta tags [\#3278](https://github.com/decidim/decidim/pull/3278)
 - **decidim-core**: Add validation to nickname's length. [\#3342](https://github.com/decidim/decidim/pull/3342)
+- **decidim-core**: Make admin link on user menu stop disappearing [\#3508](https://github.com/decidim/decidim/pull/3508)
 
 **Removed**:
 

--- a/decidim-core/app/controllers/decidim/components/base_controller.rb
+++ b/decidim-core/app/controllers/decidim/components/base_controller.rb
@@ -57,6 +57,7 @@ module Decidim
         [
           current_component.manifest.permissions_class,
           current_participatory_space.manifest.permissions_class,
+          Decidim::Admin::Permissions,
           Decidim::Permissions
         ]
       end


### PR DESCRIPTION
#### :tophat: What? Why?
As reported on #3504, the link to the admin dashboard found on the user menu was disappearing when visiting a component-related page (index of proposals, for example).

This PR fixes it.

#### :pushpin: Related Issues
- Fixes #3504.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/PuqQB7m.png)
