### PR TITLE
Move the omniauth login buttons to before the form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ end
 - **decidim-surveys**: Extract surveys logic to decidim-forms [\#3877](https://github.com/decidim/decidim/pull/3877)
 - **decidim-core**: Improve static pages layout and make them groupable by topic. [\#4338](https://github.com/decidim/decidim/pull/4338)
 - **decidim-surveys**: Extract surveys logic to decidim-forms [\#3877](https://github.com/decidim/decidim/pull/3877)
+- **decidim-core**: Move Omniauth login buttons to before the signup/sign in forms to improve usability [\#4457](https://github.com/decidim/decidim/pull/4457)
 
 **Fixed**:
 

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -19,6 +19,8 @@
     </div>
   </div>
 
+  <%= render "decidim/devise/shared/omniauth_buttons" %>
+
   <div class="row">
     <div class="columns large-6 medium-10 medium-centered">
 
@@ -89,8 +91,6 @@
       <% end %>
     </div>
   </div>
-
-  <%= render "decidim/devise/shared/omniauth_buttons" %>
 </div>
 </main>
 <%= render "decidim/devise/shared/newsletter_modal" %>

--- a/decidim-core/app/views/decidim/devise/sessions/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/sessions/new.html.erb
@@ -21,6 +21,8 @@
         <% end %>
       </div>
     </div>
+    <%= render "decidim/devise/shared/omniauth_buttons" %>
+
     <% if current_organization.sign_in_enabled? %>
       <div class="row">
         <div class="columns large-6 medium-centered">
@@ -52,6 +54,5 @@
         </div>
       </div>
     <% end %>
-    <%= render "decidim/devise/shared/omniauth_buttons" %>
   </div>
 </main>

--- a/decidim-core/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
+++ b/decidim-core/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
@@ -1,11 +1,6 @@
 <% if Devise.mappings[:user].omniauthable? && any_social_provider_enabled? %>
   <div class="row">
     <div class="columns large-4 mediumlarge-6 medium-8 medium-centered">
-      <%- if current_organization.sign_in_enabled? %>
-        <span class="register__separator">
-          <span class="register__separator__text"><%= t(".or") %></span>
-        </span>
-      <%- end %>
       <%- Decidim::User.omniauth_providers.each do |provider| %>
         <% if social_provider_enabled? provider %>
           <div class="social-register">
@@ -18,6 +13,11 @@
           </div>
         <% end %>
       <% end %>
+      <%- if current_organization.sign_in_enabled? %>
+        <span class="register__separator">
+          <span class="register__separator__text"><%= t(".or") %></span>
+        </span>
+      <%- end %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR moves the omniauth login buttons to before the form, as stated in #4303.

#### :pushpin: Related Issues
- Fixes #4303

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/xWqe2NC.png)

![](https://i.imgur.com/8Qglfrd.png)
