### PR TITLE
Filter proposals origin by user groups and meetings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ end
 - **decidim-proposals**: Split & merge proposals to the same component [\#4415](https://github.com/decidim/decidim/pull/4415)
 - **decidim-core**: Adds the ability to send a welcome notification to new users [#4432](https://github.com/decidim/decidim/pull/4432)
 - **decidim-meetings**: Add a meetings calendar at organization and component levels [\#4376](https://github.com/decidim/decidim/pull/4376)
+- **decidim-proposals**: Add user groups and meetings options on Origin filters [\#4462](https://github.com/decidim/decidim/pull/4462)
 
 **Changed**:
 

--- a/decidim-core/lib/decidim/coauthorable.rb
+++ b/decidim-core/lib/decidim/coauthorable.rb
@@ -95,7 +95,7 @@ module Decidim
 
       # Adds a new coauthor to the list of coauthors. The coauthorship is created with
       # current object as coauthorable and `user` param as author. To set the user group
-      # use `extra_attributes` either with `user_group` or `decidim_user_group_id` keys.
+      # use `extra_attributes` with the `user_group` key.
       #
       # @param author: The new coauthor.
       # @extra_attrs: Extra

--- a/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
@@ -130,6 +130,33 @@ module Decidim
         return true if can_accumulate_supports_beyond_threshold?
         return true if minimum_votes_per_user_enabled?
       end
+
+      def filter_origin_values
+        base = if component_settings.official_proposals_enabled
+                [
+                  ["all", t(".all")],
+                  ["official", t(".official")]
+                ]
+              else
+                [ ["all", t(".all")] ]
+              end
+
+        base + [
+          ["citizens", t(".citizens")],
+          ["user_group", t(".user_groups")],
+          ["meeting", t(".meetings")]
+        ]
+      end
+
+      def filter_state_values
+        [
+          ["except_rejected", t(".except_rejected")],
+          ["accepted", t(".accepted")],
+          ["evaluating", t(".evaluating")],
+          ["rejected", t(".rejected")],
+          ["all", t(".all")]
+        ]
+      end
     end
   end
 end

--- a/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
@@ -133,28 +133,28 @@ module Decidim
 
       def filter_origin_values
         base = if component_settings.official_proposals_enabled
-                [
-                  ["all", t(".all")],
-                  ["official", t(".official")]
-                ]
-              else
-                [ ["all", t(".all")] ]
-              end
+                 [
+                   ["all", t("decidim.proposals.application_helper.filter_origin_values.all")],
+                   ["official", t("decidim.proposals.application_helper.filter_origin_values.official")]
+                 ]
+               else
+                 [["all", t("decidim.proposals.application_helper.filter_origin_values.all")]]
+               end
 
         base + [
-          ["citizens", t(".citizens")],
-          ["user_group", t(".user_groups")],
-          ["meeting", t(".meetings")]
+          ["citizens", t("decidim.proposals.application_helper.filter_origin_values.citizens")],
+          ["user_group", t("decidim.proposals.application_helper.filter_origin_values.user_groups")],
+          ["meeting", t("decidim.proposals.application_helper.filter_origin_values.meetings")]
         ]
       end
 
       def filter_state_values
         [
-          ["except_rejected", t(".except_rejected")],
-          ["accepted", t(".accepted")],
-          ["evaluating", t(".evaluating")],
-          ["rejected", t(".rejected")],
-          ["all", t(".all")]
+          ["except_rejected", t("decidim.proposals.application_helper.filter_state_values.except_rejected")],
+          ["accepted", t("decidim.proposals.application_helper.filter_state_values.accepted")],
+          ["evaluating", t("decidim.proposals.application_helper.filter_state_values.evaluating")],
+          ["rejected", t("decidim.proposals.application_helper.filter_state_values.rejected")],
+          ["all", t("decidim.proposals.application_helper.filter_state_values.all")]
         ]
       end
     end

--- a/decidim-proposals/app/services/decidim/proposals/proposal_search.rb
+++ b/decidim-proposals/app/services/decidim/proposals/proposal_search.rb
@@ -22,10 +22,28 @@ module Decidim
 
       # Handle the origin filter
       def search_origin
-        if origin == "official"
-          query.where.not(coauthorships_count: 0).joins(:coauthorships).where(decidim_coauthorships: { decidim_author_type: "Decidim::Organization" })
-        elsif origin == "citizens"
-          query.where.not(coauthorships_count: 0).joins(:coauthorships).where.not(decidim_coauthorships: { decidim_author_type: "Decidim::Organization" })
+        case origin
+        when "official"
+          query
+            .where.not(coauthorships_count: 0)
+            .joins(:coauthorships)
+            .where(decidim_coauthorships: { decidim_author_type: "Decidim::Organization" })
+        when "citizens"
+          query
+            .where.not(coauthorships_count: 0)
+            .joins(:coauthorships)
+            .where.not(decidim_coauthorships: { decidim_author_type: "Decidim::Organization" })
+        when "user_group"
+          query
+            .where.not(coauthorships_count: 0)
+            .joins(:coauthorships)
+            .where(decidim_coauthorships: { decidim_author_type: "Decidim::UserBaseEntity" })
+            .where.not(decidim_coauthorships: { decidim_user_group_id: nil })
+        when "meeting"
+          query
+            .where.not(coauthorships_count: 0)
+            .joins(:coauthorships)
+            .where(decidim_coauthorships: { decidim_author_type: "Decidim::Meetings::Meeting" })
         else # Assume 'all'
           query
         end

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
@@ -13,11 +13,11 @@
   </div>
 
   <% if component_settings.official_proposals_enabled %>
-    <%= form.collection_radio_buttons :origin, [["all", t(".all")], ["official", t(".official")], ["citizens", t(".citizens")]], :first, :last, legend_title: t(".origin") %>
+    <%= form.collection_radio_buttons :origin, filter_origin_values, :first, :last, legend_title: t(".origin") %>
   <% end %>
 
   <% if component_settings.proposal_answering_enabled && current_settings.proposal_answering_enabled %>
-    <%= form.collection_radio_buttons :state, [["except_rejected", t(".except_rejected")], ["accepted", t(".accepted")], ["evaluating", t(".evaluating")], ["rejected", t(".rejected")], ["all", t(".all")]], :first, :last, legend_title: t(".state") %>
+    <%= form.collection_radio_buttons :state, filter_state_values, :first, :last, legend_title: t(".state") %>
   <% end %>
 
   <% if linked_classes_for(Decidim::Proposals::Proposal).any? %>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -561,12 +561,14 @@ en:
           citizens: Citizens
           evaluating: Evaluating
           except_rejected: All except rejected
+          meetings: Meetings
           official: Official
           origin: Origin
           rejected: Rejected
           related_to: Related to
           search: Search
           state: State
+          user_groups: User groups
           voted: Voted
         filters_small_view:
           close_modal: Close modal

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -367,6 +367,19 @@ en:
         not_answered: Not answered
         rejected: Rejected
         withdrawn: Withdrawn
+      application_helper:
+        filter_origin_values:
+          all: All
+          citizens: Citizens
+          meetings: Meetings
+          official: Official
+          user_groups: User groups
+        filter_state_values:
+          accepted: Accepted
+          all: All
+          evaluating: Evaluating
+          except_rejected: All except rejected
+          rejected: Rejected
       collaborative_drafts:
         collaborative_draft:
           publish:
@@ -553,22 +566,13 @@ en:
         endorsements_card_row:
           comments: Comments
         filters:
-          accepted: Accepted
           activity: Activity
-          all: All
           category: Category
           category_prompt: Select a category
-          citizens: Citizens
-          evaluating: Evaluating
-          except_rejected: All except rejected
-          meetings: Meetings
-          official: Official
           origin: Origin
-          rejected: Rejected
           related_to: Related to
           search: Search
           state: State
-          user_groups: User groups
           voted: Voted
         filters_small_view:
           close_modal: Close modal

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_search_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_search_spec.rb
@@ -91,6 +91,34 @@ module Decidim
               expect(subject).to match_array(citizen_proposals)
             end
           end
+
+          context "when filtering user groups proposals" do
+            let(:origin) { "user_group" }
+            let(:user_group) { create :user_group, :verified, users: [user], organization: user.organization }
+
+            it "returns only user groups proposals" do
+              create(:proposal, :official, component: component)
+              user_group_proposal = create(:proposal, component: component)
+              user_group_proposal.coauthorships.clear
+              user_group_proposal.add_coauthor(user, user_group: user_group)
+
+              expect(subject.size).to eq(1)
+              expect(subject).to eq([user_group_proposal])
+            end
+          end
+
+          context "when filtering meetings proposals" do
+            let(:origin) { "meeting" }
+            let(:meeting) { create :meeting }
+
+            it "returns only meeting proposals" do
+              create(:proposal, :official, component: component)
+              meeting_proposal = create(:proposal, :official_meeting, component: component)
+
+              expect(subject.size).to eq(1)
+              expect(subject).to eq([meeting_proposal])
+            end
+          end
         end
 
         describe "state filter" do

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -401,7 +401,7 @@ describe "Proposals", type: :system do
           visit_component
 
           within "form.new_filter" do
-            expect(page).to have_no_content(/Origin/i)
+            expect(page).to have_no_content(/Official/i)
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR lets users filter proposals by origin, adding two new options: user groups and meetings, as stated in #4159. 

#### :pushpin: Related Issues
- Related to #4159

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/2Mjs3Ei.png)
