### PR TITLE
Unlink core and conferences (#4381)

### DIFF
--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -5,7 +5,6 @@ require "decidim/dev"
 
 require "decidim/participatory_processes/test/factories"
 require "decidim/assemblies/test/factories"
-require "decidim/conferences/test/factories"
 require "decidim/comments/test/factories"
 
 def generate_localized_title


### PR DESCRIPTION
#### :tophat: What? Why?
This PR backports #4381 to `0.15-stable`.

#### :pushpin: Related Issues
- Related to #4381

#### :clipboard: Subtasks
None