### PR TITLE
Remove removed cop from rubocop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1197,9 +1197,6 @@ Performance/RedundantMerge:
 Metrics/BlockLength:
   Enabled: false
 
-FactoryBot/StaticAttributeDefinedDynamically:
-  Enabled: false
-
 RSpec/BeforeAfterAll:
   Enabled: true
 


### PR DESCRIPTION
#### :tophat: What? Why?

On our application we follow the code style for the decidim version we're currently using, so we inherit the rubocop configuration from the corresponding stable branch in the decidim repo. This fixes a warning about a cop that has been removed.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
_None_.
