### PR TITLE
Use Foundation's Float Grid in admin zone

### DIFF
--- a/decidim-admin/app/assets/stylesheets/decidim/admin/_decidim.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/_decidim.scss
@@ -6,7 +6,7 @@
 @import "utils/toggle-expand";
 @import "foundation";
 
-@include foundation-everything();
+@include foundation-everything($flex: false);
 
 @import "utils/mixins";
 @import "utils/flex";


### PR DESCRIPTION
#### :tophat: What? Why?
In #2259 we updated to Foundation 6.4, but we keep using [Float Grid](https://foundation.zurb.com/sites/docs/grid.html) instead of the new systems (XY Grid or Flex Grid). However, we didn't change it in the admin zone, so some views were slightly broken.

#### :pushpin: Related Issues
- Related to #2259

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
**Before**
![captura de pantalla de 2018-07-18 16-44-53](https://user-images.githubusercontent.com/453545/42889999-04f6d18a-8aac-11e8-9e3d-156c7676aedc.png)
**After**
![captura de pantalla de 2018-07-18 16-46-17](https://user-images.githubusercontent.com/453545/42890000-0613abb0-8aac-11e8-82e7-301727aef3a6.png)

