### PR TITLE
Upcoming events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@
 **Added**:
 
 - **decidim-assemblies**: Add organizational chart to assemblies home. [\#4045](https://github.com/decidim/decidim/pull/4045)
+- **decidim-proposals**: Apply hashtags to Proposals. [\#3959](https://github.com/decidim/decidim/pull/3959)
+- **decidim-core**: Add the functionality of hashtags. [\#3959](https://github.com/decidim/decidim/pull/3959)
+- **decidim-assemblies**: Add the posibility to select the parent assembly when the assembly is created or edited [\#4022](https://github.com/decidim/decidim/pull/4022)
+- **decidim-meetings**: Add upcoming events content block and page. [\#3987](https://github.com/decidim/decidim/pull/3987)
+- **decidim-admin**:Add link to user profile and link to conversation from admin space. [\#3995](https://github.com/decidim/decidim/pull/3995)
+- **decidim-core**:Add compression settings to image uploader [\#3984](https://github.com/decidim/decidim/pull/3984)
+- **decidim-budgets**: Import accepted proposals to projects. [\#3873](https://github.com/decidim/decidim/pull/3873)
+- **decidim-proposals**: Results from searches should show the participatory space where they belong to if any. [\#3897](https://github.com/decidim/decidim/pull/3897)
+- **decidim-docs**: Add proposal lifecycle diagram to docs. [\#3811](https://github.com/decidim/decidim/pull/3811)
+- **decidim-budgets**: Added vote project authorization action [\#3804](https://github.com/decidim/decidim/pull/3804)
+- **decidim-meetings**: Added join meeting authorization action [\#3804](https://github.com/decidim/decidim/pull/3804)
+- **decidim-proposals**: Added vote and endorse proposal authorization actions [\#3804](https://github.com/decidim/decidim/pull/3804)
+- **decidim-core**: Support for actions authorizations at resource level [\#3804](https://github.com/decidim/decidim/pull/3804)
+- **decidim-meetings**: Allow users to accept or reject invitations to meetings, and allow admins to see their status. [\#3632](https://github.com/decidim/decidim/pull/3632)
+- **decidim-meetings**: Allow admins to invite existing users to meetings. [\#3831](https://github.com/decidim/decidim/pull/3831)
+- **decidim-meetings**: Generate a registration code and give it to users when they join to the meeting. [\#3805](https://github.com/decidim/decidim/pull/3805)
+- **decidim-meetings**: Allow admins to validate meeting registration codes and notify the user. [\#3833](https://github.com/decidim/decidim/pull/3833)
+- **decidim-core**: Make Users Searchable. [\#3796](https://github.com/decidim/decidim/pull/3796)
+- **decidim-participatory_processes**: Highlight the correct menu item when visiting a process group page [\#3737](https://github.com/decidim/decidim/pull/3737)
+- **decidim-proposals**: Add Collaborative drafts: [\#3109](https://github.com/decidim/decidim/pull/3109)
+  - Admin can en/disable this feature from the component configuration
+  - Filtrable list of Collaborative drafts in public views
+  - Collaborative drafts are: traceable, commentable, coauthorable, reportable
+  - Publish collaborative draft as Proposal
+- **decidim-participatory_processes**: Display a big card when there's just one process at the homepage [\#3970](https://github.com/decidim/decidim/pull/3970)
+- **decidim-core**: Adds support for earning badges. [\#3975](https://github.com/decidim/decidim/pull/3975)
+- **decidim-proposals**: Adds the *proposal* badge. [\#3975](https://github.com/decidim/decidim/pull/3975)
+- **decidim-proposals**: Adds the *proposal supports* badge. [\#4033](https://github.com/decidim/decidim/pull/4033)
+- **decidim-proposals**: Adds the *accepted proposals* badge. [\#4033](https://github.com/decidim/decidim/pull/4033)
+- **decidim-core**: Adds the *invitations* badge. [\#4033](https://github.com/decidim/decidim/pull/4033)
+- **decidim-initiatives**: Adds the *published initiatives* badge. [\#4033](https://github.com/decidim/decidim/pull/4033)
+- **decidim-core**: Add link to admin edit from public pages. [\#3978](https://github.com/decidim/decidim/pull/3978)
 
 **Changed**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,38 +7,7 @@
 **Added**:
 
 - **decidim-assemblies**: Add organizational chart to assemblies home. [\#4045](https://github.com/decidim/decidim/pull/4045)
-- **decidim-proposals**: Apply hashtags to Proposals. [\#3959](https://github.com/decidim/decidim/pull/3959)
-- **decidim-core**: Add the functionality of hashtags. [\#3959](https://github.com/decidim/decidim/pull/3959)
-- **decidim-assemblies**: Add the posibility to select the parent assembly when the assembly is created or edited [\#4022](https://github.com/decidim/decidim/pull/4022)
 - **decidim-meetings**: Add upcoming events content block and page. [\#3987](https://github.com/decidim/decidim/pull/3987)
-- **decidim-admin**:Add link to user profile and link to conversation from admin space. [\#3995](https://github.com/decidim/decidim/pull/3995)
-- **decidim-core**:Add compression settings to image uploader [\#3984](https://github.com/decidim/decidim/pull/3984)
-- **decidim-budgets**: Import accepted proposals to projects. [\#3873](https://github.com/decidim/decidim/pull/3873)
-- **decidim-proposals**: Results from searches should show the participatory space where they belong to if any. [\#3897](https://github.com/decidim/decidim/pull/3897)
-- **decidim-docs**: Add proposal lifecycle diagram to docs. [\#3811](https://github.com/decidim/decidim/pull/3811)
-- **decidim-budgets**: Added vote project authorization action [\#3804](https://github.com/decidim/decidim/pull/3804)
-- **decidim-meetings**: Added join meeting authorization action [\#3804](https://github.com/decidim/decidim/pull/3804)
-- **decidim-proposals**: Added vote and endorse proposal authorization actions [\#3804](https://github.com/decidim/decidim/pull/3804)
-- **decidim-core**: Support for actions authorizations at resource level [\#3804](https://github.com/decidim/decidim/pull/3804)
-- **decidim-meetings**: Allow users to accept or reject invitations to meetings, and allow admins to see their status. [\#3632](https://github.com/decidim/decidim/pull/3632)
-- **decidim-meetings**: Allow admins to invite existing users to meetings. [\#3831](https://github.com/decidim/decidim/pull/3831)
-- **decidim-meetings**: Generate a registration code and give it to users when they join to the meeting. [\#3805](https://github.com/decidim/decidim/pull/3805)
-- **decidim-meetings**: Allow admins to validate meeting registration codes and notify the user. [\#3833](https://github.com/decidim/decidim/pull/3833)
-- **decidim-core**: Make Users Searchable. [\#3796](https://github.com/decidim/decidim/pull/3796)
-- **decidim-participatory_processes**: Highlight the correct menu item when visiting a process group page [\#3737](https://github.com/decidim/decidim/pull/3737)
-- **decidim-proposals**: Add Collaborative drafts: [\#3109](https://github.com/decidim/decidim/pull/3109)
-  - Admin can en/disable this feature from the component configuration
-  - Filtrable list of Collaborative drafts in public views
-  - Collaborative drafts are: traceable, commentable, coauthorable, reportable
-  - Publish collaborative draft as Proposal
-- **decidim-participatory_processes**: Display a big card when there's just one process at the homepage [\#3970](https://github.com/decidim/decidim/pull/3970)
-- **decidim-core**: Adds support for earning badges. [\#3975](https://github.com/decidim/decidim/pull/3975)
-- **decidim-proposals**: Adds the *proposal* badge. [\#3975](https://github.com/decidim/decidim/pull/3975)
-- **decidim-proposals**: Adds the *proposal supports* badge. [\#4033](https://github.com/decidim/decidim/pull/4033)
-- **decidim-proposals**: Adds the *accepted proposals* badge. [\#4033](https://github.com/decidim/decidim/pull/4033)
-- **decidim-core**: Adds the *invitations* badge. [\#4033](https://github.com/decidim/decidim/pull/4033)
-- **decidim-initiatives**: Adds the *published initiatives* badge. [\#4033](https://github.com/decidim/decidim/pull/4033)
-- **decidim-core**: Add link to admin edit from public pages. [\#3978](https://github.com/decidim/decidim/pull/3978)
 
 **Changed**:
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -158,6 +158,7 @@ ignore_unused:
   - decidim.participatory_processes.content_blocks.*.name
   - decidim.assemblies.content_blocks.*.name
   - decidim.initiatives.content_blocks.*.name
+  - decidim.meetings.content_blocks.*.name
   - decidim.proposals.collaborative_drafts.show.hidden_authors_count.*
   - decidim.proposals.collaborative_drafts.orders*
   - decidim.proposals.collaborative_drafts.filters*

--- a/decidim-core/app/controllers/concerns/decidim/paginable.rb
+++ b/decidim-core/app/controllers/concerns/decidim/paginable.rb
@@ -11,6 +11,7 @@ module Decidim
 
     included do
       helper_method :per_page
+      helper Decidim::PaginateHelper
 
       def paginate(resources)
         resources.page(params[:page]).per(per_page)

--- a/decidim-core/app/helpers/decidim/filters_helper.rb
+++ b/decidim-core/app/helpers/decidim/filters_helper.rb
@@ -7,12 +7,13 @@ module Decidim
     # the form_for helper with a custom builder
     #
     # filter - A filter object
+    # url    - A String with the URL to post the from. Self URL by default.
     # block  - A block to be called with the form builder
     #
     # Returns the filter resource form wrapped in a div
-    def filter_form_for(filter)
+    def filter_form_for(filter, url = url_for)
       content_tag :div, class: "filters" do
-        form_for filter, builder: FilterFormBuilder, url: url_for, as: :filter, method: :get, remote: true, html: { id: nil } do |form|
+        form_for filter, builder: FilterFormBuilder, url: url, as: :filter, method: :get, remote: true, html: { id: nil } do |form|
           yield form
         end
       end

--- a/decidim-core/app/helpers/decidim/map_helper.rb
+++ b/decidim-core/app/helpers/decidim/map_helper.rb
@@ -33,7 +33,7 @@ module Decidim
         "data-here-app-id" => Decidim.geocoder[:here_app_id],
         "data-here-app-code" => Decidim.geocoder[:here_app_code]
       }
-      content = capture { yield }
+      content = capture { yield }.html_safe
       content_tag :div, class: "row column" do
         content_tag(:div, "", map_html_options) + content
       end

--- a/decidim-core/lib/decidim/content_block_manifest.rb
+++ b/decidim-core/lib/decidim/content_block_manifest.rb
@@ -27,11 +27,18 @@ module Decidim
     attribute :cell, String
     attribute :settings_form_cell, String
     attribute :images, Array[Hash]
+    attribute :default, Boolean, default: false
 
     validates :name, :cell, :public_name_key, presence: true
     validates :settings_form_cell, presence: true, if: :has_settings?
     validate :image_names_are_unique
     validate :images_have_an_uploader
+
+    # Public: Registers whether this content block should be shown by default
+    # when creating an organization. Use `#default` to retrieve it.
+    def default!
+      self.default = true
+    end
 
     def has_settings?
       settings.attributes.any?

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -292,31 +292,38 @@ module Decidim
           content_block.settings do |settings|
             settings.attribute :welcome_text, type: :text, translated: true
           end
+
+          content_block.default!
         end
 
         Decidim.content_blocks.register(:homepage, :sub_hero) do |content_block|
           content_block.cell = "decidim/content_blocks/sub_hero"
           content_block.public_name_key = "decidim.content_blocks.sub_hero.name"
+          content_block.default!
         end
 
         Decidim.content_blocks.register(:homepage, :highlighted_content_banner) do |content_block|
           content_block.cell = "decidim/content_blocks/highlighted_content_banner"
           content_block.public_name_key = "decidim.content_blocks.highlighted_content_banner.name"
+          content_block.default!
         end
 
         Decidim.content_blocks.register(:homepage, :how_to_participate) do |content_block|
           content_block.cell = "decidim/content_blocks/how_to_participate"
           content_block.public_name_key = "decidim.content_blocks.how_to_participate.name"
+          content_block.default!
         end
 
         Decidim.content_blocks.register(:homepage, :stats) do |content_block|
           content_block.cell = "decidim/content_blocks/stats"
           content_block.public_name_key = "decidim.content_blocks.stats.name"
+          content_block.default!
         end
 
         Decidim.content_blocks.register(:homepage, :footer_sub_hero) do |content_block|
           content_block.cell = "decidim/content_blocks/footer_sub_hero"
           content_block.public_name_key = "decidim.content_blocks.footer_sub_hero.name"
+          content_block.default!
         end
       end
 

--- a/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_events/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_events/show.erb
@@ -1,0 +1,26 @@
+<section class="wrapper-home upcoming-events home-section">
+  <div class="row">
+    <h3 class="section-heading"><%= t(".upcoming_events") %></h3>
+    <div class="row">
+      <div class="columns medium-6">
+        <% upcoming_events.first(4).each do |event|  %>
+          <%= card_for event, size: :s %>
+        <% end %>
+      </div>
+      <div class="columns medium-6">
+        <% if geolocation_enabled? %>
+          <div id="google-map" class="google-map"></div>
+        <% else %>
+          <% upcoming_events.last(4).each do |event|  %>
+            <%= card_for event, size: :s %>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+    <div class="row">
+      <div class="column">
+        <%= link_to t(".view_all_events"), "/upcoming-events", class: "button hollow button--sc pull-right" %>
+      </div>
+    </div>
+  </div>
+</section>

--- a/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_events/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_events/show.erb
@@ -9,7 +9,7 @@
       </div>
       <div class="columns medium-6">
         <% if geolocation_enabled? %>
-          <div id="google-map" class="google-map"></div>
+          <%= cell "decidim/meetings/meetings_map", upcoming_events %>
         <% else %>
           <% upcoming_events.last(4).each do |event| %>
             <%= card_for event, size: :s %>

--- a/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_events/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_events/show.erb
@@ -3,7 +3,7 @@
     <h3 class="section-heading"><%= t("decidim.meetings.content_blocks.upcoming_events.upcoming_events") %></h3>
     <div class="row">
       <div class="columns medium-6">
-        <% upcoming_events.first(4).each do |event|  %>
+        <% upcoming_events.first(4).each do |event| %>
           <%= card_for event, size: :s %>
         <% end %>
       </div>
@@ -11,7 +11,7 @@
         <% if geolocation_enabled? %>
           <div id="google-map" class="google-map"></div>
         <% else %>
-          <% upcoming_events.last(4).each do |event|  %>
+          <% upcoming_events.last(4).each do |event| %>
             <%= card_for event, size: :s %>
           <% end %>
         <% end %>
@@ -19,7 +19,7 @@
     </div>
     <div class="row">
       <div class="column">
-        <%= link_to t("decidim.meetings.content_blocks.upcoming_events.view_all_events"), "/upcoming-events", class: "button hollow button--sc pull-right" %>
+        <%= link_to t("decidim.meetings.content_blocks.upcoming_events.view_all_events"), meetings_directory_path, class: "button hollow button--sc pull-right" %>
       </div>
     </div>
   </div>

--- a/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_events/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_events/show.erb
@@ -1,6 +1,6 @@
 <section class="wrapper-home upcoming-events home-section">
   <div class="row">
-    <h3 class="section-heading"><%= t(".upcoming_events") %></h3>
+    <h3 class="section-heading"><%= t("decidim.meetings.content_blocks.upcoming_events.upcoming_events") %></h3>
     <div class="row">
       <div class="columns medium-6">
         <% upcoming_events.first(4).each do |event|  %>
@@ -19,7 +19,7 @@
     </div>
     <div class="row">
       <div class="column">
-        <%= link_to t(".view_all_events"), "/upcoming-events", class: "button hollow button--sc pull-right" %>
+        <%= link_to t("decidim.meetings.content_blocks.upcoming_events.view_all_events"), "/upcoming-events", class: "button hollow button--sc pull-right" %>
       </div>
     </div>
   </div>

--- a/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_events_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_events_cell.rb
@@ -8,6 +8,10 @@ module Decidim
 
         delegate :current_organization, to: :controller
 
+        def show
+          return if upcoming_events.blank?
+        end
+
         def upcoming_events
           @upcoming_events ||= Decidim::Meetings::Meeting
                                .includes(component: :participatory_space)

--- a/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_events_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_events_cell.rb
@@ -28,7 +28,10 @@ module Decidim
         end
 
         def meeting_components
-          @meeting_components ||= Decidim::Component.where(manifest_name: "meetings").published
+          @meeting_components ||= Decidim::Component
+                                  .where(manifest_name: "meetings")
+                                  .where(participatory_space: participatory_spaces)
+                                  .published
         end
 
         def participatory_spaces

--- a/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_events_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_events_cell.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    module ContentBlocks
+      class UpcomingEventsCell < Decidim::ViewModel
+        include Decidim::CardHelper
+
+        delegate :current_organization, to: :controller
+
+        def upcoming_events
+          @upcoming_events ||= Decidim::Meetings::Meeting
+                               .includes(component: :participatory_space)
+                               .where(component: meeting_components)
+                               .where("end_time >= ?", Time.current)
+                               .order(start_time: :desc)
+                               .limit(limit)
+        end
+
+        def geolocation_enabled?
+          Decidim.geocoder.present?
+        end
+
+        private
+
+        def limit
+          geolocation_enabled? ? 4 : 8
+        end
+
+        def meeting_components
+          @meeting_components ||= Decidim::Component.where(manifest_name: "meetings").published
+        end
+
+        def participatory_spaces
+          @participatory_spaces ||= current_organization.public_participatory_spaces
+        end
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_events_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_events_cell.rb
@@ -21,6 +21,10 @@ module Decidim
           Decidim.geocoder.present?
         end
 
+        def meetings_directory_path
+          Decidim::Meetings::DirectoryEngine.routes.url_helpers.root_path
+        end
+
         private
 
         def limit

--- a/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_events_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_events_cell.rb
@@ -10,6 +10,7 @@ module Decidim
 
         def show
           return if upcoming_events.blank?
+          render
         end
 
         def upcoming_events

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_cell.rb
@@ -19,6 +19,8 @@ module Decidim
         case @options[:size]
         when :list_item
           "decidim/meetings/meeting_list_item"
+        when :s
+          "decidim/meetings/meeting_s"
         else
           "decidim/meetings/meeting_m"
         end

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_s/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_s/show.erb
@@ -1,0 +1,27 @@
+<article class="card">
+  <div class="p-s">
+    <div class="card__header">
+      <%= link_to meeting_path, class: "card__link" do %>
+        <h5 class="card__title">
+          <%= title %>
+        </h5>
+      <% end %>
+    </div>
+    <div class="card__text">
+      <div class="row collapse text-medium">
+        <time datetime="<%= model.start_time.utc %>" class="column medium-4 icon--container">
+          <%= icon "datetime", class: "primary" %>
+          &nbsp;
+          <%= l start_date, format: :decidim_with_month_name %>
+          &nbsp;-&nbsp;
+          <%= formatted_start_time %>
+        </time>
+        <span class="column medium-8">
+          <%= participatory_space_class_name %>
+          &nbsp;
+          <%= link_to participatory_space_title, participatory_space_path %>
+        </span>
+      </div>
+    </div>
+  </div>
+</article>

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_s_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_s_cell.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    # This cell renders the Small (:s) meeting card
+    # for an given instance of a Meeting
+    class MeetingSCell < MeetingMCell
+      def title
+        translated_attribute model.title
+      end
+
+      def meeting_path
+        resource_locator(model).path
+      end
+
+      def participatory_space_class_name
+        model.component.participatory_space.class.model_name.human
+      end
+
+      def participatory_space_title
+        translated_attribute model.component.participatory_space.title
+      end
+
+      def participatory_space_path
+        resource_locator(model.component.participatory_space).path
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/cells/decidim/meetings/meetings_map/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/meetings_map/show.erb
@@ -22,7 +22,7 @@
         </div>
         <div class="map-info__button">
           <a href="${link}" class="button button--sc">
-            <%= t(".view_meeting") %>
+            <%= t("decidim.meetings.meetings_map.view_meeting") %>
           </a>
         </div>
       </div>

--- a/decidim-meetings/app/cells/decidim/meetings/meetings_map/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/meetings_map/show.erb
@@ -1,0 +1,33 @@
+<%= dynamic_map_for meetings_data_for_map(geocoded_meetings) do %>
+  <template id="marker-popup">
+    <div class="map-info__content">
+      <h3>${title}</h3>
+      <div id="bodyContent">
+        <p>{{html description}}</p>
+        <div class="map__date-adress">
+          <div class="card__datetime">
+            <div class="card__datetime__date">
+              ${startTimeDay} <span class="card__datetime__month">${startTimeMonth} ${startTimeYear}</span>
+            </div>
+            <div class="card__datetime__time">${starTime}</div>
+          </div>
+          <div class="address card__extra">
+            <div class="address__icon">{{html icon}}</div>
+            <div class="address__details">
+              <strong>{{html location}}</strong><br />
+              <span>${address}</span><br />
+              <span>{{html locationHints}}</span>
+            </div>
+          </div>
+        </div>
+        <div class="map-info__button">
+          <a href="${link}" class="button button--sc">
+            <%= t(".view_meeting") %>
+          </a>
+        </div>
+      </div>
+    </div>
+  </template>
+  <%= stylesheet_link_tag "decidim/map" %>
+  <%= javascript_include_tag "decidim/map" %>
+<% end.html_safe %>

--- a/decidim-meetings/app/cells/decidim/meetings/meetings_map_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meetings_map_cell.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    class MeetingsMapCell < MeetingMCell
+      include Decidim::MapHelper
+      include Decidim::Meetings::MapHelper
+
+      def show
+        return if Decidim.geocoder.blank?
+        render
+      end
+
+      def geocoded_meetings
+        @geocoded_meetings ||= meetings.select(&:geocoded?)
+      end
+
+      def meetings
+        model
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/controllers/decidim/meetings/directory/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/directory/meetings_controller.rb
@@ -12,15 +12,20 @@ module Decidim
 
         helper Decidim::WidgetUrlsHelper
         helper Decidim::FiltersHelper
+        helper Decidim::Meetings::MapHelper
+        helper Decidim::ResourceHelper
 
         helper_method :meetings, :search
 
         def index
           @meeting_spaces = search.results.map do |meeting|
             klass = meeting.component.participatory_space.class
-            [klass.model_name.name.underscore, klass.model_name.human]
+            [klass.model_name.name.underscore, klass.model_name.human.pluralize]
           end.uniq
-          @meeting_spaces << ["all", "All translated"]
+          @meeting_spaces = @meeting_spaces.sort_by do |_param, name|
+            name
+          end
+          @meeting_spaces = @meeting_spaces.prepend(["all", t(".all")])
         end
 
         private

--- a/decidim-meetings/app/controllers/decidim/meetings/directory/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/directory/meetings_controller.rb
@@ -15,7 +15,13 @@ module Decidim
 
         helper_method :meetings, :search
 
-        def index; end
+        def index
+          @meeting_spaces = search.results.map do |meeting|
+            klass = meeting.component.participatory_space.class
+            [klass.model_name.name.underscore, klass.model_name.human]
+          end.uniq
+          @meeting_spaces << ["all", "All translated"]
+        end
 
         private
 
@@ -31,7 +37,8 @@ module Decidim
           {
             date: "upcoming",
             search_text: "",
-            scope_id: ""
+            scope_id: "",
+            space: "all"
           }
         end
 

--- a/decidim-meetings/app/controllers/decidim/meetings/directory/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/directory/meetings_controller.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    module Directory
+      # Exposes the meeting resource so users can view them
+      class MeetingsController < Decidim::ApplicationController
+        layout "layouts/decidim/application"
+
+        include FilterResource
+        include Paginable
+
+        helper Decidim::WidgetUrlsHelper
+        helper Decidim::FiltersHelper
+
+        helper_method :meetings, :search
+
+        def index; end
+
+        private
+
+        def meetings
+          @meetings ||= paginate(search.results)
+        end
+
+        def search_klass
+          MeetingSearch
+        end
+
+        def default_filter_params
+          {
+            date: "upcoming",
+            search_text: "",
+            scope_id: ""
+          }
+        end
+
+        def default_search_params
+          {
+            scope: Meeting.visible_meeting_for(current_user)
+          }
+        end
+
+        def context_params
+          { component: meeting_components, organization: current_organization }
+        end
+
+        def meeting_components
+          @meeting_components ||= Decidim::Component
+                                  .where(manifest_name: "meetings")
+                                  .where(participatory_space: participatory_spaces)
+                                  .published
+        end
+
+        def participatory_spaces
+          @participatory_spaces ||= current_organization.public_participatory_spaces
+        end
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -8,7 +8,7 @@ module Decidim
       include Paginable
       helper Decidim::WidgetUrlsHelper
 
-      helper_method :meetings, :geocoded_meetings, :meeting
+      helper_method :meetings, :meeting, :search
 
       def index
         return unless search.results.empty? && params.dig("filter", "date") != "past"
@@ -35,11 +35,7 @@ module Decidim
       end
 
       def meetings
-        @meetings ||= paginate(search.results).visible_meeting_for(current_user)
-      end
-
-      def geocoded_meetings
-        @geocoded_meetings ||= search.results.select(&:geocoded?)
+        @meetings ||= paginate(search.results)
       end
 
       def search_klass
@@ -52,6 +48,12 @@ module Decidim
           search_text: "",
           scope_id: "",
           category_id: ""
+        }
+      end
+
+      def default_search_params
+        {
+          scope: Meeting.visible_meeting_for(current_user)
         }
       end
 

--- a/decidim-meetings/app/helpers/decidim/meetings/map_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/map_helper.rb
@@ -6,8 +6,9 @@ module Decidim
     module MapHelper
       # Serialize a collection of geocoded meetings to be used by the dynamic map component
       #
-      # geocoded_meetings - A collection of geocoded meetings
-      def meetings_data_for_map(geocoded_meetings)
+      # meetings - A collection of meetings
+      def meetings_data_for_map(meetings)
+        geocoded_meetings = meetings.select(&:geocoded?)
         geocoded_meetings.map do |meeting|
           meeting.slice(:latitude, :longitude, :address).merge(title: translated_attribute(meeting.title),
                                                                description: translated_attribute(meeting.description),
@@ -18,7 +19,7 @@ module Decidim
                                                                icon: icon("meetings", width: 40, height: 70, remove_icon_class: true),
                                                                location: translated_attribute(meeting.location),
                                                                locationHints: translated_attribute(meeting.location_hints),
-                                                               link: meeting_path(meeting))
+                                                               link: resource_locator(meeting).path)
         end
       end
     end

--- a/decidim-meetings/app/services/decidim/meetings/meeting_search.rb
+++ b/decidim-meetings/app/services/decidim/meetings/meeting_search.rb
@@ -31,6 +31,12 @@ module Decidim
         end
       end
 
+      def search_space
+        return query if options[:space].blank? || options[:space] == "all"
+
+        query.joins(:component).where(decidim_components: { participatory_space_type: options[:space].classify })
+      end
+
       private
 
       # Internal: builds the needed query to search for a text in the organization's

--- a/decidim-meetings/app/services/decidim/meetings/meeting_search.rb
+++ b/decidim-meetings/app/services/decidim/meetings/meeting_search.rb
@@ -11,7 +11,8 @@ module Decidim
       # page        - The page number to paginate the results.
       # per_page    - The number of proposals to return per page.
       def initialize(options = {})
-        super(Meeting.all, options)
+        scope = options.fetch(:scope, Meeting.all)
+        super(scope, options)
       end
 
       # Handle the search_text filter

--- a/decidim-meetings/app/views/decidim/meetings/directory/meetings/_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/directory/meetings/_meetings.html.erb
@@ -1,0 +1,14 @@
+<% if meetings.length == 0 %>
+  <div class="callout warning">
+    <%= t "decidim.meetings.meetings.meetings.no_meetings_warning" %>
+  </div>
+<% else %>
+  <%= render partial: "decidim/shared/results_per_page" %>
+
+  <div class="row small-up-1 medium-up-2 card-grid">
+    <% meetings.each do |meeting| %>
+      <%= card_for meeting %>
+    <% end %>
+  </div>
+  <%= decidim_paginate meetings, order_start_time: params[:order_start_time], scope_id: params[:scope_id] %>
+<% end %>

--- a/decidim-meetings/app/views/decidim/meetings/directory/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/directory/meetings/index.html.erb
@@ -1,6 +1,6 @@
 <div class="wrapper">
   <div class="row">
-    <h1 class="section-heading">Meetings TRANSLATE THIS</h1>
+    <h1 class="section-heading"><%= t(".meetings") %></h1>
 
     <%= cell "decidim/meetings/meetings_map", search.results %>
 
@@ -21,7 +21,7 @@
           </div>
 
           <%= form.collection_radio_buttons :date, [["upcoming", t(".upcoming")], ["past", t(".past")]], :first, :last, legend_title: t(".date") %>
-          <%= form.collection_radio_buttons :space, @meeting_spaces, :first, :last, legend_title: "Space" %>
+          <%= form.collection_radio_buttons :space, @meeting_spaces, :first, :last, legend_title: t(".space_type") %>
         <% end %>
       </div>
     </div>

--- a/decidim-meetings/app/views/decidim/meetings/directory/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/directory/meetings/index.html.erb
@@ -21,8 +21,7 @@
           </div>
 
           <%= form.collection_radio_buttons :date, [["upcoming", t(".upcoming")], ["past", t(".past")]], :first, :last, legend_title: t(".date") %>
-
-          <%= form.collection_radio_buttons :date, [search.results.map{|meeting| meeting.component.participatory_space.class}.uniq.inject({}) {|all, klass| [klass.model_name.name.underscore, klass.model_name.human]}], :first, :last, legend_title: "Space" %>
+          <%= form.collection_radio_buttons :space, @meeting_spaces, :first, :last, legend_title: "Space" %>
         <% end %>
       </div>
     </div>

--- a/decidim-meetings/app/views/decidim/meetings/directory/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/directory/meetings/index.html.erb
@@ -1,0 +1,35 @@
+<div class="wrapper">
+  <div class="row">
+    <h1 class="section-heading">Meetings TRANSLATE THIS</h1>
+
+    <%= cell "decidim/meetings/meetings_map", search.results %>
+
+    <div class="columns mediumlarge-4 large-3">
+      <div class="card card--secondary show-for-mediumlarge">
+        <%= filter_form_for filter, meetings_directory.root_path do |form| %>
+          <div class="filters__section">
+            <div class="filters__search">
+              <div class="input-group">
+                <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t(".search") %>
+                <div class="input-group-button">
+                  <button type="submit" class="button button--muted">
+                    <%= icon "magnifying-glass", aria_label: t(".search") %>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <%= form.collection_radio_buttons :date, [["upcoming", t(".upcoming")], ["past", t(".past")]], :first, :last, legend_title: t(".date") %>
+
+          <%= form.collection_radio_buttons :date, [search.results.map{|meeting| meeting.component.participatory_space.class}.uniq.inject({}) {|all, klass| [klass.model_name.name.underscore, klass.model_name.human]}], :first, :last, legend_title: "Space" %>
+        <% end %>
+      </div>
+    </div>
+    <div id="meetings" class="columns mediumlarge-8 large-9">
+      <%= render partial: "meetings" %>
+    </div>
+  </div>
+</div>
+
+<%= javascript_include_tag("decidim/filters") %>

--- a/decidim-meetings/app/views/decidim/meetings/directory/meetings/index.js.erb
+++ b/decidim-meetings/app/views/decidim/meetings/directory/meetings/index.js.erb
@@ -4,3 +4,8 @@ $meetings.html('<%= j(render partial: "meetings").strip.html_safe %>');
 
 var $dropdownMenu = $('.dropdown.menu', $meetings);
 $dropdownMenu.foundation();
+
+window.Decidim.currentMap = window.Decidim.loadMap(
+  'map',
+  JSON.parse('<%= escape_javascript meetings_data_for_map(search.results).to_json.html_safe %>')
+);

--- a/decidim-meetings/app/views/decidim/meetings/directory/meetings/index.js.erb
+++ b/decidim-meetings/app/views/decidim/meetings/directory/meetings/index.js.erb
@@ -1,0 +1,6 @@
+var $meetings = $('#meetings');
+
+$meetings.html('<%= j(render partial: "meetings").strip.html_safe %>');
+
+var $dropdownMenu = $('.dropdown.menu', $meetings);
+$dropdownMenu.foundation();

--- a/decidim-meetings/app/views/decidim/meetings/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/index.html.erb
@@ -1,38 +1,6 @@
 <%= render partial: "decidim/shared/component_announcement" %>
 
-<%= dynamic_map_for meetings_data_for_map(geocoded_meetings) do %>
-  <template id="marker-popup">
-    <div class="map-info__content">
-      <h3>${title}</h3>
-      <div id="bodyContent">
-        <p>{{html description}}</p>
-        <div class="map__date-adress">
-          <div class="card__datetime">
-            <div class="card__datetime__date">
-              ${startTimeDay} <span class="card__datetime__month">${startTimeMonth} ${startTimeYear}</span>
-            </div>
-            <div class="card__datetime__time">${starTime}</div>
-          </div>
-          <div class="address card__extra">
-            <div class="address__icon">{{html icon}}</div>
-            <div class="address__details">
-              <strong>{{html location}}</strong><br />
-              <span>${address}</span><br />
-              <span>{{html locationHints}}</span>
-            </div>
-          </div>
-        </div>
-        <div class="map-info__button">
-          <a href="${link}" class="button button--sc">
-            <%= t(".view_meeting") %>
-          </a>
-        </div>
-      </div>
-    </div>
-  </template>
-  <%= stylesheet_link_tag "decidim/map" %>
-  <%= javascript_include_tag "decidim/map" %>
-<% end %>
+<%= cell "decidim/meetings/meetings_map", search.results %>
 
 <div class="row">
   <div class="columns mediumlarge-4 large-3">

--- a/decidim-meetings/app/views/decidim/meetings/meetings/index.js.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/index.js.erb
@@ -7,5 +7,5 @@ $dropdownMenu.foundation();
 
 window.Decidim.currentMap = window.Decidim.loadMap(
   'map',
-  JSON.parse('<%= escape_javascript meetings_data_for_map(geocoded_meetings).to_json.html_safe %>')
+  JSON.parse('<%= escape_javascript meetings_data_for_map(search.results.select(&:geocoded?)).to_json.html_safe %>')
 );

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -286,6 +286,10 @@ en:
         minutes:
           create: "%{user_name} created the minutes of the meeting %{resource_name} on the %{space_name} space"
           update: "%{user_name} updated the minutes of the meeting %{resource_name} on the %{space_name} space"
+      content_blocks:
+        upcoming_events:
+          upcoming_events: Upcoming meetings
+          view_all_events: View all
       mailer:
         invite_join_meeting_mailer:
           invite:

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -293,9 +293,12 @@ en:
       directory:
         meetings:
           index:
+            all: All
             date: Date
+            meetings: Meetings
             past: Past
             search: Search
+            space_type: Participatory space
             upcoming: Upcoming
       mailer:
         invite_join_meeting_mailer:

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -288,6 +288,7 @@ en:
           update: "%{user_name} updated the minutes of the meeting %{resource_name} on the %{space_name} space"
       content_blocks:
         upcoming_events:
+          name: Upcoming events
           upcoming_events: Upcoming meetings
           view_all_events: View all
       directory:

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -136,6 +136,13 @@ en:
         preview: Preview
         registrations: Registrations
         title: Actions
+      directory:
+        meetings:
+          index:
+            search: Search
+            upcoming: Upcoming
+            past: Past
+            date: Date
       admin:
         agenda:
           agenda_item:
@@ -299,6 +306,8 @@ en:
             subject: Your meeting's registration has been confirmed
       meeting:
         not_allowed: You are not allowed to view this meeting
+      meetings_map:
+        view_meeting: View meeting
       meetings:
         filters:
           category: Category
@@ -312,8 +321,6 @@ en:
           filter: Filter
           filter_by: Filter by
           unfold: Unfold
-        index:
-          view_meeting: View meeting
         meeting_minutes:
           meeting_minutes: Meeting Minutes
           related_information: Related Information

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -136,13 +136,6 @@ en:
         preview: Preview
         registrations: Registrations
         title: Actions
-      directory:
-        meetings:
-          index:
-            search: Search
-            upcoming: Upcoming
-            past: Past
-            date: Date
       admin:
         agenda:
           agenda_item:
@@ -297,6 +290,13 @@ en:
         upcoming_events:
           upcoming_events: Upcoming meetings
           view_all_events: View all
+      directory:
+        meetings:
+          index:
+            date: Date
+            past: Past
+            search: Search
+            upcoming: Upcoming
       mailer:
         invite_join_meeting_mailer:
           invite:
@@ -306,8 +306,6 @@ en:
             subject: Your meeting's registration has been confirmed
       meeting:
         not_allowed: You are not allowed to view this meeting
-      meetings_map:
-        view_meeting: View meeting
       meetings:
         filters:
           category: Category
@@ -343,6 +341,8 @@ en:
             other: "%{count} slots remaining"
             zero: No slots remaining
           view: View
+      meetings_map:
+        view_meeting: View meeting
       models:
         invite:
           fields:

--- a/decidim-meetings/db/migrate/20180809134748_add_upcoming_events_as_content_block.rb
+++ b/decidim-meetings/db/migrate/20180809134748_add_upcoming_events_as_content_block.rb
@@ -11,11 +11,13 @@ class AddUpcomingEventsAsContentBlock < ActiveRecord::Migration[5.2]
 
   def change
     Organization.find_each do |organization|
-      next if organization.content_blocks.where(manifest_name: "upcoming_events").exists?
+      next if ContentBlock.where(decidim_organization_id: organization.id).where(manifest_name: "upcoming_events").exists?
 
-      ContentBlock.create(
+      last_weight = ContentBlock.where(decidim_organization_id: organization.id).order("weight DESC").limit(1).pluck(:weight).last.to_i
+
+      ContentBlock.create!(
         decidim_organization_id: organization.id,
-        weight: organization.content_blocks.last.try(:weight).to_i + 10,
+        weight: last_weight,
         scope: :homepage,
         manifest_name: :upcoming_events,
         published_at: Time.current

--- a/decidim-meetings/db/migrate/20180809134748_add_upcoming_events_as_content_block.rb
+++ b/decidim-meetings/db/migrate/20180809134748_add_upcoming_events_as_content_block.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class AddUpcomingEventsAsContentBlock < ActiveRecord::Migration[5.2]
+  class Organization < ApplicationRecord
+    self.table_name = :decidim_organizations
+  end
+
+  class ContentBlock < ApplicationRecord
+    self.table_name = :decidim_content_blocks
+  end
+
+  def change
+    Organization.find_each do |organization|
+      next if organization.content_blocks.where(manifest_name: "upcoming_events").exists?
+
+      ContentBlock.create(
+        decidim_organization_id: organization.id,
+        weight: organization.content_blocks.last.try(:weight).to_i + 10,
+        scope: :homepage,
+        manifest_name: :upcoming_events,
+        published_at: Time.current
+      )
+    end
+  end
+end

--- a/decidim-meetings/lib/decidim/meetings.rb
+++ b/decidim-meetings/lib/decidim/meetings.rb
@@ -3,6 +3,8 @@
 require "decidim/meetings/admin"
 require "decidim/meetings/engine"
 require "decidim/meetings/admin_engine"
+require "decidim/meetings/directory"
+require "decidim/meetings/directory_engine"
 require "decidim/meetings/component"
 
 module Decidim

--- a/decidim-meetings/lib/decidim/meetings/component.rb
+++ b/decidim-meetings/lib/decidim/meetings/component.rb
@@ -137,3 +137,9 @@ Decidim.register_component(:meetings) do |component|
     end
   end
 end
+
+Decidim.register_global_engine(
+  :meetings_directory,
+  Decidim::Meetings::DirectoryEngine,
+  at: "/meetings"
+)

--- a/decidim-meetings/lib/decidim/meetings/directory.rb
+++ b/decidim-meetings/lib/decidim/meetings/directory.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    # This module contains all the domain logic associated to Decidim's Meetings
+    # component admin panel.
+    module Directory
+    end
+  end
+end

--- a/decidim-meetings/lib/decidim/meetings/directory_engine.rb
+++ b/decidim-meetings/lib/decidim/meetings/directory_engine.rb
@@ -19,6 +19,14 @@ module Decidim
       def load_seed
         nil
       end
+
+      initializer "decidim.meetings.content_blocks" do
+        Decidim.content_blocks.register(:homepage, :upcoming_events) do |content_block|
+          content_block.cell = "decidim/meetings/content_blocks/upcoming_events"
+          content_block.public_name_key = "decidim.meetings.content_blocks.upcoming_events.name"
+          content_block.default!
+        end
+      end
     end
   end
 end

--- a/decidim-meetings/lib/decidim/meetings/directory_engine.rb
+++ b/decidim-meetings/lib/decidim/meetings/directory_engine.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    # This is the engine that runs on the public interface of `decidim-meetings`.
+    # It mostly handles rendering the created meeting associated to a participatory
+    # process.
+    class DirectoryEngine < ::Rails::Engine
+      isolate_namespace Decidim::Meetings::Directory
+
+      paths["db/migrate"] = nil
+      paths["lib/tasks"] = nil
+
+      routes do
+        resources :meetings, only: [:index], format: :html
+        root to: "meetings#index", format: :html
+      end
+
+      def load_seed
+        nil
+      end
+    end
+  end
+end

--- a/decidim-meetings/lib/decidim/meetings/engine.rb
+++ b/decidim-meetings/lib/decidim/meetings/engine.rb
@@ -98,6 +98,14 @@ module Decidim
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Meetings::Engine.root}/app/cells")
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Meetings::Engine.root}/app/views") # for partials
       end
+
+      initializer "decidim.meetings.content_blocks" do
+        Decidim.content_blocks.register(:homepage, :upcoming_events) do |content_block|
+          content_block.cell "decidim/meetings/content_blocks/upcoming_events"
+          content_block.public_name_key "decidim.meetings.content_blocks.upcoming_events.name"
+          content_block.default!
+        end
+      end
     end
   end
 end

--- a/decidim-meetings/lib/decidim/meetings/engine.rb
+++ b/decidim-meetings/lib/decidim/meetings/engine.rb
@@ -98,14 +98,6 @@ module Decidim
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Meetings::Engine.root}/app/cells")
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Meetings::Engine.root}/app/views") # for partials
       end
-
-      initializer "decidim.meetings.content_blocks" do
-        Decidim.content_blocks.register(:homepage, :upcoming_events) do |content_block|
-          content_block.cell "decidim/meetings/content_blocks/upcoming_events"
-          content_block.public_name_key "decidim.meetings.content_blocks.upcoming_events.name"
-          content_block.default!
-        end
-      end
     end
   end
 end

--- a/decidim-meetings/lib/decidim/meetings/test/factories.rb
+++ b/decidim-meetings/lib/decidim/meetings/test/factories.rb
@@ -2,6 +2,7 @@
 
 require "decidim/core/test/factories"
 require "decidim/participatory_processes/test/factories"
+require "decidim/assemblies/test/factories"
 
 FactoryBot.define do
   factory :meeting_component, parent: :component do

--- a/decidim-meetings/spec/cells/decidim/meetings/content_blocks/upcoming_events_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/content_blocks/upcoming_events_cell_spec.rb
@@ -15,15 +15,24 @@ module Decidim
           expect(controller).to receive(:current_organization).and_return(organization)
         end
 
-        context "when rendering" do
+        context "with events" do
           let(:organization) { meeting.organization }
           let(:meeting) { create(:meeting, start_time: 1.week.from_now) }
-          let!(:past_meeting) do
-            create(:meeting, start_time: 1.week.ago, component: meeting.component)
-          end
 
           it "renders the events" do
             expect(html).to have_css("article.card", count: 1)
+          end
+
+          describe "upcoming events" do
+            subject { cell.upcoming_events }
+
+            let(:cell) { described_class.new(nil, context: { controller: controller }) }
+            let!(:past_meeting) do
+              create(:meeting, start_time: 1.week.ago, component: meeting.component)
+            end
+
+            it { is_expected.not_to include(past_meeting) }
+            it { is_expected.to include(meeting) }
           end
         end
 

--- a/decidim-meetings/spec/cells/decidim/meetings/content_blocks/upcoming_events_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/content_blocks/upcoming_events_cell_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Meetings
+    module ContentBlocks
+      describe UpcomingEventsCell, type: :cell do
+        controller Decidim::Meetings::Directory::MeetingsController
+
+        let(:html) { cell("decidim/meetings/content_blocks/upcoming_events").call }
+        let(:organization) { create(:organization) }
+
+        before do
+          expect(controller).to receive(:current_organization).and_return(organization)
+        end
+
+        context "when rendering" do
+          let(:organization) { meeting.organization }
+          let(:meeting) { create(:meeting, start_time: 1.week.from_now) }
+          let!(:past_meeting) do
+            create(:meeting, start_time: 1.week.ago, component: meeting.component)
+          end
+
+          it "renders the events" do
+            expect(html).to have_css("article.card", count: 1)
+          end
+        end
+
+        context "with no events" do
+          it "renders nothing" do
+            expect(html).to have_no_css(".upcoming-events")
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-meetings/spec/system/explore_meeting_directory_spec.rb
+++ b/decidim-meetings/spec/system/explore_meeting_directory_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Explore meeting directory", type: :system do
+  let(:directory) do
+    Decidim::Meetings::DirectoryEngine.routes.url_helpers.root_path
+  end
+  let(:organization) { create(:organization) }
+  let(:components) do
+    create_list(:meeting_component, 3, organization: organization)
+  end
+  let!(:meetings) do
+    components.flat_map do |component|
+      create_list(:meeting, 2, component: component)
+    end
+  end
+
+  before do
+    switch_to_host(organization.host)
+    visit directory
+  end
+
+  it "shows all the upcoming meetings" do
+    within "#meetings" do
+      expect(page).to have_css(".card--meeting", count: 6)
+    end
+  end
+
+  context "when there's a past meeting" do
+    let!(:past_meeting) do
+      create(:meeting, component: components.last, start_time: 1.week.ago)
+    end
+
+    it "allows filtering by past events" do
+      within ".filters" do
+        choose "Past"
+      end
+
+      expect(page).to have_content(past_meeting.title["en"])
+    end
+  end
+
+  context "with different participatory spaces" do
+    let(:assembly) do
+      create(:assembly, organization: organization)
+    end
+    let(:assembly_component) do
+      create(:meeting_component, participatory_space: assembly, organization: organization)
+    end
+    let!(:assembly_meeting) do
+      create(:meeting, component: assembly_component)
+    end
+
+    before do
+      visit directory
+    end
+
+    it "allows filtering by space" do
+      expect(page).to have_content(assembly_meeting.title["en"])
+
+      # Since in the first load all the meeting are present, we need can't rely on
+      # have_content to wait for the card list to change. This is a hack to
+      # reset the contents to no meetings at all, and then showing only the upcoming
+      # assembly meetings.
+      within ".filters" do
+        choose "Past"
+      end
+
+      expect(page).to have_no_css(".card--meeting")
+
+      within ".filters" do
+        choose "Assemblies"
+        choose "Upcoming"
+      end
+
+      expect(page).to have_content(assembly_meeting.title["en"])
+      expect(page).to have_css(".card--meeting", count: 1)
+    end
+  end
+end

--- a/decidim-system/app/commands/decidim/system/create_default_content_blocks.rb
+++ b/decidim-system/app/commands/decidim/system/create_default_content_blocks.rb
@@ -5,9 +5,6 @@ module Decidim
     # A command with all the business logic to create the default content blocks
     # for a newly-created organization.
     class CreateDefaultContentBlocks < Rectify::Command
-      DEFAULT_CONTENT_BLOCKS =
-        [:hero, :sub_hero, :highlighted_content_banner, :how_to_participate, :stats, :footer_sub_hero].freeze
-
       # Public: Initializes the command.
       #
       # form - A form object with the params.
@@ -19,19 +16,23 @@ module Decidim
       #
       # Returns nothing.
       def call
-        DEFAULT_CONTENT_BLOCKS.each_with_index do |manifest_name, index|
+        content_blocks.each_with_index do |manifest, index|
           weight = (index + 1) * 10
           Decidim::ContentBlock.create(
             decidim_organization_id: organization.id,
             weight: weight,
             scope: :homepage,
-            manifest_name: manifest_name,
+            manifest_name: manifest.name,
             published_at: Time.current
           )
         end
       end
 
       private
+
+      def content_blocks
+        Decidim.content_blocks.for(:homepage).select(&:default)
+      end
 
       attr_reader :organization
     end

--- a/decidim-system/spec/commands/decidim/system/create_default_content_blocks_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/create_default_content_blocks_spec.rb
@@ -8,11 +8,14 @@ module Decidim
       subject { described_class.new(organization) }
 
       let(:organization) { create(:organization) }
+      let(:default_content_blocks) do
+        Decidim.content_blocks.for(:homepage).select(&:default).length
+      end
 
       it "creates and publishes all the default content blocks for an organization" do
         expect do
           described_class.new(organization).call
-        end.to change { Decidim::ContentBlock.where(organization: organization).where.not(published_at: nil).count }.by(described_class::DEFAULT_CONTENT_BLOCKS.length)
+        end.to change { Decidim::ContentBlock.where(organization: organization).where.not(published_at: nil).count }.by(default_content_blocks)
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

Adds a content block to the homepage to display upcoming meetings and a global page to display all the meetings.

#### :pushpin: Related Issues
- Fixes #3700

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
- [x] Add migration to add the content block as default
- [x] Add map
- [x] Handle no geolocalization
- [x] Handle no upcoming meetings
- [x] All meetings page
