### PR TITLE
Revert "Use `capybara-screenshot` again (#3782)"

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -3,6 +3,7 @@
 SimpleCov.start do
   root File.expand_path("..", ENV["ENGINE_ROOT"])
 
+  add_filter "decidim-dev/lib/decidim/dev/test/ext/screenshot_helper.rb"
   add_filter "/spec/decidim_dummy_app/"
   add_filter "/vendor/"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,6 @@ PATH
     decidim-dev (0.14.0.dev)
       byebug (~> 10.0)
       capybara (~> 3.0)
-      capybara-screenshot (~> 1.0)
       db-query-matchers (~> 0.9.0)
       decidim (~> 0.14.a)
       erb_lint (~> 0.0.22)
@@ -265,9 +264,6 @@ GEM
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       xpath (~> 3.1)
-    capybara-screenshot (1.0.21)
-      capybara (>= 1.0, < 4)
-      launchy
     carrierwave (1.2.3)
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)

--- a/decidim-admin/spec/queries/user_group_evaluation_spec.rb
+++ b/decidim-admin/spec/queries/user_group_evaluation_spec.rb
@@ -14,7 +14,7 @@ module Decidim::Admin
       let!(:user_groups) { create_list(:user_group, 3, users: [create(:user, organization: organization)]) }
 
       it "returns all the user groups" do
-        expect(subject.query).to match_array(user_groups.to_a)
+        expect(subject.query).to eq user_groups
       end
     end
 

--- a/decidim-dev/decidim-dev.gemspec
+++ b/decidim-dev/decidim-dev.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   compatible_constraint = "#{Gem::Version.new(s.version).approximate_recommendation}.a"
 
   s.add_dependency "capybara", "~> 3.0"
-  s.add_dependency "capybara-screenshot", "~> 1.0"
   s.add_dependency "decidim", compatible_constraint
   s.add_dependency "factory_bot_rails", "~> 4.8"
 

--- a/decidim-dev/lib/decidim/dev/test/ext/screenshot_helper.rb
+++ b/decidim-dev/lib/decidim/dev/test/ext/screenshot_helper.rb
@@ -1,13 +1,111 @@
 # frozen_string_literal: true
 
-require "action_dispatch/system_testing/test_helpers/setup_and_teardown"
+module ActionDispatch
+  module SystemTesting
+    module TestHelpers
+      # Screenshot helper for system testing.
+      module ScreenshotHelper
+        # Takes a screenshot of the current page in the browser.
+        #
+        # +take_screenshot+ can be used at any point in your system tests to take
+        # a screenshot of the current state. This can be useful for debugging or
+        # automating visual testing.
+        #
+        # The screenshot will be displayed in your console, if supported.
+        #
+        # You can set the +RAILS_SYSTEM_TESTING_SCREENSHOT+ environment variable to
+        # control the output. Possible values are:
+        # * [+simple+ (default)]    Only displays the screenshot path.
+        #                           This is the default value.
+        # * [+inline+]              Display the screenshot in the terminal using the
+        #                           iTerm image protocol (https://iterm2.com/documentation-images.html).
+        # * [+artifact+]            Display the screenshot in the terminal, using the terminal
+        #                           artifact format (https://buildkite.github.io/terminal/inline-images/).
+        def take_screenshot
+          save_image
+          save_page
+          STDOUT.puts display_screenshot
+        end
 
-::ActionDispatch::SystemTesting::TestHelpers::SetupAndTeardown.module_eval do
-  def before_setup
-    super
-  end
+        # Takes a screenshot of the current page in the browser if the test
+        # failed.
+        #
+        # +take_failed_screenshot+ is included in <tt>application_system_test_case.rb</tt>
+        # that is generated with the application. To take screenshots when a test
+        # fails add +take_failed_screenshot+ to the teardown block before clearing
+        # sessions.
+        def take_failed_screenshot
+          take_screenshot if failed? && supports_screenshot?
+        end
 
