### PR TITLE
Allow to disable users registration and/or login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ end
 **Added**:
 
 - **decidim-conferences**: Add conference registration types. [\#4408](https://github.com/decidim/decidim/pull/4408)
+- **decidim-core**: Added `users_registration_mode` to allow disable users registration or login [\#4428](https://github.com/decidim/decidim/pull/4428)
 - **decidim-forms**: Create a new gem to hold reusable surveys logic [\#3877](https://github.com/decidim/decidim/pull/3877)
 - **decidim-verifications**: Add SMS verification workflow [\#4429](https://github.com/decidim/decidim/pull/4429)
 - **decidim-proposals**: Split & merge proposals to the same component [\#4415](https://github.com/decidim/decidim/pull/4415)

--- a/decidim-admin/spec/system/admin_invite_spec.rb
+++ b/decidim-admin/spec/system/admin_invite_spec.rb
@@ -15,7 +15,8 @@ describe "Admin invite", type: :system do
       organization_admin_name: "Fiorello Henry La Guardia",
       organization_admin_email: "f.laguardia@gotham.gov",
       available_locales: ["en"],
-      default_locale: "en"
+      default_locale: "en",
+      users_registration_mode: "enabled"
     }
   end
 

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_navbar.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_navbar.scss
@@ -321,7 +321,7 @@ $navbar-active-shadow-medium: inset 0 4px 0 0 $primary;
     }
   }
 
-  a:first-of-type::after{
+  a::before{
     content: "";
     margin-left: .5rem;
     margin-right: .5rem;
@@ -330,6 +330,10 @@ $navbar-active-shadow-medium: inset 0 4px 0 0 $primary;
     height: 2px;
     border-left: $border;
     vertical-align: middle;
+  }
+
+  a:first-of-type::before{
+    display: none;
   }
 }
 

--- a/decidim-core/app/controllers/decidim/devise/passwords_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/passwords_controller.rb
@@ -6,7 +6,13 @@ module Decidim
     class PasswordsController < ::Devise::PasswordsController
       include Decidim::DeviseControllers
 
+      before_action :check_sign_in_enabled
+
       private
+
+      def check_sign_in_enabled
+        redirect_to new_user_session_path unless Decidim.sign_in_enabled?
+      end
 
       # Since we're using a single Devise installation for multiple
       # organizations, and user emails can be repeated across organizations,

--- a/decidim-core/app/controllers/decidim/devise/passwords_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/passwords_controller.rb
@@ -11,7 +11,7 @@ module Decidim
       private
 
       def check_sign_in_enabled
-        redirect_to new_user_session_path unless Decidim.sign_in_enabled?
+        redirect_to new_user_session_path unless current_organization.sign_in_enabled?
       end
 
       # Since we're using a single Devise installation for multiple

--- a/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
@@ -9,6 +9,7 @@ module Decidim
       include Decidim::DeviseControllers
       include NeedsTosAccepted
 
+      before_action :check_sign_up_enabled
       before_action :configure_permitted_parameters
 
       invisible_captcha
@@ -44,6 +45,10 @@ module Decidim
       end
 
       protected
+
+      def check_sign_up_enabled
+        redirect_to new_user_session_path unless Decidim.sign_up_enabled?
+      end
 
       def configure_permitted_parameters
         devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :tos_agreement])

--- a/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
@@ -47,7 +47,7 @@ module Decidim
       protected
 
       def check_sign_up_enabled
-        redirect_to new_user_session_path unless Decidim.sign_up_enabled?
+        redirect_to new_user_session_path unless current_organization.sign_up_enabled?
       end
 
       def configure_permitted_parameters

--- a/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
@@ -39,7 +39,7 @@ module Decidim
       private
 
       def check_sign_in_enabled
-        redirect_to new_user_session_path unless Decidim.sign_in_enabled?
+        redirect_to new_user_session_path unless current_organization.sign_in_enabled?
       end
     end
   end

--- a/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
@@ -8,6 +8,10 @@ module Decidim
 
       before_action :check_sign_in_enabled, only: :create
 
+      def create
+        super
+      end
+
       def after_sign_in_path_for(user)
         if first_login_and_not_authorized?(user) && !user.admin? && !pending_redirect?(user)
           decidim_verifications.first_login_authorizations_path

--- a/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
@@ -6,6 +6,8 @@ module Decidim
     class SessionsController < ::Devise::SessionsController
       include Decidim::DeviseControllers
 
+      before_action :check_sign_in_enabled, only: :create
+
       def after_sign_in_path_for(user)
         if first_login_and_not_authorized?(user) && !user.admin? && !pending_redirect?(user)
           decidim_verifications.first_login_authorizations_path
@@ -28,6 +30,12 @@ module Decidim
 
       def after_sign_out_path_for(user)
         request.referer || super
+      end
+
+      private
+
+      def check_sign_in_enabled
+        redirect_to new_user_session_path unless Decidim.sign_in_enabled?
       end
     end
   end

--- a/decidim-core/app/helpers/decidim/cta_button_helper.rb
+++ b/decidim-core/app/helpers/decidim/cta_button_helper.rb
@@ -19,7 +19,7 @@ module Decidim
         decidim_participatory_processes.participatory_processes_path
       elsif current_user
         decidim.account_path
