### PR TITLE
Hide devise's `timedout` flash messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 - **decidim-participayory_processes**: Copy categories and subcategories to the new process. [\#4143](https://github.com/decidim/decidim/pull/4143)
 - **decidim-participayory_processes**: Fix Internet Explorer 11 related issues in process filtering. [\#4166](https://github.com/decidim/decidim/pull/4166)
 - **decidim-core**: Fix newsletter opt-in migration [\#4198](https://github.com/decidim/decidim/pull/4198)
+- **decidim-core**: Hide weird flash message [\#4235](https://github.com/decidim/decidim/pull/4235)
 
 **Removed**:
 

--- a/decidim-core/config/initializers/foundation_rails_helper.rb
+++ b/decidim-core/config/initializers/foundation_rails_helper.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 FoundationRailsHelper.configuration.button_class = "button"
+FoundationRailsHelper.configuration.ignored_flash_keys = [:timedout]


### PR DESCRIPTION
#### :tophat: What? Why?
Devise uses flash messages to keep track of some events. This causes weird flash messages to appear, if not handled.

This PR ignores one of those weird flash messages, see #4227 for a full report.

#### :pushpin: Related Issues
- Fixes #4227

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry


### :camera: Screenshots (optional)
![Description](https://i.imgur.com/2CMI5si.png)
