### PR TITLE
Scope default pages to organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ must now set a resource name:
 - **decidim-core**: Sort static pages by title [\#3479](https://github.com/decidim/decidim/pull/3479)
 - **decidim-core**: Data picker form inputs having no bottom margin. [\#3463](https://github.com/decidim/decidim/pull/3463)
 - **decidim-core**: Make signup forms show the password confirmation field as required[\#3521](https://github.com/decidim/decidim/pull/3521)
+- **decidim-core**: Fix default page creation so they get scoped to the actual organization [\#3526](https://github.com/decidim/decidim/pull/3526)
 
 **Removed**:
 

--- a/decidim-system/app/commands/decidim/system/create_default_pages.rb
+++ b/decidim-system/app/commands/decidim/system/create_default_pages.rb
@@ -18,8 +18,7 @@ module Decidim
       # Returns nothing.
       def call
         Decidim::StaticPage::DEFAULT_PAGES.map do |slug|
-          Decidim::StaticPage.find_or_create_by!(slug: slug) do |page|
-            page.organization = organization
+          Decidim::StaticPage.find_or_create_by!(organization: organization, slug: slug) do |page|
             page.title = localized_attribute(slug, :title)
             page.content = localized_attribute(slug, :content)
           end

--- a/decidim-system/spec/commands/decidim/system/create_default_pages_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/create_default_pages_spec.rb
@@ -5,22 +5,27 @@ require "spec_helper"
 module Decidim
   module System
     describe CreateDefaultPages do
-      subject { described_class.new(organization).call }
+      subject { described_class.new(organization1) }
 
-      let(:organization) { create(:organization) }
+      let(:organization1) { create(:organization) }
+      let(:organization2) { create(:organization) }
 
       it "creates all the default pages for an organization" do
         expect do
-          subject
-        end.to change { organization.static_pages.count }.by(Decidim::StaticPage::DEFAULT_PAGES.length)
+          described_class.new(organization1).call
+        end.to change { organization1.static_pages.count }.by(Decidim::StaticPage::DEFAULT_PAGES.length)
+
+        expect do
+          described_class.new(organization2).call
+        end.to change { organization2.static_pages.count }.by(Decidim::StaticPage::DEFAULT_PAGES.length)
       end
 
       it "sets the content with each locale" do
         allow(Decidim).to receive(:available_locales).and_return [:en, :ca]
 
-        subject
+        described_class.new(organization1).call
 
-        organization.static_pages.each do |page|
+        organization1.static_pages.each do |page|
           expect(page.title["en"]).not_to be_nil
           expect(page.title["ca"]).not_to be_nil
           expect(page.content["en"]).not_to be_nil


### PR DESCRIPTION
#### :tophat: What? Why?
This scopes default pages to organizations.

#### :pushpin: Related Issues
- Related to #3443

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
*None*
