### PR TITLE
Remove rsrc abbreviation

### DIFF
--- a/decidim-core/spec/commands/decidim/search_spec.rb
+++ b/decidim-core/spec/commands/decidim/search_spec.rb
@@ -172,20 +172,20 @@ module Decidim
         let(:scope) { create(:scope, organization: current_organization) }
 
         context "with resource type" do
-          let(:rsrc_type) { "Decidim::Meetings::Meeting" }
+          let(:resource_type) { "Decidim::Meetings::Meeting" }
 
           before do
-            create(:searchable_resource, organization: current_organization, resource_type: rsrc_type, content_a: "Where's your crown king nothing?")
+            create(:searchable_resource, organization: current_organization, resource_type: resource_type, content_a: "Where's your crown king nothing?")
             create(:searchable_resource, organization: current_organization, resource_type: "Decidim::Proposals::Proposal", content_a: "Where's your crown king nothing?")
           end
 
           context "when resource_type is setted" do
             it "only return resources of the given type" do
-              described_class.call(term, current_organization, "resource_type" => rsrc_type) do
+              described_class.call(term, current_organization, "resource_type" => resource_type) do
                 on(:ok) do |results|
                   expect(results).not_to be_empty
                   expect(
-                    results.all? { |r| r.resource_type == rsrc_type }
+                    results.all? { |r| r.resource_type == resource_type }
                   ).to be true
                 end
                 on(:invalid) { raise("Should not happen") }

--- a/decidim-core/spec/models/decidim/searchable_resource_spec.rb
+++ b/decidim-core/spec/models/decidim/searchable_resource_spec.rb
@@ -16,8 +16,8 @@ module Decidim
 
         context "when resource is different" do
           let(:other_searchable) do
-            rsrc = create(:dummy_resource)
-            Decidim::SearchableResource.where(resource: rsrc)
+            resource = create(:dummy_resource)
+            Decidim::SearchableResource.where(resource: resource)
           end
 
           it "other_searchable must be valid" do

--- a/decidim-core/spec/services/decidim/searchable_user_resource_spec.rb
+++ b/decidim-core/spec/services/decidim/searchable_user_resource_spec.rb
@@ -15,7 +15,7 @@ module Decidim
         it "inserts a SearchableResource after User creation" do
           organization.available_locales.each do |locale|
             searchable = SearchableResource.find_by(resource_type: user.class.name, resource_id: user.id, locale: locale)
-            expect_searchable_rsrc_to_correspond_to_user(searchable, user, locale)
+            expect_searchable_resource_to_correspond_to_user(searchable, user, locale)
           end
         end
 
@@ -58,17 +58,17 @@ module Decidim
 
     private
 
-    def expect_searchable_rsrc_to_correspond_to_user(searchable, user, locale)
+    def expect_searchable_resource_to_correspond_to_user(searchable, user, locale)
       attrs = searchable.attributes
       attrs.delete("id")
       attrs.delete("created_at")
       attrs.delete("updated_at")
       expect(attrs["datetime"].to_s).to eq(user.created_at.to_s)
       attrs.delete("datetime")
-      expect(attrs).to eq(expected_searchable_rsrc_attrs(user, locale))
+      expect(attrs).to eq(expected_searchable_resource_attrs(user, locale))
     end
 
-    def expected_searchable_rsrc_attrs(resource, locale)
+    def expected_searchable_resource_attrs(resource, locale)
       {
         "content_a" => resource.name,
         "content_b" => "",

--- a/decidim-meetings/spec/services/searchable_meeting_resource_spec.rb
+++ b/decidim-meetings/spec/services/searchable_meeting_resource_spec.rb
@@ -25,7 +25,7 @@ module Decidim
         it "inserts a SearchableResource after Meeting creation" do
           organization.available_locales.each do |locale|
             searchable = SearchableResource.find_by(resource_type: meeting.class.name, resource_id: meeting.id, locale: locale)
-            expect_searchable_rsrc_to_correspond_to_meeting(searchable, meeting, locale)
+            expect_searchable_resource_to_correspond_to_meeting(searchable, meeting, locale)
           end
         end
 
@@ -82,17 +82,17 @@ module Decidim
 
     private
 
-    def expect_searchable_rsrc_to_correspond_to_meeting(searchable, meeting, locale)
+    def expect_searchable_resource_to_correspond_to_meeting(searchable, meeting, locale)
       attrs = searchable.attributes
       attrs.delete("id")
       attrs.delete("created_at")
       attrs.delete("updated_at")
       expect(attrs["datetime"].to_s).to eq(meeting.start_time.to_s)
       attrs.delete("datetime")
-      expect(attrs).to eq(expected_searchable_rsrc_attrs(meeting, locale))
+      expect(attrs).to eq(expected_searchable_resource_attrs(meeting, locale))
     end
 
-    def expected_searchable_rsrc_attrs(meeting, locale)
+    def expected_searchable_resource_attrs(meeting, locale)
       {
         "content_a" => meeting.title[locale],
         "content_b" => "",

--- a/decidim-proposals/spec/services/decidim/proposals/searchable_proposal_resource_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/searchable_proposal_resource_spec.rb
@@ -56,7 +56,7 @@ module Decidim
             it "inserts a SearchableResource after Proposal is published" do
               organization.available_locales.each do |locale|
                 searchable = SearchableResource.find_by(resource_type: proposal.class.name, resource_id: proposal.id, locale: locale)
-                expect_searchable_rsrc_to_correspond_to_proposal(searchable, proposal, locale)
+                expect_searchable_resource_to_correspond_to_proposal(searchable, proposal, locale)
               end
             end
 
@@ -127,16 +127,16 @@ module Decidim
 
     private
 
-    def expect_searchable_rsrc_to_correspond_to_proposal(searchable, proposal, locale)
+    def expect_searchable_resource_to_correspond_to_proposal(searchable, proposal, locale)
       attrs = searchable.attributes.clone
       attrs.delete("id")
       attrs.delete("created_at")
       attrs.delete("updated_at")
       expect(attrs.delete("datetime").to_s(:short)).to eq(proposal.published_at.to_s(:short))
-      expect(attrs).to eq(expected_searchable_rsrc_attrs(proposal, locale))
+      expect(attrs).to eq(expected_searchable_resource_attrs(proposal, locale))
     end
 
-    def expected_searchable_rsrc_attrs(proposal, locale)
+    def expected_searchable_resource_attrs(proposal, locale)
       {
         "content_a" => proposal.title,
         "content_b" => "",


### PR DESCRIPTION
#### :tophat: What? Why?
Abbreviations are generally discouraged, specially when used sparsely
and inconsistently.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.