### PR TITLE
Use sequences on titles for test data

### DIFF
--- a/decidim-accountability/lib/decidim/accountability/test/factories.rb
+++ b/decidim-accountability/lib/decidim/accountability/test/factories.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
     participatory_space { create(:participatory_process, :with_steps, organization: organization) }
     settings do
       {
-        intro: Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) },
+        intro: Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title },
         categories_label: Decidim::Faker::Localized.word,
         subcategories_label: Decidim::Faker::Localized.word,
         heading_parent_level_results: Decidim::Faker::Localized.word,
@@ -26,14 +26,14 @@ FactoryBot.define do
     component { create(:accountability_component) }
     sequence(:key) { |n| "status_#{n}" }
     name { Decidim::Faker::Localized.word }
-    description { Decidim::Faker::Localized.sentence(3) }
+    description { generate_localized_title }
     progress { rand(1..100) }
   end
 
   factory :result, class: "Decidim::Accountability::Result" do
     component { create(:accountability_component) }
-    title { Decidim::Faker::Localized.sentence(3) }
-    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
+    title { generate_localized_title }
+    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     start_date { "12/7/2017" }
     end_date { "30/9/2017" }
     status { create :status, component: component }
@@ -43,6 +43,6 @@ FactoryBot.define do
   factory :timeline_entry, class: "Decidim::Accountability::TimelineEntry" do
     result { create(:result) }
     entry_date { "12/7/2017" }
-    description { Decidim::Faker::Localized.sentence(2) }
+    description { generate_localized_title }
   end
 end

--- a/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
@@ -9,37 +9,37 @@ FactoryBot.define do
   end
 
   factory :assembly, class: "Decidim::Assembly" do
-    title { Decidim::Faker::Localized.sentence(3) }
+    title { generate_localized_title }
     slug { generate(:assembly_slug) }
