### PR TITLE
Require factory_bot from support file

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/factory_bot.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/factory_bot.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "factory_bot_rails"
+
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 end

--- a/decidim-dev/lib/decidim/dev/test/spec_helper.rb
+++ b/decidim-dev/lib/decidim/dev/test/spec_helper.rb
@@ -3,18 +3,18 @@
 require "rails-controller-testing"
 require "rspec/rails"
 require "rspec/cells"
-require "factory_bot_rails"
 require "byebug"
 require "rectify/rspec"
 require "wisper/rspec/stub_wisper_publisher"
 require "db-query-matchers"
 require "action_view/helpers/sanitize_helper"
-require_relative "factories"
-require_relative "screenshot_helper_ext"
 
 # Requires supporting files with custom matchers and macros, etc,
 # in ./rspec_support/ and its subdirectories.
 Dir["#{__dir__}/rspec_support/**/*.rb"].each { |f| require f }
+
+require_relative "factories"
+require_relative "screenshot_helper_ext"
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
#### :tophat: What? Why?

This is a tiny change so that it's possible to directly require this file from end applications.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.