### PR TITLE
Fix bug in `resource_text` for events

### DIFF
--- a/decidim-core/app/views/decidim/notification_mailer/event_received.html.erb
+++ b/decidim-core/app/views/decidim/notification_mailer/event_received.html.erb
@@ -2,7 +2,7 @@
 
 <p><%= @event_instance.email_intro %></p>
 
-<% if @event_instance.resource_text.present? %>
+<% if @event_instance.try(:resource_text).present? %>
 <blockquote>
   <p>
     <%= @event_instance.resource_text.html_safe %>


### PR DESCRIPTION
#### :tophat: What? Why?
Follow-up from #4518, fixes a bug on event mailers where `resource_text` might not be defined.

#### :pushpin: Related Issues
- Related to #4518

#### :clipboard: Subtasks
None