### PR TITLE
Add new profile avatar version so that images do not look scaled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,30 @@
 
 ## [Unreleased](https://github.com/decidim/decidim/tree/HEAD)
 
+**Upgrade notes: avatars**:
+
+As per [\#3716](https://github.com/decidim/decidim/pull/3716), you'll need to
+re-create the existing avatars versions. Connect to your server and run this on
+your terminal:
+
+```console
+bin/rails c
+```
+
+And then copy and paste this piece of code:
+
+```ruby
+Decidim::User.find_each do |user|
+  user.avatar.recreate_versions! if user.avatar?
+end
+```
+
 **Added**:
 
 - **decidim-core**: GDPR: Add Right of data portability. [\#3489](https://github.com/decidim/decidim/pull/3489)
 - **decidim-core**: GDPR: Opt-in for all the users with newsletters [\#3492](https://github.com/decidim/decidim/issues/3492)
 - **decidim-initiatives**: Notify the followers when an initiative's signatures end date has been extended [\#3621](https://github.com/decidim/decidim/pull/3621)
+- **decidim-core**: Add a new avatar size so that it is displayed properly on the profile page [\#3716](https://github.com/decidim/decidim/pull/3716)
 
 **Changed**:
 

--- a/decidim-core/app/uploaders/decidim/avatar_uploader.rb
+++ b/decidim-core/app/uploaders/decidim/avatar_uploader.rb
@@ -8,7 +8,7 @@ module Decidim
     process :validate_dimensions
 
     version :profile do
-      process resize_to_fill: [268, 320]
+      process resize_to_fill: [536, 640] # double the size, for retina displays
     end
 
     version :big, from_version: :profile do

--- a/decidim-core/app/uploaders/decidim/avatar_uploader.rb
+++ b/decidim-core/app/uploaders/decidim/avatar_uploader.rb
@@ -7,11 +7,15 @@ module Decidim
 
     process :validate_dimensions
 
-    version :big do
+    version :profile do
+      process resize_to_fill: [268, 320]
+    end
+
+    version :big, from_version: :profile do
       process resize_to_fit: [80, 80]
     end
 
-    version :thumb do
+    version :thumb, from_version: :big do
       process resize_to_fit: [40, 40]
     end
 

--- a/decidim-core/app/views/decidim/profiles/_user.html.erb
+++ b/decidim-core/app/views/decidim/profiles/_user.html.erb
@@ -1,6 +1,6 @@
 <% present(user) do |profile_user| %>
   <div class="card">
-    <%= image_tag profile_user.avatar_url(:big), class: "card__image card__image--larger" %>
+    <%= image_tag profile_user.avatar_url(:profile), class: "card__image card__image--larger" %>
     <div class="card__content">
       <h5>
         <div><strong><%= profile_user.name %></strong></div>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds a new profile avatar version so that images do not look scaled there. It also improves the performance of avatar versions generation.

You'll need to run this piece of code after updating Decidim so that the new version gets properly created for existing avatars:

```ruby
Decidim::User.find_each do |user|
  user.avatar.recreate_versions! if user.avatar?
end
```

#### :pushpin: Related Issues
- Fixes #3607
#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry


### :camera: Screenshots (optional)
Before:
![Description](https://i.imgur.com/fiw2XFg.png)

After: 
![](https://i.imgur.com/IHKUAtZ.png)