### PR TITLE
Add the table name to the query to avoid ambiguous names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 - **decidim-core**: Fix newsletter subscription checkbox always being unchecked [\#4238](https://github.com/decidim/decidim/pull/4238)
 - **decidim-core**: Thread safe locale switching [\#4237](https://github.com/decidim/decidim/pull/4237)
 - **decidim-core**: Don't crash when given wrong format at pages [\#4314](https://github.com/decidim/decidim/pull/4314)
+- **decidim-debates**: Fix debate search with categories [\4313](https://github.com/decidim/decidim/pull/4313)
 
 **Removed**:
 

--- a/decidim-debates/app/services/decidim/debates/debate_search.rb
+++ b/decidim-debates/app/services/decidim/debates/debate_search.rb
@@ -18,8 +18,8 @@ module Decidim
       # into a `text` type so that we can search.
       def search_search_text
         query
-          .where("title::text ILIKE ?", "%#{search_text}%")
-          .or(query.where("description::text ILIKE ?", "%#{search_text}%"))
+          .where("decidim_debates_debates.title::text ILIKE ?", "%#{search_text}%")
+          .or(query.where("decidim_debates_debates.description::text ILIKE ?", "%#{search_text}%"))
       end
 
       # Handle the origin filter


### PR DESCRIPTION
#### :tophat: What? Why?

When joining with the categories table we had an error on the `description` column.

- Fixes #4307 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
