### PR TITLE
Prefer Time over DateTime

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -811,7 +811,7 @@ Style/PreferredHashMethods:
   EnforcedStyle: verbose
 
 Style/DateTime:
-  Enabled: false
+  Enabled: true
 
 Style/Documentation:
   Enabled: false

--- a/decidim-admin/spec/commands/decidim/admin/deliver_newsletter_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/deliver_newsletter_spec.rb
@@ -14,14 +14,14 @@ module Decidim::Admin
       let(:delivering_user) { create :user, :admin, :confirmed, organization: organization }
 
       let!(:deliverable_users) do
-        create_list(:user, 5, :confirmed, organization: organization, newsletter_notifications_at: Time.zone.now)
+        create_list(:user, 5, :confirmed, organization: organization, newsletter_notifications_at: Time.current)
       end
 
       let!(:not_deliverable_users) do
         create_list(:user, 3, organization: organization, newsletter_notifications_at: nil)
       end
       let!(:unconfirmed_users) do
-        create_list(:user, 3, organization: organization, newsletter_notifications_at: Time.zone.now)
+        create_list(:user, 3, organization: organization, newsletter_notifications_at: Time.current)
       end
 
       let(:command) { described_class.new(newsletter, delivering_user) }

--- a/decidim-admin/spec/jobs/newsletter_job_spec.rb
+++ b/decidim-admin/spec/jobs/newsletter_job_spec.rb
@@ -8,11 +8,11 @@ module Decidim
       let!(:newsletter) { create(:newsletter, organization: organization, total_deliveries: 0) }
       let!(:organization) { create(:organization) }
       let!(:another_organization) { create(:organization) }
-      let!(:deliverable_user) { create(:user, :confirmed, newsletter_notifications_at: Time.zone.now, organization: organization) }
-      let!(:another_deliverable_user) { create(:user, :confirmed, newsletter_notifications_at: Time.zone.now, organization: another_organization) }
-      let!(:undeliverable_user) { create(:user, newsletter_notifications_at: Time.zone.now, organization: organization) }
+      let!(:deliverable_user) { create(:user, :confirmed, newsletter_notifications_at: Time.current, organization: organization) }
+      let!(:another_deliverable_user) { create(:user, :confirmed, newsletter_notifications_at: Time.current, organization: another_organization) }
+      let!(:undeliverable_user) { create(:user, newsletter_notifications_at: Time.current, organization: organization) }
       let!(:non_deliverable_user) { create(:user, :confirmed, newsletter_notifications_at: nil, organization: organization) }
-      let!(:deleted_user) { create(:user, :confirmed, :deleted, newsletter_notifications_at: Time.zone.now, organization: organization) }
+      let!(:deleted_user) { create(:user, :confirmed, :deleted, newsletter_notifications_at: Time.current, organization: organization) }
 
       it "delivers a newsletter to a the eligible users" do
         expect(NewsletterDeliveryJob).to receive(:perform_later).with(deliverable_user, newsletter)

--- a/decidim-admin/spec/system/admin_manages_newsletters_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_newsletters_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe "Admin manages newsletters", type: :system do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, :admin, :confirmed, name: "Sarah Kerrigan", organization: organization) }
-  let!(:deliverable_users) { create_list(:user, 5, :confirmed, newsletter_notifications_at: Time.zone.now, organization: organization) }
+  let!(:deliverable_users) { create_list(:user, 5, :confirmed, newsletter_notifications_at: Time.current, organization: organization) }
 
   before do
     switch_to_host(organization.host)

--- a/decidim-budgets/spec/commands/cancel_order_spec.rb
+++ b/decidim-budgets/spec/commands/cancel_order_spec.rb
@@ -18,7 +18,7 @@ module Decidim::Budgets
     let(:order) do
       order = create(:order, user: user, component: component)
       order.projects << project
-      order.checked_out_at = Time.zone.now
+      order.checked_out_at = Time.current
       order.save!
       order
     end

--- a/decidim-budgets/spec/models/order_spec.rb
+++ b/decidim-budgets/spec/models/order_spec.rb
@@ -68,7 +68,7 @@ module Decidim::Budgets
 
     describe "#checked_out?" do
       it "returns true if the checked_out_at attribute is present" do
-        subject.checked_out_at = Time.zone.now
+        subject.checked_out_at = Time.current
         expect(subject).to be_checked_out
       end
     end

--- a/decidim-core/app/controllers/decidim/devise/invitations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/invitations_controller.rb
@@ -25,7 +25,7 @@ module Decidim
       # When a managed user accepts the invitation is promoted to non-managed user.
       def accept_resource
         resource = resource_class.accept_invitation!(update_resource_params)
-        resource.update!(newsletter_notifications_at: Time.zone.now) if update_resource_params[:newsletter_notifications]
+        resource.update!(newsletter_notifications_at: Time.current) if update_resource_params[:newsletter_notifications]
         resource.update!(managed: false) if resource.managed?
         resource.update!(accepted_tos_version: resource.organization.tos_version)
         resource

--- a/decidim-core/app/forms/decidim/notifications_settings_form.rb
+++ b/decidim-core/app/forms/decidim/notifications_settings_form.rb
@@ -14,7 +14,7 @@ module Decidim
 
     def newsletter_notifications_at
       return nil unless newsletter_notifications
-      Time.zone.now
+      Time.current
     end
   end
 end

--- a/decidim-core/app/forms/decidim/registration_form.rb
+++ b/decidim-core/app/forms/decidim/registration_form.rb
@@ -42,7 +42,7 @@ module Decidim
 
     def newsletter_at
       return nil unless newsletter?
-      Time.zone.now
+      Time.current
     end
 
     private

--- a/decidim-core/app/models/decidim/authorization.rb
+++ b/decidim-core/app/models/decidim/authorization.rb
@@ -39,7 +39,7 @@ module Decidim
     def grant!
       remove_verification_attachment!
 
-      update!(granted_at: Time.zone.now, verification_metadata: {})
+      update!(granted_at: Time.current, verification_metadata: {})
     end
 
     def granted?
@@ -57,7 +57,7 @@ module Decidim
     end
 
     def expired?
-      expires_at.present? && expires_at < Time.zone.now
+      expires_at.present? && expires_at < Time.current
     end
 
     private

--- a/decidim-core/app/models/decidim/messaging/message.rb
+++ b/decidim-core/app/models/decidim/messaging/message.rb
@@ -38,7 +38,7 @@ module Decidim
       # @param recipients [Array<Decidim::User>]
       #
       def envelope_for(recipients)
-        receipts.build(recipient: sender, read_at: Time.zone.now)
+        receipts.build(recipient: sender, read_at: Time.current)
 
         recipients.each { |recipient| receipts.build(recipient: recipient) }
       end

--- a/decidim-core/app/models/decidim/messaging/receipt.rb
+++ b/decidim-core/app/models/decidim/messaging/receipt.rb
@@ -19,7 +19,7 @@ module Decidim
 
       # rubocop:disable Rails/SkipsModelValidations
       def self.mark_as_read(user)
-        recipient(user).update_all(read_at: Time.zone.now)
+        recipient(user).update_all(read_at: Time.current)
       end
       # rubocop:enable Rails/SkipsModelValidations
     end

--- a/decidim-core/app/types/decidim/core/date_time_type.rb
+++ b/decidim-core/app/types/decidim/core/date_time_type.rb
@@ -6,7 +6,7 @@ module Decidim
       name "DateTime"
       description "An ISO8601 date with time"
       coerce_input ->(value, _ctx) { Time.iso8601(value) }
-      coerce_result ->(value, _ctx) { value.to_datetime.iso8601 }
+      coerce_result ->(value, _ctx) { value.to_time.iso8601 }
     end
   end
 end

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -432,7 +432,7 @@ FactoryBot.define do
     locale { I18n.locale }
     scope { resource.scope }
     content_a { Faker::Lorem.sentence }
