### PR TITLE
Fix/use dates in Ruby as in DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 
 **Changed**:
 
-- **decidim-initiatives**: For consistency with DB, use Ruby Dates instead of DateTimes, rename signature_(start/end)_time fields to signature_(start/end)_date. [\#3932](https://github.com/decidim/decidim/pull/3932)
+- **decidim-initiatives**: For consistency with DB, use Ruby Dates instead of DateTimes, rename `signature_start_time` and `signature_end_time` fields to `signature_start_date` and `signature_end_date`. [\#3932](https://github.com/decidim/decidim/pull/3932)
 - **decidim-participatory_processes**: For consistency with DB, use Ruby Dates instead of DateTimes for `start_date` and `end_date`. [\#3932](https://github.com/decidim/decidim/pull/3932)
 - **decidim-participatory_processes**: Improve usability of filters on processes index page [\#3728](https://github.com/decidim/decidim/pull/3728)
 - **decidim-meetings**: The invite attendee form has been moved to the top of the new invites list. [\#3826](https://github.com/decidim/decidim/pull/3826)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 
 **Changed**:
 
+- **decidim-initiatives**: For consistency with DB, use Ruby Dates instead of DateTimes, rename signature_(start/end)_time fields to signature_(start/end)_date. [\#3932](https://github.com/decidim/decidim/pull/3932)
+- **decidim-participatory_processes**: For consistency with DB, use Ruby Dates instead of DateTimes for `start_date` and `end_date`. [\#3932](https://github.com/decidim/decidim/pull/3932)
 - **decidim-participatory_processes**: Improve usability of filters on processes index page [\#3728](https://github.com/decidim/decidim/pull/3728)
 - **decidim-meetings**: The invite attendee form has been moved to the top of the new invites list. [\#3826](https://github.com/decidim/decidim/pull/3826)
 - **decidim-core**: Load authorization modals content with AJAX requests. [\#3753](https://github.com/decidim/decidim/pull/3753)

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative.rb
@@ -53,13 +53,13 @@ module Decidim
           attrs[:answered_at] = DateTime.current if form.answer.present?
 
           if current_user.admin?
-            attrs[:signature_start_time] = form.signature_start_time
-            attrs[:signature_end_time] = form.signature_end_time
+            attrs[:signature_start_date] = form.signature_start_date
+            attrs[:signature_end_date] = form.signature_end_date
             attrs[:offline_votes] = form.offline_votes
 
             if initiative.published?
-              @notify_extended = true if form.signature_end_time != initiative.signature_end_time &&
-                                         form.signature_end_time > initiative.signature_end_time
+              @notify_extended = true if form.signature_end_date != initiative.signature_end_date &&
+                                         form.signature_end_date > initiative.signature_end_date
             end
           end
 

--- a/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_form.rb
@@ -15,8 +15,8 @@ module Decidim
         attribute :type_id, Integer
         attribute :decidim_scope_id, Integer
         attribute :signature_type, String
-        attribute :signature_start_time, Date
-        attribute :signature_end_time, Date
+        attribute :signature_start_date, Date
+        attribute :signature_end_date, Date
         attribute :hashtag, String
         attribute :offline_votes, Integer
 
@@ -25,10 +25,10 @@ module Decidim
 
         validates :title, :description, presence: true
         validates :signature_type, presence: true
-        validates :signature_start_time, presence: true, if: ->(form) { form.context.initiative.published? }
-        validates :signature_end_time, presence: true, if: ->(form) { form.context.initiative.published? }
-        validates :signature_end_time, date: { after: :signature_start_time }, if: lambda { |form|
-          form.signature_start_time.present? && form.signature_end_time.present?
+        validates :signature_start_date, presence: true, if: ->(form) { form.context.initiative.published? }
+        validates :signature_end_date, presence: true, if: ->(form) { form.context.initiative.published? }
+        validates :signature_end_date, date: { after: :signature_start_date }, if: lambda { |form|
+          form.signature_start_date.present? && form.signature_end_date.present?
         }
 
         validates :answer, translatable_presence: true, if: ->(form) { form.context.initiative.accepted? }

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -64,14 +64,14 @@ module Decidim
     scope :open, lambda {
       published
         .where.not(state: [:discarded, :rejected, :accepted])
-        .where("signature_start_time <= ?", Time.now.utc)
-        .where("signature_end_time >= ?", Time.now.utc)
+        .where("signature_start_date <= ?", Date.current)
+        .where("signature_end_date >= ?", Date.current)
     }
     scope :closed, lambda {
       published
         .where(state: [:discarded, :rejected, :accepted])
-        .or(where("signature_start_time > ?", Time.now.utc))
-        .or(where("signature_end_time < ?", Time.now.utc))
+        .or(where("signature_start_date > ?", Date.current))
+        .or(where("signature_end_date < ?", Date.current))
     }
     scope :published, -> { where.not(published_at: nil) }
     scope :with_state, ->(state) { where(state: state) if state.present? }
@@ -165,8 +165,8 @@ module Decidim
 
     def votes_enabled?
       published? &&
-        signature_start_time <= Time.zone.today &&
-        signature_end_time >= Time.zone.today
+        signature_start_date <= Date.current &&
+        signature_end_date >= Date.current
     end
 
     # Public: Checks if the organization has given an answer for the initiative.
@@ -198,8 +198,8 @@ module Decidim
       update(
         published_at: Time.current,
         state: "published",
-        signature_start_time: DateTime.now.utc,
-        signature_end_time: DateTime.now.utc + Decidim::Initiatives.default_signature_time_period_length
+        signature_start_date: Date.current,
+        signature_end_date: Date.current + Decidim::Initiatives.default_signature_time_period_length
       )
     end
 
@@ -214,7 +214,7 @@ module Decidim
 
     # Public: Returns wether the signature interval is already defined or not.
     def has_signature_interval_defined?
-      signature_end_time.present? && signature_start_time.present?
+      signature_end_date.present? && signature_start_date.present?
     end
 
     # Public: Returns the hashtag for the initiative.

--- a/decidim-initiatives/app/permissions/decidim/initiatives/admin/permissions.rb
+++ b/decidim-initiatives/app/permissions/decidim/initiatives/admin/permissions.rb
@@ -140,12 +140,12 @@ module Decidim
             toggle_allow(initiative.offline? || initiative.any?)
           when :accept
             allowed = initiative.published? &&
-                      initiative.signature_end_time < Time.zone.today &&
+                      initiative.signature_end_date < Date.current &&
                       initiative.percentage >= 100
             toggle_allow(allowed)
           when :reject
             allowed = initiative.published? &&
-                      initiative.signature_end_time < Time.zone.today &&
+                      initiative.signature_end_date < Date.current &&
                       initiative.percentage < 100
             toggle_allow(allowed)
           else

--- a/decidim-initiatives/app/presenters/decidim/initiatives/admin_log/initiative_presenter.rb
+++ b/decidim-initiatives/app/presenters/decidim/initiatives/admin_log/initiative_presenter.rb
@@ -28,8 +28,8 @@ module Decidim
           {
             state: :string,
             published_at: :date,
-            signature_start_time: :date,
-            signature_end_time: :date,
+            signature_start_date: :date,
+            signature_end_date: :date,
             description: :i18n,
             title: :i18n,
             hashtag: :string

--- a/decidim-initiatives/app/queries/decidim/initiatives/support_period_finished_initiatives.rb
+++ b/decidim-initiatives/app/queries/decidim/initiatives/support_period_finished_initiatives.rb
@@ -12,7 +12,7 @@ module Decidim
           .includes(:scoped_type)
           .where(state: "published")
           .where(signature_type: "online")
-          .where("signature_end_time < ?", DateTime.current)
+          .where("signature_end_date < ?", Date.current)
       end
     end
   end

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/_form.html.erb
@@ -33,11 +33,11 @@
     <% if current_initiative.published? && current_user.admin? %>
       <div class="row">
         <div class="columns xlarge-6">
-          <%= form.date_field :signature_start_time %>
+          <%= form.date_field :signature_start_date %>
         </div>
 
         <div class="columns xlarge-6">
-          <%= form.date_field :signature_end_time %>
+          <%= form.date_field :signature_end_date %>
         </div>
       </div>
     <% end %>

--- a/decidim-initiatives/app/views/layouts/decidim/_initiative_header_steps.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/_initiative_header_steps.html.erb
@@ -10,9 +10,9 @@
       <div>
         <span class="phase-title"><!-- Step name --></span>
         <span class="phase-date">
-          <%= l(initiative.signature_start_time, format: :default) %>
+          <%= l(initiative.signature_start_date, format: :default) %>
           -
-          <%= l(initiative.signature_end_time, format: :default) %>
+          <%= l(initiative.signature_end_date, format: :default) %>
         </span>
       </div>
     </div>

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -7,8 +7,8 @@ en:
         description: Description
         offline_votes: Face-to-face supports
         scope_id: Scope
-        signature_end_time: End of signature collection period
-        signature_start_time: Start of signature collection period
+        signature_end_date: End of signature collection period
+        signature_start_date: Start of signature collection period
         signature_type: Signature collection type
         signature_type_values:
           any: Mixed

--- a/decidim-initiatives/db/migrate/20180726071704_rename_signature_time_fields_to_signature_date.rb
+++ b/decidim-initiatives/db/migrate/20180726071704_rename_signature_time_fields_to_signature_date.rb
@@ -1,0 +1,9 @@
+# This migration comes from decidim_initiatives (originally 20171214161410)
+# frozen_string_literal: true
+
+class RenameSignatureTimeFieldsToSignatureDate < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :decidim_initiatives, :signature_start_time, :signature_start_date
+    rename_column :decidim_initiatives, :signature_end_time, :signature_end_date
+  end
+end

--- a/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
@@ -56,8 +56,8 @@ Decidim.register_participatory_space(:initiatives) do |participatory_space|
         scoped_type: Decidim::InitiativesTypeScope.reorder(Arel.sql("RANDOM()")).first,
         state: state,
         signature_type: "online",
-        signature_start_time: DateTime.current - 7.days,
-        signature_end_time:  DateTime.current + 7.days,
+        signature_start_date: Date.current - 7.days,
+        signature_end_date:  Date.current + 7.days,
         published_at: DateTime.current - 7.days,
         author: Decidim::User.reorder(Arel.sql("RANDOM()")).first,
         organization: organization

--- a/decidim-initiatives/lib/decidim/initiatives/test/factories.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/test/factories.rb
@@ -25,8 +25,8 @@ FactoryBot.define do
     published_at { Time.current }
     state "published"
     signature_type "online"
-    signature_start_time { Time.now.utc - 1.hour }
-    signature_end_time { Time.now.utc + 120.days }
+    signature_start_date { Date.current - 1.day }
+    signature_end_date { Date.current + 120.days }
 
     scoped_type do
       create(:initiatives_type_scope,
@@ -41,15 +41,15 @@ FactoryBot.define do
     trait :created do
       state "created"
       published_at nil
-      signature_start_time nil
-      signature_end_time nil
+      signature_start_date nil
+      signature_end_date nil
     end
 
     trait :validating do
       state "validating"
       published_at nil
-      signature_start_time nil
-      signature_end_time nil
+      signature_start_date nil
+      signature_end_date nil
     end
 
     trait :published do
@@ -77,8 +77,8 @@ FactoryBot.define do
     end
 
     trait :acceptable do
-      signature_start_time { Time.now.utc - 3.months }
-      signature_end_time { Time.now.utc - 2.months }
+      signature_start_date { Date.current - 3.months }
+      signature_end_date { Date.current - 2.months }
       signature_type "online"
 
       after(:build) do |initiative|
@@ -87,8 +87,8 @@ FactoryBot.define do
     end
 
     trait :rejectable do
-      signature_start_time { Time.now.utc - 3.months }
-      signature_end_time { Time.now.utc - 2.months }
+      signature_start_date { Date.current - 3.months }
+      signature_end_date { Date.current - 2.months }
       signature_type "online"
 
       after(:build) do |initiative|

--- a/decidim-initiatives/spec/commands/decidim/initiatives/admin/update_initiative_spec.rb
+++ b/decidim-initiatives/spec/commands/decidim/initiatives/admin/update_initiative_spec.rb
@@ -30,7 +30,7 @@ module Decidim
               end
 
               context "when the signature end time is not modified" do
-                let(:signature_end_time) { initiative.signature_end_time }
+                let(:signature_end_date) { initiative.signature_end_date }
 
                 it "doesn't notify the followers" do
                   expect(Decidim::EventsManager).not_to receive(:publish)

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/admin/initiatives_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/admin/initiatives_controller_spec.rb
@@ -383,8 +383,8 @@ module Decidim
               initiative.reload
               expect(initiative).to be_published
               expect(initiative.published_at).not_to be_nil
-              expect(initiative.signature_start_time).not_to be_nil
-              expect(initiative.signature_end_time).not_to be_nil
+              expect(initiative.signature_start_date).not_to be_nil
+              expect(initiative.signature_end_date).not_to be_nil
             end
           end
         end

--- a/decidim-initiatives/spec/models/decidim/initiative_spec.rb
+++ b/decidim-initiatives/spec/models/decidim/initiative_spec.rb
@@ -81,8 +81,8 @@ module Decidim
         build(:initiative,
               state: "validating",
               published_at: nil,
-              signature_start_time: nil,
-              signature_end_time: nil)
+              signature_start_date: nil,
+              signature_end_date: nil)
       end
 
       it "is valid" do

--- a/decidim-initiatives/spec/permissions/decidim/initiatives/admin/permissions_spec.rb
+++ b/decidim-initiatives/spec/permissions/decidim/initiatives/admin/permissions_spec.rb
@@ -389,7 +389,7 @@ describe Decidim::Initiatives::Admin::Permissions do
 
       context "when accepting the initiative" do
         let(:action_name) { :accept }
-        let(:initiative) { create :initiative, organization: organization, signature_end_time: 2.days.ago }
+        let(:initiative) { create :initiative, organization: organization, signature_end_date: 2.days.ago }
         let(:percentage) { 110 }
 
         before do
@@ -405,7 +405,7 @@ describe Decidim::Initiatives::Admin::Permissions do
         end
 
         context "when the initiative signature time is not finished" do
-          let(:initiative) { create :initiative, signature_end_time: 2.days.from_now, organization: organization }
+          let(:initiative) { create :initiative, signature_end_date: 2.days.from_now, organization: organization }
 
           it { is_expected.to eq false }
         end
@@ -419,7 +419,7 @@ describe Decidim::Initiatives::Admin::Permissions do
 
       context "when rejecting the initiative" do
         let(:action_name) { :reject }
-        let(:initiative) { create :initiative, organization: organization, signature_end_time: 2.days.ago }
+        let(:initiative) { create :initiative, organization: organization, signature_end_date: 2.days.ago }
         let(:percentage) { 90 }
 
         before do
@@ -435,7 +435,7 @@ describe Decidim::Initiatives::Admin::Permissions do
         end
 
         context "when the initiative signature time is not finished" do
-          let(:initiative) { create :initiative, signature_end_time: 2.days.from_now, organization: organization }
+          let(:initiative) { create :initiative, signature_end_date: 2.days.from_now, organization: organization }
 
           it { is_expected.to eq false }
         end

--- a/decidim-initiatives/spec/shared/update_initiative_example.rb
+++ b/decidim-initiatives/spec/shared/update_initiative_example.rb
@@ -19,7 +19,7 @@ shared_examples "update an initiative" do
     {
       title: { en: "A reasonable initiative title" },
       description: { en: "A reasonable initiative description" },
-      signature_start_date: Date.today + 10.days,
+      signature_start_date: Date.current + 10.days,
       signature_end_date: signature_end_date,
       signature_type: "any",
       type_id: initiative.type.id,

--- a/decidim-initiatives/spec/shared/update_initiative_example.rb
+++ b/decidim-initiatives/spec/shared/update_initiative_example.rb
@@ -14,13 +14,13 @@ shared_examples "update an initiative" do
     )
   end
 
-  let(:signature_end_time) { Time.zone.today + 130.days }
+  let(:signature_end_date) { Date.current + 130.days }
   let(:form_params) do
     {
       title: { en: "A reasonable initiative title" },
       description: { en: "A reasonable initiative description" },
-      signature_start_time: Time.zone.today + 10.days,
-      signature_end_time: signature_end_time,
+      signature_start_date: Date.today + 10.days,
+      signature_end_date: signature_end_date,
       signature_type: "any",
       type_id: initiative.type.id,
       decidim_scope_id: initiative.scope.id,
@@ -86,7 +86,7 @@ shared_examples "update an initiative" do
         command.call
         initiative.reload
 
-        [:signature_start_time, :signature_end_time].each do |key|
+        [:signature_start_date, :signature_end_date].each do |key|
           expect(initiative[key]).not_to eq(form_params[key])
         end
       end
@@ -108,7 +108,7 @@ shared_examples "update an initiative" do
           command.call
           initiative.reload
 
-          [:signature_start_time, :signature_end_time].each do |key|
+          [:signature_start_te, :signature_end_date].each do |key|
             expect(initiative[key]).to eq(form_params[key])
           end
         end

--- a/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_step_form.rb
+++ b/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_step_form.rb
@@ -14,23 +14,13 @@ module Decidim
 
         mimic :participatory_process_step
 
-        attribute :start_date, DateTime
-        attribute :end_date, DateTime
+        attribute :start_date, Date
+        attribute :end_date, Date
 
         validates :title, translatable_presence: true
 
         validates :start_date, date: { before: :end_date, allow_blank: true, if: proc { |obj| obj.end_date.present? } }
         validates :end_date, date: { after: :start_date, allow_blank: true, if: proc { |obj| obj.start_date.present? } }
-
-        def start_date
-          return nil unless super.respond_to?(:at_midnight)
-          super.at_midnight
-        end
-
-        def end_date
-          return nil unless super.respond_to?(:at_midnight)
-          super.at_midnight
-        end
       end
     end
   end

--- a/decidim-participatory_processes/app/models/decidim/participatory_process.rb
+++ b/decidim-participatory_processes/app/models/decidim/participatory_process.rb
@@ -55,9 +55,9 @@ module Decidim
     mount_uploader :hero_image, Decidim::HeroImageUploader
     mount_uploader :banner_image, Decidim::BannerImageUploader
 
-    scope :past, -> { where(arel_table[:end_date].lteq(Time.current)) }
-    scope :upcoming, -> { where(arel_table[:start_date].gt(Time.current)) }
-    scope :active, -> { where(arel_table[:start_date].lteq(Time.current).and(arel_table[:end_date].gt(Time.current).or(arel_table[:end_date].eq(nil)))) }
+    scope :past, -> { where(arel_table[:end_date].lteq(Date.current)) }
+    scope :upcoming, -> { where(arel_table[:start_date].gt(Date.current)) }
+    scope :active, -> { where(arel_table[:start_date].lteq(Date.current).and(arel_table[:end_date].gt(Date.current).or(arel_table[:end_date].eq(nil)))) }
 
     # Scope to return only the promoted processes.
     #
@@ -72,7 +72,7 @@ module Decidim
 
     def past?
       return false if end_date.blank?
-      end_date < Time.current
+      end_date < Date.current
     end
 
     def hashtag

--- a/decidim-participatory_processes/app/queries/decidim/participatory_processes/filtered_participatory_process_groups.rb
+++ b/decidim-participatory_processes/app/queries/decidim/participatory_processes/filtered_participatory_process_groups.rb
@@ -15,9 +15,9 @@ module Decidim
 
         processes = case @filter
                     when "past"
-                      processes.where("decidim_participatory_processes.end_date <= ?", Time.current)
+                      processes.where("decidim_participatory_processes.end_date <= ?", Date.current)
                     when "upcoming"
-                      processes.where("decidim_participatory_processes.start_date > ?", Time.current)
+                      processes.where("decidim_participatory_processes.start_date > ?", Date.current)
                     else
                       processes
                     end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
@@ -72,8 +72,8 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
         target: Decidim::Faker::Localized.sentence(3),
         participatory_scope: Decidim::Faker::Localized.sentence(1),
         participatory_structure: Decidim::Faker::Localized.sentence(2),
-        start_date: Time.current,
-        end_date: 2.months.from_now.at_midnight,
+        start_date: Date.current,
+        end_date: 2.months.from_now,
         participatory_process_group: process_groups.sample,
         scope: n.positive? ? nil : Decidim::Scope.reorder(Arel.sql("RANDOM()")).first
       )
@@ -86,8 +86,8 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
         description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
           Decidim::Faker::Localized.paragraph(3)
         end,
-        start_date: 1.month.ago.at_midnight,
-        end_date: 2.months.from_now.at_midnight
+        start_date: 1.month.ago,
+        end_date: 2.months.from_now
       )
 
       # Create users with specific roles

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
@@ -28,8 +28,8 @@ FactoryBot.define do
     participatory_structure { Decidim::Faker::Localized.sentence(2) }
     show_statistics true
     private_space false
-    start_date { Time.current }
-    end_date { 2.months.from_now.at_midnight }
+    start_date { Date.current }
+    end_date { 2.months.from_now }
 
     trait :promoted do
       promoted true
@@ -83,8 +83,8 @@ FactoryBot.define do
   factory :participatory_process_step, class: "Decidim::ParticipatoryProcessStep" do
     title { Decidim::Faker::Localized.sentence(3) }
     description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
-    start_date { 1.month.ago.at_midnight }
-    end_date { 2.months.from_now.at_midnight }
+    start_date { 1.month.ago }
+    end_date { 2.months.from_now }
     position nil
     participatory_process
 

--- a/decidim-participatory_processes/spec/commands/create_participatory_process_step_spec.rb
+++ b/decidim-participatory_processes/spec/commands/create_participatory_process_step_spec.rb
@@ -14,8 +14,8 @@ module Decidim::ParticipatoryProcesses
         current_user: user,
         title: { en: "title" },
         description: { en: "description" },
-        start_date: Time.current,
-        end_date: Time.current + 1.week,
+        start_date: Date.current,
+        end_date: Date.current + 1.week,
         invalid?: invalid
       )
     end

--- a/decidim-participatory_processes/spec/commands/update_participatory_process_step_spec.rb
+++ b/decidim-participatory_processes/spec/commands/update_participatory_process_step_spec.rb
@@ -67,7 +67,7 @@ module Decidim::ParticipatoryProcesses
       end
 
       context "when the dates are updated" do
-        let(:start_date) { Time.zone.now }
+        let(:start_date) { Date.current }
         let(:end_date) { 1.week.from_now }
 
         it "notifies the process followers" do

--- a/decidim-participatory_processes/spec/controllers/participatory_processes_controller_spec.rb
+++ b/decidim-participatory_processes/spec/controllers/participatory_processes_controller_spec.rb
@@ -44,18 +44,18 @@ module Decidim
             :with_steps,
             :published,
             organization: organization,
-            end_date: Time.current.advance(days: 10)
+            end_date: Date.current.advance(days: 10)
           )
-          first.active_step.update!(end_date: Time.current.advance(days: 2))
+          first.active_step.update!(end_date: Date.current.advance(days: 2))
 
           second = create(
             :participatory_process,
             :with_steps,
             :published,
             organization: organization,
-            end_date: Time.current.advance(days: 20)
+            end_date: Date.current.advance(days: 20)
           )
-          second.active_step.update!(end_date: Time.current.advance(days: 4))
+          second.active_step.update!(end_date: Date.current.advance(days: 4))
 
           expect(controller.helpers.participatory_processes.count).to eq(3)
           expect(controller.helpers.participatory_processes).not_to include(unpublished)

--- a/decidim-participatory_processes/spec/forms/participatory_process_step_form_spec.rb
+++ b/decidim-participatory_processes/spec/forms/participatory_process_step_form_spec.rb
@@ -42,12 +42,12 @@ module Decidim
 
         describe "dates" do
           context "when the dates are set" do
-            let(:start_date) { Time.zone.local(2016, 1, 1, 15, 0) }
-            let(:end_date) { Time.zone.local(2016, 1, 1, 15, 0) }
+            let(:start_date) { "1/1/2016" }
+            let(:end_date) { "1/1/2016" }
 
-            it "returns them at midnight" do
-              expect(subject.start_date).to eq(Time.zone.local(2016, 1, 1, 0, 0))
-              expect(subject.end_date).to eq(Time.zone.local(2016, 1, 1, 0, 0))
+            it "returns them" do
+              expect(subject.start_date).to eq(Date.new(2016, 1, 1))
+              expect(subject.end_date).to eq(Date.new(2016, 1, 1))
             end
           end
 

--- a/decidim-participatory_processes/spec/forms/participatory_process_step_form_spec.rb
+++ b/decidim-participatory_processes/spec/forms/participatory_process_step_form_spec.rb
@@ -42,12 +42,12 @@ module Decidim
 
         describe "dates" do
           context "when the dates are set" do
-            let(:start_date) { "1/1/2016" }
-            let(:end_date) { "1/1/2016" }
+            let(:start_date) { "22/01/2016" }
+            let(:end_date) { "13/10/2017" }
 
             it "returns them" do
-              expect(subject.start_date).to eq(Date.new(2016, 1, 1))
-              expect(subject.end_date).to eq(Date.new(2016, 1, 1))
+              expect(subject.start_date).to eq(Date.new(2016, 1, 22))
+              expect(subject.end_date).to eq(Date.new(2017, 10, 13))
             end
           end
 


### PR DESCRIPTION
#### :tophat: What? Why?
There are a pair of modules (decidim-participatory_processes and decidim-initiatives) that declare some fields as Date columns in the database schema, but then are managed as DateTime objects in the Ruby code.

This is inconsistent, confusing and error prone. This PR will refactor these modules to use Ruby Date objects instead of DateTime objects.

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/pull/3724#issuecomment-407664414

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [-] Add documentation regarding the feature 
- [x] Add/modify seeds
- [-] Add tests
- [x] Refactor
