### PR TITLE
Let nicknames be scoped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - **decidim-participatory_processes**: Make process moderators receive notifications about flagged content [\#3605](https://github.com/decidim/decidim/pull/3605)
 - **decidim-meetings**: Do not let users join a meeting from the Search page, as the button fails [\#3612](https://github.com/decidim/decidim/pull/3612)
+- **decidim-core**: Scope nicknames in organizations, so they don't have to be unique in a multi-tenant setup [\#3671](https://github.com/decidim/decidim/pull/3671)
 
 **Fixed**:
 

--- a/decidim-core/app/commands/decidim/invite_user.rb
+++ b/decidim-core/app/commands/decidim/invite_user.rb
@@ -43,7 +43,7 @@ module Decidim
       @user = Decidim::User.new(
         name: form.name,
         email: form.email.downcase,
-        nickname: User.nicknamize(form.name),
+        nickname: User.nicknamize(form.name, organization: form.organization),
         organization: form.organization,
         admin: form.role == "admin",
         roles: form.role == "admin" ? [] : [form.role].compact

--- a/decidim-core/app/forms/decidim/omniauth_registration_form.rb
+++ b/decidim-core/app/forms/decidim/omniauth_registration_form.rb
@@ -24,7 +24,7 @@ module Decidim
     end
 
     def normalized_nickname
-      User.nicknamize(nickname || name)
+      User.nicknamize(nickname || name, organization: current_organization)
     end
   end
 end

--- a/decidim-core/db/migrate/20171212103803_create_unique_nicknames.rb
+++ b/decidim-core/db/migrate/20171212103803_create_unique_nicknames.rb
@@ -11,7 +11,7 @@ class CreateUniqueNicknames < ActiveRecord::Migration[5.1]
     add_column :decidim_users, :nickname, :string, limit: 20
 
     User.where.not(name: nil).find_each do |user|
-      user.update!(nickname: User.nicknamize(user.name))
+      user.update!(nickname: User.nicknamize(user.name, decidim_organization_id: user.decidim_organization_id))
     end
 
     add_index :decidim_users,

--- a/decidim-core/db/migrate/20180221101934_fix_nickname_index.rb
+++ b/decidim-core/db/migrate/20180221101934_fix_nickname_index.rb
@@ -4,7 +4,7 @@ class FixNicknameIndex < ActiveRecord::Migration[5.1]
   class User < ApplicationRecord
     self.table_name = :decidim_users
 
-    include Decidim::Nicknamize
+    include Decidim::Nicknamizable
   end
 
   def change

--- a/decidim-core/db/migrate/20180221101934_fix_nickname_index.rb
+++ b/decidim-core/db/migrate/20180221101934_fix_nickname_index.rb
@@ -3,13 +3,15 @@
 class FixNicknameIndex < ActiveRecord::Migration[5.1]
   class User < ApplicationRecord
     self.table_name = :decidim_users
+
+    include Decidim::Nicknamize
   end
 
   def change
     User.where(nickname: nil)
         .where(deleted_at: nil)
         .where(managed: false)
-        .find_each { |u| u.update(nickname: User.nicknamize(u.name)) }
+        .find_each { |u| u.update(nickname: User.nicknamize(u.name, decidim_organization_id: u.decidim_organization_id)) }
 
     # rubocop:disable Rails/SkipsModelValidations
     User.where(nickname: nil).update_all("nickname = ''")

--- a/decidim-core/lib/decidim/nicknamizable.rb
+++ b/decidim-core/lib/decidim/nicknamizable.rb
@@ -26,9 +26,19 @@ module Decidim
       # * Trims length so it fits validation constraints.
       # * Disambiguates it so it's unique.
       #
-      def nicknamize(name)
+      # name - the String to nicknamize
+      # scope - a Hash with extra values to scope the nickname to
+      #
+      # Example to nicknamize a user name, scoped to the organization:
+      #
+      #    nicknamize(user_name, organization: current_organization)
+      #
+      def nicknamize(name, scope = {})
         return unless name
-        disambiguate(name.parameterize(separator: "_")[nickname_length_range])
+        disambiguate(
+          name.parameterize(separator: "_")[nickname_length_range],
+          scope
+        )
       end
 
       private
@@ -37,11 +47,11 @@ module Decidim
         (0...nickname_max_length)
       end
 
-      def disambiguate(name)
+      def disambiguate(name, scope)
         candidate = name
 
         2.step do |n|
-          return candidate unless exists?(nickname: candidate)
+          return candidate unless exists?(scope.merge(nickname: candidate))
 
           candidate = numbered_variation_of(name, n)
         end

--- a/decidim-core/spec/lib/nicknamizable_spec.rb
+++ b/decidim-core/spec/lib/nicknamizable_spec.rb
@@ -18,6 +18,21 @@ module Decidim
     end
 
     describe "#nicknamize" do
+      context "when a scope is provided" do
+        it "resolves conflicts with nicknames outside the scope" do
+          another_user = create(:user, nickname: "ana_pastor")
+          another_org_id = another_user.decidim_organization_id
+
+          expect(subject.nicknamize("ana_pastor", decidim_organization_id: another_org_id + 1)).to eq("ana_pastor")
+        end
+      end
+
+      it "resolves conflicts with current nicknames" do
+        create(:user, nickname: "ana_pastor")
+
+        expect(subject.nicknamize("ana_pastor")).to eq("ana_pastor_2")
+      end
+
       it "copies non-duplicated usernames following slugization rules" do
         expect(subject.nicknamize("peter")).to eq("peter")
       end

--- a/decidim-core/spec/lib/nicknamizable_spec.rb
+++ b/decidim-core/spec/lib/nicknamizable_spec.rb
@@ -27,12 +27,6 @@ module Decidim
         end
       end
 
-      it "resolves conflicts with current nicknames" do
-        create(:user, nickname: "ana_pastor")
-
-        expect(subject.nicknamize("ana_pastor")).to eq("ana_pastor_2")
-      end
-
       it "copies non-duplicated usernames following slugization rules" do
         expect(subject.nicknamize("peter")).to eq("peter")
       end

--- a/decidim-meetings/app/commands/decidim/meetings/admin/invite_user_to_join_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/invite_user_to_join_meeting.rb
@@ -40,7 +40,7 @@ module Decidim
             InviteJoinMeetingMailer.invite(user, meeting, invited_by).deliver_later
           else
             user.name = form.name
-            user.nickname = User.nicknamize(user.name)
+            user.nickname = User.nicknamize(user.name, organization: user.organization)
             user.skip_reconfirmation!
             user.invite!(invited_by, invitation_instructions: "join_meeting", meeting: meeting)
           end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR lets the `Nicknamizable` module accept scopes so that nicknames don't have to be unique per installation. This allows the same person, in a multi-tenant installation, use the same nickname in different orgs.

#### :pushpin: Related Issues
- Fixes #3533

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