-    datetime { DateTime.current }
+    datetime { Time.current }
   end
 
   factory :content_block, class: "Decidim::ContentBlock" do

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -124,7 +124,7 @@ FactoryBot.define do
     end
 
     trait :officialized do
-      officialized_at { Time.zone.now }
+      officialized_at { Time.current }
       officialized_as { Decidim::Faker::Localized.sentence(3) }
     end
   end
@@ -419,7 +419,7 @@ FactoryBot.define do
     application { build(:oauth_application) }
     token { SecureRandom.hex(32) }
     expires_in { 1.month.from_now }
-    created_at { Time.zone.now }
+    created_at { Time.current }
     scopes { "public" }
   end
 

--- a/decidim-core/lib/decidim/core/test/shared_examples/publicable.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/publicable.rb
@@ -6,7 +6,7 @@ shared_examples_for "publicable" do
   let(:factory_name) { described_class.name.demodulize.underscore.to_sym }
 
   let!(:published) do
-    create(factory_name, published_at: Time.zone.now)
+    create(factory_name, published_at: Time.current)
   end
 
   let!(:unpublished) do

--- a/decidim-core/lib/decidim/friendly_dates.rb
+++ b/decidim-core/lib/decidim/friendly_dates.rb
@@ -10,7 +10,7 @@ module Decidim
 
     # Returns the creation date in a friendly relative format.
     def friendly_created_at
-      current_datetime = Time.zone.now
+      current_datetime = Time.current
 
       if created_at > current_datetime.beginning_of_day
         I18n.l(created_at, format: :time_of_day)

--- a/decidim-core/lib/devise/models/decidim_newsletterable.rb
+++ b/decidim-core/lib/devise/models/decidim_newsletterable.rb
@@ -46,7 +46,7 @@ module Devise
       # Fill Opt-in value with current time &
       # removes any token involved
       def set_newsletter_opt_in
-        self.newsletter_notifications_at = Time.zone.now
+        self.newsletter_notifications_at = Time.current
         self.newsletter_token = ""
       end
 

--- a/decidim-core/spec/commands/decidim/search_spec.rb
+++ b/decidim-core/spec/commands/decidim/search_spec.rb
@@ -118,8 +118,8 @@ module Decidim
         let(:term) { "black" }
 
         context "when searchables are from the future" do
-          let(:datetime1) { DateTime.current + 10.seconds }
-          let(:datetime2) { DateTime.current + 20.seconds }
+          let(:datetime1) { Time.current + 10.seconds }
+          let(:datetime2) { Time.current + 20.seconds }
 
           it "returns matches sorted by date descendently" do
             described_class.call(term, current_organization) do
@@ -135,8 +135,8 @@ module Decidim
         end
 
         context "when searchables are from the past" do
-          let(:datetime1) { DateTime.current - 1.day }
-          let(:datetime2) { DateTime.current - 2.days }
+          let(:datetime1) { Time.current - 1.day }
+          let(:datetime2) { Time.current - 2.days }
 
           it "returns matches sorted by date descendently" do
             described_class.call(term, current_organization) do
@@ -151,8 +151,8 @@ module Decidim
         end
 
         context "when searchables are from the future and the past" do
-          let(:datetime1) { DateTime.current + 1.day }
-          let(:datetime2) { DateTime.current - 1.day }
+          let(:datetime1) { Time.current + 1.day }
+          let(:datetime2) { Time.current - 1.day }
 
           it "returns matches sorted by date descendently" do
             described_class.call(term, current_organization) do

--- a/decidim-core/spec/commands/decidim/unsubscribe_settings_spec.rb
+++ b/decidim-core/spec/commands/decidim/unsubscribe_settings_spec.rb
@@ -17,7 +17,7 @@ module Decidim
       end
 
       context "when valid" do
