### PR TITLE
Use "supports" as proposal exports column name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@
 - **decidim**: Correctly pass cells options to sized card cells [\#4017](https://github.com/decidim/decidim/pull/4017)
 - **decidim-initiatives**: Only show initiative types fomr the current tenant [\#3887](https://github.com/decidim/decidim/pull/3887)
 - **decidim-core**: Allows users with admin access to preview unpublished components [\#4016](https://github.com/decidim/decidim/pull/4016)
+- **decidim-proposals**: Rename "votes" column to "supports" when exporting proposals [\#4018](https://github.com/decidim/decidim/pull/4018)
 
 **Removed**:
 

--- a/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
+++ b/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
@@ -26,7 +26,7 @@ module Decidim
           },
           title: @proposal.title,
           body: @proposal.body,
-          votes: @proposal.proposal_votes_count,
+          supports: @proposal.proposal_votes_count,
           comments: @proposal.comments.count,
           published_at: @proposal.published_at,
           url: url,

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
@@ -49,8 +49,8 @@ module Decidim
           expect(serialized).to include(body: proposal.body)
         end
 
-        it "serializes the amount of votes" do
-          expect(serialized).to include(votes: proposal.proposal_votes_count)
+        it "serializes the amount of supports" do
+          expect(serialized).to include(supports: proposal.proposal_votes_count)
         end
 
         it "serializes the amount of comments" do


### PR DESCRIPTION
#### :tophat: What? Why?
The proposal exports feature was using a "votes" column. It will now use "supports" as title instead.

#### :pushpin: Related Issues
- Fixes #3718

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/gdarpbt.png)
