### PR TITLE
Fix modal styles from signup and tos 

### DIFF
--- a/decidim-core/app/cells/decidim/tos_page/refuse_btn_modal.erb
+++ b/decidim-core/app/cells/decidim/tos_page/refuse_btn_modal.erb
@@ -15,11 +15,9 @@
   </div>
 
   <div class="row">
-    <div>
-      <p>
-        <%= t("refuse.modal_body", scope: "decidim.pages.terms_and_conditions", data_portability_path: decidim.data_portability_path, delete_path: decidim.delete_account_path) %>
-      </p>
-    </div>
+    <p>
+      <%= t("refuse.modal_body", scope: "decidim.pages.terms_and_conditions", data_portability_path: decidim.data_portability_path, delete_path: decidim.delete_account_path) %>
+    </p>
   </div>
 
   <div class="row">

--- a/decidim-core/app/cells/decidim/tos_page/refuse_btn_modal.erb
+++ b/decidim-core/app/cells/decidim/tos_page/refuse_btn_modal.erb
@@ -2,22 +2,39 @@
   <%= t("refuse.modal_button", scope: "decidim.pages.terms_and_conditions") %>
 </button>
 
-<div id="tos-refuse-modal" class="reveal" data-reveal aria-labelledby="#{modal_title}" aria-hidden="true" role="dialog">
-  <h2>
-    <%= t("refuse.modal_title", scope: "decidim.pages.terms_and_conditions") %>
-  </h2>
+<div id="tos-refuse-modal" class="reveal" data-reveal aria-labelledby="<%= t("refuse.modal_title", scope: "decidim.pages.terms_and_conditions") %>" aria-hidden="true" role="dialog">
+  <div class="reveal__header">
+    <h3 class="reveal__title">
+      <%= t("refuse.modal_title", scope: "decidim.pages.terms_and_conditions") %>
+    </h3>
 
-  <p>
-    <%= t("refuse.modal_body", scope: "decidim.pages.terms_and_conditions", data_portability_path: decidim.data_portability_path, delete_path: decidim.delete_account_path) %>
-  </p>
+    <button class="close-button" data-close aria-label="<%= t("refuse.modal_close", scope: "decidim.pages.terms_and_conditions") %>"
+      type="button">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
 
-  <div class="row column flex-center">
-    <%= button_to decidim.destroy_user_session_path, method: :delete, class: "clear button secondary button--nomargin small" do %>
-      <%= t("refuse.modal_btn_exit", scope: "decidim.pages.terms_and_conditions") %>
-    <% end %>
+  <div class="row">
+    <div>
+      <p>
+        <%= t("refuse.modal_body", scope: "decidim.pages.terms_and_conditions", data_portability_path: decidim.data_portability_path, delete_path: decidim.delete_account_path) %>
+      </p>
+    </div>
 
-    <%= button_to decidim.accept_tos_path, method: :put, class: "button button--nomargin small" do %>
-      <%= t("refuse.modal_btn_continue", scope: "decidim.pages.terms_and_conditions") %>
-    <% end %>
+    <div class="columns medium-10 medium-centered">
+      <div class="row">
+        <div class="columns medium-6">
+          <%= button_to decidim.destroy_user_session_path, method: :delete, class: "clear button secondary expanded" do %>
+            <%= t("refuse.modal_btn_exit", scope: "decidim.pages.terms_and_conditions") %>
+          <% end %>
+        </div>
+
+        <div class="columns medium-6">
+          <%= button_to decidim.accept_tos_path, method: :put, class: "button expanded" do %>
+            <%= t("refuse.modal_btn_continue", scope: "decidim.pages.terms_and_conditions") %>
+          <% end %>
+        </div>
+      </div>
+    </div>
   </div>
 </div>

--- a/decidim-core/app/cells/decidim/tos_page/refuse_btn_modal.erb
+++ b/decidim-core/app/cells/decidim/tos_page/refuse_btn_modal.erb
@@ -20,21 +20,17 @@
         <%= t("refuse.modal_body", scope: "decidim.pages.terms_and_conditions", data_portability_path: decidim.data_portability_path, delete_path: decidim.delete_account_path) %>
       </p>
     </div>
+  </div>
 
-    <div class="columns medium-10 medium-centered">
-      <div class="row">
-        <div class="columns medium-6">
-          <%= button_to decidim.destroy_user_session_path, method: :delete, class: "clear button secondary expanded" do %>
-            <%= t("refuse.modal_btn_exit", scope: "decidim.pages.terms_and_conditions") %>
-          <% end %>
-        </div>
+  <div class="row">
+    <div class="column flex-center">
+      <%= button_to decidim.destroy_user_session_path, method: :delete, class: "clear button secondary expanded" do %>
+        <%= t("refuse.modal_btn_exit", scope: "decidim.pages.terms_and_conditions") %>
+      <% end %>
 
