### PR TITLE
apply copy modifications conferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ end
 
 - **decidim-meetings**: Change title to description in meetings admin form [\#4483](https://github.com/decidim/decidim/pull/4483)
 - **decidim-core**: Hashtags with unicode characters are now parsed correctly [\#4473](https://github.com/decidim/decidim/pull/4473)
+- **decidim-conferences**: Fix some translations of conferences [\#4481](https://github.com/decidim/decidim/pull/4481)
 - **decidim-conferences**: Check participatory spaces manifest exists when relating conferences to other spaces [\#4446](https://github.com/decidim/decidim/pull/4446)
 - **decidim-proposals**: Allow admins to edit proposals even if creation is not enabled [\#4390](https://github.com/decidim/decidim/pull/4390)
 - **decidim-core**: Fix events for polymorphic authors [\#4387](https://github.com/decidim/decidim/pull/4387)

--- a/decidim-conferences/app/cells/decidim/conferences/registration_type_cell.rb
+++ b/decidim-conferences/app/cells/decidim/conferences/registration_type_cell.rb
@@ -42,7 +42,7 @@ module Decidim
       end
 
       def i18n_join_text
-        return I18n.t("join", scope: "decidim.conferences.conference.show") if conference.has_available_slots?
+        return I18n.t("registration", scope: "decidim.conferences.conference.show") if conference.has_available_slots?
         I18n.t("no_slots_available", scope: "decidim.conferences.conference.show")
       end
     end

--- a/decidim-conferences/app/views/decidim/conferences/admin/invite_join_conference_mailer/invite.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/invite_join_conference_mailer/invite.html.erb
@@ -8,5 +8,5 @@
   <%= link_to t(".decline", conference_title: translated_attribute(@conference.title)),routes.decline_invitation_conference_registration_type_conference_registration_path(conference_slug: @conference.slug, registration_type_id: @registration_type.id) %>
 </p>
 <p>
-  <%= link_to t(".join", conference_title: translated_attribute(@conference.title)),routes.conference_registration_type_conference_registration_url(conference_slug: @conference.slug, registration_type_id: @registration_type.id) %>
+  <%= link_to t(".registration", conference_title: translated_attribute(@conference.title)),routes.conference_registration_type_conference_registration_url(conference_slug: @conference.slug, registration_type_id: @registration_type.id) %>
 </p>

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -331,7 +331,7 @@ en:
           invite:
             decline: Decline invitation '%{conference_title}'
             invited_you_to_join_a_conference: "%{invited_by} has invited you to join a conference at %{application}. You can decline or accept it through the links below."
-            join: Join conference '%{conference_title}'
+            registration: Registration '%{conference_title}'
         partners:
           index:
             title: Partners
@@ -346,8 +346,8 @@ en:
           confirm: Confirm
         show:
           going: Going
-          join: Join Conference
           no_slots_available: No slots available
+          registration: Registration
       conference_program:
         program_meeting:
           content: Content
@@ -392,10 +392,10 @@ en:
           speakers: Speakers
       conferences:
         partners:
-          collaborators: Collaborators
-          main_promotors: Main promotors
+          collaborators: Partners
+          main_promotors: Organizers
         show:
-          login_as: You are login as %{name} <%{email}>
+          login_as: You are logged in as %{name} <%{email}>
           make_conference_registration: 'Make your registration in the conference:'
           register: Register
       content_blocks:
@@ -448,15 +448,15 @@ en:
       registration_types:
         index:
           choose_an_option: 'Choose your registration option:'
-          login_as: You are login as %{name} <%{email}>
+          login_as: You are logged in as %{name} <%{email}>
           register: Register
           title: Registration types
       shared:
         conference_user_login:
           already_account: Do you already have an account in decidim?
           new_user: New user?
-          sign_in: Login to register at this conference
-          sign_up: Register for free in decidim to register
+          sign_in: Login to register for the conference
+          sign_up: Create an account in decidim to register for the conference
       show:
         details: Details
         introduction: Introduction

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -335,7 +335,7 @@ en:
           invite:
             decline: Decline invitation '%{conference_title}'
             invited_you_to_join_a_conference: "%{invited_by} has invited you to join a conference at %{application}. You can decline or accept it through the links below."
-            registration: Registration '%{conference_title}'
+            registration: Registration for '%{conference_title}'
         partners:
           index:
             title: Partners

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -273,6 +273,10 @@ en:
           publish: "%{user_name} published the %{resource_name} registration type in the %{space_name} conference"
           unpublish: "%{user_name} unpublished the %{resource_name} registration type in the %{space_name} conference"
           update: "%{user_name} updated the %{resource_name} registration type in the %{space_name} conference"
+      media_link:
+        create: "%{user_name} created the %{resource_name} media link in the %{space_name} conference"
+        delete: "%{user_name} removed the %{resource_name} media link from the %{space_name} conference"
+        update: "%{user_name} updated the %{resource_name} media link in the %{space_name} conference"
     conference_program:
       index:
         title: Program

--- a/decidim-conferences/spec/system/conference_registrations_spec.rb
+++ b/decidim-conferences/spec/system/conference_registrations_spec.rb
@@ -81,7 +81,7 @@ describe "Conference registrations", type: :system do
           visit_conference_registration_types
 
           within ".wrapper" do
-            first(:button, "Join Conference").click
+            first(:button, "Registration").click
           end
 
           expect(page).to have_css("#loginModal", visible: true)
@@ -98,7 +98,7 @@ describe "Conference registrations", type: :system do
         visit_conference_registration_types
 
         within "#registration-type-#{registration_type.id}" do
-          click_button "Join Conference"
+          click_button "Registration"
         end
 
         within "#conference-registration-confirm-#{registration_type.id}" do
@@ -110,7 +110,7 @@ describe "Conference registrations", type: :system do
 
         within ".wrapper" do
           expect(page).to have_css(".button", text: "GOING")
-          expect(page).to have_css("button[disabled]", text: "JOIN CONFERENCE", count: 4)
+          expect(page).to have_css("button[disabled]", text: "REGISTRATION", count: 4)
         end
       end
     end
@@ -132,7 +132,7 @@ describe "Conference registrations", type: :system do
       expect(page).to have_content("successfully")
 
       within ".wrapper" do
-        expect(page).to have_css(".button", text: "JOIN CONFERENCE", count: registration_types_count)
+        expect(page).to have_css(".button", text: "R", count: registration_types_count)
       end
     end
   end

--- a/decidim-conferences/spec/system/conference_registrations_spec.rb
+++ b/decidim-conferences/spec/system/conference_registrations_spec.rb
@@ -132,7 +132,7 @@ describe "Conference registrations", type: :system do
       expect(page).to have_content("successfully")
 
       within ".wrapper" do
-        expect(page).to have_css(".button", text: "R", count: registration_types_count)
+        expect(page).to have_css(".button", text: "REGISTRATION", count: registration_types_count)
       end
     end
   end

--- a/decidim-conferences/spec/system/partners_spec.rb
+++ b/decidim-conferences/spec/system/partners_spec.rb
@@ -36,8 +36,8 @@ describe "Conference partners", type: :system do
       visit decidim_conferences.conference_path(conference)
 
       within "#conference-partners" do
-        expect(page).to have_content("MAIN PROMOTORS")
-        expect(page).to have_content("COLLABORATORS")
+        expect(page).to have_content("ORGANIZERS")
+        expect(page).to have_content("PARTNERS")
         expect(page).to have_selector("#conference-partners .partner-box", count: 4)
 
         partners.each do |partner|


### PR DESCRIPTION
#### :tophat: What? Why?
Change some conference copies

-  Replace "Join Conference" with "Registration"
-   Replace "Main promotors" with "Organizers"
-   Replace "Collaborators" with "Partners"
-   Replace "You are login" with "You are logged in"
-   Replace "Login to register at this conference" with "Login to register for the conference"
-   Replace "Register for free in decidim to register" with "Create an account in decidim to register for the conference"

#### :pushpin: Related Issues
- Related to #3709 #4082 
- Fixes part of #4427 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Change copies
- [x] Change/fix tests

### :camera: Screenshots (optional)
![Description](URL)
