### PR TITLE
Verbose npm execution on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ references:
   install_npm_dependencies: &install_npm_dependencies
     run:
       name: Install npm dependencies
-      command: npm ci
+      command: npm ci --verbose
   save_ruby_cache: &save_ruby_cache
     save_cache:
       key: bundler-dependencies-{{ checksum "Gemfile.lock" }}


### PR DESCRIPTION
#### :tophat: What? Why?

This will give us more information about the sporadic npm hang/slowness,
and will also reduce it, since the amount of time without CI output will
be less, so the build will be less likely to timeout.

#### :pushpin: Related Issues
- Related to #3954.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.