### PR TITLE
Fix dummy app generation from end apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Fixed**:
 
 - **decidim-generators**: Dummy applications not being correctly generated for external plugins. [\#3470](https://github.com/decidim/decidim/pull/3470)
+- **decidim-generators**: Dummy applications not being correctly generated for final applications. [\#3527](https://github.com/decidim/decidim/pull/3527)
 - **decidim-core**: Data picker form inputs having no bottom margin. [\#3463](https://github.com/decidim/decidim/pull/3463)
 
 ## [0.11.1](https://github.com/decidim/decidim/tree/v0.11.1)

--- a/decidim-dev/lib/tasks/generators.rake
+++ b/decidim-dev/lib/tasks/generators.rake
@@ -15,10 +15,16 @@ namespace :decidim do
     Dir.chdir(original_folder)
   end
 
+  def base_app_name
+    File.basename(Dir.pwd).underscore
+  end
+
   desc "Generates a dummy app for testing in external installations"
   task :generate_external_test_app do
     generate_decidim_app(
       "spec/decidim_dummy_app",
+      "--app_name",
+      "#{base_app_name}_test_app",
       "--path",
       "../..",
       "--recreate_db",
@@ -31,6 +37,8 @@ namespace :decidim do
   task :generate_external_development_app do
     generate_decidim_app(
       "development_app",
+      "--app_name",
+      "#{base_app_name}_development_app",
       "--path",
       "..",
       "--recreate_db",

--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -147,6 +147,10 @@ module Decidim
         options[:app_name] || super
       end
 
+      def app_const_base
+        app_name.gsub(/\W/, "_").squeeze("_").camelize
+      end
+
       def current_gem
         return "decidim" unless options[:path]
 

--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -25,6 +25,10 @@ module Decidim
 
       source_root File.expand_path("app_templates", __dir__)
 
+      class_option :app_name, type: :string,
+                              default: nil,
+                              desc: "The name of the app"
+
       class_option :path, type: :string,
                           default: nil,
                           desc: "Path to the gem"
@@ -138,6 +142,10 @@ module Decidim
       end
 
       private
+
+      def app_name
+        options[:app_name] || super
+      end
 
       def current_gem
         return "decidim" unless options[:path]


### PR DESCRIPTION
#### :tophat: What? Why?

Hei! I'm backporting the fix for dummy application generation from final apps, which works correctly on master, but it's broken on `0.11.1`. The PR that fixes it includes plenty of other changes, including the removal of a couple of environment variables which could be considered as breaking (although there's also an argument to call them buggy and consider it a bug fix). Anyways, I selectively picked the single two commits from that PR so that only the bug fix mentioned in the PR title is backported.
 
You were probably going to run into this when upgrading `decidim-barcelona` to 0.11.

I could add a regression test for this, but due to how our current generator tests work (they only assert the exit status of the generator, and to [a bug in thor](https://github.com/erikhuda/thor/pull/578), the test will always pass, with or without these changes... :(

#### :pushpin: Related Issues
- Related to #3299.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
_None_.