### PR TITLE
[Backport] Let assembly admins access all sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,16 +179,6 @@ Decidim::Organization.find_each { |organization| Decidim::System::CreateDefaultP
 - **decidim-initiatives**: Use custom sanitizer in views instead of the default one [\#3659](https://github.com/decidim/decidim/pull/3659)
 - **decidim-sortitions**: Use custom sanitizer in views instead of the default one [\#3659](https://github.com/decidim/decidim/pull/3659)
 - **decidim-assemblies**: Let space users access the admin area from the public one [\#3666](https://github.com/decidim/decidim/pull/3683)
-- **decidim-participatory_processes**: Let space users access the admin area from the public one [\#3666](https://github.com/decidim/decidim/pull/3683)
-- **decidim-core**: Adds a missing migration to properly rename features to components [\#3657](https://github.com/decidim/decidim/pull/3657)
-- **decidim-blogs**: Use custom sanitizer in views instead of the default one [\#3655](https://github.com/decidim/decidim/pull/3655)
-- **decidim-core**: Use custom sanitizer in views instead of the default one [\#3655](https://github.com/decidim/decidim/pull/3655)
-- **decidim-initiatives**: Use custom sanitizer in views instead of the default one [\#3655](https://github.com/decidim/decidim/pull/3655)
-- **decidim-sortitions**: Use custom sanitizer in views instead of the default one [\#3655](https://github.com/decidim/decidim/pull/3655)
-- **decidim-assemblies**: Let space users access the admin area from the public one [\#3666](https://github.com/decidim/decidim/pull/3666)
-- **decidim-participatory_processes**: Let space users access the admin area from the public one [\#3666](https://github.com/decidim/decidim/pull/3666)
-- **decidim-core**: Fix comments count failing in AuthorCell [\#3668](https://github.com/decidim/decidim/pull/3668)
-- **decidim-proposals**: Fix proposal date to published_at in: card_m, details, admin and exporter [\#3649](https://github.com/decidim/decidim/pull/3649)
 - **decidim-assemblies**: Let assembly admins access all content [\#3706](https://github.com/decidim/decidim/pull/3706)
 
 **Removed**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,16 @@ Decidim::Organization.find_each { |organization| Decidim::System::CreateDefaultP
 - **decidim-sortitions**: Use custom sanitizer in views instead of the default one [\#3659](https://github.com/decidim/decidim/pull/3659)
 - **decidim-assemblies**: Let space users access the admin area from the public one [\#3666](https://github.com/decidim/decidim/pull/3683)
 - **decidim-participatory_processes**: Let space users access the admin area from the public one [\#3666](https://github.com/decidim/decidim/pull/3683)
+- **decidim-core**: Adds a missing migration to properly rename features to components [\#3657](https://github.com/decidim/decidim/pull/3657)
+- **decidim-blogs**: Use custom sanitizer in views instead of the default one [\#3655](https://github.com/decidim/decidim/pull/3655)
+- **decidim-core**: Use custom sanitizer in views instead of the default one [\#3655](https://github.com/decidim/decidim/pull/3655)
+- **decidim-initiatives**: Use custom sanitizer in views instead of the default one [\#3655](https://github.com/decidim/decidim/pull/3655)
+- **decidim-sortitions**: Use custom sanitizer in views instead of the default one [\#3655](https://github.com/decidim/decidim/pull/3655)
+- **decidim-assemblies**: Let space users access the admin area from the public one [\#3666](https://github.com/decidim/decidim/pull/3666)
+- **decidim-participatory_processes**: Let space users access the admin area from the public one [\#3666](https://github.com/decidim/decidim/pull/3666)
+- **decidim-core**: Fix comments count failing in AuthorCell [\#3668](https://github.com/decidim/decidim/pull/3668)
+- **decidim-proposals**: Fix proposal date to published_at in: card_m, details, admin and exporter [\#3649](https://github.com/decidim/decidim/pull/3649)
+- **decidim-assemblies**: Let assembly admins access all content [\#3706](https://github.com/decidim/decidim/pull/3706)
 
 **Removed**:
 

--- a/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
+++ b/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
@@ -192,7 +192,8 @@ module Decidim
           :moderation,
           :assembly,
           :assembly_user_role,
-          :assembly_member
+          :assembly_member,
+          :space_private_user
         ].include?(permission_action.subject)
         allow! if is_allowed
       end

--- a/decidim-assemblies/app/views/layouts/decidim/admin/assembly.html.erb
+++ b/decidim-assemblies/app/views/layouts/decidim/admin/assembly.html.erb
@@ -6,7 +6,7 @@
           <%= aria_selected_link_to t("info", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.edit_assembly_path(current_participatory_space) %>
         </li>
       <% end %>
-      <% if allowed_to? :read, :component %>
+      <% if allowed_to? :read, :component, assembly: current_participatory_space %>
         <li <% if is_active_link?(decidim_admin_assemblies.components_path(current_participatory_space)) %> class="is-active" <% end %>>
           <%= aria_selected_link_to t("components", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.components_path(current_participatory_space) %>
           <ul>
@@ -25,21 +25,21 @@
           </ul>
         </li>
       <% end %>
-      <% if allowed_to? :read, :category %>
+      <% if allowed_to? :read, :category, assembly: current_participatory_space %>
         <li <% if is_active_link?(decidim_admin_assemblies.categories_path(current_participatory_space)) %> class="is-active" <% end %>>
           <%= aria_selected_link_to t("categories", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.categories_path(current_participatory_space) %>
         </li>
       <% end %>
-      <% if allowed_to?(:read, :attachment_collection) || allowed_to?(:read, :attachment) %>
+      <% if allowed_to?(:read, :attachment_collection, assembly: current_participatory_space) || allowed_to?(:read, :attachment, assembly: current_participatory_space) %>
         <li>
           <span class="secondary-nav__subtitle"><%= t("attachments", scope: "decidim.admin.menu.assemblies_submenu") %></span>
           <ul>
-            <% if allowed_to? :read, :attachment_collection %>
+            <% if allowed_to? :read, :attachment_collection, assembly: current_participatory_space %>
               <li <% if is_active_link?(decidim_admin_assemblies.assembly_attachment_collections_path(current_participatory_space)) %> class="is-active" <% end %>>
                 <%= aria_selected_link_to t("attachment_collections", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.assembly_attachment_collections_path(current_participatory_space) %>
               </li>
             <% end %>
-            <% if allowed_to? :read, :attachment %>
+            <% if allowed_to? :read, :attachment, assembly: current_participatory_space %>
               <li <% if is_active_link?(decidim_admin_assemblies.assembly_attachments_path(current_participatory_space)) %> class="is-active" <% end %>>
                 <%= aria_selected_link_to t("attachment_files", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.assembly_attachments_path(current_participatory_space) %>
               </li>
@@ -47,22 +47,22 @@
           </ul>
         </li>
       <% end %>
-      <% if allowed_to? :read, :assembly_member %>
+      <% if allowed_to? :read, :assembly_member, assembly: current_participatory_space %>
         <li <% if is_active_link?(decidim_admin_assemblies.assembly_members_path(current_participatory_space)) %> class="is-active" <% end %>>
           <%= aria_selected_link_to t("assembly_members", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.assembly_members_path(current_participatory_space) %>
         </li>
       <% end %>
-      <% if allowed_to? :read, :assembly_user_role %>
+      <% if allowed_to? :read, :assembly_user_role, assembly: current_participatory_space %>
         <li <% if is_active_link?(decidim_admin_assemblies.assembly_user_roles_path(current_participatory_space)) %> class="is-active" <% end %>>
           <%= aria_selected_link_to t("assembly_admins", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.assembly_user_roles_path(current_participatory_space) %>
         </li>
       <% end %>
-      <% if allowed_to? :read, :space_private_user %>
+      <% if allowed_to? :read, :space_private_user, assembly: current_participatory_space %>
         <li <% if is_active_link?(decidim_admin_assemblies.participatory_space_private_users_path(current_participatory_space)) %> class="is-active" <% end %>>
           <%= aria_selected_link_to t("private_users", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.participatory_space_private_users_path(current_participatory_space) %>
         </li>
       <% end %>
-      <% if allowed_to? :read, :moderation %>
+      <% if allowed_to? :read, :moderation, assembly: current_participatory_space %>
         <li <% if is_active_link?(decidim_admin_assemblies.moderations_path(current_participatory_space)) %> class="is-active" <% end %>>
           <%= aria_selected_link_to t("moderations", scope: "decidim.admin.menu.assemblies_submenu"), decidim_admin_assemblies.moderations_path(current_participatory_space) %>
         </li>

--- a/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
+++ b/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
@@ -296,6 +296,7 @@ describe Decidim::Assemblies::Permissions do
       it_behaves_like "allows any action on subject", :assembly
       it_behaves_like "allows any action on subject", :assembly_member
       it_behaves_like "allows any action on subject", :assembly_user_role
+      it_behaves_like "allows any action on subject", :space_private_user
     end
 
     context "when user is n org admin" do

--- a/decidim-assemblies/spec/system/admin/assembly_admin_accesses_admin_sections_spec.rb
+++ b/decidim-assemblies/spec/system/admin/assembly_admin_accesses_admin_sections_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Assembly admin accesses admin sections", type: :system do
+  include_context "when assembly admin administrating an assembly"
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim_admin_assemblies.assemblies_path
+
+    click_link translated(assembly.title)
+  end
+
+  it "can access all sections" do
+    within ".secondary-nav" do
+      expect(page).to have_content("Info")
+      expect(page).to have_content("Components")
+      expect(page).to have_content("Categories")
+      expect(page).to have_content("Attachments")
+      expect(page).to have_content("Folders")
+      expect(page).to have_content("Files")
+      expect(page).to have_content("Members")
+      expect(page).to have_content("Assembly users")
+      expect(page).to have_content("Private users")
+      expect(page).to have_content("Moderations")
+    end
+  end
+end

--- a/decidim-assemblies/spec/system/admin/assembly_admin_accesses_admin_sections_spec.rb
+++ b/decidim-assemblies/spec/system/admin/assembly_admin_accesses_admin_sections_spec.rb
@@ -19,11 +19,11 @@ describe "Assembly admin accesses admin sections", type: :system do
       expect(page).to have_content("Components")
       expect(page).to have_content("Categories")
       expect(page).to have_content("Attachments")
-      expect(page).to have_content("Folders")
+      expect(page).to have_content("Collections")
       expect(page).to have_content("Files")
       expect(page).to have_content("Members")
       expect(page).to have_content("Assembly users")
-      expect(page).to have_content("Private users")
+      expect(page).to have_content("Private Users")
       expect(page).to have_content("Moderations")
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Backports #3706 to `0.12-stable`.

#### :pushpin: Related Issues
- Related to #3706

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

