### PR TITLE
Fix notifications settings form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ end
 - **decidim-participatory_processes**: Fix process steps CTA path on public area [\#4499](https://github.com/decidim/decidim/pull/4499)
 - **decidim-participatory_processes**: Don't filter highlighted processes by state [\#4502](https://github.com/decidim/decidim/pull/4502)
 - **decidim-participatory_processes**: Don't show grouped processes in the process list[\#4503](https://github.com/decidim/decidim/pull/4503)
+- **decidim-core**: Fix notification settings form [\#4528](https://github.com/decidim/decidim/pull/4528)
 
 **Removed**:
 

--- a/decidim-core/app/forms/decidim/notifications_settings_form.rb
+++ b/decidim-core/app/forms/decidim/notifications_settings_form.rb
@@ -6,11 +6,8 @@ module Decidim
   class NotificationsSettingsForm < Form
     mimic :user
 
-    attribute :email_on_notification
-    attribute :newsletter_notifications
-
-    validates :email_on_notification, presence: true
-    validates :newsletter_notifications, presence: true
+    attribute :email_on_notification, Boolean
+    attribute :newsletter_notifications, Boolean
 
     def newsletter_notifications_at
       return nil unless newsletter_notifications

--- a/decidim-core/spec/forms/notifications_settings_form_spec.rb
+++ b/decidim-core/spec/forms/notifications_settings_form_spec.rb
@@ -23,21 +23,5 @@ module Decidim
         expect(subject).to be_valid
       end
     end
-
-    context "with an empty email on notification" do
-      let(:email_on_notification) { "" }
-
-      it "is invalid" do
-        expect(subject).not_to be_valid
-      end
-    end
-
-    context "with an empty newsletter notifications" do
-      let(:newsletter_notifications) { "" }
-
-      it "is invalid" do
-        expect(subject).not_to be_valid
-      end
-    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
This notification settings form was not working properly because the attributes were not typed. This caused to seemingly work, but it in fact didn't.

#### :pushpin: Related Issues
- Fixes #4523

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry