### PR TITLE
Two fast fixes for the Manual Installation Guide

### DIFF
--- a/docs/manual-installation.md
+++ b/docs/manual-installation.md
@@ -49,6 +49,8 @@ You need to change the password (on this example is "thepassword") and save it s
 Next, we need to install the `decidim` gem:
 
 ```bash
+gem install bootsnap
+gem install listen
 gem install decidim
 ```
 
@@ -103,7 +105,8 @@ git commit -m "Adds figaro configuration management"
 We should now setup your database:
 
 ```bash
-bin/rails db:create db:migrate db:seed
+bin/rails db:create db:migrate
+bin/rails db:seed
 ```
 
 This will also create some default data so you can start testing the app:


### PR DESCRIPTION
#### :tophat: What? Why?
I've used the [manual installation guide](/docs/manual-installation.md) to create a new Decidim app and found two issues. In this PR I introduce fast fixes for the issues to prevent other developers to waste time with the same problems:
* When using `decidim` gem to create a new app, gems `bootsnap` and `listen` should be installed too. Probably, this problem should be solved better adding those dependencies to the `decidim` gem, but installing those gems before will solve it meanwhile.
* Seed process fails when it's done in the same task after migrating the database. Splitting the command in two steps should fix the problem (I got the error, then I ran the seed process again and it worked).

#### :pushpin: Related Issues


#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
