### PR TITLE
Hide unavailable verification methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ end
 - **decidim-meetings**: Fix title display [\#4431](https://github.com/decidim/decidim/pull/4431)
 - **decidim-proposals**: Ensure proposals search returns unique results [\#4460](https://github.com/decidim/decidim/pull/4460)
 - **decidim-core**: Improve how to copy URLs to share [\#4507](https://github.com/decidim/decidim/pull/4507)
+- **decidim-admin**: Hide the unavailable verification methods[\#4529](https://github.com/decidim/decidim/pull/4529)
 - **decidim-participatory_processes**: Fix process steps CTA path on public area [\#4499](https://github.com/decidim/decidim/pull/4499)
 - **decidim-participatory_processes**: Don't filter highlighted processes by state [\#4502](https://github.com/decidim/decidim/pull/4502)
 - **decidim-participatory_processes**: Don't show grouped processes in the process list[\#4503](https://github.com/decidim/decidim/pull/4503)

--- a/decidim-admin/app/views/layouts/decidim/admin/users.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/users.html.erb
@@ -28,6 +28,7 @@
         <%= link_to t("menu.authorization_workflows", scope: "decidim.admin"), decidim_admin.authorization_workflows_path %>
         <ul>
           <% Decidim::Verifications.admin_workflows.each do |manifest| %>
+            <% next unless current_organization.available_authorizations.include?(manifest.name.to_s) %>
             <% workflow = Decidim::Verifications::Adapter.new(manifest) %>
 
             <li <% if is_active_link?(workflow.admin_root_path) %> class="is-active" <% end %>>


### PR DESCRIPTION
#### :tophat: What? Why?
Hides the verification methods that are not available for the current organization.

#### :pushpin: Related Issues
- Fixes #4261

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry