### PR TITLE
Fix process steps CTA path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ end
 - **decidim-proposals**: Fix title display [\#4431](https://github.com/decidim/decidim/pull/4431)
 - **decidim-meetings**: Fix title display [\#4431](https://github.com/decidim/decidim/pull/4431)
 - **decidim-proposals**: Ensure proposals search returns unique results [\#4460](https://github.com/decidim/decidim/pull/4460)
+- **decidim-participatory_processes**: Fix process steps CTA path on public area [\#4499](https://github.com/decidim/decidim/pull/4499)
 
 **Removed**:
 

--- a/decidim-participatory_processes/app/views/layouts/decidim/_process_header_steps.html.erb
+++ b/decidim-participatory_processes/app/views/layouts/decidim/_process_header_steps.html.erb
@@ -26,7 +26,7 @@
         <%= link_to t(".view_steps"), decidim_participatory_processes.participatory_process_participatory_process_steps_path(current_participatory_space) %>
         <%= link_to(
           cta_text,
-          participatory_process.active_step.cta_path,
+          decidim_participatory_processes.participatory_process_path(participatory_process) + "/" + participatory_process.active_step.cta_path,
           class: "button small button--sc show-for-medium"
         ) %>
       <% else %>


### PR DESCRIPTION
#### :tophat: What? Why?
Process steps CTA path was wrongly displayed in the public part. This PR fixes it to match the admin part.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

