### PR TITLE
Fix error on invalid form when updating the meeting registrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 - **decidim-core**: Fix newsletter opt-in migration [\#4198](https://github.com/decidim/decidim/pull/4198)
 - **decidim-core**: Hide weird flash message [\#4235](https://github.com/decidim/decidim/pull/4235)
 - **decidim-core**: Fix newsletter subscription checkbox always being unchecked [\#4238](https://github.com/decidim/decidim/pull/4238)
+- **decidim-core**: Don't error when the meeting registrations are updated with invalid data [\#4319](https://github.com/decidim/decidim/pull/4319)
 - **decidim-core**: Thread safe locale switching [\#4237](https://github.com/decidim/decidim/pull/4237)
 - **decidim-core**: Don't crash when given wrong format at pages [\#4314](https://github.com/decidim/decidim/pull/4314)
 

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/registrations_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/registrations_controller.rb
@@ -16,6 +16,7 @@ module Decidim
           enforce_permission_to :update, :meeting, meeting: meeting
 
           @form = MeetingRegistrationsForm.from_params(params).with_context(current_organization: meeting.organization, meeting: meeting)
+          @validation_form = ValidateRegistrationCodeForm.new
 
           UpdateRegistrations.call(@form, meeting) do
             on(:ok) do


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes a problem that appears when editing a meeting registration with invalid data.

When the form is invalid we re-render the form, but the action was missing the line this PR adds and the view failed to render. Adding this line fixes the problem.

To reproduce, go to a meeting, enable the registrations and remove the registrations instructions for all languages. Without this PR this fails with an error, with this PR this renders the form and highlights the instructions field as errored.

#### :pushpin: Related Issues
- Fixes https://sentry.io/share/issue/e6a4c87ab3e649e19a82e6bf014cd0bd/
- Fixes #4301

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
