### PR TITLE
change scope not_ceased to assembly members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 
 **Changed**:
 
+- **decidim-assemblies**: Change the not_ceased scope for AssemblyMembers to show them publicly if they have a ceased_date bigger than today [\#4370](https://github.com/decidim/decidim/pull/4370)
 - **decidim-assemblies**: For consistency with DB, `ceased_date` and `designation_date` columns now use date attributes in forms, instead of datetime ones. [\#3724](https://github.com/decidim/decidim/pull/3724)
 - **decidim-assemblies**: Don't show child assemblies in assemblies general homepage. [\#4239](https://github.com/decidim/decidim/pull/4239)
 - **decidim-core**: Allow users to enter datetime fields manually. [\#3724](https://github.com/decidim/decidim/pull/3724)

--- a/decidim-assemblies/app/models/decidim/assembly_member.rb
+++ b/decidim-assemblies/app/models/decidim/assembly_member.rb
@@ -15,7 +15,7 @@ module Decidim
 
     default_scope { order(weight: :asc, created_at: :asc) }
 
-    scope :not_ceased, -> { where(ceased_date: nil) }
+    scope :not_ceased, -> { where("ceased_date >= ? OR ceased_date IS NULL", Time.zone.today) }
 
     def self.log_presenter_class_for(_log)
       Decidim::Assemblies::AdminLog::AssemblyMemberPresenter


### PR DESCRIPTION
#### :tophat: What? Why?
When adding members to an Assembly with a ceased_date bigger than Date.today they don't show up publicly. We change the scope not_ceased to take this into account

#### :pushpin: Related Issues
- Fixes #4208 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Change scope not_ceased

### :camera: Screenshots (optional)
![Description](URL)
