### PR TITLE
Fix design app deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -409,14 +409,7 @@ jobs:
       - run:
           name: Build image
           command: |
-            docker build -t registry.heroku.com/decidim-design/web -f Dockerfile.design .
-      - run:
-          name: Push deployment image
-          command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              docker login --username=_ --password=$HEROKU_AUTH_TOKEN registry.heroku.com
-              docker push registry.heroku.com/decidim-design/web
-            fi
+            docker build -f Dockerfile.design .
   upload-coverage:
     <<: *defaults
     environment:

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,5 @@
+build:
+  docker:
+    web: Dockerfile.design
+run:
+  web: bundle exec rails s -p $PORT


### PR DESCRIPTION
#### :tophat: What? Why?
Heroku has recently made some improvements on their platform in order to support docker images directly without having to build them manually outside. This greatly simplifies our design app deployment and potentially opens a way to create review apps for decidim itself.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*
