### PR TITLE
Add Highlighted consultations content block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - **decidim-initiatives**: Set max number of results in highlighted initiatives content block (4, 8 or 12) [\#4127](https://github.com/decidim/decidim/pull/4127)
 - **decidim-participatory_processes**: Set max number of results in highlighted processes content block (4, 8 or 12) [\#4124](https://github.com/decidim/decidim/pull/4124)
 - **decidim-core**: Add an HTML content block [\#4134](https://github.com/decidim/decidim/pull/4134)
+- **decidim-consultations**: Add a "Highlighted consultations" content block [\#4137](https://github.com/decidim/decidim/pull/4137)
 
 **Changed**:
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -153,12 +153,14 @@ ignore_unused:
   - password_validator.*
   - decidim.participatory_processes.participatory_processes.filters.*
   - decidim.participatory_processes.pages.home.highlighted_processes.*
+  - decidim.consultations.pages.home.highlighted_consultations.*
   - decidim.assemblies.pages.home.highlighted_assemblies.*
   - decidim.initiatives.pages.home.highlighted_initiatives.*
   - decidim.content_blocks.*.name
   - decidim.participatory_processes.content_blocks.*.name
   - decidim.assemblies.content_blocks.*.name
   - decidim.initiatives.content_blocks.*.name
+  - decidim.consultations.content_blocks.*.name
   - decidim.meetings.content_blocks.*.name
   - decidim.proposals.collaborative_drafts.show.hidden_authors_count.*
   - decidim.proposals.collaborative_drafts.orders*

--- a/decidim-consultations/app/cells/decidim/consultations/content_blocks/highlighted_consultations/show.erb
+++ b/decidim-consultations/app/cells/decidim/consultations/content_blocks/highlighted_consultations/show.erb
@@ -1,0 +1,32 @@
+<section class="wrapper-home home-section">
+  <div class="row" id="highlighted-consultations">
+    <h3 class="section-heading"><%= t("active_consultations", scope: i18n_scope) %></h3>
+    <div class="row collapse">
+      <div class="row small-up-1 smallmedium-up-2 mediumlarge-up-3
+        large-up-4 card-grid">
+        <% highlighted_consultations.each do |consultation| %>
+          <div class="column">
+            <article class="card card--consultation card--mini">
+              <%= link_to decidim_consultations.consultation_path(consultation), class: "card__link" do %>
+                <div class="card__image-top"
+                  style="background-image:url(<%= consultation.banner_image.url %>)"></div>
+              <% end %>
+              <div class="card__content">
+                <%= link_to decidim_consultations.consultation_path(consultation), class: "card__link" do %>
+                  <h4 class="card__title"><%= translated_attribute consultation.title %></h4>
+                <% end %>
+                <span class="card--process__small"><%= voting_ends_text_for(consultation) %></span>
+              </div>
+            </article>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+  <div class="row" id="see-all-consultations">
+    <div class="columns small-centered small-12
+      smallmedium-8 medium-6 large-4">
+      <%= link_to t("see_all_consultations", scope: i18n_scope), decidim_consultations.consultations_path, class: "button expanded hollow button--sc home-section__cta" %>
+    </div>
+  </div>
+</section>

--- a/decidim-consultations/app/cells/decidim/consultations/content_blocks/highlighted_consultations_cell.rb
+++ b/decidim-consultations/app/cells/decidim/consultations/content_blocks/highlighted_consultations_cell.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Consultations
+    module ContentBlocks
+      class HighlightedConsultationsCell < Decidim::ViewModel
+        delegate :current_organization, to: :controller
+        delegate :current_user, to: :controller
+
+        def show
+          render if highlighted_consultations.any?
+        end
+
+        def max_results
+          model.settings.max_results
+        end
+
+        def highlighted_consultations
+          @highlighted_consultations ||= OrganizationActiveConsultations
+                                         .new(current_organization)
+                                         .query
+                                         .limit(max_results)
+        end
+
+        def i18n_scope
+          "decidim.consultations.pages.home.highlighted_consultations"
+        end
+
+        def decidim_consultations
+          Decidim::Consultations::Engine.routes.url_helpers
+        end
+
+        def voting_ends_text_for(consultation)
+          remaining_days = (consultation.end_voting_date - Time.zone.today).to_i
+          return I18n.t("voting_ends_today", scope: i18n_scope) if remaining_days.zero?
+          I18n.t("voting_ends_in", scope: i18n_scope, count: remaining_days)
+        end
+      end
+    end
+  end
+end

--- a/decidim-consultations/app/cells/decidim/consultations/content_blocks/highlighted_consultations_settings_form/show.erb
+++ b/decidim-consultations/app/cells/decidim/consultations/content_blocks/highlighted_consultations_settings_form/show.erb
@@ -1,0 +1,3 @@
+<% form.fields_for :settings, form.object.settings do |settings_fields| %>
+  <%= settings_fields.select :max_results, [4, 8, 12], prompt: "", label: label %>
+<% end %>

--- a/decidim-consultations/app/cells/decidim/consultations/content_blocks/highlighted_consultations_settings_form_cell.rb
+++ b/decidim-consultations/app/cells/decidim/consultations/content_blocks/highlighted_consultations_settings_form_cell.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Consultations
+    module ContentBlocks
+      class HighlightedConsultationsSettingsFormCell < Decidim::ViewModel
+        alias form model
+
+        def content_block
+          options[:content_block]
+        end
+
+        def label
+          I18n.t("decidim.consultations.admin.content_blocks.highlighted_consultations.max_results")
+        end
+      end
+    end
+  end
+end

--- a/decidim-consultations/config/locales/en.yml
+++ b/decidim-consultations/config/locales/en.yml
@@ -175,6 +175,10 @@ en:
         questions: Questions
         responses: Responses
     consultations:
+      admin:
+        content_blocks:
+          highlighted_consultations:
+            max_results: Maximum amount of elements to show
       consultation:
         start_voting_date: Voting begins
         view_results: View results
@@ -185,6 +189,9 @@ en:
           label: 'Sort consultations by:'
           random: Random
           recent: Most recent
+      content_blocks:
+        highlighted_consultations:
+          name: Highlighted consultations
       count:
         title:
           one: "%{count} consultation"
@@ -205,6 +212,15 @@ en:
         title: Questions from %{scope_name}
       index:
         title: Consultations
+      pages:
+        home:
+          highlighted_consultations:
+            active_consultations: Active consultations
+            see_all_consultations: See all consultations
+            voting_ends_in:
+              one: Voting ends <strong>tomorrow</strong>
+              other: Voting ends in <strong>%{count} days</strong>
+            voting_ends_today: Voting ends <strong>today</strong>
       question:
         take_part: Take part
         view_results: View results

--- a/decidim-consultations/lib/decidim/consultations/engine.rb
+++ b/decidim-consultations/lib/decidim/consultations/engine.rb
@@ -73,6 +73,18 @@ module Decidim
                     active: :inclusive
         end
       end
+
+      initializer "decidim_consultations.content_blocks" do
+        Decidim.content_blocks.register(:homepage, :highlighted_consultations) do |content_block|
+          content_block.cell = "decidim/consultations/content_blocks/highlighted_consultations"
+          content_block.public_name_key = "decidim.consultations.content_blocks.highlighted_consultations.name"
+          content_block.settings_form_cell = "decidim/consultations/content_blocks/highlighted_consultations_settings_form"
+
+          content_block.settings do |settings|
+            settings.attribute :max_results, type: :integer, default: 4
+          end
+        end
+      end
     end
   end
 end

--- a/decidim-consultations/spec/cells/decidim/consultations/content_blocks/highlighted_consultations_cell_spec.rb
+++ b/decidim-consultations/spec/cells/decidim/consultations/content_blocks/highlighted_consultations_cell_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Consultations::ContentBlocks::HighlightedConsultationsCell, type: :cell do
+  subject { cell(content_block.cell, content_block).call }
+
+  let(:organization) { create(:organization) }
+  let(:content_block) { create :content_block, organization: organization, manifest_name: :highlighted_consultations, scope: :homepage, settings: settings }
+  let!(:consultations) { create_list :consultation, 5, :active, organization: organization }
+  let(:settings) { {} }
+
+  controller Decidim::PagesController
+
+  before do
+    allow(controller).to receive(:current_organization).and_return(organization)
+  end
+
+  context "when the content block has no settings" do
+    it "shows 4 processes" do
+      within "#highlighted-consultation" do
+        expect(subject).to have_selector("article.card--process", count: 4)
+      end
+    end
+  end
+
+  context "when the content block has customized the max results setting value" do
+    let(:settings) do
+      {
+        "max_results" => "8"
+      }
+    end
+
+    it "shows up to 8 consultations" do
+      within "#highlighted-consultations" do
+        expect(subject).to have_selector("article.card--consultation", count: 5)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Adds the missing "Highlighted consultations" content block.

#### :pushpin: Related Issues
- Related to #3672

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry


### :camera: Screenshots (optional)
![Description](https://i.imgur.com/D2HpiQX.png)
