### PR TITLE
fix Data portability broken if user has submitted proposals with attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 
 **Fixed**:
 
+- **decidim-core**: Fix data portability proposal images, modify command to create directory if not exists, and fix surveys ansewers whem exporting data portability. [\#4223](https://github.com/decidim/decidim/pull/4223)
 - **decidim-debates**: When a Searchable accesses its indexed resources it must scope by resource_type and organization_id. [\4079](https://github.com/decidim/decidim/pull/4079)
 - **decidim-debates**: Fix create debates as a normal user in a private space [\4108](https://github.com/decidim/decidim/pull/4108)
 - **decidim-admin**: English locale now uses a consistent date format (UK style everywhere). [\#3724](https://github.com/decidim/decidim/pull/3724)

--- a/decidim-core/lib/decidim/data_portability_file_reader.rb
+++ b/decidim-core/lib/decidim/data_portability_file_reader.rb
@@ -29,7 +29,7 @@ module Decidim
     # Returns a String with the absolute file_path to be read or generate.
     def file_path
       directory_name = Rails.root.join(Decidim::DataPortabilityUploader.new.store_dir)
-      Dir.mkdir(directory_name) unless File.exist?(directory_name)
+      FileUtils.mkdir_p(directory_name) unless File.exist?(directory_name)
       directory_name + file_name
     end
 

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -201,7 +201,7 @@ module Decidim
       end
 
       def self.data_portability_images(user)
-        user_collection(user).map { |p| p.attachments.collect(&:file_url) }
+        user_collection(user).map { |p| p.attachments.collect(&:file) }
       end
 
       # Public: Overrides the `allow_resource_permissions?` Resourceable concern method.

--- a/decidim-surveys/app/models/decidim/surveys/survey_answer.rb
+++ b/decidim-surveys/app/models/decidim/surveys/survey_answer.rb
@@ -27,7 +27,7 @@ module Decidim
       end
 
       def self.export_serializer
-        Decidim::Surveys::SurveyUserAnswersSerializer
+        Decidim::Surveys::DataPortabilitySurveyUserAnswersSerializer
       end
 
       private

--- a/decidim-surveys/lib/decidim/surveys.rb
+++ b/decidim-surveys/lib/decidim/surveys.rb
@@ -10,5 +10,6 @@ module Decidim
   # allows users to create surveys in a participatory process.
   module Surveys
     autoload :SurveyUserAnswersSerializer, "decidim/surveys/survey_user_answers_serializer"
+    autoload :DataPortabilitySurveyUserAnswersSerializer, "decidim/surveys/data_portability_survey_user_answers_serializer"
   end
 end

--- a/decidim-surveys/lib/decidim/surveys/data_portability_survey_user_answers_serializer.rb
+++ b/decidim-surveys/lib/decidim/surveys/data_portability_survey_user_answers_serializer.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Surveys
+    class DataPortabilitySurveyUserAnswersSerializer < Decidim::Exporters::Serializer
+      include Decidim::TranslationsHelper
+      # Serializes a Survey User Answer for data portability
+      def serialize
+        {
+          id: resource.id,
+          user: {
+            name: resource.user.name,
+            email: resource.user.email
+          },
+          survey: {
+            id: resource.question.survey.id,
+            title: translated_attribute(resource.question.survey.title),
+            description: translated_attribute(resource.question.survey.description),
+            tos: translated_attribute(resource.question.survey.tos)
+          },
+          question: {
+            id: resource.question.id,
+            body: translated_attribute(resource.question.body),
+            description: translated_attribute(resource.question.description)
+          },
+          answer: normalize_body(resource)
+        }
+      end
+
+      private
+
+      def normalize_body(resource)
+        resource.body || resource.choices.pluck(:body)
+      end
+    end
+  end
+end

--- a/decidim-surveys/spec/services/decidim/surveys/surveys/data_portability_survey_user_answer_serializer_spec.rb
+++ b/decidim-surveys/spec/services/decidim/surveys/surveys/data_portability_survey_user_answer_serializer_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Surveys
+    describe DataPortabilitySurveyUserAnswersSerializer do
+      include Decidim::TranslationsHelper
+
+      subject do
+        described_class.new(survey.answers.first)
+      end
+
+      let!(:survey) { create(:survey) }
+      let!(:user) { create(:user, organization: survey.component.organization) }
+
+      describe "#serialize" do
+        let(:serialized) { subject.serialize }
+
+        context "when survey_question is shortanswer" do
+          let!(:survey_question) { create :survey_question, survey: survey }
+          let!(:survey_answer) { create :survey_answer, survey: survey, question: survey_question, user: user }
+
+          it "includes the answer id" do
+            expect(serialized).to include(id: survey_answer.id)
+          end
+
+          it "includes the user" do
+            expect(serialized[:user]).to(
+              include(name: survey_answer.user.name)
+            )
+            expect(serialized[:user]).to(
+              include(email: survey_answer.user.email)
+            )
+          end
+
+          it "includes the survey information" do
+            expect(serialized[:survey]).to(
+              include(id: survey.id)
+            )
+            expect(serialized[:survey]).to(
+              include(title: translated_attribute(survey.title))
+            )
+            expect(serialized[:survey]).to(
+              include(description: translated_attribute(survey.description))
+            )
+            expect(serialized[:survey]).to(
+              include(tos: translated_attribute(survey.tos))
+            )
+          end
+
+          it "includes the question info" do
+            expect(serialized[:question]).to(
+              include(id: survey_question.id)
+            )
+            expect(serialized[:question]).to(
+              include(body: translated_attribute(survey_question.body))
+            )
+            expect(serialized[:question]).to(
+              include(description: translated_attribute(survey_question.description))
+            )
+          end
+
+          it "includes the answer " do
+            expect(serialized).to include(answer: survey_answer.body)
+          end
+        end
+
+        context "when survey_question is multiple choice" do
+          let!(:multichoice_survey_question) { create :survey_question, survey: survey, question_type: "multiple_option" }
+          let!(:multichoice_answer_options) { create_list :survey_answer_option, 2, question: multichoice_survey_question }
+          let!(:multichoice_answer) do
+            create :survey_answer, survey: survey, question: multichoice_survey_question, user: user, body: nil
+          end
+          let!(:multichoice_answer_choices) do
+            multichoice_answer_options.map do |answer_option|
+              create :survey_answer_choice, answer: multichoice_answer, answer_option: answer_option, body: answer_option.body[I18n.locale.to_s]
+            end
+          end
+
+          it "includes the answer id" do
+            expect(serialized).to include(id: multichoice_answer.id)
+          end
+
+          it "includes the user" do
+            expect(serialized[:user]).to(
+              include(name: multichoice_answer.user.name)
+            )
+            expect(serialized[:user]).to(
+              include(email: multichoice_answer.user.email)
+            )
+          end
+
+          it "includes the question info" do
+            expect(serialized[:question]).to(
+              include(id: multichoice_survey_question.id)
+            )
+            expect(serialized[:question]).to(
+              include(body: translated_attribute(multichoice_survey_question.body))
+            )
+            expect(serialized[:question]).to(
+              include(description: translated_attribute(multichoice_survey_question.description))
+            )
+          end
+
+          it "includes the answers" do
+            expect(serialized).to include(answer: multichoice_answer_choices.map(&:body))
+          end
+        end
+
+        context "when survey_question is single choice" do
+          let!(:singlechoice_survey_question) { create :survey_question, survey: survey, question_type: "single_option" }
+          let!(:singlechoice_answer_options) { create_list :survey_answer_option, 2, question: singlechoice_survey_question }
+          let!(:singlechoice_answer) do
+            create :survey_answer, survey: survey, question: singlechoice_survey_question, user: user, body: nil
+          end
+          let!(:singlechoice_answer_choice) do
+            answer_option = singlechoice_answer_options.first
+            create :survey_answer_choice, answer: singlechoice_answer, answer_option: answer_option, body: answer_option.body[I18n.locale.to_s]
+          end
+
+          it "includes the answer id" do
+            expect(serialized).to include(id: singlechoice_answer.id)
+          end
+
+          it "includes the user" do
+            expect(serialized[:user]).to(
+              include(name: singlechoice_answer.user.name)
+            )
+            expect(serialized[:user]).to(
+              include(email: singlechoice_answer.user.email)
+            )
+          end
+
+          it "includes the question info" do
+            expect(serialized[:question]).to(
+              include(id: singlechoice_survey_question.id)
+            )
+            expect(serialized[:question]).to(
+              include(body: translated_attribute(singlechoice_survey_question.body))
+            )
+            expect(serialized[:question]).to(
+              include(description: translated_attribute(singlechoice_survey_question.description))
+            )
+          end
+
+          it "includes the answers" do
+            expect(serialized).to include(answer: [singlechoice_answer_choice.body])
+          end
+        end
+      end
+    end
+  end
+end

--- a/docs/advanced/testing.md
+++ b/docs/advanced/testing.md
@@ -27,3 +27,7 @@ bundle exec rake test_all
 ```
 
 But beware, it takes a long time... :)
+
+# Make CircleCI not run tests for a specific commit
+
+If you want that CircleCI no run tests for a specific commit, add this in your commit message `[ci_skip]`

--- a/docs/advanced/testing.md
+++ b/docs/advanced/testing.md
@@ -28,6 +28,6 @@ bundle exec rake test_all
 
 But beware, it takes a long time... :)
 
-# Make CircleCI not run tests for a specific commit
+## Make CircleCI not run tests for a specific commit
 
 If you want that CircleCI no run tests for a specific commit, add this in your commit message `[ci_skip]`


### PR DESCRIPTION
#### :tophat: What? Why?
If the user has submitted any proposals that have images attached to them, the data portability feature does not work, because file is not present. 

Also, we changed `Dir.mkdir(directory_name) unless File.exist?(directory_name)` to `FileUtils.mkdir_p(directory_name) unless File.exist?(directory_name)` in `data_portability_file_reader.rb` to can create folder if not exists.

#### :pushpin: Related Issues
- Related to #3489 
- Fixes #4217 #3918 #4210 #4213 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Modifiy `data_portability_images` on `proposal.rb` to send file unless file_url
- [x] Modifiy `Dir.mkdir(directory_name) unless File.exist?(directory_name)` to `FileUtils.mkdir_p(directory_name) unless File.exist?(directory_name)`
- [x] Fix survey answers serializers for data portability
- [x] add documentation to skip circle ci on specifici commits

### :camera: Screenshots (optional)
![Description](URL)
