### PR TITLE
Add options for highlighted processes content block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - **decidim-meetings**: Add upcoming events content block and page. [\#3987](https://github.com/decidim/decidim/pull/3987)
 - **decidim-generators**: Enable one more bootsnap optimization in test apps when coverage tracking is not enabled [\#4098](https://github.com/decidim/decidim/pull/4098)
 - **decidim-initiatives**: Initiative printable form now includes the initiative type. [\#3938](https://github.com/decidim/decidim/pull/3938)
+- **decidim-participatory_processes**: Set max number of results in highlighted processes content block (4, 8 or 12) [\#4124](https://github.com/decidim/decidim/pull/4124)
 
 **Changed**:
 

--- a/decidim-admin/spec/system/admin_manages_organization_homepage_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_homepage_spec.rb
@@ -18,7 +18,9 @@ describe "Admin manages organization homepage", type: :system do
       expect(Decidim::ContentBlock.count).to eq 0
 
       within ".js-list-availables" do
-        find("svg.icon--pencil").click
+        within find("li", text: "Hero image") do
+          find("svg.icon--pencil").click
+        end
       end
 
       expect(Decidim::ContentBlock.count).to eq 1

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_cell.rb
@@ -21,10 +21,16 @@ module Decidim
           highlighted_processes.to_a.length == 1
         end
 
+        def max_results
+          model.settings.max_results
+        end
+
         def highlighted_processes
-          OrganizationPublishedParticipatoryProcesses.new(current_organization, current_user) |
+          @highlighted_processes ||= (
+            OrganizationPublishedParticipatoryProcesses.new(current_organization, current_user) |
             HighlightedParticipatoryProcesses.new |
             FilteredParticipatoryProcesses.new("active")
+          ).query.limit(max_results)
         end
 
         def i18n_scope

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form/show.erb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form/show.erb
@@ -1,0 +1,3 @@
+<% form.fields_for :settings, form.object.settings do |settings_fields| %>
+  <%= settings_fields.select :max_results, [4, 8, 12], prompt: "", label: label %>
+<% end %>

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form_cell.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ParticipatoryProcesses
+    module ContentBlocks
+      class HighlightedProcessesSettingsFormCell < Decidim::ViewModel
+        alias form model
+
+        def content_block
+          options[:content_block]
+        end
+
+        def label
+          I18n.t("decidim.participatory_processes.admin.content_blocks.highlighted_processes.max_results")
+        end
+      end
+    end
+  end
+end

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -268,6 +268,9 @@ en:
         title: Participatory process steps
     participatory_processes:
       admin:
+        content_blocks:
+          highlighted_processes:
+            max_results: Maximum amount of elements to show
         participatory_process_copies:
           form:
             slug_help: 'URL slugs are used to generate the URLs that point to this process. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
@@ -62,6 +62,11 @@ module Decidim
         Decidim.content_blocks.register(:homepage, :highlighted_processes) do |content_block|
           content_block.cell = "decidim/participatory_processes/content_blocks/highlighted_processes"
           content_block.public_name_key = "decidim.participatory_processes.content_blocks.highlighted_processes.name"
+          content_block.settings_form_cell = "decidim/participatory_processes/content_blocks/highlighted_processes_settings_form"
+
+          content_block.settings do |settings|
+            settings.attribute :max_results, type: :integer, default: 4
+          end
         end
       end
     end

--- a/decidim-participatory_processes/spec/cells/decidim/participatory_processes/content_blocks/highlighted_processes_cell_spec.rb
+++ b/decidim-participatory_processes/spec/cells/decidim/participatory_processes/content_blocks/highlighted_processes_cell_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::ParticipatoryProcesses::ContentBlocks::HighlightedProcessesCell, type: :cell do
+  subject { cell(content_block.cell, content_block).call }
+
+  let(:organization) { create(:organization) }
+  let(:content_block) { create :content_block, organization: organization, manifest_name: :highlighted_processes, scope: :homepage, settings: settings }
+  let!(:processes) { create_list :participatory_process, 5, organization: organization }
+  let(:settings) { {} }
+
+  controller Decidim::PagesController
+
+  before do
+    allow(controller).to receive(:current_organization).and_return(organization)
+  end
+
+  context "when the content block has no settings" do
+    it "shows 4 processes" do
+      within "#highlighted-processes" do
+        expect(subject).to have_selector("article.card--process", count: 4)
+      end
+    end
+  end
+
+  context "when the content block has customized the welcome text setting value" do
+    let(:settings) do
+      {
+        "max_results" => "8"
+      }
+    end
+
+    it "shows up to 8 processes" do
+      within "#highlighted-processes" do
+        expect(subject).to have_selector("article.card--process", count: 5)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds customization options for the highlighted processes content block. This can be used as a template for initiatives, assemblies and consultations.

#### :pushpin: Related Issues
- Related to #3672

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
