### PR TITLE
Let user managers visit the public space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - **decidim-core**: Fix comments count failing in AuthorCell [\#3668](https://github.com/decidim/decidim/pull/3668)
 - **decidim-proposals**: Fix proposal date to published_at in: card_m, details, admin and exporter [\#3649](https://github.com/decidim/decidim/pull/3649)
 - **decidim-assemblies**: Let assembly admins access all content [\#3706](https://github.com/decidim/decidim/pull/3706)
+- **decidim-admin**: Let user managers access the public space [\#3720](https://github.com/decidim/decidim/pull/3720)
 
 **Removed**:
 

--- a/decidim-admin/app/permissions/decidim/admin/permissions.rb
+++ b/decidim-admin/app/permissions/decidim/admin/permissions.rb
@@ -58,6 +58,7 @@ module Decidim
         return unless permission_action.subject == :admin_dashboard &&
                       permission_action.action == :read
 
+        return user_manager_permissions if user_manager?
         toggle_allow(user.admin? || space_allows_admin_access_to_current_action?)
       end
 

--- a/decidim-admin/spec/permissions/decidim/admin/permissions_spec.rb
+++ b/decidim-admin/spec/permissions/decidim/admin/permissions_spec.rb
@@ -28,6 +28,12 @@ describe Decidim::Admin::Permissions do
       end
 
       it { is_expected.to eq true }
+
+      context "when user is a user manager" do
+        let(:user) { build :user, :user_manager }
+
+        it { is_expected.to eq true }
+      end
     end
 
     it_behaves_like "permission is not set"

--- a/decidim-core/app/models/decidim/permission_action.rb
+++ b/decidim-core/app/models/decidim/permission_action.rb
@@ -16,9 +16,10 @@ module Decidim
       @scope = scope
       @subject = subject
       @state = nil
+      @backtrace = []
     end
 
-    attr_reader :action, :scope, :subject
+    attr_reader :action, :scope, :subject, :backtrace
 
     def allow!
       raise PermissionCannotBeDisallowedError, "Allowing a previously disallowed action is not permitted: #{inspect}" if @state == :disallowed
@@ -32,6 +33,10 @@ module Decidim
     def allowed?
       raise PermissionNotSetError, "Permission hasn't been allowed or disallowed yet: #{inspect}" if @state.blank?
       @state == :allowed
+    end
+
+    def trace(class_name, state)
+      @backtrace << [class_name, state]
     end
 
     class PermissionNotSetError < StandardError; end

--- a/decidim-core/app/permissions/decidim/default_permissions.rb
+++ b/decidim-core/app/permissions/decidim/default_permissions.rb
@@ -20,10 +20,12 @@ module Decidim
     attr_reader :user, :permission_action, :context
 
     def disallow!
+      permission_action.trace(self.class.name, :disallowed)
       permission_action.disallow!
     end
 
     def allow!
+      permission_action.trace(self.class.name, :allowed)
       permission_action.allow!
     end
 

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/permissions_shared_examples.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/permissions_shared_examples.rb
@@ -7,7 +7,7 @@ shared_examples "permission is not set" do
 end
 
 shared_examples "delegates permissions to" do |delegated_class|
-  it "delegates the check to the #{delegated_class.name} permissions class" do
+  it "the #{delegated_class.name} permissions class" do
     delegated_permissions = instance_double(delegated_class, permissions: :foo)
     delegated_permission_action = instance_double(Decidim::PermissionAction, allowed?: true)
 


### PR DESCRIPTION
#### :tophat: What? Why?
Currently user managers cannot visit the public page due to an error of permissions. This PR fixes it.

It also adds a little tracing to permissions to keep track of what classes allow/disallow a given permission.

This will need to be backported to `v0.12`.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
