### PR TITLE
Allow admins to validate meeting registration codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Decidim::User.find_each(&:add_to_index_as_search_resource)
 - **decidim-core**: Support for actions authorizations at resource level [\#3804](https://github.com/decidim/decidim/pull/3804)
 - **decidim-meetings**: Allow users to accept or reject invitations to meetings, and allow admins to see their status. [\#3632](https://github.com/decidim/decidim/pull/3632)
 - **decidim-meetings**: Generate a registration code and give it to users when they join to the meeting. [\#3805](https://github.com/decidim/decidim/pull/3805)
+- **decidim-meetings**: Allow admins to validate meeting registration codes and notify the user. [\#3833](https://github.com/decidim/decidim/pull/3833)
 - **decidim-core**: Make Users Searchable. [\#3796](https://github.com/decidim/decidim/pull/3796)
 - **decidim-participatory_processes**: Highlight the correct menu item when visiting a process group page [\#3737](https://github.com/decidim/decidim/pull/3737)
 

--- a/decidim-meetings/app/commands/decidim/meetings/admin/validate_registration_code.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/validate_registration_code.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    module Admin
+      # This command is executed when the admin validates a registration code in the admin panel.
+      class ValidateRegistrationCode < Rectify::Command
+        # Initializes a ValidateRegistrationCode Command.
+        #
+        # form - The form from which to get the data.
+        # meeting - The current instance of the meeting to be updated.
+        def initialize(form, meeting)
+          @form = form
+          @meeting = meeting
+        end
+
+        # Validates the registration code the meeting if valid.
+        #
+        # Broadcasts :ok if successful, :invalid otherwise.
+        def call
+          return broadcast(:invalid) if form.invalid?
+
+          if registration.blank?
+            form.errors.add :code, I18n.t("registrations.validate_registration_code.invalid", scope: "decidim.meetings.admin")
+            return broadcast(:invalid)
+          end
+
+          validate_registration_code
+          send_notification
+
+          broadcast(:ok)
+        end
+
+        private
+
+        attr_reader :form, :meeting
+
+        def validate_registration_code
+          registration.validated_at = Time.current
+          registration.save!
+        end
+
+        def registration
+          @registration ||= meeting.registrations.find_by(code: form.code, validated_at: nil)
+        end
+
+        def send_notification
+          Decidim::EventsManager.publish(
+            event: "decidim.events.meetings.registration_code_validated",
+            event_class: Decidim::Meetings::RegistrationCodeValidatedEvent,
+            resource: meeting,
+            recipient_ids: [registration.user.id],
+            extra: {
+              registration: registration
+            }
+          )
+        end
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/registrations_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/registrations_controller.rb
@@ -9,6 +9,7 @@ module Decidim
           enforce_permission_to :update, :meeting, meeting: meeting
 
           @form = MeetingRegistrationsForm.from_model(meeting)
+          @validation_form = ValidateRegistrationCodeForm.new
         end
 
         def update
@@ -35,6 +36,25 @@ module Decidim
           ExportMeetingRegistrations.call(meeting, params[:format], current_user) do
             on(:ok) do |export_data|
               send_data export_data.read, type: "text/#{export_data.extension}", filename: export_data.filename("registrations")
+            end
+          end
+        end
+
+        def validate_registration_code
+          enforce_permission_to :update, :meeting, meeting: meeting
+
+          @form = MeetingRegistrationsForm.from_model(meeting)
+          @validation_form = ValidateRegistrationCodeForm.from_params(params).with_context(current_organization: meeting.organization, meeting: meeting)
+
+          ValidateRegistrationCode.call(@validation_form, meeting) do
+            on(:ok) do
+              flash[:notice] = I18n.t("registrations.validate_registration_code.success", scope: "decidim.meetings.admin")
+              render action: "edit"
+            end
+
+            on(:invalid) do
+              flash.now[:alert] = I18n.t("registrations.validate_registration_code.invalid", scope: "decidim.meetings.admin")
+              render action: "edit"
             end
           end
         end

--- a/decidim-meetings/app/events/decidim/meetings/registration_code_validated_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/registration_code_validated_event.rb
@@ -5,8 +5,6 @@ module Decidim
     class RegistrationCodeValidatedEvent < Decidim::Events::SimpleEvent
       i18n_attributes :registration_code
 
-      # delegate :code, to: :registration, prefix: true
-
       private
 
       def registration_code

--- a/decidim-meetings/app/events/decidim/meetings/registration_code_validated_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/registration_code_validated_event.rb
@@ -1,0 +1,17 @@
+# frozen-string_literal: true
+
+module Decidim
+  module Meetings
+    class RegistrationCodeValidatedEvent < Decidim::Events::SimpleEvent
+      i18n_attributes :registration_code
+
+      # delegate :code, to: :registration, prefix: true
+
+      private
+
+      def registration_code
+        extra["registration"]["code"]
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/forms/decidim/meetings/admin/validate_registration_code_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/validate_registration_code_form.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    module Admin
+      # This class holds a Form to validate registration codes from Decidim's admin panel.
+      class ValidateRegistrationCodeForm < Decidim::Form
+        attribute :code, String
+
+        validates :code, presence: true
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/forms/decidim/meetings/admin/validate_registration_code_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/validate_registration_code_form.rb
@@ -8,6 +8,25 @@ module Decidim
         attribute :code, String
 
         validates :code, presence: true
+        validate :registration_exists
+
+        def registration
+          @registration ||= meeting.registrations.find_by(code: code, validated_at: nil)
+        end
+
+        private
+
+        def meeting
+          @meeting ||= context[:meeting]
+        end
+
+        def registration_exists
+          return unless registration.nil?
+          errors.add(
+            :code,
+            I18n.t("registrations.validate_registration_code.invalid", scope: "decidim.meetings.admin")
+          )
+        end
       end
     end
   end

--- a/decidim-meetings/app/views/decidim/meetings/admin/registrations/edit.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/registrations/edit.html.erb
@@ -1,3 +1,27 @@
+<div class="card">
+  <div class="card-divider">
+    <h2 class="card-title">
+      <%= t(".validate_registration_code") %>
+    </h2>
+  </div>
+  <div class="card-section">
+    <%= decidim_form_for(@validation_form, url: validate_registration_code_meeting_registrations_path, html: { class: "form validate_meeting_registration_code" })  do |f| %>
+
+      <div class="grid-x grid-margin-x">
+        <div class="auto cell">
+          <%= f.text_field :code %>
+        </div>
+
+        <div class="shrink cell">
+          <div class="text-center mt-sm">
+            <%= f.submit t(".validate") %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>
+
 <%= decidim_form_for(@form, url: meeting_registrations_path, html: { class: "form edit_meeting_registrations" })  do |f| %>
   <%= render partial: "form", object: f %>
 

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -107,6 +107,11 @@ en:
           email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
           email_subject: The "%{resource_title}" meeting was updated
           notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting was updated.
+        registration_code_validated:
+          email_intro: Your registration code "%{registration_code}" has been validated.
+          email_outro: You have received this notification because your registration code for the "%{resource_title}" meeting has been validated.
+          email_subject: Your registration code "%{registration_code}" has been validated
+          notification_title: Your registration code "%{registration_code}" for the <a href="%{resource_path}">%{resource_title}</a> meeting has been validated.
         registrations_enabled:
           email_intro: 'The "%{resource_title}" meeting has enabled registrations. You can register yourself on its page:'
           email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
@@ -242,6 +247,8 @@ en:
         registrations:
           edit:
             save: Save
+            validate: Validate
+            validate_registration_code: Validate registration code
           form:
             available_slots_help: Leave it to 0 if you have unlimited slots available.
             invites: Invites
@@ -254,6 +261,9 @@ en:
           update:
             invalid: There's been a problem saving the registration settings.
             success: Meeting registrations settings successfully saved.
+          validate_registration_code:
+            invalid: This registration code is invalid.
+            success: Registration code successfully validated.
       admin_log:
         invite:
           create: "%{user_name} invited %{attendee_name} to join %{resource_name} meeting on the %{space_name} space"

--- a/decidim-meetings/db/migrate/20180711111023_add_validated_at_to_decidim_meetings_registrations.rb
+++ b/decidim-meetings/db/migrate/20180711111023_add_validated_at_to_decidim_meetings_registrations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddValidatedAtToDecidimMeetingsRegistrations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_meetings_registrations, :validated_at, :datetime
+  end
+end

--- a/decidim-meetings/lib/decidim/meetings/admin_engine.rb
+++ b/decidim-meetings/lib/decidim/meetings/admin_engine.rb
@@ -17,6 +17,7 @@ module Decidim
             resources :invites, only: [:index, :create]
             collection do
               get :export
+              post :validate_registration_code
             end
           end
           resources :agenda, except: [:index, :destroy]

--- a/decidim-meetings/spec/commands/admin/validate_registration_code_spec.rb
+++ b/decidim-meetings/spec/commands/admin/validate_registration_code_spec.rb
@@ -10,7 +10,9 @@ module Decidim::Meetings
     let(:code) { "VPAGQ2DG" }
 
     let(:form) do
-      Admin::ValidateRegistrationCodeForm.from_params(code: code)
+      Admin::ValidateRegistrationCodeForm.from_params(
+        code: code
+      ).with_context(current_organization: meeting.organization, meeting: meeting)
     end
 
     context "when the form is not valid" do
@@ -20,34 +22,6 @@ module Decidim::Meetings
 
       it "broadcasts invalid" do
         expect { subject.call }.to broadcast(:invalid)
-      end
-    end
-
-    context "when the registration code doesn't exist" do
-      let!(:registration) { create(:registration, meeting: meeting) }
-
-      it "broadcasts invalid" do
-        expect { subject.call }.to broadcast(:invalid)
-      end
-
-      it "adds errors to the form" do
-        subject.call
-
-        expect(form.errors[:code]).not_to be_empty
-      end
-    end
-
-    context "when the registration code is already validated" do
-      let!(:registration) { create(:registration, meeting: meeting, code: code, validated_at: Time.current) }
-
-      it "broadcasts invalid" do
-        expect { subject.call }.to broadcast(:invalid)
-      end
-
-      it "adds errors to the form" do
-        subject.call
-
-        expect(form.errors[:code]).not_to be_empty
       end
     end
 

--- a/decidim-meetings/spec/commands/admin/validate_registration_code_spec.rb
+++ b/decidim-meetings/spec/commands/admin/validate_registration_code_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Meetings
+  describe Admin::ValidateRegistrationCode do
+    subject { described_class.new(form, meeting) }
+
+    let(:meeting) { create(:meeting) }
+    let(:code) { "VPAGQ2DG" }
+
+    let(:form) do
+      Admin::ValidateRegistrationCodeForm.from_params(code: code)
+    end
+
+    context "when the form is not valid" do
+      before do
+        expect(form).to receive(:invalid?).and_return(true)
+      end
+
+      it "broadcasts invalid" do
+        expect { subject.call }.to broadcast(:invalid)
+      end
+    end
+
+    context "when the registration code doesn't exist" do
+      let!(:registration) { create(:registration, meeting: meeting) }
+
+      it "broadcasts invalid" do
+        expect { subject.call }.to broadcast(:invalid)
+      end
+
+      it "adds errors to the form" do
+        subject.call
+
+        expect(form.errors[:code]).not_to be_empty
+      end
+    end
+
+    context "when the registration code is already validated" do
+      let!(:registration) { create(:registration, meeting: meeting, code: code, validated_at: Time.current) }
+
+      it "broadcasts invalid" do
+        expect { subject.call }.to broadcast(:invalid)
+      end
+
+      it "adds errors to the form" do
+        subject.call
+
+        expect(form.errors[:code]).not_to be_empty
+      end
+    end
+
+    context "when everything is ok" do
+      let!(:registration) { create(:registration, meeting: meeting, code: code, validated_at: nil) }
+
+      it "broadcasts ok" do
+        expect { subject.call }.to broadcast(:ok)
+      end
+
+      it "updates the registration" do
+        subject.call
+        registration.reload
+        expect(registration.validated_at).not_to be_nil
+      end
+    end
+
+    describe "events" do
+      let(:user) { create :user, :confirmed, organization: meeting.organization }
+      let!(:registration) { create(:registration, meeting: meeting, code: code, validated_at: nil, user: user) }
+
+      context "when registrations are enabled" do
+        it "notifies the change" do
+          expect(Decidim::EventsManager)
+            .to receive(:publish)
+            .with(
+              event: "decidim.events.meetings.registration_code_validated",
+              event_class: Decidim::Meetings::RegistrationCodeValidatedEvent,
+              resource: meeting,
+              recipient_ids: [user.id],
+              extra: {
+                registration: registration
+              }
+            )
+
+          subject.call
+        end
+      end
+    end
+  end
+end

--- a/decidim-meetings/spec/events/decidim/meetings/registration_code_validated_event_spec.rb
+++ b/decidim-meetings/spec/events/decidim/meetings/registration_code_validated_event_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Meetings::RegistrationCodeValidatedEvent do
+  include_context "when a simple event"
+
+  let(:resource) { create :meeting }
+  let(:event_name) { "decidim.events.meetings.registration_code_validated" }
+
+  let(:registration) { create :registration, meeting: resource }
+  let(:extra) { { registration: registration } }
+
+  it_behaves_like "a simple event"
+end

--- a/decidim-meetings/spec/forms/admin/validate_registration_code_form_spec.rb
+++ b/decidim-meetings/spec/forms/admin/validate_registration_code_form_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Meetings
+  describe Admin::ValidateRegistrationCodeForm do
+    subject(:form) do
+      described_class.from_params(
+        attributes
+      ).with_context(current_organization: organization)
+    end
+
+    let(:organization) { create :organization }
+
+    let(:code) { "RT67YU45" }
+
+    let(:attributes) do
+      {
+        code: code
+      }
+    end
+
+    it { is_expected.to be_valid }
+
+    describe "when code is missing" do
+      let(:code) { nil }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+end

--- a/decidim-meetings/spec/forms/admin/validate_registration_code_form_spec.rb
+++ b/decidim-meetings/spec/forms/admin/validate_registration_code_form_spec.rb
@@ -7,10 +7,11 @@ module Decidim::Meetings
     subject(:form) do
       described_class.from_params(
         attributes
-      ).with_context(current_organization: organization)
+      ).with_context(current_organization: meeting.organization, meeting: meeting)
     end
 
-    let(:organization) { create :organization }
+    let!(:meeting) { create :meeting }
+    let!(:registration) { create(:registration, meeting: meeting, code: code) }
 
     let(:code) { "RT67YU45" }
 
@@ -26,6 +27,20 @@ module Decidim::Meetings
       let(:code) { nil }
 
       it { is_expected.not_to be_valid }
+    end
+
+    describe "invalid code" do
+      context "when code doesn't exists" do
+        let!(:registration) { create(:registration, meeting: meeting, code: "ANOT7654") }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when code is already validated" do
+        let!(:registration) { create(:registration, meeting: meeting, code: code, validated_at: Time.current) }
+
+        it { is_expected.not_to be_valid }
+      end
     end
   end
 end

--- a/decidim-meetings/spec/shared/manage_registrations_examples.rb
+++ b/decidim-meetings/spec/shared/manage_registrations_examples.rb
@@ -63,4 +63,30 @@ shared_examples "manage registrations" do
       expect(page.response_headers["Content-Disposition"]).to match(/attachment; filename=.*\.json/)
     end
   end
+
+  context "when validating registration codes" do
+    let!(:registration) { create :registration, meeting: meeting, code: "QW12ER34" }
+
+    it "can validate a valid registration code" do
+      visit_edit_registrations_page
+
+      within ".validate_meeting_registration_code" do
+        fill_in :validate_registration_code_code, with: "QW12ER34"
+        click_button "Validate"
+      end
+
+      expect(page).to have_admin_callout("Registration code successfully validated")
+    end
+
+    it "can't validate an invalid registration code" do
+      visit_edit_registrations_page
+
+      within ".validate_meeting_registration_code" do
+        fill_in :validate_registration_code_code, with: "NOT-GOOD"
+        click_button "Validate"
+      end
+
+      expect(page).to have_admin_callout("This registration code is invalid")
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Allow admins to validate the meeting registration code and notify the user.

#### :pushpin: Related Issues
- Related to #3233

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [X] Add tests

### :camera: Screenshots (optional)

![screen shot 2018-07-11 at 18 36 12](https://user-images.githubusercontent.com/2051199/42586863-56097df2-8539-11e8-846b-af8887885ce6.png)

