### PR TITLE
Fix cards

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
@@ -739,11 +739,6 @@ $datetime-bg: $primary;
   font-weight: bold;
   position: absolute;
   background-color: transparent;
-  text-shadow:
-    -1px -1px 0 $card-bg,
-    1px -1px 0 $card-bg,
-    -1px 1px 0 $card-bg,
-    1px 1px 0 $card-bg;
   margin-top: ($global-margin * .6) * -1;
   margin-left: $card-padding-small;
   z-index: 0;
@@ -752,7 +747,7 @@ $datetime-bg: $primary;
     content: " ";
     height: $border-width;
     display: inline-block;
-    background: $card-bg;
+    background-color: $body-background;
     position: absolute;
     left: 0;
     right: 0;
@@ -921,6 +916,8 @@ $datetime-bg: $primary;
 // card - participatory space
 .card__top{
   @extend .card__footer;
+
+  border-top: 0;
 
   .card__content{
     line-height: $global-lineheight;

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
@@ -926,6 +926,10 @@ $datetime-bg: $primary;
     line-height: $global-lineheight;
     padding: $card-padding-small / 4 $card-padding-small;
 
+    > :first-child{
+      flex-shrink: 0;
+    }
+
     @include breakpoint(medium){
       padding: $card-padding / 4 $card-padding;
     }

--- a/decidim-core/app/cells/decidim/card_m/top.erb
+++ b/decidim-core/app/cells/decidim/card_m/top.erb
@@ -1,7 +1,7 @@
 <div class="card__top">
   <% if render_space? %>
     <div class="card__content text-small">
-      <span class="muted"><%= searchable_resource_human_name(model.participatory_space.class) %>:</span>&nbsp;<%= link_to translated_attribute(model.participatory_space.title), Decidim::ResourceLocatorPresenter.new(model.participatory_space).path %>
+      <span class="muted"><%= searchable_resource_human_name(model.participatory_space.class) %>:</span>&nbsp;<%= link_to translated_attribute(model.participatory_space.title), Decidim::ResourceLocatorPresenter.new(model.participatory_space).path, class: "card__link text-ellipsis" %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?
- Participatory spaces on cards adjust to one line
- Background color based on application main background. 

### ❗️ ❗️ Important
In the `.card__top` block markup, inside the `a` tag is missing `class="card__link text-ellipsis"`  after integration cc/ @decidim/lot-core 
```
<div class="card__top">
  <div class="card__content text-small">
    <span class="muted">Participatory process:</span>
    <a href="/processes/roadmap?participatory_process_slug=roadmap">Propose new functionalities for Decidim software</a>
  </div>
</div>
```

### ❗️ Consideration
Background color behind the text identifier on the card is based on the main bg color. If the background, where the card is displayed, has a different background color, CSS cannot deal with this. It should be updated by javascript or have a dynamic classes set by rails.

#### :pushpin: Related Issues
- Fixes #4312 

### :camera: Screenshots (optional)
![imagen](https://user-images.githubusercontent.com/817526/47166335-3ce48180-d2fc-11e8-88cb-2a4078c52a64.png)

