### PR TITLE
Install dependencies from each folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ references:
   install_ruby_dependencies: &install_ruby_dependencies
     run:
       name: Install ruby dependencies
-      command: bundle install
+      command: cd decidim-$CIRCLE_JOB && bundle install
   install_npm_dependencies: &install_npm_dependencies
     run:
       name: Install npm dependencies
@@ -83,7 +83,7 @@ jobs:
     steps:
       - checkout
       - *restore_ruby_cache
-      - *install_ruby_dependencies
+      - run: bundle install
       - *install_npm_dependencies
       - *save_ruby_cache
       - *wait_for_db
@@ -101,7 +101,7 @@ jobs:
       - *attach_workspace
       - checkout
       - *restore_ruby_cache
-      - *install_ruby_dependencies
+      - run: bundle install
       - *save_ruby_cache
       - *wait_for_db
       - run:
@@ -125,7 +125,6 @@ jobs:
       - *restore_ruby_cache
       - *install_ruby_dependencies
       - *save_ruby_cache
-      - run: cd decidim-$CIRCLE_JOB && bundle install && cd ..
       - *wait_for_db
       - *run_rspec
       - *install_test_reporter


### PR DESCRIPTION
#### :tophat: What? Why?
As a follow-up from #3756, let's try to install the dependencies form each folder, instead of always using the global ones. 

#### :pushpin: Related Issues
- Related to #3756.
