### PR TITLE
Add compression settings to image uploader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 **Added**:
 
+- **decidim-core**:Add compression settings to image uploader [\#3984](https://github.com/decidim/decidim/pull/3984)
 - **decidim-budgets**: Import accepted proposals to projects. [\#3873](https://github.com/decidim/decidim/pull/3873)
 - **decidim-proposals**: Results from searches should show the participatory space where they belong to if any. [\#3897](https://github.com/decidim/decidim/pull/3897)
 - **decidim-docs**: Add proposal lifecycle diagram to docs. [\#3811](https://github.com/decidim/decidim/pull/3811)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,30 @@
   times unintentionally. Check
   [\#3890](https://github.com/decidim/decidim/pull/3890) for more details.
 
+- Image compression settings :
+  The quality settings can be set in Decidim initializer with
+  `Decidim.config.image_uploader_quality = 60`
+  The quality setting is set to 80 by default because change is imperceptible.
+  My own test show that a quality between 60 and 80 is optimal.
+  You can use this feature with already uploded images,
+  it only affect newly uploaded file.
+  If you want to apply new settings to previouysly uploaded images :
+  - open `rails console`
+  - Type the following :
+
+  ```ruby
+
+  YourModel.find_each { |x| x.image.recreate_versions! if x.image? }
+
+  ```
+
+  Where YourModel is the name of your model (eg. Decidim::User) and
+  image is the name of your uploader (eg. avatar).
+  As Decidim doesn't keep original file on upload, a file cannot be
+  restored to original quality without re-uploading.
+  Be careful when playing with this feature on production.
+  Check [\#3984](https://github.com/decidim/decidim/pull/3984) for more details.
+
 **Added**:
 
 - **decidim-core**:Add compression settings to image uploader [\#3984](https://github.com/decidim/decidim/pull/3984)

--- a/decidim-core/app/uploaders/decidim/image_uploader.rb
+++ b/decidim-core/app/uploaders/decidim/image_uploader.rb
@@ -6,6 +6,7 @@ module Decidim
     include CarrierWave::MiniMagick
 
     process :validate_size, :validate_dimensions
+    process quality: Decidim.image_uploader_quality
 
     # CarrierWave automatically calls this method and validates the content
     # type fo the temp file to match against any of these options.

--- a/decidim-core/config/initializers/carrierwave.rb
+++ b/decidim-core/config/initializers/carrierwave.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module CarrierWave
+  module MiniMagick
+    # this method allow us to specify a quality for our image
+    # e.g. <process quality: 60>
+    def quality(percentage)
+      manipulate! do |img|
+        img.quality(percentage.to_s)
+        img = yield(img) if block_given?
+        img
+      end
+    end
+  end
+end

--- a/decidim-core/config/initializers/carrierwave.rb
+++ b/decidim-core/config/initializers/carrierwave.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module CarrierWave
   module MiniMagick
     # this method allow us to specify a quality for our image

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -158,6 +158,7 @@ module Decidim
     "€"
   end
 
+  # Exposes a configuration option: The image uploader quality.
   config_accessor :image_uploader_quality do
     80
   end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -158,6 +158,10 @@ module Decidim
     "€"
   end
 
+  config_accessor :image_uploader_quality do
+    80
+  end
+
   # Exposes a configuration option: The maximum file size of an attachment.
   config_accessor :maximum_attachment_size do
     10.megabytes

--- a/decidim-core/spec/uploaders/image_uploader.spec.rb
+++ b/decidim-core/spec/uploaders/image_uploader.spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "carrierwave/test/matchers"
+
+module Decidim
+  describe ImageUploader do
+    include CarrierWave::Test::Matchers
+
+    let(:organization) { build(:organization) }
+    let(:user) { build(:user, organization: organization) }
+    let(:avatar) { Decidim::Dev.test_file("avatar.jpg", "image/jpeg") }
+    let(:uploader) { ImageUploader.new(user, :avatar) }
+
+    before do
+      ImageUploader.enable_processing = true
+      File.open(avatar) { |f| uploader.store!(f) }
+    end
+
+    after do
+      ImageUploader.enable_processing = false
+      uploader.remove!
+    end
+
+    it "compress the image" do
+      expect(uploader.file.size).to be < File.size(avatar)
+    end
+
+    it "makes the image readable only to the owner and not executable" do
+      expect(uploader).to have_permissions(0o666)
+    end
+
+    it "has the correct format" do
+      expect(uploader).to be_format("jpeg")
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Image compression can save a significant amount of bandwidth. Adding a method to the `ImageUploader` class allows to compress all images at upload time.

#### How to use : 
The quality settings can be set in Decidim initializer with 
`Decidim.config.image_uploader_quality = 60`

The quality setting is set to 80 by default because change is imperceptible. My own test show that a quality between 60 and 80 is optimal.

You can use this feature with already uploded images, it only affect newly uploaded file.
If you want to apply new settings to previouysly uploaded images : 

* open `rails console`
* Type the following
```
YourModel.find_each { |x| x.image.recreate_versions! if x.image? }
```

Where YourModel is the name of your model (eg. Decidim::User) and image is the name of your uploader (eg. avatar).

⚠️ ❗️As Decidim doesn't keep original file on upload, a file cannot be restored to original quality without re-uploading. Be careful when playing with this feature on production.❗️ ⚠️ 

See ref here : http://pieroxy.net/blog/2016/05/01/jpeg_compression_is_80_the_magic_quality_part_1_the_retina_screens.html

Let's discuss this feature ! 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add documentation regarding the feature 
- [x] Add tests

### :camera: Screenshots (optional)
Before : 
<img width="752" alt="capture d ecran 2018-08-08 a 21 46 17" src="https://user-images.githubusercontent.com/20232956/43863377-cb7fc67a-9b5c-11e8-847a-4ba20e7cf320.png">

After : 
<img width="746" alt="capture d ecran 2018-08-08 a 22 39 58" src="https://user-images.githubusercontent.com/20232956/43863394-d9f8514a-9b5c-11e8-8473-68ee44ec5b82.png">

