### PR TITLE
Notify proposal followers when result progress is updated

### DIFF
--- a/decidim-accountability/app/commands/decidim/accountability/admin/update_result.rb
+++ b/decidim-accountability/app/commands/decidim/accountability/admin/update_result.rb
@@ -26,6 +26,7 @@ module Decidim
             link_proposals
             link_meetings
             link_projects
+            send_notifications if should_notify_followers?
           end
 
           broadcast(:ok)
@@ -81,6 +82,27 @@ module Decidim
 
         def link_meetings
           result.link_resources(meetings, "meetings_through_proposals")
+        end
+
+        def send_notifications
+          result.linked_resources(:proposals, "included_proposals").each do |proposal|
+            recipient_ids = proposal.follower_ids
+
+            Decidim::EventsManager.publish(
+              event: "decidim.events.accountability.result_progress_updated",
+              event_class: Decidim::Accountability::ResultProgressUpdatedEvent,
+              resource: result,
+              recipient_ids: recipient_ids,
+              extra: {
+                progress: result.progress,
+                proposal_id: proposal.id
+              }
+            )
+          end
+        end
+
+        def should_notify_followers?
+          result.previous_changes["progress"].present?
         end
       end
     end

--- a/decidim-accountability/app/events/decidim/accountability/result_progress_updated_event.rb
+++ b/decidim-accountability/app/events/decidim/accountability/result_progress_updated_event.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Accountability
+    class ResultProgressUpdatedEvent < Decidim::Events::SimpleEvent
+      i18n_attributes :proposal_title, :proposal_path, :progress
+
+      def proposal_path
+        @proposal_path ||= Decidim::ResourceLocatorPresenter.new(proposal).path
+      end
+
+      def proposal_title
+        @proposal_title ||= proposal.title
+      end
+
+      def proposal
+        @proposal ||= resource.linked_resources(:proposals, "included_proposals").find_by(id: extra[:proposal_id])
+      end
+
+      def progress
+        extra[:progress]
+      end
+    end
+  end
+end

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -24,6 +24,7 @@ en:
         entry_date: Date
     models:
       decidim/accountability/proposal_linked_event: Proposal included in a result
+      decidim/accountability/result_progress_updated_event: Result progress updated
   activerecord:
     models:
       decidim/accountability/result:
@@ -202,6 +203,11 @@ en:
           email_outro: You have received this notification because you are following "%{proposal_title}". You can stop receiving notifications following the previous link.
           email_subject: An update to %{proposal_title}
           notification_title: The proposal <a href="%{proposal_path}">%{proposal_title}</a> has been included in the <a href="%{resource_path}">%{resource_title}</a> result.
+        result_progress_updated:
+          email_intro: 'The result "%{resource_title}", which includes the proposal "%{proposal_title}", is now %{progress}% complete. You can see it from this page:'
+          email_outro: You have received this notification because you are following "%{proposal_title}", and this proposal is included in the result "%{resource_title}". You can stop receiving notifications following the previous link.
+          email_subject: An update to %{resource_title} progress
+          notification_title: The result <a href="%{resource_path}">%{resource_title}</a>, which includes the proposal <a href="%{proposal_path}">%{proposal_title}</a>, is now %{progress}% complete.
     metrics:
       results:
         object: results

--- a/decidim-accountability/spec/commands/admin/create_result_spec.rb
+++ b/decidim-accountability/spec/commands/admin/create_result_spec.rb
@@ -130,7 +130,7 @@ module Decidim::Accountability
         expect(linked_meetings).to eq [meeting]
       end
 
-      it "notifies the process followers" do
+      it "notifies the linked proposals followers" do
         follower = create(:user, organization: organization)
         create(:follow, followable: proposals.first, user: follower)
 

--- a/decidim-accountability/spec/events/decidim/accountability/result_progress_updated_event_spec.rb
+++ b/decidim-accountability/spec/events/decidim/accountability/result_progress_updated_event_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Accountability::ResultProgressUpdatedEvent do
+  include_context "when a simple event"
+
+  let(:event_name) { "decidim.events.accountability.result_progress_updated" }
+  let(:resource) { create(:result) }
+  let(:proposal_component) do
+    create(:component, manifest_name: "proposals", participatory_space: resource.component.participatory_space)
+  end
+  let(:proposal) { create :proposal, component: proposal_component }
+  let(:extra) { { proposal_id: proposal.id, progress: 95 } }
+  let(:proposal_path) { resource_locator(proposal).path }
+  let(:proposal_title) { proposal.title }
+
+  before do
+    resource.link_resources([proposal], "included_proposals")
+  end
+
+  it_behaves_like "a simple event"
+
+  describe "proposal" do
+    it "finds the linked proposal" do
+      expect(subject.proposal).to eq(proposal)
+    end
+  end
+
+  describe "types" do
+    subject { described_class }
+
+    it "supports notifications" do
+      expect(subject.types).to include :notification
+    end
+
+    it "supports emails" do
+      expect(subject.types).to include :email
+    end
+  end
+
+  describe "email_subject" do
+    it "is generated correctly" do
+      expect(subject.email_subject).to eq("An update to #{translated resource.title} progress")
+    end
+  end
+
+  describe "email_outro" do
+    it "is generated correctly" do
+      expect(subject.email_outro).to eq("You have received this notification because you are following \"#{proposal_title}\", and this proposal is included in the result \"#{translated resource.title}\". You can stop receiving notifications following the previous link.")
+    end
+  end
+
+  describe "email_intro" do
+    it "is generated correctly" do
+      expect(subject.email_intro).to eq("The result \"#{translated resource.title}\", which includes the proposal \"#{proposal_title}\", is now 95% complete. You can see it from this page:")
+    end
+  end
+
+  describe "notification_title" do
+    it "is generated correctly" do
+      expect(subject.notification_title).to eq("The result <a href=\"#{resource_path}\">#{resource_title}</a>, which includes the proposal <a href=\"#{proposal_path}\">#{proposal_title}</a>, is now 95% complete.")
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds a notification. When a result has linked proposals and its progrress is updated, proposal followers are notified.

#### :pushpin: Related Issues
- Related to #4159
- Fixes #3974

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry