### PR TITLE
Remove decidim-conferences from metagem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,6 @@ PATH
       decidim-blogs (= 0.15.0.dev)
       decidim-budgets (= 0.15.0.dev)
       decidim-comments (= 0.15.0.dev)
-      decidim-conferences (= 0.15.0.dev)
       decidim-core (= 0.15.0.dev)
       decidim-debates (= 0.15.0.dev)
       decidim-generators (= 0.15.0.dev)
@@ -725,4 +724,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.3
+   1.16.4

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -9,7 +9,6 @@ PATH
       decidim-blogs (= 0.15.0.dev)
       decidim-budgets (= 0.15.0.dev)
       decidim-comments (= 0.15.0.dev)
-      decidim-conferences (= 0.15.0.dev)
       decidim-core (= 0.15.0.dev)
       decidim-debates (= 0.15.0.dev)
       decidim-generators (= 0.15.0.dev)
@@ -57,9 +56,6 @@ PATH
     decidim-comments (0.15.0.dev)
       decidim-core (= 0.15.0.dev)
       jquery-rails (~> 4.0)
-    decidim-conferences (0.15.0.dev)
-      decidim-core (~> 0.15.a)
-      decidim-meetings (~> 0.15.a)
     decidim-consultations (0.15.0.dev)
       decidim-admin (= 0.15.0.dev)
       decidim-comments (= 0.15.0.dev)
@@ -724,4 +720,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.3
+   1.16.4

--- a/decidim.gemspec
+++ b/decidim.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |s|
   s.add_dependency "decidim-blogs", Decidim.version
   s.add_dependency "decidim-budgets", Decidim.version
   s.add_dependency "decidim-comments", Decidim.version
-  s.add_dependency "decidim-conferences", Decidim.version
   s.add_dependency "decidim-core", Decidim.version
   s.add_dependency "decidim-debates", Decidim.version
   s.add_dependency "decidim-generators", Decidim.version

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -9,7 +9,6 @@ PATH
       decidim-blogs (= 0.15.0.dev)
       decidim-budgets (= 0.15.0.dev)
       decidim-comments (= 0.15.0.dev)
-      decidim-conferences (= 0.15.0.dev)
       decidim-core (= 0.15.0.dev)
       decidim-debates (= 0.15.0.dev)
       decidim-generators (= 0.15.0.dev)
@@ -725,4 +724,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.3
+   1.16.4


### PR DESCRIPTION
#### :tophat: What? Why?
This PR removes `decidim-conferences` from the metagem so that we can test it for a while without bundling it. The `Decidim::AppGenerator` already adds `decidim-conferences` as an explicit dependency for demo apps, so we don't need to modify it.

#### :pushpin: Related Issues
- Related to #3781

#### :clipboard: Subtasks
None