### PR TITLE
Fallback value on IE

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
@@ -715,6 +715,7 @@ $datetime-bg: $primary;
 // card status
 .card__status{
   .card-data__item{
+    flex-basis: 20%;
     flex-basis: initial;
     padding: 1em .5em;
 


### PR DESCRIPTION
#### :tophat: What? Why?
IE11 requires a fallback value for `flex-basis`, when it's not a concrete value or percentage.

#### :pushpin: Related Issues
- Fixes #4336 