### PR TITLE
Let admins edit official proposals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - **decidim-admin**: Adds a link to the admin navigation so users can easily access the public page. [\#4126](https://github.com/decidim/decidim/pull/4126)
 - **decidim-dev**: Configuration tweaks to make spec support files directly requirable from end applications and components. [\#4151](https://github.com/decidim/decidim/pull/4151)
 - **decidim-generators**: Allow final applications to configure DB port through an env variable. [\#4154](https://github.com/decidim/decidim/pull/4154)
+- **decidim-proposals**: Let admins edit official proposals from the admin. They have the same restrictions as normal users form the public area [\#4150](https://github.com/decidim/decidim/pull/4150)
 
 **Changed**:
 

--- a/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    module Admin
+      # A command with all the business logic when a user updates a proposal.
+      class UpdateProposal < Rectify::Command
+        include AttachmentMethods
+
+        # Public: Initializes the command.
+        #
+        # form         - A form object with the params.
+        # proposal - the proposal to update.
+        def initialize(form, proposal)
+          @form = form
+          @proposal = proposal
+          @attached_to = proposal
+        end
+
+        # Executes the command. Broadcasts these events:
+        #
+        # - :ok when everything is valid, together with the proposal.
+        # - :invalid if the form wasn't valid and we couldn't proceed.
+        #
+        # Returns nothing.
+        def call
+          return broadcast(:invalid) if form.invalid?
+
+          if process_attachments?
+            @proposal.attachments.destroy_all
+
+            build_attachment
+            return broadcast(:invalid) if attachment_invalid?
+          end
+
+          transaction do
+            update_proposal
+            create_attachment if process_attachments?
+          end
+
+          broadcast(:ok, proposal)
+        end
+
+        private
+
+        attr_reader :form, :proposal, :current_user, :attachment
+
+        def update_proposal
+          parsed_title = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.title, current_organization: form.current_organization).rewrite
+          parsed_body = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.body, current_organization: form.current_organization).rewrite
+
+          @proposal.update!(
+            title: parsed_title,
+            body: parsed_body,
+            category: form.category,
+            scope: form.scope,
+            address: form.address,
+            latitude: form.latitude,
+            longitude: form.longitude
+          )
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal.rb
@@ -43,13 +43,15 @@ module Decidim
 
         private
 
-        attr_reader :form, :proposal, :current_user, :attachment
+        attr_reader :form, :proposal, :attachment
 
         def update_proposal
           parsed_title = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.title, current_organization: form.current_organization).rewrite
           parsed_body = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.body, current_organization: form.current_organization).rewrite
 
