### PR TITLE
Add options to highlighted assemblies content block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **decidim-debates**: Adds the *commented debates* badge. [\#4089](https://github.com/decidim/decidim/pull/4089)
 - **decidim-meetings**: Add upcoming events content block and page. [\#3987](https://github.com/decidim/decidim/pull/3987)
 - **decidim-generators**: Enable one more bootsnap optimization in test apps when coverage tracking is not enabled [\#4098](https://github.com/decidim/decidim/pull/4098)
+- **decidim-assemblies**: Set max number of results in highlighted assemblies content block (4, 8 or 12) [\#4125](https://github.com/decidim/decidim/pull/4125)
 - **decidim-initiatives**: Initiative printable form now includes the initiative type. [\#3938](https://github.com/decidim/decidim/pull/3938)
 
 **Changed**:

--- a/decidim-admin/spec/system/admin_manages_organization_homepage_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_homepage_spec.rb
@@ -18,7 +18,9 @@ describe "Admin manages organization homepage", type: :system do
       expect(Decidim::ContentBlock.count).to eq 0
 
       within ".js-list-availables" do
-        find("svg.icon--pencil").click
+        within find("li", text: "Hero image") do
+          find("svg.icon--pencil").click
+        end
       end
 
       expect(Decidim::ContentBlock.count).to eq 1

--- a/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_cell.rb
+++ b/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_cell.rb
@@ -11,8 +11,15 @@ module Decidim
           render if highlighted_assemblies.any?
         end
 
+        def max_results
+          model.settings.max_results
+        end
+
         def highlighted_assemblies
-          OrganizationPrioritizedAssemblies.new(current_organization, current_user)
+          @highlighted_assemblies ||= OrganizationPrioritizedAssemblies
+                                      .new(current_organization, current_user)
+                                      .query
+                                      .limit(max_results)
         end
 
         def i18n_scope

--- a/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_settings_form/show.erb
+++ b/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_settings_form/show.erb
@@ -1,0 +1,3 @@
+<% form.fields_for :settings, form.object.settings do |settings_fields| %>
+  <%= settings_fields.select :max_results, [4, 8, 12], prompt: "", label: label %>
+<% end %>

--- a/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_settings_form_cell.rb
+++ b/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_settings_form_cell.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Assemblies
+    module ContentBlocks
+      class HighlightedAssembliesSettingsFormCell < Decidim::ViewModel
+        alias form model
+
+        def content_block
+          options[:content_block]
+        end
+
+        def label
+          I18n.t("decidim.assemblies.admin.content_blocks.highlighted_assemblies.max_results")
+        end
+      end
+    end
+  end
+end

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -239,6 +239,9 @@ en:
               not_ceased: Not ceased
             filter_by: Filter by
             search: Search
+        content_blocks:
+          highlighted_assemblies:
+            max_results: Maximum amount of elements to show
       assembly_members:
         index:
           members: Members

--- a/decidim-assemblies/lib/decidim/assemblies/engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/engine.rb
@@ -89,6 +89,11 @@ module Decidim
         Decidim.content_blocks.register(:homepage, :highlighted_assemblies) do |content_block|
           content_block.cell = "decidim/assemblies/content_blocks/highlighted_assemblies"
           content_block.public_name_key = "decidim.assemblies.content_blocks.highlighted_assemblies.name"
+          content_block.settings_form_cell = "decidim/assemblies/content_blocks/highlighted_assemblies_settings_form"
+
+          content_block.settings do |settings|
+            settings.attribute :max_results, type: :integer, default: 4
+          end
         end
       end
     end

--- a/decidim-assemblies/spec/cells/decidim/assemblies/content_blocks/highlighted_assemblies_cell_spec.rb
+++ b/decidim-assemblies/spec/cells/decidim/assemblies/content_blocks/highlighted_assemblies_cell_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Assemblies::ContentBlocks::HighlightedAssembliesCell, type: :cell do
+  subject { cell(content_block.cell, content_block).call }
+
+  let(:organization) { create(:organization) }
+  let(:content_block) { create :content_block, organization: organization, manifest_name: :highlighted_assemblies, scope: :homepage, settings: settings }
+  let!(:assemblies) { create_list :assembly, 5, organization: organization }
+  let(:settings) { {} }
+
+  controller Decidim::PagesController
+
+  before do
+    allow(controller).to receive(:current_organization).and_return(organization)
+  end
+
+  context "when the content block has no settings" do
+    it "shows 4 processes" do
+      within "#highlighted-assembly" do
+        expect(subject).to have_selector("article.card--process", count: 4)
+      end
+    end
+  end
+
+  context "when the content block has customized the max results setting value" do
+    let(:settings) do
+      {
+        "max_results" => "8"
+      }
+    end
+
+    it "shows up to 8 assemblies" do
+      within "#highlighted-assemblies" do
+        expect(subject).to have_selector("article.card--assembly", count: 5)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds customization options for the highlighted assemblies content block.

#### :pushpin: Related Issues
- Related to #3672, #4124

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
