### PR TITLE
No comment notification for comment author

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Decidim::User.find_each(&:add_to_index_as_search_resource)
 - **decidim-core**: Don't crash when a page doesn't exist. [\#3799](https://github.com/decidim/decidim/pull/3799)
 - **decidim-admin**: Paginate private users. [\#3871](https://github.com/decidim/decidim/pull/3871)
 - **decidim-surveys**: Order survey answer options by date and time. [#3867](https://github.com/decidim/decidim/pull/3867)
+- **decidim-comments**: Users should never be notified about their own comments. [\#3888](https://github.com/decidim/decidim/pull/3888)
 
 **Removed**:
 

--- a/decidim-comments/app/services/decidim/comments/new_comment_notification_creator.rb
+++ b/decidim-comments/app/services/decidim/comments/new_comment_notification_creator.rb
@@ -48,7 +48,7 @@ module Decidim
       def notify_parent_comment_author
         return if comment.depth.zero?
 
-        recipient_ids = [comment.commentable.decidim_author_id] - already_notified_ids
+        recipient_ids = [comment.commentable.decidim_author_id] - already_notified_ids - [comment.author.id]
         @already_notified_ids += recipient_ids
 
         notify(recipient_ids, :reply_created)

--- a/decidim-comments/app/services/decidim/comments/new_comment_notification_creator.rb
+++ b/decidim-comments/app/services/decidim/comments/new_comment_notification_creator.rb
@@ -63,7 +63,7 @@ module Decidim
 
       # Notifies the users the `comment.commentable` resource implements as necessary.
       def notify_commentable_recipients
-        recipient_ids = comment.commentable.users_to_notify_on_comment_created.pluck(:id) - already_notified_ids
+        recipient_ids = comment.commentable.users_to_notify_on_comment_created.pluck(:id) - already_notified_ids - [comment.author.id]
         @already_notified_ids += recipient_ids
 
         notify(recipient_ids, :comment_created)

--- a/decidim-comments/spec/services/decidim/comments/new_comment_notification_creator_spec.rb
+++ b/decidim-comments/spec/services/decidim/comments/new_comment_notification_creator_spec.rb
@@ -14,7 +14,7 @@ describe Decidim::Comments::NewCommentNotificationCreator do
   let(:comment) { create :comment, author: comment_author, commentable: commentable, root_commentable: dummy_resource }
 
   let(:mentioned_user) { create(:user, organization: organization) }
-  let(:mentioned_user_following_comment_author) { create(:user, organization: organization) }
+  let(:another_mentioned_user) { create(:user, organization: organization) }
   let(:user_following_comment_author) { create(:user, organization: organization) }
   let(:commentable_author) { create(:user, organization: organization) }
   let(:commentable_follower) { create(:user, organization: organization) }
@@ -23,7 +23,7 @@ describe Decidim::Comments::NewCommentNotificationCreator do
     Decidim::User.where(
       id: [
         mentioned_user.id,
-        mentioned_user_following_comment_author.id
+        another_mentioned_user.id
       ]
     )
   end
@@ -38,7 +38,6 @@ describe Decidim::Comments::NewCommentNotificationCreator do
 
   before do
     create :follow, user: user_following_comment_author, followable: comment_author
-    create :follow, user: mentioned_user_following_comment_author, followable: comment_author
     create :follow, user: commentable_follower, followable: commentable
     create :follow, user: commentable_author, followable: commentable
 

--- a/decidim-comments/spec/services/decidim/comments/new_comment_notification_creator_spec.rb
+++ b/decidim-comments/spec/services/decidim/comments/new_comment_notification_creator_spec.rb
@@ -38,7 +38,6 @@ describe Decidim::Comments::NewCommentNotificationCreator do
 
   before do
     create :follow, user: user_following_comment_author, followable: comment_author
-    create :follow, user: commentable_author, followable: commentable
 
     allow(commentable)
       .to receive(:users_to_notify_on_comment_created)

--- a/decidim-comments/spec/services/decidim/comments/new_comment_notification_creator_spec.rb
+++ b/decidim-comments/spec/services/decidim/comments/new_comment_notification_creator_spec.rb
@@ -17,7 +17,7 @@ describe Decidim::Comments::NewCommentNotificationCreator do
   let(:another_mentioned_user) { create(:user, organization: organization) }
   let(:user_following_comment_author) { create(:user, organization: organization) }
   let(:commentable_author) { create(:user, organization: organization) }
-  let(:commentable_follower) { create(:user, organization: organization) }
+  let(:commentable_recipient) { create(:user, organization: organization) }
 
   let(:mentioned_users) do
     Decidim::User.where(
@@ -30,7 +30,7 @@ describe Decidim::Comments::NewCommentNotificationCreator do
   let(:commentable_recipients) do
     Decidim::User.where(
       id: [
-        commentable_follower.id,
+        commentable_recipient.id,
         commentable_author.id
       ]
     )
@@ -38,7 +38,6 @@ describe Decidim::Comments::NewCommentNotificationCreator do
 
   before do
     create :follow, user: user_following_comment_author, followable: comment_author
-    create :follow, user: commentable_follower, followable: commentable
     create :follow, user: commentable_author, followable: commentable
 
     allow(commentable)
@@ -123,7 +122,7 @@ describe Decidim::Comments::NewCommentNotificationCreator do
       Decidim::User.where(
         id: [
           comment_author.id,
-          commentable_follower.id,
+          commentable_recipient.id,
           commentable_author.id
         ]
       )
@@ -143,7 +142,7 @@ describe Decidim::Comments::NewCommentNotificationCreator do
           event: "decidim.events.comments.comment_created",
           event_class: Decidim::Comments::CommentCreatedEvent,
           resource: dummy_resource,
-          recipient_ids: a_collection_containing_exactly(commentable_follower.id, commentable_author.id),
+          recipient_ids: a_collection_containing_exactly(commentable_recipient.id, commentable_author.id),
           extra: {
             comment_id: comment.id
           }


### PR DESCRIPTION
#### :tophat: What? Why?

When I'm following a debate, I keep getting notifications of my own comments. I don't think that makes sense. In general, it never makes sense to notify a user about her own comment. This PR fixes a couple of cases where that was happening.

There's two cases I haven't fixed:

* Not notiying a user that mentions herself on a comment about her own comment. I'm not sure why a user would do that, but maybe it's worth fixing?

* Not notifying a user that is following herself about her own comment. This could be "fixed a the unit test level" but I tend to recall that following yourself is not allowed anyways?

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [x] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
_None_.