### PR TITLE
Fix rubocop offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1197,9 +1197,6 @@ Performance/RedundantMerge:
 Metrics/BlockLength:
   Enabled: false
 
-FactoryBot/StaticAttributeDefinedDynamically:
-  Enabled: false
-
 RSpec/BeforeAfterAll:
   Enabled: true
 

--- a/decidim-accountability/spec/system/admin_manages_accountability_spec.rb
+++ b/decidim-accountability/spec/system/admin_manages_accountability_spec.rb
@@ -19,18 +19,18 @@ describe "Admin manages accountability", type: :system do
   end
 
   describe "child results" do
-    it_behaves_like "manage child results"
-
     before do
       click_link translated(result.title)
     end
+
+    it_behaves_like "manage child results"
   end
 
   describe "statuses" do
-    it_behaves_like "manage statuses"
-
     before do
       click_link "Statuses"
     end
+
+    it_behaves_like "manage statuses"
   end
 end

--- a/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
@@ -35,17 +35,17 @@ module Decidim
         end
         let(:command) { described_class.new(form, verified_email) }
 
+        before do
+          stub_request(:get, "http://www.example.com/foo.jpg")
+            .to_return(status: 200, body: File.read("spec/assets/avatar.jpg"), headers: { "Content-Type" => "image/jpeg" })
+        end
+
         describe "when the form oauth_signature cannot ve verified" do
           let(:oauth_signature) { "1234" }
 
           it "raises a InvalidOauthSignature exception" do
             expect { command.call }.to raise_error InvalidOauthSignature
           end
-        end
-
-        before do
-          stub_request(:get, "http://www.example.com/foo.jpg")
-            .to_return(status: 200, body: File.read("spec/assets/avatar.jpg"), headers: { "Content-Type" => "image/jpeg" })
         end
 
         context "when the form is not valid" do

--- a/decidim-core/spec/helpers/decidim/action_authorization_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/action_authorization_helper_spec.rb
@@ -26,20 +26,20 @@ module Decidim
           let(:authorized) { false }
 
           it "renders a widget toggling the authorization modal" do
-            is_expected.not_to include(path)
-            is_expected.to include('data-open="authorizationModal"')
-            is_expected.to include("data-open-url=\"/authorization_modals/#{action}/f/#{component.id}\"")
-            is_expected.to include(*params[:widget_parts])
+            expect(subject).not_to include(path)
+            expect(subject).to include('data-open="authorizationModal"')
+            expect(subject).to include("data-open-url=\"/authorization_modals/#{action}/f/#{component.id}\"")
+            expect(subject).to include(*params[:widget_parts])
           end
 
           context "when called with a resource" do
             let(:resource) { create(:dummy_resource, component: component) }
 
             it "renders a widget toggling the authorization modal" do
-              is_expected.not_to include(path)
-              is_expected.to include('data-open="authorizationModal"')
-              is_expected.to include("data-open-url=\"/authorization_modals/#{action}/f/#{component.id}/#{resource.resource_manifest.name}/#{resource.id}\"")
-              is_expected.to include(*params[:widget_parts])
+              expect(subject).not_to include(path)
+              expect(subject).to include('data-open="authorizationModal"')
+              expect(subject).to include("data-open-url=\"/authorization_modals/#{action}/f/#{component.id}/#{resource.resource_manifest.name}/#{resource.id}\"")
+              expect(subject).to include(*params[:widget_parts])
             end
           end
         end
@@ -50,9 +50,9 @@ module Decidim
 
       context "when #{params[:has_action] ? "the action is authorized" : "the user is logged"}" do
         it "renders a regular widget" do
-          is_expected.not_to include("data-open")
-          is_expected.to include(path)
-          is_expected.to include(*params[:widget_parts])
+          expect(subject).not_to include("data-open")
+          expect(subject).to include(path)
+          expect(subject).to include(*params[:widget_parts])
         end
       end
 
@@ -60,9 +60,9 @@ module Decidim
         let(:user) { nil }
 
         it "renders a widget toggling the login modal" do
-          is_expected.not_to include(path)
-          is_expected.to include('data-open="loginModal"')
-          is_expected.to include(*params[:widget_parts])
+          expect(subject).not_to include(path)
+          expect(subject).to include('data-open="loginModal"')
+          expect(subject).to include(*params[:widget_parts])
         end
       end
     end

--- a/decidim-core/spec/models/decidim/scope_spec.rb
+++ b/decidim-core/spec/models/decidim/scope_spec.rb
@@ -63,12 +63,12 @@ module Decidim
 
       it "don't allows two scopes cycles" do
         scope.parent = subscope
-        is_expected.to be_invalid
+        expect(subject).to be_invalid
       end
 
       it "don't allows three scopes cycles" do
         scope.parent = subsubscope