-  def after_teardown
-    super
+        private
+
+        def screenshot_name
+          failed? ? "failures_#{method_name}" : method_name
+        end
+
+        def image_path
+          @image_path ||= absolute_image_path.to_s
+        end
+
+        def page_path
+          @page_path ||= absolute_page_path.to_s
+        end
+
+        def absolute_image_path
+          Rails.root.join("tmp/screenshots/#{screenshot_name}.png")
+        end
+
+        def absolute_page_path
+          Rails.root.join("tmp/screenshots/#{screenshot_name}.html")
+        end
+
+        def save_image
+          page.save_screenshot(absolute_image_path)
+        end
+
+        def save_page
+          page.save_page(absolute_page_path)
+        end
+
+        def output_type
+          # Environment variables have priority
+          output_type = ENV["RAILS_SYSTEM_TESTING_SCREENSHOT"] || ENV["CAPYBARA_INLINE_SCREENSHOT"]
+
+          # Default to outputting a path to the screenshot
+          output_type ||= "simple"
+
+          output_type
+        end
+
+        def display_screenshot
+          message = "[Image screenshot]: file://#{image_path}\n"
+          message += "       [Page HTML]: file://#{page_path}\n"
+
+          case output_type
+          when "artifact"
+            message << "\e]1338;url=artifact://#{absolute_image_path}\a\n"
+          when "inline"
+            name = inline_base64(File.basename(absolute_image_path))
+            image = inline_base64(File.read(absolute_image_path))
+            message << "\e]1337;File=name=#{name};height=400px;inline=1:#{image}\a\n"
+          end
+
+          message
+        end
+
+        def inline_base64(path)
+          Base64.strict_encode64(path)
+        end
+
+        def failed?
+          !passed? && !skipped?
+        end
+
+        def supports_screenshot?
+          Capybara.current_driver != :rack_test
+        end
+      end
+    end
   end
 end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "selenium-webdriver"
-require "capybara-screenshot/rspec"
 
 module Decidim
   # Helpers meant to be used only during capybara test runs.
@@ -38,23 +37,10 @@ Capybara.asset_host = "http://localhost:3000"
 
 Capybara.server_errors = [SyntaxError, StandardError]
 
-Capybara.save_path = "/tmp/screenshots"
-
-Capybara::Screenshot.prune_strategy = :keep_last_run
-Capybara::Screenshot::RSpec.add_link_to_screenshot_for_failed_examples = true
-
-Capybara::Screenshot.register_driver(:headless_chrome) do |driver, path|
-  driver.browser.save_screenshot(path)
-end
-
 RSpec.configure do |config|
   config.before :each, type: :system do
     driven_by(:headless_chrome)
     switch_to_default_host
-  end
-
-  config.after :each, type: :system do |example|
-    Capybara::Screenshot::RSpec.after_failed_example(example)
   end
 
   config.before :each, driver: :rack_test do

--- a/decidim-dev/lib/decidim/dev/test/spec_helper.rb
+++ b/decidim-dev/lib/decidim/dev/test/spec_helper.rb
@@ -1,14 +1,7 @@
 # frozen_string_literal: true
 
 require "rails-controller-testing"
-
-# Removes rails default before/after hooks for screenshots, so that we can use
-# `capybara-screenshot` instead. Needs to be required _before_ rspec/rails,
-# because `rspec-rails` uses these hooks, so we need the monkeypatch to be
-# applied first so that it uses the monkeypatched version.
-require_relative "screenshot_helper_ext"
 require "rspec/rails"
-
 require "rspec/cells"
 require "byebug"
 require "rectify/rspec"
@@ -21,6 +14,7 @@ require "action_view/helpers/sanitize_helper"
 Dir["#{__dir__}/rspec_support/**/*.rb"].each { |f| require f }
 
 require_relative "factories"
+require_relative "screenshot_helper_ext"
 
 RSpec.configure do |config|
   config.color = true

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -112,7 +112,6 @@ PATH
     decidim-dev (0.14.0.dev)
       byebug (~> 10.0)
       capybara (~> 3.0)
-      capybara-screenshot (~> 1.0)
       db-query-matchers (~> 0.9.0)
       decidim (~> 0.14.a)
       erb_lint (~> 0.0.22)
@@ -265,9 +264,6 @@ GEM
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       xpath (~> 3.1)
-    capybara-screenshot (1.0.21)
-      capybara (>= 1.0, < 4)
-      launchy
     carrierwave (1.2.3)
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -112,7 +112,6 @@ PATH
     decidim-dev (0.14.0.dev)
       byebug (~> 10.0)
       capybara (~> 3.0)
-      capybara-screenshot (~> 1.0)
       db-query-matchers (~> 0.9.0)
       decidim (~> 0.14.a)
       erb_lint (~> 0.0.22)
@@ -265,9 +264,6 @@ GEM
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       xpath (~> 3.1)
-    capybara-screenshot (1.0.21)
-      capybara (>= 1.0, < 4)
-      launchy
     carrierwave (1.2.3)
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)


### PR DESCRIPTION
#### :tophat: What? Why?

This reverts commit 2da5a0f8e2492f0b0aa726375c97eba62c4c9062. Since it seems to cause a lot of flakies for some reason. I tried 22f5c93 but [it didn't work](https://circleci.com/gh/decidim/decidim/124947).

Sorry for the trouble and the "stolen CI resources" :pray: 

#### :pushpin: Related Issues
- Related to #3782.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.