### PR TITLE
Rename "Officializations" to "Participants"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ end
 - **decidim-accountability**: Show one highlighted resources block per component in process page [\#4456](https://github.com/decidim/decidim/pull/4456)
 - **decidim-meetings**: Show one highlighted resources block per component in process page [\#4456](https://github.com/decidim/decidim/pull/4456)
 - **decidim-proposals**: Show one highlighted resources block per component in process page [\#4456](https://github.com/decidim/decidim/pull/4456)
+- **decidim-admin**: Rename "Officializations" section to "Participants" [\#4510](https://github.com/decidim/decidim/pull/4510)
 
 **Fixed**:
 

--- a/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
@@ -37,7 +37,7 @@
 
 <div class="card" id='user-groups'>
   <div class="card-divider">
-    <h2 class="card-title"><%= t "decidim.admin.titles.officializations" %></h2>
+    <h2 class="card-title"><%= t "decidim.admin.titles.participants" %></h2>
   </div>
   <div class="card-section">
     <div class="table-scroll">

--- a/decidim-admin/app/views/layouts/decidim/admin/users.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/users.html.erb
@@ -16,7 +16,7 @@
       <% end %>
       <% if allowed_to? :index, :officialization %>
         <li <% if is_active_link?(decidim_admin.officializations_path) %> class="is-active" <% end %>>
-          <%= link_to t("menu.officializations", scope: "decidim.admin"), decidim_admin.officializations_path %>
+          <%= link_to t("menu.participants", scope: "decidim.admin"), decidim_admin.officializations_path %>
         </li>
       <% end %>
       <% if allowed_to? :index, :impersonatable_user %>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -314,7 +314,7 @@ en:
         impersonations: Impersonations
         newsletters: Newsletters
         oauth_applications: OAuth applications
-        officializations: Officializations
+        participants: Participants
         scope_types: Scope types
         scopes: Scopes
         settings: Settings
@@ -604,7 +604,7 @@ en:
         dashboard: Dashboard
         impersonatable_users: Impersonatable users
         impersonations: Impersonations
-        officializations: Officializations
+        participants: Participants
         scope_types: Scope types
         scopes: Scopes
         static_pages: Pages

--- a/decidim-admin/spec/system/admin_manages_officializations_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_officializations_spec.rb
@@ -26,7 +26,7 @@ describe "Admin manages officializations", type: :system do
     let!(:external_not_officialized) { create(:user) }
 
     before do
-      click_link "Officializations"
+      click_link "Participants"
     end
 
     it "shows each user and its officialization status" do
@@ -45,7 +45,7 @@ describe "Admin manages officializations", type: :system do
       let!(:user) { create(:user, organization: organization) }
 
       before do
-        click_link "Officializations"
+        click_link "Participants"
 
         within "tr[data-user-id=\"#{user.id}\"]" do
           click_link "Officialize"
@@ -91,7 +91,7 @@ describe "Admin manages officializations", type: :system do
       end
 
       before do
-        click_link "Officializations"
+        click_link "Participants"
 
         within "tr[data-user-id=\"#{user.id}\"]" do
           click_link "Reofficialize"
@@ -121,7 +121,7 @@ describe "Admin manages officializations", type: :system do
     let!(:user) { create(:user, :officialized, organization: organization) }
 
     before do
-      click_link "Officializations"
+      click_link "Participants"
 
       within "tr[data-user-id=\"#{user.id}\"]" do
         click_link "Unofficialize"
@@ -141,7 +141,7 @@ describe "Admin manages officializations", type: :system do
     let!(:user) { create(:user, organization: organization) }
 
     before do
-      click_link "Officializations"
+      click_link "Participants"
     end
 
     it "redirect to conversation path" do
@@ -156,7 +156,7 @@ describe "Admin manages officializations", type: :system do
     let!(:user) { create(:user, organization: organization) }
 
     before do
-      click_link "Officializations"
+      click_link "Participants"
     end
 
     it "redirect to user profile page" do
@@ -171,7 +171,7 @@ describe "Admin manages officializations", type: :system do
     let!(:user) { create(:user, organization: organization) }
 
     before do
-      click_link "Officializations"
+      click_link "Participants"
     end
 
     it "redirect to user profile page" do


### PR DESCRIPTION
#### :tophat: What? Why?
This PR renames the "Officializations" admin section to "Participants".

#### :pushpin: Related Issues
- Fixes #4141

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/sUtk8pA.png)
