### PR TITLE
Fix migration order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 **Fixed**:
 
 - **decidim-core**: Fix hero content block migration [\#4061](https://github.com/decidim/decidim/pull/4061)
+- **decidim-core**: Fix default content block creation migration [\#4084](https://github.com/decidim/decidim/pull/4084)
 
 **Removed**:
 

--- a/decidim-core/db/migrate/20180730071851_add_core_content_blocks.rb
+++ b/decidim-core/db/migrate/20180730071851_add_core_content_blocks.rb
@@ -4,9 +4,25 @@ class AddCoreContentBlocks < ActiveRecord::Migration[5.2]
   class Organization < ApplicationRecord
     self.table_name = :decidim_organizations
   end
+
+  class ContentBlock < ApplicationRecord
+    self.table_name = :decidim_content_blocks
+  end
+
   def change
-    Organization.find_each do |organization|
-      Decidim::System::CreateDefaultContentBlocks.call(organization)
+    default_blocks = Decidim.content_blocks.for(:homepage).select(&:default)
+
+    Organization.pluck(:id).each do |organization_id|
+      default_blocks.each_with_index do |manifest, index|
+        weight = (index + 1) * 10
+        ContentBlock.create(
+          decidim_organization_id: organization_id,
+          weight: weight,
+          scope: :homepage,
+          manifest_name: manifest.name,
+          published_at: Time.current
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Version 0.14.0 has an error on the upgrade path. This PR should fix it.

#### :pushpin: Related Issues
- Fixes #4068

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

