### PR TITLE
Move related configuration together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - **decidim-core**: Add an HTML content block [\#4134](https://github.com/decidim/decidim/pull/4134)
 - **decidim-consultations**: Add a "Highlighted consultations" content block [\#4137](https://github.com/decidim/decidim/pull/4137)
 - **decidim-admin**: Adds a link to the admin navigation so users can easily access the public page. [\#4126](https://github.com/decidim/decidim/pull/4126)
+- **decidim-dev**: Configuration tweaks to make spec support files directly requirable from end applications and components. [\#4151](https://github.com/decidim/decidim/pull/4151)
 
 **Changed**:
 

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/attachment_helpers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/attachment_helpers.rb
@@ -10,3 +10,7 @@ module AttachmentHelpers
     ActiveSupport::NumberHelper.number_to_human_size(attachment.file_size)
   end
 end
+
+RSpec.configure do |config|
+  config.include AttachmentHelpers
+end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/react_select.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/react_select.rb
@@ -23,3 +23,7 @@ module Capybara
     end
   end
 end
+
+RSpec.configure do |config|
+  config.include Capybara::ReactSelect, type: :system
+end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb
@@ -97,3 +97,7 @@ module TranslationHelpers
     upcase ? content.upcase : content
   end
 end
+
+RSpec.configure do |config|
+  config.include TranslationHelpers
+end

--- a/decidim-dev/lib/decidim/dev/test/spec_helper.rb
+++ b/decidim-dev/lib/decidim/dev/test/spec_helper.rb
@@ -29,10 +29,7 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
-  config.include AttachmentHelpers
-  config.include TranslationHelpers
   config.include Rectify::RSpec::Helpers
   config.include ActionView::Helpers::SanitizeHelper
   config.include ERB::Util
-  config.include Capybara::ReactSelect, type: :system
 end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR moves some related RSpec configuration bits together. The idea is that external plugins or applications can require these testing utilities and use them without needing to configure anything else.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
_None_.