### PR TITLE
Use correct cell to render a meeting organizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ end
 **Fixed**:
 
 - **decidim-meetings**: Change title to description in meetings admin form [\#4483](https://github.com/decidim/decidim/pull/4483)
+- **decidim-meetings**: Use the correct cell to render a meeting organizer [\#4501](https://github.com/decidim/decidim/pull/4501)
 - **decidim-core**: Hashtags with unicode characters are now parsed correctly [\#4473](https://github.com/decidim/decidim/pull/4473)
 - **decidim-conferences**: Check participatory spaces manifest exists when relating conferences to other spaces [\#4446](https://github.com/decidim/decidim/pull/4446)
 - **decidim-proposals**: Allow admins to edit proposals even if creation is not enabled [\#4390](https://github.com/decidim/decidim/pull/4390)

--- a/decidim-core/app/views/decidim/shared/_author_reference.html.erb
+++ b/decidim-core/app/views/decidim/shared/_author_reference.html.erb
@@ -1,1 +1,0 @@
-<%= card_for author, context: { extra_classes: ["author-data--small"] } %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -18,7 +18,7 @@ edit_link(
 <div class="row column view-header">
   <h2 class="heading2"><%= present(meeting).html_title %></h2>
   <% if meeting.organizer.present? %>
-    <%= render partial: "decidim/shared/author_reference", locals: { author: present(meeting.organizer) } %>
+    <%= cell "decidim/author", present(meeting.organizer) %>
   <% end %>
 </div>
 <div class="row">


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes how a meeting organizer is rendered.

#### :pushpin: Related Issues
- Fixes #4491 
- Fixes #4169

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/6iNpz5G.png)
