### PR TITLE
Fix rpsec binstub arg handling

### DIFF
--- a/bin/rspec
+++ b/bin/rspec
@@ -19,7 +19,9 @@ if ARGV[0]
 
     other_parts = argument_parts[1..-1]
 
-    ARGV.replace([!other_parts.empty? ? other_parts.join("/") : nil, *ARGV[1..-1]])
+    new_args = [!other_parts.empty? ? other_parts.join("/") : nil, *ARGV[1..-1]].compact
+
+    ARGV.replace(new_args)
   end
 end
 

--- a/d/rspec
+++ b/d/rspec
@@ -2,4 +2,8 @@
 
 fail_fast=${FAIL_FAST:-false}
 
-docker-compose run --rm -e "FAIL_FAST=$fail_fast" decidim bash -c "bin/rspec $*"
+args=("$@")
+
+printf -v cmd '%q ' "${args[@]}"
+
+docker-compose run --rm -e "FAIL_FAST=$fail_fast" decidim bash -c "bin/rspec $cmd"


### PR DESCRIPTION
#### :tophat: What? Why?
This is a tiny improvement (also extracted from #3684) in the docker rspec binstub that allows it to handle commands like `d/rspec decidim-generators -e "without flags"` (with spaces in some args).

#### :pushpin: Related Issues
- Related to #3684.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.