### PR TITLE
Show members count on user group profile sidebar

### DIFF
--- a/decidim-core/app/cells/decidim/profile_sidebar/show.erb
+++ b/decidim-core/app/cells/decidim/profile_sidebar/show.erb
@@ -28,18 +28,33 @@
   <%= render_hook(:user_profile_bottom) %>
   <div class="card__footer card__footer--transparent">
     <div class="flex--cc p-s text-center">
-      <div class="mr-s">
-        <%= link_to profile_followers_path(nickname: profile_holder.nickname) do %>
-          <%= t("decidim.profiles.show.followers") %>
-          <h1 class="heading1"><%= profile_user.followers_count %></h1>
-        <% end %>
-      </div>
-      <div class="ml-s">
-        <%= link_to profile_following_path(nickname: profile_holder.nickname) do %>
-          <%= t("decidim.profiles.show.following") %>
-          <h1 class="heading1"><%= profile_user.following_count %></h1>
-        <% end %>
-      </div>
+      <% if profile_user_can_follow? %>
+        <div class="mr-s">
+          <%= link_to profile_followers_path(nickname: profile_holder.nickname) do %>
+            <%= t("decidim.profiles.show.followers") %>
+            <h1 class="heading1"><%= profile_user.followers_count %></h1>
+          <% end %>
+        </div>
+        <div class="ml-s">
+          <%= link_to profile_following_path(nickname: profile_holder.nickname) do %>
+            <%= t("decidim.profiles.show.following") %>
+            <h1 class="heading1"><%= profile_user.following_count %></h1>
+          <% end %>
+        </div>
+      <% else %>
+        <div class="mr-s">
+          <%= link_to profile_followers_path(nickname: profile_holder.nickname) do %>
+            <%= t("decidim.profiles.show.followers") %>
+            <h1 class="heading1"><%= profile_user.followers_count %></h1>
+          <% end %>
+        </div>
+        <div class="ml-s">
+          <%= link_to profile_members_path(nickname: profile_holder.nickname) do %>
+            <%= t("decidim.profiles.show.members") %>
+            <h1 class="heading1"><%= profile_user.members_count %></h1>
+          <% end %>
+        </div>
+      <% end %>
     </div>
   </div>
 

--- a/decidim-core/app/cells/decidim/profile_sidebar_cell.rb
+++ b/decidim-core/app/cells/decidim/profile_sidebar_cell.rb
@@ -38,5 +38,9 @@ module Decidim
       return false if model.is_a?(Decidim::User)
       Decidim::UserGroups::ManageableUserGroups.for(current_user).include?(model)
     end
+
+    def profile_user_can_follow?
+      profile_user.can_follow?
+    end
   end
 end

--- a/decidim-core/app/presenters/decidim/user_group_presenter.rb
+++ b/decidim-core/app/presenters/decidim/user_group_presenter.rb
@@ -24,5 +24,13 @@ module Decidim
     def officialization_text
       I18n.t("decidim.profiles.default_officialization_text_for_user_groups")
     end
+
+    def can_follow?
+      false
+    end
+
+    def members_count
+      Decidim::UserGroups::AcceptedUsers.for(__getobj__).count
+    end
   end
 end

--- a/decidim-core/app/presenters/decidim/user_presenter.rb
+++ b/decidim-core/app/presenters/decidim/user_presenter.rb
@@ -56,5 +56,9 @@ module Decidim
       translated_attribute(officialized_as).presence ||
         I18n.t("decidim.profiles.default_officialization_text_for_users")
     end
+
+    def can_follow?
+      true
+    end
   end
 end

--- a/decidim-core/spec/system/user_group_profile_spec.rb
+++ b/decidim-core/spec/system/user_group_profile_spec.rb
@@ -40,7 +40,6 @@ describe "User group profile", type: :system do
 
     it "shows the number of followers and following" do
       expect(page).to have_link("Followers 1")
-      expect(page).to have_link("Follows 0")
     end
 
     it "lists the followers" do
@@ -55,6 +54,7 @@ describe "User group profile", type: :system do
     let!(:pending_membership) { create :user_group_membership, user_group: user_group, user: pending_user, role: "requested" }
 
     it "lists the members" do
+      expect(page).to have_link("Members 1")
       click_link "Members"
 
       expect(page).to have_content(user.name)


### PR DESCRIPTION

#### :tophat: What? Why?
This PR replaces the follows count from the user group profiles by the members count. This is due to Product freezing the "User group follows resources" feature, as per #3893.

#### :pushpin: Related Issues
- Related to #3893

#### :clipboard: Subtasks
None
