### PR TITLE
Split & merge proposals to the same component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ end
 **Changed**:
 
 - **decidim-surveys**: Extract surveys logic to decidim-forms [\#3877](https://github.com/decidim/decidim/pull/3877)
+
+**Added**:
+
+- **decidim-proposals**: Split & merge proposals to the same component [\#4415](https://github.com/decidim/decidim/pull/4415)
+
+**Changed**:
 - **decidim-core**: Improve static pages layout and make them groupable by topic. [\#4338](https://github.com/decidim/decidim/pull/4338)
 
 **Fixed**:

--- a/decidim-proposals/app/commands/decidim/proposals/admin/import_proposals.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/import_proposals.rb
@@ -33,19 +33,14 @@ module Decidim
           proposals.map do |original_proposal|
             next if proposal_already_copied?(original_proposal, target_component)
 
-            proposal = Decidim::Proposals::ProposalBuilder.copy(
+            Decidim::Proposals::ProposalBuilder.copy(
               original_proposal,
-              author: original_proposal.coauthorships.first.author,
-              user_group_author: original_proposal.coauthorships.first.user_group,
+              author: form.current_organization,
               action_user: form.current_user,
               extra_attributes: {
                 "component" => target_component
               }
             )
-
-            original_proposal.coauthorships.each do |coauthorship|
-              proposal.add_coauthor(coauthorship.author, user_group: coauthorship.user_group)
-            end
           end.compact
         end
 

--- a/decidim-proposals/app/commands/decidim/proposals/admin/merge_proposals.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/merge_proposals.rb
@@ -32,8 +32,20 @@ module Decidim
         def merge_proposals
           transaction do
             merged_proposal = create_new_proposal
-            merged_proposal.link_resources(form.proposals, "copied_from_component")
+            merged_proposal.link_resources(proposals_to_link, "copied_from_component")
+            form.proposals.each(&:destroy!) if form.same_component?
             merged_proposal
+          end
+        end
+
+        def proposals_to_link
+          return previous_links if form.same_component?
+          form.proposals
+        end
+
+        def previous_links
+          @previous_links ||= form.proposals.flat_map do |proposal|
+            proposal.linked_resources(:proposals, "copied_from_component")
           end
         end
 

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_merges_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_merges_controller.rb
@@ -16,7 +16,7 @@ module Decidim
             end
 
             on(:invalid) do
-              flash.now[:alert] = I18n.t("proposals_merges.create.invalid", scope: "decidim.proposals.admin")
+              flash[:alert] = I18n.t("proposals_merges.create.invalid", scope: "decidim.proposals.admin")
               redirect_to EngineRouter.admin_proxy(current_component).root_path
             end
           end

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposals_fork_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposals_fork_form.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    module Admin
+      # A common abstract to be used by the Merge and Split proposals forms.
+      class ProposalsForkForm < Decidim::Form
+        mimic :proposals_import
+
+        attribute :target_component_id, Integer
+        attribute :proposal_ids, Array
+
+        validates :target_component, :proposals, :current_component, presence: true
+        validate :same_participatory_space
+        validate :mergeable_to_same_component
+
+        def proposals
+          @proposals ||= Decidim::Proposals::Proposal.where(component: current_component, id: proposal_ids).uniq
+        end
+
+        def target_component
+          return current_component if clean_target_component_id == current_component.id
+          @target_component ||= current_component.siblings.find_by(id: target_component_id)
+        end
+
+        def same_component?
+          target_component == current_component
+        end
+
+        private
+
+        def mergeable_to_same_component
+          return true unless same_component?
+
+          public_proposals = proposals.any? do |proposal|
+            !proposal.official? || proposal.votes.any? || proposal.endorsements.any?
+          end
+
+          errors.add(:proposal_ids, :invalid) if public_proposals
+        end
+
+        def same_participatory_space
+          return if !target_component || !current_component
+
+          errors.add(:target_component, :invalid) if current_component.participatory_space != target_component.participatory_space
+        end
+
+        # Private: Returns the id of the target component.
+        #
+        # We receive this as ["id"] since it's from a select in a form.
+        def clean_target_component_id
+          target_component_id.first.to_i
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposals_merge_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposals_merge_form.rb
@@ -14,21 +14,44 @@ module Decidim
         validates :target_component, :proposals, :current_component, presence: true
         validates :proposals, length: { minimum: 2 }
         validate :same_participatory_space
+        validate :mergeable_to_same_component
 
         def proposals
           @proposals ||= Decidim::Proposals::Proposal.where(component: current_component, id: proposal_ids).uniq
         end
 
         def target_component
+          return current_component if clean_target_component_id == current_component.id
           @target_component ||= current_component.siblings.find_by(id: target_component_id)
         end
 
+        def same_component?
+          target_component == current_component
+        end
+
         private
+
+        def mergeable_to_same_component
+          return true unless same_component?
+
+          public_proposals = proposals.any? do |proposal|
+            proposal.votes.any? || proposal.endorsements.any?
+          end
+
+          errors.add(:proposal_ids, :invalid) if public_proposals
+        end
 
         def same_participatory_space
           return if !target_component || !current_component
 
           errors.add(:target_component, :invalid) if current_component.participatory_space != target_component.participatory_space
+        end
+
+        # Private: Returns the id of the target component.
+        #
+        # We receive this as ["id"] since it's from a select in a form.
+        def clean_target_component_id
+          target_component_id.first.to_i
         end
       end
     end

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposals_merge_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposals_merge_form.rb
@@ -5,54 +5,8 @@ module Decidim
     module Admin
       # A form object to be used when admin users wants to merge two or more
       # proposals into a new one to another proposal component in the same space.
-      class ProposalsMergeForm < Decidim::Form
-        mimic :proposals_import
-
-        attribute :target_component_id, Integer
-        attribute :proposal_ids, Array
-
-        validates :target_component, :proposals, :current_component, presence: true
+      class ProposalsMergeForm < ProposalsForkForm
         validates :proposals, length: { minimum: 2 }
-        validate :same_participatory_space
-        validate :mergeable_to_same_component
-
-        def proposals
-          @proposals ||= Decidim::Proposals::Proposal.where(component: current_component, id: proposal_ids).uniq
-        end
-
-        def target_component
-          return current_component if clean_target_component_id == current_component.id
-          @target_component ||= current_component.siblings.find_by(id: target_component_id)
-        end
-
-        def same_component?
-          target_component == current_component
-        end
-
-        private
-
-        def mergeable_to_same_component
-          return true unless same_component?
-
-          public_proposals = proposals.any? do |proposal|
-            proposal.votes.any? || proposal.endorsements.any?
-          end
-
-          errors.add(:proposal_ids, :invalid) if public_proposals
-        end
-
-        def same_participatory_space
-          return if !target_component || !current_component
-
-          errors.add(:target_component, :invalid) if current_component.participatory_space != target_component.participatory_space
-        end
-
-        # Private: Returns the id of the target component.
-        #
-        # We receive this as ["id"] since it's from a select in a form.
-        def clean_target_component_id
-          target_component_id.first.to_i
-        end
       end
     end
   end

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposals_split_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposals_split_form.rb
@@ -19,6 +19,7 @@ module Decidim
         end
 
         def target_component
+          return current_component if target_component_id == current_component.id
           @target_component ||= current_component.siblings.find_by(id: target_component_id)
         end
 

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposals_split_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposals_split_form.rb
@@ -5,31 +5,7 @@ module Decidim
     module Admin
       # A form object to be used when admin users wants to split two or more
       # proposals into a new one to another proposal component in the same space.
-      class ProposalsSplitForm < Decidim::Form
-        mimic :proposals_import
-
-        attribute :target_component_id, Integer
-        attribute :proposal_ids, Array
-
-        validates :target_component, :proposals, :current_component, presence: true
-        validate :same_participatory_space
-
-        def proposals
-          @proposals ||= Decidim::Proposals::Proposal.where(component: current_component, id: proposal_ids).uniq
-        end
-
-        def target_component
-          return current_component if target_component_id == current_component.id
-          @target_component ||= current_component.siblings.find_by(id: target_component_id)
-        end
-
-        private
-
-        def same_participatory_space
-          return if !target_component || !current_component
-
-          errors.add(:target_component, :invalid) if current_component.participatory_space != target_component.participatory_space
-        end
+      class ProposalsSplitForm < ProposalsForkForm
       end
     end
   end

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -86,9 +86,11 @@ module Decidim
       # Public: Updates the vote count of this proposal.
       #
       # Returns nothing.
+      # rubocop:disable Rails/SkipsModelValidations
       def update_votes_count
         update_columns(proposal_votes_count: votes.count)
       end
+      # rubocop:enable Rails/SkipsModelValidations
 
       # Public: Check if the user has voted the proposal.
       #

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -87,7 +87,7 @@ module Decidim
       #
       # Returns nothing.
       def update_votes_count
-        update!(proposal_votes_count: votes.count)
+        update_columns(proposal_votes_count: votes.count)
       end
 
       # Public: Check if the user has voted the proposal.

--- a/decidim-proposals/app/services/decidim/proposals/proposal_builder.rb
+++ b/decidim-proposals/app/services/decidim/proposals/proposal_builder.rb
@@ -46,6 +46,7 @@ module Decidim
           "decidim_component_id",
           "reference",
           "proposal_votes_count",
+          "proposal_endorsements_count",
           "proposal_notes_count"
         ).merge(
           "category" => original_proposal.category

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_bulk-actions.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_bulk-actions.html.erb
@@ -15,9 +15,6 @@
   </div>
 
   <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/recategorize" %>
-
-  <% if current_component.siblings.any? %>
-    <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/merge" %>
-    <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/split" %>
-  <% end %>
+  <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/merge" %>
+  <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/split" %>
 </div>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_dropdown.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_dropdown.html.erb
@@ -21,18 +21,16 @@
           <%= t("decidim.proposals.admin.proposals.index.change_category") %>
         </button>
       </li>
-      <% if current_component.siblings.any? %>
-        <li>
-          <button type="button" data-action="merge-proposals">
-            <%= t("decidim.proposals.admin.proposals.index.merge") %>
-          </button>
-        </li>
-        <li>
-          <button type="button" data-action="split-proposals">
-            <%= t("decidim.proposals.admin.proposals.index.split") %>
-          </button>
-        </li>
-      <% end %>
+      <li>
+        <button type="button" data-action="merge-proposals">
+          <%= t("decidim.proposals.admin.proposals.index.merge") %>
+        </button>
+      </li>
+      <li>
+        <button type="button" data-action="split-proposals">
+          <%= t("decidim.proposals.admin.proposals.index.split") %>
+        </button>
+      </li>
     </ul>
   </div>
 </div>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_merge.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_merge.html.erb
@@ -6,7 +6,7 @@
       <% end %>
     </div>
 
-    <%= bulk_components_select current_component.siblings %>
+    <%= bulk_components_select((current_component.siblings + [current_component])) %>
 
     <%= submit_tag(t("decidim.proposals.admin.proposals.index.merge_button"), id: "js-submit-merge-proposals", class: "button small button--simple float-left") %>
 

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_split.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_split.html.erb
@@ -6,7 +6,7 @@
       <% end %>
     </div>
 
-    <%= bulk_components_select current_component.siblings %>
+    <%= bulk_components_select((current_component.siblings + [current_component])) %>
 
     <%= submit_tag(t("decidim.proposals.admin.proposals.index.split_button"), id: "js-submit-split-proposals", class: "button small button--simple float-left") %>
 

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/import_proposals_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/import_proposals_spec.rb
@@ -19,6 +19,7 @@ module Decidim
               ProposalsImportForm,
               origin_component: proposal.component,
               current_component: current_component,
+              current_organization: current_component.organization,
               states: states,
               current_user: create(:user),
               valid?: valid
@@ -87,7 +88,7 @@ module Decidim
               new_proposal = Proposal.where(component: current_component).last
               expect(new_proposal.title).to eq(proposal.title)
               expect(new_proposal.body).to eq(proposal.body)
-              expect(new_proposal.creator_author).to eq(proposal.creator_author)
+              expect(new_proposal.creator_author).to eq(current_component.organization)
               expect(new_proposal.category).to eq(proposal.category)
 
               expect(new_proposal.state).to be_nil

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/merge_proposals_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/merge_proposals_spec.rb
@@ -18,10 +18,12 @@ module Decidim
               target_component: target_component,
               proposals: proposals,
               valid?: valid,
+              same_component?: same_component,
               current_user: create(:user, :admin, organization: current_component.organization)
             )
           end
           let(:command) { described_class.new(form) }
+          let(:same_component) { false }
 
           describe "when the form is not valid" do
             let(:valid) { false }
@@ -73,6 +75,33 @@ module Decidim
               expect(new_proposal.answer).to be_nil
               expect(new_proposal.answered_at).to be_nil
               expect(new_proposal.reference).not_to eq(proposal.reference)
+            end
+
+            context "when merging from the same component" do
+              let(:same_component) { true }
+              let(:target_component) { current_component }
+
+              it "deletes the original proposals" do
+                command.call
+                proposal_ids = proposals.map(&:id)
+
+                expect(Decidim::Proposals::Proposal.where(id: proposal_ids)).to be_empty
+              end
+
+              it "links the merged proposal to the links the other proposals had" do
+                other_component = create(:proposal_component, participatory_space: current_component.participatory_space)
+                other_proposals = create_list(:proposal, 3, component: other_component)
+
+                proposals.each_with_index do |proposal, index|
+                  proposal.link_resources(other_proposals[index], "copied_from_component")
+                end
+
+                command.call
+
+                proposal = Proposal.where(component: target_component).last
+                linked = proposal.linked_resources(:proposals, "copied_from_component")
+                expect(linked).to match_array(other_proposals)
+              end
             end
           end
         end

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/split_proposals_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/split_proposals_spec.rb
@@ -7,7 +7,7 @@ module Decidim
     module Admin
       describe SplitProposals do
         describe "call" do
-          let!(:proposal) { create(:proposal, component: current_component) }
+          let!(:proposals) { Array(create(:proposal, component: current_component)) }
           let!(:current_component) { create(:proposal_component) }
           let!(:target_component) { create(:proposal_component, participatory_space: current_component.participatory_space) }
           let(:form) do
@@ -16,12 +16,14 @@ module Decidim
               current_component: current_component,
               current_organization: current_component.organization,
               target_component: target_component,
-              proposals: [proposal],
+              proposals: proposals,
               valid?: valid,
+              same_component?: same_component,
               current_user: create(:user, :admin, organization: current_component.organization)
             )
           end
           let(:command) { described_class.new(form) }
+          let(:same_component) { false }
 
           describe "when the form is not valid" do
             let(:valid) { false }
@@ -54,13 +56,14 @@ module Decidim
               command.call
               new_proposals = Proposal.where(component: target_component)
 
-              linked = proposal.linked_resources(:proposals, "copied_from_component")
+              linked = proposals.first.linked_resources(:proposals, "copied_from_component")
 
               expect(linked).to match_array(new_proposals)
             end
 
             it "only copies wanted attributes" do
               command.call
+              proposal = proposals.first
               new_proposal = Proposal.where(component: target_component).last
 
               expect(new_proposal.title).to eq(proposal.title)
@@ -72,6 +75,38 @@ module Decidim
               expect(new_proposal.answer).to be_nil
               expect(new_proposal.answered_at).to be_nil
               expect(new_proposal.reference).not_to eq(proposal.reference)
+            end
+
+            context "when spliting to the same component" do
+              let(:same_component) { true }
+              let!(:target_component) { current_component }
+              let!(:proposals) { create_list(:proposal, 2, component: current_component) }
+
+              it "only creates one copy for each proposal" do
+                expect do
+                  command.call
+                end.to change { Proposal.where(component: current_component).count }.by(2)
+              end
+
+              context "when the original proposal has links to other proposals" do
+                let(:previous_component) { create(:proposal_component, participatory_space: current_component.participatory_space) }
+                let(:previous_proposals) { create(:proposal, component: previous_component) }
+
+                before do
+                  proposals.each do |proposal|
+                    proposal.link_resources(previous_proposals, "copied_from_component")
+                  end
+                end
+
+                it "links the copy to the same links the proposal has" do
+                  new_proposals = Proposal.where(component: target_component).last(2)
+
+                  new_proposals.each do |proposal|
+                    linked = proposal.linked_resources(:proposals, "copied_from_component")
+                    expect(linked).to eq([previous_proposals])
+                  end
+                end
+              end
             end
           end
         end

--- a/decidim-proposals/spec/forms/decidim/proposals/admin/propoals_split_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/admin/propoals_split_form_spec.rb
@@ -13,7 +13,7 @@ module Decidim
         let(:target_component) { create(:proposal_component, participatory_space: component.participatory_space) }
         let(:params) do
           {
-            target_component_id: target_component.try(:id),
+            target_component_id: [target_component.try(:id).to_s],
             proposal_ids: proposals.map(&:id)
           }
         end
@@ -45,6 +45,33 @@ module Decidim
           let(:target_component) { create(:proposal_component) }
 
           it { is_expected.to be_invalid }
+        end
+
+        context "when merging to the same component" do
+          let(:target_component) { component }
+          let(:proposals) { create_list(:proposal, 3, :official, component: component) }
+
+          context "when the proposal is not official" do
+            let(:proposals) { create_list(:proposal, 3, component: component) }
+
+            it { is_expected.to be_invalid }
+          end
+
+          context "when a proposal has a vote" do
+            before do
+              create(:proposal_vote, proposal: proposals.sample)
+            end
+
+            it { is_expected.to be_invalid }
+          end
+
+          context "when a proposal has an endorsement" do
+            before do
+              create(:proposal_endorsement, proposal: proposals.sample)
+            end
+
+            it { is_expected.to be_invalid }
+          end
         end
       end
     end

--- a/decidim-proposals/spec/forms/decidim/proposals/admin/proposals_merge_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/admin/proposals_merge_form_spec.rb
@@ -13,7 +13,7 @@ module Decidim
         let(:target_component) { create(:proposal_component, participatory_space: component.participatory_space) }
         let(:params) do
           {
-            target_component_id: target_component.try(:id),
+            target_component_id: [target_component.try(:id).to_s],
             proposal_ids: proposals.map(&:id)
           }
         end
@@ -45,6 +45,26 @@ module Decidim
           let(:target_component) { create(:proposal_component) }
 
           it { is_expected.to be_invalid }
+        end
+
+        context "when merging to the same component" do
+          let(:target_component) { component }
+
+          context "when a proposal has a vote" do
+            before do
+              create(:proposal_vote, proposal: proposals.sample)
+            end
+
+            it { is_expected.to be_invalid }
+          end
+
+          context "when a proposal has an endorsement" do
+            before do
+              create(:proposal_endorsement, proposal: proposals.sample)
+            end
+
+            it { is_expected.to be_invalid }
+          end
         end
       end
     end

--- a/decidim-proposals/spec/forms/decidim/proposals/admin/proposals_merge_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/admin/proposals_merge_form_spec.rb
@@ -49,6 +49,13 @@ module Decidim
 
         context "when merging to the same component" do
           let(:target_component) { component }
+          let(:proposals) { create_list(:proposal, 3, :official, component: component) }
+
+          context "when the proposal is not official" do
+            let(:proposals) { create_list(:proposal, 3, component: component) }
+
+            it { is_expected.to be_invalid }
+          end
 
           context "when a proposal has a vote" do
             before do

--- a/decidim-proposals/spec/shared/merge_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/merge_proposals_examples.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 shared_examples "merge proposals" do
-  let!(:proposals) { create_list :proposal, 3, component: current_component }
+  let!(:proposals) { create_list :proposal, 3, :official, component: current_component }
   let!(:target_component) { create :proposal_component, participatory_space: current_component.participatory_space }
   include Decidim::ComponentPathHelper
+
+  before do
+    Decidim::Proposals::Proposal.where.not(id: proposals.map(&:id)).destroy_all
+  end
 
   context "when selecting proposals" do
     before do
@@ -57,6 +61,22 @@ shared_examples "merge proposals" do
         it "creates a new proposal" do
           expect(page).to have_content("Successfully merged the proposals into a new one")
           expect(page).to have_css(".table-list tbody tr", count: 1)
+          expect(page).to have_current_path(manage_component_path(target_component))
+        end
+
+        context "when merging to the same component" do
+          let!(:target_component) { current_component }
+          let!(:proposal_ids) { proposals.map(&:id) }
+
+          it "creates a new proposal and deletes the other ones" do
+            expect(page).to have_content("Successfully merged the proposals into a new one")
+            expect(page).to have_css(".table-list tbody tr", count: 1)
+            expect(page).to have_current_path(manage_component_path(current_component))
+
+            proposal_ids.each do |id|
+              expect(page).not_to have_xpath("//tr[@data-id='#{id}']")
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

Improves #4360 by adding an option to split & merge to the same component.

#### :pushpin: Related Issues
- Related to #4360 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
