### PR TITLE
Hide supports on linked proposals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ must now set a resource name:
 - **decidim-surveys**: Fix answer exporter for single/multi-choice questions [\#3535](https://github.com/decidim/decidim/pull/3535)
 - **decidim-core**: Do not allow users to follow themselves [\#3536](https://github.com/decidim/decidim/pull/3536)
 - **decidim-system**: Fix new organization admin not being invited properly [\#3543](https://github.com/decidim/decidim/pull/3543)
+- **decidim-proposals**: Hide supports on linked proposals if theya re supposed to be hidden [\#3544](https://github.com/decidim/decidim/pull/3544)
 
 **Removed**:
 

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -210,6 +210,6 @@ en:
         see_all_results: See all results
     resource_links:
       included_projects:
-        result_projects: Projects included in this result
+        result_project: Projects included in this result
       included_proposals:
-        result_proposals: Proposals included in this result
+        result_proposal: Proposals included in this result

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -138,7 +138,7 @@ en:
         success: Your vote has been canceled successfully
     resource_links:
       included_proposals:
-        project_proposals: 'Proposals included in this project:'
+        project_proposal: 'Proposals included in this project:'
   index:
     confirmed_orders_count: Votes count
   total_budget: Total budget

--- a/decidim-core/app/helpers/decidim/resource_helper.rb
+++ b/decidim-core/app/helpers/decidim/resource_helper.rb
@@ -20,7 +20,7 @@ module Decidim
       safe_join(linked_resources.map do |klass, resources|
         resource_manifest = klass.constantize.resource_manifest
         content_tag(:div, class: "section") do
-          i18n_name = "#{resource.class.name.demodulize.underscore}_#{resource_manifest.name.pluralize}"
+          i18n_name = "#{resource.class.name.demodulize.underscore}_#{resource_manifest.name}"
           content_tag(:h3, I18n.t(i18n_name, scope: "decidim.resource_links.#{link_name}"), class: "section-heading") +
             render(partial: resource_manifest.template, locals: { resources: resources })
         end

--- a/decidim-core/app/helpers/decidim/resource_helper.rb
+++ b/decidim-core/app/helpers/decidim/resource_helper.rb
@@ -20,7 +20,7 @@ module Decidim
       safe_join(linked_resources.map do |klass, resources|
         resource_manifest = klass.constantize.resource_manifest
         content_tag(:div, class: "section") do
-          i18n_name = "#{resource.class.name.demodulize.underscore}_#{resource_manifest.name}"
+          i18n_name = "#{resource.class.name.demodulize.underscore}_#{resource_manifest.name.pluralize}"
           content_tag(:h3, I18n.t(i18n_name, scope: "decidim.resource_links.#{link_name}"), class: "section-heading") +
             render(partial: resource_manifest.template, locals: { resources: resources })
         end

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -292,11 +292,11 @@ en:
         upcoming_meeting: Upcoming meeting
     resource_links:
       meetings_through_proposals:
-        meeting_results: 'Related results:'
-        result_meetings: 'Related meetings:'
+        meeting_result: 'Related results:'
+        result_meeting: 'Related meetings:'
       proposals_from_meeting:
-        meeting_proposals: 'Related proposals:'
-        proposal_meetings: 'Related meetings:'
+        meeting_proposal: 'Related proposals:'
+        proposal_meeting: 'Related meetings:'
   devise:
     mailer:
       join_meeting:

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_linked_proposals.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_linked_proposals.html.erb
@@ -22,11 +22,13 @@
           <% end %>
         </div>
       </div>
-      <div class="card--list__data">
-        <span class="card--list__data__number">
-          <%= proposal.votes.size %>
-        </span> <%= t(".proposal_votes", count: proposal.votes.size) %>
-      </div>
+      <% if !current_settings.try(:votes_hidden?) && !proposal.component.current_settings.votes_hidden? %>
+        <div class="card--list__data">
+          <span class="card--list__data__number">
+            <%= proposal.votes.size %>
+          </span> <%= t(".proposal_votes", count: proposal.votes.size) %>
+        </div>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -404,9 +404,9 @@ en:
         success: Proposal draft updated successfully.
     resource_links:
       copied_from_component:
-        proposal_proposals: Related proposals
+        proposal_proposal: Related proposals
       included_projects:
-        project_results: 'Results appearing in this project:'
+        project_result: 'Results appearing in this project:'
       included_proposals:
-        proposal_projects: 'Proposal appearing in these projects:'
-        proposal_results: 'Proposal appearing in these results:'
+        proposal_project: 'Proposal appearing in these projects:'
+        proposal_result: 'Proposal appearing in these results:'


### PR DESCRIPTION
#### :tophat: What? Why?
When a proposal is included, it should not show the supports count if they are supposed to be hidden.

#### :pushpin: Related Issues
- Fixes #3379

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/LtbaCCu.png)
