### PR TITLE
Add readonly attribute to date_field so that user can not fill it manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Decidim::Organization.find_each { |organization| Decidim::System::CreateDefaultP
 
 **Added**:
 
+**decidim-core**: Add readonly attribute to date_fields so that the user is forced to use the datepicker. [#3705](https://github.com/CodiTramuntana/decidim/pull/3705)
 - **decidim-core**: Added a global search engine for Proposals and Meetings. [\#3559](https://github.com/decidim/decidim/pull/3559)
 - **decidim-meetings**: Add Agenda and Agenda Item entities to manage meeting agenda. [\#3305](https://github.com/decidim/decidim/pull/3305)
 - **decidim-docs**: Add documentation for developers getting started. [\#3297](https://github.com/decidim/decidim/pull/3297)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ Decidim::Organization.find_each { |organization| Decidim::System::CreateDefaultP
 
 **Added**:
 
-**decidim-core**: Add readonly attribute to date_fields so that the user is forced to use the datepicker. [#3705](https://github.com/CodiTramuntana/decidim/pull/3705)
+**decidim-core**: Add readonly attribute to date_fields so that the user is forced to use the datepicker. [#3705](https://github.com/decidim/decidim/pull/3705)
 - **decidim-core**: Added a global search engine for Proposals and Meetings. [\#3559](https://github.com/decidim/decidim/pull/3559)
 - **decidim-meetings**: Add Agenda and Agenda Item entities to manage meeting agenda. [\#3305](https://github.com/decidim/decidim/pull/3305)
 - **decidim-docs**: Add documentation for developers getting started. [\#3297](https://github.com/decidim/decidim/pull/3297)

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -261,7 +261,8 @@ module Decidim
         attribute,
         options.merge(name: nil,
                       id: "date_field_#{@object_name}_#{attribute}",
-                      data: data)
+                      data: data,
+                      readonly: true)
       )
       template += @template.hidden_field(@object_name, attribute, value: iso_value)
       template += error_and_help_text(attribute, options)


### PR DESCRIPTION
#### :tophat: What? Why?
On the public side, in a date_field field if the date is entered manually (without using the calendar widget) this is not copied to the value of the hidden input that is sent.
By making the visible text field readonly the user will be forced to use the calendar widget avoiding the problem.

This is a fast bugfix expected to be added to 0.12.1. Will work on a better solution for 0.13.0.

#### :pushpin: Related Issues
- Fixes #3574 partially

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [-] Add documentation regarding the feature 
- [-] Add/modify seeds
- [-] Add tests

### :camera: Screenshots (optional)
![Description](URL)
