### PR TITLE
[Backport] Port #4139 and #4143 to 0.14-stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,8 +179,8 @@
 - **decidim-core**: Fix default content block creation migration [\#4100](https://github.com/decidim/decidim/pull/4100)
 - **decidim-core**: Fix default content block creation migration [\#4084](https://github.com/decidim/decidim/pull/4084)
 - **decidim-generators**: Bootsnap warnings when generating test applications [\#4098](https://github.com/decidim/decidim/pull/4098)
-- **decidim-admin**: Don't list deleted users at officialized list. [\#4139](https://github.com/decidim/decidim/pull/4139)
-- **decidim-participayory_processes**: Copy categories and subcategories to the new process. [\#4143](https://github.com/decidim/decidim/pull/4143)
+- **decidim-admin**: Don't list deleted users at officialized list. [\#4203](https://github.com/decidim/decidim/pull/4203)
+- **decidim-participayory_processes**: Copy categories and subcategories to the new process. [\#4203](https://github.com/decidim/decidim/pull/4203)
 
 **Removed**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,7 @@
 - **decidim-core**: Fix default content block creation migration [\#4084](https://github.com/decidim/decidim/pull/4084)
 - **decidim-generators**: Bootsnap warnings when generating test applications [\#4098](https://github.com/decidim/decidim/pull/4098)
 - **decidim-admin**: Don't list deleted users at officialized list. [\#4139](https://github.com/decidim/decidim/pull/4139)
+- **decidim-participayory_processes**: Copy categories and subcategories to the new process. [\#4143](https://github.com/decidim/decidim/pull/4143)
 
 **Removed**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,9 @@
 - **decidim-proposals**: Rename "votes" column to "supports" when exporting proposals [\#4018](https://github.com/decidim/decidim/pull/4018)
 - **decidim-core**: Fix hero content block migration [\#4061](https://github.com/decidim/decidim/pull/4061)
 - **decidim-core**: Fix default content block creation migration [\#4100](https://github.com/decidim/decidim/pull/4100)
+- **decidim-core**: Fix default content block creation migration [\#4084](https://github.com/decidim/decidim/pull/4084)
+- **decidim-generators**: Bootsnap warnings when generating test applications [\#4098](https://github.com/decidim/decidim/pull/4098)
+- **decidim-admin**: Don't list deleted users at officialized list. [\#4139](https://github.com/decidim/decidim/pull/4139)
 
 **Removed**:
 

--- a/decidim-admin/app/controllers/decidim/admin/officializations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/officializations_controller.rb
@@ -15,7 +15,7 @@ module Decidim
         @query = params[:q]
         @state = params[:state]
 
-        @users = Decidim::Admin::UserFilter.for(current_organization.users, @query, @state)
+        @users = Decidim::Admin::UserFilter.for(current_organization.users.not_deleted, @query, @state)
                                            .page(params[:page])
                                            .per(15)
       end

--- a/decidim-admin/spec/system/admin_manages_officializations_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_officializations_spec.rb
@@ -18,6 +18,11 @@ describe "Admin manages officializations", type: :system do
     let!(:officialized) { create(:user, :officialized, organization: organization) }
 
     let!(:not_officialized) { create(:user, organization: organization) }
+    let!(:deleted) do
+      user = create(:user, organization: organization)
+      result = Decidim::DestroyAccount.call(user, OpenStruct.new(valid?: true, delete_reason: "Testing"))
+      result["ok"]
+    end
     let!(:external_not_officialized) { create(:user) }
 
     before do

--- a/decidim-core/app/models/decidim/category.rb
+++ b/decidim-core/app/models/decidim/category.rb
@@ -34,6 +34,7 @@ module Decidim
 
     private
 
+    # This is done since we only allow one level of subcategories.
     def forbid_deep_nesting
       return unless parent
       return if parent.parent.blank?

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/copy_participatory_process.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/copy_participatory_process.rb
@@ -81,13 +81,21 @@ module Decidim
         end
 
         def copy_participatory_process_categories
-          @participatory_process.categories.each do |category|
-            Category.create!(
+          @participatory_process.categories.first_class.each do |category|
+            new_category = Category.create!(
               name: category.name,
               description: category.description,
-              parent_id: category.parent_id,
               participatory_space: @copied_process
             )
+
+            category.descendants.each do |child|
+              Category.create!(
+                name: child.name,
+                description: child.description,
+                participatory_space: @copied_process,
+                parent: new_category
+              )
+            end
           end
         end
 

--- a/decidim-participatory_processes/spec/commands/copy_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/commands/copy_participatory_process_spec.rb
@@ -102,7 +102,19 @@ module Decidim::ParticipatoryProcesses
 
         expect(new_participatory_process_category.name).to eq(old_participatory_process_category.name)
         expect(new_participatory_process_category.description).to eq(old_participatory_process_category.description)
-        expect(new_participatory_process_category.parent).to eq(old_participatory_process_category.parent)
+        expect(new_participatory_process_category.participatory_space).not_to eq(participatory_process)
+      end
+
+      context "with subcategories" do
+        let!(:subcategory) { create(:category, parent: category, participatory_space: participatory_process) }
+
+        it "duplicates the parent and its children" do
+          expect { subject.call }.to change { Decidim::Category.count }.by(2)
+          new_participatory_process = Decidim::ParticipatoryProcess.last
+
+          expect(participatory_process.categories.count).to eq(2)
+          expect(new_participatory_process.categories.count).to eq(2)
+        end
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
This PR backports #4139 and #4143 to `0.14-stable` so that we can release 0.14.2.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None