### PR TITLE
Correcting NewsletterOptIn migration

### DIFF
--- a/decidim-core/db/migrate/20180611121852_change_newsletter_notification_type_value.rb
+++ b/decidim-core/db/migrate/20180611121852_change_newsletter_notification_type_value.rb
@@ -8,12 +8,14 @@ class ChangeNewsletterNotificationTypeValue < ActiveRecord::Migration[5.2]
   def up
     add_column :decidim_users, :newsletter_token, :string, default: ""
     add_column :decidim_users, :newsletter_notifications_at, :datetime
+    User.reset_column_information
     User.where(newsletter_notifications: true).update(newsletter_notifications_at: Time.zone.parse("2018-05-24 00:00 +02:00"))
     remove_column :decidim_users, :newsletter_notifications
   end
 
   def down
     add_column :decidim_users, :newsletter_notifications, :boolean
+    User.reset_column_information
     User.where.not(newsletter_notifications_at: nil).update(newsletter_notifications: true)
     remove_column :decidim_users, :newsletter_notifications_at
     remove_column :decidim_users, :newsletter_token


### PR DESCRIPTION
#### :tophat: What? Why?
`ChangeNewsletterNotificationTypeValue` migration has a failure execution related to the temporal `User` class, leading to lose which users were subscribed to the newsletter.

Added `reset_column_information` method inside the migration to update temporal class and evade it. No test's updates needed.

#### :pushpin: Related Issues
- Fixes #4195

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
