### PR TITLE
Fix hero content block data migration

### DIFF
--- a/decidim-core/db/migrate/20180810092428_move_organization_fields_to_hero_content_block.rb
+++ b/decidim-core/db/migrate/20180810092428_move_organization_fields_to_hero_content_block.rb
@@ -8,6 +8,7 @@ class MoveOrganizationFieldsToHeroContentBlock < ActiveRecord::Migration[5.2]
   end
 
   def change
+    Decidim::ContentBlock.reset_column_information
     Organization.find_each do |organization|
       content_block = Decidim::ContentBlock.find_by(organization: organization, scope: :homepage, manifest_name: :hero)
       settings = {}


### PR DESCRIPTION
#### :tophat: What? Why?
Under certain conditions, the hero content block data migration was not working properly. This PR fixes this problem.

Explanation:
If you migrate from 0.13.x to 0.14.x and run all the migrations at the same time, the `Decidim::ContentBlock` attribute schema is loaded *before* we add the `images` and `settings` columns. This causes the migration not to be aware of these columns, as the schema is already loaded, and thus the data is not saved as those columns are ignored on save.

By adding the `reset_column_information` call, we ensure the columns schema is reloaded and has the correct structure.

Sorry all for the inconveniences this might have caused. This is already on `0.14-stable` branch, we'll release 0.14.3 shortly and probably yank 0.14.2.

#### :pushpin: Related Issues
None.