### PR TITLE
Fix Coauthorships migration to handle official proposals

### DIFF
--- a/decidim-proposals/db/migrate/20180529110230_move_authorships_to_coauthorships.rb
+++ b/decidim-proposals/db/migrate/20180529110230_move_authorships_to_coauthorships.rb
@@ -14,6 +14,9 @@ class MoveAuthorshipsToCoauthorships < ActiveRecord::Migration[5.1]
     proposals.each do |proposal|
       author_id = proposal.attributes["decidim_author_id"]
       user_group_id = proposal.attributes["decidim_user_group_id"]
+
+      next if author_id.nil?
+
       Coauthorship.create!(
         coauthorable_id: proposal.id,
         coauthorable_type: "Decidim::Proposals::Proposal",


### PR DESCRIPTION
#### :tophat: What? Why?
PR #3532 added a migration to move proposals to coaurhorships, but didn't take into account the official proposals and failed using production data.

This PR fixes it.

#### :pushpin: Related Issues
- Related to #3532.

#### :clipboard: Subtasks
None
