### PR TITLE
Highlight navigation bar item when showing a process group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@
 
 **Added**:
 
-- **decidim-core**: GDPR: Add Right of data portability. [\#3489](https://github.com/decidim/decidim/pull/3489)
-- **decidim-core**: GDPR: Opt-in for all the users with newsletters [\#3492](https://github.com/decidim/decidim/issues/3492)
-- **decidim-initiatives**: Notify the followers when an initiative's signatures end date has been extended [\#3621](https://github.com/decidim/decidim/pull/3621)
-- **decidim-core**: Add a new avatar size so that it is displayed properly on the profile page [\#3716](https://github.com/decidim/decidim/pull/3716)
 - **decidim-participatory_processes**: Highlight the correct menu item when visiting a process group page [\#3737](https://github.com/decidim/decidim/pull/3737)
 
 **Changed**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 **Added**:
 
+- **decidim-core**: GDPR: Add Right of data portability. [\#3489](https://github.com/decidim/decidim/pull/3489)
+- **decidim-core**: GDPR: Opt-in for all the users with newsletters [\#3492](https://github.com/decidim/decidim/issues/3492)
+- **decidim-initiatives**: Notify the followers when an initiative's signatures end date has been extended [\#3621](https://github.com/decidim/decidim/pull/3621)
+- **decidim-core**: Add a new avatar size so that it is displayed properly on the profile page [\#3716](https://github.com/decidim/decidim/pull/3716)
+- **decidim-participatory_processes**: Highlight the correct menu item when visiting a process group page [\#3737](https://github.com/decidim/decidim/pull/3737)
+
 **Changed**:
 
 **Fixed**:

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
@@ -54,7 +54,7 @@ module Decidim
                     decidim_participatory_processes.participatory_processes_path,
                     position: 2,
                     if: Decidim::ParticipatoryProcess.where(organization: current_organization).published.any?,
-                    active: :inclusive
+                    active: /^\/process(es|_groups)/
         end
       end
 

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
@@ -54,7 +54,7 @@ module Decidim
                     decidim_participatory_processes.participatory_processes_path,
                     position: 2,
                     if: Decidim::ParticipatoryProcess.where(organization: current_organization).published.any?,
-                    active: /^\/process(es|_groups)/
+                    active: %r{^\/process(es|_groups)}
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
when visiting a process group, the navigation bar does not properly highlight the processes menu item.

This PR fixes it.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/9XTr0oA.png)
