### PR TITLE
Fix survey answer exports for multi-choice questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ must now set a resource name:
 - **decidim-core**: Make signup forms show the password confirmation field as required[\#3521](https://github.com/decidim/decidim/pull/3521)
 - **decidim-core**: Fix default page creation so they get scoped to the actual organization [\#3526](https://github.com/decidim/decidim/pull/3526)
 - **decidim-consultations**: Do not allow votes on upcoming consultations [\#3529](https://github.com/decidim/decidim/pull/3529)
+- **decidim-surveys**: Fix answer exporter for single/multi-choice questions [\#3535](https://github.com/decidim/decidim/pull/3535)
 
 **Removed**:
 

--- a/decidim-surveys/lib/decidim/surveys/survey_user_answers_serializer.rb
+++ b/decidim-surveys/lib/decidim/surveys/survey_user_answers_serializer.rb
@@ -15,8 +15,14 @@ module Decidim
       # Public: Exports a hash with the serialized data for the user answers.
       def serialize
         @survey_answers.each_with_index.inject({}) do |serialized, (answer, idx)|
-          serialized.update("#{idx + 1}. #{translated_attribute(answer.question.body)}" => answer.body)
+          serialized.update("#{idx + 1}. #{translated_attribute(answer.question.body)}" => normalize_body(answer))
         end
+      end
+
+      private
+
+      def normalize_body(answer)
+        answer.body || answer.choices.pluck(:body)
       end
     end
   end

--- a/decidim-surveys/lib/decidim/surveys/test/factories.rb
+++ b/decidim-surveys/lib/decidim/surveys/test/factories.rb
@@ -52,4 +52,7 @@ FactoryBot.define do
   factory :survey_answer_option, class: Decidim::Surveys::SurveyAnswerOption do
     body { Decidim::Faker::Localized.sentence }
   end
+
+  factory :survey_answer_choice, class: Decidim::Surveys::SurveyAnswerChoice do
+  end
 end

--- a/decidim-surveys/spec/services/decidim/surveys/surveys/survey_user_answer_serializer_spec.rb
+++ b/decidim-surveys/spec/services/decidim/surveys/surveys/survey_user_answer_serializer_spec.rb
@@ -6,7 +6,7 @@ module Decidim
   module Surveys
     describe SurveyUserAnswersSerializer do
       subject do
-        described_class.new(survey_answers)
+        described_class.new(survey.answers)
       end
 
       let!(:survey) { create(:survey) }
@@ -18,15 +18,44 @@ module Decidim
         end
       end
 
+      let!(:multichoice_survey_question) { create :survey_question, survey: survey, question_type: "multiple_option" }
+      let!(:multichoice_answer_options) { create_list :survey_answer_option, 2, question: multichoice_survey_question }
+      let!(:multichoice_answer) do
+        create :survey_answer, survey: survey, question: multichoice_survey_question, user: user, body: nil
+      end
+      let!(:multichoice_answer_choices) do
+        multichoice_answer_options.map do |answer_option|
+          create :survey_answer_choice, answer: multichoice_answer, answer_option: answer_option, body: answer_option.body[I18n.locale.to_s]
+        end
+      end
+
+      let!(:singlechoice_survey_question) { create :survey_question, survey: survey, question_type: "single_option" }
+      let!(:singlechoice_answer_options) { create_list :survey_answer_option, 2, question: multichoice_survey_question }
+      let!(:singlechoice_answer) do
+        create :survey_answer, survey: survey, question: singlechoice_survey_question, user: user, body: nil
+      end
+      let!(:singlechoice_answer_choice) do
+        answer_option = singlechoice_answer_options.first
+        create :survey_answer_choice, answer: singlechoice_answer, answer_option: answer_option, body: answer_option.body[I18n.locale.to_s]
+      end
+
       describe "#serialize" do
         let(:serialized) { subject.serialize }
 
         it "includes the answer for each question" do
           survey_questions.each_with_index do |question, idx|
             expect(serialized).to include(
-              "#{idx + 1}. #{translated(question.body, locale: I18n.locale)}" => survey_answers[idx].body
+              "#{idx + 1}. #{translated(question.body, locale: I18n.locale)}" => survey_answers[idx].body || multichoice_answer_choices.map(&:body)
             )
           end
+
+          expect(serialized).to include(
+            "4. #{translated(multichoice_survey_question.body, locale: I18n.locale)}" => multichoice_answer_choices.map(&:body)
+          )
+
+          expect(serialized).to include(
+            "5. #{translated(singlechoice_survey_question.body, locale: I18n.locale)}" => [singlechoice_answer_choice.body]
+          )
         end
       end
     end

--- a/decidim-surveys/spec/services/decidim/surveys/surveys/survey_user_answer_serializer_spec.rb
+++ b/decidim-surveys/spec/services/decidim/surveys/surveys/survey_user_answer_serializer_spec.rb
@@ -45,7 +45,7 @@ module Decidim
         it "includes the answer for each question" do
           survey_questions.each_with_index do |question, idx|
             expect(serialized).to include(
-              "#{idx + 1}. #{translated(question.body, locale: I18n.locale)}" => survey_answers[idx].body || multichoice_answer_choices.map(&:body)
+              "#{idx + 1}. #{translated(question.body, locale: I18n.locale)}" => survey_answers[idx].body
             )
           end
 


### PR DESCRIPTION
#### :tophat: What? Why?
The survey answers exporter was not correctly exporting the answers for multi-choice/single-choice questions (radio buttons/check boxes).

This PR fixes it. Answers to this kind of questions are exported as Arrays in JSON, comma-separated values in CSV files.

#### :pushpin: Related Issues
- Fixes #3368

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