-        let(:user) { create(:user, organization: organization, newsletter_notifications_at: Time.zone.now) }
+        let(:user) { create(:user, organization: organization, newsletter_notifications_at: Time.current) }
 
         it "unsubscribes user" do
           user.newsletter_notifications_at = nil

--- a/decidim-core/spec/commands/decidim/update_notifications_settings_spec.rb
+++ b/decidim-core/spec/commands/decidim/update_notifications_settings_spec.rb
@@ -10,7 +10,7 @@ module Decidim
     let(:data) do
       {
         email_on_notification: "1",
-        newsletter_notifications_at: Time.zone.now
+        newsletter_notifications_at: Time.current
       }
     end
 

--- a/decidim-core/spec/controllers/decidim/searches_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/searches_controller_spec.rb
@@ -18,7 +18,7 @@ module Decidim
     describe "GET /search" do
       context "when having resources with the term 'Great' in their content" do
         let!(:results) do
-          now = DateTime.current
+          now = Time.current
           [create(:searchable_resource, organization: organization, content_a: "Great proposal of mine", datetime: now + 1.second),
            create(:searchable_resource, organization: organization, content_a: "The great-est place of the world", datetime: now)]
         end

--- a/decidim-core/spec/controllers/newsletters_controller_spec.rb
+++ b/decidim-core/spec/controllers/newsletters_controller_spec.rb
@@ -64,7 +64,7 @@ module Decidim
           let(:sent_at_time) { Time.zone.at(decrypted_string.split("-").second.to_i) }
 
           context "and newsletter notifications is true" do
-            let!(:user) { create(:user, organization: organization, id: user_id, newsletter_notifications_at: Time.zone.now) }
+            let!(:user) { create(:user, organization: organization, id: user_id, newsletter_notifications_at: Time.current) }
 
             it "unsubscribe user" do
               get :unsubscribe, params: { u: encryptor.sent_at_encrypted(user_id, time) }

--- a/decidim-core/spec/lib/exporters/excel_spec.rb
+++ b/decidim-core/spec/lib/exporters/excel_spec.rb
@@ -27,8 +27,8 @@ module Decidim
 
     let(:collection) do
       [
-        OpenStruct.new(id: 1, name: { ca: "foocat", es: "fooes" }, ids: [1, 2, 3], float: 1.66, date: DateTime.civil(2017, 10, 1, 5, 0)),
-        OpenStruct.new(id: 2, name: { ca: "barcat", es: "bares" }, ids: [2, 3, 4], float: 0.55, date: DateTime.civil(2017, 9, 20))
+        OpenStruct.new(id: 1, name: { ca: "foocat", es: "fooes" }, ids: [1, 2, 3], float: 1.66, date: Time.zone.local(2017, 10, 1, 5, 0)),
+        OpenStruct.new(id: 2, name: { ca: "barcat", es: "bares" }, ids: [2, 3, 4], float: 0.55, date: Time.zone.local(2017, 9, 20))
       ]
     end
 
@@ -42,10 +42,10 @@ module Decidim
         headers = worksheet.rows[0]
         expect(headers).to eq(["id", "serialized_name/ca", "serialized_name/es", "other_ids", "float", "date"])
         expect(worksheet.rows[1][0..4]).to eq([1, "foocat", "fooes", "1, 2, 3", 1.66])
-        expect(worksheet.rows[1].datetime(5)).to eq(DateTime.civil(2017, 10, 1, 5, 0))
+        expect(worksheet.rows[1].datetime(5)).to eq(Time.zone.local(2017, 10, 1, 5, 0))
 
         expect(worksheet.rows[2][0..4]).to eq([2, "barcat", "bares", "2, 3, 4", 0.55])
-        expect(worksheet.rows[2].datetime(5)).to eq(DateTime.civil(2017, 9, 20))
+        expect(worksheet.rows[2].datetime(5)).to eq(Time.zone.local(2017, 9, 20))
       end
     end
   end

--- a/decidim-core/spec/lib/friendly_dates_spec.rb
+++ b/decidim-core/spec/lib/friendly_dates_spec.rb
@@ -28,7 +28,7 @@ module Decidim
       end
 
       describe "when in the same day" do
