### PR TITLE
add paginate on admin assembly members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 
 **Fixed**:
 
+- **decidim-assemblies**: Add paginate on admin site assembly members. [\#4369](https://github.com/decidim/decidim/pull/4369)
 - **decidim-admin**: Adds traceability when creating and deleting Participatory Space private user [\#4332](https://github.com/decidim/decidim/pull/4332)
 - **decidim-proposals**: Rework URL_REGEX regular expression so that it is more restrictive for general URIs causing problems with Scandinavian locales. [\4290](https://github.com/decidim/decidim/pull/4290)
 - **decidim-accountability**: Fix inclusion of ApplicationHelper in results controller. [\#4272](https://github.com/decidim/decidim/pull/4272)

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/index.html.erb
@@ -86,6 +86,7 @@
           <% end %>
         </tbody>
       </table>
+      <%= paginate @assembly_members, theme: "decidim" %>
     </div>
   </div>
 </div>

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/index.html.erb
@@ -23,7 +23,7 @@
       <div class="filters__search">
         <div class="input-group">
           <%= search_field_tag :q, @query,label: false, class: "input-group-field", placeholder: t(".search") %>
-          <%= hidden_field_tag :state, @state %>
+          <%= hidden_field_tag :status, @status %>
           <div class="input-group-button">
             <button type="submit" class="button button--muted">
               <%= icon "magnifying-glass", aria_label: t(".search") %>

--- a/decidim-assemblies/spec/shared/manage_assembly_members_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assembly_members_examples.rb
@@ -131,14 +131,4 @@ shared_examples "manage assembly members examples" do
       expect(page).to have_css(resource_selector, count: 5)
     end
   end
-
-  # context "with few members" do
-  #   let!(:assembly_member) { create(:assembly_member, assembly: assembly) }
-  #
-  #   it "shows assembly members list" do
-  #     within "#assembly_members table" do
-  #       expect(page).to have_content(assembly_member.full_name)
-  #     end
-  #   end
-  # end
 end

--- a/decidim-assemblies/spec/shared/manage_assembly_members_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assembly_members_examples.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 shared_examples "manage assembly members examples" do
-  let!(:assembly_member) { create(:assembly_member, assembly: assembly) }
-
   before do
     switch_to_host(organization.host)
     login_as user, scope: :user
@@ -10,13 +8,9 @@ shared_examples "manage assembly members examples" do
     click_link "Members"
   end
 
-  it "shows assembly members list" do
-    within "#assembly_members table" do
-      expect(page).to have_content(assembly_member.full_name)
-    end
-  end
-
   context "without existing user" do
+    let!(:assembly_member) { create(:assembly_member, assembly: assembly) }
+
     it "creates a new assembly member" do
       find(".card-title a.new").click
 
@@ -71,8 +65,16 @@ shared_examples "manage assembly members examples" do
   end
 
   describe "when managing other assembly members" do
+    let!(:assembly_member) { create(:assembly_member, assembly: assembly) }
+
     before do
       visit current_path
+    end
+
+    it "shows assembly members list" do
+      within "#assembly_members table" do
+        expect(page).to have_content(assembly_member.full_name)
+      end
     end
 
     it "updates an assembly member" do
@@ -109,4 +111,34 @@ shared_examples "manage assembly members examples" do
       end
     end
   end
+
+  context "when paginating" do
+    let!(:collection_size) { 20 }
+    let!(:collection) { create_list(:assembly_member, collection_size, assembly: assembly) }
+    let!(:resource_selector) { "#assembly_members tbody tr" }
+
+    before do
+      visit current_path
+    end
+
+    it "lists 15 members per page by default" do
+      expect(page).to have_css(resource_selector, count: 15)
+      expect(page).to have_css(".pagination .page", count: 2)
+      click_link "Next"
+
+      expect(page).to have_selector(".pagination .current", text: "2")
+
+      expect(page).to have_css(resource_selector, count: 5)
+    end
+  end
+
+  # context "with few members" do
+  #   let!(:assembly_member) { create(:assembly_member, assembly: assembly) }
+  #
+  #   it "shows assembly members list" do
+  #     within "#assembly_members table" do
+  #       expect(page).to have_content(assembly_member.full_name)
+  #     end
+  #   end
+  # end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR add a pagination on the list of members of an assembly in the management panel, because only show 15 members. From that number does not allow you to manage or displays them in the list of the Administration panel.

Also, fix the search filter and the order.

#### :pushpin: Related Issues
- Related to #3008
- Fixes #4300 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add paginate on admin members list 
- [x] Add tests
- [x] Fix filter admin members list

### :camera: Screenshots (optional)
![Description](URL)
