### PR TITLE
Fix warnings for Rails 6 on StaticPages

### DIFF
--- a/decidim-core/app/models/decidim/static_page.rb
+++ b/decidim-core/app/models/decidim/static_page.rb
@@ -37,7 +37,7 @@ module Decidim
     end
 
     def self.sorted_by_i18n_title(locale = I18n.locale)
-      order(["title->? ASC", locale])
+      order([Arel.sql("title->? ASC"), locale])
     end
 
     # Whether this is page is a default one or not.

--- a/decidim-core/spec/models/decidim/static_page_spec.rb
+++ b/decidim-core/spec/models/decidim/static_page_spec.rb
@@ -42,6 +42,22 @@ module Decidim
       end
     end
 
+    context ".sorted_by_i18n_title" do
+      let!(:page1) { create :static_page, title: { ca: "Bcde", en: "Afgh" } }
+      let!(:page2) { create :static_page, title: { ca: "Abcd", en: "Defg" } }
+
+      before { I18n.locale = :ca }
+      after { I18n.locale = :en }
+
+      it "orders by the title in the current locale" do
+        expect(described_class.sorted_by_i18n_title).to eq [page2, page1]
+      end
+
+      it "orders by the title in the specified locale" do
+        expect(described_class.sorted_by_i18n_title(:en)).to eq [page1, page2]
+      end
+    end
+
     describe "#to_param" do
       subject { page.to_param }
 

--- a/decidim-core/spec/models/decidim/static_page_spec.rb
+++ b/decidim-core/spec/models/decidim/static_page_spec.rb
@@ -42,7 +42,7 @@ module Decidim
       end
     end
 
-    context ".sorted_by_i18n_title" do
+    describe ".sorted_by_i18n_title" do
       let!(:page1) { create :static_page, title: { ca: "Bcde", en: "Afgh" } }
       let!(:page2) { create :static_page, title: { ca: "Abcd", en: "Defg" } }
 


### PR DESCRIPTION
#### :tophat: What? Why?
After upgrading to Rails 5.2, we're getting some deprecation warnings. Some of them have already been solved, but some were pending. This PR fixes one of them.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
No need for changelog entry.