### PR TITLE
[REFACTOR|TEST] Refactor searchable test to avoid flake tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Decidim::User.find_each(&:add_to_index_as_search_resource)
 
 **Fixed**:
 
+- **decidim-proposals**: Refactor searchable proposal test to avoid flakes. [\#3825](https://github.com/decidim/decidim/pull/3825)
 - **decidim-proposals**: Proposal seeds iterate over a sample of users to add coauthorships. [\#3796](https://github.com/decidim/decidim/pull/3796)
 - **decidim-core**: Make proposal m-card render its authorship again. [\#3727](https://github.com/decidim/decidim/pull/3727)
 - **decidim-generators**: Generated application not including bootsnap.

--- a/decidim-proposals/spec/services/decidim/proposals/searchable_proposal_rsrc_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/searchable_proposal_rsrc_spec.rb
@@ -67,6 +67,7 @@ module Decidim
               proposal.update(title: updated_title)
 
               proposal.save!
+              searchable.reload
 
               organization.available_locales.each do |locale|
                 searchable = SearchableResource.find_by(resource_type: proposal.class.name, resource_id: proposal.id, locale: locale)


### PR DESCRIPTION
#### :tophat: What? Why?
Somehow "spec/services/decidim/proposals/searchable_proposal_rsrc_spec.rb:63" test failed after merging one PR into master, but it use to pass until the date.

My hypothesis is that randomly the list of available locales starts with the locale of the SearchableResource retrieved at the begining, but normaly it doesn't. When both have the same locale the SearchableResource in the iteration won't be retrieved and the cached instance will be reused. 

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [-] Add documentation regarding the feature 
- [-] Add/modify seeds
- [x] Add tests