### PR TITLE
Create user groups from the user profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 - **decidim-core**: Allow users to enter datetime fields manually. [\#3724](https://github.com/decidim/decidim/pull/3724)
 - **decidim-core**: Allow users to enter date fields manually. [\#3724](https://github.com/decidim/decidim/pull/3724)
 - **decidim-core**: Merge Users and UserGroups DB tables [\#4196](https://github.com/decidim/decidim/pull/4196)
+- **decidim-core**: Move user group creation to user profile [\#4256](https://github.com/decidim/decidim/pull/4256)
 
 **Fixed**:
 

--- a/decidim-core/app/cells/decidim/profile_sidebar/show.erb
+++ b/decidim-core/app/cells/decidim/profile_sidebar/show.erb
@@ -79,6 +79,13 @@
       </span>
     <% end %>
   </div>
+  <div class="text-center">
+    <%= link_to decidim.new_group_path, class: "button secondary light" do %>
+      <span>
+        <%= t("decidim.profiles.user.create_user_group") %>
+      </span>
+    <% end %>
+  </div>
 <% elsif logged_in? %>
   <%= cell "decidim/follow_button", profile_holder, inline: false, context: { current_user: current_user } %>
 <% end %>

--- a/decidim-core/app/commands/decidim/create_registration.rb
+++ b/decidim-core/app/commands/decidim/create_registration.rb
@@ -20,10 +20,7 @@ module Decidim
     def call
       return broadcast(:invalid) if form.invalid?
 
-      transaction do
-        create_user
-        create_user_group if form.user_group?
-      end
+      create_user
 
       broadcast(:ok, @user)
     end
@@ -33,29 +30,17 @@ module Decidim
     attr_reader :form
 
     def create_user
-      @user = User.create!(email: form.email,
-                           name: form.name,
-                           nickname: form.nickname,
-                           password: form.password,
-                           password_confirmation: form.password_confirmation,
-                           organization: form.current_organization,
-                           tos_agreement: form.tos_agreement,
-                           newsletter_notifications_at: form.newsletter_at,
-                           email_on_notification: true,
-                           accepted_tos_version: form.current_organization.tos_version)
-    end
-
-    def create_user_group
-      UserGroupMembership.create!(
-        user: @user,
-        user_group: UserGroup.new(
-          name: form.user_group_name,
-          extended_data: {
-            document_number: form.user_group_document_number,
-            phone: form.user_group_phone
-          },
-          decidim_organization_id: form.current_organization.id
-        )
+      @user = User.create!(
+        email: form.email,
+        name: form.name,
+        nickname: form.nickname,
+        password: form.password,
+        password_confirmation: form.password_confirmation,
+        organization: form.current_organization,
+        tos_agreement: form.tos_agreement,
+        newsletter_notifications_at: form.newsletter_at,
+        email_on_notification: true,
+        accepted_tos_version: form.current_organization.tos_version
       )
     end
   end

--- a/decidim-core/app/controllers/decidim/groups_controller.rb
+++ b/decidim-core/app/controllers/decidim/groups_controller.rb
@@ -12,6 +12,20 @@ module Decidim
 
     def create
       enforce_permission_to :create, :user_group, current_user: current_user
+      @form = form(UserGroupForm).from_params(params)
+
+      CreateUserGroup.call(@form) do
+        on(:ok) do |user_group|
+          flash[:notice] = t("groups.create.success", scope: "decidim")
+
+          redirect_to profile_path(user_group.nickname)
+        end
+
+        on(:invalid) do
+          flash[:alert] = t("groups.create.error", scope: "decidim")
+          render action: :show
+        end
+      end
     end
   end
 end

--- a/decidim-core/app/controllers/decidim/groups_controller.rb
+++ b/decidim-core/app/controllers/decidim/groups_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Decidim
+  # The controller to handle user groups creation
+  class GroupsController < Decidim::ApplicationController
+    include FormFactory
+
+    def new
+      enforce_permission_to :create, :user_group, current_user: current_user
+      @form = form(UserGroupForm).instance
+    end
+
+    def create
+      enforce_permission_to :create, :user_group, current_user: current_user
+    end
+  end
+end

--- a/decidim-core/app/forms/decidim/account_form.rb
+++ b/decidim-core/app/forms/decidim/account_form.rb
@@ -17,7 +17,7 @@ module Decidim
     attribute :about
 
     validates :name, presence: true
-    validates :email, presence: true
+    validates :email, presence: true, 'valid_email_2/email': { disposable: true }
     validates :nickname, presence: true
 
     validates :nickname, length: { maximum: Decidim::User.nickname_max_length, allow_blank: true }

--- a/decidim-core/app/forms/decidim/registration_form.rb
+++ b/decidim-core/app/forms/decidim/registration_form.rb
@@ -5,7 +5,6 @@ module Decidim
   class RegistrationForm < Form
     mimic :user
 
-    attribute :sign_up_as, String
     attribute :name, String
     attribute :nickname, String
     attribute :email, String
@@ -14,11 +13,6 @@ module Decidim
     attribute :newsletter, Boolean
     attribute :tos_agreement, Boolean
 
-    attribute :user_group_name, String
-    attribute :user_group_document_number, String
-    attribute :user_group_phone, String
-
-    validates :sign_up_as, inclusion: { in: %w(user user_group) }
     validates :name, presence: true
     validates :nickname, presence: true, length: { maximum: Decidim::User.nickname_max_length }
     validates :email, presence: true, 'valid_email_2/email': { disposable: true }
@@ -27,18 +21,8 @@ module Decidim
     validates :password_confirmation, presence: true
     validates :tos_agreement, allow_nil: false, acceptance: true
 
-    validates :user_group_name, presence: true, if: :user_group?
-    validates :user_group_document_number, presence: true, if: :user_group?
-    validates :user_group_phone, presence: true, if: :user_group?
-
     validate :email_unique_in_organization
     validate :nickname_unique_in_organization
-    validate :user_group_name_unique_in_organization
-    validate :user_group_document_number_unique_in_organization
-
-    def user_group?
-      sign_up_as == "user_group"
-    end
 
     def newsletter_at
       return nil unless newsletter?
@@ -53,17 +37,6 @@ module Decidim
 
     def nickname_unique_in_organization
       errors.add :nickname, :taken if User.find_by(nickname: nickname, organization: current_organization).present?
-    end
-
-    def user_group_name_unique_in_organization
-      errors.add :user_group_name, :taken if UserGroup.find_by(name: user_group_name, decidim_organization_id: current_organization.id).present?
-    end
-
-    def user_group_document_number_unique_in_organization
-      errors.add :user_group_document_number, :taken if UserGroup.with_document_number(
-        current_organization,
-        user_group_document_number
-      ).present?
     end
   end
 end

--- a/decidim-core/app/forms/decidim/user_group_form.rb
+++ b/decidim-core/app/forms/decidim/user_group_form.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Decidim
+  # The form object that handles the data behind creating a user group.
+  class UserGroupForm < Form
+    mimic :group
+
+    attribute :name
+    attribute :nickname
+    attribute :email
+    attribute :avatar
+    attribute :about
+    attribute :document_number
+    attribute :phone
+
+    validates :name, presence: true
+    validates :email, presence: true, 'valid_email_2/email': { disposable: true }
+    validates :nickname, presence: true
+    validates :document_number, presence: true
+    validates :phone, presence: true
+
+    validates :nickname, length: { maximum: Decidim::User.nickname_max_length, allow_blank: true }
+    validates :avatar, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_avatar_size } }
+
+    validate :unique_document_number
+    validate :unique_email
+    validate :unique_name
+    validate :unique_nickname
+
+    private
+
+    def user_group_document_number_unique_in_organization
+      errors.add :document_number, :taken if UserGroup.with_document_number(
+        context.current_organization,
+        document_number
+      ).present?
+    end
+
+    def unique_email
+      return true if Decidim::UserBaseEntity.where(
+        organization: context.current_organization,
+        email: email
+      ).empty?
+
+      errors.add :email, :taken
+      false
+    end
+
+    def unique_name
+      return true if Decidim::UserBaseEntity.where(
+        organization: context.current_organization,
+        name: name
+      ).empty?
+
+      errors.add :name, :taken
+      false
+    end
+
+    def unique_nickname
+      return true if Decidim::UserBaseEntity.where(
+        organization: context.current_organization,
+        nickname: nickname
+      ).empty?
+
+      errors.add :nickname, :taken
+      false
+    end
+  end
+end

--- a/decidim-core/app/forms/decidim/user_group_form.rb
+++ b/decidim-core/app/forms/decidim/user_group_form.rb
@@ -29,7 +29,7 @@ module Decidim
 
     private
 
-    def user_group_document_number_unique_in_organization
+    def unique_document_number
       errors.add :document_number, :taken if UserGroup.with_document_number(
         context.current_organization,
         document_number

--- a/decidim-core/app/permissions/decidim/permissions.rb
+++ b/decidim-core/app/permissions/decidim/permissions.rb
@@ -18,6 +18,7 @@ module Decidim
       follow_action?
       notification_action?
       conversation_action?
+      user_group_action?
 
       permission_action
     end
@@ -89,6 +90,11 @@ module Decidim
 
       conversation = context.fetch(:conversation, nil)
       toggle_allow(conversation.participants.include?(user))
+    end
+
+    def user_group_action?
+      return unless permission_action.subject == :user_group
+      return allow! if [:create].include?(permission_action.action)
     end
 
     def user_can_admin_component?

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -26,11 +26,6 @@
         <%= invisible_captcha %>
         <div class="card">
           <div class="card__content">
-            <fieldset class="text-center">
-              <legend><%= t(".sign_up_as.legend") %></legend>
-              <%= f.collection_radio_buttons :sign_up_as, [["user", t(".sign_up_as.user")], ["user_group", t(".sign_up_as.user_group") ]], :first, :last %>
-            </fieldset>
-
             <div class="user-person">
               <div class="field">
                 <%= f.text_field :name, help_text: t(".username_help") %>
@@ -53,20 +48,6 @@
 
             <div class="field">
               <%= f.password_field :password_confirmation %>
-            </div>
-
-            <div class="user-group-fields">
-              <div class="field">
-                <%= f.text_field :user_group_name %>
-              </div>
-
-              <div class="field">
-                <%= f.text_field :user_group_document_number %>
-              </div>
-
-              <div class="field">
-                <%= f.text_field :user_group_phone %>
-              </div>
             </div>
           </div>
         </div>

--- a/decidim-core/app/views/decidim/groups/new.html.erb
+++ b/decidim-core/app/views/decidim/groups/new.html.erb
@@ -1,0 +1,50 @@
+<main class="wrapper">
+<div class="row collapse">
+  <div class="row collapse">
+    <div class="columns large-8 large-centered text-center page-title">
+      <h1><%= t(".new_user_group") %></h1>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="columns large-6 medium-10 medium-centered">
+
+      <%= decidim_form_for(@form) do |f| %>
+        <div class="card">
+          <div class="card__content">
+            <div class="user-group-fields">
+              <div class="field">
+                <%= f.text_field :name %>
+              </div>
+              <div class="field">
+                <%= f.text_field :nickname %>
+              </div>
+              <div class="field">
+                <%= f.text_field :email %>
+              </div>
+               <div class="field">
+                <%= f.text_field :document_number %>
+              </div>
+              <div class="field">
+                <%= f.text_field :phone %>
+              </div>
+              <div class="field">
+                <%= f.text_area :about, rows: 5 %>
+              </div>
+              <div class="field">
+                <%= f.upload :avatar %>
+              </div>
+            </div>
+
+            <div class="actions">
+              <%= f.submit t(".create_user_group"), class: "button expanded" %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+</main>
+
+

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -427,6 +427,9 @@ en:
       level: Level %{level}
       reached_top: You've reached the top level for this badge.
     groups:
+      new:
+        create_user_group: Create user group
+        new_user_group: New user group
       no_user_groups: Doesn't belong to any user group yet.
     invitations:
       create:
@@ -621,6 +624,7 @@ en:
           info: Badges are earned by performing specific activity in the platform.
           title: Badges
       user:
+        create_user_group: Create user group
         edit_profile: Edit profile
     reported_mailer:
       hide:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -427,6 +427,9 @@ en:
       level: Level %{level}
       reached_top: You've reached the top level for this badge.
     groups:
+      create:
+        error: There has been a problem creating the user group
+        success: User group created successfully
       new:
         create_user_group: Create user group
         new_user_group: New user group

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -15,9 +15,6 @@ en:
         password_confirmation: Confirm your password
         personal_url: Personal URL
         remove_avatar: Remove avatar
-        user_group_document_number: Organization document number
-        user_group_name: Organization name
-        user_group_phone: Organization phone
     models:
       decidim/attachment_created_event: Attachment
       decidim/component_published_event: Active component
@@ -33,9 +30,6 @@ en:
         password: Password
         password_confirmation: Password confirmation
         remember_me: Remember me
-        user_group_document_number: Organization document number
-        user_group_name: Organization name
-        user_group_phone: Organization phone
     models:
       decidim/user:
         one: User
@@ -258,8 +252,6 @@ en:
           sign_up: Sign up
           sign_up_as:
             legend: Sign up as
-            user: Individual
-            user_group: Organization/Collective
           subtitle: Sign up to participate in discussions and support proposals.
           terms: the terms and conditions of use
           tos_agreement: By signing up you agree to %{link}.

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -428,12 +428,12 @@ en:
       reached_top: You've reached the top level for this badge.
     groups:
       create:
-        error: There has been a problem creating the user group
-        success: User group created successfully
+        error: There has been a problem creating the organization
+        success: Organization created successfully
       new:
-        create_user_group: Create user group
-        new_user_group: New user group
-      no_user_groups: Doesn't belong to any user group yet.
+        create_user_group: Create organization
+        new_user_group: New organization
+      no_user_groups: Doesn't belong to any organization yet.
     invitations:
       create:
         error: There were some problems while inviting your friends
@@ -619,7 +619,7 @@ en:
         conversations: Conversations
         followers: Followers
         following: Follows
-        groups: Groups
+        groups: Organizations
         members: Members
         notifications: Notifications
       sidebar:
@@ -627,7 +627,7 @@ en:
           info: Badges are earned by performing specific activity in the platform.
           title: Badges
       user:
-        create_user_group: Create user group
+        create_user_group: Create organization
         edit_profile: Edit profile
     reported_mailer:
       hide:

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -58,6 +58,8 @@ Decidim::Core::Engine.routes.draw do
     end
 
     get "/authorization_modals/:authorization_action/f/:component_id(/:resource_name/:resource_id)", to: "authorization_modals#show", as: :authorization_modal
+
+    resources :groups, only: [:new, :create]
   end
 
   resources :profiles, only: [:show], param: :nickname, constraints: { nickname: %r{[^\/]+} }, format: false

--- a/decidim-core/spec/commands/decidim/create_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_registration_spec.rb
@@ -8,7 +8,6 @@ module Decidim
       describe "call" do
         let(:organization) { create(:organization, :with_tos) }
 
-        let(:sign_up_as) { "user" }
         let(:name) { "Username" }
         let(:nickname) { "nickname" }
         let(:email) { "user@example.org" }
@@ -17,24 +16,16 @@ module Decidim
         let(:tos_agreement) { "1" }
         let(:newsletter) { "1" }
 
-        let(:user_group_name) { "My organization" }
-        let(:user_group_document_number) { "123456789Z" }
-        let(:user_group_phone) { "333-333-333" }
-
         let(:form_params) do
           {
             "user" => {
-              "sign_up_as" => sign_up_as,
               "name" => name,
               "nickname" => nickname,
               "email" => email,
               "password" => password,
               "password_confirmation" => password_confirmation,
               "tos_agreement" => tos_agreement,
-              "newsletter_at" => newsletter,
-              "user_group_name" => user_group_name,
-              "user_group_document_number" => user_group_document_number,
-              "user_group_phone" => user_group_phone
+              "newsletter_at" => newsletter
             }
           }
         end
@@ -93,51 +84,6 @@ module Decidim
                 command.call
                 expect(User.last.newsletter_notifications_at).to eq(nil)
               end.to change(User, :count).by(1)
-            end
-          end
-        end
-
-        describe "when the user is signing up as a user group" do
-          let(:sign_up_as) { "user_group" }
-
-          let(:user_group_name) { "My organization" }
-          let(:user_group_document_number) { "123456789Z" }
-          let(:user_group_phone) { "333-333-333" }
-          let(:user_group_decidim_organization_id) { organization.id }
-
-          describe "when the form is not valid" do
-            before do
-              expect(form).to receive(:invalid?).and_return(true)
-            end
-
-            it "broadcasts invalid" do
-              expect { command.call }.to broadcast(:invalid)
-            end
-
-            it "doesn't create a user group" do
-              expect { command.call }.not_to change(UserGroup, :count)
-            end
-          end
-
-          describe "when the form is valid" do
-            it "broadcasts ok" do
-              expect { command.call }.to broadcast(:ok)
-            end
-
-            it "creates a new user group" do
-              expect(UserGroup).to receive(:new).with(
-                name: form.user_group_name,
-                extended_data: {
-                  document_number: form.user_group_document_number,
-                  phone: form.user_group_phone
-                },
-                decidim_organization_id: organization.id
-              ).and_call_original
-
-              expect do
-                command.call
-                expect(UserGroup.last.users.first).to eq(User.last)
-              end.to change(UserGroup, :count).by(1)
             end
           end
         end

--- a/decidim-core/spec/commands/decidim/create_user_group_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_user_group_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Comments
+    describe CreateUserGroup do
+      describe "call" do
+        let(:organization) { create(:organization, :with_tos) }
+        let(:user) { create :user, :confirmed, organization: organization }
+
+        let(:name) { "User group name" }
+        let(:nickname) { "nickname" }
+        let(:email) { "user@myrealdomain.org" }
+        let(:phone) { "Y1fERVzL2F" }
+        let(:document_number) { "123456780X" }
+        let(:about) { "This is us." }
+        let(:avatar) { File.open("spec/assets/avatar.jpg") }
+
+        let(:form_params) do
+          {
+            "group" => {
+              "name" => name,
+              "nickname" => nickname,
+              "email" => email,
+              "phone" => phone,
+              "document_number" => document_number,
+              "about" => about,
+              "avatar" => avatar
+            }
+          }
+        end
+        let(:form) do
+          UserGroupForm.from_params(
+            form_params
+          ).with_context(
+            current_user: user,
+            current_organization: organization
+          )
+        end
+        let(:command) { described_class.new(form) }
+
+        describe "when the form is not valid" do
+          before do
+            expect(form).to receive(:invalid?).and_return(true)
+          end
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+
+          it "doesn't create a user group" do
+            expect do
+              command.call
+            end.not_to change(UserGroup, :count)
+          end
+        end
+
+        describe "when the form is valid" do
+          it "broadcasts ok" do
+            expect { command.call }.to broadcast(:ok)
+          end
+
+          it "creates a new user" do
+            expect(UserGroup).to receive(:create!).with(
+              name: form.name,
+              nickname: form.nickname,
+              email: form.email,
+              avatar: form.avatar,
+              about: form.about,
+              organization: organization,
+              extended_data: {
+                phone: form.phone,
+                document_number: form.document_number
+              }
+            ).and_call_original
+
+            expect { command.call }.to change(UserGroup, :count).by(1)
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/forms/registration_form_spec.rb
+++ b/decidim-core/spec/forms/registration_form_spec.rb
@@ -13,7 +13,6 @@ module Decidim
     end
 
     let(:organization) { create(:organization) }
-    let(:sign_up_as) { "user" }
     let(:name) { "User" }
     let(:nickname) { "justme" }
     let(:email) { "user@example.org" }
@@ -21,22 +20,14 @@ module Decidim
     let(:password_confirmation) { password }
     let(:tos_agreement) { "1" }
 
-    let(:user_group_name) { nil }
-    let(:user_group_document_number) { nil }
-    let(:user_group_phone) { nil }
-
     let(:attributes) do
       {
-        sign_up_as: sign_up_as,
         name: name,
         nickname: nickname,
         email: email,
         password: password,
         password_confirmation: password_confirmation,
-        tos_agreement: tos_agreement,
-        user_group_name: user_group_name,
-        user_group_document_number: user_group_document_number,
-        user_group_phone: user_group_phone
+        tos_agreement: tos_agreement
       }
     end
 
@@ -52,12 +43,6 @@ module Decidim
 
     context "when the email is a disposable account" do
       let(:email) { "user@mailbox92.biz" }
-
-      it { is_expected.to be_invalid }
-    end
-
-    context "when the sign_up_as is different from 'user' and 'user_group'" do
-      let(:sign_up_as) { "community" }
 
       it { is_expected.to be_invalid }
     end
@@ -126,50 +111,6 @@ module Decidim
       let(:tos_agreement) { "0" }
 
       it { is_expected.to be_invalid }
-    end
-
-    describe "when sign_up_as is 'user_group'" do
-      let(:sign_up_as) { "user_group" }
-
-      let(:user_group_name) { "My organization" }
-      let(:user_group_document_number) { "123456789Z" }
-      let(:user_group_phone) { "333-333-333" }
-
-      context "when everything is OK" do
-        it { is_expected.to be_valid }
-      end
-
-      context "when user_group_name is not present" do
-        let(:user_group_name) { nil }
-
-        it { is_expected.to be_invalid }
-      end
-
-      context "when user_group_document_number is not present" do
-        let(:user_group_document_number) { nil }
-
-        it { is_expected.to be_invalid }
-      end
-
-      context "when user_group_phone is not present" do
-        let(:user_group_phone) { nil }
-
-        it { is_expected.to be_invalid }
-      end
-
-      context "when user_group_name is already taken" do
-        let!(:user_group) { create(:user_group, name: user_group_name, decidim_organization_id: organization.id) }
-        let(:user_group_name) { "Taken User Name" }
-
-        it { is_expected.to be_invalid }
-      end
-
-      context "when user_group_document_number is already taken" do
-        let!(:user_group) { create(:user_group, document_number: user_group_document_number, decidim_organization_id: organization.id) }
-        let(:user_group_document_number) { "Y12345678" }
-
-        it { is_expected.to be_invalid }
-      end
     end
   end
 end

--- a/decidim-core/spec/forms/user_group_form_spec.rb
+++ b/decidim-core/spec/forms/user_group_form_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe UserGroupForm do
+    subject do
+      described_class.new(
+        name: name,
+        email: email,
+        nickname: nickname,
+        phone: phone,
+        document_number: document_number,
+        avatar: avatar,
+        about: about
+      ).with_context(
+        current_organization: organization,
+        current_user: user
+      )
+    end
+
+    let(:user) { create(:user) }
+    let(:organization) { user.organization }
+
+    let(:name) { "Lord of the Foo" }
+    let(:email) { "depths@ofthe.bar" }
+    let(:nickname) { "foo_bar" }
+    let(:phone) { "987654321" }
+    let(:document_number) { "12345678X" }
+    let(:avatar) { File.open("spec/assets/avatar.jpg") }
+    let(:about) { "This is a description about me" }
+
+    context "with correct data" do
+      it "is valid" do
+        expect(subject).to be_valid
+      end
+    end
+
+    context "with an empty name" do
+      let(:name) { "" }
+
+      it "is invalid" do
+        expect(subject).not_to be_valid
+      end
+    end
+
+    describe "phone" do
+      context "with an empty phone" do
+        let(:phone) { "" }
+
+        it { is_expected.not_to be_valid }
+      end
+    end
+
+    describe "document number" do
+      context "with an empty document_number" do
+        let(:document_number) { "" }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when it's already in use in the same organization" do
+        let!(:existing_user_group) { create(:user_group, document_number: document_number, organization: organization) }
+
+        it "is invalid" do
+          expect(subject).not_to be_valid
+        end
+      end
+
+      context "when it's already in use in another organization" do
+        let!(:existing_user_group) { create(:user_group, document_number: document_number) }
+
+        it "is valid" do
+          expect(subject).to be_valid
+        end
+      end
+    end
+
+    describe "email" do
+      context "with an empty email" do
+        let(:email) { "" }
+
+        it "is invalid" do
+          expect(subject).not_to be_valid
+        end
+      end
+
+      context "when it's already in use in the same organization" do
+        let!(:existing_user) { create(:user, email: email, organization: organization) }
+
+        it "is invalid" do
+          expect(subject).not_to be_valid
+        end
+      end
+
+      context "when it's already in use in another organization" do
+        let!(:existing_user) { create(:user, email: email) }
+
+        it "is valid" do
+          expect(subject).to be_valid
+        end
+      end
+    end
+
+    describe "name" do
+      context "with an empty name" do
+        let(:name) { "" }
+
+        it "is invalid" do
+          expect(subject).not_to be_valid
+        end
+      end
+
+      context "when it's already in use in the same organization" do
+        let!(:existing_user) { create(:user, name: name, organization: organization) }
+
+        it "is invalid" do
+          expect(subject).not_to be_valid
+        end
+      end
+
+      context "when it's already in use in another organization" do
+        let!(:existing_user) { create(:user, name: name) }
+
+        it "is valid" do
+          expect(subject).to be_valid
+        end
+      end
+    end
+
+    describe "nickname" do
+      context "with an empty nickname" do
+        let(:nickname) { "" }
+
+        it "is invalid" do
+          expect(subject).not_to be_valid
+        end
+      end
+
+      context "when it's already in use in the same organization" do
+        let!(:existing_user) { create(:user, nickname: nickname, organization: organization) }
+
+        it "is invalid" do
+          expect(subject).not_to be_valid
+        end
+      end
+
+      context "when it's already in use in another organization" do
+        let!(:existing_user) { create(:user, nickname: nickname) }
+
+        it "is valid" do
+          expect(subject).to be_valid
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/permissions/decidim/permissions_spec.rb
+++ b/decidim-core/spec/permissions/decidim/permissions_spec.rb
@@ -239,5 +239,15 @@ describe Decidim::Permissions do
         end
       end
     end
+
+    context "when action is on user group" do
+      let(:action_subject) { :user_group }
+
+      context "when creating user groups" do
+        let(:action_name) { :create }
+
+        it { is_expected.to eq true }
+      end
+    end
   end
 end

--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -192,33 +192,6 @@ describe "Authentication", type: :system do
     end
   end
 
-  describe "Sign Up as a organization" do
-    it "creates a new User" do
-      find(".sign-up-link").click
-
-      within ".new_user" do
-        choose "Organization/Collective"
-
-        fill_in :user_email, with: "user@example.org"
-        fill_in :user_name, with: "Responsible Citizen"
-        fill_in :user_nickname, with: "responsible"
-        fill_in :user_password, with: "DfyvHn425mYAy2HL"
-        fill_in :user_password_confirmation, with: "DfyvHn425mYAy2HL"
-
-        fill_in :user_user_group_name, with: "My organization"
-        fill_in :user_user_group_document_number, with: "12345678Z"
-        fill_in :user_user_group_phone, with: "333-333-3333"
-
-        check :user_tos_agreement
-        check :user_newsletter
-
-        find("*[type=submit]").click
-      end
-
-      expect(page).to have_content("confirmation link")
-    end
-  end
-
   describe "Confirm email" do
     it "confirms the user" do
       perform_enqueued_jobs { create(:user, organization: organization) }

--- a/decidim-core/spec/system/registration_spec.rb
+++ b/decidim-core/spec/system/registration_spec.rb
@@ -22,7 +22,7 @@ describe "Registration", type: :system do
   context "when signing up" do
     describe "on first sight" do
       it "shows fields empty" do
-        expect(page).to have_content("Sign up as")
+        expect(page).to have_content("Sign up to participate")
         expect(page).to have_field("user_name", with: "")
         expect(page).to have_field("user_nickname", with: "")
         expect(page).to have_field("user_email", with: "")

--- a/decidim-core/spec/system/user_group_creation_spec.rb
+++ b/decidim-core/spec/system/user_group_creation_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "User group creation", type: :system do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :confirmed, organization: organization) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim.profile_path(user.nickname)
+  end
+
+  it "creates a user group for the current user" do
+    click_link "Create user group"
+
+    fill_in "Name", with: "My super user group"
+    fill_in "Nickname", with: "my_usergroup"
+    fill_in "Email", with: "user_group@decidim.org"
+    fill_in "Document number", with: "12345678X"
+    fill_in "Phone", with: "12345678"
+    fill_in "About", with: "This is us."
+
+    attach_file "Avatar", Decidim::Dev.asset("avatar.jpg")
+
+    click_button "Create user group"
+
+    expect(page).to have_content("My super user group")
+    expect(page).to have_content("@my_usergroup")
+    expect(page).to have_content("This is us.")
+
+    click_link "Members"
+
+    within ".card--user" do
+      expect(page).to have_content(user.name)
+    end
+  end
+end

--- a/decidim-core/spec/system/user_group_creation_spec.rb
+++ b/decidim-core/spec/system/user_group_creation_spec.rb
@@ -13,7 +13,7 @@ describe "User group creation", type: :system do
   end
 
   it "creates a user group for the current user" do
-    click_link "Create user group"
+    click_link "Create organization"
 
     fill_in "Name", with: "My super user group"
     fill_in "Nickname", with: "my_usergroup"
@@ -24,7 +24,7 @@ describe "User group creation", type: :system do
 
     attach_file "Avatar", Decidim::Dev.asset("avatar.jpg")
 
-    click_button "Create user group"
+    click_button "Create organization"
 
     expect(page).to have_content("My super user group")
     expect(page).to have_content("@my_usergroup")

--- a/decidim-core/spec/system/user_group_profile_spec.rb
+++ b/decidim-core/spec/system/user_group_profile_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Profile", type: :system do
+describe "User group profile", type: :system do
   let(:user) { create(:user, :confirmed) }
   let(:user_group) { create(:user_group, users: [user], organization: user.organization) }
 

--- a/decidim-core/spec/system/user_groups_verification_status_on_account_page_spec.rb
+++ b/decidim-core/spec/system/user_groups_verification_status_on_account_page_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "User groups", type: :system do
+describe "User group verification status on account page", type: :system do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, :confirmed, organization: organization) }
 

--- a/decidim-core/spec/system/user_profile_spec.rb
+++ b/decidim-core/spec/system/user_profile_spec.rb
@@ -143,7 +143,7 @@ describe "Profile", type: :system do
       end
 
       it "lists the user groups" do
-        click_link "Groups"
+        click_link "Organizations"
 
         expect(page).to have_content(user_group.name)
       end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR moves the user group creation to the user profile, as per #3893.

#### :pushpin: Related Issues
- Related to #3893

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Remove "Sign up as organization" feature
- [x] Ensure tests pass
- [x] Add form to the user profile

Submitting the form takes you to the user group profile.

### :camera: Screenshots (optional)
Button to create user group:
![](https://i.imgur.com/tJQA2x6.png)

User group creation form:
![](https://i.imgur.com/k2LlVd8.png)