### PR TITLE
Fix DataPortabilityExportJob:  private method `file' called when Carrierwave Storage fog enable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 **Fixed**:
 
+- **decidim-core**: Fix DataPortabilityExportJob: private method 'file' called when Carrierwave Storage fog enable [#4337](https://github.com/decidim/decidim/pull/4337)
 - **decidim-assemblies**: Fix assemblies filter by type [\#4778](https://github.com/decidim/decidim/pull/4778)
 - **decidim-conferences**: Fix error when visiting a Conference event[\#4776](https://github.com/decidim/decidim/pull/4776)
 - **decidim-proposals** Fix unhideable reported collaborative drafts and mail jobs [\#4706](https://github.com/decidim/decidim/pull/4706)

--- a/decidim-core/lib/decidim/data_portability_file_zipper.rb
+++ b/decidim-core/lib/decidim/data_portability_file_zipper.rb
@@ -45,14 +45,17 @@ module Decidim
           if image.file.respond_to? :file
             uploader.cache!(File.open(image.file.file))
             uploader.retrieve_from_store!(image.file.filename)
-            my_image_path = File.open(image.file.file)
           else
-            uploader.cache!(File.open(image.file.public_url))
-            uploader.retrieve_from_store!(image.file.filename)
-            my_image_path = File.open(image.file.public_url)
+            my_uploader = image.mounted_as
+            element = image.model
+
+            element.send(my_uploader).cache_stored_file!
+            element.send(my_uploader).retrieve_from_cache!(element.send(my_uploader).cache_name)
           end
+          my_image_path = File.open(image.file.file)
           next unless File.exist?(my_image_path)
           zipfile.add("#{folder_name}/#{image.file.filename}", my_image_path)
+          CarrierWave.clean_cached_files!
         end
       end
       zipfile.close


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds a new case of use to DataPortabilityExportJob zip file images when Carrierwave Storage Fog is enabled. Because 'file' is a private method.

#### :pushpin: Related Issues
- Related to #3314 #4223 
- Fixes #4325

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add case when image.file not respond to :file

### :camera: Screenshots (optional)
![Description](URL)
