### PR TITLE
Add unique email validation on form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 
 **Fixed**:
 
-**decidim-admin**: Add email validation to ManagedUserPromotionForm. [\#4225](https://github.com/decidim/decidim/pull/4225)
+- **decidim-admin**: Add email validation to ManagedUserPromotionForm. [\#4225](https://github.com/decidim/decidim/pull/4225)
 - **decidim-debates**: When a Searchable accesses its indexed resources it must scope by resource_type and organization_id. [\4079](https://github.com/decidim/decidim/pull/4079)
 - **decidim-debates**: Fix create debates as a normal user in a private space [\4108](https://github.com/decidim/decidim/pull/4108)
 - **decidim-admin**: English locale now uses a consistent date format (UK style everywhere). [\#3724](https://github.com/decidim/decidim/pull/3724)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 
 **Fixed**:
 
+**decidim-admin**: Add email validation to ManagedUserPromotionForm. [\#4225](https://github.com/decidim/decidim/pull/4225)
 - **decidim-debates**: When a Searchable accesses its indexed resources it must scope by resource_type and organization_id. [\4079](https://github.com/decidim/decidim/pull/4079)
 - **decidim-debates**: Fix create debates as a normal user in a private space [\4108](https://github.com/decidim/decidim/pull/4108)
 - **decidim-admin**: English locale now uses a consistent date format (UK style everywhere). [\#3724](https://github.com/decidim/decidim/pull/3724)

--- a/decidim-admin/app/forms/decidim/admin/managed_user_promotion_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/managed_user_promotion_form.rb
@@ -8,6 +8,18 @@ module Decidim
       attribute :email, String
 
       validates :email, presence: true, 'valid_email_2/email': { disposable: true }
+      validate :unique_email
+
+      private
+
+      def unique_email
+        return true if Decidim::User.where(
+          organization: context.current_organization,
+          email: email
+        ).where.not(id: context.current_user.id).empty?
+        errors.add :email, :taken
+        false
+      end
     end
   end
 end

--- a/decidim-admin/spec/commands/decidim/admin/promote_managed_user_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/promote_managed_user_spec.rb
@@ -18,7 +18,8 @@ module Decidim::Admin
       ManagedUserPromotionForm.from_params(
         form_params
       ).with_context(
-        current_organization: organization
+        current_organization: organization,
+        current_user: current_user
       )
     end
     let!(:user) { create :user, :managed, organization: organization }

--- a/decidim-admin/spec/forms/managed_user_promotion_form_spec.rb
+++ b/decidim-admin/spec/forms/managed_user_promotion_form_spec.rb
@@ -5,7 +5,15 @@ require "spec_helper"
 module Decidim
   module Admin
     describe ManagedUserPromotionForm do
-      subject { described_class.from_params(attributes) }
+      subject do
+        described_class.from_params(attributes).with_context(
+          current_organization: current_organization,
+          current_user: user
+        )
+      end
+
+      let(:current_organization) { create(:organization) }
+      let!(:user) { create :user, :confirmed, organization: current_organization }
 
       let(:email) { "foo@example.org" }
       let(:attributes) do
@@ -22,6 +30,12 @@ module Decidim
 
       context "when email is missing" do
         let(:email) {}
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "when email already exist" do
+        let!(:another_user) { create :user, :confirmed, email: email, organization: current_organization }
 
         it { is_expected.to be_invalid }
       end


### PR DESCRIPTION
#### :tophat: What? Why?
I noticed a validation on from was missing when playing with impersonating users. When a user has already registered with an email, you cannot invite him with the same address. This is normal, but currently, the error message was not explicit enough and the admin may not understand why it's not working.

Add validation on the ImpersonateUserForm has been added to check the uniqueness of email.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)
Before:
![image](https://user-images.githubusercontent.com/20232956/46404642-145a6600-c706-11e8-99c1-6c4e244d5a70.png)
After:
![image](https://user-images.githubusercontent.com/20232956/46404749-63a09680-c706-11e8-9018-ca040d7bf416.png)
