### PR TITLE
Generate a code for meetings registrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Added**:
 
 - **decidim-meetings**: Allow users to accept or reject invitations to meetings, and allow admins to see their status. [\#3632](https://github.com/decidim/decidim/pull/3632)
+- **decidim-meetings**: Generate a registration code and give it to users when they join to the meeting. [\#3805](https://github.com/decidim/decidim/pull/3805)
 - **decidim-core**: Make Users Searchable. [\#3796](https://github.com/decidim/decidim/pull/3796)
 - **decidim-participatory_processes**: Highlight the correct menu item when visiting a process group page [\#3737](https://github.com/decidim/decidim/pull/3737)
 

--- a/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
@@ -30,14 +30,14 @@ module Decidim
 
       private
 
-      attr_reader :meeting, :user
+      attr_reader :meeting, :user, :registration
 
       def accept_invitation
         meeting.invites.find_by(user: user)&.accept!
       end
 
       def create_registration
-        Decidim::Meetings::Registration.create!(meeting: meeting, user: user)
+        @registration = Decidim::Meetings::Registration.create!(meeting: meeting, user: user)
       end
 
       def can_join_meeting?
@@ -45,7 +45,7 @@ module Decidim
       end
 
       def send_email_confirmation
-        Decidim::Meetings::RegistrationMailer.confirmation(user, meeting).deliver_later
+        Decidim::Meetings::RegistrationMailer.confirmation(user, meeting, registration).deliver_later
       end
 
       def participatory_space_admins

--- a/decidim-meetings/app/mailers/decidim/meetings/registration_mailer.rb
+++ b/decidim-meetings/app/mailers/decidim/meetings/registration_mailer.rb
@@ -11,10 +11,11 @@ module Decidim
       helper Decidim::ResourceHelper
       helper Decidim::TranslationsHelper
 
-      def confirmation(user, meeting)
+      def confirmation(user, meeting, registration)
         with_user(user) do
           @user = user
           @meeting = meeting
+          @registration = registration
           @organization = @meeting.organization
           @locator = Decidim::ResourceLocatorPresenter.new(@meeting)
 

--- a/decidim-meetings/app/serializers/decidim/meetings/data_portability_registration_serializer.rb
+++ b/decidim-meetings/app/serializers/decidim/meetings/data_portability_registration_serializer.rb
@@ -7,6 +7,7 @@ module Decidim
       def serialize
         {
           id: resource.id,
+          code: resource.code,
           user: {
             name: resource.user.name,
             email: resource.user.email

--- a/decidim-meetings/app/serializers/decidim/meetings/registration_serializer.rb
+++ b/decidim-meetings/app/serializers/decidim/meetings/registration_serializer.rb
@@ -7,6 +7,7 @@ module Decidim
       def serialize
         {
           id: resource.id,
+          code: resource.code,
           user: {
             name: resource.user.name,
             email: resource.user.email

--- a/decidim-meetings/app/views/decidim/meetings/registration_mailer/confirmation.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/registration_mailer/confirmation.html.erb
@@ -1,3 +1,5 @@
 <p><%= t(".confirmed_html", title: translated_attribute(@meeting.title), url: @locator.url) %></p>
 
+<p><%= t(".registration_code", code: @registration.code) %></p>
+
 <p><%= t(".details") %></p>

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -340,6 +340,7 @@ en:
         confirmation:
           confirmed_html: Your registration for the meeting <a href="%{url}">%{title}</a> has been confirmed.
           details: You will find the meeting's details in the attachment.
+          registration_code: Your registration code is %{code}.
       registrations:
         create:
           invalid: There's been a problem joining this meeting.

--- a/decidim-meetings/db/migrate/20180615160839_add_code_to_decidim_meetings_registrations.rb
+++ b/decidim-meetings/db/migrate/20180615160839_add_code_to_decidim_meetings_registrations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCodeToDecidimMeetingsRegistrations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_meetings_registrations, :code, :string, index: true
+  end
+end

--- a/decidim-meetings/lib/decidim/meetings.rb
+++ b/decidim-meetings/lib/decidim/meetings.rb
@@ -9,5 +9,6 @@ module Decidim
   # Base module for this engine.
   module Meetings
     autoload :ViewModel, "decidim/meetings/view_model"
+    autoload :Registrations, "decidim/meetings/registrations"
   end
 end

--- a/decidim-meetings/lib/decidim/meetings/registrations.rb
+++ b/decidim-meetings/lib/decidim/meetings/registrations.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "decidim/meetings/registrations/code_generator"
+
+module Decidim
+  module Meetings
+    module Registrations
+
+      # Public: Stores an instance of Registrations::CodeGenerator
+      def self.code_generator
+        @code_generator ||= Decidim::Meetings::Registrations::CodeGenerator.new
+      end
+    end
+  end
+end

--- a/decidim-meetings/lib/decidim/meetings/registrations.rb
+++ b/decidim-meetings/lib/decidim/meetings/registrations.rb
@@ -5,7 +5,6 @@ require "decidim/meetings/registrations/code_generator"
 module Decidim
   module Meetings
     module Registrations
-
       # Public: Stores an instance of Registrations::CodeGenerator
       def self.code_generator
         @code_generator ||= Decidim::Meetings::Registrations::CodeGenerator.new

--- a/decidim-meetings/lib/decidim/meetings/registrations/code_generator.rb
+++ b/decidim-meetings/lib/decidim/meetings/registrations/code_generator.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "securerandom"
+
+module Decidim
+  module Meetings
+    module Registrations
+      # This class handles the generation of meeting registration codes
+      class CodeGenerator
+        # excluded digits: 0, 1, excluded letters: O, I
+        ALPHABET = [*"A".."Z", *"2".."9"] - %w(O I)
+        LENGTH = 8
+
+        def initialize(options = {})
+          @length = options[:length] || LENGTH
+        end
+
+        def generate(registration)
+          loop do
+            registration_code = choose(@length)
+
+            # Use the random number if no other registration exists with it.
+            break registration_code unless registration.class.exists?(meeting: registration.meeting, code: registration_code)
+          end
+        end
+
+        private
+
+        def choose(length)
+          limit = ALPHABET.size
+
+          (1..length).map do
+            ALPHABET[SecureRandom.random_number(limit)]
+          end.join
+        end
+      end
+    end
+  end
+end

--- a/decidim-meetings/spec/commands/join_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/join_meeting_spec.rb
@@ -31,9 +31,13 @@ module Decidim::Meetings
         perform_enqueued_jobs { subject.call }
 
         email = last_email
-        expect(email.subject).to include("confirmed")
-        attachment = email.attachments.first
+        email_body = last_email_body
+        last_registration = Registration.last
 
+        expect(email.subject).to include("confirmed")
+        expect(email_body).to include(last_registration.code)
+
+        attachment = email.attachments.first
         expect(attachment.read.length).to be_positive
         expect(attachment.mime_type).to eq("text/calendar")
         expect(attachment.filename).to match(/meeting-calendar-info.ics/)

--- a/decidim-meetings/spec/lib/meetings/registrations/code_generator_spec.rb
+++ b/decidim-meetings/spec/lib/meetings/registrations/code_generator_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Meetings
+    module Registrations
+      describe CodeGenerator do
+        subject { described_class.new(length: length) }
+
+        let(:length) { 6 }
+        let(:meeting) { build(:meeting) }
+        let(:registration) { build :registration, meeting: meeting }
+
+        describe "#generate" do
+          let(:existing_code) { "AS35TY58" }
+          let(:valid_code) { "QW89HJ34" }
+          let(:code) { subject.generate(registration) }
+
+          before do
+            create :registration, meeting: meeting, code: existing_code
+
+            expect(subject)
+              .to receive(:choose)
+              .with(length)
+              .exactly(2).times
+              .and_return(existing_code, valid_code)
+          end
+
+          it "returns an unique code" do
+            expect(code).to eq valid_code
+          end
+        end
+
+        describe "#choose" do
+          let(:code) { subject.generate(registration) }
+
+          it "returns a code with correct length" do
+            expect(code.length).to eq(length)
+          end
+
+          it "returns a code where all chars are valid" do
+            code.split("").each do |char|
+              expect(CodeGenerator::ALPHABET).to include char
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-meetings/spec/lib/meetings/registrations/code_generator_spec.rb
+++ b/decidim-meetings/spec/lib/meetings/registrations/code_generator_spec.rb
@@ -20,11 +20,13 @@ module Decidim
           before do
             create :registration, meeting: meeting, code: existing_code
 
+            # rubocop:disable RSpec/SubjectStub
             expect(subject)
               .to receive(:choose)
               .with(length)
-              .exactly(2).times
+              .twice
               .and_return(existing_code, valid_code)
+            # rubocop:enable RSpec/SubjectStub
           end
 
           it "returns an unique code" do

--- a/decidim-meetings/spec/mailers/registration_mailer_spec.rb
+++ b/decidim-meetings/spec/mailers/registration_mailer_spec.rb
@@ -11,7 +11,8 @@ module Decidim::Meetings
     let(:component) { create(:component, manifest_name: :meetings, participatory_space: participatory_process) }
     let(:user) { create(:user, organization: organization) }
     let(:meeting) { create(:meeting, component: component) }
-    let(:mail) { described_class.confirmation(user, meeting) }
+    let(:registration) { create(:registration, meeting: meeting, user: user) }
+    let(:mail) { described_class.confirmation(user, meeting, registration) }
 
     describe "confirmation" do
       let(:subject) { "La teva inscripció a la trobada ha estat confirmada" }
@@ -21,6 +22,10 @@ module Decidim::Meetings
       let(:default_body) { "details in the attachment" }
 
       include_examples "user localised email"
+    end
+
+    it "includes the registration code" do
+      expect(email_body(mail)).to match("Your registration code is #{registration.code}")
     end
 
     it "includes the meeting's details in a ics file" do

--- a/decidim-meetings/spec/models/registration_spec.rb
+++ b/decidim-meetings/spec/models/registration_spec.rb
@@ -19,5 +19,33 @@ module Decidim::Meetings
 
       it { is_expected.not_to be_valid }
     end
+
+    context "when a registration with the same code already exists" do
+      let(:code) { "AZ45HJ87" }
+
+      context "when in the same meeting" do
+        before do
+          create :registration, meeting: meeting, user: create(:user, organization: meeting.organization), code: code
+        end
+
+        it "is invalid" do
+          registration.code = code
+
+          is_expected.not_to be_valid
+        end
+      end
+
+      context "when in another meeting" do
+        before do
+          create :registration, code: code
+        end
+
+        it "is invalid" do
+          registration.code = code
+
+          is_expected.to be_valid
+        end
+      end
+    end
   end
 end

--- a/decidim-meetings/spec/serializers/data_portability_registration_serializer_spec.rb
+++ b/decidim-meetings/spec/serializers/data_portability_registration_serializer_spec.rb
@@ -12,6 +12,10 @@ module Decidim::Meetings
         expect(subject.serialize).to include(id: resource.id)
       end
 
+      it "includes the registration code" do
+        expect(subject.serialize).to include(code: resource.code)
+      end
+
       it "includes the user" do
         expect(subject.serialize[:user]).to(
           include(name: resource.user.name)

--- a/decidim-meetings/spec/serializers/registration_serializer_spec.rb
+++ b/decidim-meetings/spec/serializers/registration_serializer_spec.rb
@@ -12,6 +12,10 @@ module Decidim::Meetings
         expect(subject.serialize).to include(id: registration.id)
       end
 
+      it "includes the registration code" do
+        expect(subject.serialize).to include(code: registration.code)
+      end
+
       it "includes the user" do
         expect(subject.serialize[:user]).to(
           include(name: registration.user.name)


### PR DESCRIPTION
#### :tophat: What? Why?

Registered participants receive a registration code (8 digit alphanumeric only capital letters and excluding ambiguous characters such as 1, O/0, etc.)

#### :pushpin: Related Issues
- Related to #3233

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
