### PR TITLE
Invite new admins outside the transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ must now set a resource name:
 - **decidim-consultations**: Do not allow votes on upcoming consultations [\#3529](https://github.com/decidim/decidim/pull/3529)
 - **decidim-surveys**: Fix answer exporter for single/multi-choice questions [\#3535](https://github.com/decidim/decidim/pull/3535)
 - **decidim-core**: Do not allow users to follow themselves [\#3536](https://github.com/decidim/decidim/pull/3536)
+- **decidim-system**: Fix new organization admin not being invited properly [\#3543](https://github.com/decidim/decidim/pull/3543)
 
 **Removed**:
 

--- a/decidim-system/app/commands/decidim/system/register_organization.rb
+++ b/decidim-system/app/commands/decidim/system/register_organization.rb
@@ -21,14 +21,16 @@ module Decidim
       # Returns nothing.
       def call
         return broadcast(:invalid) if form.invalid?
+        @organization = nil
+        invite_form = nil
 
         transaction do
           @organization = create_organization
           CreateDefaultPages.call(@organization)
           invite_form = invite_user_form(@organization)
           return broadcast(:invalid) if invite_form.invalid?
-          Decidim::InviteUser.call(invite_form)
         end
+        Decidim::InviteUser.call(invite_form) if @organization && invite_form
 
         broadcast(:ok)
       rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique


### PR DESCRIPTION
#### :tophat: What? Why?
When you create an organization, and set the admin email to something that already exists, the invitation mail might not be delivered.

This PR fixes this problem.

#### :pushpin: Related Issues
- Related to #3359.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
I created an organization called `localhost4`, with host as `localhost4`, and the admin user is the default one. HEre's the invitation email:
![Description](https://i.imgur.com/T2NjJZ6.png)
