### PR TITLE
Added 'reset_column_information' method for NewsOptin for 0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,16 @@
 
   After this change you'll be able to safely migrate your database.
 
+- **Newsletter OptIn migration**: *Only for upgrades from 0.13 version* With the
+  0.13 version, User's field `newsletter_notifications_at` could had not been correctly
+  filled for subscribed users with `ChangeNewsletterNotificationTypeValue` migration.
+  To solve it, and in case you have an updated list of old subscribed users, you could
+  execute the following command in Rails console.
+
+   ```ruby
+  Decidim::User.where(**search for old subscribed users**).update(newsletter_notifications_at: Time.zone.parse("2018-05-24 00:00 +02:00"))
+  ```
+
 **Added**:
 
 - **decidim-proposals**: Apply hashtags to Proposals. [\#3959](https://github.com/decidim/decidim/pull/3959)
@@ -181,6 +191,7 @@
 - **decidim-generators**: Bootsnap warnings when generating test applications [\#4098](https://github.com/decidim/decidim/pull/4098)
 - **decidim-admin**: Don't list deleted users at officialized list. [\#4203](https://github.com/decidim/decidim/pull/4203)
 - **decidim-participayory_processes**: Copy categories and subcategories to the new process. [\#4203](https://github.com/decidim/decidim/pull/4203)
+- **decidim-core**: Fix newsletter opt-in migration [\#4198](https://github.com/decidim/decidim/pull/4218)
 
 **Removed**:
 

--- a/decidim-core/db/migrate/20180611121852_change_newsletter_notification_type_value.rb
+++ b/decidim-core/db/migrate/20180611121852_change_newsletter_notification_type_value.rb
@@ -8,12 +8,14 @@ class ChangeNewsletterNotificationTypeValue < ActiveRecord::Migration[5.2]
   def up
     add_column :decidim_users, :newsletter_token, :string, default: ""
     add_column :decidim_users, :newsletter_notifications_at, :datetime
+    User.reset_column_information
     User.where(newsletter_notifications: true).update(newsletter_notifications_at: Time.zone.parse("2018-05-24 00:00 +02:00"))
     remove_column :decidim_users, :newsletter_notifications
   end
 
   def down
     add_column :decidim_users, :newsletter_notifications, :boolean
+    User.reset_column_information
     User.where.not(newsletter_notifications_at: nil).update(newsletter_notifications: true)
     remove_column :decidim_users, :newsletter_notifications_at
     remove_column :decidim_users, :newsletter_token


### PR DESCRIPTION
#### :tophat: What? Why?
Backport for 0.14 Decidim version to correct Newsletter opt-in migration

#### :pushpin: Related Issues
- Fixes #4195 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add documentation regarding the feature 
