### PR TITLE
Make authors optionals through the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@
   - Fix ability to update the proposal's `author/user_group`
 - **decidim-comments**: Users should never be notified about their own comments. [\#3888](https://github.com/decidim/decidim/pull/3888)
 - **decidim-core**: Consider only users in profile follow counters. [\#3887](https://github.com/decidim/decidim/pull/3887)
+- **decidim-core**: Make API authors optional [\#4014](https://github.com/decidim/decidim/pull/4014)
 - **decidim**: Make sure the same task on each decidim module is only loaded once. [\#3890](https://github.com/decidim/decidim/pull/3890)
 
 **Removed**:

--- a/decidim-core/lib/decidim/api/authorable_interface.rb
+++ b/decidim-core/lib/decidim/api/authorable_interface.rb
@@ -7,7 +7,7 @@ module Decidim
       name "AuthorableInterface"
       description "An interface that can be used in authorable objects."
 
-      field :author, !Decidim::Core::AuthorInterface, "The comment's author" do
+      field :author, Decidim::Core::AuthorInterface, "The resource author" do
         # can be an Authorable or a Coauthorable
         resolve ->(authorable, _, _) {
           if authorable.respond_to?(:normalized_author)

--- a/decidim-core/lib/decidim/core/test/shared_examples/authorable_interface_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/authorable_interface_examples.rb
@@ -4,6 +4,16 @@ require "spec_helper"
 
 shared_examples_for "authorable interface" do
   describe "author" do
+    describe "when author is not present" do
+      before do
+        model.update(author: author)
+      end
+
+      it "does not include the author" do
+        expect(response["author"]).to be_nil
+      end
+    end
+
     describe "with a regular user" do
       let(:author) { create(:user, organization: model.participatory_space.organization) }
       let(:query) { "{ author { name } }" }


### PR DESCRIPTION
#### :tophat: What? Why?
Makes authors optional through the API. If no author is present, it means it's official.

#### :pushpin: Related Issues
- Fixes #3909

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
