### PR TITLE
Add default context to cells

### DIFF
--- a/decidim-core/app/cells/decidim/profile_sidebar/show.erb
+++ b/decidim-core/app/cells/decidim/profile_sidebar/show.erb
@@ -101,7 +101,7 @@
         <% end %>
       </div>
     <% elsif logged_in? %>
-      <%= cell "decidim/follow_button", profile_holder, inline: false, context: { current_user: current_user } %>
+      <%= cell "decidim/follow_button", profile_holder, inline: false %>
     <% end %>
 
     <% if can_edit_user_group_profile? %>

--- a/decidim-core/app/helpers/decidim/application_helper.rb
+++ b/decidim-core/app/helpers/decidim/application_helper.rb
@@ -50,5 +50,19 @@ module Decidim
 
       content_for(:edit_link, link)
     end
+
+    # Public: Overwrites the `cell` helper method to automatically set some
+    # common context.
+    #
+    # name - the name of the cell to render
+    # model - the cell model
+    # options - a Hash with options
+    #
+    # Renders the cell contents.
+    def cell(name, model, options = {}, &block)
+      options = { context: { current_user: current_user } }.deep_merge(options)
+
+      super(name, model, options, &block)
+    end
   end
 end

--- a/decidim-core/app/helpers/decidim/card_helper.rb
+++ b/decidim-core/app/helpers/decidim/card_helper.rb
@@ -10,8 +10,6 @@ module Decidim
     #
     # Returns an HTML.
     def card_for(model, options = {})
-      options = { context: { current_user: current_user } }.deep_merge(options)
-
       cell "decidim/card", model, options
     end
   end

--- a/decidim-core/app/views/decidim/follows/update_button.js.erb
+++ b/decidim-core/app/views/decidim/follows/update_button.js.erb
@@ -1,3 +1,3 @@
 var $followResource = $("#<%= dom_id(resource, :follow) %>");
 
-morphdom($followResource[0], "<%= j((cell "decidim/follow_button", resource, inline: @inline, context: { current_user: current_user }).to_s.strip.html_safe) %>");
+morphdom($followResource[0], "<%= j((cell "decidim/follow_button", resource, inline: @inline).to_s.strip.html_safe) %>");

--- a/decidim-core/app/views/decidim/group_members/index.html.erb
+++ b/decidim-core/app/views/decidim/group_members/index.html.erb
@@ -9,7 +9,7 @@
       <%= cell "decidim/profile_sidebar", user_group %>
     </div>
     <div class="columns medium-9">
-      <%= cell "decidim/user_group_pending_requests_list", user_group, context: { current_user: current_user } %>
+      <%= cell "decidim/user_group_pending_requests_list", user_group %>
       <section class="section">
         <p><%= t(".current_members_without_admins") %></p>
         <%= cell "decidim/members", user_group, role: "member", from_admin: true %>

--- a/decidim-core/app/views/decidim/profiles/show.html.erb
+++ b/decidim-core/app/views/decidim/profiles/show.html.erb
@@ -1,1 +1,1 @@
-<%= cell "decidim/profile", profile_holder, context: { content_cell: @content_cell, current_user: current_user } %>
+<%= cell "decidim/profile", profile_holder, context: { content_cell: @content_cell } %>

--- a/decidim-core/app/views/decidim/shared/_follow_button.html.erb
+++ b/decidim-core/app/views/decidim/shared/_follow_button.html.erb
@@ -1,1 +1,1 @@
-<%= cell "decidim/follow_button", followable, inline: false, context: { current_user: current_user } %>
+<%= cell "decidim/follow_button", followable, inline: false %>

--- a/decidim-proposals/app/views/decidim/participatory_processes/participatory_process_groups/_highlighted_proposals.html.erb
+++ b/decidim-proposals/app/views/decidim/participatory_processes/participatory_process_groups/_highlighted_proposals.html.erb
@@ -5,7 +5,7 @@
       <%= cell(
         "decidim/collapsible_list",
         proposals,
-        cell_options: { context: { current_user: current_user } },
+        cell_options: {},
         list_class: "row small-up-1 medium-up-2 large-up-3 card-grid",
         size: proposals.count
         ) %>

--- a/decidim-proposals/app/views/decidim/participatory_spaces/_highlighted_proposals.html.erb
+++ b/decidim-proposals/app/views/decidim/participatory_spaces/_highlighted_proposals.html.erb
@@ -7,7 +7,7 @@
     <%= cell(
       "decidim/collapsible_list",
       proposals,
-      cell_options: { context: { current_user: current_user } },
+      cell_options: {},
       list_class: "row small-up-1 medium-up-2 card-grid",
       size: proposals.count
       ) %>


### PR DESCRIPTION
#### :tophat: What? Why?
Related to #4472, this PR adds default context to cells by overwriting the helper method. This way we don't need to replace so many calls.

#### :pushpin: Related Issues
- Related to #4472

#### :clipboard: Subtasks
None