### PR TITLE
An author should always follow their proposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **decidim-generators**: Generated application not including bootsnap.
 - **decidim-generators**: Generated application not including optional gems.
 - **decidim-core**: Fix follow within search results. [\#3745](https://github.com/decidim/decidim/pull/3745)
+- **decidim-proposals**: An author should always follow their proposal. [\#3791](https://github.com/decidim/decidim/pull/3791)
 
 **Removed**:
 

--- a/decidim-core/lib/decidim/coauthorable.rb
+++ b/decidim-core/lib/decidim/coauthorable.rb
@@ -63,6 +63,7 @@ module Decidim
       def add_coauthor(user, extra_attrs = {})
         attrs = { coauthorable: self, author: user }
         Decidim::Coauthorship.create!(attrs.merge(extra_attrs))
+        Decidim::Follow.create!(followable: self, user: user)
       end
     end
   end

--- a/decidim-proposals/spec/shared/create_proposal_examples.rb
+++ b/decidim-proposals/spec/shared/create_proposal_examples.rb
@@ -89,6 +89,13 @@ shared_examples "create a proposal" do |with_author|
             expect(creator.user_group).to eq(nil)
           end
 
+          it "adds the author as a follower" do
+            command.call
+            proposal = Decidim::Proposals::Proposal.last
+
+            expect(proposal.followers).to include(author)
+          end
+
           context "with a proposal limit" do
             let(:component) do
               create(:proposal_component, settings: { "proposal_limit" => 2 })


### PR DESCRIPTION
#### :tophat: What? Why?

An author (or co-aouthors) should follow their own proposals so they get notifications.

#### :pushpin: Related Issues
- Fixes #3751

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
