### PR TITLE
Add docs for content blocks

### DIFF
--- a/decidim-core/app/views/decidim/pages/home.html.erb
+++ b/decidim-core/app/views/decidim/pages/home.html.erb
@@ -1,3 +1,4 @@
 <% Decidim::ContentBlock.published.for_scope(:homepage, organization: current_organization).each do |content_block| %>
+  <% next unless content_block.manifest %>
   <%= cell content_block.manifest.cell_name %>
 <% end %>

--- a/docs/advanced/content_blocks.md
+++ b/docs/advanced/content_blocks.md
@@ -1,0 +1,60 @@
+# Content blocks
+
+Content blocks come from the need of making sortable and configurable layout chunks. The abstraction is similar to view hooks, but content blocks allow the user to manually configure and sort each block. The order and configuration is backed in the database.
+
+As of today, content blocks can be:
+
+- Sorted
+- Published
+
+Configuration will come in the near future.
+
+Content blocks are defined per scope, and must be unique in that scope. Examples of scopes could be `:homepage` or `:process_page`.
+
+Content blocks are used in the organization homepage.
+
+## Registering a content block
+
+Content blocks use the same manifests-registry pattern used in other places around Decidim. Here's how to register them:
+
+```ruby
+Decidim.content_blocks.register(:homepage, :stats) do |content_block|
+  content_block.cell "decidim/content_blocks/stats_block"
+  content_block.public_name_key "decidim.content_blocks.stats_block.name"
+end
+```
+
+Let's analyze the example. In the first line, we register a content block named `:stats` for the `:homepage` scope. Then we define the name of the `cell` that will be used to render the content block, and we define the i18n key that holds the name for the content block. These are the only required fields to register a content block.
+
+Note that content blocks need to be registered from an initializer. If you are adding a content block from a module, use this in the `engine.rb` file of your module:
+
+```ruby
+module Decidim::MyModule::Engine < ::Rails::Engine
+  # ...
+
+  initializer "decidim.my_module.content_blocks" do
+    Decidim.content_blocks.register(:homepage, :my_content_block) do |content_block|
+      # ...
+    end
+  end
+
+  # ...
+end
+```
+
+## Managing content blocks
+
+Currently content blocks are only used in the homepage. You can manage them in the admin area, under Settings -> Homepage. you need to be an organization admin in order to enter this section.
+
+You'll see all the registered content blocks, those active and those inactive. You can reorder blocks and (un)publish them.
+
+## Rendering content blocks
+
+You can check the code we use in the homepage to render them, or use something like this:
+
+```ruby
+<% Decidim::ContentBlock.published.for_scope(:homepage, organization: current_organization).each do |content_block| %>
+  <% next unless content_block.manifest %>
+  <%= cell content_block.manifest.cell_name %>
+<% end %>
+```

--- a/docs/advanced/view_hooks.md
+++ b/docs/advanced/view_hooks.md
@@ -85,3 +85,7 @@ Ideally, each engine should hold their own instance of `Decidim::ViewHooks`. Thi
 ## The engine I want to extend does not support view hooks, what can I do?
 
 First of all, send a PR to the engine to add the view hook you need. Expose your needs, so the developers can assess a view hook is the best solution. Sometimes a view hook can be replaced with another abstraction, or another UI. Meanwhile, you can use [`deface`](https://github.com/spree/deface) to extend a view file without replacing it. Be careful, since `deface` is *very* powerful and can be a double-edged sword. We considered adding `deface` to `decidim`, but found that it opened to a code that would be much harder to maintain.
+
+## View hooks drawbacks and alternatives
+
+View hooks allow components to extend the views of other components without coupling, but they cannot be sorted by the user, and cannot hold options. Consider checking the content blocks abstraction for a more configurable setup.


### PR DESCRIPTION
#### :tophat: What? Why?
Followup from #3839. This PR adds global docs on how to use content blocks.

#### :pushpin: Related Issues
- Related to #3839, #3941.

#### :clipboard: Subtasks
None