### PR TITLE
Put share URLs in inputs so they're easier to copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ end
 - **decidim-proposals**: Fix title display [\#4431](https://github.com/decidim/decidim/pull/4431)
 - **decidim-meetings**: Fix title display [\#4431](https://github.com/decidim/decidim/pull/4431)
 - **decidim-proposals**: Ensure proposals search returns unique results [\#4460](https://github.com/decidim/decidim/pull/4460)
+- **decidim-core**: Improve how to copy URLs to share [\#4507](https://github.com/decidim/decidim/pull/4507)
 
 **Removed**:
 

--- a/decidim-core/app/views/decidim/shared/_share_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_share_modal.html.erb
@@ -29,5 +29,5 @@
       <span aria-hidden="true">&times;</span>
     </button>
   </div>
-  <h4 class="heading4"><%= "#{decidim_meta_url}" %></h4>
+  <input type="text" value="<%= "#{decidim_meta_url}" %>" readonly />
 </div>

--- a/decidim-debates/app/views/decidim/debates/debates/_share.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/_share.html.erb
@@ -29,5 +29,5 @@
       <span aria-hidden="true">&times;</span>
     </button>
   </div>
-  <h4 class="heading4"><%= "#{content_for(:meta_url)}" %></h4>
+  <input type="text" value="<%= "#{content_for(:meta_url)}" %>" readonly />
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?
Copying URLs to share is hard with the current layout, and it's broken with certain devices. Putting the URLs inside inputs makes it easier to copy them.

#### :pushpin: Related Issues
- Fixes #4232

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/apwNjA5.png)