-      elsif Decidim.sign_up_enabled?
+      elsif current_organization.sign_up_enabled?
         decidim.new_user_registration_path
       else
         decidim.new_user_session_path

--- a/decidim-core/app/helpers/decidim/cta_button_helper.rb
+++ b/decidim-core/app/helpers/decidim/cta_button_helper.rb
@@ -19,8 +19,10 @@ module Decidim
         decidim_participatory_processes.participatory_processes_path
       elsif current_user
         decidim.account_path
-      else
+      elsif Decidim.sign_up_enabled?
         decidim.new_user_registration_path
+      else
+        decidim.new_user_session_path
       end
     end
   end

--- a/decidim-core/app/models/decidim/organization.rb
+++ b/decidim-core/app/models/decidim/organization.rb
@@ -22,6 +22,12 @@ module Decidim
     has_many :oauth_applications, foreign_key: "decidim_organization_id", class_name: "Decidim::OAuthApplication", inverse_of: :organization, dependent: :destroy
     has_many :hashtags, foreign_key: "decidim_organization_id", class_name: "Decidim::Hashtag", dependent: :destroy
 
+    # Users registration mode. Whether users can register or access the system. Doesn't affect users that access through Omniauth integrations.
+    #  enabled: Users registration and sign in are enabled (default value).
+    #  existing: Users can't be registered in the system. Only existing users can sign in.
+    #  disable: Users can't register or sign in.
+    enum users_registration_mode: [:enabled, :existing, :disabled], _prefix: true
+
     validates :name, :host, uniqueness: true
     validates :reference_prefix, presence: true
     validates :default_locale, inclusion: { in: :available_locales }
@@ -69,6 +75,14 @@ module Decidim
     def welcome_notification_body
       self[:welcome_notification_body] ||
         multi_translation("decidim.welcome_notification.default_body", available_locales)
+    end
+
+    def sign_up_enabled?
+      users_registration_mode_enabled?
+    end
+
+    def sign_in_enabled?
+      !users_registration_mode_disabled?
     end
   end
 end

--- a/decidim-core/app/views/decidim/devise/sessions/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/sessions/new.html.erb
@@ -5,12 +5,12 @@
     <div class="row collapse">
       <div class="columns large-8 large-centered text-center page-title">
         <h1 class="heading1"><%= t("devise.sessions.new.sign_in") %></h1>
-        <% if Decidim.sign_up_enabled? %>
+        <% if current_organization.sign_up_enabled? %>
           <p>
             <%= t(".are_you_new?") %>
             <%= link_to t(".register"), new_user_registration_path %>
           </p>
-        <% elsif Decidim.sign_in_enabled? %>
+        <% elsif current_organization.sign_in_enabled? %>
           <p>
             <%= t(".sign_up_disabled") %>
           </p>
@@ -21,7 +21,7 @@
         <% end %>
       </div>
     </div>
-    <% if Decidim.sign_in_enabled? %>
+    <% if current_organization.sign_in_enabled? %>
       <div class="row">
         <div class="columns large-6 medium-centered">
           <div class="card">

--- a/decidim-core/app/views/decidim/devise/sessions/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/sessions/new.html.erb
@@ -5,41 +5,53 @@
     <div class="row collapse">
       <div class="columns large-8 large-centered text-center page-title">
         <h1 class="heading1"><%= t("devise.sessions.new.sign_in") %></h1>
-        <p>
-          <%= t(".are_you_new?") %>
-          <%= link_to t(".register"), new_user_registration_path %>
-        </p>
+        <% if Decidim.sign_up_enabled? %>
+          <p>
+            <%= t(".are_you_new?") %>
+            <%= link_to t(".register"), new_user_registration_path %>
+          </p>
+        <% elsif Decidim.sign_in_enabled? %>
+          <p>
+            <%= t(".sign_up_disabled") %>
+          </p>
+        <% else %>
+          <p>
+            <%= t(".sign_in_disabled") %>
+          </p>
+        <% end %>
       </div>
     </div>
-    <div class="row">
-      <div class="columns large-6 medium-centered">
-        <div class="card">
-          <div class="card__content">
-            <%= decidim_form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "register-form new_user" }) do |f| %>
-              <div>
-                <div class="field">
-                  <%= f.email_field :email, autofocus: true %>
-                </div>
-                <div class="field">
-                  <%= f.password_field :password, autocomplete: "off" %>
-                </div>
-              </div>
-              <fieldset>
-                <% if devise_mapping.rememberable? %>
+    <% if Decidim.sign_in_enabled? %>
+      <div class="row">
+        <div class="columns large-6 medium-centered">
+          <div class="card">
+            <div class="card__content">
+              <%= decidim_form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "register-form new_user" }) do |f| %>
+                <div>
                   <div class="field">
-                    <%= f.check_box :remember_me %>
+                    <%= f.email_field :email, autofocus: true %>
                   </div>
