### PR TITLE
Added 'reset_column_information' method for NewsOptin for 0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ end
 - **decidim-generators**: Generated application not including bootsnap.
 - **decidim-generators**: Generated application not including optional gems.
 - **decidim-core**: Fix invitations form newsletter optin [\#3789](https://github.com/decidim/decidim/issues/3789)
+- **decidim-core**: Fix newsletter opt-in migration [\#4198](https://github.com/decidim/decidim/pull/4219)
 
 **Removed**:
 

--- a/decidim-core/db/migrate/20180611121852_change_newsletter_notification_type_value.rb
+++ b/decidim-core/db/migrate/20180611121852_change_newsletter_notification_type_value.rb
@@ -8,12 +8,14 @@ class ChangeNewsletterNotificationTypeValue < ActiveRecord::Migration[5.2]
   def up
     add_column :decidim_users, :newsletter_token, :string, default: ""
     add_column :decidim_users, :newsletter_notifications_at, :datetime
+    User.reset_column_information
     User.where(newsletter_notifications: true).update(newsletter_notifications_at: Time.zone.parse("2018-05-24 00:00 +02:00"))
     remove_column :decidim_users, :newsletter_notifications
   end
 
   def down
     add_column :decidim_users, :newsletter_notifications, :boolean
+    User.reset_column_information
     User.where.not(newsletter_notifications_at: nil).update(newsletter_notifications: true)
     remove_column :decidim_users, :newsletter_notifications_at
     remove_column :decidim_users, :newsletter_token


### PR DESCRIPTION
#### :tophat: What? Why?
Backport for 0.13 Decidim version to correct Newsletter opt-in migration

#### :pushpin: Related Issues
- Fixes #4195

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add documentation regarding the feature

