### PR TITLE
Merge and split proposals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 - **decidim-core**: Added metrics visualization for Assemblies, ParticipatoryProcesses, Results (Accountability), Comments, and Meetings [\#36042283](https://github.com/decidim/decidim/pull/4228)
 - **decidim-core**: Let admins and creators edit the user group profile [\#4283](https://github.com/decidim/decidim/pull/4283)
 - **decidim-core**: User groups can also have badges. [\#4310](https://github.com/decidim/decidim/pull/4310)
+- **decidim-proposals**: Merge and split proposals [\#4360](https://github.com/decidim/decidim/pull/4360)
 
 **Changed**:
 

--- a/decidim-admin/app/helpers/decidim/admin/bulk_actions_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/bulk_actions_helper.rb
@@ -3,21 +3,6 @@
 module Decidim
   module Admin
     module BulkActionsHelper
-      # Renders an actions dropdown, including an item
-      # for each bulk action.
-      #
-      # Returns a rendered dropdown.
-      def bulk_actions_dropdown
-        render partial: "decidim/admin/bulk_actions/dropdown"
-      end
-
-      # Renders a form to change the category of selected items
-      #
-      # Returns a rendered form.
-      def bulk_action_recategorize
-        render partial: "decidim/admin/bulk_actions/recategorize"
-      end
-
       def proposal_find(id)
         Decidim::Proposals::Proposal.find(id)
       end
@@ -56,6 +41,20 @@ module Decidim
 
       def bulk_disabled_categories_for(scope)
         scope.first_class.joins(:subcategories).pluck(:id)
+      end
+
+      # Public: Generates a select field with the components.
+      #
+      # siblings - A collection of components.
+      #
+      # Returns a String.
+      def bulk_components_select(siblings)
+        components = siblings.map do |component|
+          [translated_attribute(component.name, component.organization), component.id]
+        end
+
+        prompt = t("decidim.proposals.admin.proposals.index.select_component")
+        select(:target_component_id, nil, options_for_select(components, selected: []), prompt: prompt)
       end
     end
   end

--- a/decidim-core/app/models/decidim/component.rb
+++ b/decidim-core/app/models/decidim/component.rb
@@ -20,6 +20,11 @@ module Decidim
       Decidim::AdminLog::ComponentPresenter
     end
 
+    # Other components with the same manifest and same participatory space as this one.
+    def siblings
+      @siblings ||= participatory_space.components.where.not(id: id).where(manifest_name: manifest_name)
+    end
+
     # Public: Finds the manifest this component is associated to.
     #
     # Returns a ComponentManifest.

--- a/decidim-core/lib/decidim/coauthorable.rb
+++ b/decidim-core/lib/decidim/coauthorable.rb
@@ -95,15 +95,22 @@ module Decidim
 
       # Adds a new coauthor to the list of coauthors. The coauthorship is created with
       # current object as coauthorable and `user` param as author. To set the user group
-      # use `extra_attrs` either with `user_group` or `decidim_user_group_id` keys.
+      # use `extra_attributes` either with `user_group` or `decidim_user_group_id` keys.
       #
       # @param author: The new coauthor.
       # @extra_attrs: Extra
-      def add_coauthor(author, extra_attrs = {})
+      def add_coauthor(author, extra_attributes = {})
+        user_group = extra_attributes[:user_group]
+
+        return if coauthorships.where(decidim_author_id: author.id, decidim_author_type: author.class.base_class.name).exists?
+        return if user_group && coauthorships.where(user_group: user_group).exists?
+
+        coauthorship_attributes = extra_attributes.merge(author: author)
+
         if persisted?
-          coauthorships.create!(extra_attrs.merge(author: author))
+          coauthorships.create!(coauthorship_attributes)
         else
-          coauthorships.build(extra_attrs.merge(author: author))
+          coauthorships.build(coauthorship_attributes)
         end
 
         authors << author

--- a/decidim-core/lib/decidim/coauthorable.rb
+++ b/decidim-core/lib/decidim/coauthorable.rb
@@ -102,7 +102,7 @@ module Decidim
       def add_coauthor(author, extra_attributes = {})
         user_group = extra_attributes[:user_group]
 
-        return if coauthorships.where(decidim_author_id: author.id, decidim_author_type: author.class.base_class.name).exists?
+        return if coauthorships.where(decidim_author_id: author.id, decidim_author_type: author.class.base_class.name).exists? && user_group.blank?
         return if user_group && coauthorships.where(user_group: user_group).exists?
 
         coauthorship_attributes = extra_attributes.merge(author: author)

--- a/decidim-proposals/app/assets/javascripts/decidim/proposals/admin/proposals.es6
+++ b/decidim-proposals/app/assets/javascripts/decidim/proposals/admin/proposals.es6
@@ -6,9 +6,15 @@ $(document).ready(function () {
 
   window.selectedProposalsCountUpdate = function() {
     if(selectedProposalsCount() == 0){
-      $("#js-recategorize-proposals-count").text("")
+      $("#js-selected-proposals-count").text("")
     } else {
-      $("#js-recategorize-proposals-count").text(selectedProposalsCount());
+      $("#js-selected-proposals-count").text(selectedProposalsCount());
+    }
+
+    if(selectedProposalsCount() >= 2) {
+      $("#js-bulk-actions-merge").parent().show();
+    } else {
+      $("#js-bulk-actions-merge").parent().hide();
     }
   }
 
@@ -33,16 +39,12 @@ $(document).ready(function () {
     $("#js-other-actions-wrapper").addClass('hide');
   }
 
-  let showRecategorizeProposalActions = function() {
-    $("#js-recategorize-proposals-actions").removeClass('hide');
+  window.hideBulkActionForms = function() {
+    return $(".js-bulk-action-form").addClass('hide');
   }
 
-  window.hideRecategorizeProposalActions = function() {
-    return $("#js-recategorize-proposals-actions").addClass('hide');
-  }
-
-  if ($('#js-form-recategorize-proposals').length) {
-    window.hideRecategorizeProposalActions();
+  if ($('.js-bulk-action-form').length) {
+    window.hideBulkActionForms();
     $("#js-bulk-actions-button").addClass('hide');
 
     $("#js-bulk-actions-recategorize").click(function(e){
@@ -52,7 +54,19 @@ $(document).ready(function () {
         $('.layout-content > .callout-wrapper').html("");
       })
 
-      showRecategorizeProposalActions();
+      $("#js-recategorize-proposals-actions").removeClass('hide');
+      hideBulkActionsButton(true);
+      hideOtherActionsButtons();
+    })
+
+    $("#js-bulk-actions-merge").click(function(e){
+      e.preventDefault();
+
+      $('#js-form-merge-proposals').submit(function(){
+        $('.layout-content > .callout-wrapper').html("");
+      })
+
+      $("#js-merge-proposals-actions").removeClass('hide');
       hideBulkActionsButton(true);
       hideOtherActionsButtons();
     })
@@ -99,12 +113,12 @@ $(document).ready(function () {
         hideBulkActionsButton();
       }
 
-      $('#js-form-recategorize-proposals').find(".js-proposal-id-"+proposal_id).prop('checked', checked);
+      $('.js-bulk-action-form').find(".js-proposal-id-"+proposal_id).prop('checked', checked);
       selectedProposalsCountUpdate();
     });
 
-    $('#js-cancel-edit-category').on('click', function (e) {
-      window.hideRecategorizeProposalActions()
+    $('.js-cancel-bulk-action').on('click', function (e) {
+      window.hideBulkActionForms()
       showBulkActionsButton();
       showOtherActionsButtons();
     });

--- a/decidim-proposals/app/assets/javascripts/decidim/proposals/admin/proposals.es6
+++ b/decidim-proposals/app/assets/javascripts/decidim/proposals/admin/proposals.es6
@@ -12,9 +12,9 @@ $(document).ready(function () {
     }
 
     if(selectedProposalsCount() >= 2) {
-      $("#js-bulk-actions-merge").parent().show();
+      $('button[data-action="merge-proposals"]').parent().show();
     } else {
-      $("#js-bulk-actions-merge").parent().hide();
+      $('button[data-action="merge-proposals"]').parent().hide();
     }
   }
 
@@ -47,28 +47,19 @@ $(document).ready(function () {
     window.hideBulkActionForms();
     $("#js-bulk-actions-button").addClass('hide');
 
-    $("#js-bulk-actions-recategorize").click(function(e){
+    $("#js-bulk-actions-dropdown ul li button").click(function(e){
       e.preventDefault();
+      let action = $(e.target).data("action");
 
-      $('#js-form-recategorize-proposals').submit(function(){
-        $('.layout-content > .callout-wrapper').html("");
-      })
+      if(action) {
+        $(`#js-form-${action}`).submit(function(){
+          $('.layout-content > .callout-wrapper').html("");
+        })
 
-      $("#js-recategorize-proposals-actions").removeClass('hide');
-      hideBulkActionsButton(true);
-      hideOtherActionsButtons();
-    })
-
-    $("#js-bulk-actions-merge").click(function(e){
-      e.preventDefault();
-
-      $('#js-form-merge-proposals').submit(function(){
-        $('.layout-content > .callout-wrapper').html("");
-      })
-
-      $("#js-merge-proposals-actions").removeClass('hide');
-      hideBulkActionsButton(true);
-      hideOtherActionsButtons();
+        $(`#js-${action}-actions`).removeClass('hide');
+        hideBulkActionsButton(true);
+        hideOtherActionsButtons();
+      }
     })
 
     // select all checkboxes

--- a/decidim-proposals/app/commands/decidim/proposals/admin/create_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/create_proposal.rb
@@ -40,12 +40,11 @@ module Decidim
         attr_reader :form, :proposal, :attachment
 
         def create_proposal
-          @proposal = Decidim.traceability.perform_action!(:create, Proposal, form.current_user, visibility: "all") do
-            proposal = Proposal.new(attributes)
-            proposal.add_coauthor(form.current_organization)
-            proposal.save!
-            proposal
-          end
+          @proposal = Decidim::Proposals::ProposalBuilder.create(
+            attributes: attributes,
+            author: form.current_organization,
+            action_user: form.current_user
+          )
         end
 
         def attributes

--- a/decidim-proposals/app/commands/decidim/proposals/admin/import_participatory_text.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/import_participatory_text.rb
@@ -40,7 +40,7 @@ module Decidim
         end
 
         def parse_participatory_text_doc(document)
-          parser = MarkdownToProposals.new(form.current_component)
+          parser = MarkdownToProposals.new(form.current_component, form.current_user)
           parser.parse(document)
         end
       end

--- a/decidim-proposals/app/commands/decidim/proposals/admin/merge_proposals.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/merge_proposals.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    module Admin
+      # A command with all the business logic when an admin merges proposals from
+      # one component to another.
+      class MergeProposals < Rectify::Command
+        # Public: Initializes the command.
+        #
+        # form - A form object with the params.
+        def initialize(form)
+          @form = form
+        end
+
+        # Executes the command. Broadcasts these events:
+        #
+        # - :ok when everything is valid.
+        # - :invalid if the form wasn't valid and we couldn't proceed.
+        #
+        # Returns nothing.
+        def call
+          return broadcast(:invalid) unless form.valid?
+
+          broadcast(:ok, merge_proposals)
+        end
+
+        private
+
+        attr_reader :form
+
+        def merge_proposals
+          transaction do
+            merged_proposal = create_new_proposal
+            merged_proposal.link_resources(form.proposals, "copied_from_component")
+            merged_proposal
+          end
+        end
+
+        def create_new_proposal
+          original_proposal = form.proposals.first
+          origin_attributes = original_proposal.attributes.except(
+            "id",
+            "created_at",
+            "updated_at",
+            "state",
+            "answer",
+            "answered_at",
+            "decidim_component_id",
+            "reference",
+            "proposal_votes_count",
+            "proposal_notes_count"
+          )
+
+          Decidim.traceability.perform_action!(:create, Proposal, form.current_user, visibility: "all") do
+            proposal = Proposal.new(origin_attributes)
+            proposal.component = form.target_component
+            proposal.category = original_proposal.category
+            proposal.add_coauthor(form.current_organization)
+            proposal.save!
+            proposal
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/commands/decidim/proposals/admin/merge_proposals.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/merge_proposals.rb
@@ -39,27 +39,16 @@ module Decidim
 
         def create_new_proposal
           original_proposal = form.proposals.first
-          origin_attributes = original_proposal.attributes.except(
-            "id",
-            "created_at",
-            "updated_at",
-            "state",
-            "answer",
-            "answered_at",
-            "decidim_component_id",
-            "reference",
-            "proposal_votes_count",
-            "proposal_notes_count"
-          )
 
-          Decidim.traceability.perform_action!(:create, Proposal, form.current_user, visibility: "all") do
-            proposal = Proposal.new(origin_attributes)
-            proposal.component = form.target_component
-            proposal.category = original_proposal.category
-            proposal.add_coauthor(form.current_organization)
-            proposal.save!
-            proposal
-          end
+          Decidim::Proposals::ProposalBuilder.copy(
+            original_proposal,
+            author: form.current_organization,
+            action_user: form.current_user,
+            extra_attributes: {
+              component: form.target_component
+            },
+            skip_link: true
+          )
         end
       end
     end

--- a/decidim-proposals/app/commands/decidim/proposals/admin/split_proposals.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/split_proposals.rb
@@ -39,28 +39,14 @@ module Decidim
         end
 
         def create_proposal(original_proposal)
-          origin_attributes = original_proposal.attributes.except(
-            "id",
-            "created_at",
-            "updated_at",
-            "state",
-            "answer",
-            "answered_at",
-            "decidim_component_id",
-            "reference",
-            "proposal_votes_count",
-            "proposal_notes_count"
+          Decidim::Proposals::ProposalBuilder.copy(
+            original_proposal,
+            author: form.current_organization,
+            action_user: form.current_user,
+            extra_attributes: {
+              component: form.target_component
+            }
           )
-
-          Decidim.traceability.perform_action!(:create, Proposal, form.current_user, visibility: "all") do
-            proposal = Proposal.new(origin_attributes)
-            proposal.component = form.target_component
-            proposal.category = original_proposal.category
-            proposal.add_coauthor(form.current_organization)
-            proposal.save!
-            proposal.link_resources(original_proposal, "copied_from_component")
-            proposal
-          end
         end
       end
     end

--- a/decidim-proposals/app/commands/decidim/proposals/admin/split_proposals.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/split_proposals.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    module Admin
+      # A command with all the business logic when an admin splits proposals from
+      # one component to another.
+      class SplitProposals < Rectify::Command
+        # Public: Initializes the command.
+        #
+        # form - A form object with the params.
+        def initialize(form)
+          @form = form
+        end
+
+        # Executes the command. Broadcasts these events:
+        #
+        # - :ok when everything is valid.
+        # - :invalid if the form wasn't valid and we couldn't proceed.
+        #
+        # Returns nothing.
+        def call
+          return broadcast(:invalid) unless form.valid?
+
+          broadcast(:ok, split_proposals)
+        end
+
+        private
+
+        attr_reader :form
+
+        def split_proposals
+          transaction do
+            form.proposals.flat_map do |original_proposal|
+              create_proposal(original_proposal)
+              create_proposal(original_proposal)
+            end
+          end
+        end
+
+        def create_proposal(original_proposal)
+          origin_attributes = original_proposal.attributes.except(
+            "id",
+            "created_at",
+            "updated_at",
+            "state",
+            "answer",
+            "answered_at",
+            "decidim_component_id",
+            "reference",
+            "proposal_votes_count",
+            "proposal_notes_count"
+          )
+
+          Decidim.traceability.perform_action!(:create, Proposal, form.current_user, visibility: "all") do
+            proposal = Proposal.new(origin_attributes)
+            proposal.component = form.target_component
+            proposal.category = original_proposal.category
+            proposal.add_coauthor(form.current_organization)
+            proposal.save!
+            proposal.link_resources(original_proposal, "copied_from_component")
+            proposal
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_merges_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_merges_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    module Admin
+      class ProposalsMergesController < Admin::ApplicationController
+        def create
+          enforce_permission_to :merge, :proposals
+
+          @form = form(Admin::ProposalsMergeForm).from_params(params)
+
+          Admin::MergeProposals.call(@form) do
+            on(:ok) do |_proposal|
+              flash[:notice] = I18n.t("proposals_merges.create.success", scope: "decidim.proposals.admin")
+              redirect_to EngineRouter.admin_proxy(@form.target_component).root_path
+            end
+
+            on(:invalid) do
+              flash.now[:alert] = I18n.t("proposals_merges.create.invalid", scope: "decidim.proposals.admin")
+              redirect_to EngineRouter.admin_proxy(current_component).root_path
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_splits_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_splits_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    module Admin
+      class ProposalsSplitsController < Admin::ApplicationController
+        def create
+          enforce_permission_to :split, :proposals
+
+          @form = form(Admin::ProposalsSplitForm).from_params(params)
+
+          Admin::SplitProposals.call(@form) do
+            on(:ok) do |_proposal|
+              flash[:notice] = I18n.t("proposals_splits.create.success", scope: "decidim.proposals.admin")
+              redirect_to EngineRouter.admin_proxy(@form.target_component).root_path
+            end
+
+            on(:invalid) do
+              flash.now[:alert] = I18n.t("proposals_splits.create.invalid", scope: "decidim.proposals.admin")
+              redirect_to EngineRouter.admin_proxy(current_component).root_path
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposals_merge_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposals_merge_form.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    module Admin
+      # A form object to be used when admin users wants to merge two or more
+      # proposals into a new one to another proposal component in the same space.
+      class ProposalsMergeForm < Decidim::Form
+        mimic :proposals_import
+
+        attribute :target_component_id, Integer
+        attribute :proposal_ids, Array
+
+        validates :target_component, :proposals, :current_component, presence: true
+        validates :proposals, length: { minimum: 2 }
+        validate :same_participatory_space
+
+        def proposals
+          @proposals ||= Decidim::Proposals::Proposal.where(component: current_component, id: proposal_ids).uniq
+        end
+
+        def target_component
+          @target_component ||= current_component.siblings.find_by(id: target_component_id)
+        end
+
+        private
+
+        def same_participatory_space
+          return if !target_component || !current_component
+
+          errors.add(:target_component, :invalid) if current_component.participatory_space != target_component.participatory_space
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposals_split_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposals_split_form.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    module Admin
+      # A form object to be used when admin users wants to split two or more
+      # proposals into a new one to another proposal component in the same space.
+      class ProposalsSplitForm < Decidim::Form
+        mimic :proposals_import
+
+        attribute :target_component_id, Integer
+        attribute :proposal_ids, Array
+
+        validates :target_component, :proposals, :current_component, presence: true
+        validate :same_participatory_space
+
+        def proposals
+          @proposals ||= Decidim::Proposals::Proposal.where(component: current_component, id: proposal_ids).uniq
+        end
+
+        def target_component
+          @target_component ||= current_component.siblings.find_by(id: target_component_id)
+        end
+
+        private
+
+        def same_participatory_space
+          return if !target_component || !current_component
+
+          errors.add(:target_component, :invalid) if current_component.participatory_space != target_component.participatory_space
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/permissions/decidim/proposals/admin/permissions.rb
+++ b/decidim-proposals/app/permissions/decidim/proposals/admin/permissions.rb
@@ -32,6 +32,9 @@ module Decidim
           # Every user allowed by the space can import proposals from another_component
           allow! if permission_action.subject == :proposals && permission_action.action == :import
 
+          # Every user allowed by the space can import proposals from another_component
+          allow! if permission_action.subject == :proposals && permission_action.action == :merge
+
           if permission_action.subject == :participatory_texts && participatory_texts_are_enabled?
             # Every user allowed by the space can import participatory texts to proposals
             allow! if permission_action.action == :import

--- a/decidim-proposals/app/permissions/decidim/proposals/admin/permissions.rb
+++ b/decidim-proposals/app/permissions/decidim/proposals/admin/permissions.rb
@@ -32,8 +32,11 @@ module Decidim
           # Every user allowed by the space can import proposals from another_component
           allow! if permission_action.subject == :proposals && permission_action.action == :import
 
-          # Every user allowed by the space can import proposals from another_component
+          # Every user allowed by the space can merge proposals to another component
           allow! if permission_action.subject == :proposals && permission_action.action == :merge
+
+          # Every user allowed by the space can split proposals to another component
+          allow! if permission_action.subject == :proposals && permission_action.action == :split
 
           if permission_action.subject == :participatory_texts && participatory_texts_are_enabled?
             # Every user allowed by the space can import participatory texts to proposals

--- a/decidim-proposals/app/services/decidim/proposals/proposal_builder.rb
+++ b/decidim-proposals/app/services/decidim/proposals/proposal_builder.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    # A factory class to ensure we always create Proposals the same way since it involves some logic.
+    module ProposalBuilder
+      # Public: Creates a new Proposal.
+      def create(attributes:, author:, action_user:, user_group_author: nil)
+        Decidim.traceability.perform_action!(:create, Proposal, action_user, visibility: "all") do
+          proposal = Proposal.new(attributes)
+          proposal.add_coauthor(author, user_group: user_group_author)
+          proposal.save!
+          proposal
+        end
+      end
+
+      module_function :create
+
+      # Public: Creates a new Proposal by copying the attributes from another one.
+      # rubocop:disable Metrics/ParameterLists
+      def copy(original_proposal, author:, action_user:, user_group_author: nil, extra_attributes: {}, skip_link: false)
+        origin_attributes = original_proposal.attributes.except(
+          "id",
+          "created_at",
+          "updated_at",
+          "state",
+          "answer",
+          "answered_at",
+          "decidim_component_id",
+          "reference",
+          "proposal_votes_count",
+          "proposal_notes_count"
+        ).merge(
+          "category" => original_proposal.category
+        ).merge(
+          extra_attributes
+        )
+
+        proposal = create(
+          attributes: origin_attributes,
+          author: author,
+          user_group_author: user_group_author,
+          action_user: action_user
+        )
+
+        proposal.link_resources(original_proposal, "copied_from_component") unless skip_link
+        proposal
+      end
+      # rubocop:enable Metrics/ParameterLists
+
+      module_function :copy
+    end
+  end
+end

--- a/decidim-proposals/app/services/decidim/proposals/proposal_builder.rb
+++ b/decidim-proposals/app/services/decidim/proposals/proposal_builder.rb
@@ -5,6 +5,13 @@ module Decidim
     # A factory class to ensure we always create Proposals the same way since it involves some logic.
     module ProposalBuilder
       # Public: Creates a new Proposal.
+      #
+      # attributes        - The Hash of attributes to create the Proposal with.
+      # author            - An Authorable the will be the first coauthor of the Proposal.
+      # user_group_author - A User Group to, optionally, set it as the author too.
+      # action_user       - The User to be used as the user who is creating the proposal in the traceability logs.
+      #
+      # Returns a Proposal.
       def create(attributes:, author:, action_user:, user_group_author: nil)
         Decidim.traceability.perform_action!(:create, Proposal, action_user, visibility: "all") do
           proposal = Proposal.new(attributes)
@@ -17,6 +24,16 @@ module Decidim
       module_function :create
 
       # Public: Creates a new Proposal by copying the attributes from another one.
+      #
+      # original_proposal - The Proposal to be used as base to create the new one.
+      # author            - An Authorable the will be the first coauthor of the Proposal.
+      # user_group_author - A User Group to, optionally, set it as the author too.
+      # action_user       - The User to be used as the user who is creating the proposal in the traceability logs.
+      # extra_attributes  - A Hash of attributes to create the new proposal, will overwrite the original ones.
+      # skip_link         - Whether to skip linking the two proposals or not (default false).
+      #
+      # Returns a Proposal
+      #
       # rubocop:disable Metrics/ParameterLists
       def copy(original_proposal, author:, action_user:, user_group_author: nil, extra_attributes: {}, skip_link: false)
         origin_attributes = original_proposal.attributes.except(

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_bulk-actions.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_bulk-actions.html.erb
@@ -1,9 +1,9 @@
 <div class="flex--cc flex-gap--1">
-  <%= bulk_actions_dropdown %>
+  <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/dropdown" %>
 
   <div id="js-other-actions-wrapper">
     <% if component_settings.participatory_texts_enabled? %>
-    <%= link_to t("actions.participatory_texts", scope: "decidim.proposals"), participatory_texts_path, id: "participatory_texts", class: "button tiny button--simple" %>
+      <%= link_to t("actions.participatory_texts", scope: "decidim.proposals"), participatory_texts_path, id: "participatory_texts", class: "button tiny button--simple" %>
     <% end %>
     <%= link_to t("actions.import", scope: "decidim.proposals", name: t("models.proposal.name", scope: "decidim.proposals.admin")), new_proposals_import_path, class: "button tiny button--simple" if allowed_to? :import, :proposals %>
 
@@ -14,5 +14,9 @@
     <%= export_dropdown %>
   </div>
 
-  <%= bulk_action_recategorize %>
+  <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/recategorize" %>
+
+  <% if current_component.siblings.any? %>
+    <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/merge" %>
+  <% end %>
 </div>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_bulk-actions.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_bulk-actions.html.erb
@@ -18,5 +18,6 @@
 
   <% if current_component.siblings.any? %>
     <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/merge" %>
+    <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/split" %>
   <% end %>
 </div>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_dropdown.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_dropdown.html.erb
@@ -17,14 +17,19 @@
     data-events="resize">
     <ul class="list-reset">
       <li>
-        <button type="button" id="js-bulk-actions-recategorize">
+        <button type="button" data-action="recategorize-proposals">
           <%= t("decidim.proposals.admin.proposals.index.change_category") %>
         </button>
       </li>
       <% if current_component.siblings.any? %>
         <li>
-          <button type="button" id="js-bulk-actions-merge">
+          <button type="button" data-action="merge-proposals">
             <%= t("decidim.proposals.admin.proposals.index.merge") %>
+          </button>
+        </li>
+        <li>
+          <button type="button" data-action="split-proposals">
+            <%= t("decidim.proposals.admin.proposals.index.split") %>
           </button>
         </li>
       <% end %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_dropdown.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_dropdown.html.erb
@@ -21,6 +21,13 @@
           <%= t("decidim.proposals.admin.proposals.index.change_category") %>
         </button>
       </li>
+      <% if current_component.siblings.any? %>
+        <li>
+          <button type="button" id="js-bulk-actions-merge">
+            <%= t("decidim.proposals.admin.proposals.index.merge") %>
+          </button>
+        </li>
+      <% end %>
     </ul>
   </div>
 </div>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_merge.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_merge.html.erb
@@ -1,0 +1,15 @@
+<div id="js-merge-proposals-actions" class="hide js-bulk-action-form">
+  <%= form_tag(proposals_merge_path, method: :post, id: "js-form-merge-proposals", class: "flex--cc flex-gap--1") do %>
+    <div class="checkboxes hide">
+      <% proposals.each do |proposal| %>
+        <%= check_box_tag "proposal_ids[]", proposal.id, false, class: "js-check-all-proposal js-proposal-id-#{proposal.id}" %>
+      <% end %>
+    </div>
+
+    <%= bulk_components_select current_component.siblings %>
+
+    <%= submit_tag(t("decidim.proposals.admin.proposals.index.merge_button"), id: "js-submit-merge-proposals", class: "button small button--simple float-left") %>
+
+    <button id="js-cancel-merge-proposals" class="button tiny clear compact js-cancel-bulk-action" type="button"><%= t("decidim.proposals.admin.proposals.index.cancel") %></button>
+  <% end %>
+</div>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_recategorize.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_recategorize.html.erb
@@ -1,4 +1,4 @@
-<div id="js-recategorize-proposals-actions" class="hide">
+<div id="js-recategorize-proposals-actions" class="hide js-bulk-action-form">
   <%= form_tag(update_category_proposals_path, method: :post, remote: true, id: "js-form-recategorize-proposals", class: "flex--cc flex-gap--1") do %>
     <div class="checkboxes hide">
       <% proposals.each do |proposal| %>
@@ -10,6 +10,6 @@
 
     <%= submit_tag(t("decidim.proposals.admin.proposals.index.update"), id: "js-submit-edit-category", class: "button small button--simple float-left") %>
 
-    <button id="js-cancel-edit-category" class="button tiny clear compact" type="button"><%= t("decidim.proposals.admin.proposals.index.cancel") %></button>
+    <button id="js-cancel-edit-category" class="button tiny clear compact js-cancel-bulk-action" type="button"><%= t("decidim.proposals.admin.proposals.index.cancel") %></button>
   <% end %>
 </div>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_split.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_split.html.erb
@@ -1,0 +1,15 @@
+<div id="js-split-proposals-actions" class="hide js-bulk-action-form">
+  <%= form_tag(proposals_split_path, method: :post, id: "js-form-split-proposals", class: "flex--cc flex-gap--1") do %>
+    <div class="checkboxes hide">
+      <% proposals.each do |proposal| %>
+        <%= check_box_tag "proposal_ids[]", proposal.id, false, class: "js-check-all-proposal js-proposal-id-#{proposal.id}" %>
+      <% end %>
+    </div>
+
+    <%= bulk_components_select current_component.siblings %>
+
+    <%= submit_tag(t("decidim.proposals.admin.proposals.index.split_button"), id: "js-submit-split-proposals", class: "button small button--simple float-left") %>
+
+    <button id="js-cancel-split-proposals" class="button tiny clear compact js-cancel-bulk-action" type="button"><%= t("decidim.proposals.admin.proposals.index.cancel") %></button>
+  <% end %>
+</div>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -3,7 +3,7 @@
     <h2 class="card-title flex--sbc">
       <div>
         <%= t(".title") %>
-        <span id="js-recategorize-proposals-count" class="component-counter component-counter--inline" title="<%= t("decidim.proposals.admin.proposals.index.selected") %>"></span>
+        <span id="js-selected-proposals-count" class="component-counter component-counter--inline" title="<%= t("decidim.proposals.admin.proposals.index.selected") %>"></span>
       </div>
       <%= render partial: "bulk-actions" %>
     </h2>
@@ -14,7 +14,7 @@
         <thead>
           <tr>
             <th>
-              <%= check_box_tag "proposals_recategorize", "all", false, class: "js-check-all" %>
+              <%= check_box_tag "proposals_bulk", "all", false, class: "js-check-all" %>
             </th>
             <th>
               <%= sort_link(query, :id, t("models.proposal.fields.id", scope: "decidim.proposals"), default_order: :desc ) %>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -23,7 +23,8 @@ en:
       proposal_answer:
         answer: Answer
       proposals_copy:
-        copy_proposals: I understand that this will import all proposals from the selected component to the current one and that this action can't be reversed.
+        copy_proposals: I understand that this will import all proposals from the
+          selected component to the current one and that this action can't be reversed.
         origin_component_id: Component to copy the proposals from
     errors:
       models:
@@ -72,7 +73,8 @@ en:
           global:
             announcement: Announcement
             attachments_allowed: Allow attachments
-            can_accumulate_supports_beyond_threshold: Can accumulate supports beyond threshold
+            can_accumulate_supports_beyond_threshold: Can accumulate supports beyond
+              threshold
             collaborative_drafts_enabled: Collaborative drafts enabled
             comments_enabled: Comments enabled
             geocoding_enabled: Geocoding enabled
@@ -81,14 +83,19 @@ en:
             official_proposals_enabled: Official proposals enabled
             participatory_texts_enabled: Participatory texts enabled
             proposal_answering_enabled: Proposal answering enabled
-            proposal_edit_before_minutes: Proposals can be edited by authors before this many minutes passes
+            proposal_edit_before_minutes: Proposals can be edited by authors before
+              this many minutes passes
             proposal_length: Maximum proposal body length
             proposal_limit: Proposal limit per user
             proposal_wizard_step_1_help_text: Proposal wizard "Create" step help text
-            proposal_wizard_step_2_help_text: Proposal wizard "Compare" step help text
-            proposal_wizard_step_3_help_text: Proposal wizard "Complete" step help text
-            proposal_wizard_step_4_help_text: Proposal wizard "Publish" step help text
-            resources_permissions_enabled: Actions permissions can be set for each proposal
+            proposal_wizard_step_2_help_text: Proposal wizard "Compare" step help
+              text
+            proposal_wizard_step_3_help_text: Proposal wizard "Complete" step help
+              text
+            proposal_wizard_step_4_help_text: Proposal wizard "Publish" step help
+              text
+            resources_permissions_enabled: Actions permissions can be set for each
+              proposal
             threshold_per_proposal: Threshold per proposal
             vote_limit: Vote limit per user
           step:
@@ -100,100 +107,175 @@ en:
             proposal_answering_enabled: Proposal answering enabled
             votes_blocked: Voting blocked
             votes_enabled: Voting enabled
-            votes_hidden: Votes hidden (if votes are enabled, checking this will hide the number of votes)
+            votes_hidden: Votes hidden (if votes are enabled, checking this will hide
+              the number of votes)
     events:
       proposals:
         collaborative_draft_access_accepted:
-          email_intro: '%{requester_name} has been accepted to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.'
-          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
-          email_subject: "%{requester_name} has been accepted to access as a contributor of the %{resource_title}."
-          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> has been <strong>accepted to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_intro: '%{requester_name} has been accepted to access as a contributor
+            of the <a href="%{resource_path}">%{resource_title}</a> collaborative
+            draft.'
+          email_outro: You have received this notification because you are a collaborator
+            of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{requester_name} has been accepted to access as a contributor
+            of the %{resource_title}."
+          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a>
+            has been <strong>accepted to access as a contributor</strong> of the <a
+            href="%{resource_path}">%{resource_title}</a> collaborative draft.
         collaborative_draft_access_rejected:
-          email_intro: '%{requester_name} has been rejected to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.'
-          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
-          email_subject: "%{requester_name} has been rejected to access as a contributor of the %{resource_title} collaborative draft."
-          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> has been <strong>rejected to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_intro: '%{requester_name} has been rejected to access as a contributor
+            of the <a href="%{resource_path}">%{resource_title}</a> collaborative
+            draft.'
+          email_outro: You have received this notification because you are a collaborator
+            of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{requester_name} has been rejected to access as a contributor
+            of the %{resource_title} collaborative draft."
+          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a>
+            has been <strong>rejected to access as a contributor</strong> of the <a
+            href="%{resource_path}">%{resource_title}</a> collaborative draft.
         collaborative_draft_access_requested:
-          email_intro: '%{requester_name} requested access as a contributor. You can <strong>accept or reject the request</strong> from the <a href="%{resource_path}">%{resource_title}</a> collaborative draft page.'
-          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: '%{requester_name} requested access as a contributor. You can
+            <strong>accept or reject the request</strong> from the <a href="%{resource_path}">%{resource_title}</a>
+            collaborative draft page.'
+          email_outro: You have received this notification because you are a collaborator
+            of <a href="%{resource_path}">%{resource_title}</a>.
           email_subject: "%{requester_name} requested access to contribute to %{resource_title}."
-          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> requested access to contribute to the <a href="%{resource_path}">%{resource_title}</a> collaborative draft. Please <strong>accept or reject the request</strong>.
+          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a>
+            requested access to contribute to the <a href="%{resource_path}">%{resource_title}</a>
+            collaborative draft. Please <strong>accept or reject the request</strong>.
         collaborative_draft_access_requester_accepted:
-          email_intro: You have been accepted to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
-          email_outro: You have received this notification because you requested to become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: You have been accepted to access as a contributor of the <a
+            href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_outro: You have received this notification because you requested to
+            become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
           email_subject: You have been accepted as a contributor of %{resource_title}.
-          notification_title: You have been <strong>accepted to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          notification_title: You have been <strong>accepted to access as a contributor</strong>
+            of the <a href="%{resource_path}">%{resource_title}</a> collaborative
+            draft.
         collaborative_draft_access_requester_rejected:
-          email_intro: You have been rejected to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
-          email_outro: You have received this notification because you requested to become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: You have been rejected to access as a contributor of the <a
+            href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_outro: You have received this notification because you requested to
+            become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
           email_subject: You have been rejected as a contributor of %{resource_title}.
-          notification_title: You have been <strong>rejected to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          notification_title: You have been <strong>rejected to access as a contributor</strong>
+            of the <a href="%{resource_path}">%{resource_title}</a> collaborative
+            draft.
         collaborative_draft_withdrawn:
-          email_intro: <a href="%{author_path}">%{author_name} %{author_nickname}</a> withdrawn the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
-          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
-          email_subject: "%{author_name} %{author_nickname} withdrawn the %{resource_title} collaborative draft."
-          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> <strong>withdrawn</strong> the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_intro: <a href="%{author_path}">%{author_name} %{author_nickname}</a>
+            withdrawn the <a href="%{resource_path}">%{resource_title}</a> collaborative
+            draft.
+          email_outro: You have received this notification because you are a collaborator
+            of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{author_name} %{author_nickname} withdrawn the %{resource_title}
+            collaborative draft."
+          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a>
+            <strong>withdrawn</strong> the <a href="%{resource_path}">%{resource_title}</a>
+            collaborative draft.
         creation_enabled:
-          email_intro: 'You can now create new proposals in %{participatory_space_title}! Start participating in this page:'
-          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_intro: 'You can now create new proposals in %{participatory_space_title}!
+            Start participating in this page:'
+          email_outro: You have received this notification because you are following
+            %{participatory_space_title}. You can stop receiving notifications following
+            the previous link.
           email_subject: Proposals now available in %{participatory_space_title}
-          notification_title: You can now put forward <a href="%{resource_path}">new proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+          notification_title: You can now put forward <a href="%{resource_path}">new
+            proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
         endorsing_enabled:
-          email_intro: 'You can endorse proposals in %{participatory_space_title}! Start participating in this page:'
-          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_intro: 'You can endorse proposals in %{participatory_space_title}!
+            Start participating in this page:'
+          email_outro: You have received this notification because you are following
+            %{participatory_space_title}. You can stop receiving notifications following
+            the previous link.
           email_subject: Proposals endorsing has started for %{participatory_space_title}
-          notification_title: You can now start <a href="%{resource_path}">endorsing proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+          notification_title: You can now start <a href="%{resource_path}">endorsing
+            proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
         proposal_accepted:
-          email_intro: 'The proposal "%{resource_title}" has been accepted. You can read the answer in this page:'
-          email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
+          email_intro: 'The proposal "%{resource_title}" has been accepted. You can
+            read the answer in this page:'
+          email_outro: You have received this notification because you are following
+            "%{resource_title}". You can unfollow it from the previous link.
           email_subject: A proposal you're following has been accepted
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal has been accepted.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
+            proposal has been accepted.
         proposal_endorsed:
-          email_intro: "%{endorser_name} %{endorser_nickname}, who you are following, has just endorsed a proposal that may be interesting to you, check it out and contribute:"
-          email_outro: You have received this notification because you are following %{endorser_nickname}. You can stop receiving notifications following the previous link.
+          email_intro: "%{endorser_name} %{endorser_nickname}, who you are following,
+            has just endorsed a proposal that may be interesting to you, check it
+            out and contribute:"
+          email_outro: You have received this notification because you are following
+            %{endorser_nickname}. You can stop receiving notifications following the
+            previous link.
           email_subject: "%{endorser_nickname} has endorsed a new proposal"
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal has been endorsed by <a href="%{endorser_path}">%{endorser_name} %{endorser_nickname}</a>.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
+            proposal has been endorsed by <a href="%{endorser_path}">%{endorser_name}
+            %{endorser_nickname}</a>.
         proposal_evaluating:
-          email_intro: 'The proposal "%{resource_title}" is currently being evaluated. You can check for an answer in this page:'
-          email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
+          email_intro: 'The proposal "%{resource_title}" is currently being evaluated.
+            You can check for an answer in this page:'
+          email_outro: You have received this notification because you are following
+            "%{resource_title}". You can unfollow it from the previous link.
           email_subject: A proposal you're following is being evaluated
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal is being evaluated.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
+            proposal is being evaluated.
         proposal_mentioned:
-          email_intro: Your proposal "%{mentioned_proposal_title}" has been mentioned <a href="%{resource_path}">in this space</a> in the comments.
+          email_intro: Your proposal "%{mentioned_proposal_title}" has been mentioned
+            <a href="%{resource_path}">in this space</a> in the comments.
           email_subject: Your proposal "%{mentioned_proposal_title}" has been mentioned
-          notification_title: Your proposal "%{mentioned_proposal_title}" has been mentioned <a href="%{resource_path}">in this space</a> in the comments.
+          notification_title: Your proposal "%{mentioned_proposal_title}" has been
+            mentioned <a href="%{resource_path}">in this space</a> in the comments.
         proposal_published:
-          email_intro: "%{author_name} %{author_nickname}, who you are following, has published a new proposal, check it out and contribute:"
-          email_outro: You have received this notification because you are following %{author_nickname}. You can stop receiving notifications following the previous link.
+          email_intro: "%{author_name} %{author_nickname}, who you are following,
+            has published a new proposal, check it out and contribute:"
+          email_outro: You have received this notification because you are following
+            %{author_nickname}. You can stop receiving notifications following the
+            previous link.
           email_subject: New proposal by %{author_nickname}
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal was published by <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
+            proposal was published by <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
         proposal_published_for_space:
-          email_intro: The proposal "%{resource_title}" has been added to "%{participatory_space_title}" that you are following.
-          email_outro: You have received this notification because you are following "%{participatory_space_title}". You can unfollow it from the previous link.
+          email_intro: The proposal "%{resource_title}" has been added to "%{participatory_space_title}"
+            that you are following.
+          email_outro: You have received this notification because you are following
+            "%{participatory_space_title}". You can unfollow it from the previous
+            link.
           email_subject: New proposal added to %{participatory_space_title}
-          notification_title: The proposal <a href="%{resource_path}">%{resource_title}</a> has been added to %{participatory_space_title}
+          notification_title: The proposal <a href="%{resource_path}">%{resource_title}</a>
+            has been added to %{participatory_space_title}
         proposal_rejected:
-          email_intro: 'The proposal "%{resource_title}" has been rejected. You can read the answer in this page:'
-          email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
+          email_intro: 'The proposal "%{resource_title}" has been rejected. You can
+            read the answer in this page:'
+          email_outro: You have received this notification because you are following
+            "%{resource_title}". You can unfollow it from the previous link.
           email_subject: A proposal you're following has been rejected
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal has been rejected.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
+            proposal has been rejected.
         proposal_update_category:
-          email_intro: 'An admin has updated the category of your proposal "%{resource_title}", check it out:'
-          email_outro: You have received this notification because you are the author of the proposal.
+          email_intro: 'An admin has updated the category of your proposal "%{resource_title}",
+            check it out:'
+          email_outro: You have received this notification because you are the author
+            of the proposal.
           email_subject: The %{resource_title} proposal category has been updated
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal category has been updated by an admin.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
+            proposal category has been updated by an admin.
         voting_enabled:
-          email_intro: 'You can vote proposals in %{participatory_space_title}! Start participating in this page:'
-          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_intro: 'You can vote proposals in %{participatory_space_title}! Start
+            participating in this page:'
+          email_outro: You have received this notification because you are following
+            %{participatory_space_title}. You can stop receiving notifications following
+            the previous link.
           email_subject: Proposals voting has started for %{participatory_space_title}
-          notification_title: You can now start <a href="%{resource_path}">voting proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+          notification_title: You can now start <a href="%{resource_path}">voting
+            proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
     gamification:
       badges:
         accepted_proposals:
           conditions:
-          - Choose the participation space of your interest with submission for proposals enabled
-          - Try to make proposals that can be carried out. This way they are more likely to be accepted.
-          description: This badge is granted when you actively participate with new proposals and these are accepted.
+          - Choose the participation space of your interest with submission for proposals
+            enabled
+          - Try to make proposals that can be carried out. This way they are more
+            likely to be accepted.
+          description: This badge is granted when you actively participate with new
+            proposals and these are accepted.
           description_another: This user has gotten %{score} proposals accepted.
           description_own: You got %{score} proposals accepted.
           name: Accepted proposals
@@ -208,14 +290,17 @@ en:
           description_another: This user has given support to %{score} proposals.
           description_own: You have given support to %{score} proposals.
           name: Proposal supports
-          next_level_in: Give support to %{score} more proposals to reach the next level!
+          next_level_in: Give support to %{score} more proposals to reach the next
+            level!
           unearned_another: This user hasn't given support to any proposals yet.
           unearned_own: You have given support to no proposals yet.
         proposals:
           conditions:
-          - Choose the participation space of your interest with submission for proposals enabled
+          - Choose the participation space of your interest with submission for proposals
+            enabled
           - Create a new proposal
-          description: This badge is granted when you actively participate with new proposals.
+          description: This badge is granted when you actively participate with new
+            proposals.
           description_another: This user has created %{score} proposals.
           description_own: You have created %{score} proposals.
           name: Proposals
@@ -263,14 +348,19 @@ en:
             import_doc: Import document
           import:
             invalid: The form is invalid!
-            success: Congratulations, the following sections have been parsed from the imported document, they have been converted to proposals. Now you can review and adjust whatever you need before publishing.
+            success: Congratulations, the following sections have been parsed from
+              the imported document, they have been converted to proposals. Now you
+              can review and adjust whatever you need before publishing.
           index:
-            info_1: The following sections have been parsed from the imported document, they have been converted to proposals. Now you can review and adjust whatever you need before publishing.
+            info_1: The following sections have been parsed from the imported document,
+              they have been converted to proposals. Now you can review and adjust
+              whatever you need before publishing.
             publish_document: Publish document
             title: PREVIEW PARTICIPATORY TEXT
           new_import:
             bottom_hint: "(You will be able to preview and sort document sections)"
-            document_legend: 'Add a document lesser than 2MB, each section until 3 levels deep will be parsed into Proposals. Suported formats are: Markdown'
+            document_legend: 'Add a document lesser than 2MB, each section until 3
+              levels deep will be parsed into Proposals. Suported formats are: Markdown'
             title: ADD DOCUMENT
             upload_document: Upload document
           publish:
@@ -313,6 +403,9 @@ en:
             actions: Actions
             cancel: Cancel
             change_category: Change category
+            merge: Merge into a new one
+            merge_button: Merge
+            select_component: Select a component
             selected: selected
             title: Proposals
             update: Update
@@ -323,16 +416,22 @@ en:
             invalid: 'These proposals already had the %{category} category: %{proposals}.'
             select_a_category: Please select a category
             select_a_proposal: Please select a proposal
-            success: 'Proposals successfully updated to the %{category} category: %{proposals}.'
+            success: 'Proposals successfully updated to the %{category} category:
+              %{proposals}.'
         proposals_imports:
           create:
             invalid: There's been a problem importing the proposals
             success: "%{number} proposals successfully imported"
           new:
             create: Import proposals
-            no_components: There are no other proposal components in this participatory space to import the proposals from.
+            no_components: There are no other proposal components in this participatory
+              space to import the proposals from.
             select_component: Please select a component
             select_states: Check the states of the proposals to import
+        proposals_merges:
+          create:
+            invalid: There was an error merging the selected proposals.
+            success: Successfully merged the proposals into a new one.
         shared:
           info_proposal:
             body: Body
@@ -341,11 +440,15 @@ en:
             proposals: Proposals
       admin_log:
         proposal:
-          answer: "%{user_name} answered the %{resource_name} proposal on the %{space_name} space"
-          create: "%{user_name} created the %{resource_name} proposal on the %{space_name} space as an official proposal"
-          update: "%{user_name} updated the %{resource_name} official proposal on the %{space_name} space"
+          answer: "%{user_name} answered the %{resource_name} proposal on the %{space_name}
+            space"
+          create: "%{user_name} created the %{resource_name} proposal on the %{space_name}
+            space as an official proposal"
+          update: "%{user_name} updated the %{resource_name} official proposal on
+            the %{space_name} space"
         proposal_note:
-          create: "%{user_name} left a private note on the %{resource_name} proposal on the %{space_name} space"
+          create: "%{user_name} left a private note on the %{resource_name} proposal
+            on the %{space_name} space"
       answers:
         accepted: Accepted
         evaluating: Evaluating
@@ -357,7 +460,8 @@ en:
           publish:
             error: There's been errors when publishing the collaborative draft.
             irreversible_action_modal:
-              body: After publishing the draft as a proposal, the draft won't be editable anymore. The proposal won't accept new authors or contributions.
+              body: After publishing the draft as a proposal, the draft won't be editable
+                anymore. The proposal won't accept new authors or contributions.
               cancel: Cancel
               ok: Publish as a Proposal
               title: The following action is irreversible
@@ -366,7 +470,8 @@ en:
           withdraw:
             error: There's been errors closing the collaborative draft.
             irreversible_action_modal:
-              body: After closing the draft, the draft won't be editable anymore. The draft won't accept new authors or contributions.
+              body: After closing the draft, the draft won't be editable anymore.
+                The draft won't accept new authors or contributions.
               cancel: Cancel
               ok: Withdraw the collaborative draft
               title: The following action is irreversible
@@ -435,11 +540,16 @@ en:
           back: Back
           edit: Edit collaborative draft
           final_proposal: final proposal
-          final_proposal_help_text: This draft is finished. You can see the final finished proposal
+          final_proposal_help_text: This draft is finished. You can see the final
+            finished proposal
           hidden_authors_count:
             one: and 1 more person
             other: and %{count} more people
-          info-message: This is a <strong>collaborative draft</strong> for a proposal. This means that you can help their authors to shape the proposal using the comment section below or improve it directly by requesting access to edit it. Once the authors grant you access, youl'll be able to make changes to this draft.
+          info-message: This is a <strong>collaborative draft</strong> for a proposal.
+            This means that you can help their authors to shape the proposal using
+            the comment section below or improve it directly by requesting access
+            to edit it. Once the authors grant you access, youl'll be able to make
+            changes to this draft.
           of_versions: "(of %{number})"
           publish: Publish
           publish_info: Publish this version of the draft or
@@ -578,8 +688,12 @@ en:
         preview:
           modify: Modify the proposal
           proposal_edit_before_minutes:
-            one: You will be able to edit this proposal during the first minute after the proposal is published. Once this time window passes, you will not be able to edit the proposal.
-            other: You will be able to edit this proposal during the first %{count} minutes after the proposal is published. Once this time window passes, you will not be able to edit the proposal.
+            one: You will be able to edit this proposal during the first minute after
+              the proposal is published. Once this time window passes, you will not
+              be able to edit the proposal.
+            other: You will be able to edit this proposal during the first %{count}
+              minutes after the proposal is published. Once this time window passes,
+              you will not be able to edit the proposal.
           publish: Publish
           title: Publish your proposal
         proposal:
@@ -591,7 +705,8 @@ en:
           hidden_endorsers_count:
             one: and 1 more person
             other: and %{count} more people
-          link_to_collaborative_draft_help_text: This proposal is the result of a collaborative draft. Review the history
+          link_to_collaborative_draft_help_text: This proposal is the result of a
+            collaborative draft. Review the history
           link_to_collaborative_draft_text: See the collaborative draft
           proposal_accepted_reason: 'This proposal has been accepted because:'
           proposal_in_evaluation_reason: This proposal is being evaluated
@@ -600,7 +715,9 @@ en:
           sign_in: Sign in
           sign_in_or_up: "%{in} or %{up} to participate"
           sign_up: sign up
-          withdraw_btn_hint: You can withdraw your proposal if you change your mind, as long as you have not received any support. The proposal is not deleted, it will appear in the list of withdrawn proposals.
+          withdraw_btn_hint: You can withdraw your proposal if you change your mind,
+            as long as you have not received any support. The proposal is not deleted,
+            it will appear in the list of withdrawn proposals.
           withdraw_confirmation: Are you sure to withdraw this proposal?
           withdraw_proposal: Withdraw proposal
         tags:
@@ -623,13 +740,16 @@ en:
           can_accumulate_supports_beyond_threshold:
             description: Each proposal can accumulate more than %{limit} supports
           minimum_votes_per_user:
-            description: You must distribute a minimum of 3 votes among different proposals.
+            description: You must distribute a minimum of 3 votes among different
+              proposals.
             given_enough_votes: You've given enough supports.
-            supports_remaining: You have to vote %{remaining_votes} more proposals for your votes to be taken into account.
+            supports_remaining: You have to vote %{remaining_votes} more proposals
+              for your votes to be taken into account.
           proposal_limit:
             description: You can create up to %{limit} proposals.
           threshold_per_proposal:
-            description: In order to be validated proposals need to reach %{limit} supports
+            description: In order to be validated proposals need to reach %{limit}
+              supports
           title: 'Voting is subject to the following rules:'
           vote_limit:
             description: You can vote up to %{limit} proposals.

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -404,7 +404,9 @@ en:
             cancel: Cancel
             change_category: Change category
             merge: Merge into a new one
+            split: Split proposals
             merge_button: Merge
+            split_button: Split
             select_component: Select a component
             selected: selected
             title: Proposals
@@ -432,6 +434,10 @@ en:
           create:
             invalid: There was an error merging the selected proposals.
             success: Successfully merged the proposals into a new one.
+        proposals_splits:
+          create:
+            invalid: There was an error spliting the selected proposals.
+            success: Successfully splitted the proposals into new ones.
         shared:
           info_proposal:
             body: Body

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -23,8 +23,7 @@ en:
       proposal_answer:
         answer: Answer
       proposals_copy:
-        copy_proposals: I understand that this will import all proposals from the
-          selected component to the current one and that this action can't be reversed.
+        copy_proposals: I understand that this will import all proposals from the selected component to the current one and that this action can't be reversed.
         origin_component_id: Component to copy the proposals from
     errors:
       models:
@@ -73,8 +72,7 @@ en:
           global:
             announcement: Announcement
             attachments_allowed: Allow attachments
-            can_accumulate_supports_beyond_threshold: Can accumulate supports beyond
-              threshold
+            can_accumulate_supports_beyond_threshold: Can accumulate supports beyond threshold
             collaborative_drafts_enabled: Collaborative drafts enabled
             comments_enabled: Comments enabled
             geocoding_enabled: Geocoding enabled
@@ -83,19 +81,14 @@ en:
             official_proposals_enabled: Official proposals enabled
             participatory_texts_enabled: Participatory texts enabled
             proposal_answering_enabled: Proposal answering enabled
-            proposal_edit_before_minutes: Proposals can be edited by authors before
-              this many minutes passes
+            proposal_edit_before_minutes: Proposals can be edited by authors before this many minutes passes
             proposal_length: Maximum proposal body length
             proposal_limit: Proposal limit per user
             proposal_wizard_step_1_help_text: Proposal wizard "Create" step help text
-            proposal_wizard_step_2_help_text: Proposal wizard "Compare" step help
-              text
-            proposal_wizard_step_3_help_text: Proposal wizard "Complete" step help
-              text
-            proposal_wizard_step_4_help_text: Proposal wizard "Publish" step help
-              text
-            resources_permissions_enabled: Actions permissions can be set for each
-              proposal
+            proposal_wizard_step_2_help_text: Proposal wizard "Compare" step help text
+            proposal_wizard_step_3_help_text: Proposal wizard "Complete" step help text
+            proposal_wizard_step_4_help_text: Proposal wizard "Publish" step help text
+            resources_permissions_enabled: Actions permissions can be set for each proposal
             threshold_per_proposal: Threshold per proposal
             vote_limit: Vote limit per user
           step:
@@ -107,175 +100,100 @@ en:
             proposal_answering_enabled: Proposal answering enabled
             votes_blocked: Voting blocked
             votes_enabled: Voting enabled
-            votes_hidden: Votes hidden (if votes are enabled, checking this will hide
-              the number of votes)
+            votes_hidden: Votes hidden (if votes are enabled, checking this will hide the number of votes)
     events:
       proposals:
         collaborative_draft_access_accepted:
-          email_intro: '%{requester_name} has been accepted to access as a contributor
-            of the <a href="%{resource_path}">%{resource_title}</a> collaborative
-            draft.'
-          email_outro: You have received this notification because you are a collaborator
-            of <a href="%{resource_path}">%{resource_title}</a>.
-          email_subject: "%{requester_name} has been accepted to access as a contributor
-            of the %{resource_title}."
-          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a>
-            has been <strong>accepted to access as a contributor</strong> of the <a
-            href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_intro: '%{requester_name} has been accepted to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.'
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{requester_name} has been accepted to access as a contributor of the %{resource_title}."
+          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> has been <strong>accepted to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         collaborative_draft_access_rejected:
-          email_intro: '%{requester_name} has been rejected to access as a contributor
-            of the <a href="%{resource_path}">%{resource_title}</a> collaborative
-            draft.'
-          email_outro: You have received this notification because you are a collaborator
-            of <a href="%{resource_path}">%{resource_title}</a>.
-          email_subject: "%{requester_name} has been rejected to access as a contributor
-            of the %{resource_title} collaborative draft."
-          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a>
-            has been <strong>rejected to access as a contributor</strong> of the <a
-            href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_intro: '%{requester_name} has been rejected to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.'
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{requester_name} has been rejected to access as a contributor of the %{resource_title} collaborative draft."
+          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> has been <strong>rejected to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         collaborative_draft_access_requested:
-          email_intro: '%{requester_name} requested access as a contributor. You can
-            <strong>accept or reject the request</strong> from the <a href="%{resource_path}">%{resource_title}</a>
-            collaborative draft page.'
-          email_outro: You have received this notification because you are a collaborator
-            of <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: '%{requester_name} requested access as a contributor. You can <strong>accept or reject the request</strong> from the <a href="%{resource_path}">%{resource_title}</a> collaborative draft page.'
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
           email_subject: "%{requester_name} requested access to contribute to %{resource_title}."
-          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a>
-            requested access to contribute to the <a href="%{resource_path}">%{resource_title}</a>
-            collaborative draft. Please <strong>accept or reject the request</strong>.
+          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> requested access to contribute to the <a href="%{resource_path}">%{resource_title}</a> collaborative draft. Please <strong>accept or reject the request</strong>.
         collaborative_draft_access_requester_accepted:
-          email_intro: You have been accepted to access as a contributor of the <a
-            href="%{resource_path}">%{resource_title}</a> collaborative draft.
-          email_outro: You have received this notification because you requested to
-            become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: You have been accepted to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_outro: You have received this notification because you requested to become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
           email_subject: You have been accepted as a contributor of %{resource_title}.
-          notification_title: You have been <strong>accepted to access as a contributor</strong>
-            of the <a href="%{resource_path}">%{resource_title}</a> collaborative
-            draft.
+          notification_title: You have been <strong>accepted to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         collaborative_draft_access_requester_rejected:
-          email_intro: You have been rejected to access as a contributor of the <a
-            href="%{resource_path}">%{resource_title}</a> collaborative draft.
-          email_outro: You have received this notification because you requested to
-            become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: You have been rejected to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_outro: You have received this notification because you requested to become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
           email_subject: You have been rejected as a contributor of %{resource_title}.
-          notification_title: You have been <strong>rejected to access as a contributor</strong>
-            of the <a href="%{resource_path}">%{resource_title}</a> collaborative
-            draft.
+          notification_title: You have been <strong>rejected to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         collaborative_draft_withdrawn:
-          email_intro: <a href="%{author_path}">%{author_name} %{author_nickname}</a>
-            withdrawn the <a href="%{resource_path}">%{resource_title}</a> collaborative
-            draft.
-          email_outro: You have received this notification because you are a collaborator
-            of <a href="%{resource_path}">%{resource_title}</a>.
-          email_subject: "%{author_name} %{author_nickname} withdrawn the %{resource_title}
-            collaborative draft."
-          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a>
-            <strong>withdrawn</strong> the <a href="%{resource_path}">%{resource_title}</a>
-            collaborative draft.
+          email_intro: <a href="%{author_path}">%{author_name} %{author_nickname}</a> withdrawn the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{author_name} %{author_nickname} withdrawn the %{resource_title} collaborative draft."
+          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> <strong>withdrawn</strong> the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         creation_enabled:
-          email_intro: 'You can now create new proposals in %{participatory_space_title}!
-            Start participating in this page:'
-          email_outro: You have received this notification because you are following
-            %{participatory_space_title}. You can stop receiving notifications following
-            the previous link.
+          email_intro: 'You can now create new proposals in %{participatory_space_title}! Start participating in this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
           email_subject: Proposals now available in %{participatory_space_title}
-          notification_title: You can now put forward <a href="%{resource_path}">new
-            proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+          notification_title: You can now put forward <a href="%{resource_path}">new proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
         endorsing_enabled:
-          email_intro: 'You can endorse proposals in %{participatory_space_title}!
-            Start participating in this page:'
-          email_outro: You have received this notification because you are following
-            %{participatory_space_title}. You can stop receiving notifications following
-            the previous link.
+          email_intro: 'You can endorse proposals in %{participatory_space_title}! Start participating in this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
           email_subject: Proposals endorsing has started for %{participatory_space_title}
-          notification_title: You can now start <a href="%{resource_path}">endorsing
-            proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+          notification_title: You can now start <a href="%{resource_path}">endorsing proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
         proposal_accepted:
-          email_intro: 'The proposal "%{resource_title}" has been accepted. You can
-            read the answer in this page:'
-          email_outro: You have received this notification because you are following
-            "%{resource_title}". You can unfollow it from the previous link.
+          email_intro: 'The proposal "%{resource_title}" has been accepted. You can read the answer in this page:'
+          email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
           email_subject: A proposal you're following has been accepted
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
-            proposal has been accepted.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal has been accepted.
         proposal_endorsed:
-          email_intro: "%{endorser_name} %{endorser_nickname}, who you are following,
-            has just endorsed a proposal that may be interesting to you, check it
-            out and contribute:"
-          email_outro: You have received this notification because you are following
-            %{endorser_nickname}. You can stop receiving notifications following the
-            previous link.
+          email_intro: "%{endorser_name} %{endorser_nickname}, who you are following, has just endorsed a proposal that may be interesting to you, check it out and contribute:"
+          email_outro: You have received this notification because you are following %{endorser_nickname}. You can stop receiving notifications following the previous link.
           email_subject: "%{endorser_nickname} has endorsed a new proposal"
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
-            proposal has been endorsed by <a href="%{endorser_path}">%{endorser_name}
-            %{endorser_nickname}</a>.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal has been endorsed by <a href="%{endorser_path}">%{endorser_name} %{endorser_nickname}</a>.
         proposal_evaluating:
-          email_intro: 'The proposal "%{resource_title}" is currently being evaluated.
-            You can check for an answer in this page:'
-          email_outro: You have received this notification because you are following
-            "%{resource_title}". You can unfollow it from the previous link.
+          email_intro: 'The proposal "%{resource_title}" is currently being evaluated. You can check for an answer in this page:'
+          email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
           email_subject: A proposal you're following is being evaluated
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
-            proposal is being evaluated.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal is being evaluated.
         proposal_mentioned:
-          email_intro: Your proposal "%{mentioned_proposal_title}" has been mentioned
-            <a href="%{resource_path}">in this space</a> in the comments.
+          email_intro: Your proposal "%{mentioned_proposal_title}" has been mentioned <a href="%{resource_path}">in this space</a> in the comments.
           email_subject: Your proposal "%{mentioned_proposal_title}" has been mentioned
-          notification_title: Your proposal "%{mentioned_proposal_title}" has been
-            mentioned <a href="%{resource_path}">in this space</a> in the comments.
+          notification_title: Your proposal "%{mentioned_proposal_title}" has been mentioned <a href="%{resource_path}">in this space</a> in the comments.
         proposal_published:
-          email_intro: "%{author_name} %{author_nickname}, who you are following,
-            has published a new proposal, check it out and contribute:"
-          email_outro: You have received this notification because you are following
-            %{author_nickname}. You can stop receiving notifications following the
-            previous link.
+          email_intro: "%{author_name} %{author_nickname}, who you are following, has published a new proposal, check it out and contribute:"
+          email_outro: You have received this notification because you are following %{author_nickname}. You can stop receiving notifications following the previous link.
           email_subject: New proposal by %{author_nickname}
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
-            proposal was published by <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal was published by <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
         proposal_published_for_space:
-          email_intro: The proposal "%{resource_title}" has been added to "%{participatory_space_title}"
-            that you are following.
-          email_outro: You have received this notification because you are following
-            "%{participatory_space_title}". You can unfollow it from the previous
-            link.
+          email_intro: The proposal "%{resource_title}" has been added to "%{participatory_space_title}" that you are following.
+          email_outro: You have received this notification because you are following "%{participatory_space_title}". You can unfollow it from the previous link.
           email_subject: New proposal added to %{participatory_space_title}
-          notification_title: The proposal <a href="%{resource_path}">%{resource_title}</a>
-            has been added to %{participatory_space_title}
+          notification_title: The proposal <a href="%{resource_path}">%{resource_title}</a> has been added to %{participatory_space_title}
         proposal_rejected:
-          email_intro: 'The proposal "%{resource_title}" has been rejected. You can
-            read the answer in this page:'
-          email_outro: You have received this notification because you are following
-            "%{resource_title}". You can unfollow it from the previous link.
+          email_intro: 'The proposal "%{resource_title}" has been rejected. You can read the answer in this page:'
+          email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
           email_subject: A proposal you're following has been rejected
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
-            proposal has been rejected.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal has been rejected.
         proposal_update_category:
-          email_intro: 'An admin has updated the category of your proposal "%{resource_title}",
-            check it out:'
-          email_outro: You have received this notification because you are the author
-            of the proposal.
+          email_intro: 'An admin has updated the category of your proposal "%{resource_title}", check it out:'
+          email_outro: You have received this notification because you are the author of the proposal.
           email_subject: The %{resource_title} proposal category has been updated
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
-            proposal category has been updated by an admin.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal category has been updated by an admin.
         voting_enabled:
-          email_intro: 'You can vote proposals in %{participatory_space_title}! Start
-            participating in this page:'
-          email_outro: You have received this notification because you are following
-            %{participatory_space_title}. You can stop receiving notifications following
-            the previous link.
+          email_intro: 'You can vote proposals in %{participatory_space_title}! Start participating in this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
           email_subject: Proposals voting has started for %{participatory_space_title}
-          notification_title: You can now start <a href="%{resource_path}">voting
-            proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+          notification_title: You can now start <a href="%{resource_path}">voting proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
     gamification:
       badges:
         accepted_proposals:
           conditions:
-          - Choose the participation space of your interest with submission for proposals
-            enabled
-          - Try to make proposals that can be carried out. This way they are more
-            likely to be accepted.
-          description: This badge is granted when you actively participate with new
-            proposals and these are accepted.
+          - Choose the participation space of your interest with submission for proposals enabled
+          - Try to make proposals that can be carried out. This way they are more likely to be accepted.
+          description: This badge is granted when you actively participate with new proposals and these are accepted.
           description_another: This user has gotten %{score} proposals accepted.
           description_own: You got %{score} proposals accepted.
           name: Accepted proposals
@@ -290,17 +208,14 @@ en:
           description_another: This user has given support to %{score} proposals.
           description_own: You have given support to %{score} proposals.
           name: Proposal supports
-          next_level_in: Give support to %{score} more proposals to reach the next
-            level!
+          next_level_in: Give support to %{score} more proposals to reach the next level!
           unearned_another: This user hasn't given support to any proposals yet.
           unearned_own: You have given support to no proposals yet.
         proposals:
           conditions:
-          - Choose the participation space of your interest with submission for proposals
-            enabled
+          - Choose the participation space of your interest with submission for proposals enabled
           - Create a new proposal
-          description: This badge is granted when you actively participate with new
-            proposals.
+          description: This badge is granted when you actively participate with new proposals.
           description_another: This user has created %{score} proposals.
           description_own: You have created %{score} proposals.
           name: Proposals
@@ -348,19 +263,14 @@ en:
             import_doc: Import document
           import:
             invalid: The form is invalid!
-            success: Congratulations, the following sections have been parsed from
-              the imported document, they have been converted to proposals. Now you
-              can review and adjust whatever you need before publishing.
+            success: Congratulations, the following sections have been parsed from the imported document, they have been converted to proposals. Now you can review and adjust whatever you need before publishing.
           index:
-            info_1: The following sections have been parsed from the imported document,
-              they have been converted to proposals. Now you can review and adjust
-              whatever you need before publishing.
+            info_1: The following sections have been parsed from the imported document, they have been converted to proposals. Now you can review and adjust whatever you need before publishing.
             publish_document: Publish document
             title: PREVIEW PARTICIPATORY TEXT
           new_import:
             bottom_hint: "(You will be able to preview and sort document sections)"
-            document_legend: 'Add a document lesser than 2MB, each section until 3
-              levels deep will be parsed into Proposals. Suported formats are: Markdown'
+            document_legend: 'Add a document lesser than 2MB, each section until 3 levels deep will be parsed into Proposals. Suported formats are: Markdown'
             title: ADD DOCUMENT
             upload_document: Upload document
           publish:
@@ -404,11 +314,11 @@ en:
             cancel: Cancel
             change_category: Change category
             merge: Merge into a new one
-            split: Split proposals
             merge_button: Merge
-            split_button: Split
             select_component: Select a component
             selected: selected
+            split: Split proposals
+            split_button: Split
             title: Proposals
             update: Update
           new:
@@ -418,16 +328,14 @@ en:
             invalid: 'These proposals already had the %{category} category: %{proposals}.'
             select_a_category: Please select a category
             select_a_proposal: Please select a proposal
-            success: 'Proposals successfully updated to the %{category} category:
-              %{proposals}.'
+            success: 'Proposals successfully updated to the %{category} category: %{proposals}.'
         proposals_imports:
           create:
             invalid: There's been a problem importing the proposals
             success: "%{number} proposals successfully imported"
           new:
             create: Import proposals
-            no_components: There are no other proposal components in this participatory
-              space to import the proposals from.
+            no_components: There are no other proposal components in this participatory space to import the proposals from.
             select_component: Please select a component
             select_states: Check the states of the proposals to import
         proposals_merges:
@@ -446,15 +354,11 @@ en:
             proposals: Proposals
       admin_log:
         proposal:
-          answer: "%{user_name} answered the %{resource_name} proposal on the %{space_name}
-            space"
-          create: "%{user_name} created the %{resource_name} proposal on the %{space_name}
-            space as an official proposal"
-          update: "%{user_name} updated the %{resource_name} official proposal on
-            the %{space_name} space"
+          answer: "%{user_name} answered the %{resource_name} proposal on the %{space_name} space"
+          create: "%{user_name} created the %{resource_name} proposal on the %{space_name} space as an official proposal"
+          update: "%{user_name} updated the %{resource_name} official proposal on the %{space_name} space"
         proposal_note:
-          create: "%{user_name} left a private note on the %{resource_name} proposal
-            on the %{space_name} space"
+          create: "%{user_name} left a private note on the %{resource_name} proposal on the %{space_name} space"
       answers:
         accepted: Accepted
         evaluating: Evaluating
@@ -466,8 +370,7 @@ en:
           publish:
             error: There's been errors when publishing the collaborative draft.
             irreversible_action_modal:
-              body: After publishing the draft as a proposal, the draft won't be editable
-                anymore. The proposal won't accept new authors or contributions.
+              body: After publishing the draft as a proposal, the draft won't be editable anymore. The proposal won't accept new authors or contributions.
               cancel: Cancel
               ok: Publish as a Proposal
               title: The following action is irreversible
@@ -476,8 +379,7 @@ en:
           withdraw:
             error: There's been errors closing the collaborative draft.
             irreversible_action_modal:
-              body: After closing the draft, the draft won't be editable anymore.
-                The draft won't accept new authors or contributions.
+              body: After closing the draft, the draft won't be editable anymore. The draft won't accept new authors or contributions.
               cancel: Cancel
               ok: Withdraw the collaborative draft
               title: The following action is irreversible
@@ -546,16 +448,11 @@ en:
           back: Back
           edit: Edit collaborative draft
           final_proposal: final proposal
-          final_proposal_help_text: This draft is finished. You can see the final
-            finished proposal
+          final_proposal_help_text: This draft is finished. You can see the final finished proposal
           hidden_authors_count:
             one: and 1 more person
             other: and %{count} more people
-          info-message: This is a <strong>collaborative draft</strong> for a proposal.
-            This means that you can help their authors to shape the proposal using
-            the comment section below or improve it directly by requesting access
-            to edit it. Once the authors grant you access, youl'll be able to make
-            changes to this draft.
+          info-message: This is a <strong>collaborative draft</strong> for a proposal. This means that you can help their authors to shape the proposal using the comment section below or improve it directly by requesting access to edit it. Once the authors grant you access, youl'll be able to make changes to this draft.
           of_versions: "(of %{number})"
           publish: Publish
           publish_info: Publish this version of the draft or
@@ -694,12 +591,8 @@ en:
         preview:
           modify: Modify the proposal
           proposal_edit_before_minutes:
-            one: You will be able to edit this proposal during the first minute after
-              the proposal is published. Once this time window passes, you will not
-              be able to edit the proposal.
-            other: You will be able to edit this proposal during the first %{count}
-              minutes after the proposal is published. Once this time window passes,
-              you will not be able to edit the proposal.
+            one: You will be able to edit this proposal during the first minute after the proposal is published. Once this time window passes, you will not be able to edit the proposal.
+            other: You will be able to edit this proposal during the first %{count} minutes after the proposal is published. Once this time window passes, you will not be able to edit the proposal.
           publish: Publish
           title: Publish your proposal
         proposal:
@@ -711,8 +604,7 @@ en:
           hidden_endorsers_count:
             one: and 1 more person
             other: and %{count} more people
-          link_to_collaborative_draft_help_text: This proposal is the result of a
-            collaborative draft. Review the history
+          link_to_collaborative_draft_help_text: This proposal is the result of a collaborative draft. Review the history
           link_to_collaborative_draft_text: See the collaborative draft
           proposal_accepted_reason: 'This proposal has been accepted because:'
           proposal_in_evaluation_reason: This proposal is being evaluated
@@ -721,9 +613,7 @@ en:
           sign_in: Sign in
           sign_in_or_up: "%{in} or %{up} to participate"
           sign_up: sign up
-          withdraw_btn_hint: You can withdraw your proposal if you change your mind,
-            as long as you have not received any support. The proposal is not deleted,
-            it will appear in the list of withdrawn proposals.
+          withdraw_btn_hint: You can withdraw your proposal if you change your mind, as long as you have not received any support. The proposal is not deleted, it will appear in the list of withdrawn proposals.
           withdraw_confirmation: Are you sure to withdraw this proposal?
           withdraw_proposal: Withdraw proposal
         tags:
@@ -746,16 +636,13 @@ en:
           can_accumulate_supports_beyond_threshold:
             description: Each proposal can accumulate more than %{limit} supports
           minimum_votes_per_user:
-            description: You must distribute a minimum of 3 votes among different
-              proposals.
+            description: You must distribute a minimum of 3 votes among different proposals.
             given_enough_votes: You've given enough supports.
-            supports_remaining: You have to vote %{remaining_votes} more proposals
-              for your votes to be taken into account.
+            supports_remaining: You have to vote %{remaining_votes} more proposals for your votes to be taken into account.
           proposal_limit:
             description: You can create up to %{limit} proposals.
           threshold_per_proposal:
-            description: In order to be validated proposals need to reach %{limit}
-              supports
+            description: In order to be validated proposals need to reach %{limit} supports
           title: 'Voting is subject to the following rules:'
           vote_limit:
             description: You can vote up to %{limit} proposals.

--- a/decidim-proposals/lib/decidim/proposals/admin_engine.rb
+++ b/decidim-proposals/lib/decidim/proposals/admin_engine.rb
@@ -15,6 +15,7 @@ module Decidim
           collection do
             resource :proposals_import, only: [:new, :create]
             resource :proposals_merge, only: [:create]
+            resource :proposals_split, only: [:create]
           end
           resources :proposal_answers, only: [:edit, :update]
           resources :proposal_notes, only: [:index, :create]

--- a/decidim-proposals/lib/decidim/proposals/admin_engine.rb
+++ b/decidim-proposals/lib/decidim/proposals/admin_engine.rb
@@ -14,6 +14,7 @@ module Decidim
           post :update_category, on: :collection
           collection do
             resource :proposals_import, only: [:new, :create]
+            resource :proposals_merge, only: [:create]
           end
           resources :proposal_answers, only: [:edit, :update]
           resources :proposal_notes, only: [:index, :create]

--- a/decidim-proposals/lib/decidim/proposals/markdown_to_proposals.rb
+++ b/decidim-proposals/lib/decidim/proposals/markdown_to_proposals.rb
@@ -13,9 +13,10 @@ module Decidim
     #
     class MarkdownToProposals < ::Redcarpet::Render::Base
       # Public: Initializes the serializer with a proposal.
-      def initialize(component)
+      def initialize(component, current_user)
         super()
         @component = component
+        @current_user = current_user
         @last_position = 0
         @num_sections = 0
       end
@@ -67,14 +68,18 @@ module Decidim
       private
 
       def create_proposal(title, body, participatory_text_level)
-        proposal = Decidim::Proposals::Proposal.new(
+        attributes = {
           component: @component,
           title: title,
           body: body,
           participatory_text_level: participatory_text_level
+        }
+
+        proposal = Decidim::Proposals::ProposalBuilder.create(
+          attributes: attributes,
+          author: @component.organization,
+          action_user: @current_user
         )
-        proposal.add_coauthor(@component.organization)
-        proposal.save!
 
         @last_position = proposal.position
 

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/import_participatory_text_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/import_participatory_text_spec.rb
@@ -21,6 +21,7 @@ module Decidim
               title: {},
               description: {},
               document_text: document_file,
+              current_user: create(:user),
               valid?: valid
             )
           end

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/import_proposals_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/import_proposals_spec.rb
@@ -20,6 +20,7 @@ module Decidim
               origin_component: proposal.component,
               current_component: current_component,
               states: states,
+              current_user: create(:user),
               valid?: valid
             )
           end

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/merge_proposals_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/merge_proposals_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Proposals
+    module Admin
+      describe MergeProposals do
+        describe "call" do
+          let!(:proposals) { create_list(:proposal, 3, component: current_component) }
+          let!(:current_component) { create(:proposal_component) }
+          let!(:target_component) { create(:proposal_component, participatory_space: current_component.participatory_space) }
+          let(:form) do
+            instance_double(
+              ProposalsMergeForm,
+              current_component: current_component,
+              current_organization: current_component.organization,
+              target_component: target_component,
+              proposals: proposals,
+              valid?: valid,
+              current_user: create(:user, :admin, organization: current_component.organization)
+            )
+          end
+          let(:command) { described_class.new(form) }
+
+          describe "when the form is not valid" do
+            let(:valid) { false }
+
+            it "broadcasts invalid" do
+              expect { command.call }.to broadcast(:invalid)
+            end
+
+            it "doesn't create the proposal" do
+              expect do
+                command.call
+              end.to change(Proposal, :count).by(0)
+            end
+          end
+
+          describe "when the form is valid" do
+            let(:valid) { true }
+
+            it "broadcasts ok" do
+              expect { command.call }.to broadcast(:ok)
+            end
+
+            it "creates a proposal in the new component" do
+              expect do
+                command.call
+              end.to change { Proposal.where(component: target_component).count }.by(1)
+            end
+
+            it "links the proposals" do
+              command.call
+              proposal = Proposal.where(component: target_component).last
+
+              linked = proposal.linked_resources(:proposals, "copied_from_component")
+
+              expect(linked).to match_array(proposals)
+            end
+
+            it "only merges wanted attributes" do
+              command.call
+              new_proposal = Proposal.where(component: target_component).last
+              proposal = proposals.first
+
+              expect(new_proposal.title).to eq(proposal.title)
+              expect(new_proposal.body).to eq(proposal.body)
+              expect(new_proposal.creator_author).to eq(current_component.organization)
+              expect(new_proposal.category).to eq(proposal.category)
+
+              expect(new_proposal.state).to be_nil
+              expect(new_proposal.answer).to be_nil
+              expect(new_proposal.answered_at).to be_nil
+              expect(new_proposal.reference).not_to eq(proposal.reference)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/split_proposals_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/split_proposals_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Proposals
+    module Admin
+      describe SplitProposals do
+        describe "call" do
+          let!(:proposal) { create(:proposal, component: current_component) }
+          let!(:current_component) { create(:proposal_component) }
+          let!(:target_component) { create(:proposal_component, participatory_space: current_component.participatory_space) }
+          let(:form) do
+            instance_double(
+              ProposalsSplitForm,
+              current_component: current_component,
+              current_organization: current_component.organization,
+              target_component: target_component,
+              proposals: [proposal],
+              valid?: valid,
+              current_user: create(:user, :admin, organization: current_component.organization)
+            )
+          end
+          let(:command) { described_class.new(form) }
+
+          describe "when the form is not valid" do
+            let(:valid) { false }
+
+            it "broadcasts invalid" do
+              expect { command.call }.to broadcast(:invalid)
+            end
+
+            it "doesn't create the proposal" do
+              expect do
+                command.call
+              end.to change(Proposal, :count).by(0)
+            end
+          end
+
+          describe "when the form is valid" do
+            let(:valid) { true }
+
+            it "broadcasts ok" do
+              expect { command.call }.to broadcast(:ok)
+            end
+
+            it "creates two proposals for each original in the new component" do
+              expect do
+                command.call
+              end.to change { Proposal.where(component: target_component).count }.by(2)
+            end
+
+            it "links the proposals" do
+              command.call
+              new_proposals = Proposal.where(component: target_component)
+
+              linked = proposal.linked_resources(:proposals, "copied_from_component")
+
+              expect(linked).to match_array(new_proposals)
+            end
+
+            it "only copies wanted attributes" do
+              command.call
+              new_proposal = Proposal.where(component: target_component).last
+
+              expect(new_proposal.title).to eq(proposal.title)
+              expect(new_proposal.body).to eq(proposal.body)
+              expect(new_proposal.creator_author).to eq(current_component.organization)
+              expect(new_proposal.category).to eq(proposal.category)
+
+              expect(new_proposal.state).to be_nil
+              expect(new_proposal.answer).to be_nil
+              expect(new_proposal.answered_at).to be_nil
+              expect(new_proposal.reference).not_to eq(proposal.reference)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/forms/decidim/proposals/admin/propoals_split_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/admin/propoals_split_form_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Proposals
+    module Admin
+      describe ProposalsSplitForm do
+        subject { form }
+
+        let(:proposals) { create_list(:proposal, 2, component: component) }
+        let(:component) { create(:proposal_component) }
+        let(:target_component) { create(:proposal_component, participatory_space: component.participatory_space) }
+        let(:params) do
+          {
+            target_component_id: target_component.try(:id),
+            proposal_ids: proposals.map(&:id)
+          }
+        end
+
+        let(:form) do
+          described_class.from_params(params).with_context(
+            current_component: component,
+            current_participatory_space: component.participatory_space
+          )
+        end
+
+        context "when everything is OK" do
+          it { is_expected.to be_valid }
+        end
+
+        context "without a target component" do
+          let(:target_component) { nil }
+
+          it { is_expected.to be_invalid }
+        end
+
+        context "when not enough proposals" do
+          let(:proposals) { [] }
+
+          it { is_expected.to be_invalid }
+        end
+
+        context "when given a target component from another space" do
+          let(:target_component) { create(:proposal_component) }
+
+          it { is_expected.to be_invalid }
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/forms/decidim/proposals/admin/proposals_merge_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/admin/proposals_merge_form_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Proposals
+    module Admin
+      describe ProposalsMergeForm do
+        subject { form }
+
+        let(:proposals) { create_list(:proposal, 3, component: component) }
+        let(:component) { create(:proposal_component) }
+        let(:target_component) { create(:proposal_component, participatory_space: component.participatory_space) }
+        let(:params) do
+          {
+            target_component_id: target_component.try(:id),
+            proposal_ids: proposals.map(&:id)
+          }
+        end
+
+        let(:form) do
+          described_class.from_params(params).with_context(
+            current_component: component,
+            current_participatory_space: component.participatory_space
+          )
+        end
+
+        context "when everything is OK" do
+          it { is_expected.to be_valid }
+        end
+
+        context "without a target component" do
+          let(:target_component) { nil }
+
+          it { is_expected.to be_invalid }
+        end
+
+        context "when not enough proposals" do
+          let(:proposals) { create_list(:proposal, 1, component: component) }
+
+          it { is_expected.to be_invalid }
+        end
+
+        context "when given a target component from another space" do
+          let(:target_component) { create(:proposal_component) }
+
+          it { is_expected.to be_invalid }
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/lib/decidim/proposals/markdown_to_proposals_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/markdown_to_proposals_spec.rb
@@ -17,7 +17,7 @@ module Decidim
       end
 
       let!(:component) { create(:proposal_component) }
-      let(:parser) { MarkdownToProposals.new(component) }
+      let(:parser) { MarkdownToProposals.new(component, create(:user)) }
       let(:items) { [] }
       let(:document) do
         items.join("\n")

--- a/decidim-proposals/spec/shared/manage_proposals_category_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_category_examples.rb
@@ -18,11 +18,11 @@ shared_examples "when managing proposals category as an admin" do
 
     context "when selecting proposals" do
       before do
-        page.find("#proposals_recategorize.js-check-all").set(true)
+        page.find("#proposals_bulk.js-check-all").set(true)
       end
 
       it "shows the number of selected proposals" do
-        expect(page).to have_css("span#js-recategorize-proposals-count", count: 1)
+        expect(page).to have_css("span#js-selected-proposals-count", count: 1)
       end
 
       it "shows the bulk actions button" do

--- a/decidim-proposals/spec/shared/merge_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/merge_proposals_examples.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+shared_examples "merge proposals" do
+  let!(:proposals) { create_list :proposal, 3, component: current_component }
+  let!(:target_component) { create :proposal_component, participatory_space: current_component.participatory_space }
+  include Decidim::ComponentPathHelper
+
+  context "when selecting proposals" do
+    before do
+      visit current_path
+      page.find("#proposals_bulk.js-check-all").set(true)
+    end
+
+    context "when click the bulk action button" do
+      before do
+        click_button "Actions"
+      end
+
+      it "shows the change action option" do
+        expect(page).to have_selector(:link_or_button, "Merge into a new one")
+      end
+
+      context "when less than one proposal is checked" do
+        before do
+          page.find("#proposals_bulk.js-check-all").set(false)
+          page.first(".js-proposal-list-check").set(true)
+        end
+
+        it "does not show the merge action option" do
+          expect(page).to have_no_selector(:link_or_button, "Merge into a new one")
+        end
+      end
+    end
+
+    context "when merge into a new one is selected from the actions dropdown" do
+      before do
+        click_button "Actions"
+        click_button "Merge into a new one"
+      end
+
+      it "shows the component select" do
+        expect(page).to have_css("#js-form-merge-proposals select", count: 1)
+      end
+
+      it "shows an update button" do
+        expect(page).to have_css("button#js-submit-merge-proposals", count: 1)
+      end
+
+      context "when submiting the form" do
+        before do
+          within "#js-form-merge-proposals" do
+            select translated(target_component.name), from: :target_component_id_
+            page.find("button#js-submit-merge-proposals").click
+          end
+        end
+
+        it "creates a new proposal" do
+          expect(page).to have_content("Successfully merged the proposals into a new one")
+          expect(page).to have_css(".table-list tbody tr", count: 1)
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/shared/split_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/split_proposals_examples.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+shared_examples "split proposals" do
+  let!(:proposals) { create_list :proposal, 3, component: current_component }
+  let!(:target_component) { create :proposal_component, participatory_space: current_component.participatory_space }
+  include Decidim::ComponentPathHelper
+
+  context "when selecting proposals" do
+    before do
+      visit current_path
+      page.find("#proposals_bulk.js-check-all").set(true)
+    end
+
+    context "when click the bulk action button" do
+      before do
+        click_button "Actions"
+      end
+
+      it "shows the change action option" do
+        expect(page).to have_selector(:link_or_button, "Split proposals")
+      end
+    end
+
+    context "when split into a new one is selected from the actions dropdown" do
+      before do
+        page.find("#proposals_bulk.js-check-all").set(false)
+        page.first(".js-proposal-list-check").set(true)
+
+        click_button "Actions"
+        click_button "Split proposals"
+      end
+
+      it "shows the component select" do
+        expect(page).to have_css("#js-form-split-proposals select", count: 1)
+      end
+
+      it "shows an update button" do
+        expect(page).to have_css("button#js-submit-split-proposals", count: 1)
+      end
+
+      context "when submiting the form" do
+        before do
+          within "#js-form-split-proposals" do
+            select translated(target_component.name), from: :target_component_id_
+            page.find("button#js-submit-split-proposals").click
+          end
+        end
+
+        it "creates a new proposal" do
+          expect(page).to have_content("Successfully splitted the proposals into new ones")
+          expect(page).to have_css(".table-list tbody tr", count: 2)
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/system/admin_manages_proposals_spec.rb
+++ b/decidim-proposals/spec/system/admin_manages_proposals_spec.rb
@@ -22,4 +22,5 @@ describe "Admin manages proposals", type: :system do
   it_behaves_like "import proposals"
   it_behaves_like "manage proposals permissions"
   it_behaves_like "merge proposals"
+  it_behaves_like "split proposals"
 end

--- a/decidim-proposals/spec/system/admin_manages_proposals_spec.rb
+++ b/decidim-proposals/spec/system/admin_manages_proposals_spec.rb
@@ -21,4 +21,5 @@ describe "Admin manages proposals", type: :system do
   it_behaves_like "when managing proposals category as an admin"
   it_behaves_like "import proposals"
   it_behaves_like "manage proposals permissions"
+  it_behaves_like "merge proposals"
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Adds two features so admins can select different proposals and either merge them into a single one or split each of them to a new proposals component in the same participatory space.

I also refactored how we create proposals, since it was spread in different parts of the project.

#### :pushpin: Related Issues

- Fixes #1970 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
