### PR TITLE
Only log permissions data in development mode

### DIFF
--- a/decidim-core/app/controllers/concerns/decidim/needs_permission.rb
+++ b/decidim-core/app/controllers/concerns/decidim/needs_permission.rb
@@ -37,9 +37,11 @@ module Decidim
       end
 
       def enforce_permission_to(action, subject, extra_context = {})
-        Rails.logger.debug "==========="
-        Rails.logger.debug [permission_scope, action, subject, permission_class_chain].map(&:inspect).join("\n")
-        Rails.logger.debug "==========="
+        if Rails.env.development?
+          Rails.logger.debug "==========="
+          Rails.logger.debug [permission_scope, action, subject, permission_class_chain].map(&:inspect).join("\n")
+          Rails.logger.debug "==========="
+        end
 
         raise Decidim::ActionForbidden unless allowed_to?(action, subject, extra_context)
       end


### PR DESCRIPTION
#### :tophat: What? Why?
I didn't know Rails used `:debug` as the default log level in production. This PR removes permission logs from the production env, so that they're only posted in development mode.

#### :pushpin: Related Issues
- Related to #3881

#### :clipboard: Subtasks
None