### PR TITLE
Don't send notifications to users without access to the space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ must now set a resource name:
 - **decidim-assembly**: Fix Non private users can participate to a private, transparent assembly [\#3438](https://github.com/decidim/decidim/pull/3438)
 - **decidim-proposals**: Fixes artificial margin between proposal "header" and list of endorsements. [\#2893](https://github.com/decidim/decidim/pull/2893)
 - **decidim-proposals**: Use translations for hardcoded text. [\#3464](https://github.com/decidim/decidim/pull/3464)
+- **decidim-core**: Don't send notifications to users without access to the space. [\#3542](https://github.com/decidim/decidim/pull/3542)
 - **decidim-core**: Include datepicker locales in front pages too. [\#3448](https://github.com/decidim/decidim/pull/3448)
 - **decidim-core**: Uses current organization scopes in scopes picker. [\#3386](https://github.com/decidim/decidim/pull/3386)
 - **decidim-blog**: Add `params[:id]` when editing/deleting a post from admin site [\#3329](https://github.com/decidim/decidim/pull/3329)

--- a/decidim-core/lib/decidim/events/base_event.rb
+++ b/decidim-core/lib/decidim/events/base_event.rb
@@ -68,11 +68,14 @@ module Decidim
       # event to decide based on the params.
       #
       # It returns false when the resource or any element in the chain is a
-      # `Decidim::Publicable` and it isn't published.
+      # `Decidim::Publicable` and it isn't published or participatory_space
+      # is a `Decidim::Participable` and the user can't participate.
       def notifiable?
         return false if resource.is_a?(Decidim::Publicable) && !resource.published?
         return false if participatory_space.is_a?(Decidim::Publicable) && !participatory_space&.published?
         return false unless component&.published?
+
+        return false if participatory_space.is_a?(Decidim::Participable) && !participatory_space.can_participate?(user)
 
         true
       end

--- a/decidim-core/spec/lib/events/base_event_spec.rb
+++ b/decidim-core/spec/lib/events/base_event_spec.rb
@@ -4,6 +4,8 @@ require "spec_helper"
 
 module Decidim
   describe Events::BaseEvent do
+    let(:user) { build(:user) }
+
     describe ".types" do
       subject { described_class }
 
@@ -17,7 +19,7 @@ module Decidim
         described_class.new(
           resource: resource,
           event_name: "some.event",
-          user: build(:user),
+          user: user,
           extra: {}
         )
       end
@@ -83,6 +85,26 @@ module Decidim
           end
 
           it { is_expected.not_to be_notifiable }
+        end
+
+        context "and participatory space is participable" do
+          before do
+            resource.published_at = Time.current
+            resource.component.published_at = Time.current
+            resource.component.participatory_space.published_at = Time.current
+          end
+
+          context "and the user can participate" do
+            it { is_expected.to be_notifiable }
+          end
+
+          context "and the user can't participate" do
+            before do
+              allow(resource.component.participatory_space).to receive(:can_participate?).with(user).and_return(false)
+            end
+
+            it { is_expected.not_to be_notifiable }
+          end
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

If an User A follows an User B, User A receives notifications for actions that User B has done in private spaces.

#### :pushpin: Related Issues

- Fixes #3510

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
