### PR TITLE
Update conversations every time a message is sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 - **decidim-participayory_processes**: Copy categories and subcategories to the new process. [\#4143](https://github.com/decidim/decidim/pull/4143)
 - **decidim-participayory_processes**: Fix Internet Explorer 11 related issues in process filtering. [\#4166](https://github.com/decidim/decidim/pull/4166)
 - **decidim-core**: Don't crash when showing the edit link for a component that does not have an admin engine [\#4318](https://github.com/decidim/decidim/pull/4318)
+- **decidim-core**: Update conversations on each new message, so conversations list always shows the most recently active one on top [\#4329](https://github.com/decidim/decidim/pull/4329)
 - **decidim-core**: Fix newsletter opt-in migration [\#4198](https://github.com/decidim/decidim/pull/4198)
 - **decidim-core**: Hide weird flash message [\#4235](https://github.com/decidim/decidim/pull/4235)
 - **decidim-core**: Fix newsletter subscription checkbox always being unchecked [\#4238](https://github.com/decidim/decidim/pull/4238)

--- a/decidim-core/app/models/decidim/messaging/message.rb
+++ b/decidim-core/app/models/decidim/messaging/message.rb
@@ -16,6 +16,7 @@ module Decidim
 
       belongs_to :conversation,
                  foreign_key: :decidim_conversation_id,
+                 touch: true,
                  class_name: "Decidim::Messaging::Conversation"
 
       has_many :receipts,


### PR DESCRIPTION
#### :tophat: What? Why?
Conversations are ordered by _updated_at, but this value is never changed and keeps the one from creation. with this PR, this value is changed every time a new message is sent to the conversation, so the conversation list always shows the most recently active one on top.

#### :pushpin: Related Issues
- Fixes #4262

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
