### PR TITLE
Fix proposal mentioned notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 - **decidim-core**: Adds a "Continuity" badge. [\#4257](https://github.com/decidim/decidim/pull/4257)
 - **decidim-core**: Add activity feed content block and page. [\#4130](https://github.com/decidim/decidim/pull/4130)
 - **decidim-core**: Allow user to sign-in without confirming their email. [\#4269](https://github.com/decidim/decidim/pull/4269)
+- **decidim-core**: Fix proposal mentioned notification. [\#4281](https://github.com/decidim/decidim/pull/4281)
 
 **Changed**:
 

--- a/decidim-proposals/app/jobs/decidim/proposals/notify_proposals_mentioned_job.rb
+++ b/decidim-proposals/app/jobs/decidim/proposals/notify_proposals_mentioned_job.rb
@@ -3,9 +3,9 @@
 module Decidim
   module Proposals
     class NotifyProposalsMentionedJob < ApplicationJob
-      def perform(comment_id, proposal_metadata)
+      def perform(comment_id, linked_proposals)
         comment = Decidim::Comments::Comment.find(comment_id)
-        linked_proposals = proposal_metadata.linked_proposals
+
         linked_proposals.each do |proposal_id|
           proposal = Proposal.find(proposal_id)
           next if proposal.official?

--- a/decidim-proposals/lib/decidim/proposals/engine.rb
+++ b/decidim-proposals/lib/decidim/proposals/engine.rb
@@ -113,8 +113,8 @@ module Decidim
 
       initializer "decidim_proposals.mentions_listener" do
         Decidim::Comments::CommentCreation.subscribe do |data|
-          metadata = data[:metadatas][:proposals]
-          Decidim::Proposals::NotifyProposalsMentionedJob.perform_later(data[:comment_id], metadata)
+          proposals = data.dig(:metadatas, :proposal).try(:linked_proposals)
+          Decidim::Proposals::NotifyProposalsMentionedJob.perform_later(data[:comment_id], proposals) if proposals
         end
       end
 

--- a/decidim-proposals/spec/jobs/decidim/proposals/notify_proposals_mentioned_job_spec.rb
+++ b/decidim-proposals/spec/jobs/decidim/proposals/notify_proposals_mentioned_job_spec.rb
@@ -11,14 +11,28 @@ module Decidim
       let(:comment) { create(:comment, commentable: commentable) }
       let(:proposal_component) { create(:proposal_component, organization: organization) }
       let(:proposal_metadata) { Decidim::ContentParsers::ProposalParser::Metadata.new([]) }
+      let(:linked_proposal) { create(:proposal, component: proposal_component) }
+      let(:linked_proposal_no_author) { create(:proposal, :official, component: proposal_component) }
+
+      describe "integration" do
+        it "is correctly scheduled" do
+          ActiveJob::Base.queue_adapter = :test
+          proposal_metadata[:linked_proposals] << linked_proposal
+          proposal_metadata[:linked_proposals] << linked_proposal_no_author
+          comment = create(:comment)
+
+          expect do
+            Decidim::Comments::CommentCreation.publish(comment, proposal: proposal_metadata)
+          end.to have_enqueued_job.with(comment.id, proposal_metadata.linked_proposals)
+        end
+      end
 
       describe "with mentioned proposals" do
-        let(:linked_proposal) { create(:proposal, component: proposal_component) }
-        let(:linked_proposal_no_author) { create(:proposal, :official, component: proposal_component) }
-
-        before do
-          proposal_metadata[:linked_proposals] << linked_proposal.id
-          proposal_metadata[:linked_proposals] << linked_proposal_no_author.id
+        let(:linked_proposals) do
+          [
+            linked_proposal.id,
+            linked_proposal_no_author.id
+          ]
         end
 
         it "notifies the author about it" do
@@ -34,7 +48,7 @@ module Decidim
                 mentioned_proposal_id: linked_proposal.id
               }
             )
-          subject.perform_now(comment.id, proposal_metadata)
+          subject.perform_now(comment.id, linked_proposals)
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

There was a typo and afterwards a serialization error (since ActiveJob can't serialize the `Metadata` class) and when someone was mentioning your proposal in a comment you weren't notified.

#### :pushpin: Related Issues

- Fixes #4211

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

