### PR TITLE
Consider components without admin engine on edit links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 - **decidim-admin**: Don't list deleted users at officialized list. [\#4139](https://github.com/decidim/decidim/pull/4139)
 - **decidim-participayory_processes**: Copy categories and subcategories to the new process. [\#4143](https://github.com/decidim/decidim/pull/4143)
 - **decidim-participayory_processes**: Fix Internet Explorer 11 related issues in process filtering. [\#4166](https://github.com/decidim/decidim/pull/4166)
+- **decidim-core**: Don't crash when showing the edit link for a component that does not have an admin engine [\#4318](https://github.com/decidim/decidim/pull/4318)
 - **decidim-core**: Fix newsletter opt-in migration [\#4198](https://github.com/decidim/decidim/pull/4198)
 - **decidim-core**: Hide weird flash message [\#4235](https://github.com/decidim/decidim/pull/4235)
 - **decidim-core**: Fix newsletter subscription checkbox always being unchecked [\#4238](https://github.com/decidim/decidim/pull/4238)

--- a/decidim-core/app/helpers/decidim/component_path_helper.rb
+++ b/decidim-core/app/helpers/decidim/component_path_helper.rb
@@ -32,5 +32,15 @@ module Decidim
       current_params = try(:params) || {}
       EngineRouter.admin_proxy(component).root_path(locale: current_params[:locale])
     end
+
+    # Returns whether the component can be managed or not by checking if it has
+    # an admin engine.
+    #
+    # component - the Component we want to find if it's manageable or not.
+    #
+    # Returns a boolean matching the question.
+    def can_be_managed?(component)
+      component.manifest.admin_engine.present?
+    end
   end
 end

--- a/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
@@ -1,5 +1,5 @@
 <%
-if respond_to?(:current_component) && current_component
+if respond_to?(:current_component) && current_component && can_be_managed?(current_component)
   edit_link(
     manage_component_path(current_component),
     :read,


### PR DESCRIPTION
#### :tophat: What? Why?
Some PRs ago we added a way to access the admin page for a given resource, from the public area. But we assumed all components had an admin engine to handle them. This assumption was wrong, see `decidim-dataviz` in Decidim Barcelona.

This PR takes into account this case.

#### :pushpin: Related Issues
- Fixes https://sentry.io/share/issue/e531a55255ca41668aaf02bcb7aa712a/

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
