### PR TITLE
Fix meetings cell when rendered outside of a component engine

### DIFF
--- a/decidim-meetings/app/cells/decidim/meetings/join_meeting_button_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/join_meeting_button_cell.rb
@@ -13,7 +13,8 @@ module Decidim
 
       private
 
-      delegate :current_user, :current_component, to: :controller, prefix: false
+      delegate :current_user, to: :controller, prefix: false
+      delegate :current_component, to: :model, prefix: false
 
       def button_classes
         return "button expanded button--sc" if big_button?


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes meeting cards when rendered outside of a controller with a `current_component`.

**Needs to be backported to the 0.12-stable branch**

#### :pushpin: Related Issues
- Fixes #3608

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*
