### PR TITLE
Disable http caching

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/application_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/application_controller.rb
@@ -9,6 +9,7 @@ module Decidim
       include FormFactory
       include LocaleSwitcher
       include PayloadInfo
+      include HttpCachingDisabler
 
       helper Decidim::Admin::ApplicationHelper
       helper Decidim::Admin::AttributesDisplayHelper

--- a/decidim-core/app/controllers/concerns/decidim/http_caching_disabler.rb
+++ b/decidim-core/app/controllers/concerns/decidim/http_caching_disabler.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  # This module will disable http caching from the controller in
+  # order to prevent proxies from storing sensible information.
+  module HttpCachingDisabler
+    extend ActiveSupport::Concern
+
+    included do
+      before_action :disable_http_caching
+    end
+
+    def disable_http_caching
+      response.headers["Cache-Control"] = "no-cache, no-store"
+      response.headers["Pragma"] = "no-cache"
+      response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
+    end
+  end
+end

--- a/decidim-core/app/controllers/decidim/application_controller.rb
+++ b/decidim-core/app/controllers/decidim/application_controller.rb
@@ -9,6 +9,7 @@ module Decidim
     include PayloadInfo
     include ImpersonateUsers
     include NeedsTosAccepted
+    include HttpCachingDisabler
 
     helper Decidim::MetaTagsHelper
     helper Decidim::DecidimFormHelper
@@ -30,6 +31,8 @@ module Decidim
     after_action :add_vary_header
 
     layout "layouts/decidim/application"
+
+    skip_before_action :disable_http_caching, unless: :user_signed_in?
 
     private
 

--- a/decidim-core/spec/controllers/application_controller_spec.rb
+++ b/decidim-core/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe ApplicationController, type: :controller do
+    let!(:organization) { create :organization }
+    let!(:user) { create :user, :confirmed, organization: organization }
+
+    controller Decidim::ApplicationController do
+      def show
+        render plain: "Hello World"
+      end
+    end
+
+    before do
+      request.env["decidim.current_organization"] = organization
+      routes.draw { get "show" => "decidim/application#show" }
+    end
+
+    describe "#show" do
+      context "when authenticated" do
+        before do
+          sign_in user
+        end
+
+        it "sets the appropiate headers" do
+          get :show
+
+          expect(response.headers["Cache-Control"]).to eq("no-cache, no-store")
+          expect(response.headers["Pragma"]).to eq("no-cache")
+          expect(response.headers["Expires"]).to eq("Fri, 01 Jan 1990 00:00:00 GMT")
+        end
+      end
+
+      context "when not authenticated" do
+        it "sets the appropiate headers" do
+          get :show
+
+          expect(response.headers["Cache-Control"]).to be_nil
+          expect(response.headers["Pragma"]).to be_nil
+          expect(response.headers["Expires"]).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/controllers/concerns/http_caching_disabler_spec.rb
+++ b/decidim-core/spec/controllers/concerns/http_caching_disabler_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe "HttpCachingDisabler", type: :controller do
+    let!(:organization) { create :organization }
+    let!(:user) { create :user, :confirmed, organization: organization }
+
+    controller do
+      include HttpCachingDisabler
+
+      def show
+        render plain: "Hello World"
+      end
+    end
+
+    before do
+      request.env["decidim.current_organization"] = organization
+      routes.draw { get "show" => "anonymous#show" }
+    end
+
+    it "sets the appropiate headers" do
+      get :show
+
+      expect(response.headers["Cache-Control"]).to eq("no-cache, no-store")
+      expect(response.headers["Pragma"]).to eq("no-cache")
+      expect(response.headers["Expires"]).to eq("Fri, 01 Jan 1990 00:00:00 GMT")
+    end
+  end
+end

--- a/decidim-system/app/controllers/decidim/system/application_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/application_controller.rb
@@ -6,6 +6,7 @@ module Decidim
     class ApplicationController < ActionController::Base
       include FormFactory
       include PayloadInfo
+      include HttpCachingDisabler
 
       protect_from_forgery with: :exception, prepend: true
 


### PR DESCRIPTION
#### :tophat: What? Why?
Disables HTTP caching when logged in to prevent leaking personal data, as suggested in #2663.

#### :pushpin: Related Issues
- Related to #2826

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*
