### PR TITLE
Backport/4079 editing multi lang entities that are searchable fail in some cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@
 
 **Fixed**:
 
+- **decidim-core**: When a Searchable accesses its indexed resources it must scope by resource_type and organization_id. [\#4320](https://github.com/decidim/decidim/pull/4320)
 - **decidim-accountability**: Fix inclusion of ApplicationHelper in results controller. [\#4278](https://github.com/decidim/decidim/pull/4278)
 - **decidim-proposals**: Fix hashtags on title when showing proposals related. [\4107](https://github.com/decidim/decidim/pull/4107)
 - **decidim-participatory_processes**: Fix hastag display on participatory processes. [\#4024](https://github.com/decidim/decidim/pull/4024)

--- a/decidim-core/app/models/decidim/searchable_resource.rb
+++ b/decidim-core/app/models/decidim/searchable_resource.rb
@@ -28,7 +28,7 @@ module Decidim
     belongs_to :resource, polymorphic: true
     belongs_to :decidim_participatory_space, polymorphic: true, optional: true
 
-    validates :locale, uniqueness: { scope: :resource }
+    validates :locale, uniqueness: { scope: [:decidim_organization_id, :resource_type, :resource_id] }
 
     pg_search_scope :global_search,
                     against: { content_a: "A", content_b: "B", content_c: "C", content_d: "D" },

--- a/decidim-core/lib/decidim/search_resource_fields_mapper.rb
+++ b/decidim-core/lib/decidim/search_resource_fields_mapper.rb
@@ -58,16 +58,24 @@ module Decidim
       fields
     end
 
-    private
-
-    def map_common_fields(resource)
-      participatory_space = read_field(resource, @declared_fields, :participatory_space)
+    def retrieve_organization(resource)
       if @declared_fields[:organization_id].present?
         organization_id = read_field(resource, @declared_fields, :organization_id)
-        @organization = Decidim::Organization.find(organization_id)
+        Decidim::Organization.find(organization_id)
       else
-        @organization = participatory_space.organization
+        participatory_space(resource).organization
       end
+    end
+
+    private
+
+    def participatory_space(resource)
+      read_field(resource, @declared_fields, :participatory_space)
+    end
+
+    def map_common_fields(resource)
+      participatory_space = participatory_space(resource)
+      @organization = retrieve_organization(resource)
       {
         decidim_scope_id: read_field(resource, @declared_fields, :scope_id),
         decidim_participatory_space_id: participatory_space&.id,

--- a/decidim-core/spec/lib/searchable_spec.rb
+++ b/decidim-core/spec/lib/searchable_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+module Decidim
+  describe Searchable do
+    let(:component) { create(:component, manifest_name: "dummy") }
+
+    COMMON_ID = 666
+    context "when having searchables of different kinds indexed" do
+      let(:organization_1) { create(:organization) }
+      let(:component_1) { create(:component, organization: organization_1) }
+      let(:organization_2) { create(:organization) }
+      let(:component_2) { create(:component, organization: organization_2) }
+      let!(:dummy_resource_1) do
+        Decidim::DummyResources::DummyResource.create(
+          id: COMMON_ID,
+          component: component_1,
+          published_at: Time.current
+        )
+      end
+      let!(:dummy_resource_2) do
+        Decidim::DummyResources::DummyResource.create(
+          id: COMMON_ID + 1,
+          component: component_2,
+          published_at: Time.current
+        )
+      end
+      let!(:user_1) { create(:user, id: COMMON_ID, organization: organization_1) }
+      let!(:user_2) { create(:user, id: COMMON_ID + 1, organization: organization_2) }
+
+      it "each searchable should link to its own searchable_resources" do
+        org = user_1.organization
+        num_locales = org.available_locales.size
+        expect(dummy_resource_1.searchable_resources.by_organization(org.id).pluck(:resource_id, :resource_type)).to eq([[COMMON_ID, "Decidim::DummyResources::DummyResource"]] * num_locales)
+        expect(user_1.searchable_resources.by_organization(org.id).pluck(:resource_id, :resource_type)).to eq([[COMMON_ID, "Decidim::User"]] * num_locales)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
When a Searchable accesses its indexed resources it must scope by resource_type and organization_id. It wasn't being done.

This is a backport of https://github.com/decidim/decidim/pull/4144

#### :pushpin: Related Issues
- Fixes #4079

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add documentation regarding the feature 
- [-] Add/modify seeds
- [x] Add tests
- [x] Fix
