### PR TITLE
Normalize budgets authorization 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ end
 
 **Fixed**:
 
+- **decidim-budgets**: Normalized authorization and permissions checks with the rest of components. [\#3710](https://github.com/decidim/decidim/pull/3710)
 - **decidim-core**: Search results should be paginated so that server does not hang when search term is too wide. [\#3605](https://github.com/decidim/decidim/pull/3605)
 - **decidim-assemblies**: Fix private assemblies showing more than once for private users. [\#3638](https://github.com/decidim/decidim/pull/3638)
 - **decidim-proposals**: Do not index non published Proposals. [\#3618](https://github.com/decidim/decidim/pull/3618)
@@ -91,6 +92,8 @@ end
 - **decidim-admin**: Let user managers access the public space [\#3720](https://github.com/decidim/decidim/pull/3720)
 
 **Removed**:
+
+- **decidim-core**: Removed redundant `authorize_action!` method. [\#3710](https://github.com/decidim/decidim/pull/3710)
 
 ## Previous versions
 

--- a/decidim-budgets/app/controllers/decidim/budgets/line_items_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/line_items_controller.rb
@@ -9,7 +9,7 @@ module Decidim
       helper_method :project
 
       def create
-        authorize_action! "vote"
+        enforce_permission_to :vote, :project, project: project
 
         respond_to do |format|
           AddLineItem.call(current_order, project, current_user) do

--- a/decidim-budgets/app/controllers/decidim/budgets/orders_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/orders_controller.rb
@@ -7,6 +7,8 @@ module Decidim
       include NeedsCurrentOrder
 
       def checkout
+        enforce_permission_to :vote, :project, order: current_order
+
         Checkout.call(current_order, current_component) do
           on(:ok) do
             flash[:notice] = I18n.t("orders.checkout.success", scope: "decidim")

--- a/decidim-budgets/app/controllers/decidim/budgets/orders_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/orders_controller.rb
@@ -7,8 +7,6 @@ module Decidim
       include NeedsCurrentOrder
 
       def checkout
-        authorize_action! "vote"
-
         Checkout.call(current_order, current_component) do
           on(:ok) do
             flash[:notice] = I18n.t("orders.checkout.success", scope: "decidim")

--- a/decidim-budgets/app/permissions/decidim/budgets/permissions.rb
+++ b/decidim-budgets/app/permissions/decidim/budgets/permissions.rb
@@ -13,11 +13,26 @@ module Decidim
         return permission_action if permission_action.subject != :project
 
         case permission_action.action
+        when :vote
+          can_vote_project?
         when :report
           permission_action.allow!
         end
 
         permission_action
+      end
+
+      private
+
+      def project
+        @project ||= context.fetch(:project, nil)
+      end
+
+      def can_vote_project?
+        is_allowed = project &&
+                     authorized?(:vote)
+
+        toggle_allow(is_allowed)
       end
     end
   end

--- a/decidim-budgets/app/permissions/decidim/budgets/permissions.rb
+++ b/decidim-budgets/app/permissions/decidim/budgets/permissions.rb
@@ -14,7 +14,7 @@ module Decidim
 
         case permission_action.action
         when :vote
-          can_vote_project?
+          can_vote_project?(project || order&.projects&.first)
         when :report
           permission_action.allow!
         end
@@ -28,9 +28,12 @@ module Decidim
         @project ||= context.fetch(:project, nil)
       end
 
-      def can_vote_project?
-        is_allowed = project &&
-                     authorized?(:vote)
+      def order
+        @order ||= context.fetch(:order, nil)
+      end
+
+      def can_vote_project?(a_project)
+        is_allowed = a_project && authorized?(:vote)
 
         toggle_allow(is_allowed)
       end

--- a/decidim-core/app/controllers/concerns/decidim/action_authorization.rb
+++ b/decidim-core/app/controllers/concerns/decidim/action_authorization.rb
@@ -10,20 +10,6 @@ module Decidim
       helper_method :authorize_action_path, :action_authorization
     end
 
-    # Public: Authorizes an action of a component given an action name.
-    #
-    # action_name  - The action name to authorize. Actions are set up on the
-    #                component's permissions panel.
-    # redirect_url - Url to be redirected to when the authorization is finished.
-    def authorize_action!(action_name, redirect_url: nil)
-      status = action_authorization(action_name)
-
-      return if status.ok?
-      raise Unauthorized if status.code == :unauthorized
-
-      redirect_to authorize_action_path(action_name, redirect_url: redirect_url)
-    end
-
     # Public: Returns the authorization object for an authorization.
     #
     # action_name - The action to authorize against.


### PR DESCRIPTION
#### :tophat: What? Why?
When working with authorizations and permissions, I always end up confused by the `authorize_action!` method, that is only used in the Budgets component, and seems to be some kind of redundant in relation to the `ensure_permissions_to` method and the `action_authorized_button_to` and other helpers.

Today, I've forced that code to be executed. First, I've allowed a user to vote projects without an authorization. Then, I set an authorization handler for the vote action, And finally, I tried to checkout the list of supported projects by the user. The result was an error page, when trying to add a second redirect to the success page after the `authorize_action!` adding a redirect to the authorize page. In other words, that code doesn't even seems to work. :confounded:

So, this is a PR-question: can this method be removed completely to avoid future headaches? I've replaced the `authorize_action!` in the `vote` action of the Budgets component, but I completely removed it in the `checkout` action. I don't know if that is the desired behavior; maybe we should add a `checkout` action in the permissions class that checks that the user can vote any or all of the projects.

#### :pushpin: Related Issues


#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)

