### PR TITLE
Precompile missing admin asset file

### DIFF
--- a/decidim-admin/app/assets/config/decidim_admin_manifest.js
+++ b/decidim-admin/app/assets/config/decidim_admin_manifest.js
@@ -1,4 +1,5 @@
 //= link decidim/admin/application.js
 //= link decidim/admin/managed_users.js
 //= link decidim/admin/component_permissions.js
+//= link decidim/admin/welcome_notification.js
 //= link decidim/admin/application.css


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes an error when deploying Decidim to production:

```
The asset "decidim/admin/welcome_notification.js" is not present in the asset pipeline
```

#### :pushpin: Related Issues
- Related to #4470

#### :clipboard: Subtasks
None
