### PR TITLE
Notify about extended initiatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Added**:
 
 - **decidim-core**: GDPR: Add Right of data portability. [\#3489](https://github.com/decidim/decidim/pull/3489)
+- **decidim-initiatives**: Notify the followers when an initiative's signatures end date has been extended [\#3621](https://github.com/decidim/decidim/pull/3621)
 
 **Changed**:
 

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative.rb
@@ -30,6 +30,7 @@ module Decidim
             current_user,
             attributes
           )
+          notify_initiative_is_extended if @notify_extended
           broadcast(:ok, initiative)
         rescue ActiveRecord::RecordInvalid
           broadcast(:invalid, initiative)
@@ -55,9 +56,21 @@ module Decidim
             attrs[:signature_start_time] = form.signature_start_time
             attrs[:signature_end_time] = form.signature_end_time
             attrs[:offline_votes] = form.offline_votes
+
+            @notify_extended = true if form.signature_end_time != initiative.signature_end_time &&
+                                       form.signature_end_time > initiative.signature_end_time
           end
 
           attrs
+        end
+
+        def notify_initiative_is_extended
+          Decidim::EventsManager.publish(
+            event: "decidim.events.initiatives.initiative_extended",
+            event_class: Decidim::Initiatives::ExtendInitiativeEvent,
+            resource: initiative,
+            recipient_ids: initiative.followers.pluck(:id)
+          )
         end
       end
     end

--- a/decidim-initiatives/app/events/decidim/initiatives/extend_initiative_event.rb
+++ b/decidim-initiatives/app/events/decidim/initiatives/extend_initiative_event.rb
@@ -1,0 +1,11 @@
+# frozen-string_literal: true
+
+module Decidim
+  module Initiatives
+    class ExtendInitiativeEvent < Decidim::Events::SimpleEvent
+      def participatory_space
+        resource
+      end
+    end
+  end
+end

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -71,6 +71,11 @@ en:
         initiatives_types: Initiative types
     events:
       initiatives:
+        initiative_extended:
+          email_intro: The signatures end date for the initiative %{resource_title} has been extended!
+          email_outro: You have received this notification because you are following %{resource_title}. You can stop receiving notifications following the previous link.
+          email_subject: Initiative signatures end date extended!
+          notification_title: The signatures end date for the <a href="%{resource_path}">%{resource_title}</a> initiative has been extended.
         milestone_completed:
           email_intro: The initiative %{resource_title} has achieved the %{percentage}% of signatures!
           email_outro: You have received this notification because you are following %{resource_title}. You can stop receiving notifications following the previous link.

--- a/decidim-initiatives/spec/events/decidim/initiatives/extend_initiative_event_spec.rb
+++ b/decidim-initiatives/spec/events/decidim/initiatives/extend_initiative_event_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Initiatives::ExtendInitiativeEvent do
+  include_context "when a simple event"
+
+  let(:event_name) { "decidim.events.initiatives.initiative_extended" }
+  let(:resource) { initiative }
+
+  let(:initiative) { create :initiative }
+  let(:participatory_space) { initiative }
+
+  it_behaves_like "a simple event"
+
+  describe "types" do
+    subject { described_class }
+
+    it "supports notifications" do
+      expect(subject.types).to include :notification
+    end
+
+    it "supports emails" do
+      expect(subject.types).to include :email
+    end
+  end
+
+  describe "email_subject" do
+    it "is generated correctly" do
+      expect(subject.email_subject).to eq("Initiative signatures end date extended!")
+    end
+  end
+
+  describe "email_intro" do
+    it "is generated correctly" do
+      expect(subject.email_intro)
+        .to eq("The signatures end date for the initiative #{resource_title} has been extended!")
+    end
+  end
+
+  describe "notification_title" do
+    it "is generated correctly" do
+      expect(subject.notification_title)
+        .to include("The signatures end date for the <a href=\"#{resource_path}\">#{resource_title}</a> initiative has been extended")
+    end
+  end
+end

--- a/decidim-initiatives/spec/shared/update_initiative_example.rb
+++ b/decidim-initiatives/spec/shared/update_initiative_example.rb
@@ -14,25 +14,27 @@ shared_examples "update an initiative" do
     )
   end
 
+  let(:signature_end_time) { Time.zone.today + 130.days }
+  let(:form_params) do
+    {
+      title: { en: "A reasonable initiative title" },
+      description: { en: "A reasonable initiative description" },
+      signature_start_time: Time.zone.today + 10.days,
+      signature_end_time: signature_end_time,
+      signature_type: "any",
+      type_id: initiative.type.id,
+      decidim_scope_id: initiative.scope.id,
+      answer: { en: "Measured answer" },
+      answer_url: "http://decidim.org",
+      hashtag: "update_initiative_example",
+      offline_votes: 1
+    }
+  end
+  let(:current_user) { initiative.author }
+
+  let(:command) { described_class.new(initiative, form, current_user) }
+
   describe "call" do
-    let(:form_params) do
-      {
-        title: { en: "A reasonable initiative title" },
-        description: { en: "A reasonable initiative description" },
-        signature_start_time: Time.zone.today + 10.days,
-        signature_end_time: Time.zone.today + 130.days,
-        signature_type: "any",
-        type_id: initiative.type.id,
-        decidim_scope_id: initiative.scope.id,
-        answer: { en: "Measured answer" },
-        answer_url: "http://decidim.org",
-        hashtag: "update_initiative_example",
-        offline_votes: 1
-      }
-    end
-
-    let(:command) { described_class.new(initiative, form, initiative.author) }
-
     describe "when the form is not valid" do
       before do
         expect(form).to receive(:invalid?).and_return(true)


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds a notification to the users when an initiative's signatures end date has been extended.

#### :pushpin: Related Issues
- Related to #2334

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
