### PR TITLE
Don't crash when a page doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Decidim::User.find_each(&:add_to_index_as_search_resource)
 - **decidim-core**: Fix followable type for Decidim::Accountability::Result. [\#3798](https://github.com/decidim/decidim/pull/3798)
 - **decidim-accountability**: Fix accountability diff renderer when a locale is missing. [\#3797](https://github.com/decidim/decidim/pull/3797)
 - **decidim-core**: Don't crash when a nickname has a dot. [\#3793](https://github.com/decidim/decidim/pull/3793)
+- **decidim-core**: Don't crash when a page doesn't exist. [\#3799](https://github.com/decidim/decidim/pull/3799)
 
 **Removed**:
 

--- a/decidim-core/app/controllers/decidim/newsletters_controller.rb
+++ b/decidim-core/app/controllers/decidim/newsletters_controller.rb
@@ -13,12 +13,10 @@ module Decidim
       @user = current_user
       @organization = current_organization
 
-      if newsletter.sent?
-        @encrypted_token = Decidim::NewsletterEncryptor.sent_at_encrypted(@user.id, newsletter.sent_at) if @user.present?
-        @body = parse_interpolations(newsletter.body[I18n.locale.to_s], @user, newsletter.id)
-      else
-        redirect_to "/404"
-      end
+      raise ActionController::RoutingError, "Not Found" unless newsletter.sent?
+
+      @encrypted_token = Decidim::NewsletterEncryptor.sent_at_encrypted(@user.id, newsletter.sent_at) if @user.present?
+      @body = parse_interpolations(newsletter.body[I18n.locale.to_s], @user, newsletter.id)
     end
 
     def unsubscribe

--- a/decidim-core/app/controllers/decidim/pages_controller.rb
+++ b/decidim-core/app/controllers/decidim/pages_controller.rb
@@ -22,7 +22,7 @@ module Decidim
       elsif page
         render :decidim_page
       else
-        redirect_to "/404"
+        raise ActionController::RoutingError, "Not Found"
       end
     end
 

--- a/decidim-core/app/controllers/decidim/pages_controller.rb
+++ b/decidim-core/app/controllers/decidim/pages_controller.rb
@@ -19,8 +19,10 @@ module Decidim
       enforce_permission_to :read, :public_page, page: page
       if params[:id] == "home"
         render :home
-      else
+      elsif page
         render :decidim_page
+      else
+        redirect_to "/404"
       end
     end
 

--- a/decidim-core/spec/controllers/newsletters_controller_spec.rb
+++ b/decidim-core/spec/controllers/newsletters_controller_spec.rb
@@ -17,9 +17,8 @@ module Decidim
         let(:newsletter) { create(:newsletter, organization: organization) }
 
         it "expect a 404 page" do
-          get :show, params: { id: newsletter.id }
-          expect(response.status).to eq(302)
-          expect(response).to redirect_to("/404")
+          expect { get :show, params: { id: newsletter.id } }
+            .to raise_error(ActionController::RoutingError)
         end
       end
 

--- a/decidim-core/spec/controllers/pages_controller_spec.rb
+++ b/decidim-core/spec/controllers/pages_controller_spec.rb
@@ -36,6 +36,15 @@ module Decidim
           expect(response.body).to include(page.content[I18n.locale.to_s])
         end
       end
+
+      context "when a page doesn't exist" do
+        it "redirects to the 404" do
+          get :show, params: { id: "some-page" }
+
+          expect(response.status).to eq(302)
+          expect(response).to redirect_to("/404")
+        end
+      end
     end
   end
 end

--- a/decidim-core/spec/controllers/pages_controller_spec.rb
+++ b/decidim-core/spec/controllers/pages_controller_spec.rb
@@ -39,10 +39,8 @@ module Decidim
 
       context "when a page doesn't exist" do
         it "redirects to the 404" do
-          get :show, params: { id: "some-page" }
-
-          expect(response.status).to eq(302)
-          expect(response).to redirect_to("/404")
+          expect { get :show, params: { id: "some-page" } }
+            .to raise_error(ActionController::RoutingError)
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

Redirect to `404` when trying to render a page that doesn't exist.

#### :pushpin: Related Issues
- Fixes #3778

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry