### PR TITLE
Make authors polymorphic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 - **decidim-core**: Allow users to enter date fields manually. [\#3724](https://github.com/decidim/decidim/pull/3724)
 - **decidim-core**: Merge Users and UserGroups DB tables [\#4196](https://github.com/decidim/decidim/pull/4196)
 - **decidim-core**: Move user group creation to user profile [\#4256](https://github.com/decidim/decidim/pull/4256)
+- **decidim-core**: Make authors polymorphic [\#4282](https://github.com/decidim/decidim/pull/4282)
 
 **Fixed**:
 

--- a/decidim-accountability/app/commands/decidim/accountability/admin/create_result.rb
+++ b/decidim-accountability/app/commands/decidim/accountability/admin/create_result.rb
@@ -87,12 +87,11 @@ module Decidim
 
         def notify_proposal_followers
           proposals.each do |proposal|
-            authors_ids = proposal.authors.pluck(:id)
             Decidim::EventsManager.publish(
               event: "decidim.events.accountability.proposal_linked",
               event_class: Decidim::Accountability::ProposalLinkedEvent,
               resource: result,
-              recipient_ids: authors_ids + proposal.followers.pluck(:id),
+              recipient_ids: proposal.followers.pluck(:id),
               extra: {
                 proposal_id: proposal.id
               }

--- a/decidim-accountability/spec/commands/admin/create_result_spec.rb
+++ b/decidim-accountability/spec/commands/admin/create_result_spec.rb
@@ -140,7 +140,7 @@ module Decidim::Accountability
             event: "decidim.events.accountability.proposal_linked",
             event_class: Decidim::Accountability::ProposalLinkedEvent,
             resource: kind_of(Result),
-            recipient_ids: [proposals.first.creator_author.id, follower.id],
+            recipient_ids: match_array([proposals.first.creator_author.id, follower.id]),
             extra: {
               proposal_id: proposals.first.id
             }

--- a/decidim-blogs/app/commands/decidim/blogs/admin/create_post.rb
+++ b/decidim-blogs/app/commands/decidim/blogs/admin/create_post.rb
@@ -32,7 +32,7 @@ module Decidim
             title: @form.title,
             body: @form.body,
             component: @form.current_component,
-            decidim_author_id: @current_user.id
+            author: @current_user
           }
 
           @post = Decidim.traceability.create!(

--- a/decidim-blogs/db/migrate/20181017084519_make_blogposts_authors_polymorphics.rb
+++ b/decidim-blogs/db/migrate/20181017084519_make_blogposts_authors_polymorphics.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class MakeBlogpostsAuthorsPolymorphics < ActiveRecord::Migration[5.2]
+  class Post < ApplicationRecord
+    self.table_name = :decidim_blogs_posts
+  end
+  class User < ApplicationRecord
+    self.table_name = :decidim_users
+  end
+
+  def change
+    add_column :decidim_blogs_posts, :decidim_author_type, :string
+
+    Post.reset_column_information
+    Post.find_each do |post|
+      author = if post.decidim_author_id.present?
+                 User.find(post.decidim_author_id)
+               else
+                 post.organization
+               end
+      post.author = author
+      post.save!
+    end
+
+    add_index :decidim_blogs_posts,
+              [:decidim_author_id, :decidim_author_type],
+              name: "index_decidim_blogs_posts_on_decidim_author"
+    change_column_null :decidim_blogs_posts, :decidim_author_id, false
+    change_column_null :decidim_blogs_posts, :decidim_author_type, false
+
+    Post.reset_column_information
+  end
+end

--- a/decidim-blogs/spec/commands/decidim/blogs/admin/create_post_spec.rb
+++ b/decidim-blogs/spec/commands/decidim/blogs/admin/create_post_spec.rb
@@ -21,8 +21,7 @@ module Decidim
             invalid?: invalid,
             title: { en: title },
             body: { en: body },
-            current_component: current_component,
-            decidim_author_id: current_user.id
+            current_component: current_component
           )
         end
 
@@ -53,7 +52,7 @@ module Decidim
 
           it "sets the author" do
             subject.call
-            expect(post.decidim_author_id).to eq current_user.id
+            expect(post.author).to eq current_user
           end
 
           it "sets the component" do

--- a/decidim-comments/app/models/decidim/comments/comment_vote.rb
+++ b/decidim-comments/app/models/decidim/comments/comment_vote.rb
@@ -8,7 +8,7 @@ module Decidim
       include Decidim::DataPortability
 
       belongs_to :comment, foreign_key: "decidim_comment_id", class_name: "Comment"
-      belongs_to :author, foreign_key: "decidim_author_id", class_name: "Decidim::User"
+      belongs_to :author, foreign_key: "decidim_author_id", foreign_type: "decidim_author_type", polymorphic: true
 
       validates :comment, uniqueness: { scope: :author }
       validates :weight, inclusion: { in: [-1, 1] }

--- a/decidim-comments/app/models/decidim/comments/seed.rb
+++ b/decidim-comments/app/models/decidim/comments/seed.rb
@@ -14,6 +14,8 @@ module Decidim
       def self.comments_for(resource)
         return unless resource.accepts_new_comments?
 
+        Decidim::Comments::Comment.reset_column_information
+
         organization = resource.organization
 
         2.times do

--- a/decidim-comments/db/migrate/20181016142511_make_authors_polymorphic_for_comments.rb
+++ b/decidim-comments/db/migrate/20181016142511_make_authors_polymorphic_for_comments.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class MakeAuthorsPolymorphicForComments < ActiveRecord::Migration[5.2]
+  class Comment < ApplicationRecord
+    self.table_name = :decidim_comments_comments
+  end
+  def change
+    add_column :decidim_comments_comments, :decidim_author_type, :string
+
+    reversible do |direction|
+      direction.up do
+        execute <<~SQL.squish
+          UPDATE decidim_comments_comments
+          SET decidim_author_type = 'Decidim::UserBaseEntity'
+        SQL
+      end
+    end
+
+    add_index :decidim_comments_comments,
+              [:decidim_author_id, :decidim_author_type],
+              name: "index_decidim_comments_comments_on_decidim_author"
+
+    change_column_null :decidim_comments_comments, :decidim_author_id, false
+    change_column_null :decidim_comments_comments, :decidim_author_type, false
+    Comment.reset_column_information
+  end
+end

--- a/decidim-comments/db/migrate/20181019092928_make_author_polymorphic_for_comment_votes.rb
+++ b/decidim-comments/db/migrate/20181019092928_make_author_polymorphic_for_comment_votes.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class MakeAuthorPolymorphicForCommentVotes < ActiveRecord::Migration[5.2]
+  class CommentVote < ApplicationRecord
+    self.table_name = :decidim_comments_comment_votes
+  end
+  def change
+    add_column :decidim_comments_comment_votes, :decidim_author_type, :string
+
+    reversible do |direction|
+      direction.up do
+        execute <<~SQL.squish
+          UPDATE decidim_comments_comment_votes
+          SET decidim_author_type = 'Decidim::UserBaseEntity'
+        SQL
+      end
+    end
+
+    add_index :decidim_comments_comment_votes,
+              [:decidim_author_id, :decidim_author_type],
+              name: "index_decidim_comments_comment_votes_on_decidim_author"
+
+    change_column_null :decidim_comments_comment_votes, :decidim_author_id, false
+    change_column_null :decidim_comments_comment_votes, :decidim_author_type, false
+    CommentVote.reset_column_information
+  end
+end

--- a/decidim-consultations/app/models/decidim/consultations/vote.rb
+++ b/decidim-consultations/app/models/decidim/consultations/vote.rb
@@ -4,7 +4,7 @@ module Decidim
   module Consultations
     # The data store for question's votes in the Decidim::Consultations component.
     class Vote < ApplicationRecord
-      include Authorable
+      belongs_to :author, foreign_key: "decidim_author_id", class_name: "Decidim::User"
 
       belongs_to :question,
                  foreign_key: "decidim_consultation_question_id",
@@ -19,8 +19,17 @@ module Decidim
                  counter_cache: :votes_count
 
       validates :author, uniqueness: { scope: [:decidim_user_group_id, :question] }
+      validate :author_and_question_same_organization
 
       delegate :organization, to: :question
+
+      private
+
+      # Private: check if the question and the author have the same organization
+      def author_and_question_same_organization
+        return if !question || !author
+        errors.add(:question, :invalid) unless author.organization == question.organization
+      end
     end
   end
 end

--- a/decidim-core/app/models/decidim/coauthorship.rb
+++ b/decidim-core/app/models/decidim/coauthorship.rb
@@ -8,6 +8,8 @@ module Decidim
 
     validates :coauthorable, presence: true
 
+    after_commit :author_is_follower, on: [:create]
+
     def identity
       user_group || author
     end
@@ -18,6 +20,13 @@ module Decidim
     # @returns The Organization for the Coauthorable
     def organization
       coauthorable&.organization
+    end
+
+    def author_is_follower
+      return unless author.is_a?(Decidim::User)
+      return unless coauthorable.is_a?(Decidim::Followable)
+
+      Decidim::Follow.find_or_create_by!(followable: coauthorable, user: author)
     end
   end
 end

--- a/decidim-core/db/migrate/20181016091601_make_authors_polymorphic.rb
+++ b/decidim-core/db/migrate/20181016091601_make_authors_polymorphic.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class MakeAuthorsPolymorphic < ActiveRecord::Migration[5.2]
+  class Coauthorship < ApplicationRecord
+    self.table_name = :decidim_coauthorships
+  end
+
+  def change
+    remove_index :decidim_coauthorships, :decidim_author_id
+
+    add_column :decidim_coauthorships, :decidim_author_type, :string
+
+    reversible do |direction|
+      direction.up do
+        execute <<~SQL.squish
+          UPDATE decidim_coauthorships
+          SET decidim_author_type = 'Decidim::UserBaseEntity'
+        SQL
+      end
+    end
+
+    add_index :decidim_coauthorships,
+              [:decidim_author_id, :decidim_author_type],
+              name: "index_decidim_coauthorships_on_decidim_author"
+
+    change_column_null :decidim_coauthorships, :decidim_author_id, false
+    change_column_null :decidim_coauthorships, :decidim_author_type, false
+
+    Coauthorship.reset_column_information
+  end
+end

--- a/decidim-core/lib/decidim/coauthorable.rb
+++ b/decidim-core/lib/decidim/coauthorable.rb
@@ -12,23 +12,62 @@ module Decidim
     extend ActiveSupport::Concern
 
     included do
-      has_many :coauthorships, -> { order(:created_at) }, as: :coauthorable, class_name: "Decidim::Coauthorship", dependent: :destroy
-      has_many :authors, -> { order(:created_at) }, through: :coauthorships, class_name: "Decidim::User"
+      has_many :coauthorships, -> { order(:created_at) }, as: :coauthorable, class_name: "Decidim::Coauthorship", dependent: :destroy, inverse_of: :coauthorable
       has_many :user_groups, -> { order(:created_at) }, as: :coauthorable, class_name: "Decidim::UserGroup", through: :coauthorships
 
-      # retrieves models from all identities of the user.
-      scope :from_all_user_identities, ->(user) { joins(:coauthorships).where("decidim_coauthorships.decidim_author_id": user.id) }
-      # retrieves models from the given User, ignoring the UserGroups it belongs to.
-      scope :from_author, ->(author) { joins(:coauthorships).where("decidim_coauthorships.decidim_author_id": author.id).where("decidim_coauthorships.decidim_user_group_id": nil) }
+      # retrieves models from all identities of the author.
+      scope :from_all_author_identities, lambda { |author|
+        joins(:coauthorships).where("decidim_coauthorships.decidim_author_id = ? AND decidim_coauthorships.decidim_author_type = ?", author.id, author.class.base_class.name)
+      }
+      # retrieves models from the given author, ignoring the UserGroups it belongs to.
+      scope :from_author, ->(author) { from_all_author_identities(author).where("decidim_coauthorships.decidim_user_group_id": nil) }
       # retrieves models from the given UserGroup.
       scope :from_user_group, ->(user_group) { joins(:coauthorships).where("decidim_coauthorships.decidim_user_group_id": user_group.id) }
+
+      validates :coauthorships, presence: true
+
+      # Overwrite default reload method to unset the instance variables so reloading works as expected.
+      def reload(options = nil)
+        remove_instance_variable(:@authors) if defined?(@authors)
+        remove_instance_variable(:@notifiable_authors) if defined?(@notifiable_authors)
+        super(options)
+      end
+
+      # Returns all the authors of a coauthorable.
+      #
+      # We need to do it this ways since the authors are polymorphic, and we can't have a has_many through relation
+      # with polymorphic objects.
+      def authors
+        return @authors if defined?(@authors)
+
+        authors = coauthorships.pluck(:decidim_author_id, :decidim_author_type).each_with_object({}) do |(id, klass), all|
+          all[klass] ||= []
+          all[klass] << id
+        end
+
+        @authors = authors.flat_map do |klass, ids|
+          klass.constantize.where(id: ids)
+        end.compact.uniq
+      end
+
+      # Returns the authors that should be notified for a coauthorable.
+      #
+      def notifiable_authors
+        @notifiable_authors ||= authors.flat_map do |author|
+          if author.is_a?(Decidim::User)
+            author
+          elsif respond_to?(:component)
+            component.participatory_space.admins
+          end
+        end.compact.uniq
+      end
 
       # Checks whether the user is author of the given proposal, either directly
       # authoring it or via a user group.
       #
-      # user - the user to check for authorship
-      def authored_by?(user)
-        coauthorships.where(author: user).exists?
+      # author - the author to check for authorship
+      def authored_by?(author)
+        coauthorships.where(author: author).exists?
       end
 
       # Returns the identities for the authors, whether they are user groups or users.
@@ -40,30 +79,34 @@ module Decidim
 
       # Syntactic sugar to access first coauthor as a Coauthorship.
       def creator
-        coauthorships.first
+        coauthorships.order(:created_at).first
       end
 
       # Syntactic sugar to access first coauthor Author
       def creator_author
-        authors.first
+        creator.try(:author)
       end
 
       # Syntactic sugar to access first identity whether it is a User or a UserGroup.
       # @return The User od UserGroup that created this Coauthorable.
       def creator_identity
-        coauthorships.order(:created_at).first&.identity
+        creator.try(:identity)
       end
 
       # Adds a new coauthor to the list of coauthors. The coauthorship is created with
       # current object as coauthorable and `user` param as author. To set the user group
       # use `extra_attrs` either with `user_group` or `decidim_user_group_id` keys.
       #
-      # @param user: The new coauthor.
+      # @param author: The new coauthor.
       # @extra_attrs: Extra
-      def add_coauthor(user, extra_attrs = {})
-        attrs = { coauthorable: self, author: user }
-        Decidim::Coauthorship.create!(attrs.merge(extra_attrs))
-        Decidim::Follow.create!(followable: self, user: user) unless followers.exists?(user.id)
+      def add_coauthor(author, extra_attrs = {})
+        if persisted?
+          coauthorships.create!(extra_attrs.merge(author: author))
+        else
+          coauthorships.build(extra_attrs.merge(author: author))
+        end
+
+        authors << author
       end
     end
   end

--- a/decidim-core/lib/decidim/core/test/shared_examples/coauthorable_interface_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/coauthorable_interface_examples.rb
@@ -9,7 +9,7 @@ shared_examples_for "coauthorable interface" do
     describe "with a regular user" do
       let(:query) { "{ author { name } }" }
 
-      it "includes the user's ID" do
+      it "returns the user's name as the author name" do
         expect(response["author"]["name"]).to eq(author.name)
       end
     end
@@ -23,7 +23,7 @@ shared_examples_for "coauthorable interface" do
         coauthorship.update!(user_group: user_group)
       end
 
-      it "includes the user's ID" do
+      it "includes returns the user group's name as the author name" do
         expect(response["author"]["name"]).to eq(user_group.name)
       end
     end

--- a/decidim-core/lib/decidim/data_portability.rb
+++ b/decidim-core/lib/decidim/data_portability.rb
@@ -11,7 +11,9 @@ module Decidim
       # Returns a collection scoped by user.
       # This is the default, if you want, you can overwrite in each Class to be export.
       def self.user_collection(user)
-        where(decidim_author_id: user.id)
+        return unless user.is_a?(Decidim::User)
+
+        where(decidim_author_id: user.id, decidim_author_type: "Decidim::UserBaseEntity")
       end
 
       # Returns a Default export serializer

--- a/decidim-core/lib/decidim/gamification.rb
+++ b/decidim-core/lib/decidim/gamification.rb
@@ -14,6 +14,7 @@ module Decidim
     #
     # Returns a `BadgeStatus` instance.
     def self.status_for(user, badge_name)
+      return unless user.is_a?(Decidim::UserBaseEntity)
       BadgeStatus.new(user, find_badge(badge_name))
     end
 
@@ -26,7 +27,7 @@ module Decidim
     # Returns nothing.
     def self.increment_score(user, badge_name, amount = 1)
       return unless amount.positive?
-
+      return unless user.is_a?(Decidim::UserBaseEntity)
       BadgeScorer.new(user, find_badge(badge_name)).increment(amount)
     end
 
@@ -39,7 +40,7 @@ module Decidim
     # Returns nothing.
     def self.decrement_score(user, badge_name, amount = 1)
       return unless amount.positive?
-
+      return unless user.is_a?(Decidim::UserBaseEntity)
       BadgeScorer.new(user, find_badge(badge_name)).decrement(amount)
     end
 
@@ -51,6 +52,7 @@ module Decidim
     #
     # Returns nothing.
     def self.set_score(user, badge_name, score)
+      return unless user.is_a?(Decidim::UserBaseEntity)
       BadgeScorer.new(user, find_badge(badge_name)).set(score)
     end
 

--- a/decidim-core/spec/lib/searchable_spec.rb
+++ b/decidim-core/spec/lib/searchable_spec.rb
@@ -15,17 +15,19 @@ module Decidim
       let(:component_2) { create(:component, organization: organization_2) }
 
       let!(:dummy_resource_1) do
-        Decidim::DummyResources::DummyResource.create(
+        Decidim::DummyResources::DummyResource.create!(
           id: COMMON_ID,
           component: component_1,
-          published_at: Time.current
+          published_at: Time.current,
+          author: organization_1
         )
       end
       let!(:dummy_resource_2) do
-        Decidim::DummyResources::DummyResource.create(
+        Decidim::DummyResources::DummyResource.create!(
           id: COMMON_ID + 1,
           component: component_2,
-          published_at: Time.current
+          published_at: Time.current,
+          author: organization_2
         )
       end
       let!(:user_1) { create(:user, id: COMMON_ID, organization: organization_1) }

--- a/decidim-debates/app/commands/decidim/debates/admin/create_debate.rb
+++ b/decidim-debates/app/commands/decidim/debates/admin/create_debate.rb
@@ -36,7 +36,8 @@ module Decidim
             instructions: form.instructions,
             end_time: form.end_time,
             start_time: form.start_time,
-            component: form.current_component
+            component: form.current_component,
+            author: form.current_organization
           }
 
           @debate = Decidim.traceability.create!(

--- a/decidim-debates/app/models/decidim/debates/debate.rb
+++ b/decidim-debates/app/models/decidim/debates/debate.rb
@@ -31,7 +31,7 @@ module Decidim
       #
       # Returns a boolean.
       def official?
-        author.blank?
+        author.is_a?(Decidim::Organization)
       end
 
       # Public: Overrides the `reported_content_url` Reportable concern method.

--- a/decidim-debates/app/services/decidim/debates/debate_search.rb
+++ b/decidim-debates/app/services/decidim/debates/debate_search.rb
@@ -23,12 +23,11 @@ module Decidim
       end
 
       # Handle the origin filter
-      # The 'official' debates don't have an author ID
       def search_origin
         if origin == "official"
-          query.where(decidim_author_id: nil)
+          query.where(author: component.organization)
         elsif origin == "citizens"
-          query.where.not(decidim_author_id: nil)
+          query.where.not(decidim_author_type: "Decidim::Organization")
         else # Assume 'all'
           query
         end

--- a/decidim-debates/db/migrate/20181016132850_add_organization_as_author_to_debates.rb
+++ b/decidim-debates/db/migrate/20181016132850_add_organization_as_author_to_debates.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class AddOrganizationAsAuthorToDebates < ActiveRecord::Migration[5.2]
+  class Debate < ApplicationRecord
+    self.table_name = :decidim_debates_debates
+  end
+  class User < ApplicationRecord
+    self.table_name = :decidim_users
+  end
+  def change
+    add_column :decidim_debates_debates, :decidim_author_type, :string
+
+    Debate.reset_column_information
+    Debate.includes(:author).find_each do |debate|
+      author = if debate.decidim_author_id.present?
+                 User.find(debate.decidim_author_id)
+               else
+                 debate.organization
+               end
+      debate.author = author
+      debate.save!
+    end
+
+    add_index :decidim_debates_debates,
+              [:decidim_author_id, :decidim_author_type],
+              name: "index_decidim_debates_debates_on_decidim_author"
+    change_column_null :decidim_debates_debates, :decidim_author_id, false
+    change_column_null :decidim_debates_debates, :decidim_author_type, false
+  end
+end

--- a/decidim-debates/lib/decidim/debates/component.rb
+++ b/decidim-debates/lib/decidim/debates/component.rb
@@ -70,7 +70,8 @@ Decidim.register_component(:debates) do |component|
           Decidim::Faker::Localized.paragraph(3)
         end,
         start_time: 3.weeks.from_now,
-        end_time: 3.weeks.from_now + 4.hours
+        end_time: 3.weeks.from_now + 4.hours,
+        author: component.organization
       }
 
       debate = Decidim.traceability.create!(

--- a/decidim-debates/lib/decidim/debates/engine.rb
+++ b/decidim-debates/lib/decidim/debates/engine.rb
@@ -36,7 +36,7 @@ module Decidim
           badge.levels = [1, 5, 10, 30, 50]
           badge.reset = lambda do |user|
             debates = Decidim::Comments::Comment.where(
-              decidim_author_id: user.id,
+              author: user,
               decidim_root_commentable_type: "Decidim::Debates::Debate"\
             )
             debates.pluck(:decidim_root_commentable_id).uniq.count

--- a/decidim-debates/lib/decidim/debates/test/factories.rb
+++ b/decidim-debates/lib/decidim/debates/test/factories.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     start_time { 1.day.from_now }
     end_time { start_time.advance(hours: 2) }
     component { build(:component, manifest_name: "debates") }
+    author { component.try(:organization) }
 
     trait :open_ama do
       start_time { 1.day.ago }

--- a/decidim-debates/spec/commands/decidim/debates/admin/create_debate_spec.rb
+++ b/decidim-debates/spec/commands/decidim/debates/admin/create_debate_spec.rb
@@ -21,7 +21,8 @@ describe Decidim::Debates::Admin::CreateDebate do
       end_time: 1.day.from_now + 1.hour,
       category: category,
       current_user: user,
-      current_component: current_component
+      current_component: current_component,
+      current_organization: organization
     )
   end
   let(:invalid) { false }
@@ -49,6 +50,12 @@ describe Decidim::Debates::Admin::CreateDebate do
     it "sets the component" do
       subject.call
       expect(debate.component).to eq current_component
+    end
+
+    it "sets the organization as author" do
+      subject.call
+
+      expect(debate.author).to eq(organization)
     end
 
     it "traces the action", versioning: true do

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
@@ -69,7 +69,7 @@ module Decidim
       end
 
       def self.user_collection(user)
-        where(decidim_author_id: user.id)
+        where(decidim_author_id: user.id, decidim_author_type: "Decidim::User")
       end
 
       def self.export_serializer
@@ -148,7 +148,8 @@ RSpec.configure do |config|
           t.integer :coauthorships_count, null: false, default: 0
 
           t.references :decidim_component, index: false
-          t.references :decidim_author, index: false
+          t.integer :decidim_author_id, index: false
+          t.string :decidim_author_type, index: false
           t.references :decidim_category, index: false
           t.references :decidim_scope, index: false
 

--- a/decidim-initiatives/db/migrate/20181016095744_make_initiative_authors_polymorphic.rb
+++ b/decidim-initiatives/db/migrate/20181016095744_make_initiative_authors_polymorphic.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class MakeInitiativeAuthorsPolymorphic < ActiveRecord::Migration[5.2]
+  class Initiative < ApplicationRecord
+    self.table_name = :decidim_initiatives
+  end
+
+  def change
+    remove_index :decidim_initiatives, :decidim_author_id
+
+    add_column :decidim_initiatives, :decidim_author_type, :string
+
+    reversible do |direction|
+      direction.up do
+        execute <<~SQL.squish
+          UPDATE decidim_initiatives
+          SET decidim_author_type = 'Decidim::UserBaseEntity'
+        SQL
+      end
+    end
+
+    add_index :decidim_initiatives,
+              [:decidim_author_id, :decidim_author_type],
+              name: "index_decidim_initiatives_on_decidim_author"
+
+    change_column_null :decidim_initiatives, :decidim_author_id, false
+    change_column_null :decidim_initiatives, :decidim_author_type, false
+
+    Initiative.reset_column_information
+  end
+end

--- a/decidim-proposals/app/commands/decidim/proposals/admin/answer_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/answer_proposal.rb
@@ -81,7 +81,7 @@ module Decidim
         def increment_score
           return unless proposal.accepted?
 
-          proposal.authors.find_each do |author|
+          proposal.authors.each do |author|
             Decidim::Gamification.increment_score(author, :accepted_proposals)
           end
         end

--- a/decidim-proposals/app/commands/decidim/proposals/admin/create_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/create_proposal.rb
@@ -40,12 +40,12 @@ module Decidim
         attr_reader :form, :proposal, :attachment
 
         def create_proposal
-          @proposal = Decidim.traceability.create!(
-            Proposal,
-            form.current_user,
-            attributes,
-            visibility: "all"
-          )
+          @proposal = Decidim.traceability.perform_action!(:create, Proposal, form.current_user, visibility: "all") do
+            proposal = Proposal.new(attributes)
+            proposal.add_coauthor(form.current_organization)
+            proposal.save!
+            proposal
+          end
         end
 
         def attributes

--- a/decidim-proposals/app/commands/decidim/proposals/admin/import_proposals.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/import_proposals.rb
@@ -49,12 +49,12 @@ module Decidim
             proposal = Decidim::Proposals::Proposal.new(origin_attributes)
             proposal.category = original_proposal.category
             proposal.component = target_component
+            original_proposal.coauthorships.each do |coauthorship|
+              proposal.coauthorships.build(author: coauthorship.author, user_group: coauthorship.user_group)
+            end
             proposal.save!
 
             proposal.link_resources([original_proposal], "copied_from_component")
-            original_proposal.coauthorships.each do |coauthorship|
-              Decidim::Coauthorship.create(author: coauthorship.author, user_group: coauthorship.user_group, coauthorable: proposal)
-            end
           end.compact
         end
 

--- a/decidim-proposals/app/commands/decidim/proposals/create_collaborative_draft.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/create_collaborative_draft.rb
@@ -42,23 +42,28 @@ module Decidim
       attr_reader :form, :collaborative_draft, :attachment
 
       def create_collaborative_draft
-        @collaborative_draft = Decidim.traceability.create!(
+        @collaborative_draft = Decidim.traceability.perform_action!(
+          :create,
           CollaborativeDraft,
-          @form.current_user,
-          title: form.title,
-          body: form.body,
-          category: form.category,
-          scope: form.scope,
-          component: form.component,
-          address: form.address,
-          latitude: form.latitude,
-          longitude: form.longitude,
-          state: "open"
-        )
+          @form.current_user
+        ) do
+          draft = CollaborativeDraft.new(
+            title: form.title,
+            body: form.body,
+            category: form.category,
+            scope: form.scope,
+            component: form.component,
+            address: form.address,
+            latitude: form.latitude,
+            longitude: form.longitude,
+            state: "open"
+          )
+          draft.coauthorships.build(author: @current_user, user_group: @form.user_group)
+          draft.save!
+          draft
+        end
 
         @attached_to = @collaborative_draft
-
-        @collaborative_draft.add_coauthor(@current_user, user_group: @form.user_group)
       end
 
       def user_group

--- a/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
@@ -45,12 +45,14 @@ module Decidim
         parsed_title = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.title, current_organization: form.current_organization).rewrite
         parsed_body = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.body, current_organization: form.current_organization).rewrite
 
-        @proposal = Proposal.create!(
+        @proposal = Proposal.new(
           title: parsed_title,
           body: parsed_body,
           component: form.component
         )
-        proposal.add_coauthor(@current_user, user_group: user_group)
+        @proposal.add_coauthor(@current_user, user_group: user_group)
+        @proposal.save!
+        @proposal
       end
 
       def proposal_limit_reached?

--- a/decidim-proposals/app/controllers/decidim/proposals/collaborative_drafts_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/collaborative_drafts_controller.rb
@@ -20,7 +20,6 @@ module Decidim
       def index
         @collaborative_drafts = search
                                 .results
-                                .includes(:authors)
                                 .includes(:category)
                                 .includes(:scope)
 

--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -203,7 +203,7 @@ module Decidim
       end
 
       def proposal_draft
-        Proposal.from_all_user_identities(current_user).not_hidden.where(component: current_component).find_by(published_at: nil)
+        Proposal.from_all_author_identities(current_user).not_hidden.where(component: current_component).find_by(published_at: nil)
       end
 
       def ensure_is_draft

--- a/decidim-proposals/app/jobs/decidim/proposals/notify_proposals_mentioned_job.rb
+++ b/decidim-proposals/app/jobs/decidim/proposals/notify_proposals_mentioned_job.rb
@@ -8,12 +8,7 @@ module Decidim
 
         linked_proposals.each do |proposal_id|
           proposal = Proposal.find(proposal_id)
-          next if proposal.official?
-
-          recipients = proposal.authors.select do |author|
-            author.is_a?(Decidim::User)
-          end
-          recipient_ids = recipients.map(&:id)
+          recipient_ids = proposal.notifiable_authors.map(&:id)
 
           Decidim::EventsManager.publish(
             event: "decidim.events.proposals.proposal_mentioned",

--- a/decidim-proposals/app/jobs/decidim/proposals/notify_proposals_mentioned_job.rb
+++ b/decidim-proposals/app/jobs/decidim/proposals/notify_proposals_mentioned_job.rb
@@ -10,7 +10,11 @@ module Decidim
           proposal = Proposal.find(proposal_id)
           next if proposal.official?
 
-          recipient_ids = proposal.authors.pluck(:decidim_author_id)
+          recipients = proposal.authors.select do |author|
+            author.is_a?(Decidim::User)
+          end
+          recipient_ids = recipients.map(&:id)
+
           Decidim::EventsManager.publish(
             event: "decidim.events.proposals.proposal_mentioned",
             event_class: Decidim::Proposals::ProposalMentionedEvent,

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -73,12 +73,14 @@ module Decidim
         Decidim::Proposals::AdminLog::ProposalPresenter
       end
 
-      # Returns a collection scoped by user.
+      # Returns a collection scoped by an author.
       # Overrides this method in DataPortability to support Coauthorable.
-      def self.user_collection(user)
+      def self.user_collection(author)
+        return unless author.is_a?(Decidim::User)
+
         joins(:coauthorships)
           .where("decidim_coauthorships.coauthorable_type = ?", name)
-          .where("decidim_coauthorships.decidim_author_id = ?", user.id)
+          .where("decidim_coauthorships.decidim_author_id = ? AND decidim_coauthorships.decidim_author_type = ? ", author.id, author.class.base_class.name)
       end
 
       # Public: Updates the vote count of this proposal.
@@ -152,7 +154,7 @@ module Decidim
 
       # Public: Whether the proposal is official or not.
       def official?
-        authors.empty?
+        authors.first.is_a?(Decidim::Organization)
       end
 
       # Public: The maximum amount of votes allowed for this proposal.

--- a/decidim-proposals/app/services/decidim/proposals/proposal_search.rb
+++ b/decidim-proposals/app/services/decidim/proposals/proposal_search.rb
@@ -24,9 +24,9 @@ module Decidim
       # The 'official' proposals doesn't have an author id
       def search_origin
         if origin == "official"
-          query.where(coauthorships_count: 0)
+          query.where.not(coauthorships_count: 0).joins(:coauthorships).where(decidim_coauthorships: { decidim_author_type: "Decidim::Organization" })
         elsif origin == "citizens"
-          query.where.not(coauthorships_count: 0)
+          query.where.not(coauthorships_count: 0).joins(:coauthorships).where.not(decidim_coauthorships: { decidim_author_type: "Decidim::Organization" })
         else # Assume 'all'
           query
         end

--- a/decidim-proposals/db/migrate/20181016132225_add_organization_as_author.rb
+++ b/decidim-proposals/db/migrate/20181016132225_add_organization_as_author.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddOrganizationAsAuthor < ActiveRecord::Migration[5.2]
+  class Proposal < ApplicationRecord
+    self.table_name = :decidim_proposals_proposals
+  end
+  def change
+    official_proposals = Proposal.find_each.select do |proposal|
+      proposal.coauthorships.count.zero?
+    end
+
+    official_proposals.each do |proposal|
+      proposal.add_coauthor(proposal.organization)
+    end
+  end
+end

--- a/decidim-proposals/db/migrate/20181017084221_make_author_polymorhpic_for_proposal_endorsements.rb
+++ b/decidim-proposals/db/migrate/20181017084221_make_author_polymorhpic_for_proposal_endorsements.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class MakeAuthorPolymorhpicForProposalEndorsements < ActiveRecord::Migration[5.2]
+  class ProposalEndorsement < ApplicationRecord
+    self.table_name = :decidim_proposals_proposal_endorsements
+  end
+
+  def change
+    remove_index :decidim_proposals_proposal_endorsements, :decidim_author_id
+
+    add_column :decidim_proposals_proposal_endorsements, :decidim_author_type, :string
+
+    reversible do |direction|
+      direction.up do
+        execute <<~SQL.squish
+          UPDATE decidim_proposals_proposal_endorsements
+          SET decidim_author_type = 'Decidim::UserBaseEntity'
+        SQL
+      end
+    end
+
+    add_index :decidim_proposals_proposal_endorsements,
+              [:decidim_author_id, :decidim_author_type],
+              name: "index_decidim_proposals_proposal_endorsements_on_decidim_author"
+
+    change_column_null :decidim_proposals_proposal_endorsements, :decidim_author_id, false
+    change_column_null :decidim_proposals_proposal_endorsements, :decidim_author_type, false
+
+    ProposalEndorsement.reset_column_information
+  end
+end

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -181,7 +181,10 @@ Decidim.register_component(:proposals) do |component|
         admin_user,
         visibility: "all"
       ) do
-        Decidim::Proposals::Proposal.create!(params)
+        proposal = Decidim::Proposals::Proposal.new(params)
+        proposal.add_coauthor(participatory_space.organization)
+        proposal.save!
+        proposal
       end
 
       if n.positive?
@@ -271,18 +274,20 @@ Decidim.register_component(:proposals) do |component|
               end
       author = Decidim::User.where(organization: component.organization).all.sample
 
-      draft = Decidim.traceability.create!(
-        Decidim::Proposals::CollaborativeDraft,
-        author,
-        component: component,
-        category: participatory_space.categories.sample,
-        scope: Faker::Boolean.boolean(0.5) ? global : scopes.sample,
-        title: Faker::Lorem.sentence(2),
-        body: Faker::Lorem.paragraphs(2).join("\n"),
-        state: state,
-        published_at: Time.current
-      )
-      Decidim::Coauthorship.create(coauthorable: draft, author: author)
+      draft = Decidim.traceability.perform_action!("create", Decidim::Proposals::CollaborativeDraft, author) do
+        draft = Decidim::Proposals::CollaborativeDraft.new(
+          component: component,
+          category: participatory_space.categories.sample,
+          scope: Faker::Boolean.boolean(0.5) ? global : scopes.sample,
+          title: Faker::Lorem.sentence(2),
+          body: Faker::Lorem.paragraphs(2).join("\n"),
+          state: state,
+          published_at: Time.current
+        )
+        draft.coauthorships.build(author: participatory_space.organization)
+        draft.save!
+        draft
+      end
 
       if n == 2
         author2 = Decidim::User.where(organization: component.organization).all.sample

--- a/decidim-proposals/lib/decidim/proposals/markdown_to_proposals.rb
+++ b/decidim-proposals/lib/decidim/proposals/markdown_to_proposals.rb
@@ -39,13 +39,8 @@ module Decidim
                                      Decidim::Proposals::ParticipatoryTextSection::LEVELS[:section]
                                    end
 
-        proposal = Decidim::Proposals::Proposal.create!(
-          component: @component,
-          title: title,
-          body: title,
-          participatory_text_level: participatory_text_level
-        )
-        @last_position = proposal.position
+        create_proposal(title, title, participatory_text_level)
+
         @num_sections += 1
         title
       end
@@ -55,19 +50,35 @@ module Decidim
       def paragraph(text)
         return if text.blank?
 
-        proposal = Decidim::Proposals::Proposal.create!(
-          component: @component,
-          title: (@last_position + 1 - @num_sections).to_s,
-          body: text,
-          participatory_text_level: Decidim::Proposals::ParticipatoryTextSection::LEVELS[:article]
+        create_proposal(
+          (@last_position + 1 - @num_sections).to_s,
+          text,
+          Decidim::Proposals::ParticipatoryTextSection::LEVELS[:article]
         )
-        @last_position = proposal.position
+
         text
       end
 
       # ignore images
       def image(_link, _title, _alt_text)
         ""
+      end
+
+      private
+
+      def create_proposal(title, body, participatory_text_level)
+        proposal = Decidim::Proposals::Proposal.new(
+          component: @component,
+          title: title,
+          body: body,
+          participatory_text_level: participatory_text_level
+        )
+        proposal.add_coauthor(@component.organization)
+        proposal.save!
+
+        @last_position = proposal.position
+
+        proposal
       end
     end
   end

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -197,7 +197,7 @@ FactoryBot.define do
         users = evaluator.users || [create(:user, organization: proposal.component.participatory_space.organization)]
         users.each_with_index do |user, idx|
           user_group = evaluator.user_groups[idx]
-          Decidim::Coauthorship.create(author: user, user_group: user_group, coauthorable: proposal)
+          proposal.coauthorships.build(author: user, user_group: user_group)
         end
       end
     end
@@ -206,9 +206,14 @@ FactoryBot.define do
       published_at { Time.current }
     end
 
+    trait :unpublished do
+      published_at { nil }
+    end
+
     trait :official do
       after :build do |proposal|
         proposal.coauthorships.clear
+        proposal.coauthorships.build(author: proposal.organization)
       end
     end
 
@@ -242,8 +247,8 @@ FactoryBot.define do
     end
 
     trait :hidden do
-      moderation do
-        create(:moderation, hidden_at: Time.current)
+      after :create do |proposal|
+        create(:moderation, hidden_at: Time.current, reportable: proposal)
       end
     end
 
@@ -300,7 +305,7 @@ FactoryBot.define do
         users = evaluator.users || [create(:user, organization: collaborative_draft.component.participatory_space.organization)]
         users.each_with_index do |user, idx|
           user_group = evaluator.user_groups[idx]
-          Decidim::Coauthorship.create(author: user, user_group: user_group, coauthorable: collaborative_draft)
+          collaborative_draft.coauthorships.build(author: user, user_group: user_group)
         end
       end
     end

--- a/decidim-proposals/spec/commands/decidim/proposals/accept_access_to_collaborative_draft_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/accept_access_to_collaborative_draft_spec.rb
@@ -43,9 +43,9 @@ module Decidim
           end
 
           it "adds the requester as a co-author of the collaborative draft" do
-            expect do
-              command.call
-            end.to change(collaborative_draft.authors, :count).by(1)
+            command.call
+            updated_draft = CollaborativeDraft.find(collaborative_draft.id)
+            expect(updated_draft.authors).to include(requester_user)
           end
 
           it "notifies the requester and authors of the collaborative draft that access to requester has been accepted" do

--- a/decidim-proposals/spec/commands/decidim/proposals/admin_create_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin_create_proposal_spec.rb
@@ -69,10 +69,16 @@ module Decidim
               end.to change(Decidim::Proposals::Proposal, :count).by(1)
             end
 
+            it "sets the organization as author" do
+              command.call
+
+              expect(Decidim::Proposals::Proposal.last.authors).to include(organization)
+            end
+
             it "traces the action", versioning: true do
               expect(Decidim.traceability)
-                .to receive(:create!)
-                .with(Decidim::Proposals::Proposal, kind_of(Decidim::User), kind_of(Hash), visibility: "all")
+                .to receive(:perform_action!)
+                .with(:create, Decidim::Proposals::Proposal, kind_of(Decidim::User), visibility: "all")
                 .and_call_original
 
               expect { command.call }.to change(Decidim::ActionLog, :count)

--- a/decidim-proposals/spec/commands/decidim/proposals/answer_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/answer_proposal_spec.rb
@@ -95,7 +95,7 @@ module Decidim
                     event: "decidim.events.proposals.proposal_rejected",
                     event_class: Decidim::Proposals::RejectedProposalEvent,
                     resource: proposal,
-                    recipient_ids: [follower.id]
+                    recipient_ids: match_array([follower.id, proposal.creator_author.id])
                   )
 
                 command.call

--- a/decidim-proposals/spec/commands/decidim/proposals/create_collaborative_draft_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/create_collaborative_draft_spec.rb
@@ -103,8 +103,8 @@ module Decidim
 
           it "traces the action", versioning: true do
             expect(Decidim.traceability)
-              .to receive(:create!)
-              .with(Decidim::Proposals::CollaborativeDraft, kind_of(Decidim::User), kind_of(Hash))
+              .to receive(:perform_action!)
+              .with(:create, Decidim::Proposals::CollaborativeDraft, kind_of(Decidim::User))
               .and_call_original
 
             expect { command.call }.to change(Decidim::ActionLog, :count)

--- a/decidim-proposals/spec/jobs/decidim/proposals/notify_proposals_mentioned_job_spec.rb
+++ b/decidim-proposals/spec/jobs/decidim/proposals/notify_proposals_mentioned_job_spec.rb
@@ -12,13 +12,13 @@ module Decidim
       let(:proposal_component) { create(:proposal_component, organization: organization) }
       let(:proposal_metadata) { Decidim::ContentParsers::ProposalParser::Metadata.new([]) }
       let(:linked_proposal) { create(:proposal, component: proposal_component) }
-      let(:linked_proposal_no_author) { create(:proposal, :official, component: proposal_component) }
+      let(:linked_proposal_official) { create(:proposal, :official, component: proposal_component) }
 
       describe "integration" do
         it "is correctly scheduled" do
           ActiveJob::Base.queue_adapter = :test
           proposal_metadata[:linked_proposals] << linked_proposal
-          proposal_metadata[:linked_proposals] << linked_proposal_no_author
+          proposal_metadata[:linked_proposals] << linked_proposal_official
           comment = create(:comment)
 
           expect do
@@ -31,8 +31,12 @@ module Decidim
         let(:linked_proposals) do
           [
             linked_proposal.id,
-            linked_proposal_no_author.id
+            linked_proposal_official.id
           ]
+        end
+
+        let!(:space_admin) do
+          create(:process_admin, participatory_process: linked_proposal_official.component.participatory_space)
         end
 
         it "notifies the author about it" do
@@ -48,6 +52,20 @@ module Decidim
                 mentioned_proposal_id: linked_proposal.id
               }
             )
+
+          expect(Decidim::EventsManager)
+            .to receive(:publish)
+            .with(
+              event: "decidim.events.proposals.proposal_mentioned",
+              event_class: Decidim::Proposals::ProposalMentionedEvent,
+              resource: commentable,
+              recipient_ids: [space_admin.id],
+              extra: {
+                comment_id: comment.id,
+                mentioned_proposal_id: linked_proposal_official.id
+              }
+            )
+
           subject.perform_now(comment.id, linked_proposals)
         end
       end

--- a/decidim-proposals/spec/models/decidim/proposals/collaborative_draft_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/collaborative_draft_spec.rb
@@ -15,8 +15,6 @@ module Decidim
       include_examples "coauthorable"
       include_examples "has scope"
       include_examples "has category"
-      # include_examples "has reference"
-      # include_examples "reportable"
 
       it { is_expected.to be_valid }
       it { is_expected.to be_versioned }
@@ -31,7 +29,7 @@ module Decidim
         end
 
         it "returns the followers" do
-          expect(subject.users_to_notify_on_comment_created).to match_array(followers)
+          expect(subject.users_to_notify_on_comment_created).to match_array(followers.push(collaborative_draft.creator_author))
         end
       end
 

--- a/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
@@ -9,7 +9,7 @@ module Decidim
 
       let(:component) { build :proposal_component }
       let(:organization) { component.participatory_space.organization }
-      let(:proposal) { build(:proposal, component: component) }
+      let(:proposal) { create(:proposal, component: component) }
       let(:coauthorable) { proposal }
 
       include_examples "coauthorable"
@@ -102,8 +102,8 @@ module Decidim
         end
 
         context "when the proposal is not official" do
-          it "returns the followers" do
-            expect(subject.users_to_notify_on_comment_created).to match_array(followers)
+          it "returns the followers and the author" do
+            expect(subject.users_to_notify_on_comment_created).to match_array(followers.concat([proposal.creator.author]))
           end
         end
       end
@@ -135,10 +135,10 @@ module Decidim
       end
 
       describe "#editable_by?" do
-        let(:author) { build(:user, organization: organization) }
+        let(:author) { create(:user, organization: organization) }
 
         context "when user is author" do
-          let(:proposal) { build :proposal, component: component, users: [author], updated_at: Time.current }
+          let(:proposal) { create :proposal, component: component, users: [author], updated_at: Time.current }
 
           it { is_expected.to be_editable_by(author) }
 
@@ -159,7 +159,7 @@ module Decidim
 
         context "when proposal is from user group and user is admin" do
           let(:user_group) { create :user_group, :verified, users: [author], organization: author.organization }
-          let(:proposal) { build :proposal, component: component, updated_at: Time.current, users: [author], user_groups: [user_group] }
+          let(:proposal) { create :proposal, component: component, updated_at: Time.current, users: [author], user_groups: [user_group] }
 
           it { is_expected.to be_editable_by(author) }
         end
@@ -198,10 +198,10 @@ module Decidim
       end
 
       describe "#withdrawable_by" do
-        let(:author) { build(:user, organization: organization) }
+        let(:author) { create(:user, organization: organization) }
 
         context "when user is author" do
-          let(:proposal) { build :proposal, component: component, users: [author], created_at: Time.current }
+          let(:proposal) { create :proposal, component: component, users: [author], created_at: Time.current }
 
           it { is_expected.to be_withdrawable_by(author) }
         end

--- a/decidim-proposals/spec/services/decidim/proposals/searchable_proposal_resource_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/searchable_proposal_resource_spec.rb
@@ -24,14 +24,7 @@ module Decidim
       context "when implementing Searchable" do
         context "when on create" do
           let(:proposal2) do
-            # by default the factory creates as published
-            create(
-              :proposal,
-              users: [],
-              component: current_component,
-              title: "Proposal without authors.",
-              body: "body of Proposal without authors"
-            )
+            create(:proposal, component: current_component)
           end
 
           it "does not index a SearchableResource after Proposal creation" do

--- a/decidim-sortitions/db/migrate/20181017110803_make_sortitions_authors_polymorphic.rb
+++ b/decidim-sortitions/db/migrate/20181017110803_make_sortitions_authors_polymorphic.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class MakeSortitionsAuthorsPolymorphic < ActiveRecord::Migration[5.2]
+  class Sortition < ApplicationRecord
+    self.table_name = :decidim_sortitions_sortitions
+  end
+  class User < ApplicationRecord
+    self.table_name = :decidim_users
+  end
+
+  def change
+    add_column :decidim_sortitions_sortitions, :decidim_author_type, :string
+
+    Sortition.reset_column_information
+    Sortition.includes(:author).find_each do |sortition|
+      author = if sortition.decidim_author_id.present?
+                 User.find(sortition.decidim_author_id)
+               else
+                 sortition.organization
+               end
+      sortition.author = author
+      sortition.save!
+    end
+
+    add_index :decidim_sortitions_sortitions,
+              [:decidim_author_id, :decidim_author_type],
+              name: "index_decidim_sortitions_sortitions_on_decidim_author"
+    change_column_null :decidim_sortitions_sortitions, :decidim_author_id, false
+    change_column_null :decidim_sortitions_sortitions, :decidim_author_type, false
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Changes authors in Debates, Proposals and Initiatives (so far) to make them polymorphic. Now, official resources have the author as the organization.

#### :pushpin: Related Issues
- Related to #3801, #4035
- Fixes #3901

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add documentation regarding the feature 
- [x] Add/modify seeds
- [x] Add tests
- [x] Add organization as author for official proposals
- [x] Add organization as author for official debates
- [x] Migrate columns for debates
- [x] Migrate columns for proposals
- [x] Migrate columns for initiatives
- [x] Migrate columns for posts
- [x] Migrate columns for sortitions
- [x] Migrate columns for endorsements
- [x] Migrate columns for comments
- [x] Migrate columns for dummy resource
- [x] Set organization as author when creating a proposal from the admin
- [x] Set organization as author when creating a debate from the admin
- [x] Forward proposal notifications to admins & space admin (see NotifyProposalsMentionedJob)
- [x] Forward debate notifications to admins & space admin
