### PR TITLE
add admin log when creating and delating a private user

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/create_participatory_space_private_user.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_participatory_space_private_user.rb
@@ -41,10 +41,19 @@ module Decidim
       attr_reader :form, :private_user_to, :current_user, :user
 
       def create_private_user
-        Decidim::ParticipatorySpacePrivateUser.find_or_create_by!(
-          user: user,
-          privatable_to: @private_user_to
-        )
+        Decidim.traceability.perform_action!(
+          :create,
+          Decidim::ParticipatorySpacePrivateUser,
+          current_user,
+          resource: {
+            title: user.name
+          }
+        ) do
+          Decidim::ParticipatorySpacePrivateUser.find_or_create_by!(
+            user: user,
+            privatable_to: @private_user_to
+          )
+        end
       end
 
       def existing_user

--- a/decidim-admin/app/commands/decidim/admin/destroy_participatory_space_private_user.rb
+++ b/decidim-admin/app/commands/decidim/admin/destroy_participatory_space_private_user.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # A command with all the business logic to destroy a participatory space private user.
+    class DestroyParticipatorySpacePrivateUser < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # participatory_space_private_user - The participatory space private user to destroy
+      # current_user - the user performing the action
+      def initialize(participatory_space_private_user, current_user)
+        @participatory_space_private_user = participatory_space_private_user
+        @current_user = current_user
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid.
+      # - :invalid if the form wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        destroy_participatory_space_private_user
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :current_user
+
+      def destroy_participatory_space_private_user
+        Decidim.traceability.perform_action!(
+          "delete",
+          @participatory_space_private_user,
+          current_user,
+          resource: {
+            title: @participatory_space_private_user.user.name
+          }
+        ) do
+          @participatory_space_private_user.destroy!
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/app/controllers/decidim/admin/concerns/has_private_users.rb
+++ b/decidim-admin/app/controllers/decidim/admin/concerns/has_private_users.rb
@@ -48,11 +48,18 @@ module Decidim
           def destroy
             @private_user = collection.find(params[:id])
             enforce_permission_to :destroy, :space_private_user, private_user: @private_user
-            @private_user.destroy!
 
-            flash[:notice] = I18n.t("participatory_space_private_users.destroy.success", scope: "decidim.admin")
+            DestroyParticipatorySpacePrivateUser.call(@private_user, current_user) do
+              on(:ok) do
+                flash[:notice] = I18n.t("participatory_space_private_users.destroy.success", scope: "decidim.admin")
+                redirect_to after_destroy_path
+              end
 
-            redirect_to after_destroy_path
+              on(:invalid) do
+                flash.now[:alert] = I18n.t("participatory_space_private_users.destroy.error", scope: "decidim.admin")
+                render template: "decidim/admin/participatory_space_private_users/index"
+              end
+            end
           end
 
           def resend_invitation

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -508,6 +508,7 @@ en:
           error: There was an error adding a private user for this participatory space.
           success: Participatory space private user access created successfully.
         destroy:
+          error: There was an error deleting a private user for this participatory space.
           success: Participatory space private user access destroyed successfully.
         index:
           title: Participatory space private user

--- a/decidim-admin/spec/commands/create_participatory_space_private_user_spec.rb
+++ b/decidim-admin/spec/commands/create_participatory_space_private_user_spec.rb
@@ -42,6 +42,22 @@ module Decidim::Admin
         expect(Decidim::User.last).not_to be_admin
       end
 
+      it "traces the action", versioning: true do
+        expect(Decidim.traceability)
+          .to receive(:perform_action!)
+          .with(
+            :create,
+            Decidim::ParticipatorySpacePrivateUser,
+            current_user,
+            resource: { title: user.name }
+          )
+          .and_call_original
+
+        expect { subject.call }.to change(Decidim::ActionLog, :count)
+        action_log = Decidim::ActionLog.last
+        expect(action_log.version).to be_nil
+      end
+
       context "when there is no user with the given email" do
         let(:email) { "does_not_exist@example.com" }
 

--- a/decidim-admin/spec/commands/decidim/admin/destroy_participatory_space_private_user_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/destroy_participatory_space_private_user_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Admin
+  describe DestroyParticipatorySpacePrivateUser do
+    subject { described_class.new(participatory_space_private_user, user) }
+
+    let(:organization) { create :organization }
+    # let(:privatable_to) { create :participatory_process }
+    let(:user) { create :user, :admin, :confirmed, organization: organization }
+    let(:participatory_space_private_user) { create :participatory_space_private_user, user: user }
+
+    it "destroys the participatory space private user" do
+      subject.call
+      expect { participatory_space_private_user.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "broadcasts ok" do
+      expect do
+        subject.call
+      end.to broadcast(:ok)
+    end
+
+    it "traces the action", versioning: true do
+      expect(Decidim.traceability)
+        .to receive(:perform_action!)
+        .with(
+          "delete",
+          participatory_space_private_user,
+          user,
+          resource: { title: user.name }
+        )
+        .and_call_original
+
+      expect { subject.call }.to change(Decidim::ActionLog, :count)
+      action_log = Decidim::ActionLog.last
+      expect(action_log.version).to be_nil
+    end
+  end
+end

--- a/decidim-core/app/models/decidim/participatory_space_private_user.rb
+++ b/decidim-core/app/models/decidim/participatory_space_private_user.rb
@@ -18,6 +18,10 @@ module Decidim
       Decidim::DataPortabilitySerializers::DataPortabilityParticipatorySpacePrivateUserSerializer
     end
 
+    def self.log_presenter_class_for(_log)
+      Decidim::AdminLog::ParticipatorySpacePrivateUserPresenter
+    end
+
     private
 
     # Private: check if the participatory space and the user have the same organization

--- a/decidim-core/app/presenters/decidim/admin_log/participatory_space_private_user_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/participatory_space_private_user_presenter.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Decidim
+  module AdminLog
+    # This class holds the logic to present a `Decidim::ParticipatorySpacePrivateUserPresenter`
+    # for the `AdminLog` log.
+    #
+    # Usage should be automatic and you shouldn't need to call this class
+    # directly, but here's an example:
+    #
+    #    action_log = Decidim::ActionLog.last
+    #    view_helpers # => this comes from the views
+    #    ParticipatorySpacePrivateUserPresenter.new(action_log, view_helpers).present
+    class ParticipatorySpacePrivateUserPresenter < Decidim::Log::BasePresenter
+      private
+
+      def diff_fields_mapping
+        {
+          name: :string,
+          email: :string
+        }
+      end
+
+      def action_string
+        case action
+        when "invite", "delete"
+          "decidim.admin_log.participatory_space_private_user.#{action}"
+        else
+          super
+        end
+      end
+
+      def i18n_labels_scope
+        "activemodel.attributes.participatory_space_private_user"
+      end
+    end
+  end
+end

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -100,6 +100,9 @@ en:
         update: "%{user_name} updated the %{resource_name} OAuth application"
       organization:
         update: "%{user_name} updated the organization settings"
+      participatory_space_private_user:
+        create: "%{user_name} invited %{resource_name} to be a private user"
+        delete: "%{user_name} removed the user %{resource_name} as a private user"
       scope:
         create: "%{user_name} created the %{resource_name} scope"
         create_with_parent: "%{user_name} created the %{resource_name} scope inside the %{parent_scope} scope"


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds the log to de admin dashboard, when are creating and deleting participatory space private users. 

#### :pushpin: Related Issues
- Related to #2282
- Fixes #4206 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [x] Add log translations 
- [x] changetests

### :camera: Screenshots (optional)
![Description](URL)