-                <% end %>
-              </fieldset>
-              <div class="actions">
-                <%= f.submit t("devise.sessions.new.sign_in"), class: "button expanded" %>
-              </div>
-            <% end %>
-            <%= render "decidim/devise/shared/links" %>
+                  <div class="field">
+                    <%= f.password_field :password, autocomplete: "off" %>
+                  </div>
+                </div>
+                <fieldset>
+                  <% if devise_mapping.rememberable? %>
+                    <div class="field">
+                      <%= f.check_box :remember_me %>
+                    </div>
+                  <% end %>
+                </fieldset>
+                <div class="actions">
+                  <%= f.submit t("devise.sessions.new.sign_in"), class: "button expanded" %>
+                </div>
+              <% end %>
+              <%= render "decidim/devise/shared/links" %>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    <% end %>
     <%= render "decidim/devise/shared/omniauth_buttons" %>
   </div>
 </main>

--- a/decidim-core/app/views/decidim/devise/shared/_links.html.erb
+++ b/decidim-core/app/views/decidim/devise/shared/_links.html.erb
@@ -4,7 +4,7 @@
   </p>
 <% end -%>
 
-<%- if devise_mapping.registerable? && controller_name != "registrations" %>
+<%- if Decidim.sign_up_enabled? && devise_mapping.registerable? && controller_name != "registrations" %>
   <p class="text-center">
     <%= link_to t("devise.shared.links.sign_up"), new_registration_path(resource_name) %>
   </p>
@@ -16,7 +16,7 @@
   </p>
 <% end -%>
 
-<%- if devise_mapping.confirmable? && controller_name != "confirmations" %>
+<%- if Decidim.sign_up_enabled? && devise_mapping.confirmable? && controller_name != "confirmations" %>
   <p class="text-center">
     <%= link_to t("devise.shared.links.didn_t_receive_confirmation_instructions"), new_confirmation_path(resource_name) %>
   </p>

--- a/decidim-core/app/views/decidim/devise/shared/_links.html.erb
+++ b/decidim-core/app/views/decidim/devise/shared/_links.html.erb
@@ -4,7 +4,7 @@
   </p>
 <% end -%>
 
-<%- if Decidim.sign_up_enabled? && devise_mapping.registerable? && controller_name != "registrations" %>
+<%- if current_organization.sign_up_enabled? && devise_mapping.registerable? && controller_name != "registrations" %>
   <p class="text-center">
     <%= link_to t("devise.shared.links.sign_up"), new_registration_path(resource_name) %>
   </p>
@@ -16,7 +16,7 @@
   </p>
 <% end -%>
 
-<%- if Decidim.sign_up_enabled? && devise_mapping.confirmable? && controller_name != "confirmations" %>
+<%- if current_organization.sign_up_enabled? && devise_mapping.confirmable? && controller_name != "confirmations" %>
   <p class="text-center">
     <%= link_to t("devise.shared.links.didn_t_receive_confirmation_instructions"), new_confirmation_path(resource_name) %>
   </p>

--- a/decidim-core/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
+++ b/decidim-core/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
@@ -1,10 +1,12 @@
-<% if devise_mapping.omniauthable? && any_social_provider_enabled? %>
+<% if Devise.mappings[:user].omniauthable? && any_social_provider_enabled? %>
   <div class="row">
     <div class="columns large-4 mediumlarge-6 medium-8 medium-centered">
-      <span class="register__separator">
-        <span class="register__separator__text"><%= t(".or") %></span>
-      </span>
-      <%- resource_class.omniauth_providers.each do |provider| %>
+      <%- if Decidim.sign_in_enabled? %>
+        <span class="register__separator">
+          <span class="register__separator__text"><%= t(".or") %></span>
+        </span>
+      <%- end %>
+      <%-  Decidim::User.omniauth_providers.each do |provider| %>
         <% if social_provider_enabled? provider %>
           <div class="social-register">
             <%= link_to decidim.send("user_#{provider}_omniauth_authorize_path"), class: "button button--social button--#{normalize_provider_name(provider)}" do %>

--- a/decidim-core/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
+++ b/decidim-core/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
@@ -6,7 +6,7 @@
           <span class="register__separator__text"><%= t(".or") %></span>
         </span>
       <%- end %>
-      <%-  Decidim::User.omniauth_providers.each do |provider| %>
+      <%- Decidim::User.omniauth_providers.each do |provider| %>
         <% if social_provider_enabled? provider %>
           <div class="social-register">
             <%= link_to decidim.send("user_#{provider}_omniauth_authorize_path"), class: "button button--social button--#{normalize_provider_name(provider)}" do %>

--- a/decidim-core/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
+++ b/decidim-core/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
@@ -1,7 +1,7 @@
 <% if Devise.mappings[:user].omniauthable? && any_social_provider_enabled? %>
   <div class="row">
     <div class="columns large-4 mediumlarge-6 medium-8 medium-centered">
-      <%- if Decidim.sign_in_enabled? %>
+      <%- if current_organization.sign_in_enabled? %>
         <span class="register__separator">
           <span class="register__separator__text"><%= t(".or") %></span>
         </span>

--- a/decidim-core/app/views/decidim/shared/_login_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_login_modal.html.erb
@@ -6,7 +6,7 @@
       <span aria-hidden="true">&times;</span>
     </button>
   </div>
