### PR TITLE
Replace organization with group in locales

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -18,14 +18,14 @@ en:
     models:
       decidim/attachment_created_event: Attachment
       decidim/component_published_event: Active component
-      decidim/demoted_membership: No longer an organization admin
+      decidim/demoted_membership: No longer a group admin
       decidim/gamification/badge_earned_event: Badge earned
       decidim/gamification/level_up_event: You've leveled up
       decidim/join_request_accepted_event: Join request accepted
       decidim/join_request_rejected_event: Join request rejected
       decidim/profile_updated_event: Profile updated
-      decidim/promote_to_admin: Promoted to organization admin
-      decidim/removed_from_group: Removed from organization
+      decidim/promote_to_admin: Promoted to group admin
+      decidim/removed_from_group: Removed from group
   activerecord:
     attributes:
       decidim/user:
@@ -354,40 +354,40 @@ en:
           notification_title: Great job! You've reached level %{current_level} on the <a href="%{resource_path}">%{badge_name} badge</a>!
       groups:
         demoted_membership:
-          email_intro: An admin of the <a href="%{resource_url}">%{user_group_name}</a> organization has removed your admin rights to that organization.
-          email_outro: You have received this notification because you are a member of that organization.
-          email_subject: You are no longer an admin of the %{user_group_name} organization!
-          notification_title: You are no longer an admin of the <a href="%{resource_path}">%{user_group_name}</a> organization.
+          email_intro: An admin of the <a href="%{resource_url}">%{user_group_name}</a> group has removed your admin rights to that group.
+          email_outro: You have received this notification because you are a member of that group.
+          email_subject: You are no longer an admin of the %{user_group_name} group!
+          notification_title: You are no longer an admin of the <a href="%{resource_path}">%{user_group_name}</a> group.
         invited_to_group:
-          email_intro: An admin of the <a href="%{resource_url}">%{user_group_name}</a> organization has invited you to join it.
-          email_outro: You have received this notification because you have been invited to an organization. Please check the Organizations tab in your profile to approve it.
-          email_subject: You have been invited to join the %{user_group_name} organization!
-          notification_title: You have been invited to join the <a href="%{resource_path}">%{user_group_name}</a> organization. Check the <a href="%{groups_profile_tab_path}">Organizations page</a> in your profile to approve it!
+          email_intro: An admin of the <a href="%{resource_url}">%{user_group_name}</a> group has invited you to join it.
+          email_outro: You have received this notification because you have been invited to an group. Please check the Groups tab in your profile to approve it.
+          email_subject: You have been invited to join the %{user_group_name} group!
+          notification_title: You have been invited to join the <a href="%{resource_path}">%{user_group_name}</a> group. Check the <a href="%{groups_profile_tab_path}">Groups page</a> in your profile to approve it!
         join_request_accepted:
-          email_intro: Congratulations! An admin of the <a href="%{resource_url}">%{user_group_name}</a> organization has accepted your request to join it.
+          email_intro: Congratulations! An admin of the <a href="%{resource_url}">%{user_group_name}</a> group has accepted your request to join it.
           email_outro: You have received this notification because your join request has been updated.
-          email_subject: You have been accepted to the %{user_group_name} organization!
-          notification_title: You have been accepted to the <a href="%{resource_path}">%{user_group_name}</a> organization.
+          email_subject: You have been accepted to the %{user_group_name} group!
+          notification_title: You have been accepted to the <a href="%{resource_path}">%{user_group_name}</a> group.
         join_request_created:
-          email_intro: Someone requested to join the %{user_group_name} organization. You can accept or reject it from <a href="%{resource_url}">the organization members page</a>.
-          email_outro: You have received this notification because you can manage the %{user_group_name} organization.
-          email_subject: Someone requested to join the %{user_group_name} organization!
-          notification_title: Someone requested to join the %{user_group_name} organization. You can accept or reject it from <a href="%{resource_path}">the organization members page</a>.
+          email_intro: Someone requested to join the %{user_group_name} group. You can accept or reject it from <a href="%{resource_url}">the group members page</a>.
+          email_outro: You have received this notification because you can manage the %{user_group_name} group.
+          email_subject: Someone requested to join the %{user_group_name} group!
+          notification_title: Someone requested to join the %{user_group_name} group. You can accept or reject it from <a href="%{resource_path}">the group members page</a>.
         join_request_rejected:
-          email_intro: An admin of the <a href="%{resource_url}">%{user_group_name}</a> organization rejected your request to join it.
+          email_intro: An admin of the <a href="%{resource_url}">%{user_group_name}</a> group rejected your request to join it.
           email_outro: You have received this notification because your join request has been updated.
-          email_subject: Your request to join the %{user_group_name} organization has been rejected!
-          notification_title: Your request to join the <a href="%{resource_path}">%{user_group_name}</a> organization has been rejected.
+          email_subject: Your request to join the %{user_group_name} group has been rejected!
+          notification_title: Your request to join the <a href="%{resource_path}">%{user_group_name}</a> group has been rejected.
         promoted_to_admin:
-          email_intro: An admin of the <a href="%{resource_url}">%{user_group_name}</a> organization has given you admin rights to that organization.
-          email_outro: You have received this notification because you are a member of that organization.
-          email_subject: You are now an admin of the %{user_group_name} organization!
-          notification_title: You are now an admin of the <a href="%{resource_path}">%{user_group_name}</a> organization.
+          email_intro: An admin of the <a href="%{resource_url}">%{user_group_name}</a> group has given you admin rights to that group.
+          email_outro: You have received this notification because you are a member of that group.
+          email_subject: You are now an admin of the %{user_group_name} group!
+          notification_title: You are now an admin of the <a href="%{resource_path}">%{user_group_name}</a> group.
         removed_from_group:
-          email_intro: An admin of the <a href="%{resource_url}">%{user_group_name}</a> organization has removed you from it.
-          email_outro: You have received this notification because you were a member of that organization.
-          email_subject: You have been removed from the %{user_group_name} organization!
-          notification_title: You have been removed from the <a href="%{resource_path}">%{user_group_name}</a> organization.
+          email_intro: An admin of the <a href="%{resource_url}">%{user_group_name}</a> group has removed you from it.
+          email_outro: You have received this notification because you were a member of that group.
+          email_subject: You have been removed from the %{user_group_name} group!
+          notification_title: You have been removed from the <a href="%{resource_path}">%{user_group_name}</a> group.
       notification_event:
         notification_title: An event occured to <a href="%{resource_path}">%{resource_title}</a>.
       users:
@@ -483,10 +483,10 @@ en:
       reached_top: You've reached the top level for this badge.
     group_admins:
       actions:
-        are_you_sure: Are you sure? This won't remove the user from the organization.
+        are_you_sure: Are you sure? This won't remove the user from the group.
         demote_admin: Remove admin
       demote:
-        error: There was an error removing this user fmor the admins list
+        error: There was an error removing this user from the admins list
         success: User removed from admin successfully
       index:
         current_admins: 'Current admins:'
@@ -496,7 +496,7 @@ en:
         error: There was an error accepting this invitation
         success: Invitation accepted successfully
       accept_invitation: Accept
-      accept_or_reject_group_invitations: 'The following organizations have invited you to join them. Accept or reject their requests:'
+      accept_or_reject_group_invitations: 'The following groups have invited you to join them. Accept or reject their requests:'
       index:
         invite: Invite
         invite_user: Invite a user
@@ -531,32 +531,32 @@ en:
       actions:
         are_you_sure: Are you sure?
       create:
-        error: There has been a problem creating the organization
-        success: Organization created successfully
+        error: There has been a problem creating the group
+        success: Group created successfully
       edit:
-        edit_user_group: Edit organization
-        update_user_group: Update organization
+        edit_user_group: Edit group
+        update_user_group: Update group
       join:
-        error: There has been a problem joining the organization
-        success: Join request created successfully. An admin will review your request before accepting you to the organization.
+        error: There has been a problem joining the group
+        success: Join request created successfully. An admin will review your request before accepting you to the group.
       leave:
-        error: There has been a problem leaving the organization
-        success: Organization left successfully.
+        error: There has been a problem leaving the group
+        success: Group left successfully.
       members:
         accept_or_reject_join_requests: 'The following users have applied to join this group. Accept or reject their requests:'
         accept_request: Accept
         reject_request: Reject
       new:
-        create_user_group: Create organization
-        new_user_group: New organization
-      no_user_groups: Doesn't belong to any organization yet.
+        create_user_group: Create group
+        new_user_group: New group
+      no_user_groups: Doesn't belong to any group yet.
       roles:
         admin: Administrator
         creator: Creator
         member: Member
       update:
-        error: There has been a problem updating the organization
-        success: Organization updated successfully
+        error: There has been a problem updating the group
+        success: Group updated successfully
     invitations:
       create:
         error: There were some problems while inviting your friends
@@ -749,7 +749,7 @@ en:
         conversations: Conversations
         followers: Followers
         following: Follows
-        groups: Organizations
+        groups: Groups
         members: Members
         notifications: Notifications
       sidebar:
@@ -757,12 +757,12 @@ en:
           info: Badges are earned by performing specific activity in the platform.
           title: Badges
       user:
-        create_user_group: Create organization
+        create_user_group: Create group
         edit_profile: Edit profile
-        edit_user_group: Edit organization profile
+        edit_user_group: Edit group profile
         invite_user: Invite user
-        join_user_group: Request to join organization
-        leave_user_group: Leave organization
+        join_user_group: Request to join group
+        leave_user_group: Leave group
         manage_user_group_admins: Manage admins
         manage_user_group_users: Manage members
     reported_mailer:
@@ -1040,7 +1040,7 @@ en:
         my_data: My data
         notifications_settings: Notifications settings
         title: User settings
-        user_groups: Organizations
+        user_groups: Groups
       widget:
         see_more: See more
   locale:

--- a/decidim-core/spec/system/user_group_creation_spec.rb
+++ b/decidim-core/spec/system/user_group_creation_spec.rb
@@ -13,7 +13,7 @@ describe "User group creation", type: :system do
   end
 
   it "creates a user group for the current user" do
-    click_link "Create organization"
+    click_link "Create group"
 
     fill_in "Name", with: "My super user group"
     fill_in "Nickname", with: "my_usergroup"
@@ -24,7 +24,7 @@ describe "User group creation", type: :system do
 
     attach_file "Avatar", Decidim::Dev.asset("avatar.jpg")
 
-    click_button "Create organization"
+    click_button "Create group"
 
     expect(page).to have_content("My super user group")
     expect(page).to have_content("@my_usergroup")

--- a/decidim-core/spec/system/user_group_joining_spec.rb
+++ b/decidim-core/spec/system/user_group_joining_spec.rb
@@ -16,16 +16,16 @@ describe "User group joining", type: :system do
     let!(:user_group) { create(:user_group, users: [user], organization: user.organization) }
 
     it "does not show the link to join" do
-      expect(page).to have_no_content("Request to join organization")
+      expect(page).to have_no_content("Request to join group")
     end
   end
 
   context "when the user does not belong to the group" do
     it "allows the user to join" do
-      click_link "Request to join organization"
+      click_link "Request to join group"
 
       expect(page).to have_content("Join request created successfully")
-      expect(page).to have_no_content("Request to join organization")
+      expect(page).to have_no_content("Request to join group")
     end
   end
 end

--- a/decidim-core/spec/system/user_group_leaving_spec.rb
+++ b/decidim-core/spec/system/user_group_leaving_spec.rb
@@ -17,7 +17,7 @@ describe "User group leaving", type: :system do
       let!(:user_group) { create(:user_group, users: [user], organization: user.organization) }
 
       it "does not show the link to leave" do
-        expect(page).to have_no_content("Leave organization")
+        expect(page).to have_no_content("Leave group")
       end
     end
 
@@ -25,16 +25,16 @@ describe "User group leaving", type: :system do
       create :user_group_membership, user: user, user_group: user_group, role: :admin
       visit decidim.profile_path(user_group.nickname)
 
-      accept_confirm { click_link "Leave organization" }
+      accept_confirm { click_link "Leave group" }
 
-      expect(page).to have_content("Organization left successfully")
-      expect(page).to have_content("Request to join organization")
+      expect(page).to have_content("Group left successfully")
+      expect(page).to have_content("Request to join group")
     end
   end
 
   context "when the user does not belong to the group" do
     it "does not show the link to leave" do
-      expect(page).to have_no_content("Leave organization")
+      expect(page).to have_no_content("Leave group")
     end
   end
 end

--- a/decidim-core/spec/system/user_group_profile_edition_spec.rb
+++ b/decidim-core/spec/system/user_group_profile_edition_spec.rb
@@ -20,7 +20,7 @@ describe "User group profile edition", type: :system do
     end
 
     it "does not show the link to edit" do
-      expect(page).to have_no_content("Edit organization profile")
+      expect(page).to have_no_content("Edit group profile")
     end
 
     it "rejects the user that accesses manually" do
@@ -36,16 +36,16 @@ describe "User group profile edition", type: :system do
     end
 
     it "allows editing the profile" do
-      expect(page).to have_content("Edit organization profile")
-      click_link "Edit organization profile"
+      expect(page).to have_content("Edit group profile")
+      click_link "Edit group profile"
 
       fill_in "Name", with: "My super duper group"
       fill_in "About", with: "We are awesome"
       attach_file "Avatar", Decidim::Dev.asset("city.jpeg")
 
-      click_button "Update organization"
+      click_button "Update group"
 
-      expect(page).to have_content("Organization updated successfully")
+      expect(page).to have_content("Group updated successfully")
       expect(page).to have_content("My super duper group")
       expect(page).to have_content("We are awesome")
     end

--- a/decidim-core/spec/system/user_groups_verification_status_on_account_page_spec.rb
+++ b/decidim-core/spec/system/user_groups_verification_status_on_account_page_spec.rb
@@ -18,7 +18,7 @@ describe "User group verification status on account page", type: :system do
     it "the user can check its status on his account page" do
       visit decidim.own_user_groups_path
 
-      click_link "Organizations"
+      click_link "Groups"
 
       expect(page).to have_content(user_group.name)
       expect(page).to have_content("Pending")
@@ -37,7 +37,7 @@ describe "User group verification status on account page", type: :system do
     it "the user can check its status on his account page" do
       visit decidim.own_user_groups_path
 
-      click_link "Organizations"
+      click_link "Groups"
 
       expect(page).to have_content(user_group.name)
       expect(page).to have_content("Rejected")
@@ -50,7 +50,7 @@ describe "User group verification status on account page", type: :system do
     it "the user can check its status on his account page" do
       visit decidim.own_user_groups_path
 
-      click_link "Organizations"
+      click_link "Groups"
 
       expect(page).to have_content(user_group.name)
       expect(page).to have_content("Verified")

--- a/decidim-core/spec/system/user_profile_spec.rb
+++ b/decidim-core/spec/system/user_profile_spec.rb
@@ -146,7 +146,7 @@ describe "Profile", type: :system do
       end
 
       it "lists the user groups" do
-        click_link "Organizations"
+        click_link "Groups"
 
         expect(page).to have_content(accepted_user_group.name)
         expect(page).to have_no_content(pending_user_group.name)


### PR DESCRIPTION
#### :tophat: What? Why?
This PR improves locales by replacing "organization" with "group" when refering to `Decidim::UserGroup`s

#### :pushpin: Related Issues
- Related to #3893

#### :clipboard: Subtasks
None