### PR TITLE
fix create debates as a normal user in a private space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 **Fixed**:
 
+- **decidim-debates**: Fix create debates as a normal user in a private space [\4108](https://github.com/decidim/decidim/pull/4108)
 - **decidim-proposals**: Fix hashtags on title when showing proposals related. [\4081](https://github.com/decidim/decidim/pull/4081)
 - **decidim-core**: Fix hero content block migration [\#4061](https://github.com/decidim/decidim/pull/4061)
 - **decidim-core**: Fix default content block creation migration [\#4084](https://github.com/decidim/decidim/pull/4084)

--- a/decidim-debates/app/permissions/decidim/debates/permissions.rb
+++ b/decidim-debates/app/permissions/decidim/debates/permissions.rb
@@ -24,7 +24,7 @@ module Decidim
 
       def can_create_debate?
         authorized?(:create) &&
-          current_settings&.creation_enabled?
+          current_settings&.creation_enabled? && component.participatory_space.can_participate?(user)
       end
     end
   end

--- a/decidim-debates/app/views/decidim/debates/debates/index.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/index.html.erb
@@ -5,7 +5,7 @@
     <h2 id="debates-count" class="title-action__title section-heading">
       <%= render partial: "count" %>
     </h2>
-    <% if current_settings.creation_enabled? %>
+    <% if current_settings.creation_enabled? && current_component.participatory_space.can_participate?(current_user) %>
       <%= action_authorized_link_to :create, new_debate_path, class: "title-action__action button small hollow", data: { "redirect_url" => new_debate_path } do %>
         <%= t(".new_debate") %>
         <%= icon "plus" %>

--- a/decidim-debates/spec/system/private_space_debate_spec.rb
+++ b/decidim-debates/spec/system/private_space_debate_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Private Space Debate", type: :system do
+  let(:manifest_name) { "debates" }
+  let(:manifest) { Decidim.find_component_manifest(manifest_name) }
+
+  let!(:organization) { create(:organization) }
+  let(:user) { create :user, :confirmed, organization: organization }
+  let!(:other_user) { create(:user, :confirmed, organization: organization) }
+
+  let!(:participatory_space_private_user) { create :participatory_space_private_user, user: other_user, privatable_to: participatory_space_private }
+
+  let!(:participatory_space) { participatory_space_private }
+
+  let!(:component) { create(:component, manifest: manifest, participatory_space: participatory_space) }
+
+  before do
+    switch_to_host(organization.host)
+    component.update!(default_step_settings: { creation_enabled: true })
+  end
+
+  def visit_component
+    page.visit main_component_path(component)
+  end
+
+  context "when space is private and transparent" do
+    let!(:participatory_space_private) { create :assembly, :published, organization: organization, private_space: true, is_transparent: true }
+
+    context "when the user is not logged in" do
+      it "does not allow create a debate" do
+        visit_component
+
+        within ".title-action" do
+          expect(page).to have_no_link("New debate")
+        end
+      end
+    end
+
+    context "when the user is logged in" do
+      context "and is private user space" do
+        before do
+          login_as other_user, scope: :user
+        end
+
+        it "not allows create a debate" do
+          visit_component
+
+          expect(page).to have_link("New debate")
+        end
+      end
+
+      context "and is not private user space" do
+        before do
+          login_as user, scope: :user
+        end
+
+        it "not allows create a debate" do
+          visit_component
+
+          within ".title-action" do
+            expect(page).to have_no_link("New debate")
+          end
+        end
+      end
+    end
+  end
+
+  context "when the spaces is private and not transparent" do
+    let!(:participatory_space_private) { create :assembly, :published, organization: organization, private_space: true, is_transparent: false }
+
+    context "when the user is not logged in" do
+      it_behaves_like "a 404 page" do
+        let(:target_path) { main_component_path(component) }
+      end
+    end
+
+    context "when the user is logged in" do
+      context "and is private user space" do
+        before do
+          login_as other_user, scope: :user
+        end
+
+        it "allows create a debate" do
+          visit_component
+
+          click_link "New debate"
+
+          within ".new_debate" do
+            fill_in :debate_title, with: "Creating my debate"
+            fill_in :debate_description, with: "This is my debate's description and I'm using it unwisely."
+
+            find("*[type=submit]").click
+          end
+
+          expect(page).to have_content("Debate created successfully.")
+        end
+      end
+
+      context "and is not private user space" do
+        before do
+          login_as user, scope: :user
+        end
+
+        it_behaves_like "a 404 page" do
+          let(:target_path) { main_component_path(component) }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR solves the creation of debate as a normal user (non private user). A non private user can create debates on when the space is private and user is not a private user. 


#### :pushpin: Related Issues
- Related to #3438 #2708 
- Fixes #4004 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Fix creation only when user can_participate
- [x] Add tests

### :camera: Screenshots (optional)
![Description](URL)