-        let(:date) { Time.zone.now.beginning_of_day + 1.minute }
+        let(:date) { Time.current.beginning_of_day + 1.minute }
 
         it "returns hour only" do
           expect(enhanced_instance.friendly_created_at).to eq("00:01")
@@ -36,7 +36,7 @@ module Decidim
       end
 
       describe "when in the same week" do
-        let(:date) { Time.zone.now.beginning_of_week + 1.minute }
+        let(:date) { Time.current.beginning_of_week + 1.minute }
 
         it "returns the day of the week" do
           expect(enhanced_instance.friendly_created_at).to eq("Mon")
@@ -44,7 +44,7 @@ module Decidim
       end
 
       describe "when in the same year" do
-        let(:date) { Time.zone.now.beginning_of_year + 1.minute }
+        let(:date) { Time.current.beginning_of_year + 1.minute }
 
         it "returns the date in short format" do
           expect(enhanced_instance.friendly_created_at).to eq("Jan 01")
@@ -52,7 +52,7 @@ module Decidim
       end
 
       describe "when in previous years" do
-        let(:date) { Time.zone.now - 1.year }
+        let(:date) { Time.current - 1.year }
 
         it "returns the full date" do
           expect(enhanced_instance.friendly_created_at).to eq("06.02.44")

--- a/decidim-core/spec/lib/resourceable_spec.rb
+++ b/decidim-core/spec/lib/resourceable_spec.rb
@@ -134,7 +134,7 @@ module Decidim
       subject { resource }
 
       context "when all hierarchy is visible" do
-        before { subject.update(published_at: DateTime.current) }
+        before { subject.update(published_at: Time.current) }
 
         it { is_expected.to be_visible }
       end

--- a/decidim-core/spec/lib/search_resource_fields_mapper_spec.rb
+++ b/decidim-core/spec/lib/search_resource_fields_mapper_spec.rb
@@ -14,7 +14,7 @@ module Decidim
             component: component,
             title: "The resource title",
             address: "The resource address.",
-            published_at: DateTime.current
+            published_at: Time.current
           )
         end
         let(:component) { create(:component, manifest_name: "dummy") }

--- a/decidim-core/spec/models/decidim/user_spec.rb
+++ b/decidim-core/spec/models/decidim/user_spec.rb
@@ -85,7 +85,7 @@ module Decidim
 
         context "when deleted" do
           before do
-            user.deleted_at = Time.zone.now
+            user.deleted_at = Time.current
           end
 
           it "is valid" do
@@ -102,7 +102,7 @@ module Decidim
             expect do
               create(:user, organization: user.organization,
                             nickname: user.nickname,
-                            deleted_at: Time.zone.now)
+                            deleted_at: Time.current)
             end.not_to raise_error
           end
         end

--- a/decidim-core/spec/types/date_time_type_spec.rb
+++ b/decidim-core/spec/types/date_time_type_spec.rb
@@ -7,7 +7,7 @@ module Decidim
   module Core
     describe DateTimeType, type: :graphql do
       include_context "with a graphql scalar type"
-      let(:model) { DateTime.civil(2018, 2, 22, 9, 47, 0, "+1") }
+      let(:model) { Time.new(2018, 2, 22, 9, 47, 0, "+01:00") }
 
       it "returns the formatted date" do
         expect(response).to eq("2018-02-22T09:47:00+01:00")

--- a/decidim-core/spec/types/date_type_spec.rb
+++ b/decidim-core/spec/types/date_type_spec.rb
@@ -7,7 +7,7 @@ module Decidim
   module Core
     describe DateType, type: :graphql do
       include_context "with a graphql scalar type"
-      let(:model) { DateTime.civil(2018, 2, 22, 9, 47, 0, "+1") }
+      let(:model) { Time.new(2018, 2, 22, 9, 47, 0, "+01:00") }
 
       it "returns the formatted date" do
         expect(response).to eq("2018-02-22")

