### PR TITLE
Content blocks: use settings manifest

### DIFF
--- a/decidim-core/app/models/decidim/content_block.rb
+++ b/decidim-core/app/models/decidim/content_block.rb
@@ -13,7 +13,7 @@ module Decidim
 
     belongs_to :organization, foreign_key: :decidim_organization_id, class_name: "Decidim::Organization"
 
-    delegate :i18n_name_key, to: :manifest
+    delegate :i18n_name_key, :has_settings?, to: :manifest
 
     # Public: finds the published content blocks for the given scope and
     # organization. Returns them ordered by ascending weight (lowest first).
@@ -24,6 +24,10 @@ module Decidim
 
     def manifest
       @manifest ||= Decidim.content_blocks.for(scope).find { |manifest| manifest.name.to_s == manifest_name }
+    end
+
+    def settings
+      manifest.settings.schema.new(self[:options])
     end
   end
 end

--- a/decidim-core/app/models/decidim/content_block.rb
+++ b/decidim-core/app/models/decidim/content_block.rb
@@ -27,7 +27,7 @@ module Decidim
     end
 
     def settings
-      manifest.settings.schema.new(self[:options])
+      manifest.settings.schema.new(self[:settings])
     end
   end
 end

--- a/decidim-core/db/migrate/20180802132147_rename_content_block_options_to_settings.rb
+++ b/decidim-core/db/migrate/20180802132147_rename_content_block_options_to_settings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameContentBlockOptionsToSettings < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :decidim_content_blocks, :options, :settings
+  end
+end

--- a/decidim-core/lib/decidim/content_block_manifest.rb
+++ b/decidim-core/lib/decidim/content_block_manifest.rb
@@ -12,7 +12,7 @@ module Decidim
   #
   # Content blocks are intended to be used in the home page, for example.
   #
-  # A content block has a set of options and an associated `cell` that will
+  # A content block has a set of settings and an associated `cell` that will
   # handle the layout logic. They can also have attached images that can be used
   # as background images, for example. You must explicitly specify the number of
   # images the block will have (this means the number of attached images cannot
@@ -26,11 +26,9 @@ module Decidim
     attribute :i18n_name_key, String
     attribute :cell_name, String, writer: :private
     attribute :image_names, Array[Symbol]
-    attribute :options, Array[Hash]
 
     validates :name, :cell_name, :i18n_name_key, presence: true
     validate :image_names_are_unique
-    validate :option_names_are_unique
 
     # Public: Registers an image with a given name. Use `#images` to retrieve
     # them all.
@@ -52,27 +50,22 @@ module Decidim
       self.i18n_name_key = i18n_key
     end
 
-    # Public: Registers an option. Use `#options` to retrieve them all.
-    def option(name, type, metadata = {})
-      raise OptionNameCannotBeBlank, "Option names cannot be blank" if name.blank?
-      raise OptionTypeCannotBeBlank, "Option types cannot be blank" if type.blank?
+    def has_settings?
+      settings.attributes.any?
+    end
 
-      options << { name: name, type: type }.merge(metadata)
+    def settings(&block)
+      @settings ||= SettingsManifest.new
+      yield(@settings) if block
+      @settings
     end
 
     private
-
-    def option_names_are_unique
-      option_names = options.map { |option| option.fetch(:name) }
-      errors.add(:options, :invalid) if option_names.count != option_names.uniq.count
-    end
 
     def image_names_are_unique
       errors.add(:image_names, :invalid) if image_names.count != image_names.uniq.count
     end
 
     class ImageNameCannotBeBlank < StandardError; end
-    class OptionNameCannotBeBlank < StandardError; end
-    class OptionTypeCannotBeBlank < StandardError; end
   end
 end

--- a/decidim-core/lib/decidim/content_block_registry.rb
+++ b/decidim-core/lib/decidim/content_block_registry.rb
@@ -7,24 +7,27 @@ module Decidim
   # In order to register a content block, you can follow this example:
   #
   #     Decidim.content_blocks.register(:homepage, :global_stats) do |content_block|
-  #       content_block.option :minimum_priority_level,
-  #                         :integer
-  #                         default: lambda { StatsRegistry::HIGH_PRIORITY }
-  #                         values: lambda { [StatsRegistry::HIGH_PRIORITY, StatsRegistry::MEDIUM_PRIORITY] }
   #       content_block.cell "decidim/content_blocks/stats_block"
   #       content_block.public_name_key "decidim.content_blocks.stats_block.name"
