### PR TITLE
Allow admins to edit proposals even if creation is not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 **Fixed**:
 
+- **decidim-proposals**: Allow admins to edit proposals even if creation is not enabled [\#4390](https://github.com/decidim/decidim/pull/4390)
+
 **Removed**:
 
 ## Previous versions

--- a/decidim-proposals/app/permissions/decidim/proposals/admin/permissions.rb
+++ b/decidim-proposals/app/permissions/decidim/proposals/admin/permissions.rb
@@ -61,7 +61,7 @@ module Decidim
 
         def admin_edition_is_available?
           return unless proposal
-          admin_creation_is_enabled? && proposal.official? && proposal.votes.empty?
+          proposal.official? && proposal.votes.empty?
         end
 
         def admin_proposal_answering_is_enabled?

--- a/decidim-proposals/spec/permissions/decidim/proposals/admin/permissions_spec.rb
+++ b/decidim-proposals/spec/permissions/decidim/proposals/admin/permissions_spec.rb
@@ -86,12 +86,6 @@ describe Decidim::Proposals::Admin::Permissions do
         it { is_expected.to eq true }
       end
 
-      context "when creation is disabled" do
-        let(:creation_enabled?) { false }
-
-        it_behaves_like "permission is not set"
-      end
-
       context "when it has some votes" do
         before do
           create :proposal_vote, proposal: proposal


### PR DESCRIPTION
#### :tophat: What? Why?

Admins should be able to edit proposals even if the current step doesn't have creation enabled.

#### :pushpin: Related Issues
- Related to #4364 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
