### PR TITLE
Find accepted, managed and not pending user groups

### DIFF
--- a/decidim-comments/app/models/decidim/comments/seed.rb
+++ b/decidim-comments/app/models/decidim/comments/seed.rb
@@ -18,7 +18,7 @@ module Decidim
 
         2.times do
           author = Decidim::User.where(organization: organization).all.sample
-          user_group = [true, false].sample ? author.user_groups.verified.sample : nil
+          user_group = [true, false].sample ? Decidim::UserGroups::ManageableUserGroups.for(author).verified.sample : nil
 
           params = {
             commentable: resource,

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_reveal.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_reveal.scss
@@ -36,6 +36,7 @@
 
   li{
     @extend .p-s;
+
     display: flex;
   }
 

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_reveal.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_reveal.scss
@@ -36,11 +36,11 @@
 
   li{
     @extend .p-s;
+    display: flex;
   }
 
   li.selected{
     background-color: rgba($warning, .3);
-    display: flex;
     justify-content: space-between;
 
     svg{

--- a/decidim-core/app/cells/decidim/groups_cell.rb
+++ b/decidim-core/app/cells/decidim/groups_cell.rb
@@ -13,7 +13,7 @@ module Decidim
     end
 
     def user_groups
-      @user_groups ||= model.user_groups.page(params[:page]).per(20)
+      @user_groups ||= Decidim::UserGroups::AcceptedUserGroups.for(model).page(params[:page]).per(20)
     end
   end
 end

--- a/decidim-core/app/cells/decidim/members_cell.rb
+++ b/decidim-core/app/cells/decidim/members_cell.rb
@@ -14,7 +14,7 @@ module Decidim
     end
 
     def members
-      @members ||= model.users.page(params[:page]).per(20)
+      @members ||= Decidim::UserGroups::AcceptedUsers.for(model).page(params[:page]).per(20)
     end
   end
 end

--- a/decidim-core/app/queries/decidim/user_groups/accepted_user_groups.rb
+++ b/decidim-core/app/queries/decidim/user_groups/accepted_user_groups.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Decidim
+  module UserGroups
+    # Use this class to find the user groups the given user is accepted. In order
+    # to calculate this, we get those groups where the user has a role of
+    # member, creator or admin.
+    class AcceptedUserGroups < Rectify::Query
+      # Syntactic sugar to initialize the class and return the queried objects.
+      #
+      # user - a User that needs to find which processes can manage
+      def self.for(user)
+        new(user).query
+      end
+
+      # Initializes the class.
+      #
+      # user - a User that needs to find the groups where they are accepted
+      def initialize(user)
+        @user = user
+      end
+
+      # Finds the UserGroups where the user has an accepted membership.
+      #
+      # Returns an ActiveRecord::Relation.
+      def query
+        user
+          .user_groups
+          .includes(:memberships)
+          .where.not(decidim_user_group_memberships: { role: "requested" })
+      end
+
+      private
+
+      attr_reader :user
+    end
+  end
+end

--- a/decidim-core/app/queries/decidim/user_groups/accepted_user_groups.rb
+++ b/decidim-core/app/queries/decidim/user_groups/accepted_user_groups.rb
@@ -8,7 +8,7 @@ module Decidim
     class AcceptedUserGroups < Rectify::Query
       # Syntactic sugar to initialize the class and return the queried objects.
       #
-      # user - a User that needs to find which processes can manage
+      # user - a User that needs to find the groups where they are accepted
       def self.for(user)
         new(user).query
       end

--- a/decidim-core/app/queries/decidim/user_groups/accepted_user_groups.rb
+++ b/decidim-core/app/queries/decidim/user_groups/accepted_user_groups.rb
@@ -27,7 +27,7 @@ module Decidim
         user
           .user_groups
           .includes(:memberships)
-          .where.not(decidim_user_group_memberships: { role: "requested" })
+          .where(decidim_user_group_memberships: { role: %w(creator admin member) })
       end
 
       private

--- a/decidim-core/app/queries/decidim/user_groups/accepted_users.rb
+++ b/decidim-core/app/queries/decidim/user_groups/accepted_users.rb
@@ -25,7 +25,7 @@ module Decidim
         user_group
           .users
           .includes(:memberships)
-          .where.not(decidim_user_group_memberships: { role: "requested" })
+          .where(decidim_user_group_memberships: { role: %w(creator admin member) })
       end
 
       private

--- a/decidim-core/app/queries/decidim/user_groups/accepted_users.rb
+++ b/decidim-core/app/queries/decidim/user_groups/accepted_users.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Decidim
+  module UserGroups
+    # Use this class to find the accepted members of the given user group.
+    class AcceptedUsers < Rectify::Query
+      # Syntactic sugar to initialize the class and return the queried objects.
+      #
+      # user_group - a UserGroup that needs to find its accepted members
+      def self.for(user_group)
+        new(user_group).query
+      end
+
+      # Initializes the class.
+      #
+      # user_group - a UserGroup that needs to find its accepted members
+      def initialize(user_group)
+        @user_group = user_group
+      end
+
+      # Finds the accepted members of the user group.
+      #
+      # Returns an ActiveRecord::Relation.
+      def query
+        user_group
+          .users
+          .includes(:memberships)
+          .where.not(decidim_user_group_memberships: { role: "requested" })
+      end
+
+      private
+
+      attr_reader :user_group
+    end
+  end
+end

--- a/decidim-core/app/queries/decidim/user_groups/manageable_user_groups.rb
+++ b/decidim-core/app/queries/decidim/user_groups/manageable_user_groups.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Decidim
+  module UserGroups
+    # Use this class to find the user groups the given user can manage. In order
+    # to calculate this, we get those groups where the user has a role of
+    # creator or admin.
+    class ManageableUserGroups < Rectify::Query
+      # Syntactic sugar to initialize the class and return the queried objects.
+      #
+      # user - a User that needs to find which groups can manage
+      def self.for(user)
+        new(user).query
+      end
+
+      # Initializes the class.
+      #
+      # user - a User that needs to find which groups can manage
+      def initialize(user)
+        @user = user
+      end
+
+      # Finds the UserGroups where the user has a role of `:admin` or
+      # `:creator`.
+      #
+      # Returns an ActiveRecord::Relation.
+      def query
+        user
+          .user_groups
+          .includes(:memberships)
+          .where(decidim_user_group_memberships: { role: %w(admin creator) })
+      end
+
+      private
+
+      attr_reader :user
+    end
+  end
+end

--- a/decidim-core/app/queries/decidim/user_groups/pending_user_groups.rb
+++ b/decidim-core/app/queries/decidim/user_groups/pending_user_groups.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Decidim
+  module UserGroups
+    # Use this class to find the user groups the given user has a membership
+    # that has yet to be accepted.
+    class PendingUserGroups < Rectify::Query
+      # Syntactic sugar to initialize the class and return the queried objects.
+      #
+      # user - a User that needs to find which groups they are pending to be accepted
+      def self.for(user)
+        new(user).query
+      end
+
+      # Initializes the class.
+      #
+      # user - a User that needs to find which groups they are pending to be accepted
+      def initialize(user)
+        @user = user
+      end
+
+      # Finds the UserGroups where the user has a membership that is pending to
+      # be accepted.
+      #
+      # Returns an ActiveRecord::Relation.
+      def query
+        user
+          .user_groups
+          .includes(:memberships)
+          .where(decidim_user_group_memberships: { role: "requested" })
+      end
+
+      private
+
+      attr_reader :user
+    end
+  end
+end

--- a/decidim-core/app/types/decidim/core/session_type.rb
+++ b/decidim-core/app/types/decidim/core/session_type.rb
@@ -12,7 +12,7 @@ module Decidim
       end
 
       field :verifiedUserGroups, !types[!UserGroupType], "The current user verified user groups" do
-        resolve ->(obj, _args, _ctx) { obj.user_groups.verified }
+        resolve ->(obj, _args, _ctx) { Decidim::UserGroups::ManageableUserGroups.for(obj).verified }
       end
     end
   end

--- a/decidim-core/spec/queries/decidim/user_groups/accepted_user_groups_spec.rb
+++ b/decidim-core/spec/queries/decidim/user_groups/accepted_user_groups_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::UserGroups::AcceptedUserGroups do
+  subject { described_class.for(user) }
+
+  let(:organization) { create(:organization) }
+  let(:user) { create :user, organization: organization }
+
+  let!(:creator_user_group) { create :user_group, organization: organization, users: [] }
+  let!(:admin_user_group) { create :user_group, organization: organization, users: [] }
+  let!(:member_user_group) { create :user_group, organization: organization, users: [] }
+  let!(:requested_user_group) { create :user_group, organization: organization, users: [] }
+
+  before do
+    create :user_group_membership, user: user, user_group: creator_user_group, role: :creator
+    create :user_group_membership, user: user, user_group: admin_user_group, role: :admin
+    create :user_group_membership, user: user, user_group: member_user_group, role: :member
+    create :user_group_membership, user: user, user_group: requested_user_group, role: :requested
+  end
+
+  it "finds the user groups where the user has an accepted membership" do
+    expect(subject).to match_array([creator_user_group, admin_user_group, member_user_group])
+  end
+end

--- a/decidim-core/spec/queries/decidim/user_groups/accepted_users_spec.rb
+++ b/decidim-core/spec/queries/decidim/user_groups/accepted_users_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::UserGroups::AcceptedUsers do
+  subject { described_class.for(user_group) }
+
+  let(:organization) { create(:organization) }
+
+  let!(:creator_user) { create :user, organization: organization }
+  let!(:admin_user) { create :user, organization: organization }
+  let!(:member_user) { create :user, organization: organization }
+  let!(:requested_user) { create :user, organization: organization }
+
+  let!(:user_group) { create :user_group, organization: organization, users: [] }
+
+  before do
+    create :user_group_membership, user: creator_user, user_group: user_group, role: :creator
+    create :user_group_membership, user: admin_user, user_group: user_group, role: :admin
+    create :user_group_membership, user: member_user, user_group: user_group, role: :member
+    create :user_group_membership, user: requested_user, user_group: user_group, role: :requested
+  end
+
+  it "finds the active members for the user group" do
+    expect(subject).to match_array([creator_user, admin_user, member_user])
+  end
+end

--- a/decidim-core/spec/queries/decidim/user_groups/manageable_user_groups_spec.rb
+++ b/decidim-core/spec/queries/decidim/user_groups/manageable_user_groups_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::UserGroups::ManageableUserGroups do
+  subject { described_class.for(user) }
+
+  let(:organization) { create(:organization) }
+  let(:user) { create :user, organization: organization }
+
+  let!(:creator_user_group) { create :user_group, organization: organization, users: [] }
+  let!(:admin_user_group) { create :user_group, organization: organization, users: [] }
+  let!(:member_user_group) { create :user_group, organization: organization, users: [] }
+  let!(:requested_user_group) { create :user_group, organization: organization, users: [] }
+
+  before do
+    create :user_group_membership, user: user, user_group: creator_user_group, role: :creator
+    create :user_group_membership, user: user, user_group: admin_user_group, role: :admin
+    create :user_group_membership, user: user, user_group: member_user_group, role: :member
+    create :user_group_membership, user: user, user_group: requested_user_group, role: :requested
+  end
+
+  it "finds the user groups the user can manage" do
+    expect(subject).to match_array([creator_user_group, admin_user_group])
+  end
+end

--- a/decidim-core/spec/queries/decidim/user_groups/pending_user_groups_spec.rb
+++ b/decidim-core/spec/queries/decidim/user_groups/pending_user_groups_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::UserGroups::PendingUserGroups do
+  subject { described_class.for(user) }
+
+  let(:organization) { create(:organization) }
+  let(:user) { create :user, organization: organization }
+
+  let!(:creator_user_group) { create :user_group, organization: organization, users: [] }
+  let!(:admin_user_group) { create :user_group, organization: organization, users: [] }
+  let!(:member_user_group) { create :user_group, organization: organization, users: [] }
+  let!(:requested_user_group) { create :user_group, organization: organization, users: [] }
+
+  before do
+    create :user_group_membership, user: user, user_group: creator_user_group, role: :creator
+    create :user_group_membership, user: user, user_group: admin_user_group, role: :admin
+    create :user_group_membership, user: user, user_group: member_user_group, role: :member
+    create :user_group_membership, user: user, user_group: requested_user_group, role: :requested
+  end
+
+  it "finds the user groups where the user has a pending membership" do
+    expect(subject).to match_array([requested_user_group])
+  end
+end

--- a/decidim-core/spec/system/user_group_profile_spec.rb
+++ b/decidim-core/spec/system/user_group_profile_spec.rb
@@ -51,10 +51,14 @@ describe "User group profile", type: :system do
   end
 
   context "when displaying members" do
+    let!(:pending_user) { create :user, organization: user.organization }
+    let!(:pending_membership) { create :user_group_membership, user_group: user_group, user: pending_user, role: "requested" }
+
     it "lists the members" do
       click_link "Members"
 
       expect(page).to have_content(user.name)
+      expect(page).to have_no_content(pending_user.name)
     end
   end
 end

--- a/decidim-core/spec/system/user_profile_spec.rb
+++ b/decidim-core/spec/system/user_profile_spec.rb
@@ -136,7 +136,9 @@ describe "Profile", type: :system do
     end
 
     context "when belonging to user groups" do
-      let!(:user_group) { create :user_group, users: [user], organization: user.organization }
+      let!(:accepted_user_group) { create :user_group, users: [user], organization: user.organization }
+      let!(:pending_user_group) { create :user_group, users: [], organization: user.organization }
+      let!(:pending_membership) { create :user_group_membership, user_group: pending_user_group, user: user, role: "requested" }
 
       before do
         visit decidim.profile_path(user.nickname)
@@ -145,7 +147,8 @@ describe "Profile", type: :system do
       it "lists the user groups" do
         click_link "Organizations"
 
-        expect(page).to have_content(user_group.name)
+        expect(page).to have_content(accepted_user_group.name)
+        expect(page).to have_no_content(pending_user_group.name)
       end
     end
   end

--- a/decidim-core/spec/types/session_type_spec.rb
+++ b/decidim-core/spec/types/session_type_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/api/test/type_context"
+
+module Decidim
+  module Core
+    describe SessionType do
+      include_context "with a graphql type"
+
+      let(:model) { current_user }
+
+      describe "user" do
+        let(:query) { '{ user { nickname } }' }
+
+        it "returns the current user" do
+          expect(response["user"]["nickname"]).to eq("@#{model.nickname}")
+        end
+      end
+
+      describe "verifiedUserGroups" do
+        let(:query) { '{ verifiedUserGroups { id } }' }
+        let(:organization) { current_user.organization }
+
+        let!(:creator_user_group) { create :user_group, organization: organization, users: [] }
+        let!(:admin_user_group) { create :user_group, organization: organization, users: [] }
+        let!(:member_user_group) { create :user_group, organization: organization, users: [] }
+        let!(:verified_creator_user_group) { create :user_group, :verified, organization: organization, users: [] }
+        let!(:verified_admin_user_group) { create :user_group, :verified, organization: organization, users: [] }
+        let!(:verified_member_user_group) { create :user_group, :verified, organization: organization, users: [] }
+        let!(:requested_user_group) { create :user_group, organization: organization, users: [] }
+
+        before do
+          create :user_group_membership, user: current_user, user_group: creator_user_group, role: :creator
+          create :user_group_membership, user: current_user, user_group: admin_user_group, role: :admin
+          create :user_group_membership, user: current_user, user_group: member_user_group, role: :member
+          create :user_group_membership, user: current_user, user_group: verified_creator_user_group, role: :creator
+          create :user_group_membership, user: current_user, user_group: verified_admin_user_group, role: :admin
+          create :user_group_membership, user: current_user, user_group: verified_member_user_group, role: :member
+          create :user_group_membership, user: current_user, user_group: requested_user_group, role: :requested
+        end
+
+        it "returns the verified user groups the user is manager of" do
+          ids = response["verifiedUserGroups"].map{ |group| group["id"] }
+
+          expect(ids).to match_array([verified_admin_user_group.id, verified_creator_user_group.id].map(&:to_s))
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/types/session_type_spec.rb
+++ b/decidim-core/spec/types/session_type_spec.rb
@@ -11,7 +11,7 @@ module Decidim
       let(:model) { current_user }
 
       describe "user" do
-        let(:query) { '{ user { nickname } }' }
+        let(:query) { "{ user { nickname } }" }
 
         it "returns the current user" do
           expect(response["user"]["nickname"]).to eq("@#{model.nickname}")
@@ -19,7 +19,7 @@ module Decidim
       end
 
       describe "verifiedUserGroups" do
-        let(:query) { '{ verifiedUserGroups { id } }' }
+        let(:query) { "{ verifiedUserGroups { id } }" }
         let(:organization) { current_user.organization }
 
         let!(:creator_user_group) { create :user_group, organization: organization, users: [] }
@@ -41,7 +41,7 @@ module Decidim
         end
 
         it "returns the verified user groups the user is manager of" do
-          ids = response["verifiedUserGroups"].map{ |group| group["id"] }
+          ids = response["verifiedUserGroups"].map { |group| group["id"] }
 
           expect(ids).to match_array([verified_admin_user_group.id, verified_creator_user_group.id].map(&:to_s))
         end

--- a/decidim-debates/app/views/decidim/debates/debates/new.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/new.html.erb
@@ -25,9 +25,9 @@
             </div>
           <% end %>
 
-          <% if current_user.user_groups.verified.any? %>
+          <% if Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.any? %>
             <div class="field">
-              <%= form.select :user_group_id, current_user.user_groups.verified.map{|g| [g.name, g.id]}, prompt: current_user.name %>
+              <%= form.select :user_group_id, Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.map{|g| [g.name, g.id]}, prompt: current_user.name %>
             </div>
           <% end %>
 

--- a/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
+++ b/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
@@ -67,7 +67,7 @@ module Decidim
         Decidim::Initiatives.creation_enabled && (
           Decidim::Initiatives.do_not_require_authorization ||
             UserAuthorizations.for(user).any? ||
-            user.user_groups.verified.any?
+            Decidim::UserGroups::ManageableUserGroups.for(user).verified.any?
         )
       end
 
@@ -80,7 +80,7 @@ module Decidim
                       (
                         Decidim::Initiatives.do_not_require_authorization ||
                         UserAuthorizations.for(user).any? ||
-                        user.user_groups.verified.any?
+                        Decidim::UserGroups::ManageableUserGroups.for(user).verified.any?
                       )
 
         toggle_allow(can_request)
@@ -107,7 +107,7 @@ module Decidim
         can_vote = initiative.votes_enabled? &&
                    initiative.organization&.id == user.organization&.id &&
                    initiative.votes.where(decidim_author_id: user.id, decidim_user_group_id: decidim_user_group_id).empty? &&
-                   (can_user_support?(initiative) || user.user_groups.verified.any?)
+                   (can_user_support?(initiative) || Decidim::UserGroups::ManageableUserGroups.for(user).verified.any?)
 
         toggle_allow(can_vote)
       end
@@ -119,7 +119,7 @@ module Decidim
         can_unvote = initiative.votes_enabled? &&
                      initiative.organization&.id == user.organization&.id &&
                      initiative.votes.where(decidim_author_id: user.id, decidim_user_group_id: decidim_user_group_id).any? &&
-                     (can_user_support?(initiative) || user.user_groups.verified.any?)
+                     (can_user_support?(initiative) || Decidim::UserGroups::ManageableUserGroups.for(user).verified.any?)
 
         toggle_allow(can_unvote)
       end

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
@@ -46,10 +46,10 @@
                            prompt: t(".select_scope") %>
             </div>
 
-            <% if current_user.user_groups.verified.any? %>
+            <% if Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.any? %>
               <div class="field">
                 <%= f.select :decidim_user_group_id,
-                             current_user.user_groups.verified.map{ |g| [g.name, g.id] },
+                             Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.map{ |g| [g.name, g.id] },
                              prompt: current_user.name %>
               </div>
             <% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_vote_cabin.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_vote_cabin.html.erb
@@ -1,4 +1,4 @@
-<% if current_user && current_user.user_groups.verified.any? %>
+<% if current_user && Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.any? %>
   <button id="select-identity-button"
           class="card__button button expanded button--sc">
     <%= t(".vote") %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/signature_identities.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/signature_identities.html.erb
@@ -9,7 +9,7 @@
                unvote_label: current_user.name
            } unless current_initiative.offline? %>
 
-<% current_user.user_groups.verified.each do |g| %>
+<% Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.each do |g| %>
   <br />
   <% if @voted_groups.include? g.id %>
     <%= button_to(

--- a/decidim-proposals/app/commands/decidim/proposals/endorse_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/endorse_proposal.rb
@@ -35,8 +35,12 @@ module Decidim
 
       def build_proposal_endorsement
         endorsement = @proposal.endorsements.build(author: @current_user)
-        endorsement.user_group = @current_user.user_groups.verified.find(@current_group_id) if @current_group_id.present?
+        endorsement.user_group = user_groups.find(@current_group_id) if @current_group_id.present?
         endorsement
+      end
+
+      def user_groups
+        Decidim::UserGroups::ManageableUserGroups.for(@current_user).verified
       end
 
       def notify_endorser_followers

--- a/decidim-proposals/app/controllers/decidim/proposals/proposal_endorsements_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposal_endorsements_controller.rb
@@ -42,7 +42,7 @@ module Decidim
       def identities
         enforce_permission_to :endorse, :proposal, proposal: proposal
 
-        @user_verified_groups = current_user.user_groups.verified
+        @user_verified_groups = Decidim::UserGroups::ManageableUserGroups.for(current_user).verified
         render :identities, layout: false
       end
 

--- a/decidim-proposals/app/controllers/decidim/proposals/proposal_endorsements_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposal_endorsements_controller.rb
@@ -29,7 +29,7 @@ module Decidim
         enforce_permission_to :unendorse, :proposal, proposal: proposal
         @from_proposals_list = params[:from_proposals_list] == "true"
         user_group_id = params[:user_group_id]
-        user_group = current_user.user_groups.verified.find(user_group_id) if user_group_id
+        user_group = user_groups.find(user_group_id) if user_group_id
 
         UnendorseProposal.call(proposal, current_user, user_group) do
           on(:ok) do
@@ -47,6 +47,10 @@ module Decidim
       end
 
       private
+
+      def user_groups
+        Decidim::UserGroups::ManageableUserGroups.for(current_user).verified
+      end
 
       def proposal
         @proposal ||= Proposal.where(component: current_component).find(params[:proposal_id])

--- a/decidim-proposals/app/helpers/decidim/proposals/proposal_endorsements_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/proposal_endorsements_helper.rb
@@ -79,7 +79,7 @@ module Decidim
       def fully_endorsed?(proposal, user)
         return false unless user
 
-        user_group_endorsements = user.user_groups.verified.all? { |user_group| proposal.endorsed_by?(user, user_group) }
+        user_group_endorsements = Decidim::UserGroups::ManageableUserGroups.for(user).verified.all? { |user_group| proposal.endorsed_by?(user, user_group) }
 
         user_group_endorsements && proposal.endorsed_by?(user)
       end

--- a/decidim-proposals/app/helpers/decidim/proposals/proposal_wizard_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/proposal_wizard_helper.rb
@@ -101,9 +101,10 @@ module Decidim
       # Returns nothing.
       def user_group_select_field(form, name)
         selected = @form.user_group_id.presence
+        user_groups = Decidim::UserGroups::ManageableUserGroups.for(current_user).verified
         form.select(
           name,
-          current_user.user_groups.verified.map { |g| [g.name, g.id] },
+          user_groups.map { |g| [g.name, g.id] },
           selected: selected,
           include_blank: current_user.name
         )

--- a/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/complete.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/complete.html.erb
@@ -36,7 +36,7 @@
             </div>
           <% end %>
 
-          <% if current_user.user_groups.verified.any? %>
+          <% if Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.any? %>
             <div class="field">
               <%= user_group_select_field form, :user_group_id %>
             </div>

--- a/decidim-proposals/app/views/decidim/proposals/proposal_endorsements/_identity.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposal_endorsements/_identity.html.erb
@@ -1,5 +1,9 @@
 <li class="<%= selected ? "selected" : "" %>" data-method="<%= http_method.to_s.upcase %>" data-url="<%= current_endorsement_url %>">
-  <%= card_for identity, context: { extra_classes: ["author-data--small"] } %>
+  <div class="author-data author-data--small">
+    <div class="author-data__main">
+      <%== cell("decidim/author", identity).profile %>
+    </div>
+  </div>
 
   <%= icon("circle-check", class: "icon--big #{selected ? '' : 'invisible'}") %>
 </li>

--- a/decidim-proposals/app/views/decidim/proposals/proposal_endorsements/update_buttons_and_counters.js.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposal_endorsements/update_buttons_and_counters.js.erb
@@ -1,4 +1,4 @@
-<% if current_user.user_groups.empty? %>
+<% if Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.empty? %>
 update_main_page_button();
 <% end %>
 update_identities_rows();

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
@@ -28,7 +28,7 @@
   </div>
 <% end %>
 
-<% if current_user.user_groups.verified.any? %>
+<% if Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.any? %>
   <div class="field">
     <%= user_group_select_field form, :user_group_id %>
   </div>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_endorsement_identities_cabin.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_endorsement_identities_cabin.html.erb
@@ -1,5 +1,5 @@
 <%= javascript_include_tag "decidim/proposals/identity_selector_dialog" %>
-<% if current_user && current_user.user_groups.verified.any? %>
+<% if current_user && Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.any? %>
   <button id="select-identity-button" type="button" name="button" class="button small compact light button--sc <%= fully_endorsed ? "success": "secondary" %>">
     <%= t(".endorse") %>
   </button>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/new.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/new.html.erb
@@ -15,7 +15,7 @@
             <%= form.text_area :body, rows: 10, class: "js-hashtags", hashtaggable: true %>
           </div>
 
-          <% if current_user.user_groups.verified.any? %>
+          <% if Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.any? %>
             <div class="field">
               <%= user_group_select_field form, :user_group_id %>
             </div>

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -184,7 +184,7 @@ Decidim.register_component(:proposals) do |component|
 
       if n.positive?
         Decidim::User.where(decidim_organization_id: participatory_space.decidim_organization_id).all.sample(n).each do |author|
-          user_group = [true, false].sample ? author.user_groups.verified.sample : nil
+          user_group = [true, false].sample ? Decidim::UserGroups::ManageableUserGroups.for(author).verified.sample : nil
           proposal.add_coauthor(author, user_group: user_group)
         end
       end

--- a/decidim-proposals/spec/commands/decidim/proposals/endorse_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/endorse_proposal_spec.rb
@@ -62,13 +62,8 @@ module Decidim
       end
 
       describe "Organization endorses Proposal" do
-        let(:user_group) { create(:user_group, verified_at: Time.current) }
+        let(:user_group) { create(:user_group, verified_at: Time.current, users: [current_user]) }
         let(:command) { described_class.new(proposal, current_user, user_group.id) }
-
-        before do
-          current_user.user_groups << user_group
-          current_user.save!
-        end
 
         context "when in normal conditions" do
           it "broadcasts ok" do

--- a/decidim-proposals/spec/controllers/decidim/proposal_endorsements_controller_as_user_spec.rb
+++ b/decidim-proposals/spec/controllers/decidim/proposal_endorsements_controller_as_user_spec.rb
@@ -34,7 +34,7 @@ module Decidim
 
           context "when requesting user identities while belonging to UNverified user_groups" do
             it "only returns the user identity endorse button" do
-              create_user_groups
+              create_list(:user_group, 2, users: [user], organization: user.organization)
               get :identities, params: params
 
               expect(response).to have_http_status(:ok)
@@ -45,25 +45,13 @@ module Decidim
 
           context "when requesting user identities while belonging to verified user_groups" do
             it "returns the user's and user_groups's identities for the endorse button" do
-              create_user_groups(true)
+              create_list(:user_group, 2, :verified, users: [user], organization: user.organization)
               get :identities, params: params
 
               expect(response).to have_http_status(:ok)
               expect(assigns[:user_verified_groups]).to eq user.user_groups
               expect(subject).to render_template("decidim/proposals/proposal_endorsements/identities")
             end
-          end
-          #
-          # UTIL METHODS
-          #
-
-          def create_user_groups(verified = false)
-            2.times do
-              user_group = create(:user_group)
-              user_group.verify! if verified
-              user.user_groups << user_group
-            end
-            user.save!
           end
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?
This PR ensures only users with management level can act as a user group (those with "creator" or "admin" roles). 

#### :pushpin: Related Issues
- Related to #3893

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Show only accepted user groups in user profile tab
- [x] Show only accepted users in user group profile tab. Will need to add a way to find accepted users and pending users.
- [x] Only show the user group modal dialog for managers
- [x] Check if permissions need to be updated
- [x] Ensure only managers can act as a user group

Actions the user groups can perform and need to be checked:

- [x] Endorse proposal
- [x] Create proposal
- [x] Add comment