### PR TITLE
Eager-load test app

### DIFF
--- a/decidim-dev/lib/tasks/generators.rake
+++ b/decidim-dev/lib/tasks/generators.rake
@@ -20,17 +20,20 @@ namespace :decidim do
   end
 
   desc "Generates a dummy app for testing in external installations"
-  task :generate_external_test_app do
+  task :generate_external_test_app, [:ci] do |_t, _args|
     generate_decidim_app(
-      "spec/decidim_dummy_app",
-      "--app_name",
-      "#{base_app_name}_test_app",
-      "--path",
-      "../..",
-      "--eager-load",
-      "--recreate_db",
-      "--skip_gemfile",
-      "--demo"
+      *[
+        "spec/decidim_dummy_app",
+        "--app_name",
+        "#{base_app_name}_test_app",
+        "--path",
+        "../..",
+        "--eager-load",
+        "--recreate_db",
+        "--skip_gemfile",
+        "--demo",
+        ENV["CI"] ? "--ci" : nil
+      ].compact
     )
   end
 

--- a/decidim-dev/lib/tasks/generators.rake
+++ b/decidim-dev/lib/tasks/generators.rake
@@ -27,6 +27,7 @@ namespace :decidim do
       "#{base_app_name}_test_app",
       "--path",
       "../..",
+      "--eager-load",
       "--recreate_db",
       "--skip_gemfile",
       "--demo"

--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -61,6 +61,10 @@ module Decidim
                           default: false,
                           desc: "Generate demo authorization handlers"
 
+      class_option :ci, type: :boolean,
+                        default: false,
+                        desc: "Generate an application meant to be run in a CI environment"
+
       def database_yml
         template "database.yml.erb", "config/database.yml", force: true
       end
@@ -153,7 +157,7 @@ module Decidim
       end
 
       def eager_load
-        gsub_file "config/environments/test.rb", "config.eager_load = false", "config.eager_load = true" if options[:demo]
+        gsub_file "config/environments/test.rb", "config.eager_load = false", "config.eager_load = true" if options[:ci]
       end
 
       def install

--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -152,6 +152,10 @@ module Decidim
         end
       end
 
+      def eager_load
+        gsub_file "config/environments/test.rb", "config.eager_load = false", "config.eager_load = true" if options[:demo]
+      end
+
       def install
         Decidim::Generators::InstallGenerator.start(
           [


### PR DESCRIPTION
#### :tophat: What? Why?
This forces eager-loading the test app on the `CI` environment, potentially detecting bugs that might occur on production.

#### :pushpin: Related Issues
- #3830

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*
