### PR TITLE
Remove card from consultation page

### DIFF
--- a/decidim-consultations/app/views/decidim/consultations/consultations/show.html.erb
+++ b/decidim-consultations/app/views/decidim/consultations/consultations/show.html.erb
@@ -1,9 +1,4 @@
 <%= render partial: "consultation_details", locals: { consultation: current_consultation } %>
-<div class="row">
-  <div class="columns large-up-3">
-    <%= card_for current_consultation %>
-  </div>
-</div>
 <%= render partial: "highlighted_questions", locals: { consultation: current_consultation } %>
 <%= render partial: "regular_questions", locals: { consultation: current_consultation } %>
 


### PR DESCRIPTION
#### :tophat: What? Why?
While working on adding the cards for consultations, I added the card to the consultation page as a way to check the design, and forgot to remove it. This PR removes this card, which shouldn't be there.

#### :pushpin: Related Issues
- Related to #3487

#### :clipboard: Subtasks
None