### PR TITLE
Allow users with admin level to the space to preview unpublished components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@
 - **decidim-core**: Make API authors optional [\#4014](https://github.com/decidim/decidim/pull/4014)
 - **decidim**: Make sure the same task on each decidim module is only loaded once. [\#3890](https://github.com/decidim/decidim/pull/3890)
 - **decidim-initiatives**: Only show initiative types fomr the current tenant [\#3887](https://github.com/decidim/decidim/pull/3887)
+- **decidim-core**: Allows users with admin access to preview unpublished components [\#4016](https://github.com/decidim/decidim/pull/4016)
 
 **Removed**:
 

--- a/decidim-core/spec/permissions/decidim/permissions_spec.rb
+++ b/decidim-core/spec/permissions/decidim/permissions_spec.rb
@@ -37,6 +37,7 @@ describe Decidim::Permissions do
       { scope: :public, action: :read, subject: :component }
     end
     let(:context) { { current_component: component } }
+    let(:organization) { component.participatory_space.organization }
 
     context "when the component is published" do
       let(:component) { create :component, :published }
@@ -47,7 +48,27 @@ describe Decidim::Permissions do
     context "when the component is not published" do
       let(:component) { create :component, :unpublished }
 
-      it { is_expected.to eq false }
+      context "when the user does not exist" do
+        it { is_expected.to eq false }
+      end
+
+      context "when the user has no admin access" do
+        let(:user) { create :user, organization: organization }
+
+        it { is_expected.to eq false }
+      end
+
+      context "when the user is an admin" do
+        let(:user) { create :user, :admin, organization: organization }
+
+        it { is_expected.to eq true }
+      end
+
+      context "when the space gives the user admin access" do
+        let(:user) { create :process_admin, participatory_process: component.participatory_space }
+
+        it { is_expected.to eq true }
+      end
     end
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Looks like after merging the new permissions system admins and space admins cannot preview unpublished components.

This PR fixes this.

#### :pushpin: Related Issues
- Fixes #3927

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry