### PR TITLE
Update development_guide.md to add MarkDown linter info

### DIFF
--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -101,6 +101,10 @@ bundle exec rubocop
 bundle exec rubocop -a
 ```
 
+### Markdown linter
+
+This project uses [markdownlint](https://github.com/markdownlint/markdownlint) to check markdown files and flag style issues.
+
 ## Good to know
 
 - There is an application with current designs at: https://decidim-design.herokuapp.com/


### PR DESCRIPTION
#### :tophat: What? Why?

Add `markdownlint` missing documentation to [`development_guide.md`](https://github.com/decidim/decidim/blob/c5f11fc334ef6cc571634d9c85fb41eba37012eb/docs/development_guide.md)

#### :pushpin: Related Issues
- Related to none
- Fixes none

#### :clipboard: Subtasks
none

### :camera: Screenshots (optional)
none