### PR TITLE
Correctly find the user asking for confirmation email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ must now set a resource name:
 - **decidim-core**: Do not allow users to follow themselves [\#3536](https://github.com/decidim/decidim/pull/3536)
 - **decidim-system**: Fix new organization admin not being invited properly [\#3543](https://github.com/decidim/decidim/pull/3543)
 - **decidim-proposals**: Hide supports on linked proposals if theya re supposed to be hidden [\#3544](https://github.com/decidim/decidim/pull/3544)
+- **decidim-core**: Fix cofnirmation emails resending for multitenant systems [\#3546](https://github.com/decidim/decidim/pull/3546)
 
 **Removed**:
 

--- a/decidim-core/app/controllers/decidim/devise/confirmations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/confirmations_controller.rb
@@ -5,6 +5,19 @@ module Decidim
     # Custom Devise ConfirmationsController to avoid namespace problems.
     class ConfirmationsController < ::Devise::ConfirmationsController
       include Decidim::DeviseControllers
+
+      # Since we're using a single Devise installation for multiple
+      # organizations, and user emails can be repeated across organizations,
+      # we need to identify the user by both the email and the organization.
+      # Setting the organization ID here will be used by Devise internally to
+      # find the correct user.
+      #
+      # Note that in order for this to work we need to define the `confirmation_keys`
+      # Devise attribute in the `Decidim::User` model to include the
+      # `decidim_organization_id` attribute.
+      def resource_params
+        super.merge(decidim_organization_id: current_organization.id)
+      end
     end
   end
 end

--- a/decidim-core/app/controllers/decidim/devise/passwords_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/passwords_controller.rb
@@ -14,7 +14,7 @@ module Decidim
       # Setting the organization ID here will be used by Devise internally to
       # find the correct user.
       #
-      # Note that in orther for this to work we need to define the `reset_password_keys`
+      # Note that in order for this to work we need to define the `reset_password_keys`
       # Devise attribute in the `Decidim::User` model to include the
       # `decidim_organization_id` attribute.
       def resource_params

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -17,7 +17,8 @@ module Decidim
     devise :invitable, :database_authenticatable, :registerable, :confirmable,
            :recoverable, :rememberable, :trackable, :decidim_validatable,
            :omniauthable, omniauth_providers: OMNIAUTH_PROVIDERS,
-                          request_keys: [:env], reset_password_keys: [:decidim_organization_id, :email]
+                          request_keys: [:env], reset_password_keys: [:decidim_organization_id, :email],
+                          confirmation_keys: [:decidim_organization_id, :email]
 
     belongs_to :organization, foreign_key: "decidim_organization_id", class_name: "Decidim::Organization"
     has_many :identities, foreign_key: "decidim_user_id", class_name: "Decidim::Identity", dependent: :destroy


### PR DESCRIPTION
#### :tophat: What? Why?
Given a multi-tenant installation and a recently created user that has the same email as another older user in another tenant, when that user asks for the the confirmation email the system fails to correctly identify the user and mistakes it by the first one.

This PR applies the same fix on Devise we applied for the "Forgot Password" feature.

#### :pushpin: Related Issues
- Related to #3359

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

