### PR TITLE
fix `linked_classes_for` to use `underscore` instead of `downcase`

### DIFF
--- a/decidim-core/app/helpers/decidim/resource_helper.rb
+++ b/decidim-core/app/helpers/decidim/resource_helper.rb
@@ -45,7 +45,7 @@ module Decidim
       return [] unless klass.respond_to?(:linked_classes_for)
 
       klass.linked_classes_for(current_component).map do |k|
-        [k.underscore, t(k.demodulize.downcase, scope: "decidim.filters.linked_classes")]
+        [k.underscore, t(k.demodulize.underscore, scope: "decidim.filters.linked_classes")]
       end
     end
 

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -326,7 +326,7 @@ en:
     filters:
       linked_classes:
         all: All
-        dummyresource: Dummy resources
+        dummy_resource: Dummy resources
         meeting: Meetings
         project: Projects
         proposal: Proposals


### PR DESCRIPTION
#### :tophat: What? Why?

The `decidim-core/app/helpers/decidim/resource_helper.rb` does a `downcase` instead of an `underscore`, so for `DummyResource` searches for the translation `dummyresource` not `dummy_resource` that would be the convention.


#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/pull/3109/files#r205357203