-          @proposal.update!(
+          Decidim.traceability.update!(
+            proposal,
+            form.current_user,
             title: parsed_title,
             body: parsed_body,
             category: form.category,

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
@@ -72,7 +72,7 @@ module Decidim
 
           @form = form(Admin::ProposalForm).from_params(params)
           Admin::UpdateProposal.call(@form, @proposal) do
-            on(:ok) do |proposal|
+            on(:ok) do |_proposal|
               flash[:notice] = I18n.t("proposals.update.success", scope: "decidim")
               redirect_to proposals_path
             end

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
@@ -61,6 +61,29 @@ module Decidim
           end
         end
 
+        def edit
+          enforce_permission_to :edit, :proposal, proposal: proposal
+          @form = form(Admin::ProposalForm).from_model(proposal)
+          @form.attachment = form(AttachmentForm).from_params({})
+        end
+
+        def update
+          enforce_permission_to :edit, :proposal, proposal: proposal
+
+          @form = form(Admin::ProposalForm).from_params(params)
+          Admin::UpdateProposal.call(@form, @proposal) do
+            on(:ok) do |proposal|
+              flash[:notice] = I18n.t("proposals.update.success", scope: "decidim")
+              redirect_to proposals_path
+            end
+
+            on(:invalid) do
+              flash.now[:alert] = I18n.t("proposals.update.error", scope: "decidim")
+              render :edit
+            end
+          end
+        end
+
         private
 
         def query

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
@@ -31,6 +31,7 @@ module Decidim
           return unless model.categorization
 
           self.category_id = model.categorization.decidim_category_id
+          self.scope_id = model.decidim_scope_id
         end
 
         alias component current_component

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
@@ -16,7 +16,8 @@ module Decidim
         attribute :scope_id, Integer
         attribute :attachment, AttachmentForm
 
-        validates :title, :body, presence: true
+        validates :title, :body, presence: true, etiquette: true
+        validates :title, length: { maximum: 150 }
         validates :address, geocoding: true, if: -> { current_component.settings.geocoding_enabled? }
         validates :category, presence: true, if: ->(form) { form.category_id.present? }
         validates :scope, presence: true, if: ->(form) { form.scope_id.present? }

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -209,14 +209,14 @@ module Decidim
         component.settings.resources_permissions_enabled
       end
 
-      private
-
       # Checks whether the proposal is inside the time window to be editable or not once published.
       def within_edit_time_limit?
         return true if draft?
         limit = updated_at + component.settings.proposal_edit_before_minutes.minutes
         Time.current < limit
       end
+
+      private
 
       def copied_from_other_component?
         linked_resources(:proposals, "copied_from_component").any?

--- a/decidim-proposals/app/permissions/decidim/proposals/admin/permissions.rb
+++ b/decidim-proposals/app/permissions/decidim/proposals/admin/permissions.rb
@@ -24,7 +24,7 @@ module Decidim
 
           # Admins can only edit official proposals if they are within the
           # time limit.
-          allow! if admin_edition_is_available? && permission_action.subject == :proposal && permission_action.action == :edit
+          allow! if permission_action.subject == :proposal && permission_action.action == :edit && admin_edition_is_available?
 
           # Every user allowed by the space can update the category of the proposal
           allow! if permission_action.subject == :proposal_category && permission_action.action == :update

--- a/decidim-proposals/app/presenters/decidim/proposals/admin_log/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/admin_log/proposal_presenter.rb
@@ -31,7 +31,7 @@ module Decidim
 
         def action_string
           case action
-          when "answer", "create"
+          when "answer", "create", "update"
             "decidim.proposals.admin_log.proposal.#{action}"
           else
             super

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
@@ -51,6 +51,10 @@
   </td>
 
   <td class="table-list__actions">
+    <% if allowed_to? :edit, :proposal, proposal: proposal %>
+      <%= icon_link_to "pencil", "#", t("actions.edit_proposal", scope: "decidim.proposals"), class: "action-icon--edit-proposal" %>
+    <% end %>
+
     <% if allowed_to? :create, :proposal_note %>
       <%= icon_link_to "chat", proposal_proposal_notes_path(proposal_id: proposal.id), t("actions.private_notes", scope: "decidim.proposals"), class: "action-icon--index-notes" %>
     <% end %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
@@ -52,7 +52,7 @@
 
   <td class="table-list__actions">
     <% if allowed_to? :edit, :proposal, proposal: proposal %>
-      <%= icon_link_to "pencil", "#", t("actions.edit_proposal", scope: "decidim.proposals"), class: "action-icon--edit-proposal" %>
+      <%= icon_link_to "pencil", edit_proposal_path(proposal), t("actions.edit_proposal", scope: "decidim.proposals"), class: "action-icon--edit-proposal" %>
     <% end %>
 
     <% if allowed_to? :create, :proposal_note %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/edit.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/edit.html.erb
@@ -1,0 +1,7 @@
+<%= decidim_form_for(@form, html: { class: "form edit_proposal" })  do |f| %>
+  <%= render partial: "form", object: f, locals: { title: t(".title") } %>
+
+    <div class="button--double form-general-submit">
+      <%= f.submit t(".update") %>
+    </div>
+<% end %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/new.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/new.html.erb
@@ -1,4 +1,10 @@
 <%= decidim_form_for(@form, html: { class: "form new_proposal" }) do |f| %>
+  <div class="callout warning">
+    <p>
+      <%= t("decidim.proposals.proposals.preview.proposal_edit_before_minutes", count: component_settings.proposal_edit_before_minutes) %>
+    </p>
+  </div>
+
   <%= render partial: "form", object: f, locals: { title: t(".title") } %>
 
   <div class="button--double form-general-submit">

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -222,6 +222,7 @@ en:
     proposals:
       actions:
         answer: Answer
+        edit_proposal: Edit proposal
         import: Import from another component
         new: New proposal
         private_notes: Private notes

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -259,6 +259,9 @@ en:
           create:
             invalid: There's been a problem creating this proposal
             success: Proposal successfully created
+          edit:
+            title: Update proposal
+            update: Update
           form:
             attachment_legend: "(Optional) Add an attachment"
             select_a_category: Select a category

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -299,6 +299,7 @@ en:
         proposal:
           answer: "%{user_name} answered the %{resource_name} proposal on the %{space_name} space"
           create: "%{user_name} created the %{resource_name} proposal on the %{space_name} space as an official proposal"
+          update: "%{user_name} updated the %{resource_name} official proposal on the %{space_name} space"
         proposal_note:
           create: "%{user_name} left a private note on the %{resource_name} proposal on the %{space_name} space"
       answers:

--- a/decidim-proposals/lib/decidim/proposals/admin_engine.rb
+++ b/decidim-proposals/lib/decidim/proposals/admin_engine.rb
@@ -10,7 +10,7 @@ module Decidim
       paths["lib/tasks"] = nil
 
       routes do
-        resources :proposals, only: [:index, :new, :create] do
+        resources :proposals, only: [:index, :new, :create, :edit, :update] do
           post :update_category, on: :collection
           collection do
             resource :proposals_import, only: [:new, :create]

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/update_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/update_proposal_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Proposals::Admin::UpdateProposal do
+  let(:form_klass) { Decidim::Proposals::Admin::ProposalForm }
+
+  let(:component) { create(:proposal_component) }
+  let(:organization) { component.organization }
+  let(:form) do
+    form_klass.from_params(
+      form_params
+    ).with_context(
+      current_organization: organization,
+      current_participatory_space: component.participatory_space,
+      current_component: component
+    )
+  end
+
+  let!(:proposal) { create :proposal, :official, component: component }
+
+  let(:has_address) { false }
+  let(:address) { nil }
+  let(:latitude) { 40.1234 }
+  let(:longitude) { 2.1234 }
+
+  describe "call" do
+    let(:form_params) do
+      {
+        title: "A reasonable proposal title",
+        body: "A reasonable proposal body",
+        address: address,
+        has_address: has_address
+      }
+    end
+
+    let(:command) do
+      described_class.new(form, proposal)
+    end
+
+    describe "when the form is not valid" do
+      before do
+        expect(form).to receive(:invalid?).and_return(true)
+      end
+
+      it "broadcasts invalid" do
+        expect { command.call }.to broadcast(:invalid)
+      end
+
+      it "doesn't update the proposal" do
+        expect do
+          command.call
+        end.not_to change(proposal, :title)
+      end
+    end
+
+    describe "when the form is valid" do
+      it "broadcasts ok" do
+        expect { command.call }.to broadcast(:ok)
+      end
+
+      it "updates the proposal" do
+        expect do
+          command.call
+        end.to change(proposal, :title)
+      end
+
+      context "when geocoding is enabled" do
+        let(:component) { create(:proposal_component, :with_geocoding_enabled) }
+
+        context "when the has address checkbox is checked" do
+          let(:has_address) { true }
+
+          context "when the address is present" do
+            let(:address) { "Carrer Pare Llaurador 113, baixos, 08224 Terrassa" }
+
+            before do
+              stub_geocoding(address, [latitude, longitude])
+            end
+
+            it "sets the latitude and longitude" do
+              command.call
+              proposal = Decidim::Proposals::Proposal.last
+
+              expect(proposal.latitude).to eq(latitude)
+              expect(proposal.longitude).to eq(longitude)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/permissions/decidim/proposals/admin/permissions_spec.rb
+++ b/decidim-proposals/spec/permissions/decidim/proposals/admin/permissions_spec.rb
@@ -6,9 +6,12 @@ describe Decidim::Proposals::Admin::Permissions do
   subject { described_class.new(user, permission_action, context).permissions.allowed? }
 
   let(:user) { build :user }
+  let(:current_component) { create(:proposal_component) }
+  let(:proposal) { nil }
   let(:context) do
     {
-      current_component: create(:proposal_component),
+      proposal: proposal,
+      current_component: current_component,
       current_settings: current_settings,
       component_settings: component_settings
     }
@@ -60,6 +63,43 @@ describe Decidim::Proposals::Admin::Permissions do
       let(:official_proposals_enabled?) { false }
 
       it { is_expected.to eq false }
+    end
+  end
+
+  describe "proposal edition" do
+    let(:action) do
+      { scope: :admin, action: :edit, subject: :proposal }
+    end
+
+    context "when the proposal is not official" do
+      let(:proposal) { create :proposal, component: current_component }
+
+      it_behaves_like "permission is not set"
+    end
+
+    context "when the proposal is official" do
+      let(:proposal) { create :proposal, :official, component: current_component }
+      let(:within_edit_time_limit?) { true }
+
+      before do
+        allow(proposal).to receive(:within_edit_time_limit?).and_return(within_edit_time_limit?)
+      end
+
+      context "when everything is OK" do
+        it { is_expected.to eq true }
+      end
+
+      context "when creation is disabled" do
+        let(:creation_enabled?) { false }
+
+        it_behaves_like "permission is not set"
+      end
+
+      context "when outside the edit time limit" do
+        let(:within_edit_time_limit?) { false }
+
+        it_behaves_like "permission is not set"
+      end
     end
   end
 

--- a/decidim-proposals/spec/shared/proposal_form_examples.rb
+++ b/decidim-proposals/spec/shared/proposal_form_examples.rb
@@ -56,6 +56,18 @@ shared_examples "a proposal form" do |options|
     end
   end
 
+  context "when the title is too long" do
+    let(:body) { "A" * 200 }
+
+    it { is_expected.to be_invalid }
+  end
+
+  context "when the body is not etiquette-compliant" do
+    let(:body) { "A" }
+
+    it { is_expected.to be_invalid }
+  end
+
   context "when there's no body" do
     let(:body) { nil }
 

--- a/decidim-proposals/spec/system/admin_edits_proposal_spec.rb
+++ b/decidim-proposals/spec/system/admin_edits_proposal_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin edits proposals", type: :system do
+  let(:manifest_name) { "proposals" }
+  let(:organization) { participatory_process.organization }
+  let!(:user) { create :user, :admin, :confirmed, organization: organization }
+  let!(:proposal) { create :proposal, :official, component: component }
+  let(:creation_enabled?) { true }
+
+  include_context "when managing a component as an admin"
+
+  before do
+    component.update!(
+      step_settings: {
+        component.participatory_space.active_step.id => {
+          creation_enabled: creation_enabled?
+        }
+      }
+    )
+  end
+
+  describe "editing an official proposal" do
+    let(:new_title) { "This is my proposal new title" }
+    let(:new_body) { "This is my proposal new body" }
+
+    it "can be updated" do
+      visit_component_admin
+
+      find("a.action-icon--edit-proposal").click
+      expect(page).to have_content "UPDATE PROPOSAL"
+
+      fill_in "Title", with: new_title
+      fill_in "Body", with: new_body
+      click_button "Update"
+
+      preview_window = window_opened_by { find("a.action-icon--preview").click }
+
+      within_window preview_window do
+        expect(page).to have_content(new_title)
+        expect(page).to have_content(new_body)
+      end
+    end
+
+    context "when updating with wrong data" do
+      let(:component) { create(:proposal_component, :with_creation_enabled, :with_attachments_allowed, participatory_space: participatory_process) }
+
+      it "returns an error message" do
+        visit_component_admin
+
+        find("a.action-icon--edit-proposal").click
+        expect(page).to have_content "UPDATE PROPOSAL"
+
+        fill_in "Body", with: "A"
+        click_button "Update"
+
+        expect(page).to have_content("is using too much capital letters (over 25% of the text), is too short (under 15 characters)")
+      end
+    end
+  end
+
+  describe "editing a non-official proposal" do
+    let!(:proposal) { create :proposal, users: [user], component: component }
+
+    it "renders an error" do
+      visit_component_admin
+
+      expect(page).to have_content(proposal.title)
+      expect(page).to have_no_css("a.action-icon--edit-proposal")
+      visit current_path + "proposals/#{proposal.id}/edit"
+
+      expect(page).to have_content("not authorized")
+    end
+  end
+
+  describe "editing my proposal outside the time limit" do
+    let!(:proposal) { create :proposal, :official, component: component, updated_at: 1.hour.ago }
+
+    it "renders an error" do
+      visit_component_admin
+
+      expect(page).to have_text(proposal.title)
+      expect(page).to have_no_css("a.action-icon--edit-proposal")
+      visit current_path + "proposals/#{proposal.id}/edit"
+
+      expect(page).to have_content("not authorized")
+    end
+  end
+end

--- a/decidim-proposals/spec/system/admin_edits_proposal_spec.rb
+++ b/decidim-proposals/spec/system/admin_edits_proposal_spec.rb
@@ -55,7 +55,7 @@ describe "Admin edits proposals", type: :system do
         fill_in "Body", with: "A"
         click_button "Update"
 
-        expect(page).to have_content("is using too much capital letters (over 25% of the text), is too short (under 15 characters)")
+        expect(page).to have_content("is using too many capital letters (over 25% of the text), is too short (under 15 characters)")
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Admins should be able to edit official proposals with the same restrictions that apply to normal users (a proposal can be edited within X minutes after its creation).

#### :pushpin: Related Issues
- Fixes #3802.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests: system & command
- [x] Add edit view
- [x] Show banner on creation form

### :camera: Screenshots (optional)
Callout:
![Description](https://i.imgur.com/ss7VwjM.png)
