### PR TITLE
[FIX] Catch failing URI parsings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 
 **Fixed**:
 
+- **decidim-proposals**: Fix uncatched exception when trying to retrieve a Proposal from an invalid url match. [\4157](https://github.com/decidim/decidim/pull/4157)
 - **decidim-core**: Fix data portability proposal images, modify command to create directory if not exists, and fix surveys ansewers whem exporting data portability. [\#4223](https://github.com/decidim/decidim/pull/4223)
 - **decidim-debates**: When a Searchable accesses its indexed resources it must scope by resource_type and organization_id. [\4079](https://github.com/decidim/decidim/pull/4079)
 - **decidim-debates**: Fix create debates as a normal user in a private space [\4108](https://github.com/decidim/decidim/pull/4108)

--- a/decidim-proposals/lib/decidim/content_parsers/proposal_parser.rb
+++ b/decidim-proposals/lib/decidim/content_parsers/proposal_parser.rb
@@ -72,7 +72,7 @@ module Decidim
 
       def proposal_from_url_match(match)
         uri = URI.parse(match)
-        return unless uri.path.present?
+        return if uri.path.blank?
 
         proposal_id = uri.path.split("/").last
         find_proposal_by_id(proposal_id)

--- a/decidim-proposals/lib/decidim/content_parsers/proposal_parser.rb
+++ b/decidim-proposals/lib/decidim/content_parsers/proposal_parser.rb
@@ -72,9 +72,11 @@ module Decidim
 
       def proposal_from_url_match(match)
         uri = URI.parse(match)
+        return unless uri.path.present?
+
         proposal_id = uri.path.split("/").last
         find_proposal_by_id(proposal_id)
-      rescue URI::InvalidURIError, NoMethodError
+      rescue URI::InvalidURIError
         nil
       end
 

--- a/decidim-proposals/lib/decidim/content_parsers/proposal_parser.rb
+++ b/decidim-proposals/lib/decidim/content_parsers/proposal_parser.rb
@@ -74,6 +74,8 @@ module Decidim
         uri = URI.parse(match)
         proposal_id = uri.path.split("/").last
         find_proposal_by_id(proposal_id)
+      rescue URI::InvalidURIError, NoMethodError
+        nil
       end
 
       def proposal_from_id_match(match)

--- a/decidim-proposals/spec/lib/decidim/content_parsers/proposal_parser_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/content_parsers/proposal_parser_spec.rb
@@ -88,6 +88,20 @@ module Decidim
           end
         end
 
+        context "when content has one link that is a simple domain" do
+          let(:link) { "aaa:bbb" }
+          let(:content) do
+            "This content contains #{link} which is not a URI."
+          end
+
+          it { is_expected.to eq(content) }
+          it "has metadata with the proposal" do
+            subject
+            expect(parser.metadata).to be_a(Decidim::ContentParsers::ProposalParser::Metadata)
+            expect(parser.metadata.linked_proposals).to be_empty
+          end
+        end
+
         context "when content has many links" do
           let(:proposal1) { create(:proposal, component: component) }
           let(:proposal2) { create(:proposal, component: component) }


### PR DESCRIPTION
#### :tophat: What? Why?
This is a quick fix but required to avoid the notification of mentioned Proposals.

Further testing of the regexp will be done in another PR.

#### :pushpin: Related Issues
- Fixes #4157 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [-] Add documentation regarding the feature 
- [-] Add/modify seeds
- [-] Add tests
- [x] Fix
