### PR TITLE
More consistent circle ci env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,6 @@ references:
     restore_cache:
       keys:
         - bundler-dependencies-{{ checksum "Gemfile.lock" }}
-  restore_npm_cache: &restore_npm_cache
-    restore_cache:
-      keys:
-        - npm-dependencies-{{ checksum "package-lock.json" }}
   install_ruby_dependencies: &install_ruby_dependencies
     run:
       name: Install ruby dependencies
@@ -39,11 +35,6 @@ references:
       key: bundler-dependencies-{{ checksum "Gemfile.lock" }}
       paths:
         - /usr/local/bundle/
-  save_npm_cache: &save_npm_cache
-    save_cache:
-      key: npm-dependencies-{{ checksum "package-lock.json" }}
-      paths:
-        - node_modules
   wait_for_db: &wait_for_db
     run:
       name: Wait for db
@@ -92,11 +83,9 @@ jobs:
     steps:
       - checkout
       - *restore_ruby_cache
-      - *restore_npm_cache
       - *install_ruby_dependencies
       - *install_npm_dependencies
       - *save_ruby_cache
-      - *save_npm_cache
       - *wait_for_db
       - run:
           name: Generate test app
@@ -216,7 +205,7 @@ jobs:
     <<: *defaults
     steps:
       - *attach_workspace
-      - *restore_npm_cache
+      - *install_npm_dependencies
       - *restore_ruby_cache
       - *wait_for_db
       - *create_test_db
@@ -259,7 +248,7 @@ jobs:
     <<: *defaults
     steps:
       - *attach_workspace
-      - *restore_npm_cache
+      - *install_npm_dependencies
       - run:
           name: Run main folder lint & tests
           command: npm run test:ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ references:
   run_rspec: &run_rspec
     run:
       name: Run RSpec
-      command: mkdir ~/rspec && cd decidim-$CIRCLE_JOB && rake
+      command: mkdir ~/rspec && cd decidim-$CIRCLE_JOB && bundle exec rake
   format_test_coverage: &format_test_coverage
     run:
       name: Format CodeClimate test coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ defaults: &defaults
     # latest digest by doing `$ docker pull decidim/decidim:latest-test`.
     - image: decidim/decidim@sha256:743a212e757a0c0d4cb85cf99251290864b6d02d1a17aa285d342d0bdcff796b
       environment:
-        BUNDLE_GEMFILE: /app/Gemfile
         SIMPLECOV: true
         DATABASE_USERNAME: postgres
         FAIL_FAST: true

--- a/d/rspec
+++ b/d/rspec
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 fail_fast=${FAIL_FAST:-false}
+simplecov=${SIMPLECOV:-true}
 
 args=("$@")
 
 printf -v cmd '%q ' "${args[@]}"
 
-docker-compose run --rm -e "FAIL_FAST=$fail_fast" decidim bash -c "bin/rspec $cmd"
+docker-compose run --rm -e "FAIL_FAST=$fail_fast" -e "SIMPLECOV=$simplecov" decidim bash -c "bin/rspec $cmd"


### PR DESCRIPTION
#### :tophat: What? Why?

These are some other changes that I extracted from #3684. The idea is to make local docker & circleCI enviroments as similar as possible so it's easier to troubleshoot CI issues. I added an extra fixup to the `package-lock.json`, because `npm install` hang on the first run. I suspect there's some multiplatform issues hitting `npm` again. Let's see how it goes.

#### :pushpin: Related Issues
- Related to #3684.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.