### PR TITLE
Select parent assembly when the assembly is created or edited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 
 **Added**:
 
+- **decidim-assemblies**: Add the posibility to select the parent assembly when the assembly is created or edited [\#4022](https://github.com/decidim/decidim/pull/4022)
 - **decidim-admin**:Add link to user profile and link to conversation from admin space. [\#3995](https://github.com/decidim/decidim/pull/3995)
 - **decidim-core**:Add compression settings to image uploader [\#3984](https://github.com/decidim/decidim/pull/3984)
 - **decidim-budgets**: Import accepted proposals to projects. [\#3873](https://github.com/decidim/decidim/pull/3873)

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
@@ -9,6 +9,8 @@ module Decidim
         helper_method :current_assembly, :parent_assembly, :parent_assemblies, :current_participatory_space
         layout "decidim/admin/assemblies"
 
+        before_action :set_all_assemblies, except: [:index, :destroy]
+
         def index
           enforce_permission_to :read, :assembly_list
           @assemblies = collection
@@ -77,6 +79,10 @@ module Decidim
         end
 
         private
+
+        def set_all_assemblies
+          @all_assemblies = OrganizationAssemblies.new(current_user.organization).query
+        end
 
         def current_assembly
           scope = OrganizationAssemblies.new(current_user.organization).query

--- a/decidim-assemblies/app/models/decidim/assembly.rb
+++ b/decidim-assemblies/app/models/decidim/assembly.rb
@@ -115,6 +115,10 @@ module Decidim
       return false if private_space? && is_transparent?
     end
 
+    def translated_title
+      Decidim::AssemblyPresenter.new(self).translated_title
+    end
+
     private
 
     # When an assembly changes their parent, we need to update the parents_path attribute

--- a/decidim-assemblies/app/presenters/decidim/assembly_presenter.rb
+++ b/decidim-assemblies/app/presenters/decidim/assembly_presenter.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Decidim
+  #
+  # Decorator for areas
+  #
+  class AssemblyPresenter < SimpleDelegator
+    include Decidim::TranslationsHelper
+
+    def translated_title
+      @translated_title ||= translated_attribute title
+    end
+  end
+end

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
@@ -1,6 +1,6 @@
 <%= javascript_include_tag "decidim/slug_form" %>
 
-<%= form.hidden_field :parent_id, value: @form.parent_id %>
+<%#= form.hidden_field :parent_id, value: @form.parent_id %>
 
 <div class="card">
   <div class="card-divider">
@@ -14,6 +14,10 @@
 
     <div class="row column">
       <%= form.translated :text_field, :subtitle %>
+    </div>
+
+    <div class="row column">
+      <%= form.select :parent_id, options_from_collection_for_select(@all_assemblies, :id, :translated_title, selected: current_assembly.try(:parent_id)), include_blank: t(".select_parent_assembly") %>
     </div>
 
     <div class="row">

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
@@ -14,9 +14,13 @@
       <%= form.translated :text_field, :subtitle %>
     </div>
 
-    <div class="row column">
-      <%= form.select :parent_id, options_from_collection_for_select(@all_assemblies, :id, :translated_title, selected: current_assembly.try(:parent_id)), include_blank: t(".select_parent_assembly") %>
-    </div>
+    <% if params[:parent_id].present? %>
+      <%= form.hidden_field :parent_id, value: @form.parent_id %>
+    <% else %>
+      <div class="row column">
+        <%= form.select :parent_id, options_from_collection_for_select(@all_assemblies, :id, :translated_title, selected: current_assembly.try(:parent_id)), include_blank: t(".select_parent_assembly") %>
+      </div>
+    <% end %>
 
     <div class="row">
       <div class="columns xlarge-6 slug">

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
@@ -1,7 +1,5 @@
 <%= javascript_include_tag "decidim/slug_form" %>
 
-<%#= form.hidden_field :parent_id, value: @form.parent_id %>
-
 <div class="card">
   <div class="card-divider">
     <h2 class="card-title"><%= t "assemblies.form.title", scope: "decidim.admin" %></h2>

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -32,6 +32,7 @@ en:
         is_transparent: Is transparent
         local_area: Organization area
         meta_scope: Scope metadata
+        parent_id: Parent assembly
         participatory_processes_ids: Related Participatory processes
         participatory_scope: What is decided
         participatory_structure: How is it decided
@@ -218,6 +219,7 @@ en:
             select_a_created_by: Select a created by
             select_an_area: Select an Area
             select_an_assembly_type: Select an assembly type
+            select_parent_assembly: Select parent assembly
             slug_help: 'URL slugs are used to generate the URLs that point to this assembly. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
             social_handlers: Social
         assembly_copies:

--- a/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
@@ -24,8 +24,8 @@ FactoryBot.define do
     target { Decidim::Faker::Localized.sentence(3) }
     participatory_scope { Decidim::Faker::Localized.sentence(1) }
     participatory_structure { Decidim::Faker::Localized.sentence(2) }
-    show_statistics true
-    private_space false
+    show_statistics { true }
+    private_space { false }
     purpose_of_action { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(2) } }
     composition { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(2) } }
     assembly_type { "others" }
@@ -38,7 +38,7 @@ FactoryBot.define do
     closing_date { 2.months.from_now.at_midnight }
     closing_date_reason { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(2) } }
     internal_organisation { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(2) } }
-    is_transparent true
+    is_transparent { true }
     special_features { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(2) } }
     twitter_handler { "others" }
     facebook_handler { "others" }
