### PR TITLE
Fix how cards are displayed on the search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@
 **Changed**:
 
 - **decidim-participatory_processes**: Make process moderators receive notifications about flagged content [\#3605](https://github.com/decidim/decidim/pull/3605)
+- **decidim-meetings**: Do not let users join a meeting from the Search page, as the button fails [\#3612](https://github.com/decidim/decidim/pull/3612)
 
 **Fixed**:
 
 - **decidim-proposals**: Fix link to endorsements behaviour, now it does not link when there are no endorsements. [\#3531](https://github.com/decidim/decidim/pull/3531)
+- **decidim-meetings**: Fix meetings M card cell so that it works outside the component [\#3612](https://github.com/decidim/decidim/pull/3612)
+- **decidim-proposals**: Fix proposals M card cell so that it works outside the component [\#3612](https://github.com/decidim/decidim/pull/3612)
 
 **Removed**:
 

--- a/decidim-core/app/views/decidim/searches/_results.html.erb
+++ b/decidim-core/app/views/decidim/searches/_results.html.erb
@@ -1,5 +1,5 @@
 <div class="row small-up-1 medium-up-2 card-grid">
   <% @results.each do |result| %>
-    <%= card_for result.resource, context: { label: true } %>
+    <%= card_for result.resource, context: { label: true }, show_footer_actions: false %>
   <% end %>
 </div>

--- a/decidim-meetings/app/cells/decidim/meetings/join_meeting_button_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/join_meeting_button_cell.rb
@@ -13,7 +13,11 @@ module Decidim
 
       private
 
-      delegate :current_user, :current_component, to: :controller, prefix: false
+      delegate :current_user, to: :controller, prefix: false
+
+      def current_component
+        model.component
+      end
 
       def button_classes
         return "button expanded button--sc" if big_button?

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_m/footer.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_m/footer.erb
@@ -1,6 +1,6 @@
 <div class="card__footer">
   <div class="card__support">
-    <% if can_join? %>
+    <% if can_join? && show_footer_actions? %>
       <%= cell "decidim/meetings/join_meeting_button", model %>
     <% else %>
       <%= link_to t("view", scope: "decidim.meetings.meetings.show"), resource_path, class: "card__button button secondary button--sc small light" %>

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_m_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_m_cell.rb
@@ -45,6 +45,10 @@ module Decidim
       def can_join?
         model.can_be_joined_by?(current_user)
       end
+
+      def show_footer_actions?
+        options[:show_footer_actions]
+      end
     end
   end
 end

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_cell.rb
@@ -35,8 +35,12 @@ module Decidim
         model.component.participatory_space
       end
 
+      def current_component
+        model.component
+      end
+
       def component_name
-        translated_attribute current_component.name
+        translated_attribute model.component.name
       end
 
       def component_type_name


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes how cards are displayed on the search page. This PR also replaces the "Join Meeting" button for a "View" button, as this button fails outside the component.

#### :pushpin: Related Issues
- Fixes #3608

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/Ug95z1d.png)
