### PR TITLE
[FIX]  Endorse button broken if endorse action is authorized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Decidim::User.find_each(&:add_to_index_as_search_resource)
 
 **Fixed**:
 
+- **decidim-proposals**: Fix Endorse button broken if endorse action is authorized. [\#3875](https://github.com/decidim/decidim/pull/3875)
 - **decidim-proposals**: Refactor searchable proposal test to avoid flakes. [\#3825](https://github.com/decidim/decidim/pull/3825)
 - **decidim-proposals**: Proposal seeds iterate over a sample of users to add coauthorships. [\#3796](https://github.com/decidim/decidim/pull/3796)
 - **decidim-core**: Make proposal m-card render its authorship again. [\#3727](https://github.com/decidim/decidim/pull/3727)

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -174,6 +174,10 @@ en:
           authorize: Authorize with "%{authorization}"
           explanation: In order to perform this action, you need to be authorized with "%{authorization}".
           title: Authorization required
+        ok:
+          explanation: I dontknowwhathappened
+          ok: OK
+          title: Authorized???
         pending:
           explanation: In order to perform this action, you need to be authorized with "%{authorization}", but your authorization is still in progress
           resume: Check your "%{authorization}" authorization progress

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -174,10 +174,6 @@ en:
           authorize: Authorize with "%{authorization}"
           explanation: In order to perform this action, you need to be authorized with "%{authorization}".
           title: Authorization required
-        ok:
-          explanation: I dontknowwhathappened
-          ok: OK
-          title: Authorized???
         pending:
           explanation: In order to perform this action, you need to be authorized with "%{authorization}", but your authorization is still in progress
           resume: Check your "%{authorization}" authorization progress

--- a/decidim-proposals/app/helpers/decidim/proposals/proposal_endorsements_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/proposal_endorsements_helper.rb
@@ -124,16 +124,17 @@ module Decidim
       end
 
       def render_endorsements_button_card_part(proposal, fully_endorsed)
+        endorse_translated = t("decidim.proposals.proposal_endorsements_helper.render_endorsements_button_card_part.endorse")
         if current_settings.endorsements_blocked? || !current_component.participatory_space.can_participate?(current_user)
-          content_tag :span, t(".endorse"), class: "card__button button #{endorsement_button_classes(false)} disabled", disabled: true, title: t(".endorse")
+          content_tag :span, endorse_translated, class: "card__button button #{endorsement_button_classes(false)} disabled", disabled: true, title: endorse_translated
         elsif current_user && allowed_to?(:endorse, :proposal, proposal: proposal)
           render partial: "endorsement_identities_cabin", locals: { proposal: proposal, fully_endorsed: fully_endorsed }
         elsif current_user
-          button_to(t(".endorse"), proposal_path(proposal),
+          button_to(endorse_translated, proposal_path(proposal),
                     data: { open: "authorizationModal", "open-url": modal_path(:endorse, proposal) },
                     class: "card__button button #{endorsement_button_classes(false)} secondary")
         else
-          action_authorized_button_to :endorse, t(".endorse"), "", resource: proposal, class: "card__button button #{endorsement_button_classes(false)} secondary"
+          action_authorized_button_to :endorse, endorse_translated, "", resource: proposal, class: "card__button button #{endorsement_button_classes(false)} secondary"
         end
       end
     end

--- a/decidim-proposals/app/helpers/decidim/proposals/proposal_endorsements_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/proposal_endorsements_helper.rb
@@ -122,6 +122,20 @@ module Decidim
           end
         end
       end
+
+      def render_endorsements_button_card_part(proposal, fully_endorsed)
+        if current_settings.endorsements_blocked? || !current_component.participatory_space.can_participate?(current_user)
+          content_tag :span, t(".endorse"), class: "card__button button #{endorsement_button_classes(false)} disabled", disabled: true, title: t(".endorse")
+        elsif current_user && allowed_to?(:endorse, :proposal, proposal: proposal)
+          render partial: "endorsement_identities_cabin", locals: { proposal: proposal, fully_endorsed: fully_endorsed }
+        elsif current_user
+          button_to(t(".endorse"), proposal_path(proposal),
+                    data: { open: "authorizationModal", "open-url": modal_path(:endorse, proposal) },
+                    class: "card__button button #{endorsement_button_classes(false)} secondary")
+        else
+          action_authorized_button_to :endorse, t(".endorse"), "", resource: proposal, class: "card__button button #{endorsement_button_classes(false)} secondary"
+        end
+      end
     end
   end
 end

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_endorsements_card_row.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_endorsements_card_row.html.erb
@@ -6,8 +6,10 @@
         <%= render_endorsements_count_card_part(@proposal, fully_endorsed) %>
         <% if current_settings.endorsements_blocked? || !current_component.participatory_space.can_participate?(current_user) %>
           <%= content_tag :span, t(".endorse"), class: "card__button button #{endorsement_button_classes(false)} disabled", disabled: true, title: t(".endorse") %>
-        <% elsif current_user %>
+        <% elsif current_user && allowed_to?(:endorse, resource: @proposal) %>
           <%= render partial: "endorsement_identities_cabin", locals: { proposal: @proposal, fully_endorsed: fully_endorsed } %>
+        <% elsif current_user %>
+          <%= button_to('ENDORSE', proposal_path(@proposal), {data: {open: "authorizationModal", :"open-url" => modal_path(:endorse, @proposal)}, class: "card__button button #{endorsement_button_classes(false)} secondary"}) %>
         <% else %>
           <%= action_authorized_button_to :endorse, t(".endorse"), "", resource: @proposal, class: "card__button button #{endorsement_button_classes(false)} secondary" %>
         <% end %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_endorsements_card_row.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_endorsements_card_row.html.erb
@@ -4,15 +4,7 @@
     <div class="column small-9 collapse">
       <div class="button-group button-group--collapse button--nomargin small">
         <%= render_endorsements_count_card_part(@proposal, fully_endorsed) %>
-        <% if current_settings.endorsements_blocked? || !current_component.participatory_space.can_participate?(current_user) %>
-          <%= content_tag :span, t(".endorse"), class: "card__button button #{endorsement_button_classes(false)} disabled", disabled: true, title: t(".endorse") %>
-        <% elsif current_user && allowed_to?(:endorse, resource: @proposal) %>
-          <%= render partial: "endorsement_identities_cabin", locals: { proposal: @proposal, fully_endorsed: fully_endorsed } %>
-        <% elsif current_user %>
-          <%= button_to('ENDORSE', proposal_path(@proposal), {data: {open: "authorizationModal", :"open-url" => modal_path(:endorse, @proposal)}, class: "card__button button #{endorsement_button_classes(false)} secondary"}) %>
-        <% else %>
-          <%= action_authorized_button_to :endorse, t(".endorse"), "", resource: @proposal, class: "card__button button #{endorsement_button_classes(false)} secondary" %>
-        <% end %>
+        <%= render_endorsements_button_card_part(@proposal, fully_endorsed) %>
       </div>
     </div>
   <% end %>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -267,6 +267,8 @@ en:
         endorsement_button:
           already_endorsed: Endorsed
           endorse: Endorse
+        render_endorsements_button_card_part:
+          endorse: Endorse
       proposal_votes:
         create:
           error: There's been errors when voting the proposal.
@@ -298,7 +300,6 @@ en:
           endorse: Endorse
         endorsements_card_row:
           comments: Comments
-          endorse: Endorse
         filters:
           accepted: Accepted
           activity: Activity


### PR DESCRIPTION
#### :tophat: What? Why?
Fix  Endorse button broken if endorse action is authorized.

Current strategy is to render 4 buttons depending on the authorization state of endorsements:
1. If endorsements are blocked: render a span wich is NOT interactive.
1. If user is logedin and has permission to endorse: Then render the endorsement identities button. (open a popup where you can endorse as some of your identities)
1. If user ise logedin but has NOT permissions to endorse: Then render the modal to verify the user with the verification system that has been configured.
1. If the user is NOT logedin: Then render an `action_authorized_button_to :endorse...` to force the user to login.

#### :pushpin: Related Issues
- Fixes #3284 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [-] Add documentation regarding the feature 
- [-] Add/modify seeds
- [x] Add tests
- [x] Fix

### :camera: Screenshots (optional)
![Description](URL)
