### PR TITLE
[backport] Fix hero content block migration

### DIFF
--- a/decidim-core/db/migrate/20180810092428_move_organization_fields_to_hero_content_block.rb
+++ b/decidim-core/db/migrate/20180810092428_move_organization_fields_to_hero_content_block.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class MoveOrganizationFieldsToHeroContentBlock < ActiveRecord::Migration[5.2]
-  class ::Decidim::Organization < ApplicationRecord
+  class ::Decidim::Organization < Decidim::ApplicationRecord
     mount_uploader :homepage_image, ::Decidim::HomepageImageUploader
   end
 
@@ -14,6 +14,8 @@ class MoveOrganizationFieldsToHeroContentBlock < ActiveRecord::Migration[5.2]
 
       content_block.settings = settings
       content_block.images_container.background_image = organization.homepage_image.file
+      content_block.settings_will_change!
+      content_block.images_will_change!
       content_block.save!
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
The migration to fill the hero content block data was wrong, as Rails was not properly detecting what fields were changed. We need to manually specify them, so that the data is properly saved.

This PR properly migrates the image and text to the hero content block. See #4188 for more info, this PR closes that issue.

#### :pushpin: Related Issues
- Fixes #4188

#### :clipboard: Subtasks
None
