### PR TITLE
Fix erblint call on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,11 +119,8 @@ jobs:
           name: Run rubocop
           command: bundle exec rubocop
       - run:
-          name: Run erb_lint on Rails views
-          command: bundle exec erblint --lint-all
-      - run:
-          name: Run erb_lint on cells views
-          command: bundle exec erblint **/app/cells/**/*.erb
+          name: Run erblint
+          command: /app/.circleci/run_erblint.sh
       - *store_test_results
   generators:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,8 +119,11 @@ jobs:
           name: Run rubocop
           command: bundle exec rubocop
       - run:
-          name: Run erb_lint
-          command: bundle exec erblint **/app/{cells,views}/**/*.erb
+          name: Run erb_lint on Rails views
+          command: bundle exec erblint --lint-all
+      - run:
+          name: Run erb_lint on cells views
+          command: bundle exec erblint **/app/cells/**/*.erb
       - *store_test_results
   generators:
     <<: *defaults

--- a/.circleci/run_erblint.sh
+++ b/.circleci/run_erblint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -s globstar
+
+bundle exec erblint **/app/{cells,views}/**/*.erb
+
+set -u globstar

--- a/.circleci/run_erblint.sh
+++ b/.circleci/run_erblint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-set -s globstar
+shopt -s globstar
 
 bundle exec erblint **/app/{cells,views}/**/*.erb
 
-set -u globstar
+shopt -u globstar

--- a/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
@@ -62,7 +62,7 @@
               <td><%= translated_attribute(user.officialized_as) %></td>
 
               <td class="table-list__actions">
-                <%=  icon_link_to "envelope-closed", current_or_new_conversation_path_with(user), t("decidim.contact"), class:"action-icon--new" %>
+                <%= icon_link_to "envelope-closed", current_or_new_conversation_path_with(user), t("decidim.contact"), class:"action-icon--new" %>
                 <% if user.officialized? %>
                   <%= icon "circle-check", class: "action-icon action-icon--disabled" %>
                   <%= icon_link_to "pencil", new_officialization_path(user_id: user.id), t(".reofficialize"), class: "action-icon--new" %>

--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_copies/new.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_copies/new.html.erb
@@ -1,5 +1,5 @@
 <%= decidim_form_for(@form, url: conference_copies_path(current_conference), method: :post, html: { class: "form copy_conference" }) do |f| %>
-  <%= render partial: "form", object: f, locals: { title: t("conference_copies.new.title", scope: "decidim.admin"), select: t("conference_copies.new.select", scope: "decidim.admin")} %>
+  <%= render partial: "form", object: f, locals: { title: t("conference_copies.new.title", scope: "decidim.admin"), select: t("conference_copies.new.select", scope: "decidim.admin") } %>
 
   <div class="button--double form-general-submit">
     <%= f.submit t("conference_copies.new.copy", scope: "decidim.admin") %>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
@@ -4,11 +4,11 @@
   </div>
   <div class="card-section">
     <div class="row column  hashtags__container">
-      <%= form.translated :text_field, :title, autofocus: true, class: "js-hashtags", hashtaggable: true, value: @meeting.present? ? present(@meeting).title : ""  %>
+      <%= form.translated :text_field, :title, autofocus: true, class: "js-hashtags", hashtaggable: true, value: @meeting.present? ? present(@meeting).title : "" %>
     </div>
 
     <div class="row column hashtags__container">
-      <%= form.translated :editor, :description, class: "js-hashtags", hashtaggable: true, value: @meeting.present? ? present(@meeting).title : ""  %>
+      <%= form.translated :editor, :description, class: "js-hashtags", hashtaggable: true, value: @meeting.present? ? present(@meeting).title : "" %>
     </div>
 
     <div class="row column">

--- a/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/compare.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/compare.html.erb
@@ -2,7 +2,7 @@
   <%= render partial: "decidim/proposals/proposals/wizard_aside" %>
 
   <div class="columns large-6">
-    <%= render partial: "decidim/proposals/proposals/wizard_header", locals: {callout_step_help_text_class: "warning"} %>
+    <%= render partial: "decidim/proposals/proposals/wizard_header", locals: { callout_step_help_text_class: "warning" } %>
 
     <% if @similar_collaborative_drafts.presence %>
       <div class="row small-up-1 card-grid">
@@ -12,7 +12,7 @@
       </div>
     <% end %>
     <div class="row column text-center">
-      <%= link_to t(".mine_is_different"), complete_collaborative_drafts_path(collaborative_draft: {title: @form.title, body: @form.body}), class: "button small" %>
+      <%= link_to t(".mine_is_different"), complete_collaborative_drafts_path(collaborative_draft: { title: @form.title, body: @form.body }), class: "button small" %>
     </div>
   </div>
   <div class="columns large-3"></div>

--- a/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/show.html.erb
@@ -116,7 +116,7 @@
         <%= render partial: "decidim/shared/static_map", locals: { icon_name: "proposals", geolocalizable: @collaborative_draft } %>
       <% end %>
 
-      <%= cell "decidim/tags", @collaborative_draft, context: {extra_classes: ["tags--collaborative-draft"]} %>
+      <%= cell "decidim/tags", @collaborative_draft, context: { extra_classes: ["tags--collaborative-draft"] } %>
     </div>
   </div>
 </div>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
@@ -3,7 +3,7 @@
 </div>
 
 <div class="field hashtags__container">
-  <%= form.text_area :body, rows: 10, class: "js-hashtags", hashtaggable: true, value: present(@proposal).body  %>
+  <%= form.text_area :body, rows: 10, class: "js-hashtags", hashtaggable: true, value: present(@proposal).body %>
 </div>
 
 <% if component_settings.geocoding_enabled? %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_proposal_similar.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_proposal_similar.html.erb
@@ -16,7 +16,7 @@
       <%== cell("decidim/proposals/proposal_m", proposal).badge %>
 
       <p><%= truncate(present(proposal).html_body, length: 100) %></p>
-      <%= cell "decidim/tags", proposal, context: {extra_classes: ["tags--proposal"]} %>
+      <%= cell "decidim/tags", proposal, context: { extra_classes: ["tags--proposal"] } %>
     </div>
   </article>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?
When running `erblint` on the CI it's only checking for 210 files:

https://circleci.com/gh/decidim/decidim/151630

But when I run this locally, it's checking for a lot more files:

![](https://i.imgur.com/lY5V8iE.png)

I don't know the origin of the problem, I think this might be due to me using ZSH instead of plain bash locally and the pattern matching works different?

Still, I think the best way to fix this is splitting the process into two, one checking for the normal Rails views and another one checking for the cells files.

#### :pushpin: Related Issues
- Related to #3953, which changed the file pattern /cc @deivid-rodriguez 

#### :clipboard: Subtasks
None