### PR TITLE
[DOC] Add changelog notes for manual indexing of Users.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased](https://github.com/decidim/decidim/tree/HEAD)
 
-## Upgrade notes (search):
+**Upgrade notes (search)**:
 
 In order for the currently existing Users to be indexed, you'll have to manually trigger a reindex. You can do that executing:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased](https://github.com/decidim/decidim/tree/HEAD)
 
+## Upgrade notes (search):
+
+In order for the currently existing Users to be indexed, you'll have to manually trigger a reindex. You can do that executing:
+
+```ruby
+Decidim::User.find_each(&:add_to_index_as_search_resource)
+```
+
 **Added**:
 
 - **decidim-meetings**: Allow users to accept or reject invitations to meetings, and allow admins to see their status. [\#3632](https://github.com/decidim/decidim/pull/3632)


### PR DESCRIPTION
#### :tophat: What? Why?
In order for the Search engine to return already existing Users in the results, a manual indexing must be done after upgrading Decidim.

#### :pushpin: Related Issues
- Related to #2589 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add documentation regarding the feature 
- [-] Add/modify seeds
- [-] Add tests