### PR TITLE
Forbid users following themselves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ must now set a resource name:
 - **decidim-core**: Fix default page creation so they get scoped to the actual organization [\#3526](https://github.com/decidim/decidim/pull/3526)
 - **decidim-consultations**: Do not allow votes on upcoming consultations [\#3529](https://github.com/decidim/decidim/pull/3529)
 - **decidim-surveys**: Fix answer exporter for single/multi-choice questions [\#3535](https://github.com/decidim/decidim/pull/3535)
+- **decidim-core**: Do not allow users to follow themselves [\#3536](https://github.com/decidim/decidim/pull/3536)
 
 **Removed**:
 

--- a/decidim-core/app/cells/decidim/card_m_cell.rb
+++ b/decidim-core/app/cells/decidim/card_m_cell.rb
@@ -106,7 +106,7 @@ module Decidim
 
     def statuses
       collection = [:creation_date]
-      collection << :follow if model.is_a?(Decidim::Followable)
+      collection << :follow if model.is_a?(Decidim::Followable) && model != try(:current_user)
       collection << :comments_count if model.is_a?(Decidim::Comments::Commentable)
       collection
     end

--- a/decidim-core/app/cells/decidim/follow_button_cell.rb
+++ b/decidim-core/app/cells/decidim/follow_button_cell.rb
@@ -6,6 +6,7 @@ module Decidim
     include LayoutHelper
 
     def show
+      return if model == current_user
       render
     end
 

--- a/decidim-core/app/forms/decidim/follow_form.rb
+++ b/decidim-core/app/forms/decidim/follow_form.rb
@@ -8,6 +8,7 @@ module Decidim
     attribute :followable_gid, String
 
     validates :followable_gid, :followable, presence: true
+    validates :followable, exclusion: { in: ->(form) { [form.current_user] } }
 
     def followable
       @followable ||= GlobalID::Locator.locate_signed followable_gid

--- a/decidim-core/spec/forms/follow_form_spec.rb
+++ b/decidim-core/spec/forms/follow_form_spec.rb
@@ -10,7 +10,7 @@ module Decidim
     let(:followable) { create :dummy_resource }
     let(:params) do
       {
-        followable_gid: followable.to_sgid,
+        followable_gid: followable.to_sgid
       }
     end
 
@@ -31,7 +31,7 @@ module Decidim
     context "when the followable_gid is not present" do
       let(:params) do
         {
-          followable_gid: nil,
+          followable_gid: nil
         }
       end
 

--- a/decidim-core/spec/forms/follow_form_spec.rb
+++ b/decidim-core/spec/forms/follow_form_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe FollowForm do
+    subject { form }
+
+    let(:user) { create :user }
+    let(:followable) { create :dummy_resource }
+    let(:params) do
+      {
+        followable_gid: followable.to_sgid,
+      }
+    end
+
+    let(:form) do
+      described_class.from_params(params).with_context(current_user: user)
+    end
+
+    context "when everything is OK" do
+      it { is_expected.to be_valid }
+    end
+
+    context "when followable is the same as the current user" do
+      let(:followable) { user }
+
+      it { is_expected.to be_invalid }
+    end
+
+    context "when the followable_gid is not present" do
+      let(:params) do
+        {
+          followable_gid: nil,
+        }
+      end
+
+      it { is_expected.to be_invalid }
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes a UI bug that allowed users to follow themselves. It also makes this check in the backend side, so no-one can follow themself.

#### :pushpin: Related Issues
- Fixes #3501

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
My own user profile card:
![Description](https://i.imgur.com/i07Wcaq.png)

The user profile card of other users:
![](https://i.imgur.com/4yXij9j.png)
