### PR TITLE
[DOC] Global Search related documentation.

### DIFF
--- a/decidim-core/README.md
+++ b/decidim-core/README.md
@@ -20,6 +20,20 @@ And then execute:
 bundle
 ```
 
+## Global Search
+Core implements a Search Engine that indexes models from all modules globally.
+This feature is implemented using [PostgreSQL capability for full text search](https://www.postgresql.org/docs/current/static/textsearch.html) via [`pg_search` gem](https://github.com/Casecommons/pg_search).
+
+This module also includes the following models to Decidim's Global Search:
+
+- `Users`
+
+### Key artifacts:
+- `Searchable` module: A concern with the features needed when you want a model to be searchable.
+- `SearchableResource` class: The ActiveRecord that finally includes PgSearch and maps the indexed documents into a model.
+
+Models that want to be indexed must include `Searchable` and declare `Searchable.searchable_fields`.
+
 ## Metrics docs
 
 Core adds an implementation to show APP metrics within some pages. You can see specific documentation at [Metrics](https://github.com/decidim/decidim/tree/master/docs/advanced/metrics.md)

--- a/decidim-core/README.md
+++ b/decidim-core/README.md
@@ -21,6 +21,7 @@ bundle
 ```
 
 ## Global Search
+
 Core implements a Search Engine that indexes models from all modules globally.
 This feature is implemented using [PostgreSQL capability for full text search](https://www.postgresql.org/docs/current/static/textsearch.html) via [`pg_search` gem](https://github.com/Casecommons/pg_search).
 
@@ -29,6 +30,7 @@ This module also includes the following models to Decidim's Global Search:
 - `Users`
 
 ### Key artifacts:
+
 - `Searchable` module: A concern with the features needed when you want a model to be searchable.
 - `SearchableResource` class: The ActiveRecord that finally includes PgSearch and maps the indexed documents into a model.
 

--- a/decidim-core/README.md
+++ b/decidim-core/README.md
@@ -29,7 +29,7 @@ This module also includes the following models to Decidim's Global Search:
 
 - `Users`
 
-### Key artifacts:
+### Key artifacts
 
 - `Searchable` module: A concern with the features needed when you want a model to be searchable.
 - `SearchableResource` class: The ActiveRecord that finally includes PgSearch and maps the indexed documents into a model.

--- a/decidim-meetings/README.md
+++ b/decidim-meetings/README.md
@@ -20,6 +20,11 @@ And then execute:
 bundle
 ```
 
+## Global Search
+This module includes the following models to Decidim's Global Search:
+
+- `Meetings`
+
 ## Contributing
 
 See [Decidim](https://github.com/decidim/decidim).

--- a/decidim-meetings/README.md
+++ b/decidim-meetings/README.md
@@ -21,6 +21,7 @@ bundle
 ```
 
 ## Global Search
+
 This module includes the following models to Decidim's Global Search:
 
 - `Meetings`

--- a/decidim-proposals/README.md
+++ b/decidim-proposals/README.md
@@ -38,6 +38,7 @@ end
 `similarity_limit`: number of maximum results.
 
 ## Global Search
+
 This module includes the following models to Decidim's Global Search:
 
 - `Proposals`

--- a/decidim-proposals/README.md
+++ b/decidim-proposals/README.md
@@ -37,6 +37,11 @@ end
 
 `similarity_limit`: number of maximum results.
 
+## Global Search
+This module includes the following models to Decidim's Global Search:
+
+- `Proposals`
+
 ## Contributing
 
 See [Decidim](https://github.com/decidim/decidim).


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds documentation for the Global Search in each of the modules that implement something related.

#### :pushpin: Related Issues
- Related to #2706

#### :clipboard: Subtasks
- [-] Add `CHANGELOG` entry
- [x] Add documentation regarding the feature 
