### PR TITLE
Ensure we get unique results on proposals search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ end
 - **decidim-core**: Set `organization.tos_version` when creating `terms-and-conditions` DefaultPage [#3911](https://github.com/decidim/decidim/pull/3911)
 - **decidim-proposals**: Fix title display [\#4431](https://github.com/decidim/decidim/pull/4431)
 - **decidim-meetings**: Fix title display [\#4431](https://github.com/decidim/decidim/pull/4431)
+- **decidim-proposals**: Ensure proposals search returns unique results [\#4460](https://github.com/decidim/decidim/pull/4460)
 
 **Removed**:
 

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_search_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_search_spec.rb
@@ -79,10 +79,12 @@ module Decidim
 
           context "when filtering citizen proposals" do
             let(:origin) { "citizens" }
+            let(:another_user) { create(:user, organization: component.organization) }
 
             it "returns only citizen proposals" do
               create_list(:proposal, 3, :official, component: component)
               citizen_proposals = create_list(:proposal, 2, component: component)
+              proposal.add_coauthor(another_user)
               citizen_proposals << proposal
 
               expect(subject.size).to eq(3)


### PR DESCRIPTION
#### :tophat: What? Why?
While using the "Citizens" filter on the default development app, I get this:

```
c=Decidim::Component.find(12)
Decidim::Proposals::Proposal.where(component: c).count # => 5
```
(check the URL in the screenshot to see that the component is ID 12)


But on the website I get this:

![](https://i.imgur.com/vQTLC0e.png)
Note that I'm getting 7 results.

This is due to some proposals having multiple authorships by citizens, and it's returning the same proposal multiple times (one per each citizen authorship).

This PR ensures this doesn't happen.

#### :pushpin: Related Issues
- Related to #3532 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
