### PR TITLE
Clarify texts for user follows section in profile

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -290,7 +290,7 @@ en:
     followers:
       no_followers: No followers yet.
     following:
-      no_followings: No followings yet.
+      no_followings: Doesn't follow anyone or anything yet.
     follows:
       create:
         button: Follow
@@ -433,7 +433,7 @@ en:
       default_officialization_text: This participant is publicly verified, his/her name or role has been verified to correspond with his/her real name and role
       show:
         followers: Followers
-        following: Following
+        following: Follows
         notifications: Notifications
       user:
         edit_profile: Edit profile

--- a/decidim-core/spec/system/profile_spec.rb
+++ b/decidim-core/spec/system/profile_spec.rb
@@ -81,7 +81,7 @@ describe "Profile", type: :system do
 
       it "shows the number of followers and following" do
         expect(page).to have_link("Followers 1")
-        expect(page).to have_link("Following 2")
+        expect(page).to have_link("Follows 2")
       end
 
       it "lists the followers" do
@@ -91,7 +91,7 @@ describe "Profile", type: :system do
       end
 
       it "lists the followings" do
-        click_link "Following"
+        click_link "Follows"
 
         expect(page).to have_content(other_user.name)
         expect(page).to have_content(user_to_follow.name)


### PR DESCRIPTION
#### :tophat: What? Why?
@Digharatta reported some texts on the user profile that were not clear enough. This PR fixes them.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None
