### PR TITLE
Add .rbenv-vars to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ webpack.report.html
 schema.json
 .yardoc
 .rspec-failures
+.rbenv-vars


### PR DESCRIPTION
#### :tophat: What? Why?

When using [rbenv](https://github.com/rbenv/rbenv), the `.rbenv-vars` file shows as a file to be committed.