-    subtitle { Decidim::Faker::Localized.sentence(1) }
-    short_description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(2) } }
-    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
+    subtitle { generate_localized_title }
+    short_description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
+    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     hero_image { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
     banner_image { Decidim::Dev.test_file("city2.jpeg", "image/jpeg") }
     published_at { Time.current }
     organization
     meta_scope { Decidim::Faker::Localized.word }
-    developer_group { Decidim::Faker::Localized.sentence(1) }
-    local_area { Decidim::Faker::Localized.sentence(2) }
-    target { Decidim::Faker::Localized.sentence(3) }
-    participatory_scope { Decidim::Faker::Localized.sentence(1) }
-    participatory_structure { Decidim::Faker::Localized.sentence(2) }
+    developer_group { generate_localized_title }
+    local_area { generate_localized_title }
+    target { generate_localized_title }
+    participatory_scope { generate_localized_title }
+    participatory_structure { generate_localized_title }
     show_statistics { true }
     private_space { false }
-    purpose_of_action { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(2) } }
-    composition { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(2) } }
+    purpose_of_action { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
+    composition { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     assembly_type { "others" }
-    assembly_type_other { Decidim::Faker::Localized.sentence(1) }
+    assembly_type_other { generate_localized_title }
     creation_date { 1.month.ago }
     created_by { "others" }
     created_by_other { Decidim::Faker::Localized.word }
     duration { 2.months.from_now.at_midnight }
     included_at { 1.month.ago }
     closing_date { 2.months.from_now.at_midnight }
-    closing_date_reason { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(2) } }
-    internal_organisation { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(2) } }
+    closing_date_reason { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
+    internal_organisation { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     is_transparent { true }
-    special_features { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(2) } }
+    special_features { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     twitter_handler { "others" }
     facebook_handler { "others" }
     instagram_handler { "others" }

--- a/decidim-blogs/lib/decidim/blogs/test/factories.rb
+++ b/decidim-blogs/lib/decidim/blogs/test/factories.rb
@@ -12,8 +12,8 @@ FactoryBot.define do
   end
 
   factory :post, class: "Decidim::Blogs::Post" do
-    title { Decidim::Faker::Localized.sentence(3) }
-    body { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
+    title { generate_localized_title }
+    body { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     component { build(:component, manifest_name: "blogs") }
     author { build(:user, :confirmed, organization: component.organization) }
   end

--- a/decidim-budgets/lib/decidim/budgets/test/factories.rb
+++ b/decidim-budgets/lib/decidim/budgets/test/factories.rb
@@ -48,8 +48,8 @@ FactoryBot.define do
   end
 
   factory :project, class: "Decidim::Budgets::Project" do
-    title { Decidim::Faker::Localized.sentence(3) }
-    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
+    title { generate_localized_title }
+    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     budget { Faker::Number.number(8) }
     component { create(:budget_component) }
   end

--- a/decidim-conferences/lib/decidim/conferences/test/factories.rb
+++ b/decidim-conferences/lib/decidim/conferences/test/factories.rb
@@ -9,12 +9,12 @@ FactoryBot.define do
   end
 
   factory :conference, class: "Decidim::Conference" do
-    title { Decidim::Faker::Localized.sentence(3) }
+    title { generate_localized_title }
     slug { generate(:conference_slug) }
-    slogan { Decidim::Faker::Localized.sentence(1) }
-    short_description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(2) } }
-    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
-    objectives { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
+    slogan { generate_localized_title }
+    short_description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
+    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
+    objectives { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     hero_image { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
     banner_image { Decidim::Dev.test_file("city2.jpeg", "image/jpeg") }
     published_at { Time.current }
@@ -94,7 +94,7 @@ FactoryBot.define do
     full_name { Faker::Name.name }
     position { Decidim::Faker::Localized.word }
     affiliation { Decidim::Faker::Localized.word }
-    short_bio { Decidim::Faker::Localized.sentence(5) }
+    short_bio { generate_localized_title }
     twitter_handle { Faker::Internet.user_name }
     personal_url { Faker::Internet.url }
 

--- a/decidim-consultations/lib/decidim/consultations/test/factories.rb
+++ b/decidim-consultations/lib/decidim/consultations/test/factories.rb
@@ -15,9 +15,9 @@ FactoryBot.define do
   factory :consultation, class: "Decidim::Consultation" do
     organization
     slug { generate(:consultation_slug) }
-    title { Decidim::Faker::Localized.sentence(3) }
-    subtitle { Decidim::Faker::Localized.sentence(1) }
-    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
+    title { generate_localized_title }
+    subtitle { generate_localized_title }
+    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     banner_image { Decidim::Dev.test_file("city2.jpeg", "image/jpeg") }
     published_at { Time.current }
     start_voting_date { Time.zone.today }
@@ -63,12 +63,12 @@ FactoryBot.define do
     organization { consultation.organization }
     scope { create(:scope, organization: consultation.organization) }
     slug { generate(:question_slug) }
-    title { Decidim::Faker::Localized.sentence(3) }
-    subtitle { Decidim::Faker::Localized.sentence(3) }
-    promoter_group { Decidim::Faker::Localized.sentence(3) }
-    participatory_scope { Decidim::Faker::Localized.sentence(3) }
-    question_context { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
-    what_is_decided { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
+    title { generate_localized_title }
+    subtitle { generate_localized_title }
+    promoter_group { generate_localized_title }
+    participatory_scope { generate_localized_title }
+    question_context { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
+    what_is_decided { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     published_at { Time.current }
     hero_image { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
     banner_image { Decidim::Dev.test_file("city2.jpeg", "image/jpeg") }
@@ -93,7 +93,7 @@ FactoryBot.define do
 
   factory :response, class: "Decidim::Consultations::Response" do
     question
-    title { Decidim::Faker::Localized.sentence(3) }
+    title { generate_localized_title }
   end
 
   factory :vote, class: "Decidim::Consultations::Vote" do

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -254,7 +254,7 @@ FactoryBot.define do
       organization { create(:organization) }
     end
 
-    name { Decidim::Faker::Localized.sentence(3) }
+    name { generate_localized_title }
     participatory_space { create(:participatory_process, organization: organization) }
     manifest_name { "dummy" }
     published_at { Time.current }

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -8,7 +8,15 @@ require "decidim/assemblies/test/factories"
 require "decidim/conferences/test/factories"
 require "decidim/comments/test/factories"
 
+def generate_localized_title
+  Decidim::Faker::Localized.localized { generate(:title) }
+end
+
 FactoryBot.define do
+  sequence(:title) do |n|
+    "#{Faker::Lorem.sentence(3)} #{n}"
+  end
+
   sequence(:name) do |n|
     "#{Faker::Name.name} #{n}"
   end
@@ -42,8 +50,8 @@ FactoryBot.define do
   end
 
   factory :category, class: "Decidim::Category" do
-    name { Decidim::Faker::Localized.sentence(3) }
-    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(2) } }
+    name { generate_localized_title }
+    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
 
     association :participatory_space, factory: :participatory_process
   end
@@ -63,7 +71,7 @@ FactoryBot.define do
     youtube_handler { Faker::Hipster.word }
     github_handler { Faker::Hipster.word }
     sequence(:host) { |n| "#{n}.lvh.me" }
-    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(2) } }
+    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     favicon { Decidim::Dev.test_file("icon.png", "image/png") }
     default_locale { Decidim.default_locale }
     available_locales { Decidim.available_locales }
@@ -128,7 +136,7 @@ FactoryBot.define do
 
     trait :officialized do
       officialized_at { Time.current }
-      officialized_as { Decidim::Faker::Localized.sentence(3) }
+      officialized_as { generate_localized_title }
     end
   end
 
@@ -200,8 +208,8 @@ FactoryBot.define do
 
   factory :static_page, class: "Decidim::StaticPage" do
     slug { generate(:slug) }
-    title { Decidim::Faker::Localized.sentence(3) }
-    content { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
+    title { generate_localized_title }
+    content { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     organization
 
     trait :default do
@@ -214,16 +222,16 @@ FactoryBot.define do
   end
 
   factory :attachment_collection, class: "Decidim::AttachmentCollection" do
-    name { Decidim::Faker::Localized.sentence(1) }
-    description { Decidim::Faker::Localized.sentence(2) }
+    name { generate_localized_title }
+    description { generate_localized_title }
     weight { Faker::Number.number(1) }
 
     association :collection_for, factory: :participatory_process
   end
 
   factory :attachment, class: "Decidim::Attachment" do
-    title { Decidim::Faker::Localized.sentence(3) }
-    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
+    title { generate_localized_title }
+    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     file { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
     weight { Faker::Number.number(1) }
     attached_to { build(:participatory_process) }
@@ -317,9 +325,9 @@ FactoryBot.define do
     author { build(:user, :confirmed, organization: organization) }
     organization
 
-    subject { Decidim::Faker::Localized.sentence(3) }
+    subject { generate_localized_title }
 
-    body { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
+    body { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
 
     trait :sent do
       sent_at { Time.current }

--- a/decidim-core/lib/decidim/faker/localized.rb
+++ b/decidim-core/lib/decidim/faker/localized.rb
@@ -135,7 +135,7 @@ module Decidim
         end.with_indifferent_access
       end
 
-      # Wrapps a text build by the block with some other text.o
+      # Wrapps a text build by the block with some other text.
       #
       # before - The String text to inject at the begining of each value.
       # after  - The String text to inject at the end of each value.
@@ -155,7 +155,10 @@ module Decidim
         end
       end
 
-      # nodoc
+      # Runs the given block for each of the available locales in Decidim,
+      # momentarilly setting the locale to the current one.
+      #
+      # Returns a Hash with a value for each locale.
       def self.localized
         Decidim.available_locales.inject({}) do |result, locale|
           text = ::Faker::Base.with_locale(locale) do
@@ -165,8 +168,6 @@ module Decidim
           result.update(locale => text)
         end.with_indifferent_access
       end
-
-      private_class_method :localized
     end
   end
 end

--- a/decidim-debates/lib/decidim/debates/test/factories.rb
+++ b/decidim-debates/lib/decidim/debates/test/factories.rb
@@ -2,10 +2,10 @@
 
 FactoryBot.define do
   factory :debate, class: "Decidim::Debates::Debate" do
-    title { Decidim::Faker::Localized.sentence(3) }
-    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
-    information_updates { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
-    instructions { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
+    title { generate_localized_title }
+    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
+    information_updates { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
+    instructions { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     start_time { 1.day.from_now }
     end_time { start_time.advance(hours: 2) }
     component { build(:component, manifest_name: "debates") }

--- a/decidim-initiatives/lib/decidim/initiatives/test/factories.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/test/factories.rb
@@ -5,8 +5,8 @@ require "decidim/dev"
 
 FactoryBot.define do
   factory :initiatives_type, class: Decidim::InitiativesType do
-    title { Decidim::Faker::Localized.sentence(3) }
-    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
+    title { generate_localized_title }
+    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     banner_image { Decidim::Dev.test_file("city2.jpeg", "image/jpeg") }
     organization
   end
@@ -18,8 +18,8 @@ FactoryBot.define do
   end
 
   factory :initiative, class: Decidim::Initiative do
-    title { Decidim::Faker::Localized.sentence(3) }
-    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
+    title { generate_localized_title }
+    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     organization
     author { create(:user, :confirmed, organization: organization) }
     published_at { Time.current }

--- a/decidim-meetings/lib/decidim/meetings/test/factories.rb
+++ b/decidim-meetings/lib/decidim/meetings/test/factories.rb
@@ -12,10 +12,10 @@ FactoryBot.define do
   end
 
   factory :meeting, class: "Decidim::Meetings::Meeting" do
-    title { Decidim::Faker::Localized.sentence(3) }
-    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
-    location { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
-    location_hints { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
+    title { generate_localized_title }
+    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
+    location { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
+    location_hints { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     address { Faker::Lorem.sentence(3) }
     latitude { Faker::Address.latitude }
     longitude { Faker::Address.longitude }
@@ -25,8 +25,8 @@ FactoryBot.define do
     transparent { true }
     services do
       [
-        { title: Decidim::Faker::Localized.sentence(2), description: Decidim::Faker::Localized.sentence(5) },
-        { title: Decidim::Faker::Localized.sentence(2), description: Decidim::Faker::Localized.sentence(5) }
+        { title: generate_localized_title, description: generate_localized_title },
+        { title: generate_localized_title, description: generate_localized_title }
       ]
     end
     component { build(:component, manifest_name: "meetings") }
@@ -36,7 +36,7 @@ FactoryBot.define do
     end
 
     trait :closed do
-      closing_report { Decidim::Faker::Localized.sentence(3) }
+      closing_report { generate_localized_title }
       attendees_count { rand(50) }
       contributions_count { rand(50) }
       attending_organizations { Array.new(3) { Faker::GameOfThrones.house }.join(", ") }
@@ -47,7 +47,7 @@ FactoryBot.define do
       registrations_enabled { true }
       available_slots { 10 }
       reserved_slots { 4 }
-      registration_terms { Decidim::Faker::Localized.sentence(3) }
+      registration_terms { generate_localized_title }
     end
 
     trait :past do
@@ -67,7 +67,7 @@ FactoryBot.define do
 
   factory :agenda, class: "Decidim::Meetings::Agenda" do
     meeting
-    title { Decidim::Faker::Localized.sentence(3) }
+    title { generate_localized_title }
     visible { true }
 
     trait :with_agenda_items do
@@ -79,8 +79,8 @@ FactoryBot.define do
 
   factory :agenda_item, class: "Decidim::Meetings::AgendaItem" do
     agenda
-    title { Decidim::Faker::Localized.sentence(3) }
-    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
+    title { generate_localized_title }
+    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     duration { 15 }
     position { 0 }
 
@@ -96,7 +96,7 @@ FactoryBot.define do
   end
 
   factory :minutes, class: "Decidim::Meetings::Minutes" do
-    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
+    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     video_url { Faker::Internet.url }
     audio_url { Faker::Internet.url }
     visible { true }

--- a/decidim-pages/spec/factories.rb
+++ b/decidim-pages/spec/factories.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
   end
 
   factory :page, class: "Decidim::Pages::Page" do
-    body { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
+    body { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     component { build(:component, manifest_name: "pages") }
   end
 end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
@@ -11,21 +11,21 @@ FactoryBot.define do
   end
 
   factory :participatory_process, class: "Decidim::ParticipatoryProcess" do
-    title { Decidim::Faker::Localized.sentence(3) }
+    title { generate_localized_title }
     slug { generate(:participatory_process_slug) }
-    subtitle { Decidim::Faker::Localized.sentence(1) }
-    short_description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(2) } }
-    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
+    subtitle { generate_localized_title }
+    short_description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
+    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     hero_image { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
     banner_image { Decidim::Dev.test_file("city2.jpeg", "image/jpeg") }
     published_at { Time.current }
     organization
     meta_scope { Decidim::Faker::Localized.word }
-    developer_group { Decidim::Faker::Localized.sentence(1) }
-    local_area { Decidim::Faker::Localized.sentence(2) }
-    target { Decidim::Faker::Localized.sentence(3) }
-    participatory_scope { Decidim::Faker::Localized.sentence(1) }
-    participatory_structure { Decidim::Faker::Localized.sentence(2) }
+    developer_group { generate_localized_title }
+    local_area { generate_localized_title }
+    target { generate_localized_title }
+    participatory_scope { generate_localized_title }
+    participatory_structure { generate_localized_title }
     show_statistics { true }
     private_space { false }
     start_date { Date.current }
@@ -68,8 +68,8 @@ FactoryBot.define do
   end
 
   factory :participatory_process_group, class: "Decidim::ParticipatoryProcessGroup" do
-    name { Decidim::Faker::Localized.sentence(3) }
-    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
+    name { generate_localized_title }
+    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     hero_image { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
     organization
 
@@ -81,8 +81,8 @@ FactoryBot.define do
   end
 
   factory :participatory_process_step, class: "Decidim::ParticipatoryProcessStep" do
-    title { Decidim::Faker::Localized.sentence(3) }
-    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
+    title { generate_localized_title }
+    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     start_date { 1.month.ago }
     end_date { 2.months.from_now }
     position { nil }

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -167,7 +167,7 @@ FactoryBot.define do
       user_groups { [] }
     end
 
-    title { Faker::Lorem.sentence }
+    title { generate(:title) }
     body { Faker::Lorem.sentences(3).join("\n") }
     component { create(:proposal_component) }
     published_at { Time.current }
@@ -270,7 +270,7 @@ FactoryBot.define do
       user_groups { [] }
     end
 
-    title { Faker::Lorem.sentence }
+    title { generate(:title) }
     body { Faker::Lorem.sentences(3).join("\n") }
     component { create(:proposal_component) }
     address { "#{Faker::Address.street_name}, #{Faker::Address.city}" }

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -214,7 +214,7 @@ FactoryBot.define do
 
     trait :with_answer do
       state { "accepted" }
-      answer { Decidim::Faker::Localized.sentence }
+      answer { generate_localized_title }
       answered_at { Time.current }
     end
 

--- a/decidim-sortitions/lib/decidim/sortitions/test/factories.rb
+++ b/decidim-sortitions/lib/decidim/sortitions/test/factories.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
     component { create(:sortition_component) }
     decidim_proposals_component { create(:proposal_component, organization: component.organization) }
 
-    title { Decidim::Faker::Localized.sentence(3) }
+    title { generate_localized_title }
     author do
       create(:user, :admin, organization: component.organization) if component
     end
@@ -23,14 +23,14 @@ FactoryBot.define do
     dice { Faker::Number.between(1, 6).to_i }
     target_items { Faker::Number.between(1, 5).to_i }
     request_timestamp { Time.now.utc }
-    witnesses { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
-    additional_info { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
+    witnesses { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
+    additional_info { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     selected_proposals { create_list(:proposal, target_items, component: decidim_proposals_component).pluck(:id) }
     candidate_proposals { selected_proposals }
 
     trait :cancelled do
       cancelled_on { Time.now.utc }
-      cancel_reason { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
+      cancel_reason { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
       cancelled_by_user { create(:user, :admin, organization: component.organization) if component }
     end
   end

--- a/decidim-surveys/lib/decidim/surveys/test/factories.rb
+++ b/decidim-surveys/lib/decidim/surveys/test/factories.rb
@@ -11,13 +11,13 @@ FactoryBot.define do
   end
 
   factory :survey, class: Decidim::Surveys::Survey do
-    title { Decidim::Faker::Localized.sentence }
+    title { generate_localized_title }
     description do
       Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-        Decidim::Faker::Localized.sentence(4)
+        generate_localized_title
       end
     end
-    tos { Decidim::Faker::Localized.sentence(4) }
+    tos { generate_localized_title }
     component { build(:surveys_component) }
   end
 
@@ -26,7 +26,7 @@ FactoryBot.define do
       answer_options { [] }
     end
 
-    body { Decidim::Faker::Localized.sentence }
+    body { generate_localized_title }
     mandatory { false }
     position { 0 }
     question_type { Decidim::Surveys::SurveyQuestion::TYPES.first }
@@ -50,7 +50,7 @@ FactoryBot.define do
   end
 
   factory :survey_answer_option, class: Decidim::Surveys::SurveyAnswerOption do
-    body { Decidim::Faker::Localized.sentence }
+    body { generate_localized_title }
   end
 
   factory :survey_answer_choice, class: Decidim::Surveys::SurveyAnswerChoice do


### PR DESCRIPTION
#### :tophat: What? Why?
This is my take on fixing *some* of the flaky tests we have, for example #4073. The reasoning behind this is that #4073, although lacks more context (a URL of the failing job), seems to fail because the same text is found in different places in the same page. This happens because `faker` does not have unlimited words, and sometimes they are repeated. The shorter the sentence we generate, the higher the chance to repeat the result. #4073, specifically, seems to use a single-word title for the test.

Update: here's another job failing for the same reason of #4073: https://circleci.com/gh/decidim/decidim/154225

My take on fixing this is making all the factories use a [`FactoryBot` `sequence`](https://www.rubydoc.info/gems/factory_bot/file/GETTING_STARTED.md#Sequences), which allows us to append a number to the text. This number is automatically increased every time we call it, and this is handled by `FactoryBot`:

```ruby
def generate_localized_title
  Decidim::Faker::Localized.localized { generate(:title) }
end

FactoryBot.define do
  sequence(:title) do |n|
    "#{Faker::Lorem.sentence(3)} #{n}"
  end

  factory :static_page, class: "Decidim::StaticPage" do
    title { generate_localized_title }
    # ...
  end
end

my_page = build(:static_page)
my_page.title # => {"en"=>"Possimus dolor ut. 1", "ca"=>"Incidunt et temporibus. 2", "es"=>"Magni et totam. 3"}
```

As you can see, now the titles have a different number appended to it. This PR modifies the factories so that every appearance of `Decidim::Faker::Localized.sentence(x)` is replaced with this new code.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None