### PR TITLE
Do not allow votes on upcoming consultations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ must now set a resource name:
 - **decidim-core**: Data picker form inputs having no bottom margin. [\#3463](https://github.com/decidim/decidim/pull/3463)
 - **decidim-core**: Make signup forms show the password confirmation field as required[\#3521](https://github.com/decidim/decidim/pull/3521)
 - **decidim-core**: Fix default page creation so they get scoped to the actual organization [\#3526](https://github.com/decidim/decidim/pull/3526)
+- **decidim-consultations**: Do not allow votes on upcoming consultations [\#3529](https://github.com/decidim/decidim/pull/3529)
 
 **Removed**:
 

--- a/decidim-consultations/app/views/decidim/consultations/questions/_vote_button.html.erb
+++ b/decidim-consultations/app/views/decidim/consultations/questions/_vote_button.html.erb
@@ -1,22 +1,15 @@
 <div class="row question-vote-cabin">
   <div class="columns mediumlarge-4 mediumlarge-push-4">
     <% if question.consultation.upcoming? %>
-      <%= action_authorized_button_to :vote,
-                                    decidim_consultations.question_question_votes_path(question),
-                                    remote: true,
-                                    data: { disable: true },
-                                    class: "card__button button expanded disabled",
-                                    id: "vote_button" do %>
+      <div class="card__button button expanded disabled">
         <div class="vote-button-caption"><%= t("questions.vote_button.vote", scope: "decidim") %></div>
         <div>
           <%= t "questions.vote_button.starting_from",
                 scope: "decidim",
                 date: l(question.start_voting_date) %>
         </div>
-      <% end %>
-    <% end %>
-
-    <% if question.consultation.finished? && signed_in? && question.voted_by?(current_user) %>
+      </div>
+    <% elsif question.consultation.finished? && signed_in? && question.voted_by?(current_user) %>
       <%= action_authorized_button_to :unvote,
                                       decidim_consultations.question_question_votes_path(question),
                                       method: :delete,
@@ -28,9 +21,7 @@
           <%= t("questions.vote_button.already_voted", scope: "decidim") %>
         </div>
       <% end %>
-    <% end %>
-
-    <% if signed_in? && question.consultation.active? %>
+    <% elsif signed_in? && question.consultation.active? %>
       <% if allowed_to? :unvote, :question, question: question %>
         <%= action_authorized_button_to :unvote,
                                         decidim_consultations.question_question_votes_path(question),
@@ -47,24 +38,20 @@
             <%= t("questions.vote_button.already_voted", scope: "decidim") %>
           </div>
         <% end %>
-      <% end %>
-
-      <% if allowed_to? :vote, :question, question: question %>
+      <% elsif allowed_to? :vote, :question, question: question %>
         <%= link_to "#", class: "card__button button expanded", id: "vote_button" do %>
           <div class="vote-button-caption"><%= t "questions.vote_button.vote", scope: "decidim" %></div>
         <% end %>
       <% end %>
-    <% else %>
-      <% if question.consultation.active? %>
-        <%= action_authorized_button_to :vote,
-                                      decidim_consultations.question_question_votes_path(question),
-                                      class: "card__button button expanded",
-                                      data: { disable: true },
-                                      id: "vote_button" do %>
-          <div class="vote-button-caption">
-            <%= t("questions.vote_button.vote", scope: "decidim") %>
-          </div>
-        <% end %>
+    <% elsif question.consultation.active? %>
+      <%= action_authorized_button_to :vote,
+                                    decidim_consultations.question_question_votes_path(question),
+                                    class: "card__button button expanded",
+                                    data: { disable: true },
+                                    id: "vote_button" do %>
+        <div class="vote-button-caption">
+          <%= t("questions.vote_button.vote", scope: "decidim") %>
+        </div>
       <% end %>
     <% end %>
   </div>

--- a/decidim-consultations/lib/decidim/consultations/participatory_space.rb
+++ b/decidim-consultations/lib/decidim/consultations/participatory_space.rb
@@ -30,7 +30,7 @@ Decidim.register_participatory_space(:consultations) do |participatory_space|
     organization = Decidim::Organization.first
 
     # Active consultation
-    consultation = Decidim::Consultation.create!(
+    active_consultation = Decidim::Consultation.create!(
       slug: Faker::Internet.unique.slug(nil, "-"),
       title: Decidim::Faker::Localized.sentence(3),
       subtitle: Decidim::Faker::Localized.sentence(3),
@@ -46,53 +46,7 @@ Decidim.register_participatory_space(:consultations) do |participatory_space|
       organization: organization
     )
 
-    4.times do
-      question = Decidim::Consultations::Question.create!(
-        consultation: consultation,
-        slug: Faker::Internet.unique.slug(nil, "-"),
-        decidim_scope_id: Decidim::Scope.reorder(Arel.sql("RANDOM()")).first.id,
-        title: Decidim::Faker::Localized.sentence(3),
-        subtitle: Decidim::Faker::Localized.sentence(3),
-        what_is_decided: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-          Decidim::Faker::Localized.paragraph(3)
-        end,
-        question_context: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-          Decidim::Faker::Localized.paragraph(3)
-        end,
-        hero_image: File.new(File.join(seeds_root, "city.jpeg")),
-        banner_image: File.new(File.join(seeds_root, "city2.jpeg")),
-        promoter_group: Decidim::Faker::Localized.sentence(3),
-        participatory_scope: Decidim::Faker::Localized.sentence(3),
-        published_at: Time.now.utc,
-        organization: organization
-      )
-
-      2.times do
-        Decidim::Consultations::Response.create(
-          question: question,
-          title: Decidim::Faker::Localized.sentence(3)
-        )
-      end
-
-      Decidim::Comments::Seed.comments_for(question)
-
-      Decidim::Attachment.create!(
-        title: Decidim::Faker::Localized.sentence(2),
-        description: Decidim::Faker::Localized.sentence(5),
-        file: File.new(File.join(seeds_root, "city.jpeg")),
-        attached_to: question
-      )
-
-      Decidim::Attachment.create!(
-        title: Decidim::Faker::Localized.sentence(2),
-        description: Decidim::Faker::Localized.sentence(5),
-        file: File.new(File.join(seeds_root, "Exampledocument.pdf")),
-        attached_to: question
-      )
-    end
-
-    # Finished consultations
-    consultation = Decidim::Consultation.create!(
+    finished_consultation = Decidim::Consultation.create!(
       slug: Faker::Internet.unique.slug(nil, "-"),
       title: Decidim::Faker::Localized.sentence(3),
       subtitle: Decidim::Faker::Localized.sentence(3),
@@ -109,69 +63,67 @@ Decidim.register_participatory_space(:consultations) do |participatory_space|
       organization: organization
     )
 
-    4.times do
-      question = Decidim::Consultations::Question.create!(
-        consultation: consultation,
-        slug: Faker::Internet.unique.slug(nil, "-"),
-        decidim_scope_id: Decidim::Scope.reorder(Arel.sql("RANDOM()")).first.id,
-        title: Decidim::Faker::Localized.sentence(3),
-        subtitle: Decidim::Faker::Localized.sentence(3),
-        what_is_decided: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-          Decidim::Faker::Localized.paragraph(3)
-        end,
-        question_context: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-          Decidim::Faker::Localized.paragraph(3)
-        end,
-        banner_image: File.new(File.join(seeds_root, "city.jpeg")),
-        promoter_group: Decidim::Faker::Localized.sentence(3),
-        participatory_scope: Decidim::Faker::Localized.sentence(3),
-        hero_image: File.new(File.join(seeds_root, "city.jpeg")),
-        published_at: Time.now.utc,
-        organization: organization
-      )
+    upcoming_consultation = Decidim::Consultation.create!(
+      slug: Faker::Internet.unique.slug(nil, "-"),
+      title: Decidim::Faker::Localized.sentence(3),
+      subtitle: Decidim::Faker::Localized.sentence(3),
+      description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+        Decidim::Faker::Localized.paragraph(3)
+      end,
+      published_at: Time.zone.today + 1.month,
+      start_voting_date: Time.zone.today + 1.month + 1.day,
+      end_voting_date: Time.zone.today + 2.months,
+      banner_image: File.new(File.join(seeds_root, "city2.jpeg")),
+      introductory_video_url: "https://www.youtube.com/embed/zhMMW0TENNA",
+      decidim_highlighted_scope_id: Decidim::Scope.reorder(Arel.sql("RANDOM()")).first.id,
+      organization: organization
+    )
 
-      2.times do |i|
-        response = Decidim::Consultations::Response.create(
-          question: question,
-          title: Decidim::Faker::Localized.sentence(3)
+    [finished_consultation, active_consultation, upcoming_consultation].each do |consultation|
+      4.times do
+        question = Decidim::Consultations::Question.create!(
+          consultation: consultation,
+          slug: Faker::Internet.unique.slug(nil, "-"),
+          decidim_scope_id: Decidim::Scope.reorder(Arel.sql("RANDOM()")).first.id,
+          title: Decidim::Faker::Localized.sentence(3),
+          subtitle: Decidim::Faker::Localized.sentence(3),
+          what_is_decided: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+            Decidim::Faker::Localized.paragraph(3)
+          end,
+          question_context: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+            Decidim::Faker::Localized.paragraph(3)
+          end,
+          hero_image: File.new(File.join(seeds_root, "city.jpeg")),
+          banner_image: File.new(File.join(seeds_root, "city2.jpeg")),
+          promoter_group: Decidim::Faker::Localized.sentence(3),
+          participatory_scope: Decidim::Faker::Localized.sentence(3),
+          published_at: Time.now.utc,
+          organization: organization
         )
 
-        email = "question_vote_#{question.id}_#{response.id}_#{i}@example.org"
+        2.times do
+          Decidim::Consultations::Response.create(
+            question: question,
+            title: Decidim::Faker::Localized.sentence(3)
+          )
+        end
 
-        author = Decidim::User.find_or_initialize_by(email: email)
-        author.update!(
-          name: Faker::Name.name,
-          nickname: Faker::Twitter.unique.screen_name,
-          password: "decidim123456",
-          password_confirmation: "decidim123456",
-          organization: organization,
-          confirmed_at: Time.current,
-          locale: I18n.default_locale,
-          tos_agreement: true
+        Decidim::Comments::Seed.comments_for(question)
+
+        Decidim::Attachment.create!(
+          title: Decidim::Faker::Localized.sentence(2),
+          description: Decidim::Faker::Localized.sentence(5),
+          file: File.new(File.join(seeds_root, "city.jpeg")),
+          attached_to: question
         )
 
-        Decidim::Consultations::Vote.create(
-          question: question,
-          response: response,
-          author: author
+        Decidim::Attachment.create!(
+          title: Decidim::Faker::Localized.sentence(2),
+          description: Decidim::Faker::Localized.sentence(5),
+          file: File.new(File.join(seeds_root, "Exampledocument.pdf")),
+          attached_to: question
         )
       end
-
-      Decidim::Comments::Seed.comments_for(question)
-
-      Decidim::Attachment.create!(
-        title: Decidim::Faker::Localized.sentence(2),
-        description: Decidim::Faker::Localized.sentence(5),
-        file: File.new(File.join(seeds_root, "city.jpeg")),
-        attached_to: question
-      )
-
-      Decidim::Attachment.create!(
-        title: Decidim::Faker::Localized.sentence(2),
-        description: Decidim::Faker::Localized.sentence(5),
-        file: File.new(File.join(seeds_root, "Exampledocument.pdf")),
-        attached_to: question
-      )
     end
   end
 end

--- a/decidim-consultations/spec/system/vote_spec.rb
+++ b/decidim-consultations/spec/system/vote_spec.rb
@@ -14,12 +14,11 @@ describe "Question vote", type: :system do
       visit decidim_consultations.question_path(question)
     end
 
-    it "Page contains a disabled vote button" do
-      expect(page).to have_button(id: "vote_button")
-      expect(page).to have_css("#vote_button.disabled")
+    it "contains a disabled vote button" do
+      expect(page).to have_css(".question-vote-cabin .card__button.disabled")
     end
 
-    it "Shows when the voting period starts" do
+    it "shows when the voting period starts" do
       expect(page).to have_content("Starting from #{I18n.l(question.start_voting_date)}")
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Users can vote on upcoming consultations. This PR fixes it, and also adds more seed data to consultations.

#### :pushpin: Related Issues
- Fixes #3457.
- Fixes #3485.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
