### PR TITLE
Fix edit results in decidim-accoutability #4267

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 - **decidim-core**: Hide weird flash message [\#4235](https://github.com/decidim/decidim/pull/4235)
 - **decidim-core**: Fix newsletter subscription checkbox always being unchecked [\#4238](https://github.com/decidim/decidim/pull/4238)
 - **decidim-core**: Thread safe locale switching [\#4237](https://github.com/decidim/decidim/pull/4237)
+- **decidim-accountability**: Fix error editing results [\#4268](https://github.com/decidim/decidim/pull/4268)
 
 **Removed**:
 

--- a/decidim-accountability/app/views/decidim/accountability/admin/results/_form.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/results/_form.html.erb
@@ -56,7 +56,7 @@
       <% if @form.proposals %>
         <% picker_options = { id: "decidim_accountability_proposals", class: "picker-multiple", name: "result[proposal_ids]", multiple: true }
         prompt_params= { url: proposals_results_path(current_component, format: :html), text: t(".add_proposal") } %>
-        <%= form.data_picker(:proposals, picker_options, prompt_params) {|item| { url:proposals_results_path(current_component, format: :json), text: "##{item.id}- #{present(item).title}" }} %>
+        <%= form.data_picker(:proposals, picker_options, prompt_params) {|item| { url:proposals_results_path(current_component, format: :json), text: "##{item.id} - #{item.title}" }} %>
       <% end %>
     </div>
 


### PR DESCRIPTION
#### :tophat: What? Why?
This remove the `present` method on the admin form for edit results of participatory process.

#### :pushpin: Related Issues
- Fixes #4267

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
