### PR TITLE
Send first unread conversation message text in email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ end
 - **decidim-verifications**: Add SMS verification workflow [\#4429](https://github.com/decidim/decidim/pull/4429)
 - **decidim-proposals**: Split & merge proposals to the same component [\#4415](https://github.com/decidim/decidim/pull/4415)
 - **decidim-core**: Adds the ability to send a welcome notification to new users [#4432](https://github.com/decidim/decidim/pull/4432)
+- **decidim-core**: Shows the first unread message in a conversation in the notification email [#4463](https://github.com/decidim/decidim/pull/4463)
 - **decidim-meetings**: Add a meetings calendar at organization and component levels [\#4376](https://github.com/decidim/decidim/pull/4376)
 
 **Changed**:

--- a/decidim-core/app/commands/decidim/messaging/reply_to_conversation.rb
+++ b/decidim-core/app/commands/decidim/messaging/reply_to_conversation.rb
@@ -43,7 +43,7 @@ module Decidim
 
       def notify_interlocutors
         conversation.interlocutors(sender).each do |recipient|
-          ConversationMailer.new_message(sender, recipient, conversation).deliver_later if conversation.unread_count(recipient) == 1
+          ConversationMailer.new_message(sender, recipient, conversation, message).deliver_later if conversation.unread_count(recipient) == 1
         end
       end
 

--- a/decidim-core/app/mailers/decidim/messaging/conversation_mailer.rb
+++ b/decidim-core/app/mailers/decidim/messaging/conversation_mailer.rb
@@ -10,27 +10,30 @@ module Decidim
           from: originator,
           to: user,
           conversation: conversation,
+          message: conversation.messages.first.body,
           action: "new_conversation"
         )
       end
 
-      def new_message(sender, user, conversation)
+      def new_message(sender, user, conversation, message)
         notification_mail(
           from: sender,
           to: user,
           conversation: conversation,
+          message: message.body,
           action: "new_message"
         )
       end
 
       private
 
-      def notification_mail(from:, to:, conversation:, action:)
+      def notification_mail(from:, to:, conversation:, action:, message: nil)
         with_user(to) do
           @organization = to.organization
           @conversation = conversation
           @sender = from.name
           @recipient = to.name
+          @message = message
           @host = @organization.host
 
           subject = I18n.t(

--- a/decidim-core/app/views/decidim/messaging/conversation_mailer/new_conversation.html.erb
+++ b/decidim-core/app/views/decidim/messaging/conversation_mailer/new_conversation.html.erb
@@ -2,6 +2,12 @@
 
 <p><%= t(".intro", sender: @sender) %></p>
 
+<blockquote>
+  <p>
+    <em><%= @message %></em>
+  </p>
+</blockquote>
+
 <p>
   <%= link_to decidim.conversation_url(@conversation, host: @host), decidim.conversation_url(@conversation, host: @host) %>
 </p>

--- a/decidim-core/app/views/decidim/messaging/conversation_mailer/new_message.html.erb
+++ b/decidim-core/app/views/decidim/messaging/conversation_mailer/new_message.html.erb
@@ -2,6 +2,12 @@
 
 <p><%= t(".intro", sender: @sender) %></p>
 
+<blockquote>
+  <p>
+    <em><%= @message %></em>
+  </p>
+</blockquote>
+
 <p>
   <%= link_to decidim.conversation_url(@conversation, host: @host), decidim.conversation_url(@conversation, host: @host) %>
 </p>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR gets the first unread message in a conversation and shows it in the notification email. See screenshots.

#### :pushpin: Related Issues
- Related to #4159

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
When a conversation is created:
![Description](https://i.imgur.com/KLpt5NO.png)

When new messages are sent in an already existing conversation:
![](https://i.imgur.com/eQAhMzQ.png)
