### PR TITLE
Add missing `component_permissions` asset to the manifest.

### DIFF
--- a/decidim-admin/app/assets/config/decidim_admin_manifest.js
+++ b/decidim-admin/app/assets/config/decidim_admin_manifest.js
@@ -1,3 +1,4 @@
 //= link decidim/admin/application.js
 //= link decidim/admin/managed_users.js
+//= link decidim/admin/component_permissions.js
 //= link decidim/admin/application.css


### PR DESCRIPTION
#### :tophat: What? Why?
This adds the missing `component_permissions.js.es6` file on the `admin` manifest, as it broke on production.

**Must be backported to `0.12-stable`**

#### :pushpin: Related Issues
- Fixes #3596

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*
