### PR TITLE
List groups on user profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 - **decidim-core**: Added metrics visualization for Users and Proposals (all, accepted and votes) [\#3603](https://github.com/decidim/decidim/pull/3603)
 - **decidim-participatory_processes**: Add a Call to Action button to process steps[\#4184](https://github.com/decidim/decidim/pull/4184)
 - **decidim-core**: Show user groups profiles [\#4196](https://github.com/decidim/decidim/pull/4196)
+- **decidim-core**: Show user groups on users profiles [\#4236](https://github.com/decidim/decidim/pull/4236)
 
 **Changed**:
 

--- a/decidim-core/app/cells/decidim/groups/show.erb
+++ b/decidim-core/app/cells/decidim/groups/show.erb
@@ -1,0 +1,9 @@
+<div class="empty-notifications callout secondary <%= "hide" if user_groups.any? %>">
+  <p><%= t("decidim.groups.no_user_groups") %></p>
+</div>
+<div class="row small-up-1 medium-up-2 card-grid">
+  <% user_groups.each do |user_group| %>
+    <%= card_for user_group %>
+  <% end %>
+</div>
+<%= decidim_paginate user_groups %>

--- a/decidim-core/app/cells/decidim/groups_cell.rb
+++ b/decidim-core/app/cells/decidim/groups_cell.rb
@@ -13,7 +13,7 @@ module Decidim
     end
 
     def user_groups
-      @user_groups ||= Kaminari.paginate_array(model.user_groups).page(params[:page]).per(20)
+      @user_groups ||= model.user_groups.page(params[:page]).per(20)
     end
   end
 end

--- a/decidim-core/app/cells/decidim/groups_cell.rb
+++ b/decidim-core/app/cells/decidim/groups_cell.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This cell is intended to be used on profiles.
+  class GroupsCell < Decidim::ViewModel
+    include Decidim::CellsPaginateHelper
+    include Decidim::ApplicationHelper
+    include Decidim::Core::Engine.routes.url_helpers
+    include Decidim::CardHelper
+
+    def show
+      render :show
+    end
+
+    def user_groups
+      @user_groups ||= Kaminari.paginate_array(model.user_groups).page(params[:page]).per(20)
+    end
+  end
+end

--- a/decidim-core/app/cells/decidim/profile/show.erb
+++ b/decidim-core/app/cells/decidim/profile/show.erb
@@ -1,15 +1,7 @@
 <main class="wrapper">
   <div class="row">
     <div class="columns medium-9 medium-offset-3">
-      <ul class="tabs" id="profile-tabs">
-        <% if own_profile? %>
-          <%= user_profile_tab t("decidim.profiles.show.notifications"), notifications_path %>
-          <%= user_profile_tab t("decidim.profiles.show.conversations"), conversations_path %>
-        <% end %>
-        <%= user_profile_tab t("decidim.profiles.show.following"), profile_following_path(nickname: profile_holder.nickname) %>
-        <%= user_profile_tab t("decidim.profiles.show.followers"), profile_followers_path(nickname: profile_holder.nickname) %>
-        <%= user_profile_tab t("decidim.profiles.show.badges"), profile_badges_path(nickname: profile_holder.nickname) %>
-      </ul>
+      <%= profile_tabs %>
     </div>
   </div>
   <div class="row">

--- a/decidim-core/app/cells/decidim/profile/user_group_tabs.erb
+++ b/decidim-core/app/cells/decidim/profile/user_group_tabs.erb
@@ -1,0 +1,5 @@
+<ul class="tabs" id="profile-tabs">
+  <%= user_profile_tab t("decidim.profiles.show.following"), profile_following_path(nickname: profile_holder.nickname) %>
+  <%= user_profile_tab t("decidim.profiles.show.followers"), profile_followers_path(nickname: profile_holder.nickname) %>
+  <%= user_profile_tab t("decidim.profiles.show.badges"), profile_badges_path(nickname: profile_holder.nickname) %>
+</ul>

--- a/decidim-core/app/cells/decidim/profile/user_tabs.erb
+++ b/decidim-core/app/cells/decidim/profile/user_tabs.erb
@@ -1,0 +1,9 @@
+<ul class="tabs" id="profile-tabs">
+  <% if own_profile? %>
+    <%= user_profile_tab t("decidim.profiles.show.notifications"), notifications_path %>
+    <%= user_profile_tab t("decidim.profiles.show.conversations"), conversations_path %>
+  <% end %>
+  <%= user_profile_tab t("decidim.profiles.show.following"), profile_following_path(nickname: profile_holder.nickname) %>
+  <%= user_profile_tab t("decidim.profiles.show.followers"), profile_followers_path(nickname: profile_holder.nickname) %>
+  <%= user_profile_tab t("decidim.profiles.show.badges"), profile_badges_path(nickname: profile_holder.nickname) %>
+</ul>

--- a/decidim-core/app/cells/decidim/profile/user_tabs.erb
+++ b/decidim-core/app/cells/decidim/profile/user_tabs.erb
@@ -6,4 +6,5 @@
   <%= user_profile_tab t("decidim.profiles.show.following"), profile_following_path(nickname: profile_holder.nickname) %>
   <%= user_profile_tab t("decidim.profiles.show.followers"), profile_followers_path(nickname: profile_holder.nickname) %>
   <%= user_profile_tab t("decidim.profiles.show.badges"), profile_badges_path(nickname: profile_holder.nickname) %>
+  <%= user_profile_tab t("decidim.profiles.show.groups"), profile_groups_path(nickname: profile_holder.nickname) %>
 </ul>

--- a/decidim-core/app/cells/decidim/profile_cell.rb
+++ b/decidim-core/app/cells/decidim/profile_cell.rb
@@ -29,5 +29,10 @@ module Decidim
     def own_profile?
       current_user && current_user == profile_holder
     end
+
+    def profile_tabs
+      return render :user_group_tabs if profile_holder.is_a?(Decidim::UserGroup)
+      render :user_tabs
+    end
   end
 end

--- a/decidim-core/app/controllers/decidim/profiles_controller.rb
+++ b/decidim-core/app/controllers/decidim/profiles_controller.rb
@@ -29,6 +29,11 @@ module Decidim
       render :show
     end
 
+    def groups
+      @content_cell = "decidim/groups"
+      render :show
+    end
+
     private
 
     def ensure_profile_holder

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -412,6 +412,8 @@ en:
       description: Badges are recognitions to participant actions and progress in the platform. As you start discovering, participating and interacting in the platform, you will earn different badges.
       level: Level %{level}
       reached_top: You've reached the top level for this badge.
+    groups:
+      no_user_groups: Doesn't belong to any user group yet.
     invitations:
       create:
         error: There were some problems while inviting your friends
@@ -595,6 +597,7 @@ en:
         conversations: Conversations
         followers: Followers
         following: Follows
+        groups: Groups
         notifications: Notifications
       sidebar:
         badges:

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -65,6 +65,7 @@ Decidim::Core::Engine.routes.draw do
     get "following", to: "profiles#following", as: "profile_following"
     get "followers", to: "profiles#followers", as: "profile_followers"
     get "badges", to: "profiles#badges", as: "profile_badges"
+    get "groups", to: "profiles#groups", as: "profile_groups"
   end
 
   resources :pages, only: [:index, :show], format: false

--- a/decidim-core/spec/system/profile_spec.rb
+++ b/decidim-core/spec/system/profile_spec.rb
@@ -98,6 +98,20 @@ describe "Profile", type: :system do
         expect(page).to have_content(user_to_follow.name)
       end
     end
+
+    context "when belonging to user groups" do
+      let!(:user_group) { create :user_group, users: [user], organization: user.organization }
+
+      before do
+        visit decidim.profile_path(user.nickname)
+      end
+
+      it "lists the user groups" do
+        click_link "Groups"
+
+        expect(page).to have_content(user_group.name)
+      end
+    end
   end
 
   describe "view hooks" do


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds a tab to a user profile where all their user groups are listed. A complementary tab on user groups profiles to list the users will be added on later PRs.

#### :pushpin: Related Issues
- Related to #3893

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/bfeBKnZ.png)
