### PR TITLE
Unlink core and conferences

### DIFF
--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -5,7 +5,6 @@ require "decidim/dev"
 
 require "decidim/participatory_processes/test/factories"
 require "decidim/assemblies/test/factories"
-require "decidim/conferences/test/factories"
 require "decidim/comments/test/factories"
 
 def generate_localized_title


### PR DESCRIPTION
#### :tophat: What? Why?
#3781 links `decidim-core` with `decidim-conferences`, but `decidim-conferences` is an optional gem.

This PR removes this link.

#### :pushpin: Related Issues
- Related to #3781
