### PR TITLE
Add missing features to components migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **decidim-generators**: Dummy applications not being correctly generated for external plugins. [\#3470](https://github.com/decidim/decidim/pull/3470)
 - **decidim-generators**: Dummy applications not being correctly generated for final applications. [\#3527](https://github.com/decidim/decidim/pull/3527)
 - **decidim-core**: Data picker form inputs having no bottom margin. [\#3463](https://github.com/decidim/decidim/pull/3463)
+- **decidim-core**: Adds a missing migration to properly rename features to components [\#3656](https://github.com/decidim/decidim/pull/3656)
 
 ## [0.11.1](https://github.com/decidim/decidim/tree/v0.11.1)
 

--- a/decidim-core/db/migrate/20180613080638_rename_missing_features_to_components.rb
+++ b/decidim-core/db/migrate/20180613080638_rename_missing_features_to_components.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class RenameMissingFeaturesToComponents < ActiveRecord::Migration[5.1]
+  class Notification < ApplicationRecord
+    self.table_name = :decidim_notifications
+  end
+
+  def up
+    # rubocop:disable Rails/SkipsModelValidations
+    Notification.where(decidim_resource_type: "Decidim::Feature").update_all(decidim_resource_type: "Decidim::Component")
+    Notification.where(event_class: "Decidim::FeaturePublishedEvent").update_all(event_class: "Decidim::ComponentPublishedEvent")
+    Notification.where(event_name: "decidim.events.features.feature_published").update_all(event_name: "decidim.events.components.component_published")
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Adds a missing migration to properly rename features to components.

#### :pushpin: Related Issues
- Related to #2913

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
*None*
