### PR TITLE
[backport] Fix hashtags on title when showing proposals related

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@
 
 **Fixed**:
 
+- **decidim-proposals**: Fix hashtags on title when showing proposals related. [\4107](https://github.com/decidim/decidim/pull/4107)
 - **decidim-participatory_processes**: Fix hastag display on participatory processes. [\#4024](https://github.com/decidim/decidim/pull/4024)
 - **decidim-core**: Fix day date translation on profile notifications. [\#3994](https://github.com/decidim/decidim/pull/3994)
 - **decidim-accountability**: Fix accountability progress to be between 0 and 100 if provided. [\#3952](https://github.com/decidim/decidim/pull/3952)

--- a/decidim-accountability/app/controllers/decidim/accountability/admin/results_controller.rb
+++ b/decidim-accountability/app/controllers/decidim/accountability/admin/results_controller.rb
@@ -5,6 +5,7 @@ module Decidim
     module Admin
       # This controller allows an admin to manage results from a Participatory Process
       class ResultsController < Admin::ApplicationController
+        include Decidim::ApplicationHelper
         helper_method :results, :parent_result, :parent_results, :statuses
 
         def new
@@ -83,7 +84,7 @@ module Decidim
               else
                 query = query.where("title ilike ?", "%#{params[:term]}%")
               end
-              render json: query.all.collect { |p| [p.title, p.id] }
+              render json: query.all.collect { |p| [present(p).title, p.id] }
             end
           end
         end

--- a/decidim-accountability/app/views/decidim/accountability/admin/results/_form.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/results/_form.html.erb
@@ -56,7 +56,7 @@
       <% if @form.proposals %>
         <% picker_options = { id: "decidim_accountability_proposals", class: "picker-multiple", name: "result[proposal_ids]", multiple: true }
         prompt_params= { url: proposals_results_path(current_component, format: :html), text: t(".add_proposal") } %>
-        <%= form.data_picker(:proposals, picker_options, prompt_params) {|item| { url:proposals_results_path(current_component, format: :json), text: "##{item.id}- #{item.title}" }} %>
+        <%= form.data_picker(:proposals, picker_options, prompt_params) {|item| { url:proposals_results_path(current_component, format: :json), text: "##{item.id}- #{present(item).title}" }} %>
       <% end %>
     </div>
 

--- a/decidim-budgets/app/forms/decidim/budgets/admin/project_form.rb
+++ b/decidim-budgets/app/forms/decidim/budgets/admin/project_form.rb
@@ -7,6 +7,7 @@ module Decidim
       class ProjectForm < Decidim::Form
         include TranslatableAttributes
         include TranslationsHelper
+        include Decidim::ApplicationHelper
 
         translatable_attribute :title, String
         translatable_attribute :description, String
@@ -36,7 +37,9 @@ module Decidim
         end
 
         def proposals
-          @proposals ||= Decidim.find_resource_manifest(:proposals).try(:resource_scope, current_component)&.order(title: :asc)&.pluck(:title, :id)
+          @proposals ||= Decidim.find_resource_manifest(:proposals).try(:resource_scope, current_component)
+                         &.order(title: :asc)
+                         &.map { |proposal| [present(proposal).title, proposal.id] }
         end
 
         # Finds the Category from the decidim_category_id.

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
@@ -35,7 +35,7 @@ module Decidim
       end
 
       def description
-        truncate(present(model).html_body, length: 100)
+        truncate(present(model).body, length: 100)
       end
 
       def badge_classes

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/application_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/application_controller.rb
@@ -9,6 +9,7 @@ module Decidim
       # Note that it inherits from `Decidim::Admin::Components::BaseController`, which
       # override its layout and provide all kinds of useful methods.
       class ApplicationController < Decidim::Admin::Components::BaseController
+        helper Decidim::ApplicationHelper
       end
     end
   end

--- a/decidim-proposals/app/events/decidim/proposals/proposal_mentioned_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/proposal_mentioned_event.rb
@@ -3,12 +3,14 @@
 module Decidim
   module Proposals
     class ProposalMentionedEvent < Decidim::Events::SimpleEvent
+      include Decidim::ApplicationHelper
+
       i18n_attributes :mentioned_proposal_title
 
       private
 
       def mentioned_proposal_title
-        mentioned_proposal.title
+        present(mentioned_proposal).title
       end
 
       def mentioned_proposal

--- a/decidim-proposals/app/helpers/decidim/proposals/map_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/map_helper.rb
@@ -4,13 +4,14 @@ module Decidim
   module Proposals
     # This helper include some methods for rendering proposals dynamic maps.
     module MapHelper
+      include Decidim::ApplicationHelper
       # Serialize a collection of geocoded proposals to be used by the dynamic map component
       #
       # geocoded_proposals - A collection of geocoded proposals
       def proposals_data_for_map(geocoded_proposals)
         geocoded_proposals.map do |proposal|
-          proposal.slice(:latitude, :longitude, :address).merge(title: proposal.title,
-                                                                body: truncate(proposal.body, length: 100),
+          proposal.slice(:latitude, :longitude, :address).merge(title: present(proposal).title,
+                                                                body: truncate(present(proposal).body, length: 100),
                                                                 icon: icon("proposals", width: 40, height: 70, remove_icon_class: true),
                                                                 link: proposal_path(proposal))
         end

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposal_answers/edit.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposal_answers/edit.html.erb
@@ -2,7 +2,7 @@
 <%= decidim_form_for(@form, url: proposal_proposal_answer_path(proposal, @form), html: { class: "form edit_proposal_answer" }) do |f| %>
   <div class="card">
     <div class="card-divider">
-      <h2 class="card-title"><%= t ".title", title: proposal.title %></h2>
+      <h2 class="card-title"><%= t ".title", title: present(proposal).title %></h2>
     </div>
 
     <div class="card-section">

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
@@ -6,7 +6,7 @@
     <%= proposal.id %><br />
   </td>
   <td>
-    <%= Decidim::Proposals::ProposalPresenter.new(proposal).title %><br />
+    <%= present(proposal).title %><br />
   </td>
   <td>
     <% if proposal.category %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/shared/_info_proposal.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/shared/_info_proposal.html.erb
@@ -2,13 +2,13 @@
   <div class="card-divider">
     <h2 class="card-title">
       <%= link_to "#{t ".proposals"} > ", proposals_path %>
-      <%= Decidim::Proposals::ProposalPresenter.new(proposal).title %>
+      <%= present(proposal).title %>
     </h2>
   </div>
 
   <div class="card-section">
     <div class="row column">
-      <strong><%= t ".body" %>: </strong>  <%= Decidim::Proposals::ProposalPresenter.new(proposal).body %>
+      <strong><%= t ".body" %>: </strong>  <%= present(proposal).body %>
     </div>
     <div class="row column">
       <strong><%= t ".created_at" %>: </strong> <%= l proposal.created_at, format: :decidim_short %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_linked_proposals.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_linked_proposals.html.erb
@@ -7,7 +7,7 @@
         <% end %>
         <div>
           <%= link_to resource_locator(proposal).path, class: "card__link" do %>
-            <h5 class="card--list__heading"><%= proposal.title %></h5>
+            <h5 class="card--list__heading"><%= present(proposal).title %></h5>
           <% end %>
           <% present(proposal) do |proposal| %>
             <div class="author">

--- a/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
+++ b/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
@@ -5,6 +5,7 @@ module Decidim
     # This class serializes a Proposal so can be exported to CSV, JSON or other
     # formats.
     class ProposalSerializer < Decidim::Exporters::Serializer
+      include Decidim::ApplicationHelper
       include Decidim::ResourceHelper
 
       # Public: Initializes the serializer with a proposal.
@@ -24,8 +25,8 @@ module Decidim
             id: @proposal.scope.try(:id),
             name: @proposal.scope.try(:name)
           },
-          title: @proposal.title,
-          body: @proposal.body,
+          title: present(@proposal).title,
+          body: present(@proposal).body,
           supports: @proposal.proposal_votes_count,
           comments: @proposal.comments.count,
           published_at: @proposal.published_at,

--- a/decidim-sortitions/app/controllers/decidim/sortitions/admin/sortitions_controller.rb
+++ b/decidim-sortitions/app/controllers/decidim/sortitions/admin/sortitions_controller.rb
@@ -6,6 +6,7 @@ module Decidim
       # Controller responsible of the sortition that selects proposals from
       # a participatory space.
       class SortitionsController < Admin::ApplicationController
+        helper Decidim::ApplicationHelper
         helper_method :proposal_components
 
         def index; end

--- a/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/show.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/show.html.erb
@@ -44,7 +44,7 @@
         <tbody>
           <% sortition.proposals.each do |proposal| %>
             <tr>
-              <td><%= proposal.title %></td>
+              <td><%= present(proposal).title %></td>
               <td></td>
             </tr>
           <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR solves the display of the titles of the proposals when they contain hashtags in 0.14 version, in the following cases:

- Related proposals in the budgets
- Suggestions for sortitions.

#### :pushpin: Related Issues
- Related to #2458 #3959  #4080 
- Backports #4081 

#### :clipboard: Subtasks
- [x]  Add CHANGELOG entry
- [x] Change views when showing proposals title in related content
- [x] Change tests

### :camera: Screenshots (optional)
![Description](URL)
