### PR TITLE
Fix title display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ end
 - **decidim-meetings**: Fix order of upcoming meetings [\#4398](https://github.com/decidim/decidim/pull/4398)
 - **decidim-core**: Ignore deleted users follows [\#4401](https://github.com/decidim/decidim/pull/4401)
 - **decidim-comments**: Fix comment activity cell when commentable is a comment [\#4413](https://github.com/decidim/decidim/pull/4413)
+- **decidim-proposals**: Fix title display [\#4431](https://github.com/decidim/decidim/pull/4431)
+- **decidim-meetings**: Fix title display [\#4431](https://github.com/decidim/decidim/pull/4431)
 
 **Removed**:
 

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_activity_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_activity_cell.rb
@@ -10,6 +10,10 @@ module Decidim
           link: participatory_space_link
         )
       end
+
+      def resource_link_text
+        Decidim::Meetings::MeetingPresenter.new(resource).title
+      end
     end
   end
 end

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_s_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_s_cell.rb
@@ -5,9 +5,7 @@ module Decidim
     # This cell renders the Small (:s) meeting card
     # for an given instance of a Meeting
     class MeetingSCell < MeetingMCell
-      def title
-        translated_attribute model.title
-      end
+      delegate :title, to: :presenter
 
       def meeting_path
         resource_locator(model).path
@@ -23,6 +21,10 @@ module Decidim
 
       def participatory_space_path
         resource_locator(model.component.participatory_space).path
+      end
+
+      def presenter
+        @presenter ||= Decidim::Meetings::MeetingPresenter.new(model)
       end
     end
   end

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_activity_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_activity_cell.rb
@@ -10,6 +10,10 @@ module Decidim
           link: participatory_space_link
         )
       end
+
+      def resource_link_text
+        Decidim::Proposals::ProposalPresenter.new(resource).title
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Proposals and Meetings can have a hashtag at their title so the upcoming events block and last activity content block should keep this in mind.

#### :pushpin: Related Issues
- Related to #3699, #4404 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
