### PR TITLE
Enforce permissions when managing meeting minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ must now set a resource name:
 
 **Fixed**:
 
+- **decidim-meetings**: Enforce permissions when managing meeting minutes. [\#3560](https://github.com/decidim/decidim/pull/3560)
 - **decidim-assembly**: Fix Non private users can participate to a private, transparent assembly [\#3438](https://github.com/decidim/decidim/pull/3438)
 - **decidim-proposals**: Fixes artificial margin between proposal "header" and list of endorsements. [\#2893](https://github.com/decidim/decidim/pull/2893)
 - **decidim-proposals**: Use translations for hardcoded text. [\#3464](https://github.com/decidim/decidim/pull/3464)

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/minutes_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/minutes_controller.rb
@@ -8,10 +8,14 @@ module Decidim
         helper_method :current_meeting, :minutes
 
         def new
+          enforce_permission_to :create, :minutes, meeting: current_meeting
+
           @form = form(MinutesForm).instance
         end
 
         def create
+          enforce_permission_to :create, :minutes, meeting: current_meeting
+
           @form = form(MinutesForm).from_params(params)
 
           CreateMinutes.call(@form, current_meeting) do
@@ -28,10 +32,14 @@ module Decidim
         end
 
         def edit
+          enforce_permission_to :update, :minutes, minutes: minutes, meeting: current_meeting
+
           @form = form(MinutesForm).from_model(minutes)
         end
 
         def update
+          enforce_permission_to :update, :minutes, minutes: minutes, meeting: current_meeting
+
           @form = form(MinutesForm).from_params(params)
           UpdateMinutes.call(@form, current_meeting, minutes) do
             on(:ok) do

--- a/decidim-meetings/app/permissions/decidim/meetings/admin/permissions.rb
+++ b/decidim-meetings/app/permissions/decidim/meetings/admin/permissions.rb
@@ -6,10 +6,26 @@ module Decidim
       class Permissions < Decidim::DefaultPermissions
         def permissions
           return permission_action unless user
+          return permission_action unless permission_action.scope == :admin
 
-          return permission_action if permission_action.scope != :admin
+          allowed_meeting_action?
+          allowed_minutes_action?
 
-          return permission_action if permission_action.subject != :meeting
+          permission_action
+        end
+
+        private
+
+        def meeting
+          @meeting ||= context.fetch(:meeting, nil)
+        end
+
+        def minutes
+          @minutes ||= context.fetch(:minutes, nil)
+        end
+
+        def allowed_meeting_action?
+          return unless permission_action.subject == :meeting
 
           case permission_action.action
           when :close, :copy, :destroy, :export_registrations, :update
@@ -19,14 +35,17 @@ module Decidim
           when :create
             allow!
           end
-
-          permission_action
         end
 
-        private
+        def allowed_minutes_action?
+          return unless permission_action.subject == :minutes
 
-        def meeting
-          @meeting ||= context.fetch(:meeting, nil)
+          case permission_action.action
+          when :create
+            toggle_allow(meeting.present?)
+          when :update
+            toggle_allow(minutes.present? && meeting.present?)
+          end
         end
       end
     end

--- a/decidim-meetings/spec/permissions/decidim/meetings/admin/permissions_spec.rb
+++ b/decidim-meetings/spec/permissions/decidim/meetings/admin/permissions_spec.rb
@@ -10,17 +10,20 @@ describe Decidim::Meetings::Admin::Permissions do
   let(:context) do
     {
       current_component: meeting_component,
-      meeting: meeting
+      meeting: meeting,
+      minutes: minutes
     }
   end
   let(:meeting_component) { create :meeting_component }
   let(:meeting) { create :meeting, component: meeting_component }
+  let(:minutes) { create :minutes }
   let(:permission_action) { Decidim::PermissionAction.new(action) }
   let(:registrations_enabled) { true }
   let(:action) do
-    { scope: :admin, action: action_name, subject: :meeting }
+    { scope: :admin, action: action_name, subject: action_subject }
   end
   let(:action_name) { :foo }
+  let(:action_subject) { :foo }
 
   shared_examples "action requiring a meeting" do
     context "when meeting is present" do
@@ -34,74 +37,109 @@ describe Decidim::Meetings::Admin::Permissions do
     end
   end
 
+  shared_examples "action requiring a minutes" do
+    context "when minutes is present" do
+      it { is_expected.to eq true }
+    end
+
+    context "when minutes is missing" do
+      let(:minutes) { nil }
+
+      it { is_expected.to eq false }
+    end
+  end
+
   context "when scope is not admin" do
     let(:action) do
-      { scope: :foo, action: :vote, subject: :meeting }
+      { scope: :foo, action: :create, subject: :meeting }
     end
 
     it_behaves_like "permission is not set"
   end
 
-  context "when subject is not a meeting" do
+  context "when subject is a random one" do
     let(:action) do
-      { scope: :admin, action: :vote, subject: :foo }
+      { scope: :admin, action: :create, subject: :foo }
     end
 
     it_behaves_like "permission is not set"
   end
 
   context "when action is a random one" do
-    let(:action_name) { :foo }
+    let(:action) do
+      { scope: :admin, action: :foo, subject: :meeting }
+    end
 
     it_behaves_like "permission is not set"
   end
 
-  context "when creating a meeting" do
-    let(:action_name) { :create }
+  context "when subject is a meeting" do
+    let(:action_subject) { :meeting }
 
-    it { is_expected.to eq true }
-  end
+    context "when creating a meeting" do
+      let(:action_name) { :create }
 
-  context "when closing a meeting" do
-    let(:action_name) { :close }
+      it { is_expected.to eq true }
+    end
 
-    it_behaves_like "action requiring a meeting"
-  end
+    context "when closing a meeting" do
+      let(:action_name) { :close }
 
-  context "when copying a meeting" do
-    let(:action_name) { :copy }
+      it_behaves_like "action requiring a meeting"
+    end
 
-    it_behaves_like "action requiring a meeting"
-  end
+    context "when copying a meeting" do
+      let(:action_name) { :copy }
 
-  context "when destroying a meeting" do
-    let(:action_name) { :destroy }
+      it_behaves_like "action requiring a meeting"
+    end
 
-    it_behaves_like "action requiring a meeting"
-  end
+    context "when destroying a meeting" do
+      let(:action_name) { :destroy }
 
-  context "when exporting registrations a meeting" do
-    let(:action_name) { :export_registrations }
+      it_behaves_like "action requiring a meeting"
+    end
 
-    it_behaves_like "action requiring a meeting"
-  end
+    context "when exporting registrations a meeting" do
+      let(:action_name) { :export_registrations }
 
-  context "when inviting a user a meeting" do
-    let(:action_name) { :invite_user }
-    let(:meeting) { create :meeting, registrations_enabled: true, component: meeting_component }
+      it_behaves_like "action requiring a meeting"
+    end
 
-    it_behaves_like "action requiring a meeting"
+    context "when inviting a user a meeting" do
+      let(:action_name) { :invite_user }
+      let(:meeting) { create :meeting, registrations_enabled: true, component: meeting_component }
 
-    context "when the meeting registrations are closed" do
-      let(:meeting) { create :meeting, registrations_enabled: false, component: meeting_component }
+      it_behaves_like "action requiring a meeting"
 
-      it { is_expected.to eq false }
+      context "when the meeting registrations are closed" do
+        let(:meeting) { create :meeting, registrations_enabled: false, component: meeting_component }
+
+        it { is_expected.to eq false }
+      end
+    end
+
+    context "when updating a meeting" do
+      let(:action_name) { :update }
+
+      it_behaves_like "action requiring a meeting"
     end
   end
 
-  context "when updating a meeting" do
-    let(:action_name) { :update }
+  context "when subject is a minutes" do
+    let(:action_subject) { :minutes }
 
-    it_behaves_like "action requiring a meeting"
+    context "when creating a minutes" do
+      let(:action_name) { :create }
+
+      it_behaves_like "action requiring a meeting"
+    end
+
+    context "when updating a minutes" do
+      let(:action_name) { :update }
+
+      it_behaves_like "action requiring a meeting"
+      it_behaves_like "action requiring a minutes"
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

We aren't checking the permissions in minutes controller.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
