### PR TITLE
Don't crash when a nickname has a dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - **decidim-core**: Fix follow within search results. [\#3745](https://github.com/decidim/decidim/pull/3745)
 - **decidim-proposals**: An author should always follow their proposal. [\#3791](https://github.com/decidim/decidim/pull/3791)
 - **decidim-core**: Fix notifications sending when there's no component. [\#3792](https://github.com/decidim/decidim/pull/3792)
+- **decidim-core**: Don't crash when a nickname has a dot. [\#3793](https://github.com/decidim/decidim/pull/3793)
 
 **Removed**:
 

--- a/decidim-admin/app/controllers/decidim/admin/impersonations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/impersonations_controller.rb
@@ -80,6 +80,7 @@ module Decidim
           managed: true,
           name: params.dig(:impersonate_user, :name)
         ) do |u|
+          u.nickname = User.nicknamize(u.name, organization: current_organization)
           u.admin = false
           u.tos_agreement = true
         end

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -58,8 +58,8 @@ Decidim::Core::Engine.routes.draw do
     end
   end
 
-  resources :profiles, only: [:show], param: :nickname
-  scope "/profiles/:nickname" do
+  resources :profiles, only: [:show], param: :nickname, constraints: { nickname: %r{[^\/]+} }, format: false
+  scope "/profiles/:nickname", format: false, constraints: { nickname: %r{[^\/]+} } do
     get "notifications", to: "profiles#show", as: "profile_notifications", active: "notifications"
     get "following", to: "profiles#show", as: "profile_following", active: "following"
     get "followers", to: "profiles#show", as: "profile_followers", active: "followers"

--- a/decidim-core/db/migrate/20180706104107_add_nickname_to_managed_users.rb
+++ b/decidim-core/db/migrate/20180706104107_add_nickname_to_managed_users.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddNicknameToManagedUsers < ActiveRecord::Migration[5.2]
+  class User < ApplicationRecord
+    self.table_name = :decidim_users
+  end
+
+  def up
+    User.where(managed: true, nickname: nil).includes(:organization).find_each do |user|
+      user.nickname = User.nicknamize(user.name, organization: user.organization)
+      user.save
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

We should allow `.` at nicknames.

#### :pushpin: Related Issues
- Fixes #3321

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
