### PR TITLE
Feature smarter CollapsibleListCell

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_collapsible-list.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_collapsible-list.scss
@@ -12,6 +12,10 @@
 
     .collapsible-list__see-more{
       display: inline-block;
+      + .text-small{
+        padding-top: .15rem;
+        padding-left: .2rem;
+      }
     }
 
     .collapsible-list__see-less{

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_collapsible-list.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_collapsible-list.scss
@@ -12,6 +12,7 @@
 
     .collapsible-list__see-more{
       display: inline-block;
+
       + .text-small{
         padding-top: .15rem;
         padding-left: .2rem;

--- a/decidim-core/app/cells/decidim/collapsible_list/show.erb
+++ b/decidim-core/app/cells/decidim/collapsible_list/show.erb
@@ -1,9 +1,11 @@
 <% if collapsible? %>
   <div id="collapsible-list-<%= seed %>" class="collapsible-list is-filtered <%= list_size_class %>" data-toggler=".is-filtered">
     <% list.each do |element| %>
-      <div class="collapse">
+      <% if cell_name %>
         <%= cell cell_name, element, cell_options %>
-      </div>
+      <% else %>
+        <%= card_for element, cell_options %>
+      <% end %>
     <% end %>
     <span class="collapsible-list__see-more">
       <%= t(hidden_elements_count_i18n_key, count: hidden_elements_count) %>
@@ -16,7 +18,11 @@
 <% else %>
   <div class="collapsible-list">
     <% list.each do |element| %>
-      <%= cell cell_name, element, cell_options %>
+      <% if cell_name %>
+        <%= cell cell_name, element, cell_options %>
+      <% else %>
+        <%= card_for element, cell_options %>
+      <% end %>
     <% end %>
   </div>
 <% end %>

--- a/decidim-core/app/cells/decidim/collapsible_list/show.erb
+++ b/decidim-core/app/cells/decidim/collapsible_list/show.erb
@@ -1,5 +1,5 @@
 <% if collapsible? %>
-  <div id="collapsible-list-<%= seed %>" class="collapsible-list is-filtered <%= list_size_class %>" data-toggler=".is-filtered">
+  <div id="collapsible-list-<%= seed %>" class="collapsible-list is-filtered <%= list_size_class %> <%= list_class %>" data-toggler=".is-filtered">
     <% list.each do |element| %>
       <% if cell_name %>
         <%= cell cell_name, element, cell_options %>
@@ -16,7 +16,7 @@
     </span>
   </div>
 <% else %>
-  <div class="collapsible-list">
+  <div class="collapsible-list <%= list_class %>">
     <% list.each do |element| %>
       <% if cell_name %>
         <%= cell cell_name, element, cell_options %>

--- a/decidim-core/app/cells/decidim/collapsible_list_cell.rb
+++ b/decidim-core/app/cells/decidim/collapsible_list_cell.rb
@@ -19,6 +19,8 @@ module Decidim
   #      size: 4
   #    )
   class CollapsibleListCell < Decidim::ViewModel
+    include Decidim::CardHelper
+
     private
 
     def list

--- a/decidim-core/app/cells/decidim/collapsible_list_cell.rb
+++ b/decidim-core/app/cells/decidim/collapsible_list_cell.rb
@@ -2,7 +2,8 @@
 
 module Decidim
   # This cell renders a collapsible list of elements. Each element from the
-  # `model` array will be rendered with the `:cell` cell.
+  # `model` array will be rendered with the `:cell_name` cell.
+  # `:cell_name` is optional, if not provided `card_for` helper is used.
   #
   # Available sizes:
   #  - any number between 1 and 12
@@ -41,6 +42,10 @@ module Decidim
 
     def list_size_class
       "show-#{size}"
+    end
+
+    def list_class
+      options[:list_class]
     end
 
     def collapsible?

--- a/decidim-proposals/app/views/decidim/participatory_processes/participatory_process_groups/_highlighted_proposals.html.erb
+++ b/decidim-proposals/app/views/decidim/participatory_processes/participatory_process_groups/_highlighted_proposals.html.erb
@@ -1,8 +1,13 @@
 <% if proposals.any? %>
     <section class="section row collapse highlighted_proposals">
       <h2 class="section-heading"><%= t(".proposals") %></h2>
-      <div class="row small-up-1 medium-up-2 large-up-3 card-grid">
-        <%= render partial: "decidim/participatory_processes/participatory_process_groups/proposal", collection: proposals %>
-      </div>
+
+      <%= cell(
+        "decidim/collapsible_list",
+        proposals,
+        cell_options: { context: { current_user: current_user } },
+        list_class: "row small-up-1 medium-up-2 large-up-3 card-grid",
+        size: proposals.count
+        ) %>
     </section>
 <% end %>

--- a/decidim-proposals/app/views/decidim/participatory_processes/participatory_process_groups/_proposal.html.erb
+++ b/decidim-proposals/app/views/decidim/participatory_processes/participatory_process_groups/_proposal.html.erb
@@ -1,1 +1,0 @@
-<%= card_for proposal %>

--- a/decidim-proposals/app/views/decidim/participatory_spaces/_highlighted_proposals.html.erb
+++ b/decidim-proposals/app/views/decidim/participatory_spaces/_highlighted_proposals.html.erb
@@ -3,8 +3,13 @@
     <h4 class="section-heading">
       <%= t(".proposals") %>  <a href="<%= main_component_path(proposals.first.component) %>" class="text-small"><%= t(".see_all_proposals") %></a>
     </h4>
-    <div class="row small-up-1 medium-up-2 card-grid">
-      <%= render partial: "decidim/participatory_spaces/proposal", collection: proposals %>
-    </div>
+
+    <%= cell(
+      "decidim/collapsible_list",
+      proposals,
+      cell_options: { context: { current_user: current_user } },
+      list_class: "row small-up-1 medium-up-2 card-grid",
+      size: proposals.count
+      ) %>
   </section>
 <% end %>

--- a/decidim-proposals/app/views/decidim/participatory_spaces/_proposal.html.erb
+++ b/decidim-proposals/app/views/decidim/participatory_spaces/_proposal.html.erb
@@ -1,1 +1,0 @@
-<%= card_for proposal %>


### PR DESCRIPTION
#### :tophat: What? Why?

While developing `Amendments` PR #3958, I need to render a `CollapsibleListCell` with the `emendations` for the `amendable` resource details page.

As the `Amendable` concern is polimorphic, and the `CollapsibleList` requires the option `cell_name` (which depends on each amendable resource) I've introduced this option as optional, so if it is not given the `card_for` helper is used, and is responsible for _guessing_ the appropiate card for each model.
This feature potentialy enables the collapsible list to support a collection of mixed resources :grin:.

On the other hand, the emendations (collapsible) list has to be shown as a grid of 2 cards https://github.com/decidim/decidim/pull/3662, but currently is shown as stacked cards, so and optional `list_class` option is added for this porpouse.

Also the `%div.collapse` has been removed, as I think is not needed (@decidim/lot-core can you confirm it?) :stuck_out_tongue::
https://github.com/decidim/decidim/blob/774aed6c91a604d77ce33ccfc99dfe059333bc87/decidim-core/app/cells/decidim/collapsible_list/show.erb#L4-L6

#### :pushpin: Related Issues
- Related to #2292 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [x] Add documentation regarding the feature 

### :camera: Screenshots (optional)
+ collapsible_list@processes_groups: 
  ![screenshot from 2018-08-07 16-16-36](https://user-images.githubusercontent.com/210216/43781553-746bf6ba-9a5d-11e8-8d0b-cc53995a0429.png)
+ collapsible_list@participatory_space: 
![screenshot from 2018-08-07 16-17-06](https://user-images.githubusercontent.com/210216/43781580-85331fe6-9a5d-11e8-8825-69d050768f8a.png)


**BEFORE (staked):**
 
![screenshot from 2018-08-06 17-49-45](https://user-images.githubusercontent.com/210216/43727087-4558ba28-99a1-11e8-9bc1-775268decf81.png)

**AFTER (`small-up-1 medium-up-2 card-grid`):**
![screenshot from 2018-08-06 17-45-55](https://user-images.githubusercontent.com/210216/43726874-a2fd52b6-99a0-11e8-8e74-77007bf7b561.png)


![screenshot from 2018-08-06 17-43-15](https://user-images.githubusercontent.com/210216/43726740-406eb43c-99a0-11e8-9cb0-0bd7112c6957.png)


