### PR TITLE
Add ability to toggle badges by organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 - **decidim-core**: Show user groups on users profiles [\#4236](https://github.com/decidim/decidim/pull/4236)
 - **decidim-core**: Add a badge info page listing all the badges and how to get them. [\#4245](https://github.com/decidim/decidim/pull/4245)
 - **decidim-core**: Show members on user groups profiles [\#4252](https://github.com/decidim/decidim/pull/4252)
+- **decidim-core**: Badges can now be disabled per organization. [\#4249](https://github.com/decidim/decidim/pull/4249)
 
 **Changed**:
 

--- a/decidim-admin/app/commands/decidim/admin/update_organization.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization.rb
@@ -48,7 +48,8 @@ module Decidim
           facebook_handler: form.facebook_handler,
           instagram_handler: form.instagram_handler,
           youtube_handler: form.youtube_handler,
-          github_handler: form.github_handler
+          github_handler: form.github_handler,
+          badges_enabled: form.badges_enabled
         }
       end
     end

--- a/decidim-admin/app/forms/decidim/admin/organization_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_form.rb
@@ -18,6 +18,7 @@ module Decidim
       attribute :youtube_handler, String
       attribute :github_handler, String
       attribute :default_locale, String
+      attribute :badges_enabled, Boolean
 
       validates :name, presence: true
       validates :default_locale, :reference_prefix, presence: true

--- a/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
@@ -37,3 +37,9 @@
     <%= form.text_field :reference_prefix %>
   </div>
 </div>
+
+<div class="row">
+  <div class="columns xlarge-6">
+    <%= form.check_box :badges_enabled %>
+  </div>
+</div>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -37,6 +37,7 @@ en:
         organization_url: Organization URL
         redirect_uri: Redirect URI
       organization:
+        badges_enabled: Enable badges
         cta_button_path: Call To Action button path
         cta_button_text: Call To Action button text
         default_locale: Default locale

--- a/decidim-admin/spec/commands/decidim/admin/update_organization_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/update_organization_spec.rb
@@ -12,7 +12,8 @@ module Decidim::Admin
           organization: {
             name: "My super organization",
             reference_prefix: "MSO",
-            default_locale: "en"
+            default_locale: "en",
+            badges_enabled: true
           }
         }
       end

--- a/decidim-core/app/cells/decidim/profile/user_tabs.erb
+++ b/decidim-core/app/cells/decidim/profile/user_tabs.erb
@@ -5,6 +5,8 @@
   <% end %>
   <%= user_profile_tab t("decidim.profiles.show.following"), profile_following_path(nickname: profile_holder.nickname) %>
   <%= user_profile_tab t("decidim.profiles.show.followers"), profile_followers_path(nickname: profile_holder.nickname) %>
-  <%= user_profile_tab t("decidim.profiles.show.badges"), profile_badges_path(nickname: profile_holder.nickname) %>
+  <% if current_organization.badges_enabled? %>
+    <%= user_profile_tab t("decidim.profiles.show.badges"), profile_badges_path(nickname: profile_holder.nickname) %>
+  <% end %>
   <%= user_profile_tab t("decidim.profiles.show.groups"), profile_groups_path(nickname: profile_holder.nickname) %>
 </ul>

--- a/decidim-core/app/cells/decidim/profile_sidebar/show.erb
+++ b/decidim-core/app/cells/decidim/profile_sidebar/show.erb
@@ -1,4 +1,4 @@
-<div class="card">
+<div class="card profile--sidebar">
   <%= image_tag profile_user.avatar_url(:profile), class: "card__image card__image--larger" %>
   <div class="card__content">
     <h5>
@@ -43,30 +43,32 @@
     </div>
   </div>
 
-  <div class="card__footer card__footer--transparent">
-    <div class="card__support">
-      <div class="row column mb-s">
-        <strong class="muted"><%= t("decidim.profiles.sidebar.badges.title") %></strong>
-        <div class="badge-tip badge-tip--inline">
-          <div data-tooltip data-position="top" title="<%= t("decidim.profiles.sidebar.badges.info") %>" aria-describedby="badges-tooltip" data-yeti-box="badges-tooltip" data-toggle="badges-tooltip" data-resize="badges-tooltip" class="has-tip" data-events="resize">
-            <%= icon "info", class: "icon--small" %>
+  <% if current_organization.badges_enabled? %>
+    <div class="card__footer card__footer--transparent">
+      <div class="card__support">
+        <div class="row column mb-s">
+          <strong class="muted"><%= t("decidim.profiles.sidebar.badges.title") %></strong>
+          <div class="badge-tip badge-tip--inline">
+            <div data-tooltip data-position="top" title="<%= t("decidim.profiles.sidebar.badges.info") %>" aria-describedby="badges-tooltip" data-yeti-box="badges-tooltip" data-toggle="badges-tooltip" data-resize="badges-tooltip" class="has-tip" data-events="resize">
+              <%= icon "info", class: "icon--small" %>
+            </div>
           </div>
         </div>
-      </div>
-      <div class="collapsible-list is-filtered row small-up-2 medium-up-4 collapse">
-        <% Decidim::Gamification.badges.sort_by(&:name).each do |badge| %>
-          <% status = Decidim::Gamification.status_for(profile_holder, badge.name) %>
-          <% if status.level > 0 %>
-            <div class="column">
-              <div class="badge-container pr-xs">
-                <%= cell("decidim/badge", profile_holder, badge: badge, status: status).(:small) %>
+        <div class="collapsible-list is-filtered row small-up-2 medium-up-4 collapse">
+          <% Decidim::Gamification.badges.sort_by(&:name).each do |badge| %>
+            <% status = Decidim::Gamification.status_for(profile_holder, badge.name) %>
+            <% if status.level > 0 %>
+              <div class="column">
+                <div class="badge-container pr-xs">
+                  <%= cell("decidim/badge", profile_holder, badge: badge, status: status).(:small) %>
+                </div>
               </div>
-            </div>
+            <% end %>
           <% end %>
-        <% end %>
+        </div>
       </div>
     </div>
-  </div>
+  <% end %>
 </div>
 
 <% if own_profile? %>

--- a/decidim-core/db/migrate/20181008102144_add_badge_switch_to_organizations.rb
+++ b/decidim-core/db/migrate/20181008102144_add_badge_switch_to_organizations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddBadgeSwitchToOrganizations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_organizations, :badges_enabled, :boolean, null: false, default: false
+    execute "UPDATE decidim_organizations set badges_enabled = true"
+  end
+end

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -22,7 +22,8 @@ if !Rails.env.production? || ENV["SEED"]
     available_locales: Decidim.available_locales,
     reference_prefix: Faker::Name.suffix,
     available_authorizations: Decidim.authorization_workflows.map(&:name),
-    tos_version: Time.current
+    tos_version: Time.current,
+    badges_enabled: true
   )
 
   if organization.top_scopes.none?

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -81,6 +81,7 @@ FactoryBot.define do
     highlighted_content_banner_enabled { false }
     enable_omnipresent_banner { false }
     tos_version { Time.current }
+    badges_enabled { true }
 
     trait :with_tos do
       after(:create) do |organization|

--- a/decidim-core/lib/decidim/gamification/badge_scorer.rb
+++ b/decidim-core/lib/decidim/gamification/badge_scorer.rb
@@ -86,6 +86,7 @@ module Decidim
 
       def send_notification(previous_level, current_level)
         return unless current_level > previous_level
+        return unless badges_enabled?
 
         if previous_level.zero?
           publish_event(name: "decidim.events.gamification.badge_earned",
@@ -112,6 +113,10 @@ module Decidim
             current_level: current_level
           }
         )
