### PR TITLE
Ignore deleted users follows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **decidim-proposals**: Allow admins to edit proposals even if creation is not enabled [\#4390](https://github.com/decidim/decidim/pull/4390)
 - **decidim-core**: Fix events for polymorphic authors [\#4387](https://github.com/decidim/decidim/pull/4387)
 - **decidim-meetings**: Fix order of upcoming meetings [\#4398](https://github.com/decidim/decidim/pull/4398)
+- **decidim-core**: Ignore deleted users follows [\#4401](https://github.com/decidim/decidim/pull/4401)
 
 **Removed**:
 

--- a/decidim-core/app/commands/decidim/destroy_account.rb
+++ b/decidim-core/app/commands/decidim/destroy_account.rb
@@ -19,6 +19,7 @@ module Decidim
         destroy_user_account!
         destroy_user_identities
         destroy_user_group_memberships
+        destroy_follows
       end
 
       broadcast(:ok)
@@ -43,6 +44,11 @@ module Decidim
 
     def destroy_user_group_memberships
       Decidim::UserGroupMembership.where(user: @user).destroy_all
+    end
+
+    def destroy_follows
+      Decidim::Follow.where(followable: @user).destroy_all
+      Decidim::Follow.where(user: @user).destroy_all
     end
   end
 end

--- a/decidim-core/db/migrate/20181030090144_destroy_deleted_users_follows.rb
+++ b/decidim-core/db/migrate/20181030090144_destroy_deleted_users_follows.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class DestroyDeletedUsersFollows < ActiveRecord::Migration[5.2]
+  class Follow < ApplicationRecord
+    self.table_name = "decidim_follows"
+  end
+  class User < ApplicationRecord
+    self.table_name = "decidim_users"
+  end
+
+  def change
+    deleted_users = Decidim::User.where.not(deleted_at: nil).pluck(:id)
+    Follow.where(decidim_followable_type: "Decidim::UserBaseEntity", decidim_followable_id: deleted_users).destroy_all
+    Follow.where(decidim_user_id: deleted_users).destroy_all
+  end
+end

--- a/decidim-core/spec/commands/decidim/destroy_account_spec.rb
+++ b/decidim-core/spec/commands/decidim/destroy_account_spec.rb
@@ -70,6 +70,16 @@ module Decidim
           command.call
         end.to change(UserGroupMembership, :count).by(-1)
       end
+
+      it "deletes the follows" do
+        other_user = create(:user)
+        create(:follow, followable: user, user: other_user)
+        create(:follow, followable: other_user, user: user)
+
+        expect do
+          command.call
+        end.to change(Follow, :count).by(-2)
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

When a users deletes their account we should also delete the follows related to them.

#### :pushpin: Related Issues

- Fixes https://sentry.io/share/issue/3095c1d362aa4bbf9ffee3addf6a617d/

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
