### PR TITLE
Only show initiative types from the current tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@
 - **decidim-comments**: Users should never be notified about their own comments. [\#3888](https://github.com/decidim/decidim/pull/3888)
 - **decidim-core**: Consider only users in profile follow counters. [\#3887](https://github.com/decidim/decidim/pull/3887)
 - **decidim**: Make sure the same task on each decidim module is only loaded once. [\#3890](https://github.com/decidim/decidim/pull/3890)
+- **decidim-initiatives**: Only show initiative types fomr the current tenant [\#3887](https://github.com/decidim/decidim/pull/3887)
 
 **Removed**:
 

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_filters.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_filters.html.erb
@@ -30,11 +30,12 @@
     <fieldset>
       <legend><h6 class="heading6"><%= t ".type" %></h6></legend>
       <%= form.initiative_types_select :type,
-                                   legend_title: t(".type"),
-                                   label: false,
-                                   prompt: t(".type_prompt"),
-                                   remote_path: initiative_types_search_path,
-                                   multiple: true %>
+                                       Decidim::InitiativesType.where(organization: current_organization),
+                                       legend_title: t(".type"),
+                                       label: false,
+                                       prompt: t(".type_prompt"),
+                                       remote_path: initiative_types_search_path,
+                                       multiple: true %>
     </fieldset>
   </div>
 

--- a/decidim-initiatives/lib/decidim/initiatives/initiatives_filter_form_builder.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/initiatives_filter_form_builder.rb
@@ -13,18 +13,18 @@ module Decidim
       # - prompt   - An optional String with the text to display as prompt.
       #
       # Returns a String.
-      def initiative_types_select(name, options = {})
+      def initiative_types_select(name, collection, options = {})
         selected = object.send(name)
 
         if selected.present?
           if selected == "all"
-            types = Decidim::InitiativesType.all.map do |type|
+            types = collection.all.map do |type|
               [type.title[I18n.locale.to_s], type.id]
             end
           else
             selected = selected.values if selected.is_a?(Hash)
             selected = [selected] unless selected.is_a?(Array)
-            types = Decidim::InitiativesType.where(id: selected.map(&:to_i)).map do |type|
+            types = collection.where(id: selected.map(&:to_i)).map do |type|
               [type.title[I18n.locale.to_s], type.id]
             end
           end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR ensures only initiative types from the current tenant are being shown.

#### :pushpin: Related Issues
- Fixes #3910

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
