### PR TITLE
Fix migration error

### DIFF
--- a/decidim-core/db/migrate/20180810092428_move_organization_fields_to_hero_content_block.rb
+++ b/decidim-core/db/migrate/20180810092428_move_organization_fields_to_hero_content_block.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class MoveOrganizationFieldsToHeroContentBlock < ActiveRecord::Migration[5.2]
-  class Organization < ApplicationRecord
+  class ::Decidim::Organization < ApplicationRecord
     self.table_name = :decidim_organizations
 
     mount_uploader :homepage_image, ::Decidim::HomepageImageUploader
@@ -9,7 +9,7 @@ class MoveOrganizationFieldsToHeroContentBlock < ActiveRecord::Migration[5.2]
 
   def change
     Decidim::ContentBlock.reset_column_information
-    Organization.find_each do |organization|
+    Decidim::Organization.find_each do |organization|
       content_block = Decidim::ContentBlock.find_by(organization: organization, scope: :homepage, manifest_name: :hero)
       settings = {}
       welcome_text = organization.welcome_text || {}

--- a/decidim-generators/lib/decidim/generators/install_generator.rb
+++ b/decidim-generators/lib/decidim/generators/install_generator.rb
@@ -131,17 +131,9 @@ module Decidim
         soft_rails "db:environment:set", "db:drop"
         rails "db:create"
 
-        # In order to ensure that migrations don't eager load models with not
-        # yet fully populated schemas (which could break commands which load
-        # migrations and seeds in the same process, such as `rails db:migrate
-        # db:seed`), we make sure to run them in the same process if seeds are
-        # requested so that we can catch these situations earlier than end
-        # users.
-        if options[:seed_db]
-          rails "db:migrate", "db:seed"
-        else
-          rails "db:migrate"
-        end
+        rails "db:migrate"
+
+        rails "db:seed" if options[:seed_db]
 
         rails "db:test:prepare"
       end


### PR DESCRIPTION
#### :tophat: What? Why?
PR #4152 actually introduced a sneaky bug. The bug was causing problems when migrating applications using Amazon S3 to keep the uploads. We were using a fake model class defined inside the migration to use an uploader to migrate the data. The uploader was using this fake class scope to generate the file name (`/uploads/move_organization_fields_to_hero_content_block/organization/...`) instead of the correct folder path (`/uploads/decidim/organization/...`). Since the folder path generated does not exist, the migration fails.

This PR monkey-patches the correct class, so the uploader can generate the correct folder path and the migration can run successfully.

We need to backport this to `0.15-stable`.

#### :pushpin: Related Issues
- Related to #4152

#### :clipboard: Subtasks
None