### PR TITLE
Restore RUBYLIB after loading the right version

### DIFF
--- a/decidim-generators/exe/decidim
+++ b/decidim-generators/exe/decidim
@@ -3,6 +3,7 @@
 
 if File.exist?(File.expand_path("../../.git", __dir__))
   ENV["RUBYOPT"] = ENV["RUBYOPT"].sub("-rsimplecov ", "")
+  ENV["RUBYLIB"] = ENV["RUBYLIB"].sub("#{File.expand_path("..", __dir__)}/lib:", "")
 
   gem "decidim-core"
 end

--- a/decidim-generators/spec/generators_spec.rb
+++ b/decidim-generators/spec/generators_spec.rb
@@ -7,10 +7,17 @@ require "decidim/gem_manager"
 module Decidim
   describe Generators do
     let(:env) do |example|
+      #
+      # When tracking coverage, make sure the ruby environment points to the
+      # local version, so we get the benefits of running `decidim` directly
+      # without `bundler` (more realistic test), but also get code coverage
+      # properly measured (we track coverage on the local version and not on the
+      # installed version).
+      #
       if ENV["SIMPLECOV"]
         {
           "RUBYOPT" => "-rsimplecov #{ENV["RUBYOPT"]}",
-          "RUBYLIB" => "#{repo_root}/decidim-generators/lib",
+          "RUBYLIB" => "#{repo_root}/decidim-generators/lib:#{ENV["RUBYLIB"]}",
           "PATH" => "#{repo_root}/decidim-generators/exe:#{ENV["PATH"]}",
           "COMMAND_NAME" => example.full_description.tr(" ", "_")
         }


### PR DESCRIPTION
#### :tophat: What? Why?

This PR forward ports the fix that got https://github.com/decidim/decidim/pull/3780 green to master. Not strictly needed for greenness but it's a bug fix in the specs, so it should live in master. I'll also try to explain the why this worked on #3780.

##### Background

Generator specs are a bit special, because simulating the real environment where they run is tough. When we initially added generators specs, they run on our development repo bundled environment. However, this was not the real environment where the generator is run, since when you do `gem install decidim`, and then `decidim my_new_app`, there's no `Gemfile` or anything. This would cause issues in the generator that wouldn't be caught by our tests.

So the trick we do to test them in "real conditions" is to manually build the gems from the development version, install them, and then run the installed version. That's these [girls here](https://github.com/decidim/decidim/blob/dd474554f8fbd1d1cd815100343d4045117ecdbb/decidim-generators/spec/generators_spec.rb#L26-L34).

This technique works good but had a gotcha: we can never get code coverage stats for generators code because the code we run is an "installed copy", not the real development copy. In order to resolve this issue, what we do is "trick rubygems" so that, although running the `decidim` executable directly without a `bundler` context, it still uses our development copy. That's [this dance](https://github.com/decidim/decidim/blob/dd474554f8fbd1d1cd815100343d4045117ecdbb/decidim-generators/spec/generators_spec.rb#L10-L16).

Since we only want these environment modifications to be applied when choosing the version of `decidim-generators`, we "undo" them as soon as the right version loads. Otherwise every subsequent ruby process spawned by the generator will try to load `simplecov`, for example. That's done [here](https://github.com/decidim/decidim/blob/dd474554f8fbd1d1cd815100343d4045117ecdbb/decidim-generators/exe/decidim#L5), and it's a trick I learnt from `rails`.

##### The bug

The bug is that in that "unsetting" part, we were forgetting to unset the modifications in `RUBYLIB`. The `RUBYLIB` environment variable tells the ruby process to add a list of paths to the `LOAD_PATH` when ruby starts. Since we were not resetting it, all subsequent rubies where putting the development version of `decidim-generators` in front of the `LOAD_PATH`. That resulted in `bundle install` not being able to resolve a `Gemfile` pointing to `decidim`'s master: the `Gemfile` would expect `decidim-generators 0.14.0.dev` (current master), but it would always find an incorrect version loaded (`0.13.0.pre1`, the local one).

It's a pretty intricate issue, so I'm not sure if I properly explained it... Hopefully makes sense!

#### :pushpin: Related Issues
- Related to #3780.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.