### PR TITLE
fix private assemblies showing more than once for private users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,7 @@
 
 **Fixed**:
 
-- **decidim-assemblies**: Fix private assemblies showing more than once for private users.
-[\#3638](https://github.com/decidim/decidim/pull/3638)
+- **decidim-assemblies**: Fix private assemblies showing more than once for private users. [\#3638](https://github.com/decidim/decidim/pull/3638)
 - **decidim-proposals**: Do not index non published Proposals. [\#3618](https://github.com/decidim/decidim/pull/3618)
 - **decidim-proposals**: Fix link to endorsements behaviour, now it does not link when there are no endorsements. [\#3531](https://github.com/decidim/decidim/pull/3531)
 - **decidim-meetings**: Fix meetings M card cell so that it works outside the component [\#3612](https://github.com/decidim/decidim/pull/3612)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 **Fixed**:
 
+- **decidim-assemblies**: Fix private assemblies showing more than once for private users.
+[\#3638](https://github.com/decidim/decidim/pull/3638)
 - **decidim-proposals**: Do not index non published Proposals. [\#3618](https://github.com/decidim/decidim/pull/3618)
 - **decidim-proposals**: Fix link to endorsements behaviour, now it does not link when there are no endorsements. [\#3531](https://github.com/decidim/decidim/pull/3531)
 - **decidim-meetings**: Fix meetings M card cell so that it works outside the component [\#3612](https://github.com/decidim/decidim/pull/3612)

--- a/decidim-assemblies/app/models/decidim/assembly.rb
+++ b/decidim-assemblies/app/models/decidim/assembly.rb
@@ -69,7 +69,7 @@ module Decidim
                           joins("LEFT JOIN decidim_participatory_space_private_users ON
                           decidim_participatory_space_private_users.privatable_to_id = #{table_name}.id")
                             .where("(private_space = ? and decidim_participatory_space_private_users.decidim_user_id = ?)
-                            or private_space = ? or (private_space = ? and is_transparent = ?)", true, user, false, true, true)
+                            or private_space = ? or (private_space = ? and is_transparent = ?)", true, user, false, true, true).distinct
                         }
 
     after_create :set_parents_path

--- a/decidim-assemblies/spec/system/private_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/private_assemblies_spec.rb
@@ -7,7 +7,9 @@ describe "Private Assemblies", type: :system do
   let!(:assembly) { create :assembly, :published, organization: organization }
   let!(:user) { create :user, :confirmed, organization: organization }
   let!(:other_user) { create :user, :confirmed, organization: organization }
+  let!(:other_user_2) { create :user, :confirmed, organization: organization }
   let!(:assembly_private_user) { create :assembly_private_user, user: other_user, privatable_to: private_assembly }
+  let!(:assembly_private_user_2) { create :assembly_private_user, user: other_user_2, privatable_to: private_assembly }
 
   context "when there are private assemblies" do
     context "and the assembly is transparent" do

--- a/decidim-core/lib/decidim/has_private_users.rb
+++ b/decidim-core/lib/decidim/has_private_users.rb
@@ -15,7 +15,7 @@ module Decidim
       scope :visible_for, lambda { |user|
                             joins("LEFT JOIN decidim_participatory_space_private_users ON
                             decidim_participatory_space_private_users.privatable_to_id = #{table_name}.id")
-                              .where("(private_space = ? and decidim_participatory_space_private_users.decidim_user_id = ?) or private_space = ? ", true, user, false)
+                              .where("(private_space = ? and decidim_participatory_space_private_users.decidim_user_id = ?) or private_space = ? ", true, user, false).distinct
                           }
 
       def self.public_spaces

--- a/decidim-participatory_processes/spec/system/private_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/private_participatory_processes_spec.rb
@@ -8,7 +8,9 @@ describe "Private Participatory Processes", type: :system do
   let!(:private_participatory_process) { create :participatory_process, :published, organization: organization, private_space: true }
   let!(:user) { create :user, :confirmed, organization: organization }
   let!(:other_user) { create :user, :confirmed, organization: organization }
+  let!(:other_user_2) { create :user, :confirmed, organization: organization }
   let!(:participatory_space_private_user) { create :participatory_space_private_user, user: other_user, privatable_to: private_participatory_process }
+  let!(:participatory_space_private_user_2) { create :participatory_space_private_user, user: other_user_2, privatable_to: private_participatory_process }
 
   context "when there are private participatory processes" do
     context "and no user is loged in" do


### PR DESCRIPTION
#### :tophat: What? Why?
There's only one private assembly  and in the front end there are multiple Assemblies equals.

The Admin invites a private user to be part of the assembly. This user, when viewing Assemblies, sees that the Assembly has been repeated.

In addition, for every private user we invite, the Assembly doubles (for example: if we invite 3, we see 3 assemblies with the same name).

This is a problem that affects ONLY the private users of the assembly since the users who have not been invited privately visualize the space correctly. I leave you captures to better understand.


#### :pushpin: Related Issues
- Related to #2618 
- Fixes #3631 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add distinct to the query 
- [x] Add tests

### :camera: Screenshots (optional)
![Description](URL)
