### PR TITLE
Don't send emails to deleted users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 - **decidim-participayory_processes**: Fix Internet Explorer 11 related issues in process filtering. [\#4166](https://github.com/decidim/decidim/pull/4166)
 - **decidim-core**: Don't crash when showing the edit link for a component that does not have an admin engine [\#4318](https://github.com/decidim/decidim/pull/4318)
 - **decidim-core**: Update conversations on each new message, so conversations list always shows the most recently active one on top [\#4329](https://github.com/decidim/decidim/pull/4329)
+- **decidim-core**: Don't send emails to deleted users [\#4324](https://github.com/decidim/decidim/pull/4324)
 - **decidim-core**: Fix newsletter opt-in migration [\#4198](https://github.com/decidim/decidim/pull/4198)
 - **decidim-core**: Hide weird flash message [\#4235](https://github.com/decidim/decidim/pull/4235)
 - **decidim-core**: Fix newsletter subscription checkbox always being unchecked [\#4238](https://github.com/decidim/decidim/pull/4238)

--- a/decidim-admin/spec/jobs/newsletter_delivery_job_spec.rb
+++ b/decidim-admin/spec/jobs/newsletter_delivery_job_spec.rb
@@ -9,6 +9,22 @@ module Decidim
       let(:organization) { create(:organization) }
       let(:newsletter) { create(:newsletter, organization: organization, total_deliveries: 0) }
 
+      it "delivers the email" do
+        expect(ActionMailer::Base.deliveries).to be_empty
+        NewsletterDeliveryJob.perform_now(user, newsletter)
+        expect(ActionMailer::Base.deliveries).not_to be_empty
+      end
+
+      context "when the user is deleted" do
+        let(:user) { create(:user, :deleted) }
+
+        it "does not deliver the email" do
+          expect(ActionMailer::Base.deliveries).to be_empty
+          NewsletterDeliveryJob.perform_now(user, newsletter)
+          expect(ActionMailer::Base.deliveries).to be_empty
+        end
+      end
+
       it "delivers a newsletter to a single user" do
         NewsletterDeliveryJob.perform_now(user, newsletter)
 

--- a/decidim-core/app/mailers/decidim/newsletter_mailer.rb
+++ b/decidim-core/app/mailers/decidim/newsletter_mailer.rb
@@ -8,7 +8,7 @@ module Decidim
     add_template_helper Decidim::TranslationsHelper
 
     def newsletter(user, newsletter)
-      return unless user.email.present?
+      return if user.email.blank?
 
       @organization = user.organization
       @newsletter = newsletter

--- a/decidim-core/app/mailers/decidim/newsletter_mailer.rb
+++ b/decidim-core/app/mailers/decidim/newsletter_mailer.rb
@@ -8,6 +8,8 @@ module Decidim
     add_template_helper Decidim::TranslationsHelper
 
     def newsletter(user, newsletter)
+      return unless user.email.present?
+
       @organization = user.organization
       @newsletter = newsletter
       @user = user

--- a/decidim-core/app/mailers/decidim/notification_mailer.rb
+++ b/decidim-core/app/mailers/decidim/notification_mailer.rb
@@ -7,7 +7,7 @@ module Decidim
     helper Decidim::ResourceHelper
 
     def event_received(event, event_class_name, resource, user, extra)
-      return unless user.email.present?
+      return if user.email.blank?
 
       with_user(user) do
         @organization = user.organization

--- a/decidim-core/app/mailers/decidim/notification_mailer.rb
+++ b/decidim-core/app/mailers/decidim/notification_mailer.rb
@@ -7,7 +7,7 @@ module Decidim
     helper Decidim::ResourceHelper
 
     def event_received(event, event_class_name, resource, user, extra)
-      return unless user.email
+      return unless user.email.present?
 
       with_user(user) do
         @organization = user.organization

--- a/decidim-core/spec/mailers/notification_mailer_spec.rb
+++ b/decidim-core/spec/mailers/notification_mailer_spec.rb
@@ -46,9 +46,7 @@ module Decidim
       end
 
       context "when the user doesn't have an email" do
-        before do
-          user.update(email: nil)
-        end
+        let(:user) { create(:user, :deleted) }
 
         it "does nothing" do
           expect(mail.deliver_now).to be_nil

--- a/decidim-initiatives/app/mailers/decidim/initiatives/initiatives_mailer.rb
+++ b/decidim-initiatives/app/mailers/decidim/initiatives/initiatives_mailer.rb
@@ -12,7 +12,7 @@ module Decidim
 
       # Notifies initiative creation
       def notify_creation(initiative)
-        return unless initiative.author.email.present?
+        return if initiative.author.email.blank?
         @initiative = initiative
         @organization = initiative.organization
 
@@ -28,7 +28,7 @@ module Decidim
 
       # Notify changes in state
       def notify_state_change(initiative, user)
-        return unless user.email.present?
+        return if user.email.blank?
         @organization = initiative.organization
 
         with_user(user) do
@@ -51,7 +51,7 @@ module Decidim
 
       # Notify an initiative requesting technical validation
       def notify_validating_request(initiative, user)
-        return unless user.email.present?
+        return if user.email.blank?
         @organization = initiative.organization
         @link = decidim_admin_initiatives.edit_initiative_url(initiative, host: @organization.host)
 
@@ -71,7 +71,7 @@ module Decidim
 
       # Notify progress to all initiative subscribers.
       def notify_progress(initiative, user)
-        return unless user.email.present?
+        return if user.email.blank?
         @organization = initiative.organization
         @link = initiative_url(initiative, host: @organization.host)
 

--- a/decidim-initiatives/app/mailers/decidim/initiatives/initiatives_mailer.rb
+++ b/decidim-initiatives/app/mailers/decidim/initiatives/initiatives_mailer.rb
@@ -12,6 +12,7 @@ module Decidim
 
       # Notifies initiative creation
       def notify_creation(initiative)
+        return unless initiative.author.email.present?
         @initiative = initiative
         @organization = initiative.organization
 
@@ -27,6 +28,7 @@ module Decidim
 
       # Notify changes in state
       def notify_state_change(initiative, user)
+        return unless user.email.present?
         @organization = initiative.organization
 
         with_user(user) do
@@ -49,6 +51,7 @@ module Decidim
 
       # Notify an initiative requesting technical validation
       def notify_validating_request(initiative, user)
+        return unless user.email.present?
         @organization = initiative.organization
         @link = decidim_admin_initiatives.edit_initiative_url(initiative, host: @organization.host)
 
@@ -68,6 +71,7 @@ module Decidim
 
       # Notify progress to all initiative subscribers.
       def notify_progress(initiative, user)
+        return unless user.email.present?
         @organization = initiative.organization
         @link = initiative_url(initiative, host: @organization.host)
 


### PR DESCRIPTION
#### :tophat: What? Why?
This builds on top of #2743 and ensures we don't send emails to deleted users.

#### :pushpin: Related Issues
- Fixes #3919.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
