### PR TITLE
Fix order of upcoming meetings backport

### DIFF
--- a/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_events_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_events_cell.rb
@@ -18,7 +18,7 @@ module Decidim
                                .includes(component: :participatory_space)
                                .where(component: meeting_components)
                                .where("end_time >= ?", Time.current)
-                               .order(start_time: :desc)
+                               .order(start_time: :asc)
                                .limit(limit)
         end
 

--- a/decidim-meetings/spec/cells/decidim/meetings/content_blocks/upcoming_events_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/content_blocks/upcoming_events_cell_spec.rb
@@ -30,9 +30,19 @@ module Decidim
             let!(:past_meeting) do
               create(:meeting, start_time: 1.week.ago, component: meeting.component)
             end
+            let!(:second_meeting) do
+              create(:meeting, start_time: meeting.start_time.advance(weeks: 1), component: meeting.component)
+            end
 
             it { is_expected.not_to include(past_meeting) }
             it { is_expected.to include(meeting) }
+            it { is_expected.to include(second_meeting) }
+
+            it "orders them correctly" do
+              expect(subject.length).to eq(2)
+              expect(subject.first).to eq(meeting)
+              expect(subject.last).to eq(second_meeting)
+            end
           end
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport of #4398 to `0.15-stable`
