### PR TITLE
Set `organization.tos_version` when creating `terms-and-conditions` DefaultPage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Decidim::User.find_each(&:add_to_index_as_search_resource)
 - **decidim-core**: Don't crash when a page doesn't exist. [\#3799](https://github.com/decidim/decidim/pull/3799)
 - **decidim-admin**: Paginate private users. [\#3871](https://github.com/decidim/decidim/pull/3871)
 - **decidim-surveys**: Order survey answer options by date and time. [#3867](https://github.com/decidim/decidim/pull/3867)
+- **decidim-core**: Set `organization.tos_version` when creating `terms-and-conditions` DefaultPage [#3882](https://github.com/decidim/decidim/pull/3882)
 
 **Removed**:
 

--- a/decidim-core/app/models/decidim/static_page.rb
+++ b/decidim-core/app/models/decidim/static_page.rb
@@ -20,6 +20,7 @@ module Decidim
     # and cannot be deleted.
     DEFAULT_PAGES = %w(faq terms-and-conditions accessibility).freeze
 
+    after_create :update_organization_tos_version
     before_destroy :can_be_destroyed?
     before_update :can_update_slug?
 
@@ -56,6 +57,14 @@ module Decidim
     end
 
     private
+
+    # When creating a terms-and-conditions page
+    # set the organization tos_version
+
+    def update_organization_tos_version
+      return unless slug == "terms-and-conditions"
+      organization.update!(tos_version: created_at)
+    end
 
     def can_be_destroyed?
       throw(:abort) if default?


### PR DESCRIPTION
#### :tophat: What? Why?

When creating a new organization, `register_organization.rb` creates the default pages of every organization, when creating the `terms-and-conditions` page the `organization.tos_version` was not updated so when the administrator visits the public web raised an error.

This PR solves this issue, setting the `organization.tos_version` when creating the `terms-and-conditions` page.

#### :pushpin: Related Issues
- Fixes #3880

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