-  <% if Decidim.sign_in_enabled? %>
+  <% if current_organization.sign_in_enabled? %>
     <div class="row">
       <div class="columns medium-8 medium-centered">
           <%= decidim_form_for(Decidim::User.new, as: :user, url: session_path(:user), html: { class: "register-form new_user" }) do |f| %>
@@ -22,7 +22,7 @@
               <%= f.submit t("devise.sessions.new.sign_in"), class: "button expanded" %>
             </div>
           <% end %>
-          <% if Decidim.sign_up_enabled? %>
+          <% if current_organization.sign_up_enabled? %>
             <p class="text-center">
               <%= link_to t(".sign_up"), decidim.new_user_registration_path, class: "sign-up-link" %>
             </p>

--- a/decidim-core/app/views/decidim/shared/_login_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_login_modal.html.erb
@@ -6,28 +6,41 @@
       <span aria-hidden="true">&times;</span>
     </button>
   </div>
-  <div class="row">
-    <div class="columns medium-8 medium-centered">
-      <%= decidim_form_for(Decidim::User.new, as: :user, url: session_path(:user), html: { class: "register-form new_user" }) do |f| %>
-        <div>
-          <div class="field">
-            <%= f.email_field :email, autofocus: true %>
-          </div>
-          <div class="field">
-            <%= f.password_field :password, autocomplete: "off" %>
-          </div>
-        </div>
-        <div class="actions">
-          <%= f.submit t("devise.sessions.new.sign_in"), class: "button expanded" %>
-        </div>
-      <% end %>
-      <p class="text-center">
-        <%= link_to t(".sign_up"), decidim.new_user_registration_path, class: "sign-up-link" %>
-      </p>
-      <p class="text-center">
-        <%= link_to t("devise.shared.links.forgot_your_password"), new_password_path(:user) %>
-      </p>
+  <% if Decidim.sign_in_enabled? %>
+    <div class="row">
+      <div class="columns medium-8 medium-centered">
+          <%= decidim_form_for(Decidim::User.new, as: :user, url: session_path(:user), html: { class: "register-form new_user" }) do |f| %>
+            <div>
+              <div class="field">
+                <%= f.email_field :email, autofocus: true %>
+              </div>
+              <div class="field">
+                <%= f.password_field :password, autocomplete: "off" %>
+              </div>
+            </div>
+            <div class="actions">
+              <%= f.submit t("devise.sessions.new.sign_in"), class: "button expanded" %>
+            </div>
+          <% end %>
+          <% if Decidim.sign_up_enabled? %>
+            <p class="text-center">
+              <%= link_to t(".sign_up"), decidim.new_user_registration_path, class: "sign-up-link" %>
+            </p>
+          <% end %>
+          <p class="text-center">
+            <%= link_to t("devise.shared.links.forgot_your_password"), new_password_path(:user) %>
+          </p>
+      </div>
     </div>
     <%= render "decidim/devise/shared/omniauth_buttons_mini" %>
-  </div>
+  <% else %>
+    <div class="row">
+      <div class="columns medium-8 medium-centered">
+        <p>
+          <%= t("sign_in_disabled", scope: "decidim.devise.sessions.new") %>
+        </p>
+      </div>
+    </div>
+    <%= render "decidim/devise/shared/omniauth_buttons" %>
+  <% end %>
 </div>

--- a/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
@@ -73,7 +73,9 @@ end
             <% else %>
               <div class="topbar__user show-for-medium" data-set="nav-login-holder">
                 <div class="topbar__user__login js-append">
-                  <%= link_to t("layouts.decidim.header.sign_up"), decidim.new_user_registration_path, class: "sign-up-link" %>
+                  <% if Decidim.sign_up_enabled? %>
+                    <%= link_to t("layouts.decidim.header.sign_up"), decidim.new_user_registration_path, class: "sign-up-link" %>
+                  <% end %>
                   <%= link_to t("layouts.decidim.header.sign_in"), decidim.new_user_session_path, class: "sign-in-link" %>
                 </div>
               </div>

--- a/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
@@ -73,7 +73,7 @@ end
             <% else %>
               <div class="topbar__user show-for-medium" data-set="nav-login-holder">
                 <div class="topbar__user__login js-append">
-                  <% if Decidim.sign_up_enabled? %>
+                  <% if current_organization.sign_up_enabled? %>
                     <%= link_to t("layouts.decidim.header.sign_up"), decidim.new_user_registration_path, class: "sign-up-link" %>
                   <% end %>
                   <%= link_to t("layouts.decidim.header.sign_in"), decidim.new_user_session_path, class: "sign-in-link" %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -284,6 +284,8 @@ en:
         new:
           are_you_new?: New to the platform?
           register: Create an account
+          sign_in_disabled: You can access with an external account
+          sign_up_disabled: Sign up is disabled, you can use an existing user to access
       shared:
         newsletter_modal:
           buttons:

--- a/decidim-core/db/migrate/20181108131058_add_users_registration_mode_to_organizations.rb
+++ b/decidim-core/db/migrate/20181108131058_add_users_registration_mode_to_organizations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUsersRegistrationModeToOrganizations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_organizations, :users_registration_mode, :integer, default: 0
+  end
+end

