### PR TITLE
Remove unused authorization_object method

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/concerns/has_attachment_collections.rb
+++ b/decidim-admin/app/controllers/decidim/admin/concerns/has_attachment_collections.rb
@@ -100,14 +100,6 @@ module Decidim
             raise NotImplementedError
           end
 
-          # Public: The Class or Object to be used with the authorization layer to
-          # verify the user can manage the attachment collection
-          #
-          # By default is the same as the collection_for.
-          def authorization_object
-            collection_for
-          end
-
           def collection
             @collection ||= collection_for.attachment_collections
           end

--- a/decidim-admin/app/controllers/decidim/admin/concerns/has_private_users.rb
+++ b/decidim-admin/app/controllers/decidim/admin/concerns/has_private_users.rb
@@ -14,7 +14,7 @@ module Decidim
 
         included do
           helper PaginateHelper
-          helper_method :privatable_to, :authorization_object, :collection
+          helper_method :privatable_to, :collection
 
           def index
             enforce_permission_to :read, :space_private_user
@@ -83,14 +83,6 @@ module Decidim
           # return the object where the attachment will be attached to.
           def privatable_to
             raise NotImplementedError
-          end
-
-          # Public: The Class or Object to be used with the authorization layer to
-          # verify the user can manage the private users
-          #
-          # By default is the same as the privatable_to.
-          def authorization_object
-            privatable_to
           end
 
           def collection

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_attachment_collections_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_attachment_collections_controller.rb
@@ -16,10 +16,6 @@ module Decidim
         def collection_for
           current_assembly
         end
-
-        def authorization_object
-          @attachment_collection || AttachmentCollection
-        end
       end
     end
   end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_attachments_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_attachments_controller.rb
@@ -17,10 +17,6 @@ module Decidim
         def attached_to
           current_assembly
         end
-
-        def authorization_object
-          @attachment || Attachment
-        end
       end
     end
   end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/participatory_space_private_users_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/participatory_space_private_users_controller.rb
@@ -16,10 +16,6 @@ module Decidim
         def privatable_to
           current_assembly
         end
-
-        def authorization_object
-          @participatory_space_private_user || ParticipatorySpacePrivateUser
-        end
       end
     end
   end

--- a/decidim-budgets/app/controllers/decidim/budgets/admin/attachment_collections_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/admin/attachment_collections_controller.rb
@@ -19,10 +19,6 @@ module Decidim
         def project
           @project ||= projects.find(params[:project_id])
         end
-
-        def authorization_object
-          project.component
-        end
       end
     end
   end

--- a/decidim-budgets/app/controllers/decidim/budgets/admin/attachments_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/admin/attachments_controller.rb
@@ -20,10 +20,6 @@ module Decidim
         def project
           @project ||= projects.find(params[:project_id])
         end
-
-        def authorization_object
-          project.component
-        end
       end
     end
   end

--- a/decidim-consultations/app/controllers/decidim/consultations/admin/question_attachments_controller.rb
+++ b/decidim-consultations/app/controllers/decidim/consultations/admin/question_attachments_controller.rb
@@ -15,10 +15,6 @@ module Decidim
         def attached_to
           current_question
         end
-
-        def authorization_object
-          collection.find_by(id: params[:id]) || Decidim::Attachment
-        end
       end
     end
   end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiative_attachments_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiative_attachments_controller.rb
@@ -15,10 +15,6 @@ module Decidim
         def attached_to
           current_initiative
         end
-
-        def authorization_object
-          collection.find_by(id: params[:id]) || Decidim::Attachment
-        end
       end
     end
   end

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/attachment_collections_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/attachment_collections_controller.rb
@@ -19,10 +19,6 @@ module Decidim
         def meeting
           @meeting ||= meetings.find(params[:meeting_id])
         end
-
-        def authorization_object
-          meeting.component
-        end
       end
     end
   end

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/attachments_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/attachments_controller.rb
@@ -20,10 +20,6 @@ module Decidim
         def meeting
           @meeting ||= meetings.find(params[:meeting_id])
         end
-
-        def authorization_object
-          meeting.component
-        end
       end
     end
   end

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_space_private_users_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_space_private_users_controller.rb
@@ -15,10 +15,6 @@ module Decidim
         def privatable_to
           current_participatory_process
         end
-
-        def authorization_object
-          @participatory_space_private_user
-        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

Seems that `authorization_object` methods are not in use. Can anyone confirm this?

#### :pushpin: Related Issues


#### :clipboard: Subtasks
- ~[] Add `CHANGELOG` entry~