### PR TITLE
Hide unused user group profile tabs

### DIFF
--- a/decidim-core/app/cells/decidim/profile/user_group_tabs.erb
+++ b/decidim-core/app/cells/decidim/profile/user_group_tabs.erb
@@ -1,6 +1,4 @@
 <ul class="tabs" id="profile-tabs">
-  <%= user_profile_tab t("decidim.profiles.show.following"), profile_following_path(nickname: profile_holder.nickname) %>
-  <%= user_profile_tab t("decidim.profiles.show.followers"), profile_followers_path(nickname: profile_holder.nickname) %>
-  <%= user_profile_tab t("decidim.profiles.show.badges"), profile_badges_path(nickname: profile_holder.nickname) %>
   <%= user_profile_tab t("decidim.profiles.show.members"), profile_members_path(nickname: profile_holder.nickname) %>
+  <%= user_profile_tab t("decidim.profiles.show.followers"), profile_followers_path(nickname: profile_holder.nickname) %>
 </ul>

--- a/decidim-core/app/controllers/decidim/profiles_controller.rb
+++ b/decidim-core/app/controllers/decidim/profiles_controller.rb
@@ -8,9 +8,12 @@ module Decidim
     helper_method :profile_holder, :active_content
 
     before_action :ensure_profile_holder
+    before_action :ensure_profile_holder_is_a_group, only: [:members]
+    before_action :ensure_profile_holder_is_a_user, only: [:groups, :badges, :following]
 
     def show
       return redirect_to notifications_path if current_user == profile_holder
+      return redirect_to profile_members_path if profile_holder.is_a?(Decidim::UserGroup)
       redirect_to profile_following_path
     end
 
@@ -40,6 +43,14 @@ module Decidim
     end
 
     private
+
+    def ensure_profile_holder_is_a_group
+      raise ActionController::RoutingError, "No user group with the given nickname" unless profile_holder.is_a?(Decidim::UserGroup)
+    end
+
+    def ensure_profile_holder_is_a_user
+      raise ActionController::RoutingError, "No user with the given nickname" unless profile_holder.is_a?(Decidim::User)
+    end
 
     def ensure_profile_holder
       raise ActionController::RoutingError, "No user or user group with the given nickname" unless profile_holder


### PR DESCRIPTION
#### :tophat: What? Why?
This PR hides unused tabs on user groups profiles. It also controls the access to tabs, to ensure no one tries to access the "Members" tab on a user profile, for example.

#### :pushpin: Related Issues
- Related to #3893

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/lBW0oda.png)
