### PR TITLE
Request throttling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ must now set a resource name:
 - **decidim-blogs**: Add blog post card [\#3487](https://github.com/decidim/decidim/pull/3487)
 - **decidim-core**: GDPR: Track TOS page version in Organization [\#3491](https://github.com/decidim/decidim/pull/3491)
 - **decidim-core**: GDPR: User must review TOS when updated [\#3494](https://github.com/decidim/decidim/pull/3494)
+- **decidim-core**: Requests are throttled to prevent DoS attacks [\#3588](https://github.com/decidim/decidim/pull/3588)
 
 **Changed**:
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ PATH
       paper_trail (~> 9.0)
       pg (>= 0.18, < 2)
       premailer-rails (~> 1.9)
+      rack-attack (~> 5.2.0)
       rails (>= 5.2, < 6.0.x)
       rails-i18n (~> 5.0)
       rectify (~> 0.11.0)
@@ -225,7 +226,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
     ast (2.4.0)
-    autoprefixer-rails (8.5.0)
+    autoprefixer-rails (8.6.0)
       execjs
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -354,7 +355,7 @@ GEM
       activesupport (>= 4.1, < 6.0)
       railties (>= 4.1, < 6.0)
       tzinfo (~> 1.2, >= 1.2.2)
-    geocoder (1.4.7)
+    geocoder (1.4.9)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     graphiql-rails (1.4.10)
@@ -465,7 +466,7 @@ GEM
       omniauth-oauth (~> 1.1)
       rack
     orm_adapter (0.5.0)
-    paper_trail (9.0.2)
+    paper_trail (9.1.1)
       activerecord (>= 4.2, < 5.3)
       request_store (~> 1.1)
     parallel (1.12.1)
@@ -485,6 +486,8 @@ GEM
     public_suffix (3.0.2)
     puma (3.11.4)
     rack (2.0.5)
+    rack-attack (5.2.0)
+      rack
     rack-cors (1.0.2)
     rack-test (1.0.0)
       rack (>= 1.0, < 3)

--- a/decidim-core/config/initializers/rack_attack.rb
+++ b/decidim-core/config/initializers/rack_attack.rb
@@ -6,21 +6,21 @@ Rails.application.configure do |config|
   config.middleware.use Rack::Attack
 end
 
-Rack::Attack.throttle("requests by ip", limit: 500, period: 60, &:ip)
+Rack::Attack.throttle(
+  "requests by ip",
+  limit: Decidim.throttling_max_requests,
+  period: Decidim.throttling_period,
+  &:ip
+)
 
 # Throttle login attempts for a given email parameter to 6 reqs/minute
 # Return the email as a discriminator on POST /users/sign_in requests
-Rack::Attack.throttle("limit logins per email", limit: 6, period: 60) do |request|
-  if request.path == "/users/sign_in" && request.post?
-    request.params["user"]["email"]
-  end
+Rack::Attack.throttle("limit logins per email", limit: 5, period: 60.seconds) do |request|
+  request.params["user"]["email"] if request.path == "/users/sign_in" && request.post?
 end
 
-
 # Throttle login attempts for a given email parameter to 6 reqs/minute
 # Return the email as a discriminator on POST /users/sign_in requests
-Rack::Attack.throttle("limit password recovery attempts per email", limit: 6, period: 60) do |request|
-  if request.path == "/users/password" && request.post?
-    request.params["user"]["email"]
-  end
+Rack::Attack.throttle("limit password recovery attempts per email", limit: 5, period: 60.seconds) do |request|
+  request.params["user"]["email"] if request.path == "/users/password" && request.post?
 end

--- a/decidim-core/config/initializers/rack_attack.rb
+++ b/decidim-core/config/initializers/rack_attack.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+if Rails.env.production?
 require "rack/attack"
 
 Rails.application.configure do |config|
@@ -23,4 +24,5 @@ end
 # Return the email as a discriminator on POST /users/sign_in requests
 Rack::Attack.throttle("limit password recovery attempts per email", limit: 5, period: 60.seconds) do |request|
   request.params["user"]["email"] if request.path == "/users/password" && request.post?
+end
 end

--- a/decidim-core/config/initializers/rack_attack.rb
+++ b/decidim-core/config/initializers/rack_attack.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rack/attack"
+
+Rails.application.configure do |config|
+  config.middleware.use Rack::Attack
+end
+
+Rack::Attack.throttle("requests by ip", limit: 5, period: 2, &:ip)
+
+# Throttle login attempts for a given email parameter to 6 reqs/minute
+# Return the email as a discriminator on POST /users/sign_in requests
+Rack::Attack.throttle("limit logins per email", limit: 6, period: 60) do |request|
+  if request.path == "/users/sign_in" && request.post?
+    request.params["user"]["email"]
+  end
+end
+
+
+# Throttle login attempts for a given email parameter to 6 reqs/minute
+# Return the email as a discriminator on POST /users/sign_in requests
+Rack::Attack.throttle("limit password recovery attempts per email", limit: 6, period: 60) do |request|
+  if request.path == "/users/password" && request.post?
+    request.params["user"]["email"]
+  end
+end

--- a/decidim-core/config/initializers/rack_attack.rb
+++ b/decidim-core/config/initializers/rack_attack.rb
@@ -6,7 +6,7 @@ Rails.application.configure do |config|
   config.middleware.use Rack::Attack
 end
 
-Rack::Attack.throttle("requests by ip", limit: 5, period: 2, &:ip)
+Rack::Attack.throttle("requests by ip", limit: 10, period: 1, &:ip)
 
 # Throttle login attempts for a given email parameter to 6 reqs/minute
 # Return the email as a discriminator on POST /users/sign_in requests

--- a/decidim-core/config/initializers/rack_attack.rb
+++ b/decidim-core/config/initializers/rack_attack.rb
@@ -1,28 +1,28 @@
 # frozen_string_literal: true
 
 if Rails.env.production?
-require "rack/attack"
+  require "rack/attack"
 
-Rails.application.configure do |config|
-  config.middleware.use Rack::Attack
-end
+  Rails.application.configure do |config|
+    config.middleware.use Rack::Attack
+  end
 
-Rack::Attack.throttle(
-  "requests by ip",
-  limit: Decidim.throttling_max_requests,
-  period: Decidim.throttling_period,
-  &:ip
-)
+  Rack::Attack.throttle(
+    "requests by ip",
+    limit: Decidim.throttling_max_requests,
+    period: Decidim.throttling_period,
+    &:ip
+  )
 
-# Throttle login attempts for a given email parameter to 6 reqs/minute
-# Return the email as a discriminator on POST /users/sign_in requests
-Rack::Attack.throttle("limit logins per email", limit: 5, period: 60.seconds) do |request|
-  request.params["user"]["email"] if request.path == "/users/sign_in" && request.post?
-end
+  # Throttle login attempts for a given email parameter to 6 reqs/minute
+  # Return the email as a discriminator on POST /users/sign_in requests
+  Rack::Attack.throttle("limit logins per email", limit: 5, period: 60.seconds) do |request|
+    request.params["user"]["email"] if request.path == "/users/sign_in" && request.post?
+  end
 
-# Throttle login attempts for a given email parameter to 6 reqs/minute
-# Return the email as a discriminator on POST /users/sign_in requests
-Rack::Attack.throttle("limit password recovery attempts per email", limit: 5, period: 60.seconds) do |request|
-  request.params["user"]["email"] if request.path == "/users/password" && request.post?
-end
+  # Throttle login attempts for a given email parameter to 6 reqs/minute
+  # Return the email as a discriminator on POST /users/sign_in requests
+  Rack::Attack.throttle("limit password recovery attempts per email", limit: 5, period: 60.seconds) do |request|
+    request.params["user"]["email"] if request.path == "/users/password" && request.post?
+  end
 end

--- a/decidim-core/config/initializers/rack_attack.rb
+++ b/decidim-core/config/initializers/rack_attack.rb
@@ -6,7 +6,7 @@ Rails.application.configure do |config|
   config.middleware.use Rack::Attack
 end
 
-Rack::Attack.throttle("requests by ip", limit: 10, period: 1, &:ip)
+Rack::Attack.throttle("requests by ip", limit: 5, period: 1, &:ip)
 
 # Throttle login attempts for a given email parameter to 6 reqs/minute
 # Return the email as a discriminator on POST /users/sign_in requests

--- a/decidim-core/config/initializers/rack_attack.rb
+++ b/decidim-core/config/initializers/rack_attack.rb
@@ -6,7 +6,7 @@ Rails.application.configure do |config|
   config.middleware.use Rack::Attack
 end
 
-Rack::Attack.throttle("requests by ip", limit: 5, period: 1, &:ip)
+Rack::Attack.throttle("requests by ip", limit: 500, period: 60, &:ip)
 
 # Throttle login attempts for a given email parameter to 6 reqs/minute
 # Return the email as a discriminator on POST /users/sign_in requests

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |s|
   s.add_dependency "paper_trail", "~> 9.0"
   s.add_dependency "pg", ">= 0.18", "< 2"
   s.add_dependency "premailer-rails", "~> 1.9"
+  s.add_dependency "rack-attack", "~> 5.2.0"
   s.add_dependency "rails", ">= 5.2", "< 6.0.x"
   s.add_dependency "rails-i18n", "~> 5.0"
   s.add_dependency "rectify", "~> 0.11.0"

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -176,7 +176,7 @@ module Decidim
 
   # Max requests in a time period to prevent DoS attacks. Only applied on production.
   config_accessor :throttling_max_requests do
-    500
+    100
   end
 
   # Time window in which the throttling is applied.

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -174,6 +174,14 @@ module Decidim
     true
   end
 
+  config_accessor :throttling_max_requests do
+    500
+  end
+
+  config_accessor :throttling_period do
+    60.seconds
+  end
+
   # A base path for the uploads. If set, make sure it ends in a slash.
   # Uploads will be set to `<base_path>/uploads/`. This can be useful if you
   # want to use the same uploads place for both staging and production

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -174,12 +174,14 @@ module Decidim
     true
   end
 
+  # Max requests in a time period to prevent DoS attacks. Only applied on production.
   config_accessor :throttling_max_requests do
     500
   end
 
+  # Time window in which the throttling is applied.
   config_accessor :throttling_period do
-    60.seconds
+    1.minute
   end
 
   # A base path for the uploads. If set, make sure it ends in a slash.

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -82,6 +82,7 @@ PATH
       paper_trail (~> 9.0)
       pg (>= 0.18, < 2)
       premailer-rails (~> 1.9)
+      rack-attack (~> 5.2.0)
       rails (>= 5.2, < 6.0.x)
       rails-i18n (~> 5.0)
       rectify (~> 0.11.0)
@@ -213,7 +214,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
     ast (2.4.0)
-    autoprefixer-rails (8.5.0)
+    autoprefixer-rails (8.6.0)
       execjs
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -340,7 +341,7 @@ GEM
       activesupport (>= 4.1, < 6.0)
       railties (>= 4.1, < 6.0)
       tzinfo (~> 1.2, >= 1.2.2)
-    geocoder (1.4.7)
+    geocoder (1.4.9)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     graphiql-rails (1.4.10)
@@ -450,7 +451,7 @@ GEM
       omniauth-oauth (~> 1.1)
       rack
     orm_adapter (0.5.0)
-    paper_trail (9.0.2)
+    paper_trail (9.1.1)
       activerecord (>= 4.2, < 5.3)
       request_store (~> 1.1)
     parallel (1.12.1)
@@ -470,6 +471,8 @@ GEM
     public_suffix (3.0.2)
     puma (3.11.3)
     rack (2.0.5)
+    rack-attack (5.2.0)
+      rack
     rack-cors (1.0.2)
     rack-test (1.0.0)
       rack (>= 1.0, < 3)

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -86,6 +86,7 @@ PATH
       paper_trail (~> 9.0)
       pg (>= 0.18, < 2)
       premailer-rails (~> 1.9)
+      rack-attack (~> 5.2.0)
       rails (>= 5.2, < 6.0.x)
       rails-i18n (~> 5.0)
       rectify (~> 0.11.0)
@@ -225,7 +226,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
     ast (2.4.0)
-    autoprefixer-rails (8.5.0)
+    autoprefixer-rails (8.6.0)
       execjs
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -354,7 +355,7 @@ GEM
       activesupport (>= 4.1, < 6.0)
       railties (>= 4.1, < 6.0)
       tzinfo (~> 1.2, >= 1.2.2)
-    geocoder (1.4.7)
+    geocoder (1.4.9)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     graphiql-rails (1.4.10)
@@ -465,7 +466,7 @@ GEM
       omniauth-oauth (~> 1.1)
       rack
     orm_adapter (0.5.0)
-    paper_trail (9.0.2)
+    paper_trail (9.1.1)
       activerecord (>= 4.2, < 5.3)
       request_store (~> 1.1)
     parallel (1.12.1)
@@ -485,6 +486,8 @@ GEM
     public_suffix (3.0.2)
     puma (3.11.4)
     rack (2.0.5)
+    rack-attack (5.2.0)
+      rack
     rack-cors (1.0.2)
     rack-test (1.0.0)
       rack (>= 1.0, < 3)


### PR DESCRIPTION
#### :tophat: What? Why?
This will throttle requests in order to prevent some DoS attacks. It does it in the following ways:

* Throttles any request. Default to an amount of 100 in a period of a minute, split by IP. Values are configurable via `Decidim.throttling_max_requests` and `Decidim.throttling_period`.

* Throttles requests to `/users/sign_in` and `/users/password`, as they might be especially vulnerable to attacks. Currently not configurable.

#### :pushpin: Related Issues
- Fixes #355

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
*None*
