### PR TITLE
[WIP] Content blocks admin

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/reorder_content_blocks.rb
+++ b/decidim-admin/app/commands/decidim/admin/reorder_content_blocks.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # A command that reorders a collection of content blocks.
+    class ReorderContentBlocks < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # collection - an ActiveRecord::Relation of content blocks. Should include
+      #   both the published and unpublished content blocks for a given scope.
+      # order - an Array holding the order of IDs of published content blocks.
+      def initialize(collection, order)
+        @collection = collection
+        @order = order
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid.
+      # - :invalid if the data wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        return broadcast(:invalid) if order.blank?
+
+        reorder_steps
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :collection
+
+      def reorder_steps
+        data = order.each_with_index.inject({}) do |hash, (id, index)|
+          hash.update(id => { weight: index })
+        end
+
+        # rubocop:disable Rails/SkipsModelValidations
+        transaction do
+          collection.update_all(weight: nil)
+          collection.reload
+          collection.update(data.keys, data.values)
+          collection.where(weight: nil).update_all(published_at: nil)
+          collection.where(published_at: nil).where.not(weight: nil).update_all(published_at: Time.current)
+        end
+        # rubocop:enable Rails/SkipsModelValidations
+      end
+
+      def order
+        return nil unless @order.is_a?(Array) && @order.present?
+
+        @order
+      end
+    end
+  end
+end

--- a/decidim-admin/app/controllers/decidim/admin/organization_homepage_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/organization_homepage_controller.rb
@@ -14,12 +14,12 @@ module Decidim
 
       def update
         enforce_permission_to :update, :organization, organization: current_organization
-          ReorderParticipatoryProcessSteps.call(collection, params[:items_ids]) do
+          ReorderContentBlocks.call(content_blocks, params[:ids]) do
             on(:ok) do
               head :ok
             end
             on(:invalid) do
-              head 500
+              head :bad_request
             end
           end
       end

--- a/decidim-admin/app/controllers/decidim/admin/organization_homepage_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/organization_homepage_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # Controller that allows managing the organization homepage
+    class OrganizationHomepageController < Decidim::Admin::ApplicationController
+      layout "decidim/admin/settings"
+
+      helper_method :active_blocks, :inactive_blocks
+
+      def edit
+        enforce_permission_to :update, :organization, organization: current_organization
+      end
+
+      def update
+        enforce_permission_to :update, :organization, organization: current_organization
+          ReorderParticipatoryProcessSteps.call(collection, params[:items_ids]) do
+            on(:ok) do
+              head :ok
+            end
+            on(:invalid) do
+              head 500
+            end
+          end
+      end
+
+      private
+
+      def content_blocks
+        @content_blocks ||= Decidim::ContentBlock.for_scope(:homepage, organization: current_organization)
+      end
+
+      def active_blocks
+        @active_blocks ||= content_blocks.published
+      end
+
+      def inactive_blocks
+        @inactive_blocks ||= content_blocks.unpublished + unused_manifests
+      end
+
+      def used_manifests
+        @used_manifests ||= content_blocks.map(&:manifest_name)
+      end
+
+      def unused_manifests
+        @unused_manifests ||= Decidim.content_blocks.for(:homepage).select do |manifest|
+          !used_manifests.include?(manifest.name.to_s)
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/app/views/decidim/admin/organization_homepage/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization_homepage/edit.html.erb
@@ -25,7 +25,7 @@
           <p class="mb-m">Bloques disponibles</p>
           <ul class="draggable-list js-connect js-list-availables">
             <% inactive_blocks.each do |content_block_or_manifest| %>
-            <li draggable="true">
+            <li draggable="true" data-content-block-id="<%= content_block_or_manifest.try(:id) %>">
               <div class="draggable-content">
                 <%= content_block_or_manifest.try(:manifest_name) || content_block_or_manifest.name %>
                 <div>

--- a/decidim-admin/app/views/decidim/admin/organization_homepage/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization_homepage/edit.html.erb
@@ -1,0 +1,57 @@
+<div class="grid-container full">
+  <div class="grid-x grid-margin-x card-grid">
+    <div class="cell small-6">
+      <div class="card">
+        <div class="card-section">
+          <p class="mb-m">Bloques activos</p>
+          <ul class="draggable-list js-connect js-list-actives" data-sort-url="<%= decidim_admin.organization_homepage_path %>">
+            <% active_blocks.each do |content_block| %>
+            <li draggable="true" data-content-block-id="<%= content_block.id %>">
+              <div class="draggable-content">
+                <%= content_block.manifest_name %>
+                <div>
+                  <%= icon "menu" %>
+                </div>
+              </div>
+            </li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="cell small-6">
+      <div class="card">
+        <div class="card-section">
+          <p class="mb-m">Bloques disponibles</p>
+          <ul class="draggable-list js-connect js-list-availables">
+            <% inactive_blocks.each do |content_block_or_manifest| %>
+            <li draggable="true">
+              <div class="draggable-content">
+                <%= content_block_or_manifest.try(:manifest_name) || content_block_or_manifest.name %>
+                <div>
+                  <%= icon "menu" %>
+                </div>
+              </div>
+            </li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  document.addEventListener("dragend", function (event) {
+    var activeBlocks = Array.prototype.slice.call(document.querySelectorAll(".js-list-actives li"));
+    var activeBlocksIds = activeBlocks.map(block => block.dataset.contentBlockId);
+    var sortUrl = document.querySelector(".js-list-actives").dataset.sortUrl;
+
+    $.ajax({
+      method: "PUT",
+      url: sortUrl,
+      contentType: "application/json",
+      data: JSON.stringify({ ids: activeBlocksIds })
+    });
+  })
+</script>

