### PR TITLE
Wrap authors in an inline-block element

### DIFF
--- a/decidim-core/app/cells/decidim/collapsible_authors/show.erb
+++ b/decidim-core/app/cells/decidim/collapsible_authors/show.erb
@@ -1,10 +1,12 @@
-<%= cell(
-  "decidim/collapsible_list",
-  list,
-  cell_name: cell_name,
-  cell_options: options.merge(has_actions: false),
-  size: size
-  ) %>
+<div class="author--inline">
+  <%= cell(
+    "decidim/collapsible_list",
+    list,
+    cell_name: cell_name,
+    cell_options: options.merge(has_actions: false),
+    size: size
+    ) %>
+</div>
 <% if actionable? %>
   <div class="author-data__extra">
     <% author_cell= cell("decidim/author", model, from: from_context) %>


### PR DESCRIPTION
#### :tophat: What? Why?
When we moved to cells some styles were modified:

![](https://i.imgur.com/pLVIM3G.png)
![](https://i.imgur.com/v8GrHya.png)

Notice how the date and extra actions on the resource (a proposal in this example) are shown in a new line from the author, even though there's space next to them. There's a vertical bar that used to separate the author from the date, but now it looks weird there.

Wrapping the authors in an `inline-block` element results to this:

![](https://i.imgur.com/EhqXCsS.png)
![](https://i.imgur.com/zloQRgi.png)

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None