### PR TITLE
Add options to highlighted initiatives content block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - **decidim-meetings**: Add upcoming events content block and page. [\#3987](https://github.com/decidim/decidim/pull/3987)
 - **decidim-generators**: Enable one more bootsnap optimization in test apps when coverage tracking is not enabled [\#4098](https://github.com/decidim/decidim/pull/4098)
 - **decidim-initiatives**: Initiative printable form now includes the initiative type. [\#3938](https://github.com/decidim/decidim/pull/3938)
+- **decidim-initiatives**: Set max number of results in highlighted initiatives content block (4, 8 or 12) [\#4127](https://github.com/decidim/decidim/pull/4127)
 
 **Changed**:
 

--- a/decidim-admin/spec/system/admin_manages_organization_homepage_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_homepage_spec.rb
@@ -18,7 +18,9 @@ describe "Admin manages organization homepage", type: :system do
       expect(Decidim::ContentBlock.count).to eq 0
 
       within ".js-list-availables" do
-        find("svg.icon--pencil").click
+        within find("li", text: "Hero image") do
+          find("svg.icon--pencil").click
+        end
       end
 
       expect(Decidim::ContentBlock.count).to eq 1

--- a/decidim-initiatives/app/cells/decidim/initiatives/content_blocks/highlighted_initiatives_cell.rb
+++ b/decidim-initiatives/app/cells/decidim/initiatives/content_blocks/highlighted_initiatives_cell.rb
@@ -10,8 +10,15 @@ module Decidim
           render if highlighted_initiatives.any?
         end
 
+        def max_results
+          model.settings.max_results
+        end
+
         def highlighted_initiatives
-          OrganizationPrioritizedInitiatives.new(current_organization)
+          @highlighted_initiatives ||= OrganizationPrioritizedInitiatives
+                                       .new(current_organization)
+                                       .query
+                                       .limit(max_results)
         end
 
         def i18n_scope

--- a/decidim-initiatives/app/cells/decidim/initiatives/content_blocks/highlighted_initiatives_settings_form/show.erb
+++ b/decidim-initiatives/app/cells/decidim/initiatives/content_blocks/highlighted_initiatives_settings_form/show.erb
@@ -1,0 +1,3 @@
+<% form.fields_for :settings, form.object.settings do |settings_fields| %>
+  <%= settings_fields.select :max_results, [4, 8, 12], prompt: "", label: label %>
+<% end %>

--- a/decidim-initiatives/app/cells/decidim/initiatives/content_blocks/highlighted_initiatives_settings_form_cell.rb
+++ b/decidim-initiatives/app/cells/decidim/initiatives/content_blocks/highlighted_initiatives_settings_form_cell.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Initiatives
+    module ContentBlocks
+      class HighlightedInitiativesSettingsFormCell < Decidim::ViewModel
+        alias form model
+
+        def content_block
+          options[:content_block]
+        end
+
+        def label
+          I18n.t("decidim.initiatives.admin.content_blocks.highlighted_initiatives.max_results")
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -103,6 +103,9 @@ en:
             no_members_yet: There are no members in the promoter committee
             revoke: Revoke
             title: Committee members
+        content_blocks:
+          highlighted_initiatives:
+            max_results: Maximum amount of elements to show
         initiatives:
           edit:
             accept: Accept initiative

--- a/decidim-initiatives/lib/decidim/initiatives/engine.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/engine.rb
@@ -65,6 +65,11 @@ module Decidim
         Decidim.content_blocks.register(:homepage, :highlighted_initiatives) do |content_block|
           content_block.cell = "decidim/initiatives/content_blocks/highlighted_initiatives"
           content_block.public_name_key = "decidim.initiatives.content_blocks.highlighted_initiatives.name"
+          content_block.settings_form_cell = "decidim/initiatives/content_blocks/highlighted_initiatives_settings_form"
+
+          content_block.settings do |settings|
+            settings.attribute :max_results, type: :integer, default: 4
+          end
         end
       end
 

--- a/decidim-initiatives/spec/cells/decidim/initiatives/content_blocks/highlighted_initiatives_cell_spec.rb
+++ b/decidim-initiatives/spec/cells/decidim/initiatives/content_blocks/highlighted_initiatives_cell_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Initiatives::ContentBlocks::HighlightedInitiativesCell, type: :cell do
+  subject { cell(content_block.cell, content_block).call }
+
+  let(:organization) { create(:organization) }
+  let(:content_block) { create :content_block, organization: organization, manifest_name: :highlighted_initiatives, scope: :homepage, settings: settings }
+  let!(:initiatives) { create_list :initiative, 5, organization: organization }
+  let(:settings) { {} }
+
+  controller Decidim::PagesController
+
+  before do
+    allow(controller).to receive(:current_organization).and_return(organization)
+  end
+
+  context "when the content block has no settings" do
+    it "shows 4 initiatives" do
+      within "#highlighted-initiatives" do
+        expect(subject).to have_selector("article.card--initiative", count: 4)
+      end
+    end
+  end
+
+  context "when the content block has customized the max results setting value" do
+    let(:settings) do
+      {
+        "max_results" => "8"
+      }
+    end
+
+    it "shows up to 8 initiatives" do
+      within "#highlighted-initiatives" do
+        expect(subject).to have_selector("article.card--initiative", count: 5)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds a max results option to the highlighted initiatives content block.

#### :pushpin: Related Issues
- Related to #3672, #4124


#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
