### PR TITLE
Copy categories and subcategories to the new process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - **decidim-core**: Fix default content block creation migration [\#4084](https://github.com/decidim/decidim/pull/4084)
 - **decidim-generators**: Bootsnap warnings when generating test applications [\#4098](https://github.com/decidim/decidim/pull/4098)
 - **decidim-admin**: Don't list deleted users at officialized list. [\#4139](https://github.com/decidim/decidim/pull/4139)
+- **decidim-participayory_processes**: Copy categories and subcategories to the new process. [\#4143](https://github.com/decidim/decidim/pull/4143)
 
 **Removed**:
 

--- a/decidim-core/app/models/decidim/category.rb
+++ b/decidim-core/app/models/decidim/category.rb
@@ -34,6 +34,7 @@ module Decidim
 
     private
 
+    # This is done since we only allow one level of subcategories.
     def forbid_deep_nesting
       return unless parent
       return if parent.parent.blank?

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/copy_participatory_process.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/copy_participatory_process.rb
@@ -81,13 +81,21 @@ module Decidim
         end
 
         def copy_participatory_process_categories
-          @participatory_process.categories.each do |category|
-            Category.create!(
+          @participatory_process.categories.first_class.each do |category|
+            new_category = Category.create!(
               name: category.name,
               description: category.description,
-              parent_id: category.parent_id,
               participatory_space: @copied_process
             )
+
+            category.descendants.each do |child|
+              Category.create!(
+                name: child.name,
+                description: child.description,
+                participatory_space: @copied_process,
+                parent: new_category
+              )
+            end
           end
         end
 

--- a/decidim-participatory_processes/spec/commands/copy_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/commands/copy_participatory_process_spec.rb
@@ -102,7 +102,19 @@ module Decidim::ParticipatoryProcesses
 
         expect(new_participatory_process_category.name).to eq(old_participatory_process_category.name)
         expect(new_participatory_process_category.description).to eq(old_participatory_process_category.description)
-        expect(new_participatory_process_category.parent).to eq(old_participatory_process_category.parent)
+        expect(new_participatory_process_category.participatory_space).not_to eq(participatory_process)
+      end
+
+      context "with subcategories" do
+        let!(:subcategory) { create(:category, parent: category, participatory_space: participatory_process) }
+
+        it "duplicates the parent and its children" do
+          expect { subject.call }.to change { Decidim::Category.count }.by(2)
+          new_participatory_process = Decidim::ParticipatoryProcess.last
+
+          expect(participatory_process.categories.count).to eq(2)
+          expect(new_participatory_process.categories.count).to eq(2)
+        end
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

The previous code was only copying the parent categories to the new process since there's a before validation at `Category` that resets the participatory space of a child category, this made that the original process had a lot of duplicated subcategories.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