+      end
+
+      def badges_enabled?
+        @user.organization.badges_enabled?
       end
     end
   end

--- a/decidim-core/spec/lib/gamification/badge_scorer_spec.rb
+++ b/decidim-core/spec/lib/gamification/badge_scorer_spec.rb
@@ -123,21 +123,38 @@ module Decidim
 
       describe "notifications" do
         describe "badge earned notification" do
-          it "sends a notification when earning a new badge" do
-            expect(Decidim::EventsManager).to receive(:publish).with(
-              hash_including(
-                event: "decidim.events.gamification.badge_earned",
-                event_class: BadgeEarnedEvent,
-                resource: user,
-                recipient_ids: [user.id],
-                extra: {
-                  badge_name: "test",
-                  previous_level: 0,
-                  current_level: 1
-                }
+          context "when badges are enabled organization-wide" do
+            before do
+              user.organization.update(badges_enabled: true)
+            end
+
+            it "sends a notification when earning a new badge" do
+              expect(Decidim::EventsManager).to receive(:publish).with(
+                hash_including(
+                  event: "decidim.events.gamification.badge_earned",
+                  event_class: BadgeEarnedEvent,
+                  resource: user,
+                  recipient_ids: [user.id],
+                  extra: {
+                    badge_name: "test",
+                    previous_level: 0,
+                    current_level: 1
+                  }
+                )
               )
-            )
-            subject.increment
+              subject.increment
+            end
+          end
+
+          context "when badges are disabled organization-wide" do
+            before do
+              user.organization.update(badges_enabled: false)
+            end
+
+            it "doesn't send a notification" do
+              expect(Decidim::EventsManager).not_to receive(:publish).with(anything)
+              subject.increment
+            end
           end
         end
 

--- a/decidim-core/spec/system/user_profile_spec.rb
+++ b/decidim-core/spec/system/user_profile_spec.rb
@@ -99,6 +99,42 @@ describe "Profile", type: :system do
       end
     end
 
+    describe "badges" do
+      context "when badges are enabled" do
+        before do
+          user.organization.update(badges_enabled: true)
+          visit decidim.profile_path(user.nickname)
+        end
+
+        it "shows a badges tab" do
+          expect(page).to have_link("Badges")
+        end
+
+        it "shows a badges section on the sidebar" do
+          within ".profile--sidebar" do
+            expect(page).to have_content("Badges")
+          end
+        end
+      end
+
+      context "when badges are disabled" do
+        before do
+          user.organization.update(badges_enabled: false)
+          visit decidim.profile_path(user.nickname)
+        end
+
+        it "shows a badges tab" do
+          expect(page).not_to have_link("Badges")
+        end
+
+        it "doesn't have a badges section on the sidebar" do
+          within ".profile--sidebar" do
+            expect(page).not_to have_content("Badges")
+          end
+        end
+      end
+    end
+
     context "when belonging to user groups" do
       let!(:user_group) { create :user_group, users: [user], organization: user.organization }
 

--- a/decidim-system/app/commands/decidim/system/register_organization.rb
+++ b/decidim-system/app/commands/decidim/system/register_organization.rb
@@ -50,6 +50,7 @@ module Decidim
           reference_prefix: form.reference_prefix,
           available_locales: form.available_locales,
           available_authorizations: form.clean_available_authorizations,
+          badges_enabled: true,
           default_locale: form.default_locale
         )
       end


### PR DESCRIPTION
#### :tophat: What? Why?
This allows each organization to toggle the whole badges system on or off depending on their specific needs.

The idea is that the badges subsystem is essentially working all the time, but notifications won't be triggered and the interface won't show up - the idea is that you can activate badges at any moment and scores will be right.

#### :pushpin: Related Issues
- Fixes #4197
- Related to #3050 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
*None*
