### PR TITLE
Fix foundation warning about flex grid row align

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_help.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_help.scss
@@ -17,7 +17,7 @@
 
 .help-tooltip{
   @include flex;
-  @include flex-align(center, center);
+  @include flex-align(center, middle);
 
   border: .25rem solid lighten($secondary, 25%);
   border-radius: 50%;


### PR DESCRIPTION
#### :tophat: What? Why?

In development the log have the following warning:

```
WARNING: flex-grid-row-align(): center is not a valid value for vertical alignment. Use top, bottom, middle, or stretch.
         on line 47 of ../../../../.rvm/gems/ruby-2.5.1/gems/foundation-rails-6.4.3.0/vendor/assets/scss/util/_flex.scss, in mixin `flex-align`
         from line 20 of ../decidim-core/app/assets/stylesheets/decidim/modules/_help.scss
         from line 71 of ../decidim-core/app/assets/stylesheets/decidim/modules/_modules.scss
         from line 12 of ../decidim-core/app/assets/stylesheets/decidim/_decidim.scss
         from line 1 of ../decidim-core/app/assets/stylesheets/decidim/application.scss.erb
         from line 18 of app/assets/stylesheets/decidim.scss
```

#### :pushpin: Related Issues


#### :clipboard: Subtasks

### :camera: Screenshots (optional)

