### PR TITLE
Notification settings show Newsletter always as "not subscribed"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 - **decidim-participayory_processes**: Fix Internet Explorer 11 related issues in process filtering. [\#4166](https://github.com/decidim/decidim/pull/4166)
 - **decidim-core**: Fix newsletter opt-in migration [\#4198](https://github.com/decidim/decidim/pull/4198)
 - **decidim-core**: Hide weird flash message [\#4235](https://github.com/decidim/decidim/pull/4235)
+- **decidim-core**: Fix newsletter subscription checkbox always being unchecked [\#4238](https://github.com/decidim/decidim/pull/4238)
 
 **Removed**:
 

--- a/decidim-core/app/forms/decidim/notifications_settings_form.rb
+++ b/decidim-core/app/forms/decidim/notifications_settings_form.rb
@@ -16,5 +16,9 @@ module Decidim
       return nil unless newsletter_notifications
       Time.current
     end
+
+    def map_model(model)
+      self.newsletter_notifications = model.newsletter_notifications_at.present?
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

When subscribing to the newsletter in Account / Notification Settings by toggling the switch labelled *I want to receive newsletters* and submitting the form, the new state initially is shown (and saved) correctly. When revisiting the page (click Notification settings in sidebar again), the switch is *off* again.

#### Reason and Fix

The reason for that is that the form object's `newsletter_subscription` attribute is not initialized when it is created from the user model. The patch adds a corresponding `from_model` implementation.