### PR TITLE
fix admin meeting description form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ end
 
 **Fixed**:
 
+- **decidim-meetings**: Change title to description in meetings admin form [\#4483](https://github.com/decidim/decidim/pull/4483)
 - **decidim-core**: Hashtags with unicode characters are now parsed correctly [\#4473](https://github.com/decidim/decidim/pull/4473)
 - **decidim-conferences**: Check participatory spaces manifest exists when relating conferences to other spaces [\#4446](https://github.com/decidim/decidim/pull/4446)
 - **decidim-proposals**: Allow admins to edit proposals even if creation is not enabled [\#4390](https://github.com/decidim/decidim/pull/4390)

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
@@ -8,7 +8,7 @@
     </div>
 
     <div class="row column hashtags__container">
-      <%= form.translated :editor, :description, class: "js-hashtags", hashtaggable: true, value: @meeting.present? ? present(@meeting).title : "" %>
+      <%= form.translated :editor, :description, class: "js-hashtags", hashtaggable: true, value: @meeting.present? ? present(@meeting).description : "" %>
     </div>
 
     <div class="row column">


### PR DESCRIPTION
#### :tophat: What? Why?
Each time you update a meeting, the description field is filled in with title. 

#### :pushpin: Related Issues
- Related to #4080 
- Fixes part of #4427 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Change title to description on meeting

### :camera: Screenshots (optional)
![Description](URL)
