### PR TITLE
Don't show grouped processes in process list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ end
 - **decidim-meetings**: Fix title display [\#4431](https://github.com/decidim/decidim/pull/4431)
 - **decidim-proposals**: Ensure proposals search returns unique results [\#4460](https://github.com/decidim/decidim/pull/4460)
 - **decidim-participatory_processes**: Don't filter highlighted processes by state [\#4502](https://github.com/decidim/decidim/pull/4502)
+- **decidim-participatory_processes**: Don't show grouped processes in the process list[\#4503](https://github.com/decidim/decidim/pull/4503)
 
 **Removed**:
 

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
@@ -58,7 +58,7 @@ module Decidim
       end
 
       def participatory_processes
-        @participatory_processes ||= filtered_participatory_processes(filter)
+        @participatory_processes ||= filtered_participatory_processes(filter).query.where(decidim_participatory_process_group_id: nil)
       end
 
       def promoted_participatory_processes
@@ -92,7 +92,7 @@ module Decidim
         return @process_count_by_filter if @process_count_by_filter
 
         @process_count_by_filter = %w(active upcoming past).inject({}) do |collection_by_filter, filter_name|
-          processes = filtered_participatory_processes(filter_name)
+          processes = filtered_participatory_processes(filter_name).query.where(decidim_participatory_process_group_id: nil)
           groups = filtered_participatory_process_groups(filter_name)
           collection_by_filter.merge(filter_name.to_s => processes.count + groups.count)
         end

--- a/decidim-participatory_processes/spec/controllers/participatory_processes_controller_spec.rb
+++ b/decidim-participatory_processes/spec/controllers/participatory_processes_controller_spec.rb
@@ -104,7 +104,7 @@ module Decidim
           )
 
           expect(controller.helpers.collection)
-            .to match_array([*published, *organization_groups, *organization_groups.map(&:participatory_processes).flatten])
+            .to match_array([*published, *organization_groups])
         end
       end
 

--- a/decidim-participatory_processes/spec/system/participatory_process_groups_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_process_groups_spec.rb
@@ -29,7 +29,7 @@ describe "Participatory Process Groups", type: :system do
     it "lists all the groups among the processes" do
       within "#processes-grid" do
         expect(page).to have_content(translated(participatory_process_group.name, locale: :en))
-        expect(page).to have_selector("article.card", count: 3)
+        expect(page).to have_selector("article.card", count: 1)
 
         expect(page).to have_no_content(translated(other_group.name, locale: :en))
       end

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -109,7 +109,7 @@ describe "Participatory Processes", type: :system do
     it "lists the active processes" do
       within "#processes-grid" do
         within "#processes-grid h2" do
-          expect(page).to have_content("3")
+          expect(page).to have_content("3 ACTIVE PROCESSES")
         end
 
         expect(page).to have_content(translated(participatory_process.title, locale: :en))
@@ -134,7 +134,7 @@ describe "Participatory Processes", type: :system do
       context "and choosing 'active' processes" do
         it "lists the active processes" do
           within "#processes-grid h2" do
-            expect(page).to have_content("2")
+            expect(page).to have_content("3 ACTIVE PROCESSES")
           end
 
           expect(page).to have_content(translated(participatory_process.title, locale: :en))
@@ -183,7 +183,7 @@ describe "Participatory Processes", type: :system do
 
         it "lists all processes" do
           within "#processes-grid h2" do
-            expect(page).to have_content("4")
+            expect(page).to have_content("5 PROCESSES")
           end
 
           expect(page).to have_content(translated(participatory_process.title, locale: :en))

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -72,6 +72,8 @@ describe "Participatory Processes", type: :system do
     let!(:unpublished_process) { create(:participatory_process, :unpublished, organization: organization) }
     let!(:past_process) { create :participatory_process, :past, organization: organization }
     let!(:upcoming_process) { create :participatory_process, :upcoming, organization: organization }
+    let!(:grouped_process) { create :participatory_process, organization: organization }
+    let!(:group) { create :participatory_process_group, participatory_processes: [grouped_process], organization: organization }
 
     before do
       visit decidim_participatory_processes.participatory_processes_path
@@ -107,16 +109,18 @@ describe "Participatory Processes", type: :system do
     it "lists the active processes" do
       within "#processes-grid" do
         within "#processes-grid h2" do
-          expect(page).to have_content("2")
+          expect(page).to have_content("3")
         end
 
         expect(page).to have_content(translated(participatory_process.title, locale: :en))
         expect(page).to have_content(translated(promoted_process.title, locale: :en))
-        expect(page).to have_selector("article.card", count: 2)
+        expect(page).to have_content(translated(group.name, locale: :en))
+        expect(page).to have_selector("article.card", count: 3)
 
         expect(page).to have_no_content(translated(unpublished_process.title, locale: :en))
         expect(page).to have_no_content(translated(past_process.title, locale: :en))
         expect(page).to have_no_content(translated(upcoming_process.title, locale: :en))
+        expect(page).to have_no_content(translated(grouped_process.title, locale: :en))
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
This PR hides processes belonging to a group from the processes list.

#### :pushpin: Related Issues
- Fixes #4489

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
The process group in the screenshot (the one at the bottom) contains two processes, both are promoted (that's the seed data)
![Description](https://i.imgur.com/wMZm6go.png)
