### PR TITLE
Allow destroying surveys components when there are no answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 - **decidim-consultations**: Remove unused indexes from consultations questions. [\#3840](https://github.com/decidim/decidim/pull/3840)
 - **decidim-admin**: Paginate private users. [\#3871](https://github.com/decidim/decidim/pull/3871)
 - **decidim-surveys**: Order survey answer options by date and time. [#3867](https://github.com/decidim/decidim/pull/3867)
+- **decidim-surveys**: Allow deleting surveys components when there are no answers [#4013](https://github.com/decidim/decidim/pull/4013)
 - **decidim-proposals**: Proposal creation and update fixes: [\#3744](https://github.com/decidim/decidim/pull/3744)
   - Fix `CookieOverflow` in wizard steps
   - Fix `proposal_length` validation on create_step

--- a/decidim-surveys/lib/decidim/surveys/component.rb
+++ b/decidim-surveys/lib/decidim/surveys/component.rb
@@ -18,7 +18,11 @@ Decidim.register_component(:surveys) do |component|
   component.data_portable_entities = ["Decidim::Surveys::SurveyAnswer"]
 
   component.on(:before_destroy) do |instance|
-    raise "Can't destroy this component when there are surveys" if Decidim::Surveys::Survey.where(component: instance).any?
+    survey_answers_for_component = Decidim::Surveys::SurveyAnswer
+                                   .includes(:survey)
+                                   .where(decidim_surveys_surveys: { decidim_component_id: instance.id })
+
+    raise "Can't destroy this component when there are survey answers" if survey_answers_for_component.any?
   end
 
   component.register_stat :surveys_count do |components, start_at, end_at|

--- a/decidim-surveys/spec/lib/decidim/surveys/component_spec.rb
+++ b/decidim-surveys/spec/lib/decidim/surveys/component_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Surveys component" do # rubocop:disable RSpec/DescribeClass
+  subject { component }
+
+  let(:component) { create :surveys_component }
+
+  describe "before_destroy hooks" do
+    context "when there are no answers" do
+      it "does not raise any error" do
+        expect { subject.manifest.run_hooks(:before_destroy, subject) }.not_to raise_error
+      end
+    end
+
+    context "with answers" do
+      before do
+        survey = create :survey, component: component
+        create :survey_answer, survey: survey
+      end
+
+      it "raises an error" do
+        expect { subject.manifest.run_hooks(:before_destroy, subject) }.to raise_error(
+          RuntimeError,
+          "Can't destroy this component when there are survey answers"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
The surveys component can't be destroyed even if there are no answers. This PR fixes this problem.

#### :pushpin: Related Issues
- Fixes #3926

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
\