### PR TITLE
Add help text for assemblies "Duration" and "Included at" fields

### DIFF
--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
@@ -132,10 +132,12 @@
 
     <div class="row column">
       <%= form.date_field :duration %>
+      <p class="help-text"><%== t(".duration_help") %></p>
     </div>
 
     <div class="row column">
       <%= form.date_field :included_at %>
+      <p class="help-text"><%== t(".included_at_help") %></p>
     </div>
 
     <div class="row column" id="closing_date_div">

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -211,6 +211,8 @@ en:
       admin:
         assemblies:
           form:
+            duration_help: If the duration of this assembly is limited, select the end date. Otherwise, it will appear as indefinite.
+            included_at_help: Select the date when this assembly was added to Decidim. It does not necessarily have to be the same as the creation date.
             select_a_created_by: Select a created by
             select_an_area: Select an Area
             select_an_assembly_type: Select an assembly type


### PR DESCRIPTION
#### :tophat: What? Why?

The "Durantion" and "Included at" fields in Assemblies are not clear enough

#### :pushpin: Related Issues

- Fixes #3399

#### :clipboard: Subtasks
- ~[ ] Add `CHANGELOG` entry~