--- a/decidim-core/spec/types/participatory_space_type_spec.rb
+++ b/decidim-core/spec/types/participatory_space_type_spec.rb
@@ -20,7 +20,7 @@ module Decidim
 
       describe "components" do
         let!(:published_components) do
-          create_list(:dummy_component, 2, participatory_space: model, published_at: Time.zone.now)
+          create_list(:dummy_component, 2, participatory_space: model, published_at: Time.current)
         end
 
         let!(:unpublished_components) do

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative.rb
@@ -50,7 +50,7 @@ module Decidim
             answer_url: form.answer_url
           }
 
-          attrs[:answered_at] = DateTime.current if form.answer.present?
+          attrs[:answered_at] = Time.current if form.answer.present?
 
           if current_user.admin?
             attrs[:signature_start_date] = form.signature_start_date

--- a/decidim-initiatives/app/queries/decidim/initiatives/outdated_validating_initiatives.rb
+++ b/decidim-initiatives/app/queries/decidim/initiatives/outdated_validating_initiatives.rb
@@ -16,7 +16,7 @@ module Decidim
       #
       # period_length - Maximum time in validating state
       def initialize(period_length)
-        @period_length = DateTime.current - period_length
+        @period_length = Time.current - period_length
       end
 
       # Retrieves the available initiative types for the given organization.

--- a/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
@@ -66,7 +66,7 @@ Decidim.register_participatory_space(:initiatives) do |participatory_space|
         signature_type: "online",
         signature_start_date: Date.current - 7.days,
         signature_end_date:  Date.current + 7.days,
-        published_at: DateTime.current - 7.days,
+        published_at: Time.current - 7.days,
         author: Decidim::User.reorder(Arel.sql("RANDOM()")).first,
         organization: organization
       )

--- a/decidim-initiatives/spec/lib/tasks/decidim_initiatives_check_validating_spec.rb
+++ b/decidim-initiatives/spec/lib/tasks/decidim_initiatives_check_validating_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "decidim_initiatives:check_validating", type: :task do
-  let(:threshold) { DateTime.current - Decidim::Initiatives.max_time_in_validating_state }
+  let(:threshold) { Time.current - Decidim::Initiatives.max_time_in_validating_state }
 
   it "preloads the Rails environment" do
     expect(task.prerequisites).to include "environment"
@@ -14,7 +14,7 @@ describe "decidim_initiatives:check_validating", type: :task do
   end
 
   context "when initiatives without changes" do
-    let(:initiative) { create(:initiative, :validating, updated_at: DateTime.current - 1.year) }
+    let(:initiative) { create(:initiative, :validating, updated_at: Time.current - 1.year) }
 
     it "Are marked as discarded" do
       expect(initiative.updated_at).to be < threshold

--- a/decidim-initiatives/spec/lib/tasks/decidim_initiatives_notify_progress_spec.rb
+++ b/decidim-initiatives/spec/lib/tasks/decidim_initiatives_notify_progress_spec.rb
@@ -70,7 +70,7 @@ describe "decidim_initiatives:notify_progress", type: :task do
 
   context "when initiative ready for second notification" do
     let(:initiative) do
-      initiative = create(:initiative, first_progress_notification_at: DateTime.current)
+      initiative = create(:initiative, first_progress_notification_at: Time.current)
 
       initiative.initiative_votes_count = initiative.scoped_type.supports_required *
                                           (Decidim::Initiatives.second_notification_percentage / 100.0) + 1
@@ -107,8 +107,8 @@ describe "decidim_initiatives:notify_progress", type: :task do
   context "when initiative with both notifications sent" do
     let(:initiative) do
       create(:initiative,
-             first_progress_notification_at: DateTime.current,
-             second_progress_notification_at: DateTime.current)
+             first_progress_notification_at: Time.current,
+             second_progress_notification_at: Time.current)
     end
 
     it "do not invokes the mailer" do

