### PR TITLE
Don't show child assemblies in assemblies general homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 **Changed**:
 
 - **decidim-assemblies**: For consistency with DB, `ceased_date` and `designation_date` columns now use date attributes in forms, instead of datetime ones. [\#3724](https://github.com/decidim/decidim/pull/3724)
+- **decidim-assemblies**: Don't show child assemblies in assemblies general homepage. [\#4239](https://github.com/decidim/decidim/pull/4239)
 - **decidim-core**: Allow users to enter datetime fields manually. [\#3724](https://github.com/decidim/decidim/pull/3724)
 - **decidim-core**: Allow users to enter date fields manually. [\#3724](https://github.com/decidim/decidim/pull/3724)
 - **decidim-core**: Merge Users and UserGroups DB tables [\#4196](https://github.com/decidim/decidim/pull/4196)

--- a/decidim-assemblies/app/controllers/decidim/assemblies/assemblies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/assemblies_controller.rb
@@ -14,7 +14,7 @@ module Decidim
       helper Decidim::SanitizeHelper
       helper Decidim::ResourceReferenceHelper
 
-      helper_method :collection, :promoted_assemblies, :assemblies, :stats, :assembly_participatory_processes
+      helper_method :collection, :parent_assemblies, :promoted_assemblies, :assemblies, :stats, :assembly_participatory_processes
 
       def index
         enforce_permission_to :list, :assembly
@@ -64,7 +64,11 @@ module Decidim
         @assemblies ||= OrganizationPrioritizedAssemblies.new(current_organization, current_user)
       end
 
-      alias collection assemblies
+      def parent_assemblies
+        @parent_assemblies ||= assemblies | ParentAssemblies.new
+      end
+
+      alias collection parent_assemblies
 
       def promoted_assemblies
         @promoted_assemblies ||= assemblies | PromotedAssemblies.new

--- a/decidim-assemblies/app/queries/decidim/assemblies/parent_assemblies.rb
+++ b/decidim-assemblies/app/queries/decidim/assemblies/parent_assemblies.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Assemblies
+    # This query filters assemblies so only parent assemblies are returned.
+    class ParentAssemblies < Rectify::Query
+      def query
+        Decidim::Assembly.where(parent: nil)
+      end
+    end
+  end
+end

--- a/decidim-assemblies/spec/controllers/assemblies_controller_spec.rb
+++ b/decidim-assemblies/spec/controllers/assemblies_controller_spec.rb
@@ -90,6 +90,14 @@ module Decidim
         end
       end
 
+      describe "parent_assemblies" do
+        let!(:child_assembly) { create(:assembly, parent: published, organization: organization) }
+
+        it "includes only parent assemblies" do
+          expect(controller.helpers.parent_assemblies).to contain_exactly(published, promoted)
+        end
+      end
+
       describe "GET show" do
         context "when the assembly is unpublished" do
           it "redirects to root path" do

--- a/decidim-assemblies/spec/queries/parent_assemblies_spec.rb
+++ b/decidim-assemblies/spec/queries/parent_assemblies_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Assemblies
+  describe ParentAssemblies do
+    subject { described_class.new }
+
+    let!(:parent_assembly) { create(:assembly) }
+    let!(:child_assembly) { create(:assembly, :with_parent) }
+
+    describe "query" do
+      it "only returns parent assemblies" do
+        expect(subject.count).to eq(2)
+        expect(subject.pluck(:id)).to match_array([parent_assembly.id, child_assembly.parent.id])
+      end
+    end
+  end
+end

--- a/decidim-assemblies/spec/system/assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/assemblies_spec.rb
@@ -66,6 +66,7 @@ describe "Assemblies", type: :system do
 
   context "when there are some published assemblies" do
     let!(:assembly) { base_assembly }
+    let!(:child_assembly) { create(:assembly, parent: assembly, organization: organization) }
     let!(:promoted_assembly) { create(:assembly, :promoted, organization: organization) }
     let!(:unpublished_assembly) { create(:assembly, :unpublished, organization: organization) }
 
@@ -95,7 +96,7 @@ describe "Assemblies", type: :system do
       end
     end
 
-    it "lists all the assemblies" do
+    it "lists the parent assemblies" do
       within "#assemblies-grid" do
         within "#assemblies-grid h2" do
           expect(page).to have_content("2")
@@ -105,6 +106,7 @@ describe "Assemblies", type: :system do
         expect(page).to have_content(translated(promoted_assembly.title, locale: :en))
         expect(page).to have_selector("article.card", count: 2)
 
+        expect(page).not_to have_content(translated(child_assembly.title, locale: :en))
         expect(page).not_to have_content(translated(unpublished_assembly.title, locale: :en))
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

Now we have the option to relate and establish hierarchical relationships between Assemblies. The issue right now is that every single Assembly is shown in the Assemblies general homepage, so it makes very confusing the navigation and understanding relations between them.

#### :pushpin: Related Issues

- Fixes #4140

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
