### PR TITLE
Find search results with the prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ end
 - **decidim-accountability**: Notify followers of the proposals linked in a result that the result progress has been updated [\#4466](https://github.com/decidim/decidim/pull/4466)
 - **decidim-admin**: Adds the ability to specify contextual help to participatory spaces [\#4470](https://github.com/decidim/decidim/pull/4470)
 - **decidim-core**: Show minicard with a little bit of profile data when hovering on user and user group names [\#4472](https://github.com/decidim/decidim/pull/4472)
+- **decidim-core**: Let users find search results by writing prefixes of a word instead of whole words [\#4492](https://github.com/decidim/decidim/pull/4492)
 
 **Changed**:
 

--- a/decidim-core/app/models/decidim/searchable_resource.rb
+++ b/decidim-core/app/models/decidim/searchable_resource.rb
@@ -32,6 +32,9 @@ module Decidim
 
     pg_search_scope :global_search,
                     against: { content_a: "A", content_b: "B", content_c: "C", content_d: "D" },
+                    using: {
+                      tsearch: { prefix: true }
+                    },
                     order_within_rank: "datetime DESC"
   end
 end

--- a/decidim-core/spec/controllers/decidim/searches_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/searches_controller_spec.rb
@@ -19,8 +19,10 @@ module Decidim
       context "when having resources with the term 'Great' in their content" do
         let!(:results) do
           now = Time.current
-          [create(:searchable_resource, organization: organization, content_a: "Great proposal of mine", datetime: now + 1.second),
-           create(:searchable_resource, organization: organization, content_a: "The great-est place of the world", datetime: now)]
+          [
+            create(:searchable_resource, organization: organization, content_a: "Great proposal of mine", datetime: now + 1.second),
+            create(:searchable_resource, organization: organization, content_a: "The greatest place of the world", datetime: now)
+          ]
         end
 
         before do
@@ -30,7 +32,7 @@ module Decidim
         it "returns results with 'Great' in their content" do
           get :index, params: { term: "Great" }
 
-          expect(assigns(:results)).to eq(results)
+          expect(assigns(:results)).to match_array(results)
         end
       end
     end

--- a/decidim-core/spec/services/decidim/searchable_user_resource_spec.rb
+++ b/decidim-core/spec/services/decidim/searchable_user_resource_spec.rb
@@ -53,6 +53,15 @@ module Decidim
             on(:invalid) { raise("Should not happen") }
           end
         end
+
+        it "allows searching by prefix characters" do
+          Decidim::Search.call("diam", organization, resource_type: user.class.name) do
+            on(:ok) do |results|
+              expect(results.count).to eq 1
+            end
+            on(:invalid) { raise("Should not happen") }
+          end
+        end
       end
     end
 

--- a/decidim-meetings/spec/services/searchable_meeting_resource_spec.rb
+++ b/decidim-meetings/spec/services/searchable_meeting_resource_spec.rb
@@ -77,6 +77,15 @@ module Decidim
             on(:invalid) { raise("Should not happen") }
           end
         end
+
+        it "allows searching by prefix characters" do
+          Decidim::Search.call("subu", organization, resource_type: meeting.class.name) do
+            on(:ok) do |results|
+              expect(results.count).to eq 1
+            end
+            on(:invalid) { raise("Should not happen") }
+          end
+        end
       end
     end
 

--- a/decidim-proposals/spec/services/decidim/proposals/searchable_proposal_resource_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/searchable_proposal_resource_spec.rb
@@ -115,6 +115,15 @@ module Decidim
             on(:invalid) { raise("Should not happen") }
           end
         end
+
+        it "allows searching by prefix characters" do
+          Decidim::Search.call("wait", organization, resource_type: proposal.class.name) do
+            on(:ok) do |results|
+              expect(results.count).to eq 1
+            end
+            on(:invalid) { raise("Should not happen") }
+          end
+        end
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
This PR allows users to find search results by writing the prefix of a word. See screenshots for the final result.

#### :pushpin: Related Issues
- Related to #4159

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/sdshIsb.png)