--- a/decidim-meetings/app/forms/decidim/meetings/admin/close_meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/close_meeting_form.rb
@@ -13,7 +13,7 @@ module Decidim
         attribute :attending_organizations, String
         attribute :proposal_ids, Array[Integer]
         attribute :proposals
-        attribute :closed_at, DateTime, default: ->(_form, _attribute) { Time.current }
+        attribute :closed_at, Decidim::Attributes::TimeWithZone, default: ->(_form, _attribute) { Time.current }
 
         validates :closing_report, translatable_presence: true
         validates :attendees_count, presence: true, numericality: { greater_than_or_equal_to: 0 }

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -238,7 +238,7 @@ FactoryBot.define do
   factory :user_group_proposal_endorsement, class: "Decidim::Proposals::ProposalEndorsement" do
     proposal { build(:proposal) }
     author { build(:user, organization: proposal.organization) }
-    user_group { create(:user_group, verified_at: Time.zone.now, organization: proposal.organization, users: [author]) }
+    user_group { create(:user_group, verified_at: Time.current, organization: proposal.organization, users: [author]) }
   end
 
   factory :proposal_note, class: "Decidim::Proposals::ProposalNote" do

--- a/decidim-proposals/spec/commands/decidim/proposals/endorse_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/endorse_proposal_spec.rb
@@ -46,7 +46,7 @@ module Decidim
 
         context "when the endorsement is not valid" do
           before do
-            proposal.update(answered_at: DateTime.current, state: "rejected")
+            proposal.update(answered_at: Time.current, state: "rejected")
           end
 
           it "broadcasts invalid" do
@@ -62,7 +62,7 @@ module Decidim
       end
 
       describe "Organization endorses Proposal" do
-        let(:user_group) { create(:user_group, verified_at: DateTime.current) }
+        let(:user_group) { create(:user_group, verified_at: Time.current) }
         let(:command) { described_class.new(proposal, current_user, user_group.id) }
 
         before do
@@ -84,7 +84,7 @@ module Decidim
 
         context "when the endorsement is not valid" do
           before do
-            proposal.update(answered_at: DateTime.current, state: "rejected")
+            proposal.update(answered_at: Time.current, state: "rejected")
           end
 
           it "Do not increase the endorsements counter by one" do

--- a/decidim-proposals/spec/controllers/decidim/proposal_endorsements_controller_as_org_spec.rb
+++ b/decidim-proposals/spec/controllers/decidim/proposal_endorsements_controller_as_org_spec.rb
@@ -11,7 +11,7 @@ module Decidim
       # As Organization
       #
       describe "As Organization" do
-        let(:user_group) { create(:user_group, verified_at: DateTime.current) }
+        let(:user_group) { create(:user_group, verified_at: Time.current) }
 
         before do
           create(:user_group_membership, user: user, user_group: user_group)

--- a/decidim-proposals/spec/controllers/decidim/proposal_endorsements_controller_as_user_spec.rb
+++ b/decidim-proposals/spec/controllers/decidim/proposal_endorsements_controller_as_user_spec.rb
@@ -60,7 +60,7 @@ module Decidim
           def create_user_groups(verified = false)
             2.times do
               user_group = create(:user_group)
-              user_group.verified_at = DateTime.current if verified
+              user_group.verified_at = Time.current if verified
               user.user_groups << user_group
             end
             user.save!

--- a/decidim-proposals/spec/models/decidim/proposals/proposal_endorsement_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/proposal_endorsement_spec.rb
@@ -11,7 +11,7 @@ module Decidim
       let!(:component) { create(:component, organization: organization, manifest_name: "proposals") }
       let!(:participatory_process) { create(:participatory_process, organization: organization) }
       let!(:author) { create(:user, organization: organization) }
