### PR TITLE
Make card cells delegate options to sized cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@
 - **decidim-core**: Consider only users in profile follow counters. [\#3887](https://github.com/decidim/decidim/pull/3887)
 - **decidim-core**: Make API authors optional [\#4014](https://github.com/decidim/decidim/pull/4014)
 - **decidim**: Make sure the same task on each decidim module is only loaded once. [\#3890](https://github.com/decidim/decidim/pull/3890)
+- **decidim**: Correctly pass cells options to sized card cells [\#4017](https://github.com/decidim/decidim/pull/4017)
 - **decidim-initiatives**: Only show initiative types fomr the current tenant [\#3887](https://github.com/decidim/decidim/pull/3887)
 
 **Removed**:

--- a/decidim-assemblies/app/cells/decidim/assemblies/assembly_cell.rb
+++ b/decidim-assemblies/app/cells/decidim/assemblies/assembly_cell.rb
@@ -6,7 +6,7 @@ module Decidim
     # the default size is the Medium Card (:m)
     class AssemblyCell < Decidim::ViewModel
       def show
-        cell card_size, model
+        cell card_size, model, options
       end
 
       private

--- a/decidim-blogs/app/cells/decidim/blogs/post_cell.rb
+++ b/decidim-blogs/app/cells/decidim/blogs/post_cell.rb
@@ -6,7 +6,7 @@ module Decidim
     # the default size is the Medium Card (:m)
     class PostCell < Decidim::ViewModel
       def show
-        cell card_size, model
+        cell card_size, model, options
       end
 
       private

--- a/decidim-budgets/app/cells/decidim/budgets/project_cell.rb
+++ b/decidim-budgets/app/cells/decidim/budgets/project_cell.rb
@@ -8,7 +8,7 @@ module Decidim
       include Cell::ViewModel::Partial
 
       def show
-        cell card_size, model
+        cell card_size, model, options
       end
 
       private

--- a/decidim-consultations/app/cells/decidim/consultations/consultation_cell.rb
+++ b/decidim-consultations/app/cells/decidim/consultations/consultation_cell.rb
@@ -6,7 +6,7 @@ module Decidim
     # the default size is the Medium Card (:m)
     class ConsultationCell < Decidim::ViewModel
       def show
-        cell card_size, model
+        cell card_size, model, options
       end
 
       private

--- a/decidim-core/app/cells/decidim/coauthorships_cell.rb
+++ b/decidim-core/app/cells/decidim/coauthorships_cell.rb
@@ -20,7 +20,7 @@ module Decidim
 
     def show
       if authorable? || official?
-        cell "decidim/author", presenter_for_author(model), options: extra_classes, has_actions: has_actions?, from: model
+        cell "decidim/author", presenter_for_author(model), extra_classes.merge(has_actions: has_actions?, from: model)
       else
         cell(
           "decidim/collapsible_authors",

--- a/decidim-debates/app/cells/decidim/debates/debate_cell.rb
+++ b/decidim-debates/app/cells/decidim/debates/debate_cell.rb
@@ -9,7 +9,7 @@ module Decidim
       include Cell::ViewModel::Partial
 
       def show
-        cell card_size, model
+        cell card_size, model, options
       end
 
       private

--- a/decidim-initiatives/app/cells/decidim/initiatives/initiative_cell.rb
+++ b/decidim-initiatives/app/cells/decidim/initiatives/initiative_cell.rb
@@ -6,7 +6,7 @@ module Decidim
     # the default size is the Medium Card (:m)
     class InitiativeCell < Decidim::ViewModel
       def show
-        cell card_size, model
+        cell card_size, model, options
       end
 
       private

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_cell.rb
@@ -10,7 +10,7 @@ module Decidim
       include Cell::ViewModel::Partial
 
       def show
-        cell card_size, model
+        cell card_size, model, options
       end
 
       private

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_cell.rb
@@ -6,7 +6,7 @@ module Decidim
     # the default size is the Medium Card (:m)
     class ProcessCell < Decidim::ViewModel
       def show
-        cell card_size, model
+        cell card_size, model, options
       end
 
       private

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_group_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_group_cell.rb
@@ -6,7 +6,7 @@ module Decidim
     # the default size is the Medium Card (:m)
     class ProcessGroupCell < Decidim::ViewModel
       def show
-        cell card_size, model
+        cell card_size, model, options
       end
 
       private

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_cell.rb
@@ -14,7 +14,7 @@ module Decidim
       delegate :user_signed_in?, to: :parent_controller
 
       def show
-        cell card_size, model, @options
+        cell card_size, model, options
       end
 
       private


### PR DESCRIPTION
#### :tophat: What? Why?
When using the `card_for(resource)` helper to render a card, it may render a cell that redirects to another one based on the size. This redirection used to lose the options, so they were not really working.

This PR fixes that.

#### :pushpin: Related Issues
- Fixes #3912

#### :clipboard: Subtasks
None