### PR TITLE
Use find_or_initialize_by in the invite_user_to_join command

### DIFF
--- a/decidim-meetings/app/commands/decidim/meetings/admin/invite_user_to_join_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/invite_user_to_join_meeting.rb
@@ -47,7 +47,7 @@ module Decidim
         end
 
         def user
-          @user ||= Decidim::User.find_or_create_by(
+          @user ||= Decidim::User.find_or_initialize_by(
             organization: form.current_organization,
             email: form.email.downcase
           )


### PR DESCRIPTION
#### :tophat: What? Why?

While working on another feature, I've seen that this command is using `find_or_create_by` and the previous method is calling `user.persisted?`.

This has been working because the user creation fails due to validations, but I think it is inconsistent. What do you think?

#### :pushpin: Related Issues

#### :clipboard: Subtasks

### :camera: Screenshots (optional)