-      let!(:user_group) { create(:user_group, verified_at: DateTime.current, organization: organization, users: [author]) }
+      let!(:user_group) { create(:user_group, verified_at: Time.current, organization: organization, users: [author]) }
       let!(:proposal) { create(:proposal, component: component, users: [author]) }
       let!(:proposal_endorsement) do
         build(:proposal_endorsement, proposal: proposal, author: author,
@@ -83,7 +83,7 @@ module Decidim
           proposal_endorsement.save!
         end
 
-        let!(:other_user_group) { create(:user_group, verified_at: DateTime.current, organization: author.organization, users: [author]) }
+        let!(:other_user_group) { create(:user_group, verified_at: Time.current, organization: author.organization, users: [author]) }
         let!(:other_proposal_endorsement_1) do
           create(:proposal_endorsement, proposal: proposal, author: author)
         end

--- a/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
@@ -54,7 +54,7 @@ module Decidim
         end
 
         context "with Organization endorsement" do
-          let!(:user_group) { create(:user_group, verified_at: DateTime.current, organization: user.organization) }
+          let!(:user_group) { create(:user_group, verified_at: Time.current, organization: user.organization) }
           let!(:membership) { create(:user_group_membership, user: user, user_group: user_group) }
 
           before { user_group.reload }

--- a/decidim-proposals/spec/services/decidim/proposals/searchable_proposal_resource_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/searchable_proposal_resource_spec.rb
@@ -50,7 +50,7 @@ module Decidim
 
           context "when it IS published" do
             before do
-              proposal.update published_at: DateTime.current
+              proposal.update published_at: Time.current
             end
 
             it "inserts a SearchableResource after Proposal is published" do
@@ -110,8 +110,8 @@ module Decidim
         end
 
         before do
-          proposal.update(published_at: DateTime.current)
-          proposal2.update(published_at: DateTime.current)
+          proposal.update(published_at: Time.current)
+          proposal2.update(published_at: Time.current)
         end
 
         it "returns Proposal results" do

--- a/decidim-proposals/spec/system/search_proposals_spec.rb
+++ b/decidim-proposals/spec/system/search_proposals_spec.rb
@@ -9,7 +9,7 @@ describe "Search proposals", type: :system do
   let!(:term) { searchables.first.title.split(" ").sample }
 
   before do
-    searchables.each { |s| s.update(published_at: DateTime.current) }
+    searchables.each { |s| s.update(published_at: Time.current) }
   end
 
   include_examples "searchable results"

--- a/decidim-proposals/spec/types/proposal_type_spec.rb
+++ b/decidim-proposals/spec/types/proposal_type_spec.rb
@@ -82,7 +82,7 @@ module Decidim
         let(:query) { "{ publishedAt }" }
 
         it "returns when was this query published at" do
-          expect(response["publishedAt"]).to eq(model.published_at.to_datetime.iso8601)
+          expect(response["publishedAt"]).to eq(model.published_at.to_time.iso8601)
         end
       end
 

--- a/decidim-surveys/app/forms/decidim/surveys/admin/survey_form.rb
+++ b/decidim-surveys/app/forms/decidim/surveys/admin/survey_form.rb
@@ -11,7 +11,7 @@ module Decidim
         translatable_attribute :description, String
         translatable_attribute :tos, String
 
-        attribute :published_at, DateTime
+        attribute :published_at, Decidim::Attributes::TimeWithZone
         attribute :questions, Array[SurveyQuestionForm]
 
         validates :title, :tos, translatable_presence: true

--- a/decidim-verifications/app/forms/decidim/verifications/postal_letter/postage_form.rb
+++ b/decidim-verifications/app/forms/decidim/verifications/postal_letter/postage_form.rb
@@ -25,7 +25,7 @@ module Decidim
           {
             address: full_address,
             verification_code: verification_code,
-            letter_sent_at: Time.zone.now
+            letter_sent_at: Time.current
           }
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR enforces preferring `Time` over `DateTime` all over. The subtle differences between them probably don't matter to us, but `Time` is more efficient, generally recommended, and more importantly, choosing one over the other reduces the cognitive load on the developer: "use Time", instead of "which one do I choose, what's the difference?".

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.