### PR TITLE
Fix comment activity cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ end
 - **decidim-core**: Fix events for polymorphic authors [\#4387](https://github.com/decidim/decidim/pull/4387)
 - **decidim-meetings**: Fix order of upcoming meetings [\#4398](https://github.com/decidim/decidim/pull/4398)
 - **decidim-core**: Ignore deleted users follows [\#4401](https://github.com/decidim/decidim/pull/4401)
+- **decidim-comments**: Fix comment activity cell when commentable is a comment [\#4413](https://github.com/decidim/decidim/pull/4413)
 
 **Removed**:
 

--- a/decidim-comments/app/cells/decidim/comments/comment_activity_cell.rb
+++ b/decidim-comments/app/cells/decidim/comments/comment_activity_cell.rb
@@ -4,10 +4,10 @@ module Decidim
   module Comments
     # A cell to display when a comment has been created.
     class CommentActivityCell < ActivityCell
-      delegate :commentable, to: :comment
+      delegate :root_commentable, to: :comment
 
       def renderable?
-        comment.present? && commentable.present?
+        comment.present? && root_commentable.present?
       end
 
       def resource_link_text
@@ -15,15 +15,15 @@ module Decidim
       end
 
       def resource_link_path
-        resource_locator(commentable).path(url_params)
+        resource_locator(root_commentable).path(url_params)
       end
 
       def title
         I18n.t(
           "decidim.comments.last_activity.new_comment_at_html",
           link: link_to(
-            translated_attribute(commentable.title),
-            resource_locator(commentable).path
+            translated_attribute(root_commentable.title),
+            resource_locator(root_commentable).path
           )
         )
       end

--- a/decidim-comments/lib/decidim/comments/test/factories.rb
+++ b/decidim-comments/lib/decidim/comments/test/factories.rb
@@ -8,6 +8,19 @@ FactoryBot.define do
     commentable { build(:dummy_resource) }
     root_commentable { commentable }
     body { Faker::Lorem.paragraph }
+
+    trait :comment_on_comment do
+      author { build(:user, organization: root_commentable.organization) }
+      commentable do
+        build(
+          :comment,
+          author: author,
+          root_commentable: root_commentable,
+          commentable: root_commentable
+        )
+      end
+      root_commentable { build(:dummy_resource) }
+    end
   end
 
   factory :comment_vote, class: "Decidim::Comments::CommentVote" do

--- a/decidim-comments/spec/cells/decidim/comments/comment_activity_cell_spec.rb
+++ b/decidim-comments/spec/cells/decidim/comments/comment_activity_cell_spec.rb
@@ -21,17 +21,28 @@ module Decidim::Comments
       it "renders the card" do
         html = cell("decidim/comments/comment_activity", action_log).call
         expect(html).to have_css(".card__content")
-        expect(html).to have_content("New comment at #{comment.commentable.title}")
+        expect(html).to have_content("New comment at #{comment.root_commentable.title}")
         expect(html).to have_content(comment.body)
       end
 
       context "when the commentable is missing" do
         before do
-          comment.commentable.delete
+          comment.root_commentable.delete
         end
 
         it "does not render" do
           expect(described_class.new(action_log)).not_to be_renderable
+        end
+      end
+
+      context "when the commentable is a comment" do
+        let!(:comment) { create(:comment, :comment_on_comment) }
+
+        it "renders the card" do
+          html = cell("decidim/comments/comment_activity", action_log).call
+          expect(html).to have_css(".card__content")
+          expect(html).to have_content("New comment at #{comment.root_commentable.title}")
+          expect(html).to have_content(comment.body)
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

We were using `commentable` instead of `root_commentable` so the cell crashed when we tried to display an activity that was a comment on a comment.

Needs to be backported to `0.15`.
#### :pushpin: Related Issues
- Related to #3943 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
