### PR TITLE
Remove secondary actions from consultations admin layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 - **decidim-core**: Updated the `CollapsibleList` cell to be able to show any number of elements from 1 to 12 [\#3810](https://github.com/decidim/decidim/pull/3810)
 - **decidim-core**: Move the homepage sections from view hooks to content blocks [\#3839](https://github.com/decidim/decidim/pull/3839)
 - **decidim-core**: Move conversations to a profile tab. [\#3960](https://github.com/decidim/decidim/pull/3960)
+- **decidim-consultations**: Removed the secondary navbar in the admin sections where it's redundant [\#4015](https://github.com/decidim/decidim/pull/4015)
 
 **Fixed**:
 

--- a/decidim-consultations/app/views/layouts/decidim/admin/consultations.html.erb
+++ b/decidim-consultations/app/views/layouts/decidim/admin/consultations.html.erb
@@ -1,14 +1,3 @@
-<% content_for :secondary_nav do %>
-  <div class="secondary-nav">
-    <div class="secondary-nav__title">
-      <%= t "decidim.admin.titles.consultations" %>
-    </div>
-    <div class="secondary-nav__actions">
-      <%= link_to t("actions.new", scope: "decidim.admin", name: t("models.consultation.name", scope: "decidim.admin")), ["new", "consultation"], class: "button expanded small" if allowed_to? :create, :consultation %>
-    </div>
-  </div>
-<% end %>
-
 <%= render "layouts/decidim/admin/application" do %>
   <div class="process-title">
     <div class="process-title-content">


### PR DESCRIPTION
#### :tophat: What? Why?
The consultations admin layout has an i18n problem on the secondary nav bar. This navbar only renders a button that can be accessed from the main content, so it's redundant. I'm removing the whole secondary navbar to make it look like the processes and assemblies sections.

#### :pushpin: Related Issues
- Fixes #3865

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/SPUaLhG.png)
