### PR TITLE
Fix CollaborativeDraft geocoding spec

### DIFF
--- a/decidim-proposals/spec/commands/decidim/proposals/update_collaborative_draft_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/update_collaborative_draft_spec.rb
@@ -119,10 +119,7 @@ module Decidim
                 let(:address) { "Carrer Pare Llaurador 113, baixos, 08224 Terrassa" }
 
                 before do
-                  Geocoder::Lookup::Test.add_stub(
-                    address,
-                    [{ "latitude" => latitude, "longitude" => longitude }]
-                  )
+                  stub_geocoding(address, [latitude, longitude])
                 end
 
                 it "sets the latitude and longitude" do


### PR DESCRIPTION
#### :tophat: What? Why?

Once merged the Collaborative draft MVP PR #3109 the test that passed, was failing due to #3999, this PR fixes it.

#### :pushpin: Related Issues
- Related to #3109 
- Related to #3999 
