### PR TITLE
Ignore other formats at pages controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 - **decidim-core**: Hide weird flash message [\#4235](https://github.com/decidim/decidim/pull/4235)
 - **decidim-core**: Fix newsletter subscription checkbox always being unchecked [\#4238](https://github.com/decidim/decidim/pull/4238)
 - **decidim-core**: Thread safe locale switching [\#4237](https://github.com/decidim/decidim/pull/4237)
+- **decidim-core**: Don't crash when given wrong format at pages [\#4314](https://github.com/decidim/decidim/pull/4314)
 
 **Removed**:
 

--- a/decidim-core/app/controllers/decidim/pages_controller.rb
+++ b/decidim-core/app/controllers/decidim/pages_controller.rb
@@ -10,6 +10,8 @@ module Decidim
     helper Decidim::SanitizeHelper
     skip_before_action :store_current_location
 
+    before_action :set_default_request_format
+
     def index
       enforce_permission_to :read, :public_page
       @pages = current_organization.static_pages.sorted_by_i18n_title
@@ -28,6 +30,12 @@ module Decidim
 
     def page
       @page ||= current_organization.static_pages.find_by(slug: params[:id])
+    end
+
+    private
+
+    def set_default_request_format
+      request.format = :html
     end
   end
 end

--- a/decidim-core/spec/controllers/pages_controller_spec.rb
+++ b/decidim-core/spec/controllers/pages_controller_spec.rb
@@ -35,6 +35,14 @@ module Decidim
           expect(response.body).to include(page.title[I18n.locale.to_s])
           expect(response.body).to include(page.content[I18n.locale.to_s])
         end
+
+        context "when asking the page in other formats" do
+          it "ignores them" do
+            get :show, params: { id: page.slug }, format: :text
+
+            expect(response).to render_template(:decidim_page)
+          end
+        end
       end
 
       context "when a page doesn't exist" do


### PR DESCRIPTION
#### :tophat: What? Why?

When rendering pages we ignore other request formats and return always HTML since it's the only one we support.

#### :pushpin: Related Issues

- Fixes #4214

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