--- a/decidim-core/db/migrate/20181108131058_add_users_registration_mode_to_organizations.rb
+++ b/decidim-core/db/migrate/20181108131058_add_users_registration_mode_to_organizations.rb
@@ -2,6 +2,6 @@
 
 class AddUsersRegistrationModeToOrganizations < ActiveRecord::Migration[5.2]
   def change
-    add_column :decidim_organizations, :users_registration_mode, :integer, default: 0
+    add_column :decidim_organizations, :users_registration_mode, :integer, default: 0, null: false
   end
 end

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -31,6 +31,7 @@ if !Rails.env.production? || ENV["SEED"]
     available_locales: Decidim.available_locales,
     reference_prefix: Faker::Name.suffix,
     available_authorizations: Decidim.authorization_workflows.map(&:name),
+    users_registration_mode: :enabled,
     tos_version: Time.current,
     badges_enabled: true
   )

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -220,6 +220,14 @@ module Decidim
     2.days
   end
 
+  # Users registration mode. Whether users can register or access the system. Doesn't affect users that access through Omniauth integrations.
+  #  enabled: Users registration and sign in are enabled (default value).
+  #  existing: Users can't be registered in the system. Only existing users can sign in.
+  #  disable: Users can't register or sign in.
+  config_accessor :users_registration_mode do
+    :enabled
+  end
+
   # A base path for the uploads. If set, make sure it ends in a slash.
   # Uploads will be set to `<base_path>/uploads/`. This can be useful if you
   # want to use the same uploads place for both staging and production
@@ -228,6 +236,14 @@ module Decidim
 
   # Exposes a configuration option: an object to deliver SMS codes to users.
   config_accessor :sms_gateway_service
+
+  def self.sign_up_enabled?
+    users_registration_mode == :enabled
+  end
+
+  def self.sign_in_enabled?
+    users_registration_mode != :disabled
+  end
 
   # Public: Registers a global engine. This method is intended to be used
   # by component engines that also offer unscoped functionality

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -220,14 +220,6 @@ module Decidim
     2.days
   end
 
-  # Users registration mode. Whether users can register or access the system. Doesn't affect users that access through Omniauth integrations.
-  #  enabled: Users registration and sign in are enabled (default value).
-  #  existing: Users can't be registered in the system. Only existing users can sign in.
-  #  disable: Users can't register or sign in.
-  config_accessor :users_registration_mode do
-    :enabled
-  end
-
   # A base path for the uploads. If set, make sure it ends in a slash.
   # Uploads will be set to `<base_path>/uploads/`. This can be useful if you
   # want to use the same uploads place for both staging and production
@@ -236,14 +228,6 @@ module Decidim
 
   # Exposes a configuration option: an object to deliver SMS codes to users.
   config_accessor :sms_gateway_service
-
-  def self.sign_up_enabled?
-    users_registration_mode == :enabled
-  end
-
-  def self.sign_in_enabled?
-    users_registration_mode != :disabled
-  end
 
   # Public: Registers a global engine. This method is intended to be used
   # by component engines that also offer unscoped functionality

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -78,6 +78,7 @@ FactoryBot.define do
     favicon { Decidim::Dev.test_file("icon.png", "image/png") }
     default_locale { Decidim.default_locale }
     available_locales { Decidim.available_locales }
+    users_registration_mode { :enabled }
     official_img_header { Decidim::Dev.test_file("avatar.jpg", "image/jpeg") }
     official_img_footer { Decidim::Dev.test_file("avatar.jpg", "image/jpeg") }
     official_url { Faker::Internet.url }

--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -188,6 +188,22 @@ describe "Authentication", type: :system do
         expect_user_logged
       end
     end
+
+    context "when sign up is disabled" do
+      before do
+        allow(Decidim).to receive(:users_registration_mode).and_return(:existing)
+      end
+
+      it "redirects to the sign in when accessing the sign up page" do
+        visit decidim.new_user_registration_path
+        expect(page).not_to have_content("Sign Up")
+      end
+
+      it "don't allow the user to sign up" do
+        find(".sign-in-link").click
+        expect(page).not_to have_content("Create an account")
+      end
+    end
   end
 
   describe "Confirm email" do
@@ -341,6 +357,43 @@ describe "Authentication", type: :system do
 
         expect(page).to have_content("Successfully")
         expect(page).to have_content(user.name)
+      end
+
+      context "when sign up is disabled" do
+        before do
+          allow(Decidim).to receive(:users_registration_mode).and_return(:existing)
+        end
+
+        it "doesn't allow the user to sign up" do
+          find(".sign-in-link").click
+          expect(page).not_to have_content("Sign Up")
+        end
+      end
+
+      context "when sign in is disabled" do
+        before do
+          allow(Decidim).to receive(:users_registration_mode).and_return(:disabled)
+        end
+
+        it "doesn't allow the user to sign up" do
+          find(".sign-in-link").click
+          expect(page).not_to have_content("Sign Up")
+        end
+
+        it "doesn't allow the user to sign in as a regular user, only through external accounts" do
+          find(".sign-in-link").click
+          expect(page).not_to have_content("Email")
+          expect(page).to have_css(".button--facebook")
+        end
+
+        it "authenticates an existing User" do
+          find(".sign-in-link").click
+
+          click_link "Sign in with Facebook"
+
+          expect(page).to have_content("Successfully")
+          expect(page).to have_content(user.name)
+        end
       end
     end
   end

