### PR TITLE
Fix space permissions

### DIFF
--- a/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
+++ b/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
@@ -126,7 +126,7 @@ module Decidim
 
       # Any user that can enter the space area can read the admin dashboard.
       def user_can_read_admin_dashboard?
-        toggle_allow(user.admin? || has_manageable_assemblies?)
+        allow! if user.admin? || has_manageable_assemblies?
       end
 
       # Only organization admins can create a assembly

--- a/decidim-participatory_processes/app/permissions/decidim/participatory_processes/permissions.rb
+++ b/decidim-participatory_processes/app/permissions/decidim/participatory_processes/permissions.rb
@@ -153,7 +153,7 @@ module Decidim
 
       # Any user that can enter the space area can read the admin dashboard.
       def user_can_read_admin_dashboard?
-        toggle_allow(user.admin? || has_manageable_processes?)
+        allow! if user.admin? || has_manageable_processes?
       end
 
       # Only organization admins can create a process


### PR DESCRIPTION
#### :tophat: What? Why?
When a user can manage an assembly, they cannot visit any process because the permissions behave weirdly.

This is related to #3666.

#### :pushpin: Related Issues
- Related to #3666

#### :clipboard: Subtasks
No need for a CHANGELOG entry since #3666 has not yet been released.