### PR TITLE
Alternative markup to geolocation

### DIFF
--- a/decidim_app-design/app/views/public/partials/_last_events.html.erb
+++ b/decidim_app-design/app/views/public/partials/_last_events.html.erb
@@ -21,7 +21,30 @@
     <% end %>
   </div>
   <div class="columns medium-6">
-    <%= partial "meetings_map" %>
+    <% geolocation_enabled = true %>
+    <% if geolocation_enabled %>
+      <%= partial "meetings_map" %>
+    <% else %>
+    <% 4.times do %>
+    <article class="card">
+      <div class="p-s">
+        <div class="card__header">
+          <%= link_to page_path("meetings/meeting-view"), class: "card__link" do %>
+            <h5 class="card__title">
+              <%= Faker::Lorem.sentence %>
+            </h5>
+          <% end %>
+        </div>
+        <div class="card__text">
+          <div class="row collapse text-medium">
+            <span class="column medium-4 icon--container"><%= icon "datetime", class: "primary" %>&nbsp;<%= Faker::Time.forward(Faker::Number.non_zero_digit.to_i, :afternoon).strftime("%e %^b %Y · %k:%M") %></span>
+            <span class="column medium-8">PROCESO&nbsp;<%= link_to "Plan de Equipamentos de Nou Barris", page_path("meetings/meeting-view") %></span>
+          </div>
+        </div>
+      </div>
+    </article>
+    <% end %>
+    <% end %>
   </div>
 </div>
 <div class="row">


### PR DESCRIPTION
#### :tophat: What? Why?
Provides an alternative markup for those sites which geolocation is disabled

#### :pushpin: Related Issues
- Related to #3943 

### :camera: Screenshots (optional)
![imagen](https://user-images.githubusercontent.com/817526/43512286-fd21fc44-957a-11e8-8329-b78fe8e2caa2.png)