--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -190,9 +190,7 @@ describe "Authentication", type: :system do
     end
 
     context "when sign up is disabled" do
-      before do
-        allow(Decidim).to receive(:users_registration_mode).and_return(:existing)
-      end
+      let(:organization) { create(:organization, users_registration_mode: :existing) }
 
       it "redirects to the sign in when accessing the sign up page" do
         visit decidim.new_user_registration_path
@@ -360,9 +358,7 @@ describe "Authentication", type: :system do
       end
 
       context "when sign up is disabled" do
-        before do
-          allow(Decidim).to receive(:users_registration_mode).and_return(:existing)
-        end
+        let(:organization) { create(:organization, users_registration_mode: :existing) }
 
         it "doesn't allow the user to sign up" do
           find(".sign-in-link").click
@@ -371,9 +367,7 @@ describe "Authentication", type: :system do
       end
 
       context "when sign in is disabled" do
-        before do
-          allow(Decidim).to receive(:users_registration_mode).and_return(:disabled)
-        end
+        let(:organization) { create(:organization, users_registration_mode: :disabled) }
 
         it "doesn't allow the user to sign up" do
           find(".sign-in-link").click

--- a/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
@@ -64,15 +64,6 @@ Decidim.configure do |config|
   # end
   #
   # config.sms_gateway_service = "MySMSGatewayService"
-
-  # Users registration mode
-  # Whether users can register or access the system. Doesn't affect users that access through Omniauth integrations.
-  #
-  #  - enabled: Users registration and sign in are enabled (default value).
-  #  - existing: Users can't be registered in the system. Only existing users can sign in.
-  #  - disable: Users can't register or sign in.
-  #
-  config.users_registration_mode = :enabled
 end
 
 Rails.application.config.i18n.available_locales = Decidim.available_locales

--- a/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
@@ -64,6 +64,15 @@ Decidim.configure do |config|
   # end
   #
   # config.sms_gateway_service = "MySMSGatewayService"
+
+  # Users registration mode
+  # Whether users can register or access the system. Doesn't affect users that access through Omniauth integrations.
+  #
+  #  - enabled: Users registration and sign in are enabled (default value).
+  #  - existing: Users can't be registered in the system. Only existing users can sign in.
+  #  - disable: Users can't register or sign in.
+  #
+  config.users_registration_mode = :enabled
 end
 
 Rails.application.config.i18n.available_locales = Decidim.available_locales

--- a/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
@@ -97,9 +97,14 @@ module Decidim
           render partial: "decidim/shared/follow_button.html", locals: { followable: model }
         else
           content_tag(:p, class: "mt-s mb-none") do
-            t("decidim.proposals.proposals.show.sign_in_or_up",
-              in: link_to(t("decidim.proposals.proposals.show.sign_in"), decidim.new_user_session_path),
-              up: link_to(t("decidim.proposals.proposals.show.sign_up"), decidim.new_user_registration_path)).html_safe
+            if Decidim.sign_up_enabled?
+              t("decidim.proposals.proposals.show.sign_in_or_up",
+                in: link_to(t("decidim.proposals.proposals.show.sign_in"), decidim.new_user_session_path),
+                up: link_to(t("decidim.proposals.proposals.show.sign_up"), decidim.new_user_registration_path)).html_safe
+            else
+              t("decidim.proposals.proposals.show.sign_in_to_participate",
+                in: link_to(t("decidim.proposals.proposals.show.sign_in"), decidim.new_user_session_path)).html_safe
+            end
           end
         end
       end

--- a/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
@@ -97,7 +97,7 @@ module Decidim
           render partial: "decidim/shared/follow_button.html", locals: { followable: model }
         else
           content_tag(:p, class: "mt-s mb-none") do
-            if current_user.organization.sign_up_enabled?
+            if current_organization.sign_up_enabled?
               t("decidim.proposals.proposals.show.sign_in_or_up",
                 in: link_to(t("decidim.proposals.proposals.show.sign_in"), decidim.new_user_session_path),
                 up: link_to(t("decidim.proposals.proposals.show.sign_up"), decidim.new_user_registration_path)).html_safe

--- a/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
@@ -97,7 +97,7 @@ module Decidim
           render partial: "decidim/shared/follow_button.html", locals: { followable: model }
         else
           content_tag(:p, class: "mt-s mb-none") do
-            if Decidim.sign_up_enabled?
+            if current_user.organization.sign_up_enabled?
               t("decidim.proposals.proposals.show.sign_in_or_up",
                 in: link_to(t("decidim.proposals.proposals.show.sign_in"), decidim.new_user_session_path),
                 up: link_to(t("decidim.proposals.proposals.show.sign_up"), decidim.new_user_registration_path)).html_safe

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -612,6 +612,7 @@ en:
           report: Report
           sign_in: Sign in
           sign_in_or_up: "%{in} or %{up} to participate"