-        <div class="columns medium-6">
-          <%= button_to decidim.accept_tos_path, method: :put, class: "button expanded" do %>
-            <%= t("refuse.modal_btn_continue", scope: "decidim.pages.terms_and_conditions") %>
-          <% end %>
-        </div>
-      </div>
+      <%= button_to decidim.accept_tos_path, method: :put, class: "button expanded" do %>
+        <%= t("refuse.modal_btn_continue", scope: "decidim.pages.terms_and_conditions") %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/decidim-core/app/views/decidim/devise/shared/_newsletter_modal.html.erb
+++ b/decidim-core/app/views/decidim/devise/shared/_newsletter_modal.html.erb
@@ -8,9 +8,7 @@
   </div>
 
   <div class="row">
-    <div>
-      <%= t(".notice").html_safe %>
-    </div>
+    <%= t(".notice").html_safe %>
   </div>
 
   <div class="row">

--- a/decidim-core/app/views/decidim/devise/shared/_newsletter_modal.html.erb
+++ b/decidim-core/app/views/decidim/devise/shared/_newsletter_modal.html.erb
@@ -1,15 +1,15 @@
 <div class="reveal" id="sign-up-newsletter-modal" data-reveal>
   <div class="reveal__header">
     <h3 class="reveal__title"><%= t(".title") %></h3>
-    <button class="close-button" data-close aria-label="Close modal"
+    <button class="close-button" data-close aria-label="<%= t(".buttons.close_modal") %>"
       type="button">
       <span aria-hidden="true">&times;</span>
     </button>
   </div>
 
   <div class="row">
-    <div class="columns medium-10 medium-centered">
-      <p><%= t(".notice") %></p>
+    <div>
+      <%= t(".notice").html_safe %>
     </div>
     <div class="columns medium-10 medium-centered">
       <div class="row">

--- a/decidim-core/app/views/decidim/devise/shared/_newsletter_modal.html.erb
+++ b/decidim-core/app/views/decidim/devise/shared/_newsletter_modal.html.erb
@@ -11,15 +11,17 @@
     <div>
       <%= t(".notice").html_safe %>
     </div>
-    <div class="columns medium-10 medium-centered">
-      <div class="row">
-        <div class="columns medium-6">
-          <button type="buton" class="check-newsletter clear button secondary expanded" data-check=false><%= t(".buttons.uncheck") %></button>
-        </div>
-        <div class="columns medium-6">
-          <button type="buton" class="check-newsletter button expanded" data-check=true><%= t(".buttons.check") %></button>
-        </div>
-      </div>
+  </div>
+
+  <div class="row">
+    <div class="column flex-center">
+      <button type="buton" class="check-newsletter clear button secondary expanded" data-check=false>
+        <%= t(".buttons.uncheck") %>
+      </button>
+
+      <button type="buton" class="check-newsletter button expanded" data-check=true>
+        <%= t(".buttons.check") %>
+      </button>
     </div>
   </div>
 </div>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -474,6 +474,7 @@ en:
           modal_btn_continue: Accept terms and continue
           modal_btn_exit: I'll review it later
           modal_button: Refuse the terms
+          modal_close: Close modal
           modal_title: Do you really refuse the updated Terms and Conditions?
         required_review:
           alert: We've updated our Terms of Service, please review them.

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -225,8 +225,19 @@ en:
         newsletter_modal:
           buttons:
             check: Check and continue
+            close_modal: Close modal
             uncheck: Keep uncheck
-          notice: Hey, are you sure you don't want to receive a newsletter? Please consider again ticking the newsletter checkbox below. It is very important for us that you can receive occasional emails to make important announcements, you can always change this on your notifications settings page. If you don't tick the box you might be missing relevant information about new participatory opportunities within the platform. If you still want to avoid receiving newsletters, we perfectly understand your decision. Thanks for reading this!
+          notice: |-
+            <p>Hey, are you sure you don't want to receive a newsletter?<br>
+            Please consider again ticking the newsletter checkbox below.<br>
+            It is very important for us that you can receive occasional emails
+            to make important announcements, you can always change this on your
+            notifications settings page.</p>
+            <p>If you don't tick the box you might be missing relevant information
+            about new participatory opportunities within the platform.<br>
+            If you still want to avoid receiving newsletters, we perfectly
+            understand your decision.</p>
+            <p>Thanks for reading this!</p>
           title: Newsletter notifications
         omniauth_buttons:
           or: Or


### PR DESCRIPTION
#### :tophat: What? Why?

Fix styles from modals:

- newsletter modal from sigup page
- refuse tos modal from terms-and-conditions page

#### :pushpin: Related Issues
- Fixes #3667

#### :clipboard: Subtasks
- [x] newsletter modal
- [x] refuse tos modal

### :camera: Screenshots (optional)

- newsletter modal from sigup page (before/after):
  ![screenshot from 2018-06-15 14-07-46](https://user-images.githubusercontent.com/210216/41468415-3c07e626-70aa-11e8-8153-32275f9ab837.png)

- refuse tos modal from terms-and-conditions page (before/after):
  ![screenshot from 2018-06-15 14-25-28](https://user-images.githubusercontent.com/210216/41468426-43dea29a-70aa-11e8-849e-3e3bb435b42e.png)



