### PR TITLE
Add tooltip cards for user profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ end
 - **decidim-proposals**: Add user groups and meetings options on Origin filters [\#4462](https://github.com/decidim/decidim/pull/4462)
 - **decidim-accountability**: Notify followers of the proposals linked in a result that the result progress has been updated [\#4466](https://github.com/decidim/decidim/pull/4466)
 - **decidim-admin**: Adds the ability to specify contextual help to participatory spaces [\#4470](https://github.com/decidim/decidim/pull/4470)
+- **decidim-core**: Show minicard with a little bit of profile data when hovering on user and user group names [\#4472](https://github.com/decidim/decidim/pull/4472)
 
 **Changed**:
 

--- a/decidim-core/app/cells/decidim/author/profile_inline.erb
+++ b/decidim-core/app/cells/decidim/author/profile_inline.erb
@@ -6,16 +6,35 @@
   <span class="label label--small label--basic">
     <%= t("decidim.profile.deleted") %>
   </span>
-<% else %>
-  <span class="author__name"><%= model.name %></span>
+<% elsif has_tooltip? %>
+  <span
+    class="author__name m-none"
+    data-tooltip
+    data-position="top"
+    data-show-on="medium"
+    data-alignment="center"
+    data-click-open="false"
+    data-keep-on-hover="true"
+    data-allow-html="true"
+    data-template-classes="light expanded"
+    tabindex="1"
+    data-tip-text='<%= h render(:profile_minicard) %>'>
+    <%= model.name %>
+  </span>
 
   <% if model.badge.present? %>
     <span class="author__badge">
       <%= icon model.badge %>
     </span>
   <% end %>
+<% else %>
+  <span class="author__name">
+    <%= model.name %>
+  </span>
 
-  <% if model.nickname.present? %>
-    <span class="author__nickname"><%= model.nickname %></span>
+  <% if model.badge.present? %>
+    <span class="author__badge">
+      <%= icon model.badge %>
+    </span>
   <% end %>
 <% end %>

--- a/decidim-core/app/cells/decidim/author/profile_minicard.erb
+++ b/decidim-core/app/cells/decidim/author/profile_minicard.erb
@@ -17,7 +17,7 @@
     <% if model.can_follow? %>
       <div>
         <%= link_to decidim.profile_following_path(raw_model.nickname), class: "card__link" do %>
-          <strong><%= model.following_count %></strong> <%= t("decidim.profiles.show.following") %>
+          <strong><%= model.following_users_count %></strong> <%= t("decidim.profiles.show.following") %>
         <% end %>
       </div>
     <% end %>

--- a/decidim-core/app/cells/decidim/author/profile_minicard.erb
+++ b/decidim-core/app/cells/decidim/author/profile_minicard.erb
@@ -1,0 +1,26 @@
+<div class="p-xs flex--sbc">
+  <div class="mr-s">
+    <div class="card__header collapse">
+      <%= cell("decidim/user_profile", model.__getobj__).user_data %>
+    </div>
+    <div class="card__text card--picture-offset">
+      <%= link_to "view full profile", profile_path %>
+    </div>
+  </div>
+  <div class="ml-s">
+    <button class="button small secondary hollow button--icon button--sc">
+      <%= icon "bell" %>
+      <span>Seguir</span>
+    </button>
+    <div>
+      <%= link_to "#", class: "card__link" do %>
+        <strong>20</strong> Followers
+      <% end %>
+    </div>
+    <div>
+      <%= link_to "#", class: "card__link" do %>
+        <strong>20</strong> Following
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/decidim-core/app/cells/decidim/author/profile_minicard.erb
+++ b/decidim-core/app/cells/decidim/author/profile_minicard.erb
@@ -8,10 +8,7 @@
     </div>
   </div>
   <div class="ml-s">
-    <button class="button small secondary hollow button--icon button--sc">
-      <%= icon "bell" %>
-      <span>Seguir</span>
-    </button>
+    <%= cell "decidim/follow_button", model %>
     <div>
       <%= link_to "#", class: "card__link" do %>
         <strong>20</strong> Followers

--- a/decidim-core/app/cells/decidim/author/profile_minicard.erb
+++ b/decidim-core/app/cells/decidim/author/profile_minicard.erb
@@ -1,23 +1,25 @@
 <div class="p-xs flex--sbc">
   <div class="mr-s">
     <div class="card__header collapse">
-      <%= cell("decidim/user_profile", model.__getobj__).user_data %>
+      <%= cell("decidim/user_profile", raw_model).user_data %>
     </div>
     <div class="card__text card--picture-offset">
-      <%= link_to "view full profile", profile_path %>
+      <%= link_to t("decidim.profiles.show.view_full_profile"), profile_path %>
     </div>
   </div>
   <div class="ml-s">
-    <%= cell "decidim/follow_button", model %>
+    <%= cell "decidim/follow_button", raw_model %>
     <div>
-      <%= link_to "#", class: "card__link" do %>
-        <strong>20</strong> Followers
+      <%= link_to decidim.profile_followers_path(raw_model.nickname), class: "card__link" do %>
+        <strong><%= model.followers_count %></strong> <%= t("decidim.profiles.show.followers") %>
       <% end %>
     </div>
-    <div>
-      <%= link_to "#", class: "card__link" do %>
-        <strong>20</strong> Following
-      <% end %>
-    </div>
+    <% if model.can_follow? %>
+      <div>
+        <%= link_to decidim.profile_following_path(raw_model.nickname), class: "card__link" do %>
+          <strong><%= model.following_count %></strong> <%= t("decidim.profiles.show.following") %>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/decidim-core/app/cells/decidim/author/show.erb
+++ b/decidim-core/app/cells/decidim/author/show.erb
@@ -1,7 +1,6 @@
 <div class="<%= author_classes %>">
   <div class="author-data__main">
     <%= render :profile %>
-    <%= render :contact %>
   </div>
 
   <% if actionable? %>

--- a/decidim-core/app/cells/decidim/author_cell.rb
+++ b/decidim-core/app/cells/decidim/author_cell.rb
@@ -10,6 +10,7 @@ module Decidim
     include ::Devise::Controllers::Helpers
     include ::Devise::Controllers::UrlHelpers
     include Messaging::ConversationHelper
+    include ERB::Util
 
     property :profile_path
     property :can_be_contacted?
@@ -89,6 +90,10 @@ module Decidim
 
     def profile_path?
       profile_path.present?
+    end
+
+    def has_tooltip?
+      profile_path?
     end
   end
 end

--- a/decidim-core/app/cells/decidim/author_cell.rb
+++ b/decidim-core/app/cells/decidim/author_cell.rb
@@ -14,6 +14,7 @@ module Decidim
 
     property :profile_path
     property :can_be_contacted?
+    property :has_tooltip?
 
     delegate :current_user, to: :controller, prefix: false
 
@@ -90,10 +91,6 @@ module Decidim
 
     def profile_path?
       profile_path.present?
-    end
-
-    def has_tooltip?
-      profile_path?
     end
   end
 end

--- a/decidim-core/app/cells/decidim/author_cell.rb
+++ b/decidim-core/app/cells/decidim/author_cell.rb
@@ -92,5 +92,9 @@ module Decidim
     def profile_path?
       profile_path.present?
     end
+
+    def raw_model
+      model.try(:__getobj__) || model
+    end
   end
 end

--- a/decidim-core/app/cells/decidim/profile_sidebar/show.erb
+++ b/decidim-core/app/cells/decidim/profile_sidebar/show.erb
@@ -38,7 +38,7 @@
         <div class="ml-s">
           <%= link_to profile_following_path(nickname: profile_holder.nickname) do %>
             <%= t("decidim.profiles.show.following") %>
-            <h1 class="heading1"><%= profile_user.following_count %></h1>
+            <h1 class="heading1"><%= profile_user.following_users_count %></h1>
           <% end %>
         </div>
       <% else %>

--- a/decidim-core/app/cells/decidim/user_profile/header.erb
+++ b/decidim-core/app/cells/decidim/user_profile/header.erb
@@ -1,20 +1,5 @@
 <div class="card__header">
-  <div class="author-data author-data--big">
-    <div class="author-data__main">
-      <div class="author author--flex">
-        <%= link_to resource_path, class: "author__avatar" do %>
-          <%= image_tag avatar %>
-        <% end %>
-        <div>
-          <div class="author__name--container">
-            <%= link_to name, resource_path, class: "author__name" %>
-            <%= icon badge, class: "author__verified" if badge.present? %>
-          </div>
-          <%= link_to nickname, resource_path, class: "author__nickname" %>
-        </div>
-      </div>
-    </div>
-  </div>
+  <%= render :user_data %>
 
   <%= render_authorship if has_authors? %>
 </div>

--- a/decidim-core/app/cells/decidim/user_profile/user_data.erb
+++ b/decidim-core/app/cells/decidim/user_profile/user_data.erb
@@ -1,0 +1,16 @@
+<div class="author-data author-data--big">
+  <div class="author-data__main">
+    <div class="author author--flex">
+      <%= link_to resource_path, class: "author__avatar" do %>
+        <%= image_tag avatar %>
+      <% end %>
+      <div>
+        <div class="author__name--container">
+          <%= link_to name, resource_path, class: "author__name" %>
+          <%= icon badge, class: "author__verified" if badge.present? %>
+        </div>
+        <%= link_to nickname, resource_path, class: "author__nickname" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/decidim-core/app/cells/decidim/user_profile_cell.rb
+++ b/decidim-core/app/cells/decidim/user_profile_cell.rb
@@ -3,6 +3,10 @@
 module Decidim
   # This cell renders the profile of the given user.
   class UserProfileCell < Decidim::CardMCell
+    def user_data
+      render
+    end
+
     def user
       model
     end

--- a/decidim-core/app/models/decidim/follow.rb
+++ b/decidim-core/app/models/decidim/follow.rb
@@ -9,12 +9,46 @@ module Decidim
 
     validates :user, uniqueness: { scope: [:followable] }
 
+    after_create :increase_following_counters
+    after_create :increase_followers_counter
+
+    after_destroy :decrease_following_counters
+    after_destroy :decrease_followers_counter
+
     def self.user_collection(user)
       where(decidim_user_id: user.id)
     end
 
     def self.export_serializer
       Decidim::DataPortabilitySerializers::DataPortabilityFollowSerializer
+    end
+
+    private
+
+    def increase_following_counters
+      user.following_count += 1
+      user.following_users_count += 1 if decidim_followable_type == "Decidim::UserBaseEntity"
+      user.save
+    end
+
+    def increase_followers_counter
+      return unless followable.is_a?(Decidim::UserBaseEntity)
+      followable.followers_count += 1
+      followable.save
+    end
+
+    def decrease_following_counters
+      return unless user
+      user.following_count -= 1
+      user.following_users_count -= 1 if decidim_followable_type == "Decidim::UserBaseEntity"
+      user.save
+    end
+
+    def decrease_followers_counter
+      return unless followable.is_a?(Decidim::UserBaseEntity)
+      return unless user
+      followable.followers_count -= 1
+      followable.save
     end
   end
 end

--- a/decidim-core/app/models/decidim/follow.rb
+++ b/decidim-core/app/models/decidim/follow.rb
@@ -25,6 +25,7 @@ module Decidim
 
     private
 
+    # rubocop:disable Rails/SkipsModelValidations
     def increase_following_counters
       user.increment!(:following_users_count) if decidim_followable_type == "Decidim::UserBaseEntity"
       user.increment!(:following_count)
@@ -46,5 +47,6 @@ module Decidim
       return unless user
       followable.decrement!(:followers_count)
     end
+    # rubocop:enable Rails/SkipsModelValidations
   end
 end

--- a/decidim-core/app/models/decidim/follow.rb
+++ b/decidim-core/app/models/decidim/follow.rb
@@ -26,28 +26,25 @@ module Decidim
     private
 
     def increase_following_counters
-      user.increment!(:following_count)
       user.increment!(:following_users_count) if decidim_followable_type == "Decidim::UserBaseEntity"
+      user.increment!(:following_count)
     end
 
     def increase_followers_counter
       return unless followable.is_a?(Decidim::UserBaseEntity)
-      followable.followers_count += 1
-      followable.save
+      followable.increment!(:followers_count)
     end
 
     def decrease_following_counters
       return unless user
-      user.following_count -= 1
-      user.following_users_count -= 1 if decidim_followable_type == "Decidim::UserBaseEntity"
-      user.save
+      user.decrement!(:following_users_count) if decidim_followable_type == "Decidim::UserBaseEntity"
+      user.decrement!(:following_count)
     end
 
     def decrease_followers_counter
       return unless followable.is_a?(Decidim::UserBaseEntity)
       return unless user
-      followable.followers_count -= 1
-      followable.save
+      followable.decrement!(:followers_count)
     end
   end
 end

--- a/decidim-core/app/models/decidim/follow.rb
+++ b/decidim-core/app/models/decidim/follow.rb
@@ -26,9 +26,8 @@ module Decidim
     private
 
     def increase_following_counters
-      user.following_count += 1
-      user.following_users_count += 1 if decidim_followable_type == "Decidim::UserBaseEntity"
-      user.save
+      user.increment!(:following_count)
+      user.increment!(:following_users_count) if decidim_followable_type == "Decidim::UserBaseEntity"
     end
 
     def increase_followers_counter

--- a/decidim-core/app/presenters/decidim/user_presenter.rb
+++ b/decidim-core/app/presenters/decidim/user_presenter.rb
@@ -40,14 +40,6 @@ module Decidim
       link_to nickname, profile_path, class: "user-mention"
     end
 
-    def followers_count
-      __getobj__.followers.count
-    end
-
-    def following_count
-      __getobj__.following_users.count
-    end
-
     def can_be_contacted?
       true
     end

--- a/decidim-core/app/presenters/decidim/user_presenter.rb
+++ b/decidim-core/app/presenters/decidim/user_presenter.rb
@@ -60,5 +60,9 @@ module Decidim
     def can_follow?
       true
     end
+
+    def has_tooltip?
+      true
+    end
   end
 end

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -758,6 +758,7 @@ en:
         groups: Groups
         members: Members
         notifications: Notifications
+        view_full_profile: View full profile
       sidebar:
         badges:
           info: Badges are earned by performing specific activity in the platform.

--- a/decidim-core/db/migrate/20181115102958_add_following_and_followers_counters_to_users.rb
+++ b/decidim-core/db/migrate/20181115102958_add_following_and_followers_counters_to_users.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class AddFollowingAndFollowersCountersToUsers < ActiveRecord::Migration[5.2]
+  def up
+    add_column :decidim_users, :following_count, :integer, null: false, default: 0
+    add_column :decidim_users, :following_users_count, :integer, null: false, default: 0
+    add_column :decidim_users, :followers_count, :integer, null: false, default: 0
+
+    Decidim::UserBaseEntity.find_each do |entity|
+      follower_count = Decidim::Follow.where(followable: entity).count
+      following_count = Decidim::Follow.where(decidim_user_id: entity.id).count
+      following_users_count = Decidim::Follow.where(decidim_user_id: entity.id, decidim_followable_type: ["Decidim::UserBaseEntity", "Decidim::User", "Decidim::UserGroup"]).count
+
+      entity.followers_count = follower_count
+      entity.following_count = following_count
+      entity.following_users_count = following_users_count
+      entity.save
+    end
+  end
+
+  def down
+    remove_column :decidim_users, :following_count
+    remove_column :decidim_users, :following_users_count
+    remove_column :decidim_users, :followers_count
+  end
+end

--- a/decidim-core/spec/cells/decidim/author_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/author_cell_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 describe Decidim::AuthorCell, type: :cell do
   subject { my_cell.call }
+  controller Decidim::PagesController
 
   let(:my_cell) { cell("decidim/author", model) }
   let!(:organization) { create(:organization) }

--- a/decidim-core/spec/cells/decidim/author_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/author_cell_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 describe Decidim::AuthorCell, type: :cell do
   subject { my_cell.call }
+
   controller Decidim::PagesController
 
   let(:my_cell) { cell("decidim/author", model) }

--- a/decidim-core/spec/models/decidim/follow_spec.rb
+++ b/decidim-core/spec/models/decidim/follow_spec.rb
@@ -31,4 +31,101 @@ describe Decidim::Follow do
       it { is_expected.not_to be_valid }
     end
   end
+
+  describe "after create" do
+    let(:user) { create :user }
+    let(:another_user) { create :user }
+
+    context "when following a resource" do
+      it "increases the following count" do
+        expect do
+          create :follow, user: user
+          user.reload
+        end.to change(user, :following_count).by(1)
+      end
+
+      it "does not increase the following users count" do
+        expect do
+          create :follow, user: user
+          user.reload
+        end.not_to change(user, :following_users_count)
+      end
+    end
+
+    context "when following a user" do
+      it "increases the following count" do
+        expect do
+          create :follow, user: user, followable: another_user
+          user.reload
+        end.to change(user, :following_count).by(1)
+      end
+
+      it "increases the following users count" do
+        expect do
+          create :follow, user: user, followable: another_user
+          user.reload
+        end.to change(user, :following_users_count).by(1)
+      end
+    end
+
+    context "when being followed" do
+      it "increases the followers count" do
+        expect do
+          create :follow, user: user, followable: another_user
+          user.reload
+        end.to change(another_user, :followers_count).by(1)
+      end
+    end
+  end
+
+  describe "after destroy" do
+    let(:user) { create :user }
+    let(:another_user) { create :user }
+
+    context "when unfollowing a resource" do
+      it "decreases the following count" do
+        follow = create :follow, user: user
+        expect do
+          follow.destroy!
+          user.reload
+        end.to change(user, :following_count).by(-1)
+      end
+
+      it "does not decrease the following users count" do
+        follow = create :follow, user: user
+        expect do
+          follow.destroy!
+          user.reload
+        end.not_to change(user, :following_users_count)
+      end
+    end
+
+    context "when unfollowing a user" do
+      it "decreases the following count" do
+        follow = create :follow, user: user, followable: another_user
+        expect do
+          follow.destroy!
+          user.reload
+        end.to change(user, :following_count).by(-1)
+      end
+
+      it "decreases the following users count" do
+        follow = create :follow, user: user, followable: another_user
+        expect do
+          follow.destroy!
+          user.reload
+        end.to change(user, :following_users_count).by(-1)
+      end
+    end
+
+    context "when not being followed anymore" do
+      it "decreases the followers count" do
+        follow = create :follow, user: user, followable: another_user
+        expect do
+          follow.destroy!
+          user.reload
+        end.to change(another_user, :followers_count).by(-1)
+      end
+    end
+  end
 end

--- a/decidim-core/spec/system/user_manages_group_invitations_spec.rb
+++ b/decidim-core/spec/system/user_manages_group_invitations_spec.rb
@@ -16,7 +16,6 @@ describe "User manages group invitations", type: :system do
     it "allows accepting the invitation" do
       within ".list-invitation" do
         expect(page).to have_content(membership.user_group.name)
-        expect(page).to have_content(membership.user_group.nickname)
       end
 
       click_link "Accept"
@@ -24,13 +23,11 @@ describe "User manages group invitations", type: :system do
       expect(page).to have_content("Invitation accepted successfully")
 
       expect(page).to have_content(membership.user_group.name)
-      expect(page).to have_content(membership.user_group.nickname)
     end
 
     it "allows rejecting the invitation" do
       within ".list-invitation" do
         expect(page).to have_content(membership.user_group.name)
-        expect(page).to have_content(membership.user_group.nickname)
       end
 
       click_link "Reject"
@@ -38,7 +35,6 @@ describe "User manages group invitations", type: :system do
       expect(page).to have_content("Invitation rejected successfully")
 
       expect(page).not_to have_content(membership.user_group.name)
-      expect(page).not_to have_content(membership.user_group.nickname)
     end
   end
 end

--- a/decidim-debates/app/presenters/decidim/debates/official_author_presenter.rb
+++ b/decidim-debates/app/presenters/decidim/debates/official_author_presenter.rb
@@ -33,6 +33,10 @@ module Decidim
       def can_be_contacted?
         false
       end
+
+      def has_tooltip?
+        false
+      end
     end
   end
 end

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -65,6 +65,10 @@ module Decidim
       def can_be_contacted?
         false
       end
+
+      def has_tooltip?
+        false
+      end
     end
   end
 end

--- a/decidim-proposals/app/presenters/decidim/proposals/official_author_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/official_author_presenter.rb
@@ -33,6 +33,10 @@ module Decidim
       def can_be_contacted?
         false
       end
+
+      def has_tooltip?
+        false
+      end
     end
   end
 end

--- a/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/show.html.erb
@@ -22,7 +22,7 @@
     <%= @collaborative_draft.title %>
   </h2>
 
-  <%= cell("decidim/coauthorships", @collaborative_draft, has_actions: true, size: 3) %>
+  <%= cell("decidim/coauthorships", @collaborative_draft, has_actions: true, size: 3, context: { current_user: current_user }) %>
 </div>
 
 <div class="row">

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_proposal_similar.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_proposal_similar.html.erb
@@ -5,7 +5,7 @@
         <%= link_to proposal, target: "_blank" do %>
           <h5 class="card__title"><%= present(proposal).title %></h5>
         <% end %>
-        <%= cell("decidim/coauthorships", proposal, has_actions: false) %>
+        <%= cell("decidim/coauthorships", proposal, has_actions: false, context: { current_user: current_user }) %>
 
         <div class="tech-info tech-info--text-left">
           <%= t("decidim.proposals.proposals.proposal.creation_date", date: l(proposal.created_at, format: :decidim_short)) %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -7,7 +7,7 @@
 <%= render partial: "voting_rules" %>
 <div class="row column view-header">
   <h2 class="heading2"><%= present(@proposal).html_title %></h2>
-  <%= cell("decidim/coauthorships", @proposal, has_actions: true, size: 3) %>
+  <%= cell("decidim/coauthorships", @proposal, has_actions: true, size: 3, context: { current_user: current_user }) %>
 </div>
 <div class="row">
   <div class="columns section view-side mediumlarge-4 mediumlarge-push-8 large-3 large-push-9">
@@ -71,7 +71,7 @@
     <%= linked_resources_for @proposal, :meetings, "proposals_from_meeting" %>
     <%= linked_resources_for @proposal, :proposals, "copied_from_component" %>
 
-    <%= cell "decidim/proposals/endorsers_list", @proposal %>
+    <%= cell "decidim/proposals/endorsers_list", @proposal, context: { current_user: current_user } %>
   </div>
 </div>
 <%= attachments_for @proposal %>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds profile tooltip cards for both users and user groups.

#### :pushpin: Related Issues
- Related to #4159
- Fixes #4346

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tooltip cards for users 
- [x] Ensure the system works for user groups
- [x] Fix the "Follow" button

### :camera: Screenshots (optional)
Minicard for a user group. Notice that the current user is following that user group.
![](https://i.imgur.com/ApZm77a.png)

My own card. Notice how I cannot follow myself.
![](https://i.imgur.com/1lnPRcS.png)

Another user card:
![](https://i.imgur.com/kOqmTGy.png)

Card when I'm not logged in:
![](https://i.imgur.com/x5T7oOL.png)