### PR TITLE
Fix ToS-related random failures

### DIFF
--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -173,7 +173,11 @@ module Decidim
     def tos_accepted?
       return true if managed || organization.tos_version.nil?
       return false if accepted_tos_version.nil?
-      accepted_tos_version >= organization.tos_version
+
+      # For some reason, if we don't use `#to_i` here we get some
+      # cases where the comparison returns false, but calling `#to_i` returns
+      # the same number :/
+      accepted_tos_version.to_i >= organization.tos_version.to_i
     end
 
     protected

--- a/decidim-core/lib/decidim/core/test/shared_examples/follows_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/follows_examples.rb
@@ -25,7 +25,7 @@ shared_examples "follows" do
     end
 
     context "when user clicks the Follow button" do
-      it "makes the user follow the followable" do
+      it "makes the user stop follow the followable" do
         visit resource_locator(followable).path
         expect do
           click_button "Stop following"


### PR DESCRIPTION
#### :tophat: What? Why?
For some reason, this happens in test:

![](https://i.imgur.com/L4uDNEG.png)

I'm not sure why, but calling `to_i` to the fields seems to fix it.

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/pull/3882#issuecomment-407039663

#### :clipboard: Subtasks
None