### PR TITLE
Fix hastag display on processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 
 **Fixed**:
 
+- **decidim-participatory_processes**: Fix hastag display on participatory processes. [\#4024](https://github.com/decidim/decidim/pull/4024)
 - **decidim-core**: Fix day date translation on profile notifications. [\#3994](https://github.com/decidim/decidim/pull/3994)
 - **decidim-accountability**: Fix accountability progress to be between 0 and 100 if provided. [\#3952](https://github.com/decidim/decidim/pull/3952)
 - **decidim-initiatives**: Fix initiative edition when state is not published. [\#3930](https://github.com/decidim/decidim/pull/3930)

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_m/tags.erb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_m/tags.erb
@@ -1,6 +1,8 @@
-<%= link_to(
-  "##{model.hashtag}",
-  "https://twitter.com/hashtag/#{model.hashtag}",
-  class: "card__text--category",
-  target: "_blank"
- ) %>
+<% if model.hashtag.present? %>
+  <%= link_to(
+    "##{model.hashtag}",
+    "https://twitter.com/hashtag/#{model.hashtag}",
+    class: "card__text--category",
+    target: "_blank"
+   ) %>
+<% end %>

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -5,6 +5,7 @@ require "spec_helper"
 describe "Participatory Processes", type: :system do
   let(:organization) { create(:organization) }
   let(:show_statistics) { true }
+  let(:hashtag) { true }
   let(:base_process) do
     create(
       :participatory_process,
@@ -264,6 +265,14 @@ describe "Participatory Processes", type: :system do
 
         it "the stats for those components are not visible" do
           expect(page).to have_no_content("3 PROPOSALS")
+        end
+      end
+
+      context "and the process doesn't have hashtag" do
+        let(:hashtag) { false }
+
+        it "the stats for those components are not visible" do
+          expect(page).to have_no_content("#")
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Hashtags on Participatory Processes should only appear when the field is filled by the admin.

#### :pushpin: Related Issues
- Fixes #4023

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/20232956/44456167-27a2ed80-a600-11e8-896a-a717e9b3c9a6.png)

