### PR TITLE
Denormalize components with organization reference

### DIFF
--- a/decidim-blogs/lib/decidim/blogs/test/factories.rb
+++ b/decidim-blogs/lib/decidim/blogs/test/factories.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
   factory :post, class: "Decidim::Blogs::Post" do
     title { Decidim::Faker::Localized.sentence(3) }
     body { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
-    component { build(:component, manifest_name: "blogs") }
+    component { create(:component, manifest_name: "blogs") }
     author { build(:user, :confirmed, organization: component.organization) }
   end
 end

--- a/decidim-blogs/spec/models/decidim/blogs/post_spec.rb
+++ b/decidim-blogs/spec/models/decidim/blogs/post_spec.rb
@@ -9,7 +9,7 @@ module Decidim::Blogs
     let(:current_organization) { create(:organization) }
     let(:current_user) { create(:user, :confirmed, organization: current_organization) }
     let(:participatory_process) { create :participatory_process, organization: current_organization }
-    let(:current_component) { create :component, participatory_space: participatory_process, organization: current_organization, manifest_name: "blogs" }
+    let(:current_component) { create :component, participatory_space: participatory_process, manifest_name: "blogs" }
     let(:post) { create(:post, component: current_component, author: current_user) }
 
     include_examples "has component"

--- a/decidim-blogs/spec/models/decidim/blogs/post_spec.rb
+++ b/decidim-blogs/spec/models/decidim/blogs/post_spec.rb
@@ -9,7 +9,7 @@ module Decidim::Blogs
     let(:current_organization) { create(:organization) }
     let(:current_user) { create(:user, :confirmed, organization: current_organization) }
     let(:participatory_process) { create :participatory_process, organization: current_organization }
-    let(:current_component) { create :component, participatory_space: participatory_process, manifest_name: "blogs" }
+    let(:current_component) { create :component, participatory_space: participatory_process, organization: current_organization, manifest_name: "blogs" }
     let(:post) { create(:post, component: current_component, author: current_user) }
 
     include_examples "has component"

--- a/decidim-core/app/models/decidim/component.rb
+++ b/decidim-core/app/models/decidim/component.rb
@@ -9,12 +9,13 @@ module Decidim
     include Publicable
     include Traceable
     include Loggable
+    include Organizable
 
     belongs_to :participatory_space, polymorphic: true
 
     default_scope { order(arel_table[:weight].asc, arel_table[:manifest_name].asc) }
 
-    delegate :organization, :categories, to: :participatory_space
+    delegate :categories, to: :participatory_space
 
     def self.log_presenter_class_for(_log)
       Decidim::AdminLog::ComponentPresenter

--- a/decidim-core/db/migrate/20180626124219_add_organization_id_to_components.rb
+++ b/decidim-core/db/migrate/20180626124219_add_organization_id_to_components.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToComponents < ActiveRecord::Migration[5.2]
+  class Component < ApplicationRecord
+    self.table_name = :decidim_components
+    belongs_to :participatory_space, polymorphic: true
+  end
+
+  def up
+    add_reference :decidim_components, :decidim_organization, index: true
+
+    Component.find_each do |component|
+      component.update(decidim_organization_id: component.participatory_space.decidim_organization_id)
+    end
+  end
+
+  def down
+    remove_reference :decidim_components, :decidim_organization, index: true
+  end
+end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -16,6 +16,7 @@ module Decidim
   autoload :Resourceable, "decidim/resourceable"
   autoload :Traceable, "decidim/traceable"
   autoload :Loggable, "decidim/loggable"
+  autoload :Organizable, "decidim/organizable"
   autoload :Reportable, "decidim/reportable"
   autoload :Authorable, "decidim/authorable"
   autoload :Coauthorable, "decidim/coauthorable"

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -378,7 +378,7 @@ FactoryBot.define do
     organization { user.organization }
     user
     participatory_space { build :participatory_process, organization: organization }
-    component { build :component, participatory_space: participatory_space }
+    component { create :component, participatory_space: participatory_space }
     resource { build(:dummy_resource, component: component) }
     action { "create" }
     extra do

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -239,10 +239,7 @@ FactoryBot.define do
   end
 
   factory :component, class: "Decidim::Component" do
-    transient do
-      organization { create(:organization) }
-    end
-
+    organization { create(:organization) }
     name { Decidim::Faker::Localized.sentence(3) }
     participatory_space { create(:participatory_process, organization: organization) }
     manifest_name "dummy"

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -239,7 +239,9 @@ FactoryBot.define do
   end
 
   factory :component, class: "Decidim::Component" do
-    organization { create(:organization) }
+    transient do
+      organization { create(:organization) }
+    end
     name { Decidim::Faker::Localized.sentence(3) }
     participatory_space { create(:participatory_process, organization: organization) }
     manifest_name "dummy"

--- a/decidim-core/lib/decidim/organizable.rb
+++ b/decidim-core/lib/decidim/organizable.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  # This concern contains the logic related to the relation between components and organizations
+  module Organizable
+    extend ActiveSupport::Concern
+
+    included do
+      belongs_to :organization, foreign_key: "decidim_organization_id", class_name: "Decidim::Organization"
+
+      validates :organization, presence: true
+    end
+  end
+end

--- a/decidim-core/lib/decidim/organizable.rb
+++ b/decidim-core/lib/decidim/organizable.rb
@@ -11,6 +11,13 @@ module Decidim
       belongs_to :organization, foreign_key: "decidim_organization_id", class_name: "Decidim::Organization"
 
       validates :organization, presence: true
+
+      before_validation :assign_organization
+    end
+
+    def assign_organization
+      return if organization.present? || try(:participatory_space).blank?
+      self.organization = participatory_space.organization
     end
   end
 end

--- a/decidim-core/spec/lib/resourceable_spec.rb
+++ b/decidim-core/spec/lib/resourceable_spec.rb
@@ -9,10 +9,11 @@ module Decidim
     end
 
     describe "linked_resources" do
-      let(:participatory_process) { create(:participatory_process) }
+      let(:organization) { create(:organization) }
+      let(:participatory_process) { create(:participatory_process, organization: organization) }
 
-      let!(:target_component) { create(:component, manifest_name: :dummy, participatory_space: participatory_process) }
-      let!(:current_component) { create(:component, manifest_name: :dummy, participatory_space: participatory_process) }
+      let!(:target_component) { create(:component, manifest_name: :dummy, participatory_space: participatory_process, organization: organization) }
+      let!(:current_component) { create(:component, manifest_name: :dummy, participatory_space: participatory_process, organization: organization) }
 
       let!(:resource) { create(:dummy_resource, component: current_component) }
       let!(:target_resource) { create(:dummy_resource, component: target_component) }
@@ -111,10 +112,11 @@ module Decidim
     describe "#linked_classes_for" do
       subject { Decidim::Proposals::Proposal }
 
-      let(:proposals_component_1) { create :component, manifest_name: "proposals" }
-      let(:proposals_component_2) { create :component, manifest_name: "proposals" }
-      let(:meetings_component) { create :component, manifest_name: "meetings", participatory_space: proposals_component_1.participatory_space }
-      let(:dummy_component) { create :component, manifest_name: "dummy", participatory_space: proposals_component_2.participatory_space }
+      let(:organization) { create(:organization) }
+      let(:proposals_component_1) { create :component, manifest_name: "proposals", organization: organization }
+      let(:proposals_component_2) { create :component, manifest_name: "proposals", organization: organization }
+      let(:meetings_component) { create :component, manifest_name: "meetings", participatory_space: proposals_component_1.participatory_space, organization: organization }
+      let(:dummy_component) { create :component, manifest_name: "dummy", participatory_space: proposals_component_2.participatory_space, organization: organization }
       let(:proposal_1) { create :proposal, component: proposals_component_1 }
       let(:proposal_2) { create :proposal, component: proposals_component_2 }
       let(:meeting) { create :meeting, component: meetings_component }

--- a/decidim-core/spec/presenters/decidim/resource_locator_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/resource_locator_presenter_spec.rb
@@ -11,7 +11,7 @@ module Decidim
     end
 
     let(:component) do
-      create(:component, id: 1, participatory_space: participatory_process)
+      create(:component, id: 1, participatory_space: participatory_process, organization: organization)
     end
 
     let(:resource) do

--- a/decidim-debates/lib/decidim/debates/test/factories.rb
+++ b/decidim-debates/lib/decidim/debates/test/factories.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     instructions { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
     start_time { 1.day.from_now }
     end_time { start_time.advance(hours: 2) }
-    component { build(:component, manifest_name: "debates") }
+    component { create(:component, manifest_name: "debates") }
 
     trait :open_ama do
       start_time { 1.day.ago }

--- a/decidim-meetings/lib/decidim/meetings/test/factories.rb
+++ b/decidim-meetings/lib/decidim/meetings/test/factories.rb
@@ -28,7 +28,7 @@ FactoryBot.define do
         { title: Decidim::Faker::Localized.sentence(2), description: Decidim::Faker::Localized.sentence(5) }
       ]
     end
-    component { build(:component, manifest_name: "meetings") }
+    component { create(:component, manifest_name: "meetings") }
 
     organizer do
       create(:user, organization: component.organization) if component


### PR DESCRIPTION
#### :tophat: What? Why?
Polymorphic relationship between Components and ParticipatorySpaces cannot be used in Organization contexts.
Added `decidim_organization_id` reference field in Components to access directly to Organization.

#### :pushpin: Related Issues
- Related to #3674 