### PR TITLE
Use custom sanitizer everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 - **decidim-proposals**: Fix link to endorsements behaviour, now it does not link when there are no endorsements. [\#3531](https://github.com/decidim/decidim/pull/3531)
 - **decidim-meetings**: Fix meetings M card cell so that it works outside the component [\#3612](https://github.com/decidim/decidim/pull/3612)
 - **decidim-proposals**: Fix proposals M card cell so that it works outside the component [\#3612](https://github.com/decidim/decidim/pull/3612)
+- **decidim-blogs**: Use custom sanitizer in views instead of the default one [\#3655](https://github.com/decidim/decidim/pull/3655)
+- **decidim-core**: Use custom sanitizer in views instead of the default one [\#3655](https://github.com/decidim/decidim/pull/3655)
+- **decidim-initiatives**: Use custom sanitizer in views instead of the default one [\#3655](https://github.com/decidim/decidim/pull/3655)
+- **decidim-sortitions**: Use custom sanitizer in views instead of the default one [\#3655](https://github.com/decidim/decidim/pull/3655)
 
 **Removed**:
 

--- a/decidim-blogs/app/helpers/decidim/blogs/admin/posts_helper.rb
+++ b/decidim-blogs/app/helpers/decidim/blogs/admin/posts_helper.rb
@@ -6,8 +6,7 @@ module Decidim
       # Custom helpers used in posts views
       module PostsHelper
         include Decidim::ApplicationHelper
-        # include Decidim::TranslationsHelper
-        # include Decidim::ResourceHelper
+        include SanitizeHelper
 
         # Public: truncates the post body
         #

--- a/decidim-blogs/app/helpers/decidim/blogs/application_helper.rb
+++ b/decidim-blogs/app/helpers/decidim/blogs/application_helper.rb
@@ -6,6 +6,7 @@ module Decidim
     #
     module ApplicationHelper
       include PaginateHelper
+      include SanitizeHelper
       include Decidim::Blogs::PostsHelper
       include Decidim::Comments::CommentsHelper
     end

--- a/decidim-blogs/app/views/decidim/blogs/admin/posts/index.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/admin/posts/index.html.erb
@@ -26,7 +26,7 @@
                 <%= translated_attribute(post.title) %><br />
               </td>
               <td>
-                <%= sanitize post_description_admin(post) %>
+                <%= decidim_sanitize post_description_admin(post) %>
               </td>
               <td>
                 <%= post.try(:author).try(:name) %>

--- a/decidim-blogs/app/views/decidim/blogs/posts/_posts.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/posts/_posts.html.erb
@@ -12,7 +12,7 @@
             <%= cell "decidim/author", present(post.author), from: post %>
           </div>
         </div>
-        <%= sanitize post_description(post) %>
+        <%= decidim_sanitize post_description(post) %>
       </div>
     </article>
   <% end %>

--- a/decidim-blogs/app/views/decidim/blogs/posts/show.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/posts/show.html.erb
@@ -12,7 +12,7 @@
       <%= cell "decidim/author", present(post.author), from: post %>
     </div>
     <div class="section">
-      <p><%= sanitize translated_attribute post.body %></p>
+      <p><%= decidim_sanitize translated_attribute post.body %></p>
     </div>
   </div>
   <div id="most-commented" class="columns medium-5 mediumlarge-4 large-4">

--- a/decidim-core/app/views/decidim/pages/home/_highlighted_content_banner.html.erb
+++ b/decidim-core/app/views/decidim/pages/home/_highlighted_content_banner.html.erb
@@ -8,7 +8,7 @@
             <%= translated_attribute current_organization.highlighted_content_banner_title %>
           </h1>
           <span class="text-highlight">
-            <%= sanitize translated_attribute current_organization.highlighted_content_banner_short_description %>
+            <%= decidim_sanitize translated_attribute current_organization.highlighted_content_banner_short_description %>
           </span>
         </div>
         <div class="columns large-2">

--- a/decidim-initiatives/app/helpers/decidim/initiatives/initiative_helper.rb
+++ b/decidim-initiatives/app/helpers/decidim/initiatives/initiative_helper.rb
@@ -4,6 +4,8 @@ module Decidim
   module Initiatives
     # Helper method related to initiative object and its internal state.
     module InitiativeHelper
+      include Decidim::SanitizeHelper
+
       # Public: The css class applied based on the initiative state to
       #         the initiative badge.
       #

--- a/decidim-initiatives/app/mailers/decidim/initiatives/initiatives_mailer.rb
+++ b/decidim-initiatives/app/mailers/decidim/initiatives/initiatives_mailer.rb
@@ -5,8 +5,10 @@ module Decidim
     # Mailer for initiatives engine.
     class InitiativesMailer < Decidim::ApplicationMailer
       include Decidim::TranslatableAttributes
+      include Decidim::SanitizeHelper
 
       add_template_helper Decidim::TranslatableAttributes
+      add_template_helper Decidim::SanitizeHelper
 
       # Notifies initiative creation
       def notify_creation(initiative)

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/show.html.erb
@@ -100,7 +100,7 @@
 <%= translated_attribute(current_initiative.title) %>
 
 <h2 class="print-section-title">Definició de la Iniciativa:</h2>
-<%= sanitize translated_attribute(current_initiative.description) %>
+<%= decidim_sanitize translated_attribute(current_initiative.description) %>
 
 <h2 class="print-section-title">Exposició de motius:</h2>
 <br /><br /><br /><br /><br />

--- a/decidim-initiatives/app/views/decidim/initiatives/committee_requests/new.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/committee_requests/new.html.erb
@@ -18,7 +18,7 @@
 <div class="row">
   <div class="columns large-12">
     <div class="section">
-      <%= sanitize translated_attribute(current_initiative.description) %>
+      <%= decidim_sanitize translated_attribute(current_initiative.description) %>
     </div>
 
     <div class="section">

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_result.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_result.html.erb
@@ -6,10 +6,10 @@
       <p>
         <% if initiative.answer_url %>
           <a href="<%= initiative.answer_url %>" target="_blank">
-            <%= sanitize translated_attribute initiative.answer %>
+            <%= decidim_sanitize translated_attribute initiative.answer %>
           </a>
         <% else %>
-          <%= sanitize translated_attribute initiative.answer %>
+          <%= decidim_sanitize translated_attribute initiative.answer %>
         <% end %>
       </p>
     </div>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -55,7 +55,7 @@
       <br />
       <div class="row column">
         <%= render partial: "initiative_badge", locals: { initiative: current_initiative } %>
-        <%= sanitize translated_attribute(current_initiative.description) %>
+        <%= decidim_sanitize translated_attribute(current_initiative.description) %>
         <%= render partial: "tags", locals: { resource: current_initiative } %>
       </div>
 

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives_mailer/notify_progress.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives_mailer/notify_progress.html.erb
@@ -1,3 +1,3 @@
-<%= sanitize @body %>
+<%= decidim_sanitize @body %>
 <br /><br />
 <%= render partial: "initiative_link" %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives_mailer/notify_state_change.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives_mailer/notify_state_change.html.erb
@@ -1,3 +1,3 @@
-<%= sanitize @body %>
+<%= decidim_sanitize @body %>
 <br /><br />
 <%= render partial: "initiative_link" %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives_mailer/notify_validating_request.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives_mailer/notify_validating_request.html.erb
@@ -1,3 +1,3 @@
-<%= sanitize @body %>
+<%= decidim_sanitize @body %>
 <br /><br />
 <%= render partial: "initiative_link" %>

--- a/decidim-sortitions/app/views/decidim/sortitions/sortitions/show.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/sortitions/show.html.erb
@@ -1,5 +1,5 @@
 <% add_decidim_meta_tags({
-  description: sanitize(translated_attribute(sortition.additional_info)),
+  description: decidim_sanitize(translated_attribute(sortition.additional_info)),
   title: translated_attribute(sortition.title),
   url: sortition_url(sortition.to_param)
 }) %>
@@ -31,7 +31,7 @@
 
   <div class="columns mediumlarge-8 mediumlarge-pull-4">
     <div class="section">
-      <%= sanitize translated_attribute sortition.additional_info %>
+      <%= decidim_sanitize translated_attribute sortition.additional_info %>
     </div>
   </div>
 </div>
@@ -47,7 +47,7 @@
     </div>
   </div>
   <div class=section>
-    <%= sanitize translated_attribute sortition.cancel_reason %>
+    <%= decidim_sanitize translated_attribute sortition.cancel_reason %>
   </div>
 </div>
 <% end %>
@@ -57,7 +57,7 @@
     <h2 class="title-action__title section-heading"><%= t ".witnesses" %></h2>
   </div>
   <div class="section">
-    <%= sanitize translated_attribute sortition.witnesses %>
+    <%= decidim_sanitize translated_attribute sortition.witnesses %>
   </div>
 </div>
 


### PR DESCRIPTION
#### :tophat: What? Why?
In some points we're not using the custom sanitizer to render user-inputted HTML. This causes some elements not being rendered (eg. embedded videos).

This PR fixes this problem.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
