### PR TITLE
Warn that attachment is lost when form is errored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,7 +121,8 @@ must now set a resource name:
 - **decidim-core**: Do not allow users to follow themselves [\#3536](https://github.com/decidim/decidim/pull/3536)
 - **decidim-system**: Fix new organization admin not being invited properly [\#3543](https://github.com/decidim/decidim/pull/3543)
 - **decidim-proposals**: Hide supports on linked proposals if theya re supposed to be hidden [\#3544](https://github.com/decidim/decidim/pull/3544)
-- **decidim-core**: Fix cofnirmation emails resending for multitenant systems [\#3546](https://github.com/decidim/decidim/pull/3546)
+- **decidim-core**: Fix confirmation emails resending for multitenant systems [\#3546](https://github.com/decidim/decidim/pull/3546)
+- **decidim-proposals**: Warn the user the attachment is lost when the form is errored [\#3553](https://github.com/decidim/decidim/pull/3553)
 
 **Removed**:
 

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
@@ -23,6 +23,8 @@ module Decidim
 
         validate :scope_belongs_to_participatory_space_scope
 
+        validate :notify_missing_attachment_if_errored
+
         delegate :categories, to: :current_component
 
         def map_model(model)
@@ -58,6 +60,14 @@ module Decidim
 
         def scope_belongs_to_participatory_space_scope
           errors.add(:scope_id, :invalid) if current_participatory_space.out_of_scope?(scope)
+        end
+
+        # This method will add an error to the `attachment` field only if there's
+        # any error in any other field. This is needed because when the form has
+        # an error, the attachment is lost, so we need a way to inform the user of
+        # this problem.
+        def notify_missing_attachment_if_errored
+          errors.add(:attachment, :needs_to_be_reattached) if errors.any? && attachment.present?
         end
       end
     end

--- a/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
@@ -26,6 +26,8 @@ module Decidim
       validate :proposal_length
       validate :scope_belongs_to_participatory_space_scope
 
+      validate :notify_missing_attachment_if_errored
+
       delegate :categories, to: :current_component
 
       def map_model(model)
@@ -71,6 +73,14 @@ module Decidim
 
       def scope_belongs_to_participatory_space_scope
         errors.add(:scope_id, :invalid) if current_participatory_space.out_of_scope?(scope)
+      end
+
+      # This method will add an error to the `attachment` field only if there's
+      # any error in any other field. This is needed because when the form has
+      # an error, the attachment is lost, so we need a way to inform the user of
+      # this problem.
+      def notify_missing_attachment_if_errored
+        errors.add(:attachment, :needs_to_be_reattached) if errors.any? && attachment.present?
       end
     end
   end

--- a/decidim-proposals/app/views/decidim/proposals/proposals/complete.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/complete.html.erb
@@ -45,13 +45,20 @@
           <% if component_settings.attachments_allowed? %>
             <fieldset>
               <legend><%= t(".attachment_legend") %></legend>
-              <%= form.fields_for :attachment, @form.attachment do |form| %>
+              <%= form.fields_for :attachment, @form.attachment do |nested_form| %>
                 <div class="field">
-                  <%= form.text_field :title %>
+                  <%= nested_form.text_field :title %>
                 </div>
 
                 <div class="field">
-                  <%= form.upload :file, optional: false %>
+                  <%= nested_form.upload :file, optional: false %>
+                  <% if @form.errors[:attachment].present? %>
+                    <% @form.errors[:attachment].each do |message| %>
+                      <small class="form-error is-visible">
+                        <%= message %>
+                      </small>
+                    <% end %>
+                  <% end %>
                 </div>
               <% end %>
             </fieldset>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -17,6 +17,12 @@ en:
       proposals_copy:
         copy_proposals: I understand that this will import all proposals from the selected component to the current one and that this action can't be reversed.
         origin_component_id: Component to copy the proposals from
+    errors:
+      models:
+        proposal:
+          attributes:
+            attachment:
+              needs_to_be_reattached: Needs to be reattached
     models:
       decidim/proposals/accepted_proposal_event: Proposal accepted
       decidim/proposals/admin/update_proposal_category_event: Proposal category changed

--- a/decidim-proposals/spec/shared/proposal_form_examples.rb
+++ b/decidim-proposals/spec/shared/proposal_form_examples.rb
@@ -48,6 +48,11 @@ shared_examples "a proposal form" do |options|
     let(:title) { nil }
 
     it { is_expected.to be_invalid }
+
+    it "only adds errors to this field" do
+      subject.valid?
+      expect(subject.errors.keys).to eq [:title]
+    end
   end
 
   context "when there's no body" do
@@ -192,5 +197,15 @@ shared_examples "a proposal form" do |options|
     end
 
     it { is_expected.to be_valid }
+
+    context "when the form has some errors" do
+      let(:title) { nil }
+
+      it "adds an error to the `:attachment` field" do
+        expect(subject).not_to be_valid
+        expect(subject.errors.full_messages).to match_array(["Title can't be blank", "Attachment Needs to be reattached"])
+        expect(subject.errors.keys).to match_array([:title, :attachment])
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
When the proposal form has an attachment but fails due to an error in another field, the attachment is lost and the user is not aware of it. This PR adds a message to the form to warn the user of the issue.

#### :pushpin: Related Issues
- Fixes #3031

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/8XNZK1v.png)
