### PR TITLE
Move Collaborative Draft checkbox upwards on admin

### DIFF
--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -32,13 +32,13 @@ Decidim.register_component(:proposals) do |component|
     settings.attribute :geocoding_enabled, type: :boolean, default: false
     settings.attribute :attachments_allowed, type: :boolean, default: false
     settings.attribute :resources_permissions_enabled, type: :boolean, default: true
+    settings.attribute :collaborative_drafts_enabled, type: :boolean, default: false
     settings.attribute :announcement, type: :text, translated: true, editor: true
     settings.attribute :new_proposal_help_text, type: :text, translated: true, editor: true
     settings.attribute :proposal_wizard_step_1_help_text, type: :text, translated: true, editor: true
     settings.attribute :proposal_wizard_step_2_help_text, type: :text, translated: true, editor: true
     settings.attribute :proposal_wizard_step_3_help_text, type: :text, translated: true, editor: true
     settings.attribute :proposal_wizard_step_4_help_text, type: :text, translated: true, editor: true
-    settings.attribute :collaborative_drafts_enabled, type: :boolean, default: false
   end
 
   component.settings(:step) do |settings|


### PR DESCRIPTION
#### :tophat: What? Why?

On admin dashboard, the checkbox to enable/disable Collaboritve Drafts appeared bellow the text areas.

This PR moves upwards the checkbox, with the other checkbox of the Proposal Component.

#### :pushpin: Related Issues
- Related to #3049
- Related to PR #3109

#### :clipboard: Subtasks

### :camera: Screenshots (optional)

Before:

![screenshot from 2018-08-29 11-33-49](https://user-images.githubusercontent.com/210216/44779315-795af300-ab7f-11e8-8c87-6b3d9e948c31.png)

After:

![screenshot from 2018-08-29 11-27-13](https://user-images.githubusercontent.com/210216/44779262-4c0e4500-ab7f-11e8-8676-16ae7ae8b043.png)
