### PR TITLE
Fix profile follow counter to consider only users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Decidim::User.find_each(&:add_to_index_as_search_resource)
 - **decidim-core**: Don't crash when a page doesn't exist. [\#3799](https://github.com/decidim/decidim/pull/3799)
 - **decidim-admin**: Paginate private users. [\#3871](https://github.com/decidim/decidim/pull/3871)
 - **decidim-surveys**: Order survey answer options by date and time. [#3867](https://github.com/decidim/decidim/pull/3867)
+- **decidim-core**: Consider only users in profile follow counters. [\#3887](https://github.com/decidim/decidim/pull/3887)
 
 **Removed**:
 

--- a/decidim-core/app/cells/decidim/following_cell.rb
+++ b/decidim-core/app/cells/decidim/following_cell.rb
@@ -12,13 +12,7 @@ module Decidim
     end
 
     def followings
-      @followings ||= Kaminari.paginate_array(following_users).page(params[:page]).per(20)
-    end
-
-    def following_users
-      @following_users ||= model.following.select do |following|
-        following.is_a?(Decidim::User)
-      end
+      @followings ||= Kaminari.paginate_array(model.following_users).page(params[:page]).per(20)
     end
   end
 end

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -134,6 +134,12 @@ module Decidim
                      end
     end
 
+    def following_users
+      @following_users ||= following.select do |f|
+        f.is_a?(Decidim::User)
+      end
+    end
+
     def unread_conversations
       Decidim::Messaging::Conversation.unread_by(self)
     end

--- a/decidim-core/app/presenters/decidim/user_presenter.rb
+++ b/decidim-core/app/presenters/decidim/user_presenter.rb
@@ -44,7 +44,7 @@ module Decidim
     end
 
     def following_count
-      __getobj__.following_follows.count
+      __getobj__.following_users.count
     end
   end
 end

--- a/decidim-core/spec/system/profile_spec.rb
+++ b/decidim-core/spec/system/profile_spec.rb
@@ -71,6 +71,7 @@ describe "Profile", type: :system do
     context "when displaying followers and following" do
       let(:other_user) { create(:user, organization: user.organization) }
       let(:user_to_follow) { create(:user, organization: user.organization) }
+      let!(:something_that_should_not_be_counted) { create(:follow, user: user, followable: build(:dummy_resource)) }
 
       before do
         create(:follow, user: user, followable: other_user)


### PR DESCRIPTION
#### :tophat: What? Why?

Fixes profile follow counter to consider only users.

#### :pushpin: Related Issues
- Fixes #3812.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [x] Add tests

### :camera: Screenshots (optional)
_None_.