### PR TITLE
Change default log level in production to :warn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Decidim::User.find_each(&:add_to_index_as_search_resource)
 - **decidim-meetings**: The invite attendee form has been moved to the top of the new invites list. [\#3826](https://github.com/decidim/decidim/pull/3826)
 - **decidim-core**: Load authorization modals content with AJAX requests. [\#3753](https://github.com/decidim/decidim/pull/3753)
 - **decidim-core**: Updated the `CollapsibleList` cell to be able to show any number of elements from 1 to 12 [\#3810](https://github.com/decidim/decidim/pull/3810)
+- **decidim-generators**: Change default log level to :warn in production environment [\#3881](https://github.com/decidim/decidim/pull/3881)
 
 **Fixed**:
 

--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -119,6 +119,10 @@ module Decidim
         run "bundle install"
       end
 
+      def production_log
+        gsub_file "config/environments/production.rb", "config.log_level = :debug", "config.log_level = :warn"
+      end
+
       def tweak_bootsnap
         gsub_file "config/boot.rb", %r{require 'bootsnap/setup'.*$}, <<~RUBY.rstrip
           require "bootsnap"


### PR DESCRIPTION
#### :tophat: What? Why?
This change the default rails log level :debug to :warn, that is because we have many issues in production environments where the logs become heavy with unnecessary details.

#### :pushpin: Related Issues
- No issue related

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
