### PR TITLE
add parent when duplicating assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 
 **Fixed**:
 
+- **decidim-assemblies**: Add parent when duplicating child assembly. [\#4371](https://github.com/decidim/decidim/pull/4371)
 - **decidim-assemblies**: Add paginate on admin site assembly members. [\#4369](https://github.com/decidim/decidim/pull/4369)
 - **decidim-admin**: Adds traceability when creating and deleting Participatory Space private user [\#4332](https://github.com/decidim/decidim/pull/4332)
 - **decidim-proposals**: Rework URL_REGEX regular expression so that it is more restrictive for general URIs causing problems with Scandinavian locales. [\4290](https://github.com/decidim/decidim/pull/4290)

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/copy_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/copy_assembly.rb
@@ -50,6 +50,7 @@ module Decidim
             banner_image: @assembly.banner_image,
             promoted: @assembly.promoted,
             scope: @assembly.scope,
+            parent: @assembly.parent,
             developer_group: @assembly.developer_group,
             local_area: @assembly.local_area,
             target: @assembly.target,

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_copies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_copies_controller.rb
@@ -20,7 +20,7 @@ module Decidim
           CopyAssembly.call(@form, current_assembly) do
             on(:ok) do
               flash[:notice] = I18n.t("assemblies_copies.create.success", scope: "decidim.admin")
-              redirect_to assemblies_path
+              redirect_to assemblies_path(parent_id: current_assembly.parent_id)
             end
 
             on(:invalid) do

--- a/decidim-assemblies/spec/commands/copy_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/copy_assembly_spec.rb
@@ -116,7 +116,7 @@ module Decidim::Assemblies
 
       context "when everything is ok" do
         let!(:assembly_parent) { create :assembly, organization: organization }
-        let!(:assembly) { create :assembly, parent: assembly_parent, organization: organization}
+        let!(:assembly) { create :assembly, parent: assembly_parent, organization: organization }
 
         it "duplicates an assembly" do
           expect { subject.call }.to change { Decidim::Assembly.count }.by(1)

--- a/decidim-assemblies/spec/commands/copy_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/copy_assembly_spec.rb
@@ -104,5 +104,47 @@ module Decidim::Assemblies
         expect(last_component.step_settings.values).to eq(component.step_settings.values)
       end
     end
+
+    context "when copying a child assembly" do
+      context "when the form is not valid" do
+        let(:invalid) { true }
+
+        it "broadcasts invalid" do
+          expect { subject.call }.to broadcast(:invalid)
+        end
+      end
+
+      context "when everything is ok" do
+        let!(:assembly_parent) { create :assembly, organization: organization }
+        let!(:assembly) { create :assembly, parent: assembly_parent, organization: organization}
+
+        it "duplicates an assembly" do
+          expect { subject.call }.to change { Decidim::Assembly.count }.by(1)
+
+          old_assembly = Decidim::Assembly.find_by(id: assembly.id)
+          new_assembly = Decidim::Assembly.last
+
+          expect(new_assembly.slug).to eq("copied-slug")
+          expect(new_assembly.title["en"]).to eq("title")
+          expect(new_assembly).not_to be_published
+          expect(new_assembly.organization).to eq(old_assembly.organization)
+          expect(new_assembly.subtitle).to eq(old_assembly.subtitle)
+          expect(new_assembly.description).to eq(old_assembly.description)
+          expect(new_assembly.short_description).to eq(old_assembly.short_description)
+          expect(new_assembly.promoted).to eq(old_assembly.promoted)
+          expect(new_assembly.scope).to eq(old_assembly.scope)
+          expect(new_assembly.parent).to eq(old_assembly.parent)
+          expect(new_assembly.developer_group).to eq(old_assembly.developer_group)
+          expect(new_assembly.local_area).to eq(old_assembly.local_area)
+          expect(new_assembly.target).to eq(old_assembly.target)
+          expect(new_assembly.participatory_scope).to eq(old_assembly.participatory_scope)
+          expect(new_assembly.meta_scope).to eq(old_assembly.meta_scope)
+        end
+
+        it "broadcasts ok" do
+          expect { subject.call }.to broadcast(:ok)
+        end
+      end
+    end
   end
 end

--- a/decidim-assemblies/spec/shared/copy_assemblies_examples.rb
+++ b/decidim-assemblies/spec/shared/copy_assemblies_examples.rb
@@ -86,4 +86,31 @@ shared_examples "copy assemblies" do
       end
     end
   end
+
+  context "when copying a child assembly" do
+    let!(:assembly_parent) { create(:assembly, organization: organization) }
+    let!(:assembly) { create(:assembly, parent: assembly_parent, organization: organization) }
+
+    it "copies the child assembly with the basic fields" do
+      click_link "Assemblies", match: :first
+
+      click_link "Duplicate", match: :first
+
+      within ".copy_assembly" do
+        fill_in_i18n(
+          :assembly_title,
+          "#assembly-title-tabs",
+          en: "Copy assembly",
+          es: "Copia del proceso participativo",
+          ca: "Còpia del procés participatiu"
+        )
+        fill_in :assembly_slug, with: "pp-copy"
+        click_button "Copy"
+      end
+
+      expect(page).to have_content("successfully")
+      expect(page).to have_content("Copy assembly")
+      expect(page).to have_content("Not published")
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
When duplicate a children assembly it doesn't display in children assemblies backoffice. It's like you duplicate a mother assembly.

#### :pushpin: Related Issues
- Related to #4022 
- Fixes #3908 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add parent in CopyAssembly Command
- [x] Add tests

### :camera: Screenshots (optional)
![Description](URL)