+          sign_in_to_participate: "%{in} to participate"
           sign_up: sign up
           withdraw_btn_hint: You can withdraw your proposal if you change your mind, as long as you have not received any support. The proposal is not deleted, it will appear in the list of withdrawn proposals.
           withdraw_confirmation: Are you sure to withdraw this proposal?

--- a/decidim-system/app/commands/decidim/system/register_organization.rb
+++ b/decidim-system/app/commands/decidim/system/register_organization.rb
@@ -50,6 +50,7 @@ module Decidim
           reference_prefix: form.reference_prefix,
           available_locales: form.available_locales,
           available_authorizations: form.clean_available_authorizations,
+          users_registration_mode: form.users_registration_mode,
           badges_enabled: true,
           default_locale: form.default_locale,
           send_welcome_notification: true

--- a/decidim-system/app/commands/decidim/system/update_organization.rb
+++ b/decidim-system/app/commands/decidim/system/update_organization.rb
@@ -45,6 +45,7 @@ module Decidim
         organization.host = form.host
         organization.secondary_hosts = form.clean_secondary_hosts
         organization.available_authorizations = form.clean_available_authorizations
+        organization.users_registration_mode = form.users_registration_mode
 
         organization.save!
       end

--- a/decidim-system/app/forms/decidim/system/register_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/register_organization_form.rb
@@ -14,11 +14,13 @@ module Decidim
       attribute :available_locales, Array
       attribute :default_locale, String
       attribute :reference_prefix
+      attribute :users_registration_mode, String
 
-      validates :organization_admin_email, :organization_admin_name, :name, :host, :reference_prefix, presence: true
+      validates :organization_admin_email, :organization_admin_name, :name, :host, :reference_prefix, :users_registration_mode, presence: true
       validates :available_locales, presence: true
       validates :default_locale, presence: true
       validates :default_locale, inclusion: { in: :available_locales }
+      validates :users_registration_mode, inclusion: { in: Decidim::Organization.users_registration_modes }
     end
   end
 end

--- a/decidim-system/app/forms/decidim/system/update_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/update_organization_form.rb
@@ -15,10 +15,11 @@ module Decidim
       attribute :host, String
       attribute :secondary_hosts, String
       attribute :available_authorizations, Array[String]
+      attribute :users_registration_mode, String
 
-      validates :name, presence: true
-      validates :host, presence: true
+      validates :name, :host, :users_registration_mode, presence: true
       validate :validate_organization_uniqueness
+      validates :users_registration_mode, inclusion: { in: Decidim::Organization.users_registration_modes }
 
       def map_model(model)
         self.secondary_hosts = model.secondary_hosts.join("\n")

--- a/decidim-system/app/views/decidim/system/organizations/edit.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/edit.html.erb
@@ -13,6 +13,14 @@
   </div>
 
   <div class="field">
+    <%= f.label :users_registration_mode %>
+    <%= f.collection_radio_buttons :users_registration_mode,
+                                   Decidim::Organization.users_registration_modes,
+                                   :first,
+                                   ->(mode) { t("decidim.system.organizations.users_registration_mode.#{mode.first}") } %>
+  </div>
+
+  <div class="field">
     <%= f.label :available_authorizations %>
     <%= f.collection_check_boxes :available_authorizations, Decidim.authorization_workflows, :name, :description %>
   </div>

--- a/decidim-system/app/views/decidim/system/organizations/new.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/new.html.erb
@@ -54,6 +54,14 @@
   <% end %>
 
   <div class="field">
+    <%= f.label :users_registration_mode %>
+    <%= f.collection_radio_buttons :users_registration_mode,
+                                   Decidim::Organization.users_registration_modes,
+                                   :first,
+                                   ->(mode) { t("decidim.system.organizations.users_registration_mode.#{mode.first}") } %>
+  </div>
+
+  <div class="field">
     <%= f.label :available_authorizations %>
     <%= f.collection_check_boxes :available_authorizations, Decidim.authorization_workflows, :name, :description %>
   </div>

--- a/decidim-system/config/locales/en.yml
+++ b/decidim-system/config/locales/en.yml
@@ -65,9 +65,9 @@ en:
           error: There was an error when updating this organization.
           success: Organization updated successfully.
         users_registration_mode:
+          disabled: Access only can be done with external accounts
           enabled: Allow users to register and login
           existing: Don't allow users to register, but allow existing users to login
-          disabled: Access only can be done with external accounts
       shared:
         notices:
           no_organization_warning_html: You must create an organization to get started. Make sure you read %{guide} before proceeding.

--- a/decidim-system/config/locales/en.yml
+++ b/decidim-system/config/locales/en.yml
@@ -64,6 +64,10 @@ en:
         update:
           error: There was an error when updating this organization.
           success: Organization updated successfully.
+        users_registration_mode:
+          enabled: Allow users to register and login
+          existing: Don't allow users to register, but allow existing users to login
+          disabled: Access only can be done with external accounts
       shared:
         notices:
           no_organization_warning_html: You must create an organization to get started. Make sure you read %{guide} before proceeding.

