### PR TITLE
Fix meetings in assemblies page

### DIFF
--- a/decidim-meetings/lib/decidim/meetings/engine.rb
+++ b/decidim-meetings/lib/decidim/meetings/engine.rb
@@ -55,18 +55,7 @@ module Decidim
         end
 
         Decidim.view_hooks.register(:current_participatory_space_meetings, priority: Decidim::ViewHooks::HIGH_PRIORITY) do |view_context|
-          published_components = Decidim::Component.where(participatory_space: view_context.current_participatory_space).published
-          meetings = Decidim::Meetings::Meeting.where(component: published_components)
-
-          next unless meetings.any?
-
-          view_context.render(
-            partial: "decidim/participatory_spaces/highlighted_meetings",
-            locals: {
-              past_meetings: meetings.past.order(end_time: :desc, start_time: :desc).limit(3),
-              upcoming_meetings: meetings.upcoming.order(:start_time, :end_time).limit(3)
-            }
-          )
+          view_context.cell("decidim/meetings/highlighted_meetings", view_context.current_participatory_space)
         end
 
         # This view hook is used in card cells. It renders the next upcoming


### PR DESCRIPTION
#### :tophat: What? Why?
Fix after #4456, assembly page was not working properly. Now it does.

#### :pushpin: Related Issues
- Related to #4456.

#### :clipboard: Subtasks
None