### PR TITLE
check if manifest of participatory space is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ end
 
 **Fixed**:
 
+- **decidim-conferences**: Check participatory spaces manifest exists when relating conferences to other spaces [\#4446](https://github.com/decidim/decidim/pull/4446)
 - **decidim-proposals**: Allow admins to edit proposals even if creation is not enabled [\#4390](https://github.com/decidim/decidim/pull/4390)
 - **decidim-core**: Fix events for polymorphic authors [\#4387](https://github.com/decidim/decidim/pull/4387)
 - **decidim-meetings**: Fix order of upcoming meetings [\#4398](https://github.com/decidim/decidim/pull/4398)

--- a/decidim-conferences/app/cells/decidim/conferences/linked_participatory_spaces_cell.rb
+++ b/decidim-conferences/app/cells/decidim/conferences/linked_participatory_spaces_cell.rb
@@ -19,18 +19,21 @@ module Decidim
       end
 
       def conference_participatory_processes
+        return unless Decidim.participatory_space_manifests.map(&:name).include?(:participatory_processes)
         processes = model.linked_participatory_space_resources(:participatory_processes, "included_participatory_processes")
         return unless processes.any?
         processes
       end
 
       def conference_assemblies
+        return unless Decidim.participatory_space_manifests.map(&:name).include?(:assemblies)
         assemblies = model.linked_participatory_space_resources(:assemblies, "included_assemblies")
         return unless assemblies.any?
         assemblies
       end
 
       def conference_consultations
+        return unless Decidim.participatory_space_manifests.map(&:name).include?(:consultations)
         consultations = model.linked_participatory_space_resources(:consultations, "included_consultations")
         return unless consultations.any?
         consultations

--- a/decidim-conferences/app/forms/decidim/conferences/admin/conference_form.rb
+++ b/decidim-conferences/app/forms/decidim/conferences/admin/conference_form.rb
@@ -61,6 +61,7 @@ module Decidim
         end
 
         def processes_for_select
+          return unless Decidim.participatory_space_manifests.map(&:name).include?(:participatory_processes)
           @processes_for_select ||= Decidim.find_participatory_space_manifest(:participatory_processes)
                                            .participatory_spaces.call(current_organization)&.order(title: :asc)&.map do |process|
             [
@@ -71,6 +72,7 @@ module Decidim
         end
 
         def assemblies_for_select
+          return unless Decidim.participatory_space_manifests.map(&:name).include?(:assemblies)
           @assemblies_for_select ||= Decidim.find_participatory_space_manifest(:assemblies)
                                             .participatory_spaces.call(current_organization)&.order(title: :asc)&.map do |assembly|
             [
@@ -81,6 +83,7 @@ module Decidim
         end
 
         def consultations_for_select
+          return unless Decidim.participatory_space_manifests.map(&:name).include?(:consultations)
           @consultations_for_select ||= Decidim.find_participatory_space_manifest(:consultations)
                                                .participatory_spaces.call(current_organization)&.order(title: :asc)&.map do |consultation|
             [


### PR DESCRIPTION
#### :tophat: What? Why?
This PR is to prevent error when gems of participatory spaces (processes, assemblies or consultations) are not installed

#### :pushpin: Related Issues
- Related to #3743 
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add condition if participatory space manifest not present 
### :camera: Screenshots (optional)
![Description](URL)
