### PR TITLE
[FIX] Scope searchable.searchable_resources.by_organization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 **Fixed**:
 
+- **decidim-debates**: When a Searchable accesses its indexed resources it must scope by resource_type and organization_id. [\4079](https://github.com/decidim/decidim/pull/4079)
 - **decidim-debates**: Fix create debates as a normal user in a private space [\4108](https://github.com/decidim/decidim/pull/4108)
 - **decidim-admin**: English locale now uses a consistent date format (UK style everywhere). [\#3724](https://github.com/decidim/decidim/pull/3724)
 - **decidim**: Fix crashes when sending incorrectly formatted dates to forms with date fields. [\#3724](https://github.com/decidim/decidim/pull/3724)

--- a/decidim-core/lib/decidim/search_resource_fields_mapper.rb
+++ b/decidim-core/lib/decidim/search_resource_fields_mapper.rb
@@ -58,16 +58,24 @@ module Decidim
       fields
     end
 
-    private
-
-    def map_common_fields(resource)
-      participatory_space = read_field(resource, @declared_fields, :participatory_space)
+    def retrieve_organization(resource)
       if @declared_fields[:organization_id].present?
         organization_id = read_field(resource, @declared_fields, :organization_id)
         @organization = Decidim::Organization.find(organization_id)
       else
-        @organization = participatory_space.organization
+        @organization = participatory_space(resource).organization
       end
+    end
+
+    private
+
+    def participatory_space(resource)
+      @participatory_space ||= read_field(resource, @declared_fields, :participatory_space)
+    end
+
+    def map_common_fields(resource)
+      participatory_space = participatory_space(resource)
+      @organization = retrieve_organization(resource)
       {
         decidim_scope_id: read_field(resource, @declared_fields, :scope_id),
         decidim_participatory_space_id: participatory_space&.id,

--- a/decidim-core/lib/decidim/searchable.rb
+++ b/decidim-core/lib/decidim/searchable.rb
@@ -25,7 +25,23 @@ module Decidim
     end
 
     included do
-      has_many :searchable_resources, class_name: "Decidim::SearchableResource", inverse_of: :resource, foreign_key: :resource_id, dependent: :destroy
+      # Always access to this association scoping by_organization
+      clazz = self
+      has_many :searchable_resources, -> { where(resource_type: clazz.name) },
+               class_name: "Decidim::SearchableResource",
+               inverse_of: :resource,
+               foreign_key: :resource_id do
+        def by_organization(org_id)
+          where(decidim_organization_id: org_id)
+        end
+      end
+
+      after_destroy do |searchable|
+        if self.class.search_resource_fields_mapper
+          org = self.class.search_resource_fields_mapper.organization
+          searchable.searchable_resources.by_organization(org.id).destroy_all
+        end
+      end
       # after_create and after_update callbacks are dynamically setted in `searchable_fields` method.
 
       # Public: after_create callback to index the model as a SearchableResource, if configured so.
@@ -46,17 +62,19 @@ module Decidim
       # Public: after_update callback to update index information of the model.
       #
       def try_update_index_for_search_resource
+        org = self.class.search_resource_fields_mapper.retrieve_organization(self)
+        searchables_in_org = searchable_resources.by_organization(org.id)
         if self.class.search_resource_fields_mapper.index_on_update?(self)
-          if searchable_resources.empty?
+          if searchables_in_org.empty?
             add_to_index_as_search_resource
           else
             fields = self.class.search_resource_fields_mapper.mapped(self)
-            searchable_resources.each do |sr|
+            searchables_in_org.each do |sr|
               sr.update(contents_to_searchable_resource_attributes(fields, sr.locale))
             end
           end
-        elsif searchable_resources.any?
-          searchable_resources.clear
+        elsif searchables_in_org.any?
+          searchables_in_org.destroy_all
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
When a Searchable accesses its indexed resources it must scope by resource_type and organization_id. It wasn't being done.

#### :pushpin: Related Issues
- Fixes #4079 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add documentation regarding the feature 
- [-] Add/modify seeds
- [x] Add tests
- [x] Fix

### :camera: Screenshots (optional)
![Description](URL)
