### PR TITLE
Replace "much" with "many" to make sentence correct

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -826,7 +826,7 @@ en:
         one: '1 error prohibited this %{resource} from being saved:'
         other: "%{count} errors prohibited this %{resource} from being saved:"
       too_many_marks: is using too many consecutive punctuation marks (e.g. ! and ?)
-      too_much_caps: is using too much capital letters (over 25% of the text)
+      too_much_caps: is using too many capital letters (over 25% of the text)
       too_short: is too short (under 15 characters)
   forms:
     required: Required

--- a/decidim-proposals/spec/system/edit_proposal_spec.rb
+++ b/decidim-proposals/spec/system/edit_proposal_spec.rb
@@ -52,7 +52,7 @@ describe "Edit proposals", type: :system do
         fill_in "Body", with: "A"
         click_button "Send"
 
-        expect(page).to have_content("is using too much capital letters (over 25% of the text), is too short (under 15 characters)")
+        expect(page).to have_content("is using too many capital letters (over 25% of the text), is too short (under 15 characters)")
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Builds on top of #4155 by @ahukkanen. Replaces an appearance of "much" with "many" so that the sentence is gramatically correct.

#### :pushpin: Related Issues
- Related to #4155

#### :clipboard: Subtasks
None