### PR TITLE
Pass the current component to the action authorizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 **Changed**:
 
+- **decidim-verifications**: Added a current component reference to the action authorizer. Custom ActionAuthorizer classes should receive it in a third argument of the initializer method, as `DefaultActionAuthorizer` does. [\#3708](https://github.com/decidim/decidim/pull/3708)
 - **decidim-core**: Introduce coauthorable concern and coauthorship model. [\#3310](https://github.com/decidim/decidim/pull/3310)
 - **decidim-core**: New user profile design [\#3415](https://github.com/decidim/decidim/pull/3290)
 - **decidim-core**: Force user_group.name uniqueness in user_group test factory. [\#3290](https://github.com/decidim/decidim/pull/3290)

--- a/decidim-core/app/services/decidim/action_authorizer.rb
+++ b/decidim-core/app/services/decidim/action_authorizer.rb
@@ -28,7 +28,7 @@ module Decidim
       raise AuthorizationError, "Missing data" unless component && action
 
       status_code, data = if authorization_handler_name
-                            authorization_handler.authorize(authorization, permission_options)
+                            authorization_handler.authorize(authorization, permission_options, component)
                           else
                             [:ok, {}]
                           end

--- a/decidim-verifications/README.md
+++ b/decidim-verifications/README.md
@@ -144,8 +144,9 @@ implement its public methods:
 
 * The `initialize` method receives the current authorization process context and
   saves it in local variables. This include the current authorization user state
-  (an `Authorization` record) and permission `options` related to the action is
-  trying to perform.
+  (an `Authorization` record), permission `options` related to the action is
+  trying to perform and the current `component` where the authorization is taking
+  place.
 
 * The `authorize` method is responsible of evaluating the authorization process
   context and determine if the user authorization is `:ok` or in any other

--- a/decidim-verifications/lib/decidim/verifications/adapter.rb
+++ b/decidim-verifications/lib/decidim/verifications/adapter.rb
@@ -78,11 +78,12 @@ module Decidim
       #
       # authorization - The existing authorization record to be evaluated. Can be nil.
       # options       - A hash with options related only to the current authorization process.
+      # component     - The component where the authorization is taking place
       #
       # Returns the result of authorization handler check. Check Decidim::Verifications::DefaultActionAuthorizer class docs.
       #
-      def authorize(authorization, options)
-        @action_authorizer = @manifest.action_authorizer_class.new(authorization, options)
+      def authorize(authorization, options, component)
+        @action_authorizer = @manifest.action_authorizer_class.new(authorization, options, component)
         @action_authorizer.authorize
       end
 

--- a/decidim-verifications/lib/decidim/verifications/default_action_authorizer.rb
+++ b/decidim-verifications/lib/decidim/verifications/default_action_authorizer.rb
@@ -8,10 +8,12 @@ module Decidim
       #
       # authorization - The existing authorization record to be evaluated. Can be nil.
       # options       - A hash with options related only to the current authorization process.
+      # component     - The component where the authorization is taking place
       #
-      def initialize(authorization, options)
+      def initialize(authorization, options, component)
         @authorization = authorization
         @options = options.deep_dup || {} # options hash is cloned to allow changes applied to it without risks
+        @component = component
       end
 
       #
@@ -63,7 +65,7 @@ module Decidim
 
       protected
 
-      attr_reader :authorization, :options
+      attr_reader :authorization, :options, :component
 
       def unmatched_fields
         @unmatched_fields ||= (options.keys & authorization.metadata.to_h.keys).each_with_object({}) do |field, unmatched|


### PR DESCRIPTION
#### :tophat: What? Why?
This PR slightly modifies the authorization process, adding a reference to the component where the authorization is taking place to the `DefaultActionAuthorizer` that will perform the authorization process.

This reference is not used by any code, but it can be used by a custom action authorizer. In my case, 
I need to check that the user's scope is included in the participatory space's scope to perform the authorization. With this PR I can find it out from the current component reference and compare it with the user's scope.

#### :pushpin: Related Issues

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add documentation regarding the feature
