### PR TITLE
Fix bootsnap warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@
 - **decidim-core**: Adds the *followers* badge. [\#4089](https://github.com/decidim/decidim/pull/4089)
 - **decidim-debates**: Adds the *commented debates* badge. [\#4089](https://github.com/decidim/decidim/pull/4089)
 - **decidim-meetings**: Add upcoming events content block and page. [\#3987](https://github.com/decidim/decidim/pull/3987)
+- **decidim-generators**: Enable one more bootsnap optimization in test apps when coverage tracking is not enabled [\#4098](https://github.com/decidim/decidim/pull/4098)
 
 **Changed**:
 
 **Fixed**:
 
 - **decidim-core**: Fix hero content block migration [\#4061](https://github.com/decidim/decidim/pull/4061)
+- **decidim-generators**: Bootsnap warnings when generating test applications [\#4098](https://github.com/decidim/decidim/pull/4098)
 
 **Removed**:
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -718,4 +718,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.3
+   1.16.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,7 +255,7 @@ GEM
       parser (>= 2.4)
       smart_properties
     bindex (0.5.0)
-    bootsnap (1.3.0)
+    bootsnap (1.3.2)
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (10.0.2)

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -718,4 +718,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.3
+   1.16.4

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -255,7 +255,7 @@ GEM
       parser (>= 2.4)
       smart_properties
     bindex (0.5.0)
-    bootsnap (1.3.0)
+    bootsnap (1.3.2)
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (10.0.2)

--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -131,7 +131,7 @@ module Decidim
             load_path_cache: true,
             autoload_paths_cache: true,
             disable_trace: false,
-            compile_cache_iseq: false,
+            compile_cache_iseq: !ENV["SIMPLECOV"],
             compile_cache_yaml: true
           )
         RUBY

--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -130,7 +130,7 @@ module Decidim
             development_mode: env == "development",
             load_path_cache: true,
             autoload_paths_cache: true,
-            disable_trace: true,
+            disable_trace: false,
             compile_cache_iseq: false,
             compile_cache_yaml: true
           )

--- a/decidim_app-design/Gemfile
+++ b/decidim_app-design/Gemfile
@@ -1,5 +1,3 @@
 # frozen_string_literal: true
 
-source "https://rubygems.org"
-
 eval_gemfile "../Gemfile"

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -718,4 +718,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.3
+   1.16.4

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -255,7 +255,7 @@ GEM
       parser (>= 2.4)
       smart_properties
     bindex (0.5.0)
-    bootsnap (1.3.0)
+    bootsnap (1.3.2)
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (10.0.2)


### PR DESCRIPTION
#### :tophat: What? Why?

I was getting "'This method is not allowed with this Ruby version' " warnings when generating the test application. This PR should remove them.

Also I took the chance of enabling one more setting that can be enabled unless we're tracking code coverage.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
_None_.
