### PR TITLE
Normalize content block migration

### DIFF
--- a/decidim-core/app/presenters/decidim/admin_log/organization_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/organization_presenter.rb
@@ -61,8 +61,6 @@ module Decidim
           cta_button_path: :string,
           cta_button_text: :i18n,
           description: :i18n,
-          welcome_text: :i18n,
-          homepage_image: :string,
           logo: :string,
           header_snippets: :string,
           favicon: :string,

--- a/decidim-core/db/migrate/20180810092428_move_organization_fields_to_hero_content_block.rb
+++ b/decidim-core/db/migrate/20180810092428_move_organization_fields_to_hero_content_block.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 class MoveOrganizationFieldsToHeroContentBlock < ActiveRecord::Migration[5.2]
-  class ::Decidim::Organization < ApplicationRecord
+  class Organization < ApplicationRecord
+    self.table_name = :decidim_organizations
+
     mount_uploader :homepage_image, ::Decidim::HomepageImageUploader
   end
 
   def change
-    Decidim::Organization.find_each do |organization|
+    Organization.find_each do |organization|
       content_block = Decidim::ContentBlock.find_by(organization: organization, scope: :homepage, manifest_name: :hero)
       settings = {}
       welcome_text = organization.welcome_text || {}


### PR DESCRIPTION
#### :tophat: What? Why?

Hi! So I was running migrations and seeding from scratch and I run into the classic issue (column missing in the organization model). I remembered @mrcasals had removed this check, so I decided to have a look since the migration seemed a bit weird: It's the only case where we are monkeypatching a model inside a migration.

My conclusion is that we can do what we always do, and that the monkeypatch was not necessary. We are indeed loading the real `ContentBlock` class (that contains the complex logic) but that doesn't cause any problems. I understand that this might bite us in the future, but I'd like to restore the old way for now while I think of better solutions for our migrations.

What do you think @mrcasals, am I missing something?

I also removed two attributes from the `AdminLog::OrganizationPresenter` class that I don't think are being used since the content blocks feature was introduced. Nice feature, by the way!

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/pull/3968#discussion_r209245040.

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
_None_.