+  #
+  #       content_block.settings do |settings|
+  #         settings.attribute :minimum_priority_level,
+  #                            type: :integer
+  #                            default: lambda { StatsRegistry::HIGH_PRIORITY }
+  #       end
   #     end
   #
   # Content blocks can also register attached images. Here's an example of a
   # content block with 4 attached images:
   #
   #     Decidim.content_blocks.register(:homepage, :carousel) do |content_block|
+  #       content_block.cell "decidim/content_blocks/carousel_block"
+  #       content_block.public_name_key "decidim.content_blocks.carousel_block.name"
+  #
   #       content_block.image :image_1
   #       content_block.image :image_2
   #       content_block.image :image_3
   #       content_block.image :image_4
-  #       content_block.cell "decidim/content_blocks/carousel_block"
-  #       content_block.public_name_key "decidim.content_blocks.carousel_block.name"
   #     end
   #
   # You will probably want to register your content blocks in an initializer in

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -280,6 +280,12 @@ module Decidim
         Decidim.content_blocks.register(:homepage, :hero) do |content_block|
           content_block.cell "decidim/content_blocks/hero"
           content_block.public_name_key "decidim.content_blocks.hero.name"
+
+          content_block.settings do |settings|
+            settings.attribute :cta_button_text, type: :text, translated: true
+            settings.attribute :welcome_text, type: :text, translated: true
+            settings.attribute :cta_button_link, type: :text
+          end
         end
 
         Decidim.content_blocks.register(:homepage, :sub_hero) do |content_block|

--- a/decidim-core/spec/lib/content_block_manifest_spec.rb
+++ b/decidim-core/spec/lib/content_block_manifest_spec.rb
@@ -61,10 +61,32 @@ module Decidim
         end
 
         setup.call(subject)
+
         expect(subject).to be_valid
         expect(subject.cell_name).to eq cell
         expect(subject.name).to eq name
         expect(subject.image_names).to match_array [:image_1, :image_2]
+      end
+    end
+
+    describe "when adding settings" do
+      let(:attributes) { { name: name } }
+
+      it "is valid" do
+        setup = proc do |content_block|
+          content_block.cell cell
+
+          content_block.settings do |settings|
+            settings.attribute :name, type: :text, translated: true, editor: true
+          end
+        end
+
+        setup.call(subject)
+
+        expect(subject.settings.attributes).to have_key(:name)
+        expect(subject.settings.attributes[:name].translated).to eq true
+        expect(subject.settings.attributes[:name].editor).to eq true
+        expect(subject.settings.attributes[:name].type).to eq :text
       end
     end
   end

--- a/decidim-core/spec/lib/content_block_manifest_spec.rb
+++ b/decidim-core/spec/lib/content_block_manifest_spec.rb
@@ -50,29 +50,6 @@ module Decidim
       end
     end
 
-    context "with repeated option names" do
-      it "is not valid" do
-        subject.option :my_option, :integer
-        subject.option :my_option, :text
-
-        expect(subject).not_to be_valid
-      end
-    end
-
-    context "when registering an option without a name" do
-      it "raises an error" do
-        expect { subject.option "", :integer }
-          .to raise_error(described_class::OptionNameCannotBeBlank)
-      end
-    end
-
-    context "when registering an option without a type" do
-      it "raises an error" do
-        expect { subject.option :my_option, "" }
-          .to raise_error(described_class::OptionTypeCannotBeBlank)
-      end
-    end
-
     describe "initializing via a block" do
       let(:attributes) { { name: name } }
 


### PR DESCRIPTION
#### :tophat: What? Why?
Components use a SettingsManifest in order to define and store the settings. Since the use case is similar to what content blocks need, I'm proposing changing the API to define content block options to use the same API as components do.

This allows us to easily access the content block settings through the SettingsManifest schema, just like the components do.

This is an internal change, does not affect the layout. Also, I don't think anyone has yet defined other content blocks, but this PR would break the API. I'm really sorry about that. Note that in the future the API to register images to a content block might change too.

#### :pushpin: Related Issues
- Related to #3839 and others.

#### :clipboard: Subtasks
None