### PR TITLE
Added a missing translation key: organizer_id:

### DIFF
--- a/decidim-meetings/config/locales/ca.yml
+++ b/decidim-meetings/config/locales/ca.yml
@@ -26,6 +26,7 @@ ca:
         start_time: Hora d'inici
         title: Títol
         transparent: Transparent
+        organizer_id: Organitzador
       minutes:
         audio_url: URL de l'àudio
         description: Descripció

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -27,6 +27,7 @@ en:
         start_time: Start Time
         title: Title
         transparent: Transparent
+        organizer_id: Organizer
       minutes:
         audio_url: Audio url
         description: Description

--- a/decidim-meetings/config/locales/es-PY.yml
+++ b/decidim-meetings/config/locales/es-PY.yml
@@ -26,6 +26,7 @@ es-PY:
         start_time: Hora de inicio
         title: Título
         transparent: Transparente
+        organizer_id: Organizador
       minutes:
         audio_url: URL del audio
         description: Descripción

--- a/decidim-meetings/config/locales/es.yml
+++ b/decidim-meetings/config/locales/es.yml
@@ -26,6 +26,7 @@ es:
         start_time: Hora de inicio
         title: Título
         transparent: Transparente
+        organizer_id: Organizador
       minutes:
         audio_url: URL del audio
         description: Descripción

--- a/decidim-meetings/config/locales/eu.yml
+++ b/decidim-meetings/config/locales/eu.yml
@@ -26,6 +26,7 @@ eu:
         start_time: Hasiera-ordua
         title: Titulua
         transparent: gardena
+        organizer_id: Antolatzea
       minutes:
         audio_url: Audioaren URLa
         description: deskribapena

--- a/decidim-meetings/config/locales/fi.yml
+++ b/decidim-meetings/config/locales/fi.yml
@@ -26,6 +26,7 @@ fi:
         start_time: Aloitusaika
         title: Otsikko
         transparent: Läpinäkyvä
+        organizer_id: Järjestäminen
       minutes:
         audio_url: Äänen URL-osoite
         description: Kuvaus

--- a/decidim-meetings/config/locales/fr.yml
+++ b/decidim-meetings/config/locales/fr.yml
@@ -26,6 +26,7 @@ fr:
         start_time: Heure de début
         title: Titre
         transparent: Visible par les non-membres
+        organizer_id: Organizateur
       minutes:
         audio_url: Lien vers l'audio
         description: Description

--- a/decidim-meetings/config/locales/gl.yml
+++ b/decidim-meetings/config/locales/gl.yml
@@ -26,6 +26,7 @@ gl:
         start_time: Hora de inicio
         title: Título
         transparent: Transparente
+        organizer_id: Organizador
       minutes:
         audio_url: URL de audio
         description: Descrición

--- a/decidim-meetings/config/locales/hu.yml
+++ b/decidim-meetings/config/locales/hu.yml
@@ -26,6 +26,7 @@ hu:
         start_time: Kezdő időpont
         title: Cím
         transparent: Átlátszó
+        organizer_id: Szervező
       minutes:
         audio_url: Audio url
         description: Leírás

--- a/decidim-meetings/config/locales/it.yml
+++ b/decidim-meetings/config/locales/it.yml
@@ -26,6 +26,7 @@ it:
         start_time: Orario inizio
         title: Titolo
         transparent: Trasparente
+        organizer_id: Organizzatore
       minutes:
         audio_url: URL audio
         description: Descrizione

--- a/decidim-meetings/config/locales/nl.yml
+++ b/decidim-meetings/config/locales/nl.yml
@@ -26,6 +26,7 @@ nl:
         start_time: Starttijd
         title: Titel
         transparent: Transparant
+        organizer_id: Organisator
       minutes:
         audio_url: Audio-URL
         description: Beschrijving

--- a/decidim-meetings/config/locales/pl.yml
+++ b/decidim-meetings/config/locales/pl.yml
@@ -26,6 +26,7 @@ pl:
         start_time: Czas rozpoczęcia
         title: Tytuł
         transparent: Przezroczysty
+        organizer_id: Organizator
       minutes:
         audio_url: Adres audio
         description: Opis

--- a/decidim-meetings/config/locales/pt-BR.yml
+++ b/decidim-meetings/config/locales/pt-BR.yml
@@ -26,6 +26,7 @@ pt-BR:
         start_time: Hora de início
         title: Título
         transparent: Transparente
+        organizer_id: Organizador
       minutes:
         audio_url: URL de áudio
         description: Descrição

--- a/decidim-meetings/config/locales/pt.yml
+++ b/decidim-meetings/config/locales/pt.yml
@@ -26,6 +26,7 @@ pt:
         start_time: Hora de início
         title: Título
         transparent: Transparente
+        organizer_id: Organizador
       minutes:
         audio_url: URL de áudio
         description: Descrição

--- a/decidim-meetings/config/locales/ru.yml
+++ b/decidim-meetings/config/locales/ru.yml
@@ -26,6 +26,7 @@ ru:
         start_time: Время начала
         title: Название
         transparent: Прозрачная
+        organizer_id: Организация
       minutes:
         audio_url: Веб-адрес аудиозаписи
         description: Описание

--- a/decidim-meetings/config/locales/sv.yml
+++ b/decidim-meetings/config/locales/sv.yml
@@ -26,6 +26,7 @@ sv:
         start_time: Starttid
         title: Titel
         transparent: Transparent
+        organizer_id: Organisera
       minutes:
         audio_url: Ljud-URL
         description: Beskrivning

--- a/decidim-meetings/config/locales/uk.yml
+++ b/decidim-meetings/config/locales/uk.yml
@@ -26,6 +26,7 @@ uk:
         start_time: Час початку
         title: Назва
         transparent: Прозора
+        organizer_id: Організатор
       minutes:
         audio_url: Веб-адреса аудіозапису
         description: Опис


### PR DESCRIPTION
#### :tophat: What? Why?
We found a missing translation key on meeting module causing the string "Organizer" be seen in english for all translations

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
