### PR TITLE
Fix comments stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ must now set a resource name:
 - **decidim-core**: Fix confirmation emails resending for multitenant systems [\#3546](https://github.com/decidim/decidim/pull/3546)
 - **decidim-proposals**: Warn the user the attachment is lost when the form is errored [\#3553](https://github.com/decidim/decidim/pull/3553)
 - **decidim-core**: Consistent casing of error messages [\#3565](https://github.com/decidim/decidim/pull/3565)
+- **decidim-comments**: Fix comments stats so it appears in the homepage again [\#3570](https://github.com/decidim/decidim/pull/3570)
 
 **Removed**:
 

--- a/decidim-comments/lib/decidim/comments/engine.rb
+++ b/decidim-comments/lib/decidim/comments/engine.rb
@@ -36,9 +36,9 @@ module Decidim
       end
 
       initializer "decidim.stats" do
-        Decidim.stats.register :comments_count, priority: StatsRegistry::MEDIUM_PRIORITY do |components, start_at, end_at|
+        Decidim.stats.register :comments_count, priority: StatsRegistry::MEDIUM_PRIORITY do |organization|
           Decidim.component_manifests.sum do |component|
-            component.stats.filter(tag: :comments).with_context(components, start_at, end_at).map { |_name, value| value }.sum
+            component.stats.filter(tag: :comments).with_context(organization.published_components).map { |_name, value| value }.sum
           end
         end
       end

--- a/decidim-core/app/models/decidim/organization.rb
+++ b/decidim-core/app/models/decidim/organization.rb
@@ -49,5 +49,15 @@ module Decidim
     def homepage_big_url
       homepage_image.big.url
     end
+
+    def public_participatory_spaces
+      @public_participatory_spaces ||= Decidim.participatory_space_manifests.flat_map do |manifest|
+        manifest.participatory_spaces.call(self).public_spaces
+      end
+    end
+
+    def published_components
+      @published_components ||= Component.where(participatory_space: public_participatory_spaces).published
+    end
   end
 end

--- a/decidim-core/app/presenters/decidim/home_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/home_stats_presenter.rb
@@ -74,14 +74,8 @@ module Decidim
       end
     end
 
-    def public_participatory_spaces
-      @public_participatory_spaces ||= Decidim.participatory_space_manifests.flat_map do |manifest|
-        manifest.participatory_spaces.call(organization).public_spaces
-      end
-    end
-
     def published_components
-      @published_components ||= Component.where(participatory_space: public_participatory_spaces).published
+      @published_components ||= organization.published_components
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR readds the comments stats to the homepage. They were lost due to a change in the API that was not properly ported to this stat.

#### :pushpin: Related Issues
- Fixes #3378.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/fxtTyw8.png)
