### PR TITLE
Fix proposal date shown to published_at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - **decidim-assemblies**: Let space users access the admin area from the public one [\#3666](https://github.com/decidim/decidim/pull/3666)
 - **decidim-participatory_processes**: Let space users access the admin area from the public one [\#3666](https://github.com/decidim/decidim/pull/3666)
 - **decidim-core**: Fix comments count failing in AuthorCell [\#3668](https://github.com/decidim/decidim/pull/3668)
+- **decidim-proposals**: Fix proposal date to published_at in: card_m, details, admin and exporter [\#3649](https://github.com/decidim/decidim/pull/3649)
 
 **Removed**:
 

--- a/decidim-core/app/cells/decidim/author/date.erb
+++ b/decidim-core/app/cells/decidim/author/date.erb
@@ -1,5 +1,5 @@
 <% if creation_date? %>
   <span>
-    <%= l from_context.created_at, format: :decidim_short %> &nbsp;
+    <%= creation_date %> &nbsp;
   </span>
 <% end %>

--- a/decidim-core/app/cells/decidim/author_cell.rb
+++ b/decidim-core/app/cells/decidim/author_cell.rb
@@ -63,6 +63,16 @@ module Decidim
       true
     end
 
+    def creation_date
+      date_at = if proposals_controller?
+                  from_context.published_at
+                else
+                  from_context.created_at
+                end
+
+      l date_at, format: :decidim_short
+    end
+
     def commentable?
       return unless posts_controller?
       true

--- a/decidim-core/app/cells/decidim/card_m/status.erb
+++ b/decidim-core/app/cells/decidim/card_m/status.erb
@@ -1,7 +1,7 @@
 <div class="card__status">
   <ul class="card-data">
     <% statuses.each do |status_name| %>
-      <li class="card-data__item">
+      <li class="card-data__item <%= status_name %>_status">
         <%= send("#{status_name}_status") %>
       </li>
     <% end %>

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
@@ -36,6 +36,7 @@ module Decidim
       end
 
       def statuses
+        return [:endorsements_count, :comments_count] if model.draft?
         return [:creation_date, :endorsements_count, :comments_count] unless has_link_to_resource?
         [:creation_date, :follow, :endorsements_count, :comments_count]
       end

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
@@ -40,6 +40,10 @@ module Decidim
         [:creation_date, :follow, :endorsements_count, :comments_count]
       end
 
+      def creation_date_status
+        l(model.published_at.to_date, format: :decidim_short)
+      end
+
       def endorsements_count_status
         return endorsements_count unless has_link_to_resource?
 

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -55,7 +55,7 @@
             <% end %>
 
             <th>
-              <%= sort_link(query, :created_at, t("models.proposal.fields.created_at", scope: "decidim.proposals") ) %>
+              <%= sort_link(query, :published_at, t("models.proposal.fields.published_at", scope: "decidim.proposals") ) %>
             </th>
 
             <th class="actions"><%= t("actions.title", scope: "decidim.proposals") %></th>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -245,11 +245,11 @@ en:
           fields:
             category: Category
             comments: Comments
-            created_at: Created at
             endorsements: Endorsements
             id: ID
             notes: Notes
             official_proposal: Official proposal
+            published_at: Published at
             scope: Scope
             state: State
             title: Title

--- a/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
+++ b/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
@@ -28,7 +28,7 @@ module Decidim
           body: @proposal.body,
           votes: @proposal.proposal_votes_count,
           comments: @proposal.comments.count,
-          created_at: @proposal.created_at,
+          published_at: @proposal.published_at,
           url: url,
           component: { id: component.id },
           meeting_urls: meetings

--- a/decidim-proposals/spec/cells/decidim/proposals/proposal_m_cell_spec.rb
+++ b/decidim-proposals/spec/cells/decidim/proposals/proposal_m_cell_spec.rb
@@ -9,7 +9,9 @@ module Decidim::Proposals
     subject { my_cell.call }
 
     let(:my_cell) { cell("decidim/proposals/proposal_m", proposal) }
-    let!(:proposal) { create(:proposal) }
+    let(:created_at) { Time.current - 1.month }
+    let(:published_at) { Time.current }
+    let!(:proposal) { create(:proposal, created_at: created_at, published_at: published_at) }
     let(:user) { create :user, organization: proposal.participatory_space.organization }
 
     before do
@@ -19,6 +21,14 @@ module Decidim::Proposals
     context "when rendering" do
       it "renders the card" do
         expect(subject).to have_css(".card--proposal")
+      end
+
+      it "renders the published_at date" do
+        published_date = I18n.l(published_at.to_date, format: :decidim_short)
+        creation_date = I18n.l(created_at.to_date, format: :decidim_short)
+
+        expect(subject).to have_css(".creation_date_status", text: published_date)
+        expect(subject).not_to have_css(".creation_date_status", text: creation_date)
       end
     end
   end

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
@@ -58,7 +58,7 @@ module Decidim
         end
 
         it "serializes the date of creation" do
-          expect(serialized).to include(created_at: proposal.created_at)
+          expect(serialized).to include(published_at: proposal.published_at)
         end
 
         it "serializes the url" do

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -52,7 +52,7 @@ describe "Proposals", type: :system do
       expect(page).to have_content(proposal.body)
       expect(page).to have_author(proposal.author.name)
       expect(page).to have_content(proposal.reference)
-      expect(page).to have_creation_date(I18n.l(proposal.created_at, format: :decidim_short))
+      expect(page).to have_creation_date(I18n.l(proposal.published_at, format: :decidim_short))
     end
 
     context "when process is not related to any scope" do


### PR DESCRIPTION
#### :tophat: What? Why?

Creation date is shown for `Proposal` in: card, detail, admin component index and when exported.
But the relevant date is the Publication date, this PR solves this issues

#### :pushpin: Related Issues
- Fixes #3646

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Added test for `proposal_m_cell_spec.rb`
- [x] Updated test for `proposals_spec.rb`
- [x] modified form `created_at` to `published_at`:
  - proposal card_m
  - proposal author card 
  - proposal admin index
  - proposal serializer (export)

### :camera: Screenshots (optional)
