### PR TITLE
Fix generator specs error reporting

### DIFF
--- a/decidim-generators/spec/generators_spec.rb
+++ b/decidim-generators/spec/generators_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "simplecov" if ENV["SIMPLECOV"]
+require "spec_helper"
 require "decidim/gem_manager"
 
 module Decidim

--- a/decidim-generators/spec/spec_helper.rb
+++ b/decidim-generators/spec/spec_helper.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.fail_fast = ENV["FAIL_FAST"] == "true"
+end

--- a/lib/decidim/gem_manager.rb
+++ b/lib/decidim/gem_manager.rb
@@ -68,23 +68,11 @@ module Decidim
 
     class << self
       def capture(cmd, env: {})
-        output, status = Open3.capture2e(env, cmd)
-
-        abort unless continue?(status.success?)
-
-        [output, status]
+        Open3.capture2e(env, cmd)
       end
 
       def run(cmd, out: STDOUT)
-        status = system(cmd, out: out)
-
-        abort unless continue?(status == true)
-
-        status
-      end
-
-      def continue?(status)
-        status || ENV["FAIL_FAST"] == "false"
+        system(cmd, out: out)
       end
 
       def test_participatory_space
@@ -109,7 +97,9 @@ module Decidim
 
       def run_all(command, out: STDOUT, include_root: true)
         all_dirs(include_root: include_root) do |dir|
-          new(dir).run(command, out: out)
+          status = new(dir).run(command, out: out)
+
+          break unless status || ENV["FAIL_FAST"] == "false"
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

When FAIL_FAST environment variable was set, like in CircleCI, and generator specs would hit a failure, the process was being directly aborted without giving rspec the chance to actually report the error.

This PR fixes that and thus fixes all the "ghost failures" that have appeared lately on long standing PRs.

#### :pushpin: Related Issues
- Related to #3532, and all those search engine MVP PRs.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.