--- a/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
@@ -22,7 +22,8 @@ module Decidim
               organization_admin_name: "Fiorello Henry La Guardia",
               organization_admin_email: "f.laguardia@gotham.gov",
               available_locales: ["en"],
-              default_locale: "en"
+              default_locale: "en",
+              users_registration_mode: "enabled"
             }
           end
 

--- a/decidim-system/spec/commands/decidim/system/update_organization_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/update_organization_spec.rb
@@ -18,7 +18,8 @@ module Decidim
             {
               name: "Gotham City",
               host: "decide.gotham.gov",
-              secondary_hosts: "foo.gotham.gov\r\n\r\nbar.gotham.gov"
+              secondary_hosts: "foo.gotham.gov\r\n\r\nbar.gotham.gov",
+              users_registration_mode: "existing"
             }
           end
 
@@ -33,6 +34,7 @@ module Decidim
             expect(organization.name).to eq("Gotham City")
             expect(organization.host).to eq("decide.gotham.gov")
             expect(organization.secondary_hosts).to match_array(["foo.gotham.gov", "bar.gotham.gov"])
+            expect(organization.users_registration_mode).to eq("existing")
           end
         end
 

--- a/decidim-system/spec/system/organizations_spec.rb
+++ b/decidim-system/spec/system/organizations_spec.rb
@@ -26,6 +26,7 @@ describe "Organizations", type: :system do
         fill_in "Organization admin email", with: "mayor@citizen.corp"
         check "organization_available_locales_en"
         choose "organization_default_locale_en"
+        choose "Allow users to register and login"
         check "Example authorization (Direct)"
         click_button "Create organization & invite admin"
 
@@ -75,6 +76,7 @@ describe "Organizations", type: :system do
         fill_in "Name", with: "Citizens Rule!"
         fill_in "Host", with: "www.foo.org"
         fill_in "Secondary hosts", with: "foobar.citizen.corp\n\rbar.citizen.corp"
+        choose "Don't allow users to register, but allow existing users to login"
         check "Example authorization (Direct)"
         click_button "Save"
 

--- a/docs/customization/users_registration_mode.md
+++ b/docs/customization/users_registration_mode.md
@@ -1,0 +1,17 @@
+# Users registration mode
+
+Decidim allows organizations to choose one of the three modes related to the registration and login of users. This can be configured by the system user, in the organization manager zone.
+
+## Allow users to register and login
+
+This is the default mode. It enables the registration form and allow anyone to create a new account and log in.
+
+## Don't allow users to register, but allow existing users to login
+
+This mode disables the registration form, but allows existing users to log in. This mode could be useful for organizations with a closed census that do not want to offer other people to register.
+
+Note: if you have configured [social providers](services/social_providers.md), users will still be able to sign in with external accounts even when this mode is configured.
+
+## Access only can be done with external accounts
+
+This mode disables the registration form and the login form. With this mode, users only can access through [social providers](services/social_providers.md), so it is recommended to configure at least one of them. This can be useful when an organization needs to allow participation only to users of another application of the organization itself.


### PR DESCRIPTION
#### :tophat: What? Why?
I'm working in a Decidim instance that should only allow users to access throught an OmniAuth integration. So, I've added a `users_registration_mode` setting to `Decidim::Core` to allow to customize this.

This setting has three posible values: `:enabled`, `:existing` and `:disabled`. `:enabled` is the default value and it will keep Decidim working as now. On the other hand, `:disabled` disables completely user registration and sign in with email and password. This does not affect OmniAuth integration, this kind of registration will  work even when regular registration is disabled.

The last possible value, `:existing`, allow users to sign in but not to sign up. I think that this could be helpful when working with a fixed list of users. As said before, this case doesn't affect OmniAuth integration, so I don't know if this scenario would have sense if there are OmniAuth integrations enabled. I've added this option because I think that could be helpful and it doesn't need any extra work, but I don't really need it. If you think that wouldn't be useful or could be confusing I can remove it and convert the setting to a boolean `users_registration_enabled` variable.

#### :pushpin: Related Issues

#### :clipboard: Subtasks
- [x] Disable Devise controller actions based on the setting
- [x] Hide links based on the setting
- [x] Add tests
- [x] Added default setting to application initializer template
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)

- With `:disabled` value:
![imagen](https://user-images.githubusercontent.com/453545/48060796-4d7e6e00-e1bd-11e8-8931-5137aec62ad0.png)
![imagen](https://user-images.githubusercontent.com/453545/48061652-03e35280-e1c0-11e8-9d7d-c58175bbe863.png)
![imagen](https://user-images.githubusercontent.com/453545/48060819-5bcc8a00-e1bd-11e8-9fa1-da7674219fdb.png)

- With `:existing` value:
![imagen](https://user-images.githubusercontent.com/453545/48060796-4d7e6e00-e1bd-11e8-8931-5137aec62ad0.png)
![imagen](https://user-images.githubusercontent.com/453545/48061135-3be99600-e1be-11e8-91e2-ee106d2f9f17.png)
![imagen](https://user-images.githubusercontent.com/453545/48061715-2bd2b600-e1c0-11e8-8e79-4e2410de13ee.png)


