### PR TITLE
Fix hero content block migration when no welcome_text is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 **Fixed**:
 
+- **decidim-core**: Fix hero content block migration [\#4061](https://github.com/decidim/decidim/pull/4061)
+
 **Removed**:
 
 ## Previous versions

--- a/decidim-core/db/migrate/20180810092428_move_organization_fields_to_hero_content_block.rb
+++ b/decidim-core/db/migrate/20180810092428_move_organization_fields_to_hero_content_block.rb
@@ -9,7 +9,7 @@ class MoveOrganizationFieldsToHeroContentBlock < ActiveRecord::Migration[5.2]
     Decidim::Organization.find_each do |organization|
       content_block = Decidim::ContentBlock.find_by(organization: organization, scope: :homepage, manifest_name: :hero)
       settings = {}
-      welcome_text = organization.welcome_text
+      welcome_text = organization.welcome_text || {}
       settings = welcome_text.inject(settings) { |acc, (k, v)| acc.update("welcome_text_#{k}" => v) }
 
       content_block.settings = settings


### PR DESCRIPTION
#### :tophat: What? Why?
When the organization has no `welcome_text` set, the migration to migrate the hero content block breaks.

This PR fixes this problem.

#### :pushpin: Related Issues
- Related to #3968 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

