### PR TITLE
Add binstubs to the repo

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -1,0 +1,60 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "rubygems"
+
+m = Module.new do
+  extend self
+
+  def invoked_as_script?
+    File.expand_path($PROGRAM_NAME) == File.expand_path(__FILE__)
+  end
+
+  def cli_arg_version
+    return unless invoked_as_script? # don't want to hijack other binstubs
+    return unless "update".start_with?(ARGV.first || " ") # must be running `bundle update`
+    bundler_version = nil
+    update_index = nil
+    ARGV.each_with_index do |a, i|
+      bundler_version = a if update_index && update_index.succ == i && a =~ Gem::Version::ANCHORED_VERSION_PATTERN
+      next unless a =~ /\A--bundler(?:[= ](#{Gem::Version::VERSION_PATTERN}))?\z/
+      bundler_version = Regexp.last_match(1) || ">= 0.a"
+      update_index = i
+    end
+    bundler_version
+  end
+
+  def gemfile
+    File.expand_path("../Gemfile", __dir__)
+  end
+
+  def lockfile
+    "#{gemfile}.lock"
+  end
+
+  def lockfile_version
+    lockfile_contents = File.read(lockfile)
+
+    regexp = /\n\nBUNDLED WITH\n\s{2,}(#{Gem::Version::VERSION_PATTERN})\n/
+
+    regexp.match(lockfile_contents)[1]
+  end
+
+  def bundler_version
+    @bundler_version ||= cli_arg_version || lockfile_version
+  end
+
+  def load_bundler!
+    ENV["BUNDLE_GEMFILE"] ||= gemfile
+
+    activate_bundler(bundler_version)
+  end
+
+  def activate_bundler(bundler_version)
+    gem "bundler", bundler_version
+  end
+end
+
+m.load_bundler!
+
+load Gem.bin_path("bundler", "bundle") if m.invoked_as_script?

--- a/bin/rails
+++ b/bin/rails
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+Dir.chdir("development_app")
+
+load "bin/rails"

--- a/bin/rake
+++ b/bin/rake
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+
+load File.expand_path("bundle", __dir__)
+
+require "rubygems"
+require "bundler/setup"
+
+load Gem.bin_path("rake", "rake")

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+
+load File.expand_path("bundle", __dir__)
+
+require "rubygems"
+require "bundler/setup"
+
+load Gem.bin_path("rspec-core", "rspec")

--- a/bin/rspec
+++ b/bin/rspec
@@ -8,4 +8,18 @@ load File.expand_path("bundle", __dir__)
 require "rubygems"
 require "bundler/setup"
 
+if ARGV[0]
+  argument_parts = ARGV[0].split("/")
+
+  first_part = argument_parts[0]
+
+  if first_part =~ /decidim-/ && File.directory?(first_part)
+    Dir.chdir(first_part)
+
+    other_parts = argument_parts[1..-1]
+
+    ARGV.replace([!other_parts.empty? ? other_parts.join("/") : nil, *ARGV[1..-1]])
+  end
+end
+
 load Gem.bin_path("rspec-core", "rspec")

--- a/d/bash
+++ b/d/bash
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-docker-compose run --rm decidim bash "$@"

--- a/d/gem
+++ b/d/gem
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-docker-compose run --rm decidim gem "$@"

--- a/d/rails
+++ b/d/rails
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-compose run --service-ports --rm decidim bash -c "cd development_app && bin/rails $*"
+docker-compose run --service-ports --rm decidim bash -c "bin/rails $*"

--- a/d/rake
+++ b/d/rake
@@ -2,4 +2,4 @@
 
 fail_fast=${FAIL_FAST:-false}
 
-docker-compose run --rm -e "FAIL_FAST=$fail_fast" decidim bash -c "bundle exec rake $*"
+docker-compose run --rm -e "FAIL_FAST=$fail_fast" decidim bash -c "bin/rake $*"

--- a/d/rspec
+++ b/d/rspec
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-gem=${1%%/*}
-spec=${1#*/}
 fail_fast=${FAIL_FAST:-false}
-folder=${gem:-.}
 
-docker-compose run --rm -e "FAIL_FAST=$fail_fast" decidim bash -c "cd $folder && bundle exec rspec $spec"
+docker-compose run --rm -e "FAIL_FAST=$fail_fast" decidim bash -c "bin/rspec $*"


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds bundler binstubs to the repo so that development commands are easier to run. It also adds a couple of features already present in the docker binstubs:

* Possibility of running specs from the root folder, for example, `bin/rspec decidim-core/spec/lib/form_builder_spec.rb`.

* Possibility of running `rails` commands on the development app from the root folder. For example, `bin/rails c` will give you a rails console in the development application.

Note that with these changes the version of `bundler` is itself locked and inferred from the lock file. So you might get errors if you don't have `bundler 1.16.2` installed on your system.

#### :pushpin: Related Issues
- Fixes #2755.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.