### PR TITLE
Fix commented_debates badge

### DIFF
--- a/decidim-debates/lib/decidim/debates/engine.rb
+++ b/decidim-debates/lib/decidim/debates/engine.rb
@@ -31,6 +31,10 @@ module Decidim
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Debates::Engine.root}/app/views") # for partials
       end
 
+      initializer "decidim_debates.assets" do |app|
+        app.config.assets.precompile += %w(decidim_debates_manifest.js)
+      end
+
       initializer "decidim.debates.commented_debates_badge" do
         Decidim::Gamification.register_badge(:commented_debates) do |badge|
           badge.levels = [1, 5, 10, 30, 50]


### PR DESCRIPTION
#### :tophat: What? Why?
Hopefully fixes the last missing asset on the pipeline. `sprockets` really is annoying when it comes to linking assets.

#### :pushpin: Related Issues
- Related to #4043 

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*
