### PR TITLE
Configurable OmniAuth integration icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ end
 
 **Changed**:
 
+- **decidim-core**: Allow to configure OmniAuth provider icons [\#4440](https://github.com/decidim/decidim/pull/4440)
+- **decidim-surveys**: Extract surveys logic to decidim-forms [\#3877](https://github.com/decidim/decidim/pull/3877)
 - **decidim-core**: Improve static pages layout and make them groupable by topic. [\#4338](https://github.com/decidim/decidim/pull/4338)
 - **decidim-surveys**: Extract surveys logic to decidim-forms [\#3877](https://github.com/decidim/decidim/pull/3877)
 

--- a/decidim-core/app/helpers/decidim/omniauth_helper.rb
+++ b/decidim-core/app/helpers/decidim/omniauth_helper.rb
@@ -23,8 +23,16 @@ module Decidim
 
     # Public: icon for omniauth buttons
     def oauth_icon(provider)
-      name = provider == :developer ? "phone" : normalize_provider_name(provider)
+      info = Rails.application.secrets.dig(:omniauth, provider.to_sym)
 
+      if info
+        icon_path = info[:icon_path]
+        return external_icon(icon_path) if icon_path
+
+        name = info[:icon]
+      end
+
+      name ||= normalize_provider_name(provider)
       icon(name)
     end
   end

--- a/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb
+++ b/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb
@@ -35,6 +35,7 @@ development:
   omniauth:
     developer:
       enabled: true
+      icon: phone
 
 test:
   <<: *default

--- a/docs/services/social_providers.md
+++ b/docs/services/social_providers.md
@@ -39,3 +39,22 @@ If you want to enable sign up through social providers like Facebook you will ne
 1. Select `Web applications`. Fill in the `Authorized Javascript origins` with your url. Then fill in the `Authorized redirect URIs` with your url and append the path `/users/auth/google_oauth2/callback`.
 1. Copy the CLIENT_ID AND CLIENT_SECRET
 1. Paste credentials in `config/secrets.yml`. Ensure the `enabled` attribute is `true`.
+
+## Custom providers
+
+* You can define your own provider, to allow users from other external applications to login into Decidim.
+* The provider should implement an [OmniAuth](https://github.com/omniauth/omniauth) strategy.
+* You can use any of the [existing OnmiAuth strategies](https://github.com/omniauth/omniauth/wiki/List-of-Strategies).
+* Or you can create a new strategy, as the [Decidim OmniAuth Strategy](https://github.com/decidim/omniauth-decidim). This strategy allow users from a Decidim instance to login in other Decidim instance. For example, this strategy is used to allow [decidim.barcelona](https://decidim.barcelona) users to log into [meta.decidim.barcelona](https://meta.decidim.barcelona).
+* Once you have defined your strategy, you can configure it in the `config/secrets.yml`, as it is done for the built-in providers.
+* By default, Decidim will search in its icons library for an icon named as the provider. You can change this adding an `icon` or `icon_path` attribute to the provider configuration. The `icon` attribute sets the icon name to look for in the Decidim's icons library. The `icon_path` attribute sets the route to the image that should be used.
+* Here is an example of the configuration section for the Decidim strategy, using an icon located on the application's `app/assets/images` folder:
+
+```yaml
+    decidim:
+      enabled: true
+      client_id: <%= ENV["DECIDIM_CLIENT_ID"] %>
+      client_secret: <%= ENV["DECIDIM_CLIENT_SECRET"] %>
+      site_url: <%= ENV["DECIDIM_SITE_URL"] %>
+      icon_path: decidim-logo.svg
+```


### PR DESCRIPTION
#### :tophat: What? Why?
Currently, custom OmniAuth integrations only show an icon when there is an icon with the same name in the icons.svg file. Also, the developer strategy icon is hardcoded in the helper function.

This PR allows the developer to configure in the `secrets.yml` the icon from the icons.svg to use (`icon` attribute), or even use an external icon (`icon_path` attribute).

#### :pushpin: Related Issues

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
