### PR TITLE
Don't allow weird characters in names and nicknames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 - **decidim-core**: Allow users to enter date fields manually. [\#3724](https://github.com/decidim/decidim/pull/3724)
 - **decidim-core**: Merge Users and UserGroups DB tables [\#4196](https://github.com/decidim/decidim/pull/4196)
 - **decidim-core**: Move user group creation to user profile [\#4256](https://github.com/decidim/decidim/pull/4256)
+- **decidim-core**: Don't allow weird characters in names and nicknames [\#4317](https://github.com/decidim/decidim/pull/4317)
 
 **Fixed**:
 

--- a/decidim-core/app/models/decidim/user_base_entity.rb
+++ b/decidim-core/app/models/decidim/user_base_entity.rb
@@ -19,6 +19,8 @@ module Decidim
     validates :avatar, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_avatar_size } }
     mount_uploader :avatar, Decidim::AvatarUploader
 
+    validates :name, :nickname, format: { with: /\A(?!.*[<>?%&\^*#@\(\)\[\]\=\+\:\;\"\{\}\\\|])/ }
+
     # Public: Returns a collection with all the entities this user is following.
     #
     # This can't be done as with a `has_many :following, through: :following_follows`

--- a/decidim-core/spec/models/decidim/user_group_spec.rb
+++ b/decidim-core/spec/models/decidim/user_group_spec.rb
@@ -69,6 +69,24 @@ module Decidim
 
         it { is_expected.not_to be_valid }
       end
+
+      context "with weird characters" do
+        let(:weird_characters) do
+          %w(< > ? % & ^ * # @ ( ) [ ] = + : ; " { } \ |)
+        end
+
+        it "doesn't allow them" do
+          weird_characters.each do |character|
+            user = build(:user)
+            user.name = user.name.insert(rand(0..user.name.length), character)
+            user.nickname = user.nickname.insert(rand(0..user.nickname.length), character)
+
+            expect(user).not_to be_valid
+            expect(user.errors[:name].length).to eq(1)
+            expect(user.errors[:nickname].length).to eq(1)
+          end
+        end
+      end
     end
   end
 end

--- a/decidim-core/spec/models/decidim/user_spec.rb
+++ b/decidim-core/spec/models/decidim/user_spec.rb
@@ -146,6 +146,24 @@ module Decidim
 
         it { is_expected.not_to be_valid }
       end
+
+      context "with weird characters" do
+        let(:weird_characters) do
+          %w(< > ? % & ^ * # @ ( ) [ ] = + : ; " { } \ |)
+        end
+
+        it "doesn't allow them" do
+          weird_characters.each do |character|
+            user = build(:user)
+            user.name = user.name.insert(rand(0..user.name.length), character)
+            user.nickname = user.nickname.insert(rand(0..user.nickname.length), character)
+
+            expect(user).not_to be_valid
+            expect(user.errors[:name].length).to eq(1)
+            expect(user.errors[:nickname].length).to eq(1)
+          end
+        end
+      end
     end
 
     describe "validation scopes" do


### PR DESCRIPTION
#### :tophat: What? Why?

Don't allow weird characters in names and nicknames that could mess sending emails or URLs.

#### :pushpin: Related Issues

- Fixes #4266 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

