### PR TITLE
Let admins edit official proposals if they have no supports

### DIFF
--- a/decidim-proposals/app/permissions/decidim/proposals/admin/permissions.rb
+++ b/decidim-proposals/app/permissions/decidim/proposals/admin/permissions.rb
@@ -55,7 +55,7 @@ module Decidim
 
         def admin_edition_is_available?
           return unless proposal
-          admin_creation_is_enabled? && proposal.official? && proposal.within_edit_time_limit?
+          admin_creation_is_enabled? && proposal.official? && proposal.votes.empty?
         end
 
         def admin_proposal_answering_is_enabled?

--- a/decidim-proposals/spec/permissions/decidim/proposals/admin/permissions_spec.rb
+++ b/decidim-proposals/spec/permissions/decidim/proposals/admin/permissions_spec.rb
@@ -81,11 +81,6 @@ describe Decidim::Proposals::Admin::Permissions do
 
     context "when the proposal is official" do
       let(:proposal) { create :proposal, :official, component: current_component }
-      let(:within_edit_time_limit?) { true }
-
-      before do
-        allow(proposal).to receive(:within_edit_time_limit?).and_return(within_edit_time_limit?)
-      end
 
       context "when everything is OK" do
         it { is_expected.to eq true }
@@ -97,8 +92,10 @@ describe Decidim::Proposals::Admin::Permissions do
         it_behaves_like "permission is not set"
       end
 
-      context "when outside the edit time limit" do
-        let(:within_edit_time_limit?) { false }
+      context "when it has some votes" do
+        before do
+          create :proposal_vote, proposal: proposal
+        end
 
         it_behaves_like "permission is not set"
       end

--- a/decidim-proposals/spec/system/admin_edits_proposal_spec.rb
+++ b/decidim-proposals/spec/system/admin_edits_proposal_spec.rb
@@ -43,6 +43,22 @@ describe "Admin edits proposals", type: :system do
       end
     end
 
+    context "when the proposal has some votes" do
+      before do
+        create :proposal_vote, proposal: proposal
+      end
+
+      it "doesn't let the user edit it" do
+        visit_component_admin
+
+        expect(page).to have_content(proposal.title)
+        expect(page).to have_no_css("a.action-icon--edit-proposal")
+        visit current_path + "proposals/#{proposal.id}/edit"
+
+        expect(page).to have_content("not authorized")
+      end
+    end
+
     context "when updating with wrong data" do
       let(:component) { create(:proposal_component, :with_creation_enabled, :with_attachments_allowed, participatory_space: participatory_process) }
 
@@ -67,20 +83,6 @@ describe "Admin edits proposals", type: :system do
       visit_component_admin
 
       expect(page).to have_content(proposal.title)
-      expect(page).to have_no_css("a.action-icon--edit-proposal")
-      visit current_path + "proposals/#{proposal.id}/edit"
-
-      expect(page).to have_content("not authorized")
-    end
-  end
-
-  describe "editing my proposal outside the time limit" do
-    let!(:proposal) { create :proposal, :official, component: component, updated_at: 1.hour.ago }
-
-    it "renders an error" do
-      visit_component_admin
-
-      expect(page).to have_text(proposal.title)
       expect(page).to have_no_css("a.action-icon--edit-proposal")
       visit current_path + "proposals/#{proposal.id}/edit"
 


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes #1872. 

It is an evolution of #4150, which was merged a month ago. Until now, admins could edit official proposals within the same time limit as the users. now they can edit any official proposal until it has some supports/votes. 

#### :pushpin: Related Issues
- Fixes #1872

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Fix permissions to let admins edit official proposals until they have a support
- [ ] Remove callout from creation page
- [ ] Ensure an admin log is created

### :camera: Screenshots (optional)
![Description](URL)
