### PR TITLE
Add roles to user group memberships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 - **decidim-participatory_processes**: Add a Call to Action button to process steps[\#4184](https://github.com/decidim/decidim/pull/4184)
 - **decidim-core**: Show user groups profiles [\#4196](https://github.com/decidim/decidim/pull/4196)
 - **decidim-core**: Show user groups on users profiles [\#4236](https://github.com/decidim/decidim/pull/4236)
+- **decidim-core**: Add roles to user group memberships [\#4260](https://github.com/decidim/decidim/pull/4260)
 - **decidim-core**: Add a badge info page listing all the badges and how to get them. [\#4245](https://github.com/decidim/decidim/pull/4245)
 - **decidim-core**: Show members on user groups profiles [\#4252](https://github.com/decidim/decidim/pull/4252)
 - **decidim-core**: Badges can now be disabled per organization. [\#4249](https://github.com/decidim/decidim/pull/4249)

--- a/decidim-core/app/commands/decidim/create_user_group.rb
+++ b/decidim-core/app/commands/decidim/create_user_group.rb
@@ -49,6 +49,7 @@ module Decidim
     def create_membership
       UserGroupMembership.create!(
         user: form.current_user,
+        role: "creator",
         user_group: @user_group
       )
     end

--- a/decidim-core/app/models/decidim/user_group_membership.rb
+++ b/decidim-core/app/models/decidim/user_group_membership.rb
@@ -5,5 +5,13 @@ module Decidim
   class UserGroupMembership < ApplicationRecord
     belongs_to :user, class_name: "Decidim::User", foreign_key: :decidim_user_id
     belongs_to :user_group, class_name: "Decidim::UserGroup", foreign_key: :decidim_user_group_id
+
+    ROLES = %w(creator admin member requested).freeze
+    validates :role, inclusion: { in: ROLES }
+    validates :role, uniqueness: { scope: [:role, :decidim_user_group_id] }, if: :creator?
+
+    def creator?
+      role.to_s == "creator"
+    end
   end
 end

--- a/decidim-core/db/migrate/20181011080252_add_roles_to_memberships.rb
+++ b/decidim-core/db/migrate/20181011080252_add_roles_to_memberships.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class AddRolesToMemberships < ActiveRecord::Migration[5.2]
+  def up
+    add_column :decidim_user_group_memberships, :role, :string, default: "requested"
+    execute("UPDATE decidim_user_group_memberships SET role = 'creator'")
+    change_column_null :decidim_user_group_memberships, :role, false
+    add_index(
+      :decidim_user_group_memberships,
+      %w(role decidim_user_group_id),
+      where: "(role = 'creator')",
+      name: "decidim_group_membership_one_creator_per_group",
+      unique: true
+    )
+  end
+
+  def down
+    remove_column :decidim_user_group_memberships, :role
+    remove_index(
+      :decidim_user_group_memberships,
+      name: "decidim_group_membership_one_creator_per_group"
+    )
+  end
+end

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -141,6 +141,7 @@ if !Rails.env.production? || ENV["SEED"]
 
       Decidim::UserGroupMembership.create!(
         user: user,
+        role: "creator",
         user_group: user_group
       )
     end

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -186,7 +186,7 @@ FactoryBot.define do
     end
 
     after(:create) do |user_group, evaluator|
-      users = evaluator.users
+      users = evaluator.users.dup
       next if users.empty?
 
       creator = users.shift

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -189,14 +189,18 @@ FactoryBot.define do
       users = evaluator.users
       next if users.empty?
 
+      creator = users.shift
+      create(:user_group_membership, user: creator, user_group: user_group, role: :creator)
+
       users.each do |user|
-        create(:user_group_membership, user: user, user_group: user_group)
+        create(:user_group_membership, user: user, user_group: user_group, role: :admin)
       end
     end
   end
 
   factory :user_group_membership, class: "Decidim::UserGroupMembership" do
     user
+    role { :creator }
     user_group
   end
 

--- a/decidim-core/spec/commands/decidim/create_user_group_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_user_group_spec.rb
@@ -77,6 +77,13 @@ module Decidim
 
             expect { command.call }.to change(UserGroup, :count).by(1)
           end
+
+          it "creates the membership with a creator role" do
+            command.call
+            membership = UserGroupMembership.last
+            expect(membership.user).to eq user
+            expect(membership.role).to eq "creator"
+          end
         end
       end
     end

--- a/decidim-core/spec/models/decidim/user_group_membership_spec.rb
+++ b/decidim-core/spec/models/decidim/user_group_membership_spec.rb
@@ -4,7 +4,9 @@ require "spec_helper"
 
 module Decidim
   describe UserGroupMembership do
-    subject { create(:user_group_membership) }
+    subject { membership }
+
+    let(:membership) { create(:user_group_membership) }
 
     it "is valid" do
       expect(subject).to be_valid
@@ -16,6 +18,27 @@ module Decidim
 
     it "has an association user group" do
       expect(subject.user_group).to be_a(Decidim::UserGroup)
+    end
+
+    describe "validations" do
+      it "is not valid with a weird role" do
+        membership = build :user_group_membership, role: :foo_bar_does_not_exist
+        expect(membership).not_to be_valid
+      end
+
+      it "can't have multiple creators for the same user group" do
+        membership = create :user_group_membership, role: :creator
+        failing_membership = build :user_group_membership, role: :creator, user_group: membership.user_group
+
+        expect(failing_membership).not_to be_valid
+      end
+
+      it "can have multiple roles different from creator for the same user group" do
+        membership = create :user_group_membership, role: :admin
+        membership2 = build :user_group_membership, role: :admin, user_group: membership.user_group
+
+        expect(membership2).to be_valid
+      end
     end
   end
 end

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -211,8 +211,11 @@ Decidim.register_component(:proposals) do |component|
               },
               decidim_organization_id: component.organization.id
             )
-            author.user_groups << group
-            author.save!
+            Decidim::UserGroupMembership.create!(
+              user: author,
+              role: "creator",
+              user_group: group
+            )
           end
           Decidim::Proposals::ProposalEndorsement.create!(proposal: proposal, author: author, user_group: author.user_groups.first)
         end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds roles to user group memberships. The user that creates the user group will have the "creator" role, and only one creator can exist per user group. Other available roles (admin, member or pending) can be repeated, though.

"Pending" roles will be used to find the requests to join a group that are not yet accepted. Users that request to join a group are not shown as members of the group. This part will be done on a later PR, together with the "request to join" feature.

#### :pushpin: Related Issues
- Related to #3893

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
None
