### PR TITLE
Sometimes it's useful to customize the DB port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - **decidim-core**: Add an HTML content block [\#4134](https://github.com/decidim/decidim/pull/4134)
 - **decidim-consultations**: Add a "Highlighted consultations" content block [\#4137](https://github.com/decidim/decidim/pull/4137)
 - **decidim-admin**: Adds a link to the admin navigation so users can easily access the public page. [\#4126](https://github.com/decidim/decidim/pull/4126)
+- **decidim-generators**: Allow final applications to configure DB port through an env variable. [\#4154](https://github.com/decidim/decidim/pull/4154)
 
 **Changed**:
 

--- a/decidim-generators/lib/decidim/generators/app_templates/database.yml.erb
+++ b/decidim-generators/lib/decidim/generators/app_templates/database.yml.erb
@@ -23,6 +23,7 @@ default: &default
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   host: <%%= ENV.fetch("DATABASE_HOST") { "localhost" } %>
+  port: <%%= ENV.fetch("DATABASE_PORT") { "5432" } %>
   username: <%%= ENV.fetch("DATABASE_USERNAME") { "" } %>
   password: <%%= ENV.fetch("DATABASE_PASSWORD") { "" } %>
 


### PR DESCRIPTION
#### :tophat: What? Why?

In certain situations, it's handy to be able to easily customize the DB port the application connects to.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
_None_.
