### PR TITLE
Fix dragging list glitch on reordering

### DIFF
--- a/decidim-admin/app/assets/javascripts/decidim/admin/draggable-list.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/draggable-list.js.es6
@@ -21,10 +21,8 @@
       $draggables.not(event.target.parentElement).addClass("dragging")
     })
 
-    document.addEventListener("dragend", function (event) {
-      if ($(event.target.parentElement).hasClass("dragging")) {
-        $(event.target.parentElement).removeClass("dragging")
-      }
+    document.addEventListener("dragend", function() {
+      $draggables.removeClass("dragging")
     })
 
     createSortableList(draggablesClassNames.join(", "))


### PR DESCRIPTION
#### :tophat: What? Why?
Builds on #3934. 

When reordering elements of the same draggable list, a glitch appears in the other list. This PR fixes the glitch. Check the right columns in the GIFs.

#### :pushpin: Related Issues
- Related to #3934.

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
Bugged version:
![](https://media.giphy.com/media/oz9TJNtJla8zJG5IAN/giphy.gif)

Solved version (this PR):
![](https://media.giphy.com/media/1eExXpVNIDe0Br4weT/giphy.gif)