### PR TITLE
Fix events for polymorphic authors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 **Fixed**:
 
+- **decidim-core**: Fix events for polymorphic authors [\#4387](https://github.com/decidim/decidim/pull/4387)
+
 **Removed**:
 
 ## Previous versions

--- a/decidim-core/lib/decidim/events/author_event.rb
+++ b/decidim-core/lib/decidim/events/author_event.rb
@@ -34,7 +34,10 @@ module Decidim
         end
 
         def author
-          resource.author if resource.respond_to?(:author)
+          return unless resource.respond_to?(:author)
+          return unless resource.author.is_a?(Decidim::UserBaseEntity)
+
+          resource.author
         end
       end
     end

--- a/decidim-core/lib/decidim/events/coauthor_event.rb
+++ b/decidim-core/lib/decidim/events/coauthor_event.rb
@@ -34,7 +34,10 @@ module Decidim
         end
 
         def author
-          resource.creator_author if resource.respond_to?(:creator_author)
+          return unless resource.respond_to?(:creator_author)
+          return unless resource.creator_author.is_a?(Decidim::UserBaseEntity)
+
+          resource.creator_author
         end
       end
     end

--- a/decidim-core/spec/events/decidim/author_event_spec.rb
+++ b/decidim-core/spec/events/decidim/author_event_spec.rb
@@ -76,6 +76,26 @@ module Decidim
         end
       end
 
+      context "when the author is not a user" do
+        let(:user) { create(:organization) }
+
+        it "has an empty author nickname" do
+          expect(subject.author_nickname).to eq("")
+        end
+
+        it "has an empty author name" do
+          expect(subject.author_name).to eq("")
+        end
+
+        it "has an empty author path" do
+          expect(subject.author_path).to eq("")
+        end
+
+        it "has an empty author url" do
+          expect(subject.author_url).to eq("")
+        end
+      end
+
       context "when the resource doesn't have an author" do
         let(:resource) { OpenStruct.new }
 


### PR DESCRIPTION
#### :tophat: What? Why?

Fix notification events went the author is not a user, they should behave like how it behaved previously with entities without author.

Needs to be backported to `0.15`.

#### :pushpin: Related Issues
- Related to #4282 
- Fixes https://sentry.io/share/issue/8e1608457e8545f5a9b10647e0984355/

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
