### PR TITLE
Fix newsletterable when eager loading

### DIFF
--- a/decidim-core/lib/devise/models/decidim_newsletterable.rb
+++ b/decidim-core/lib/devise/models/decidim_newsletterable.rb
@@ -8,7 +8,7 @@ module Devise
     # Validates that all users with notifications activated have Opt-in in
     # some time
     module DecidimNewsletterable
-      GDPR_DATE = Time.zone.parse("2018-05-25 00:00 +02:00")
+      GDPR_DATE = "2018-05-25 00:00 +02:00"
 
       def newsletter_opt_in_notify
         unless newsletter_opt_in_valid?
@@ -26,7 +26,7 @@ module Devise
       # Checks if Opt-in is valid or not
       # An user with notifications activated, must have an Opt-in
       def newsletter_opt_in_valid?
-        newsletter_notifications_at > GDPR_DATE
+        newsletter_notifications_at > Time.zone.parse(GDPR_DATE)
       end
 
       # Fill token value with some random value


### PR DESCRIPTION
#### :tophat: What? Why?
When upgrading apps to `0.13.0`, I've detected that `Time.zone.parse` fails on boot time, since `active_record` might not be fully loaded (as we're calling it at the class level).

This mitigates the issue, but I'm not entirely sure it's the best solution. Anyone has run into this issue?

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*
