### PR TITLE
Downcase error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ must now set a resource name:
 - **decidim-proposals**: Hide supports on linked proposals if theya re supposed to be hidden [\#3544](https://github.com/decidim/decidim/pull/3544)
 - **decidim-core**: Fix confirmation emails resending for multitenant systems [\#3546](https://github.com/decidim/decidim/pull/3546)
 - **decidim-proposals**: Warn the user the attachment is lost when the form is errored [\#3553](https://github.com/decidim/decidim/pull/3553)
+- **decidim-core**: Consistent casing of error messages [\#3565](https://github.com/decidim/decidim/pull/3565)
 
 **Removed**:
 

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -549,15 +549,15 @@ en:
       public: Your public information.
   errors:
     messages:
-      content_type_whitelist_error: The file type is not valid
+      content_type_whitelist_error: the file type is not valid
       cycle_detected: a scope's parent can't be one of its descendants
       file_size_is_less_than_or_equal_to: file size must be less than or equal to %{count}
-      long_words: Contains words that are too long
-      must_start_with_caps: Must start with caps
+      long_words: contains words that are too long
+      must_start_with_caps: must start with caps
       nesting_too_deep: can't be inside of a subcategory
-      too_many_marks: Is using too many marks
-      too_much_caps: Is using too much caps
-      too_short: Is too short
+      too_many_marks: is using too many marks
+      too_much_caps: is using too much caps
+      too_short: is too short
   forms:
     required: Required
   invisible_captcha:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -552,8 +552,6 @@ en:
       content_type_whitelist_error: The file type is not valid
       cycle_detected: a scope's parent can't be one of its descendants
       file_size_is_less_than_or_equal_to: file size must be less than or equal to %{count}
-      invalid_manifest: Invalid manifest
-      invalid_participatory_process: Invalid participatory process
       long_words: Contains words that are too long
       must_start_with_caps: Must start with caps
       nesting_too_deep: can't be inside of a subcategory

--- a/decidim-proposals/spec/system/edit_proposal_spec.rb
+++ b/decidim-proposals/spec/system/edit_proposal_spec.rb
@@ -52,7 +52,7 @@ describe "Edit proposals", type: :system do
         fill_in "Body", with: "A"
         click_button "Send"
 
-        expect(page).to have_content("Is using too much caps, Is too short")
+        expect(page).to have_content("is using too much caps, is too short")
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

I'm making use of `form.errors.full_messages` on a plugin. By default, this Rails method concatenates the attribute name with the attribute error. So the errors look like this: "Email Is too short". It reads a bit weird. Also, all of rails default error messages are lowercased, so we're currently inconsistent here. 

If we do care about keeping all uppercase errors, I think the best place is to do it is to [override this line](https://github.com/sgruhier/foundation_rails_helper/blob/8a4b53d9b348bbf49c3608aea811fe17b9282e4c/lib/foundation_rails_helper/form_builder.rb#L122) to uppercase each error message.

I'm neutral whether our errors will look better or worse after this change. Maybe "Sentence case" looks slightly better, but I'm not sure it's worth it.

See the screenshot for how these errors currently look.

Also, I removed two i18n keys that I think we're not using? :thinking:

#### :pushpin: Related Issues

_None_.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![before](https://user-images.githubusercontent.com/2887858/40859236-7e502104-65b7-11e8-8bdf-eb437fe63002.png)