--- a/decidim-admin/app/views/layouts/decidim/admin/settings.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/settings.html.erb
@@ -10,6 +10,9 @@
       <li <% if is_active_link?(decidim_admin.edit_organization_appearance_path) %> class="is-active" <% end %>>
         <%= link_to t("menu.appearance", scope: "decidim.admin"), decidim_admin.edit_organization_appearance_path %>
       </li>
+      <li <% if is_active_link?(decidim_admin.edit_organization_homepage_path) %> class="is-active" <% end %>>
+        <%= link_to t("menu.homepage", scope: "decidim.admin"), decidim_admin.edit_organization_homepage_path %>
+      </li>
       <li <% if is_active_link?(decidim_admin.scopes_path) %> class="is-active" <% end %>>
         <%= link_to t("menu.scopes", scope: "decidim.admin"), decidim_admin.scopes_path %>
       </li>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -306,6 +306,7 @@ en:
         areas: Areas
         configuration: Configuration
         dashboard: Dashboard
+        homepage: Homepage
         impersonations: Impersonations
         newsletters: Newsletters
         oauth_applications: OAuth applications
@@ -499,6 +500,9 @@ en:
           homepage_highlighted_content_banner_title: Highligted content banner
           layout_appearance_title: Edit layout appearance
           omnipresent_banner_appearance_title: Edit omnipresent banner
+      organization_homepage:
+        edit:
+          update: Update
       participatory_space_private_users:
         create:
           error: There was an error adding a private user for this participatory space.

--- a/decidim-admin/config/routes.rb
+++ b/decidim-admin/config/routes.rb
@@ -4,6 +4,7 @@ Decidim::Admin::Engine.routes.draw do
   constraints(->(request) { Decidim::Admin::OrganizationDashboardConstraint.new(request).matches? }) do
     resource :organization, only: [:edit, :update], controller: "organization" do
       resource :appearance, only: [:edit, :update], controller: "organization_appearance"
+      resource :homepage, only: [:edit, :update], controller: "organization_homepage"
 
       member do
         get :users

--- a/decidim-admin/lib/decidim/admin/engine.rb
+++ b/decidim-admin/lib/decidim/admin/engine.rb
@@ -69,6 +69,7 @@ module Decidim
                       %w(
                         decidim/admin/organization
                         decidim/admin/organization_appearance
+                        decidim/admin/organization_homepage
                         decidim/admin/scopes
                         decidim/admin/scope_types
                         decidim/admin/areas decidim/admin/area_types

--- a/decidim-core/app/models/decidim/content_block.rb
+++ b/decidim-core/app/models/decidim/content_block.rb
@@ -9,14 +9,14 @@ module Decidim
     # current attachments do not allow this, so we'll use the attachment `title`
     # field to identify each image.
     include HasAttachments
+    include Publicable
 
     belongs_to :organization, foreign_key: :decidim_organization_id, class_name: "Decidim::Organization"
 
     # Public: finds the published content blocks for the given scope and
     # organization. Returns them ordered by ascending weight (lowest first).
-    def self.published_for_scope(scope, organization:)
+    def self.for_scope(scope, organization:)
       where(organization: organization, scope: scope)
-        .where.not(published_at: nil)
         .order(weight: :asc)
     end
 

--- a/decidim-core/app/views/decidim/pages/home.html.erb
+++ b/decidim-core/app/views/decidim/pages/home.html.erb
@@ -1,3 +1,3 @@
-<% Decidim::ContentBlock.published_for_scope(:homepage, organization: current_organization).each do |content_block| %>
+<% Decidim::ContentBlock.published.for_scope(:homepage, organization: current_organization).each do |content_block| %>
   <%= cell content_block.manifest.cell_name %>
 <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
Follow-up for #3839. This PR adds an admin screen to sort/publish/unpublish homepage content blocks.

#### :pushpin: Related Issues
- Related to #3839, #3672.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add tests

### :camera: Screenshots (optional)
![Description](URL)
