### PR TITLE
Keep tooltip open on click

### DIFF
--- a/decidim_app-design/app/views/public/partials/_help-tooltip.html.erb
+++ b/decidim_app-design/app/views/public/partials/_help-tooltip.html.erb
@@ -2,7 +2,8 @@
   data-tooltip
   data-position="top"
   data-alignment="center"
-  data-click-open="true"
+  data-disable-hover="false"
+  tabindex="1"
   data-allow-html="true"
   data-template-classes="light"
   data-tip-text='<%= render("public/components/help-tooltip-template") { Faker::Lovecraft.sentence } %>'>


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes a bug on the support helper icon. On click events, it should keep the tooltip open to allow the user click on the link/s the tooltip may have.

#### :pushpin: Related Issues
- Related to comment [#3861](https://github.com/decidim/decidim/pull/3861#issuecomment-410988409)

