### PR TITLE
Fix initiative edition when state is not published.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 
 **Fixed**:
 
+- **decidim-initiatives**: Fix initiative edition when state is not published. [\#3930](https://github.com/decidim/decidim/pull/3930)
 - **decidim-proposals**: Fix Endorse button broken if endorse action is authorized. [\#3875](https://github.com/decidim/decidim/pull/3875)
 - **decidim-proposals**: Refactor searchable proposal test to avoid flakes. [\#3825](https://github.com/decidim/decidim/pull/3825)
 - **decidim-proposals**: Proposal seeds iterate over a sample of users to add coauthorships. [\#3796](https://github.com/decidim/decidim/pull/3796)

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative.rb
@@ -57,8 +57,10 @@ module Decidim
             attrs[:signature_end_time] = form.signature_end_time
             attrs[:offline_votes] = form.offline_votes
 
-            @notify_extended = true if form.signature_end_time != initiative.signature_end_time &&
-                                       form.signature_end_time > initiative.signature_end_time
+            if initiative.published?
+              @notify_extended = true if form.signature_end_time != initiative.signature_end_time &&
+                                         form.signature_end_time > initiative.signature_end_time
+            end
           end
 
           attrs

--- a/decidim-initiatives/spec/system/admin/update_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/admin/update_initiative_spec.rb
@@ -5,23 +5,47 @@ require "spec_helper"
 describe "User prints the initiative", type: :system do
   include_context "when admins initiative"
 
+  def submit_and_validate
+    find("*[type=submit]").click
+
+    within ".callout-wrapper" do
+      expect(page).to have_content("successfully")
+    end
+  end
+
   context "when initiative update" do
     before do
       switch_to_host(organization.host)
       login_as user, scope: :user
       visit decidim_admin_initiatives.initiatives_path
-      page.find(".action-icon--edit").click
     end
 
-    it "Updates initiative data" do
+    it "Updates published initiative data" do
+      page.find(".action-icon--edit").click
       within ".edit_initiative" do
         fill_in :initiative_hashtag, with: "#hashtag"
       end
+      submit_and_validate
+    end
 
-      find("*[type=submit]").click
+    context "when initiative is in accepted state" do
+      before do
+        initiative.accepted!
+      end
 
-      within ".callout-wrapper" do
-        expect(page).to have_content("successfully")
+      it "updates accepted initiative data" do
+        page.find(".action-icon--edit").click
+        within ".edit_initiative" do
+          fill_in_i18n_editor(
+            :initiative_answer,
+            "#initiative-answer-tabs",
+            ca: "Alguna resposta",
+            en: "Some answer",
+            es: "Alguna respuesta"
+          )
+          fill_in :initiative_answer_url, with: "http://meta.decidim.org"
+        end
+        submit_and_validate
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
When an Initiative is not in the `published` state, when admin tries to edit the Initiative, it crashes on update.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [-] Add documentation regarding the feature 
- [-] Add/modify seeds
- [x] Add tests
- [x] Fix
