### PR TITLE
Let space users access the admin section from the public part

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 - **decidim-core**: Use custom sanitizer in views instead of the default one [\#3655](https://github.com/decidim/decidim/pull/3655)
 - **decidim-initiatives**: Use custom sanitizer in views instead of the default one [\#3655](https://github.com/decidim/decidim/pull/3655)
 - **decidim-sortitions**: Use custom sanitizer in views instead of the default one [\#3655](https://github.com/decidim/decidim/pull/3655)
+- **decidim-assemblies**: Let space users access the admin area from the public one [\#3666](https://github.com/decidim/decidim/pull/3666)
+- **decidim-participatory_processes**: Let space users access the admin area from the public one [\#3666](https://github.com/decidim/decidim/pull/3666)
 
 **Removed**:
 

--- a/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
+++ b/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
@@ -8,6 +8,11 @@ module Decidim
 
         return permission_action if assembly && !assembly.is_a?(Decidim::Assembly)
 
+        if read_admin_dashboard_action?
+          user_can_read_admin_dashboard?
+          return permission_action
+        end
+
         if permission_action.scope == :public
           public_list_assemblies_action?
           public_read_assembly_action?
@@ -22,11 +27,6 @@ module Decidim
           return permission_action
         end
         return permission_action unless permission_action.scope == :admin
-
-        if read_admin_dashboard_action?
-          user_can_read_admin_dashboard?
-          return permission_action
-        end
 
         user_can_read_assembly_list?
         user_can_read_current_assembly?

--- a/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
+++ b/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
@@ -50,6 +50,14 @@ describe Decidim::Assemblies::Permissions do
   end
 
   context "when the action is for the public part" do
+    context "when reading the admin dashboard" do
+      let(:action) do
+        { scope: :admin, action: :read, subject: :admin_dashboard }
+      end
+
+      it_behaves_like "access for roles", org_admin: true, admin: true, collaborator: true, moderator: true
+    end
+
     context "when reading a assembly" do
       let(:action) do
         { scope: :public, action: :read, subject: :assembly }
@@ -145,7 +153,7 @@ describe Decidim::Assemblies::Permissions do
     it_behaves_like "access for roles", org_admin: true, admin: true, collaborator: true, moderator: true
   end
 
-  context "when reading the admin dashboard" do
+  context "when reading the admin dashboard from the admin part" do
     let(:action) do
       { scope: :admin, action: :read, subject: :admin_dashboard }
     end

--- a/decidim-participatory_processes/app/permissions/decidim/participatory_processes/permissions.rb
+++ b/decidim-participatory_processes/app/permissions/decidim/participatory_processes/permissions.rb
@@ -9,6 +9,11 @@ module Decidim
 
         return permission_action if process && !process.is_a?(Decidim::ParticipatoryProcess)
 
+        if read_admin_dashboard_action?
+          user_can_read_admin_dashboard?
+          return permission_action
+        end
+
         if permission_action.scope == :public
           public_list_processes_action?
           public_list_process_groups_action?
@@ -26,11 +31,6 @@ module Decidim
         return permission_action unless permission_action.scope == :admin
 
         valid_process_group_action?
-
-        if read_admin_dashboard_action?
-          user_can_read_admin_dashboard?
-          return permission_action
-        end
 
         user_can_read_process_list?
         user_can_read_current_process?

--- a/decidim-participatory_processes/spec/permissions/decidim/participatory_processes/permissions_spec.rb
+++ b/decidim-participatory_processes/spec/permissions/decidim/participatory_processes/permissions_spec.rb
@@ -49,6 +49,14 @@ describe Decidim::ParticipatoryProcesses::Permissions do
   end
 
   context "when the action is for the public part" do
+    context "when reading the admin dashboard" do
+      let(:action) do
+        { scope: :public, action: :read, subject: :admin_dashboard }
+      end
+
+      it_behaves_like "access for roles", org_admin: true, admin: true, collaborator: true, moderator: true
+    end
+
     context "when reading a process" do
       let(:action) do
         { scope: :public, action: :read, subject: :process }
@@ -144,7 +152,7 @@ describe Decidim::ParticipatoryProcesses::Permissions do
     it_behaves_like "access for roles", org_admin: true, admin: true, collaborator: true, moderator: true
   end
 
-  context "when reading the admin dashboard" do
+  context "when reading the admin dashboard from the admin part" do
     let(:action) do
       { scope: :admin, action: :read, subject: :admin_dashboard }
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Space users (process admins, assembly admins, etc) can't access the admin part from the UI because the link does not appear.

This PR fixes the permissions for both processes and assemblies so that this doesn't happen again, and adds some tests to ensure this is not repeated in the future.

#### :pushpin: Related Issues
- Related to #3029

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry


### :camera: Screenshots (optional)
An example of a process admin being able to access the admin section. Note the email of the current user (that's a seed user)
![Description](https://i.imgur.com/whcII1k.png)


