### PR TITLE
Fix notifications sending when there's no component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **decidim-generators**: Generated application not including bootsnap.
 - **decidim-generators**: Generated application not including optional gems.
 - **decidim-core**: Fix follow within search results. [\#3745](https://github.com/decidim/decidim/pull/3745)
+- **decidim-core**: Fix notifications sending when there's no componen. [\#3792](https://github.com/decidim/decidim/pull/3792)
 
 **Removed**:
 

--- a/decidim-core/lib/decidim/events/base_event.rb
+++ b/decidim-core/lib/decidim/events/base_event.rb
@@ -73,7 +73,7 @@ module Decidim
       def notifiable?
         return false if resource.is_a?(Decidim::Publicable) && !resource.published?
         return false if participatory_space.is_a?(Decidim::Publicable) && !participatory_space&.published?
-        return false unless component&.published?
+        return false if component && !component.published?
 
         return false if participatory_space.is_a?(Decidim::Participable) && !participatory_space.can_participate?(user)
 
@@ -90,6 +90,7 @@ module Decidim
       end
 
       def participatory_space
+        return resource if resource.is_a?(Decidim::ParticipatorySpaceResourceable)
         component&.participatory_space
       end
 

--- a/decidim-core/spec/lib/events/base_event_spec.rb
+++ b/decidim-core/spec/lib/events/base_event_spec.rb
@@ -119,6 +119,18 @@ module Decidim
           it { is_expected.not_to be_notifiable }
         end
       end
+
+      context "when the resource is a participatory space" do
+        let(:resource) { build(:participatory_process) }
+
+        it { is_expected.to be_notifiable }
+
+        context "when it is not published" do
+          let(:resource) { build(:participatory_process, :unpublished) }
+
+          it { is_expected.not_to be_notifiable }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

If a notification was triggered by a resource that didn't have a component (like attaching a file to a participatory process), no notification was being sent.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
