### PR TITLE
Fix flaky when running spec in isolation

### DIFF
--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -266,7 +266,7 @@ FactoryBot.define do
   factory :scope, class: "Decidim::Scope" do
     name { Decidim::Faker::Localized.literal(generate(:scope_name)) }
     code { generate(:scope_code) }
-    scope_type
+    scope_type { create(:scope_type, organization: organization) }
     organization { parent ? parent.organization : build(:organization) }
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?

`rspec decidim-core/spec/presenters/decidim/resource_locator_presenter_spec.rb:41`
was failing with

```
Failures:

  1) Decidim::ResourceLocatorPresenter with a component resource #path 
     Failure/Error: scope { create(:scope, organization: component.organization) }
     
     ActiveRecord::RecordInvalid:
       Validation failed: Host has already been taken
     # ./lib/decidim/core/test/factories.rb:304:in `block (3 levels) in <top (required)>'
     # ./spec/presenters/decidim/resource_locator_presenter_spec.rb:18:in `block (2 levels) in <module:Decidim>'
     # ./spec/presenters/decidim/resource_locator_presenter_spec.rb:39:in `block (4 levels) in <module:Decidim>'
     # ./spec/presenters/decidim/resource_locator_presenter_spec.rb:41:in `block (4 levels) in <module:Decidim>'
```

. This PR should fix it.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.