### PR TITLE
Improve proposal page

### DIFF
--- a/decidim-core/app/helpers/decidim/scopes_helper.rb
+++ b/decidim-core/app/helpers/decidim/scopes_helper.rb
@@ -13,7 +13,9 @@ module Decidim
     #
     # Returns boolean.
     def has_visible_scopes?(resource)
-      resource.participatory_space.scopes_enabled? && resource.scope.present? && resource.participatory_space.scope != resource.scope
+      resource.participatory_space.scopes_enabled? &&
+        resource.scope.present? &&
+        resource.participatory_space.scope != resource.scope
     end
 
     # Retrieves the translated name and type for an scope.
@@ -22,13 +24,11 @@ module Decidim
     #
     # Returns a string
     def scope_name_for_picker(scope, global_name)
-      if scope
-        name = translated_attribute(scope.name)
-        name << " (#{translated_attribute(scope.scope_type.name)})" if scope.scope_type
-        name
-      else
-        global_name
-      end
+      return global_name unless scope
+
+      name = translated_attribute(scope.name)
+      name << " (#{translated_attribute(scope.scope_type.name)})" if scope.scope_type
+      name
     end
 
     # Renders a scopes picker field in a form.
@@ -66,8 +66,15 @@ module Decidim
     # Returns nothing.
     def scopes_picker_filter(form, name)
       form.scopes_picker name, multiple: true, legend_title: I18n.t("decidim.scopes.scopes"), label: false do |scope|
-        { url: decidim.scopes_picker_path(root: try(:current_participatory_space)&.scope, current: scope&.id, title: I18n.t("decidim.scopes.prompt"), global_value: "global"),
-          text: scope_name_for_picker(scope, I18n.t("decidim.scopes.prompt")) }
+        {
+          url: decidim.scopes_picker_path(
+            root: try(:current_participatory_space)&.scope,
+            current: scope&.id,
+            title: I18n.t("decidim.scopes.prompt"),
+            global_value: "global"
+          ),
+          text: scope_name_for_picker(scope, I18n.t("decidim.scopes.prompt"))
+        }
       end
     end
   end

--- a/decidim-proposals/app/cells/decidim/proposals/endorsers_list/show.erb
+++ b/decidim-proposals/app/cells/decidim/proposals/endorsers_list/show.erb
@@ -1,0 +1,18 @@
+<div class="section">
+  <a name="list-of-endorsements"></a>
+  <div class="row">
+    <div class="columns large-12">
+      <h4 class="section-heading"><%= t("decidim.proposals.proposals.show.endorsements_list") %></h4>
+    </div>
+    <div class="columns large-12">
+      <%= cell(
+        "decidim/collapsible_list",
+        endorsers,
+        cell_name: "decidim/author",
+        cell_options: { extra_classes: ["author-data--small"] },
+        hidden_elements_count_i18n_key: "decidim.proposals.proposals.show.hidden_endorsers_count",
+        size: :small
+      ) %>
+    </div>
+  </div>
+</div>

--- a/decidim-proposals/app/cells/decidim/proposals/endorsers_list_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/endorsers_list_cell.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "cell/partial"
+
+module Decidim
+  module Proposals
+    # This cell renders the list of endorsers for the given Proposal.
+    #
+    # Example:
+    #
+    #    cell("decidim/proposals/endorsers_list", my_proposal)
+    class EndorsersListCell < Decidim::ViewModel
+      include ProposalCellsHelper
+
+      def show
+        return unless endorsers.any?
+        render
+      end
+
+      private
+
+      # Finds the correct author for each endorsement.
+      #
+      # Returns an Array of presented Users/UserGroups
+      def endorsers
+        @endorsers ||= model.endorsements.for_listing.map { |identity| present(identity.normalized_author) }
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_tags_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_tags_cell.rb
@@ -13,15 +13,10 @@ module Decidim
       property :scope
 
       def show
-        return unless has_category_or_scopes?
-        render
+        render if has_category_or_scopes?
       end
 
       private
-
-      def category
-        nil
-      end
 
       def show_previous_category?
         options[:show_previous_category].to_s != "false"

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_tags_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_tags_cell.rb
@@ -12,10 +12,23 @@ module Decidim
       property :previous_category
       property :scope
 
+      def show
+        return unless has_category_or_scopes?
+        render
+      end
+
       private
+
+      def category
+        nil
+      end
 
       def show_previous_category?
         options[:show_previous_category].to_s != "false"
+      end
+
+      def has_category_or_scopes?
+        category.present? || has_visible_scopes?(model)
       end
     end
   end

--- a/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
@@ -83,10 +83,6 @@ module Decidim
           end
         end
       end
-
-      def endorsers_for(proposal)
-        proposal.endorsements.for_listing.map { |identity| present(identity.normalized_author) }
-      end
     end
   end
 end

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -70,24 +70,7 @@
     <%= linked_resources_for @proposal, :meetings, "proposals_from_meeting" %>
     <%= linked_resources_for @proposal, :proposals, "copied_from_component" %>
 
-    <div class="section">
-      <a name="list-of-endorsements"></a>
-      <div class="row">
-        <div class="columns large-12">
-          <h4 class="section-heading"><%= t(".endorsements_list") %></h4>
-        </div>
-        <div class="columns large-12">
-          <%= cell(
-            "decidim/collapsible_list",
-            endorsers_for(@proposal),
-            cell_name: "decidim/author",
-            cell_options: { extra_classes: ["author-data--small"] },
-            hidden_elements_count_i18n_key: "decidim.proposals.proposals.show.hidden_endorsers_count",
-            size: :small
-          ) %>
-        </div>
-      </div>
-    </div>
+    <%= cell "decidim/proposals/endorsers_list", @proposal %>
   </div>
 </div>
 <%= attachments_for @proposal %>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR cleans up the proposal page. I saw a proposal on MetaDecidim that had no category, no scope and no endorsers and still it was showing the texts for theses sections. This PR avoids this by hiding the sections if there's nothing to show.

This used to work, but got lost when moving things to cells (my bad!)

Also, cells ❤️ 

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
No changelog entry needed since this modifies things that have not yet been released.

### :camera: Screenshots (optional)
A proposal without categories, scopes or endorsements (the sidebar shows some endorsements, ignore that number):
![Description](https://i.imgur.com/CBmWkdq.png)
