### PR TITLE
Allow paths starting with `./` to bin/rspec

### DIFF
--- a/bin/rspec
+++ b/bin/rspec
@@ -9,7 +9,8 @@ require "rubygems"
 require "bundler/setup"
 
 if ARGV[0]
-  argument_parts = ARGV[0].split("/")
+  cleaned_file_path = ARGV[0].split("./").last
+  argument_parts = cleaned_file_path.split("/")
 
   first_part = argument_parts[0]
 


### PR DESCRIPTION
#### :tophat: What? Why?
Builds on top of #3518. This allows paths to start with `./decidim-*`:

```
bin/rspec decidim-core/spec/cells/decidim/author_cell_spec.rb
bin/rspec ./decidim-core/spec/cells/decidim/author_cell_spec.rb
```

Both commands are valid.

#### :pushpin: Related Issues
- Related to #3518.

#### :clipboard: Subtasks
None