### PR TITLE
Hide withdrawn proposals from the proposals index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@
   - Fix ability to update proposal attachment
   - Fix `has_address` checked and `address` on invalid form
   - Fix ability to update the proposal's `author/user_group`
+- **decidim-proposals**: Hide withdrawn proposals from index [\#4012](https://github.com/decidim/decidim/pull/4012)
 - **decidim-comments**: Users should never be notified about their own comments. [\#3888](https://github.com/decidim/decidim/pull/3888)
 - **decidim-core**: Consider only users in profile follow counters. [\#3887](https://github.com/decidim/decidim/pull/3887)
 - **decidim**: Make sure the same task on each decidim module is only loaded once. [\#3890](https://github.com/decidim/decidim/pull/3890)

--- a/decidim-proposals/app/services/decidim/proposals/proposal_search.rb
+++ b/decidim-proposals/app/services/decidim/proposals/proposal_search.rb
@@ -57,7 +57,7 @@ module Decidim
         when "withdrawn"
           query.withdrawn
         when "except_rejected"
-          query.except_rejected
+          query.except_rejected.except_withdrawn
         else # Assume 'not_withdrawn'
           query.except_withdrawn
         end

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_search_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_search_spec.rb
@@ -103,7 +103,20 @@ module Decidim
             end
           end
 
-          context "when filtering accpeted proposals" do
+          context "when filtering :except_rejected proposals" do
+            let(:state) { "except_rejected" }
+
+            it "hides withdrawn and rejected proposals" do
+              create(:proposal, :withdrawn, component: component)
+              create(:proposal, :rejected, component: component)
+              accepted_proposal = create(:proposal, :accepted, component: component)
+
+              expect(subject.size).to eq(2)
+              expect(subject).to match_array([accepted_proposal, proposal])
+            end
+          end
+
+          context "when filtering accepted proposals" do
             let(:state) { "accepted" }
 
             it "returns only accepted proposals" do


### PR DESCRIPTION
#### :tophat: What? Why?
Withdrawn proposals are being shown on the proposals index. This PR hides those withdrawn proposals from that view.

#### :pushpin: Related Issues
- Fixes #3924

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

