### PR TITLE
Include the initiative type on printable forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **decidim-debates**: Adds the *commented debates* badge. [\#4089](https://github.com/decidim/decidim/pull/4089)
 - **decidim-meetings**: Add upcoming events content block and page. [\#3987](https://github.com/decidim/decidim/pull/3987)
 - **decidim-generators**: Enable one more bootsnap optimization in test apps when coverage tracking is not enabled [\#4098](https://github.com/decidim/decidim/pull/4098)
+- **decidim-initiatives**: Initiative printable form now includes the initiative type. [\#3938](https://github.com/decidim/decidim/pull/3938)
 
 **Changed**:
 

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/show.html.erb
@@ -99,6 +99,9 @@
 <h2 class="print-section-title">Sol·liciten que sigui admesa a tràmit la Iniciativa Ciutadana que porta el títol de:</h2>
 <%= translated_attribute(current_initiative.title) %>
 
+<h2 class="print-section-title">Tipus de la Iniciativa:</h2>
+<%= translated_attribute(current_initiative.type.title) %>
+
 <h2 class="print-section-title">Definició de la Iniciativa:</h2>
 <%= decidim_sanitize translated_attribute(current_initiative.description) %>
 

--- a/decidim-initiatives/spec/system/admin/print_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/admin/print_initiative_spec.rb
@@ -16,6 +16,7 @@ describe "User prints the initiative", type: :system do
     it "shows a printable form with all available data about the initiative" do
       within "main" do
         expect(page).to have_content(translated(initiative.title, locale: :en))
+        expect(page).to have_content(translated(initiative.type.tytle, locale: :en))
         expect(page).to have_content(ActionView::Base.full_sanitizer.sanitize(translated(initiative.description, locale: :en), tags: []))
       end
     end

--- a/decidim-initiatives/spec/system/admin/print_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/admin/print_initiative_spec.rb
@@ -16,7 +16,7 @@ describe "User prints the initiative", type: :system do
     it "shows a printable form with all available data about the initiative" do
       within "main" do
         expect(page).to have_content(translated(initiative.title, locale: :en))
-        expect(page).to have_content(translated(initiative.type.tytle, locale: :en))
+        expect(page).to have_content(translated(initiative.type.title, locale: :en))
         expect(page).to have_content(ActionView::Base.full_sanitizer.sanitize(translated(initiative.description, locale: :en), tags: []))
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Initiative's printable form includes the initiative type.

#### :pushpin: Related Issues
- Fixes #3937

### :camera: Screenshots (optional)
![decidim](https://user-images.githubusercontent.com/1701962/43384435-5b7b304c-93de-11e8-92c6-774bd39bc178.gif)

