### PR TITLE
Fix polymorphic author migration for sortitions

### DIFF
--- a/decidim-sortitions/db/migrate/20181017110803_make_sortitions_authors_polymorphic.rb
+++ b/decidim-sortitions/db/migrate/20181017110803_make_sortitions_authors_polymorphic.rb
@@ -1,20 +1,13 @@
 # frozen_string_literal: true
 
 class MakeSortitionsAuthorsPolymorphic < ActiveRecord::Migration[5.2]
-  class Sortition < ApplicationRecord
-    self.table_name = :decidim_sortitions_sortitions
-  end
-  class User < ApplicationRecord
-    self.table_name = :decidim_users
-  end
-
   def change
     add_column :decidim_sortitions_sortitions, :decidim_author_type, :string
 
-    Sortition.reset_column_information
-    Sortition.includes(:author).find_each do |sortition|
+    Decidim::Sortitions::Sortition.reset_column_information
+    Decidim::Sortitions::Sortition.includes(:author).find_each do |sortition|
       author = if sortition.decidim_author_id.present?
-                 User.find(sortition.decidim_author_id)
+                 Decidim::User.find(sortition.decidim_author_id)
                else
                  sortition.organization
                end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes the polymorphic author migration for `decidim-sortitions`. Needs to be ported to `master`.

#### :pushpin: Related Issues
None