### PR TITLE
BACKPORT fix admin meeting description form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 
 **Fixed**:
 
+- **decidim-meetings**: Change title to description in meetings admin form. [\#4484](https://github.com/decidim/decidim/pull/4484)
 - **decidim-assemblies**: Add parent when duplicating child assembly. [\#4371](https://github.com/decidim/decidim/pull/4371)
 - **decidim-assemblies**: Add paginate on admin site assembly members. [\#4369](https://github.com/decidim/decidim/pull/4369)
 - **decidim-admin**: Adds traceability when creating and deleting Participatory Space private user [\#4332](https://github.com/decidim/decidim/pull/4332)

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
@@ -8,7 +8,7 @@
     </div>
 
     <div class="row column hashtags__container">
-      <%= form.translated :editor, :description, class: "js-hashtags", hashtaggable: true, value: @meeting.present? ? present(@meeting).title : "" %>
+      <%= form.translated :editor, :description, class: "js-hashtags", hashtaggable: true, value: @meeting.present? ? present(@meeting).description : "" %>
     </div>
 
     <div class="row column">


### PR DESCRIPTION
#### :tophat: What? Why?
Each time you update a meeting, the description field is filled in with title.

#### :pushpin: Related Issues
- Related to #4080 
- Fixes part of #4427

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Change title to description on meeting
### :camera: Screenshots (optional)
![Description](URL)
