### PR TITLE
Fix testing doc path

### DIFF
--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -111,4 +111,4 @@ This project uses [markdownlint](https://github.com/markdownlint/markdownlint) t
 
 ## Testing
 
-Refer to the [testing](docs/advanced/testing.md) guide.
+Refer to the [testing](advanced/testing.md) guide.


### PR DESCRIPTION
#### :tophat: What? Why?
The url to testing docs is wrong