### PR TITLE
CoauthorshipsCell render Oficial and Coauthors

### DIFF
--- a/decidim-core/app/cells/decidim/coauthorships_cell.rb
+++ b/decidim-core/app/cells/decidim/coauthorships_cell.rb
@@ -19,7 +19,7 @@ module Decidim
     include Decidim::ApplicationHelper
 
     def show
-      if authorable? || official?
+      if authorable?
         cell "decidim/author", presenter_for_author(model), extra_classes.merge(has_actions: has_actions?, from: model)
       else
         cell(
@@ -41,7 +41,13 @@ module Decidim
     end
 
     def presenters_for_identities(coauthorable)
-      coauthorable.identities.map { |identity| present(identity) }
+      coauthorable.identities.map do |identity|
+        if identity.is_a?(Decidim::Organization)
+          "#{model.class.parent}::OfficialAuthorPresenter".constantize.new
+        else
+          present(identity)
+        end
+      end
     end
 
     def presenter_for_author(authorable)


### PR DESCRIPTION
#### :tophat: What? Why?

_Make authors polymorphic_ #4282 added support for coathorships for official proposals, but coauthorships are not rendered on the UI, only oficial, this PR fixes `coauthorships_cell` to render all coauthorships on official.

#### :pushpin: Related Issues
- Related to #3901

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
on a given proposal where 

```
>>  @proposal.coauthorship_ids
=> [21, 22, 23, 24, 25]

>>  @proposal.coauthorships.first
=> #<Decidim::Coauthorship id: 21, decidim_author_id: 1, decidim_user_group_id: nil, coauthorable_type: "Decidim::Proposals::Proposal", coauthorable_id: 5, created_at: "2018-10-23 14:22:14", updated_at: "2018-10-23 14:22:14", decidim_author_type: "Decidim::Organization">
```

Before:

+ ![screenshot from 2018-10-25 15-33-34](https://user-images.githubusercontent.com/210216/47504108-dfa47f00-d86b-11e8-95b0-91ae01e865c9.png)

+ ![screenshot from 2018-10-25 15-34-53](https://user-images.githubusercontent.com/210216/47504022-b8e64880-d86b-11e8-9267-0d7182b7895d.png)

**After:**

+ ![screenshot from 2018-10-25 15-34-06](https://user-images.githubusercontent.com/210216/47504099-d9160780-d86b-11e8-9313-7f7bd58ab31e.png)

+ ![screenshot from 2018-10-25 15-34-21](https://user-images.githubusercontent.com/210216/47504074-cdc2dc00-d86b-11e8-918a-3d943b5fa728.png)