@@ -47,11 +47,11 @@ FactoryBot.define do
     github_handler { "others" }
 
     trait :promoted do
-      promoted true
+      promoted { true }
     end
 
     trait :unpublished do
-      published_at nil
+      published_at { nil }
     end
 
     trait :published do
@@ -66,7 +66,7 @@ FactoryBot.define do
   factory :assembly_user_role, class: "Decidim::AssemblyUserRole" do
     user
     assembly { create :assembly, organization: user.organization }
-    role "admin"
+    role { "admin" }
   end
 
   factory :assembly_admin, parent: :user, class: "Decidim::User" do

--- a/decidim-assemblies/spec/system/admin/admin_manages_assemblies_with_parent_selector_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assemblies_with_parent_selector_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin manages assemblies with parent selector", type: :system do
+  include_context "when admin administrating an assembly"
+
+  let(:image1_filename) { "city.jpeg" }
+  let(:image1_path) { Decidim::Dev.asset(image1_filename) }
+  let(:image2_filename) { "city2.jpeg" }
+  let(:image2_path) { Decidim::Dev.asset(image2_filename) }
+  let!(:set_all_assemblies) { Decidim::Assemblies::OrganizationAssemblies.new(organization).query }
+
+  context "when params[:parent_id] not present" do
+    before do
+      switch_to_host(organization.host)
+      login_as user, scope: :user
+      visit decidim_admin_assemblies.assemblies_path
+      click_link "New assembly"
+    end
+
+    let!(:params) do
+      {
+        parent_id: nil
+      }
+    end
+
+    it "creates a new assembly" do
+      within ".new_assembly" do
+        fill_in_i18n(
+          :assembly_title,
+          "#assembly-title-tabs",
+          en: "My assembly",
+          es: "Mi proceso participativo",
+          ca: "El meu procés participatiu"
+        )
+        fill_in_i18n(
+          :assembly_subtitle,
+          "#assembly-subtitle-tabs",
+          en: "Subtitle",
+          es: "Subtítulo",
+          ca: "Subtítol"
+        )
+        fill_in_i18n_editor(
+          :assembly_short_description,
+          "#assembly-short_description-tabs",
+          en: "Short description",
+          es: "Descripción corta",
+          ca: "Descripció curta"
+        )
+        fill_in_i18n_editor(
+          :assembly_description,
+          "#assembly-description-tabs",
+          en: "A longer description",
+          es: "Descripción más larga",
+          ca: "Descripció més llarga"
+        )
+
+        select set_all_assemblies.first.title["en"], from: :assembly_parent_id
+
+        fill_in :assembly_slug, with: "slug"
+        fill_in :assembly_hashtag, with: "#hashtag"
+        attach_file :assembly_hero_image, image1_path
+        attach_file :assembly_banner_image, image2_path
+
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_admin_callout("successfully")
+
+      within ".container" do
+        expect(page).to have_current_path decidim_admin_assemblies.assemblies_path(parent_id: set_all_assemblies.first&.id)
+        expect(page).to have_content("My assembly")
+      end
+    end
+  end
+
+  context "when managing child assemblies" do
+    let!(:parent_assembly) { create :assembly, organization: organization }
+    let!(:child_assembly) { create :assembly, organization: organization, parent: parent_assembly }
+    let(:assembly) { child_assembly }
+    let(:image1_filename) { "city.jpeg" }
+    let(:image1_path) { Decidim::Dev.asset(image1_filename) }
+    let(:image2_filename) { "city2.jpeg" }
+    let(:image2_path) { Decidim::Dev.asset(image2_filename) }
+
+    before do
+      switch_to_host(organization.host)
+      login_as user, scope: :user
+      visit decidim_admin_assemblies.assemblies_path
+      within find("tr", text: translated(parent_assembly.title)) do
+        click_link "Assemblies"
+      end
+      click_link "New assembly"
+    end
+
+    it "creates a new assembly" do
+      within ".new_assembly" do
+        fill_in_i18n(
+          :assembly_title,
+          "#assembly-title-tabs",
+          en: "My assembly",
+          es: "Mi proceso participativo",
+          ca: "El meu procés participatiu"
+        )
+        fill_in_i18n(
+          :assembly_subtitle,
+          "#assembly-subtitle-tabs",
+          en: "Subtitle",
+          es: "Subtítulo",
+          ca: "Subtítol"
+        )
+        fill_in_i18n_editor(
+          :assembly_short_description,
+          "#assembly-short_description-tabs",
+          en: "Short description",
+          es: "Descripción corta",
+          ca: "Descripció curta"
+        )
+        fill_in_i18n_editor(
+          :assembly_description,
+          "#assembly-description-tabs",
+          en: "A longer description",
+          es: "Descripción más larga",
+          ca: "Descripció més llarga"
+        )
+
+        fill_in :assembly_slug, with: "slug"
+        fill_in :assembly_hashtag, with: "#hashtag"
+        attach_file :assembly_hero_image, image1_path
+        attach_file :assembly_banner_image, image2_path
+
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_admin_callout("successfully")
+
+      within ".container" do
+        expect(page).to have_current_path decidim_admin_assemblies.assemblies_path(parent_id: parent_assembly&.id)
+        expect(page).to have_content("My assembly")
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Add the posibility to select the parent assembly when the assembly is created or edited. This is done, because in the assemblies created previously a parent can be selected, since it was not possible.

#### :pushpin: Related Issues
- Related to #2708 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] change hidden field to select field parent_id on assembly form.  


### :camera: Screenshots (optional)
![Description](URL)
