### PR TITLE
Use faker 1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "bootsnap", "~> 1.3"
 gem "puma", "~> 3.0"
 gem "uglifier", "~> 4.1"
 
-gem "faker", "~> 1.8"
+gem "faker", "~> 1.9"
 
 group :development, :test do
   gem "byebug", "~> 10.0", platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -345,7 +345,7 @@ GEM
     factory_bot_rails (4.10.0)
       factory_bot (~> 4.10.0)
       railties (>= 3.0.0)
-    faker (1.8.7)
+    faker (1.9.1)
       i18n (>= 0.7)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
@@ -393,7 +393,7 @@ GEM
     ice_nine (0.11.2)
     invisible_captcha (0.10.0)
       rails (>= 3.2.0)
-    jaro_winkler (1.5.1-x86_64-darwin-17)
+    jaro_winkler (1.5.1)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -710,7 +710,7 @@ DEPENDENCIES
   decidim-consultations!
   decidim-dev!
   decidim-initiatives!
-  faker (~> 1.8)
+  faker (~> 1.9)
   letter_opener_web (~> 1.3)
   listen (~> 3.1)
   puma (~> 3.0)

--- a/decidim-generators/Gemfile
+++ b/decidim-generators/Gemfile
@@ -13,7 +13,7 @@ gem "bootsnap", "~> 1.3"
 gem "puma", "~> 3.0"
 gem "uglifier", "~> 4.1"
 
-gem "faker", "~> 1.8"
+gem "faker", "~> 1.9"
 
 group :development, :test do
   gem "byebug", "~> 10.0", platform: :mri

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -345,7 +345,7 @@ GEM
     factory_bot_rails (4.10.0)
       factory_bot (~> 4.10.0)
       railties (>= 3.0.0)
-    faker (1.8.7)
+    faker (1.9.1)
       i18n (>= 0.7)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
@@ -710,7 +710,7 @@ DEPENDENCIES
   decidim-consultations!
   decidim-dev!
   decidim-initiatives!
-  faker (~> 1.8)
+  faker (~> 1.9)
   letter_opener_web (~> 1.3)
   listen (~> 3.1)
   puma (~> 3.0)

--- a/decidim-generators/lib/decidim/generators/component_templates/Gemfile.erb
+++ b/decidim-generators/lib/decidim/generators/component_templates/Gemfile.erb
@@ -17,7 +17,7 @@ group :development, :test do
 end
 
 group :development do
-  gem "faker", "~> 1.8"
+  gem "faker", "~> 1.9"
   gem "letter_opener_web", "~> 1.3"
   gem "listen", "~> 3.1"
   gem "spring", "~> 2.0"

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -345,7 +345,7 @@ GEM
     factory_bot_rails (4.10.0)
       factory_bot (~> 4.10.0)
       railties (>= 3.0.0)
-    faker (1.8.7)
+    faker (1.9.1)
       i18n (>= 0.7)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
@@ -710,7 +710,7 @@ DEPENDENCIES
   decidim-consultations!
   decidim-dev!
   decidim-initiatives!
-  faker (~> 1.8)
+  faker (~> 1.9)
   letter_opener_web (~> 1.3)
   listen (~> 3.1)
   puma (~> 3.0)


### PR DESCRIPTION
#### :tophat: What? Why?

Faker 1.9 was released and it fixes an issue affecting decidim. Let's use it and install it on new applications.

#### :pushpin: Related Issues

- Closes #3644.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.