### PR TITLE
Fixed error when organization doesn't have ToS

### DIFF
--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -165,7 +165,7 @@ module Decidim
     end
 
     def tos_accepted?
-      return true if managed
+      return true if managed || organization.tos_version.nil?
       return false if accepted_tos_version.nil?
       accepted_tos_version >= organization.tos_version
     end

--- a/decidim-core/spec/models/decidim/user_spec.rb
+++ b/decidim-core/spec/models/decidim/user_spec.rb
@@ -174,5 +174,44 @@ module Decidim
         expect(subject).to be_deleted
       end
     end
+
+    describe "#tos_accepted?" do
+      subject { user.tos_accepted? }
+
+      let(:user) { build(:user, organization: organization, accepted_tos_version: accepted_tos_version) }
+      let(:accepted_tos_version) { organization.tos_version }
+
+      it { is_expected.to be_truthy }
+
+      context "when user accepted ToS before organization last update" do
+        let(:accepted_tos_version) { 1.year.before }
+
+        it { is_expected.to be_falsey }
+
+        context "when organization has no TOS" do
+          let(:organization) { build(:organization, tos_version: nil) }
+
+          it { is_expected.to be_truthy }
+        end
+      end
+
+      context "when user didn't accepted ToS" do
+        let(:accepted_tos_version) { nil }
+
+        it { is_expected.to be_falsey }
+
+        context "when user is managed" do
+          let(:user) { build(:user, :managed, organization: organization, accepted_tos_version: accepted_tos_version) }
+
+          it { is_expected.to be_truthy }
+        end
+
+        context "when organization has no TOS" do
+          let(:organization) { build(:organization, tos_version: nil) }
+
+          it { is_expected.to be_truthy }
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Currently, ToS check doesn't work if an organization doesn't have ToS defined. First, it forces the user to accept nonexistent ToS, and then fails, as it can't compare a date with a `nil` value.

#### :pushpin: Related Issues
- Related to #3494

#### :clipboard: Subtasks
- [x] Add tests

### :camera: Screenshots (optional)