-        is_expected.to be_invalid
+        expect(subject).to be_invalid
       end
     end
 

--- a/decidim-core/spec/presenters/decidim/user_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/user_presenter_spec.rb
@@ -50,7 +50,7 @@ module Decidim
       subject { described_class.new(user).display_mention }
 
       it do
-        is_expected.to \
+        expect(subject).to \
           have_link(user.nickname, href: "/profiles/#{user.nickname}") &
           have_selector(".user-mention")
       end

--- a/decidim-core/spec/system/notifications_spec.rb
+++ b/decidim-core/spec/system/notifications_spec.rb
@@ -79,12 +79,12 @@ describe "Notifications", type: :system do
   end
 
   context "with notifications" do
-    it "shows the notifications" do
-      expect(page).to have_selector(".card.card--widget")
-    end
-
     before do
       page.visit decidim.notifications_path
+    end
+
+    it "shows the notifications" do
+      expect(page).to have_selector(".card.card--widget")
     end
 
     context "when setting a single notification as read" do

--- a/decidim-debates/spec/system/admin_manages_debates_spec.rb
+++ b/decidim-debates/spec/system/admin_manages_debates_spec.rb
@@ -6,12 +6,12 @@ describe "Admin manages debates", type: :system do
   let(:manifest_name) { "debates" }
 
   include_context "when managing a component as an admin"
-  it_behaves_like "manage debates"
-  it_behaves_like "manage announcements"
-
   before do
     switch_to_host(organization.host)
     login_as user, scope: :user
     visit_component_admin
   end
+
+  it_behaves_like "manage debates"
+  it_behaves_like "manage announcements"
 end

--- a/decidim-meetings/spec/models/registration_spec.rb
+++ b/decidim-meetings/spec/models/registration_spec.rb
@@ -31,7 +31,7 @@ module Decidim::Meetings
         it "is invalid" do
           registration.code = code
 
-          is_expected.not_to be_valid
+          expect(subject).not_to be_valid
         end
       end
 
@@ -43,7 +43,7 @@ module Decidim::Meetings
         it "is invalid" do
           registration.code = code
 
-          is_expected.to be_valid
+          expect(subject).to be_valid
         end
       end
     end

--- a/decidim-participatory_processes/spec/system/admin/participatory_process_admin_manages_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/participatory_process_admin_manages_participatory_processes_spec.rb
@@ -5,14 +5,14 @@ require "spec_helper"
 describe "Participatory process admin manages participatory processes", type: :system do
   include_context "when admin administrating a participatory process"
 
-  it_behaves_like "manage processes examples"
-  it_behaves_like "manage processes announcements"
-
   before do
     switch_to_host(organization.host)
     login_as user, scope: :user
     visit decidim_admin_participatory_processes.participatory_processes_path
   end
+
+  it_behaves_like "manage processes examples"
+  it_behaves_like "manage processes announcements"
 
   it "cannot create a new participatory_process" do
     expect(page).to have_no_selector(".actions .new")

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -133,7 +133,7 @@ FactoryBot.define do
 
     trait :with_threshold_per_proposal do
       transient do
-        threshold_per_proposal 1
+        threshold_per_proposal { 1 }
       end
 
       settings do
@@ -261,9 +261,9 @@ FactoryBot.define do
 
   factory :collaborative_draft, class: "Decidim::Proposals::CollaborativeDraft" do
     transient do
-      users nil
+      users { nil }
       # user_groups correspondence to users is by sorting order
-      user_groups []
+      user_groups { [] }
     end
 
     title { Faker::Lorem.sentence }
@@ -283,16 +283,16 @@ FactoryBot.define do
     end
 
     trait :published do
-      state "published"
+      state { "published" }
       published_at { Time.current }
     end
 
     trait :open do
-      state "open"
+      state { "open" }
     end
 
     trait :withdrawn do
-      state "withdrawn"
+      state { "withdrawn" }
     end
   end
 end

--- a/decidim-proposals/spec/system/collaborative_drafts_spec.rb
+++ b/decidim-proposals/spec/system/collaborative_drafts_spec.rb
@@ -153,15 +153,15 @@ describe "Explore Collaborative Drafts", versioning: true, type: :system do
             click_button "Publish"
           end
 
+          after do
+            click_button "Publish as a Proposal"
+          end
+
           it "shows the a modal" do
             within "#publish-irreversible-action-modal" do
               expect(page).to have_css("h3", text: "The following action is irreversible")
               expect(page).to have_css("button", text: "Publish as a Proposal")
             end
-          end
-
-          after do
-            click_button "Publish as a Proposal"
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
Rubocop got unintentionally updated after the last version bump (why Bundler, why). This fixes the codebase so it complies with the latest requirements.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*
