### PR TITLE
[REFACTOR] Depend upon a more stable doc2text branch.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "decidim-initiatives", path: "."
 
 gem "bootsnap", "~> 1.3"
 
-gem "doc2text", git: "https://github.com/bostko/doc2text.git"
+gem "doc2text", git: "https://github.com/bostko/doc2text.git", branch: "0.4-stable"
 
 gem "puma", "~> 3.0"
 gem "uglifier", "~> 4.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: https://github.com/bostko/doc2text.git
-  revision: 937eb55a7767e3daf3e7e091eee2e788718f8132
+  revision: 6e88ce1e068f80e3cf7dcbeca4f22d55576b12d7
+  branch: 0.4-stable
   specs:
     doc2text (0.3.3)
       nokogiri (~> 1.6, >= 1.6.3)

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -472,7 +472,7 @@ GEM
     mustache (1.1.0)
     nio4r (2.3.1)
     nobspw (0.4.0)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     oauth (0.5.4)
     oauth2 (1.4.1)

--- a/decidim-proposals/lib/decidim/proposals/odt_to_markdown.rb
+++ b/decidim-proposals/lib/decidim/proposals/odt_to_markdown.rb
@@ -38,7 +38,7 @@ module Decidim
 
       def transform_to_md_file(doc_file)
         md_file = Tempfile.new
-        Doc2Text::XmlBasedDocument::Odt::Document.parse_and_save doc_file, md_file
+        Doc2Text::Odt::Document.parse_and_save doc_file, md_file
         md_file
       end
     end

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: https://github.com/bostko/doc2text.git
-  revision: 937eb55a7767e3daf3e7e091eee2e788718f8132
+  revision: 6e88ce1e068f80e3cf7dcbeca4f22d55576b12d7
+  branch: 0.4-stable
   specs:
     doc2text (0.3.3)
       nokogiri (~> 1.6, >= 1.6.3)
@@ -480,7 +481,7 @@ GEM
     mustache (1.1.0)
     nio4r (2.3.1)
     nobspw (0.4.0)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     oauth (0.5.4)
     oauth2 (1.4.1)


### PR DESCRIPTION
#### :tophat: What? Why?
Do not rely on what's in master (development branch). Instead depend upon 0.4-stable.

#### :pushpin: Related Issues
- Related to #3583 

#### :clipboard: Subtasks
- [-] Add `CHANGELOG` entry
- [-] Add documentation regarding the feature 
- [-] Add/modify seeds
- [x] Refactor tests
- [x] Update dependency.
