### PR TITLE
Set password confirmation as required in signup form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ must now set a resource name:
 - **decidim-core**: Make admin link on user menu stop disappearing [\#3508](https://github.com/decidim/decidim/pull/3508)
 - **decidim-core**: Sort static pages by title [\#3479](https://github.com/decidim/decidim/pull/3479)
 - **decidim-core**: Data picker form inputs having no bottom margin. [\#3463](https://github.com/decidim/decidim/pull/3463)
+- **decidim-core**: Make signup forms show the password confirmation field as required[\#3521](https://github.com/decidim/decidim/pull/3521)
 
 **Removed**:
 

--- a/decidim-core/app/forms/decidim/registration_form.rb
+++ b/decidim-core/app/forms/decidim/registration_form.rb
@@ -23,6 +23,7 @@ module Decidim
     validates :nickname, presence: true, length: { maximum: Decidim::User.nickname_max_length }
     validates :email, presence: true, 'valid_email_2/email': { disposable: true }
     validates :password, presence: true, confirmation: true, length: { in: Decidim::User.password_length }
+    validates :password_confirmation, presence: true
     validates :tos_agreement, allow_nil: false, acceptance: true
 
     validates :user_group_name, presence: true, if: :user_group?

--- a/decidim-core/spec/forms/registration_form_spec.rb
+++ b/decidim-core/spec/forms/registration_form_spec.rb
@@ -104,6 +104,12 @@ module Decidim
       it { is_expected.to be_invalid }
     end
 
+    context "when the password confirmation is not present" do
+      let(:password_confirmation) { nil }
+
+      it { is_expected.to be_invalid }
+    end
+
     context "when the password confirmation is different from password" do
       let(:password_confirmation) { "invalid" }
 


### PR DESCRIPTION
#### :tophat: What? Why?
As reported in #3337, signup forms do not show the password confirmation field as required, although it really is. This PR fixes this problem.

#### :pushpin: Related Issues
- Fixes #3337.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry


### :camera: Screenshots (optional)
![Description](https://i.imgur.com/e2Zi70G.png)
