### PR TITLE
Don't crash when showing the edit link for a component that does not have an admin engine backport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [Unreleased](https://github.com/decidim/decidim/tree/0.14-stable)
+
+- **decidim-core**: Don't crash when showing the edit link for a component that does not have an admin engine [\#4534](https://github.com/decidim/decidim/pull/4534)
+
 ## [0.14.4](https://github.com/decidim/decidim/tree/v0.14.4)
 
 **Fixed**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Change Log
 
+## [0.14.4](https://github.com/decidim/decidim/tree/v0.14.4)
+
+**Fixed**:
+
+- **decidim-accountability**: Fix inclusion of ApplicationHelper in results controller. [\#4278](https://github.com/decidim/decidim/pull/4278)
+- **decidim-core**: When a Searchable accesses its indexed resources it must scope by resource_type and organization_id. [\#4320](https://github.com/decidim/decidim/pull/4320)
+- **decidim-core**: Added Hungarian datepicker js configs [\#4358](https://github.com/decidim/decidim/pull/4358)
+
+
+## [0.14.3](https://github.com/decidim/decidim/tree/v0.14.3)
+
+**Fixed**:
+
+- **decidim-core**: [Fix organization fields migration](https://github.com/decidim/decidim/commit/7afdb9c3cbab18701c01bc360fdf13c350a41528)
+
+## [0.14.2](https://github.com/decidim/decidim/tree/v0.14.2)
+
+**Fixed**:
+
+- **decidim-core**: Fix default content block creation migration [\#4084](https://github.com/decidim/decidim/pull/4084)
+- **decidim-generators**: Bootsnap warnings when generating test applications [\#4098](https://github.com/decidim/decidim/pull/4098)
+- **decidim-admin**: Don't list deleted users at officialized list. [\#4203](https://github.com/decidim/decidim/pull/4203)
+- **decidim-participayory_processes**: Copy categories and subcategories to the new process. [\#4203](https://github.com/decidim/decidim/pull/4203)
+- **decidim-core**: Fix newsletter opt-in migration [\#4198](https://github.com/decidim/decidim/pull/4218)
+
 ## [0.14.1](https://github.com/decidim/decidim/tree/v0.14.1)
 
 **Upgrade notes**:
@@ -146,8 +171,6 @@
 
 **Fixed**:
 
-- **decidim-core**: When a Searchable accesses its indexed resources it must scope by resource_type and organization_id. [\#4320](https://github.com/decidim/decidim/pull/4320)
-- **decidim-accountability**: Fix inclusion of ApplicationHelper in results controller. [\#4278](https://github.com/decidim/decidim/pull/4278)
 - **decidim-proposals**: Fix hashtags on title when showing proposals related. [\4107](https://github.com/decidim/decidim/pull/4107)
 - **decidim-participatory_processes**: Fix hastag display on participatory processes. [\#4024](https://github.com/decidim/decidim/pull/4024)
 - **decidim-core**: Fix day date translation on profile notifications. [\#3994](https://github.com/decidim/decidim/pull/3994)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ PATH
       pg (>= 0.18, < 2)
       pg_search (~> 2.1, >= 2.1.0)
       premailer-rails (~> 1.9)
+      rack (~> 2.0.6)
       rack-attack (~> 5.2)
       rails (>= 5.2, < 6.0.x)
       rails-i18n (~> 5.0)
@@ -506,8 +507,8 @@ GEM
       premailer (~> 1.7, >= 1.7.9)
     public_suffix (3.0.2)
     puma (3.11.4)
-    rack (2.0.5)
-    rack-attack (5.4.1)
+    rack (2.0.6)
+    rack-attack (5.4.2)
       rack (>= 1.0, < 3)
     rack-cors (1.0.2)
     rack-test (1.1.0)
@@ -534,7 +535,7 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
-    rails-i18n (5.1.1)
+    rails-i18n (5.1.2)
       i18n (>= 0.7, < 2)
       railties (>= 5.0, < 6)
     railties (5.2.1)
@@ -559,7 +560,7 @@ GEM
       activesupport (>= 4.1.0)
       virtus (~> 1.0.5)
       wisper (>= 1.6.1)
-    redis (4.0.2)
+    redis (4.0.3)
     regexp_parser (1.2.0)
     request_store (1.4.1)
       rack (>= 1.4)
@@ -721,4 +722,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.6
+   1.17.1

--- a/decidim-core/app/helpers/decidim/component_path_helper.rb
+++ b/decidim-core/app/helpers/decidim/component_path_helper.rb
@@ -32,5 +32,15 @@ module Decidim
       current_params = try(:params) || {}
       EngineRouter.admin_proxy(component).root_path(locale: current_params[:locale])
     end
+
+    # Returns whether the component can be managed or not by checking if it has
+    # an admin engine.
+    #
+    # component - the Component we want to find if it's manageable or not.
+    #
+    # Returns a boolean matching the question.
+    def can_be_managed?(component)
+      component.manifest.admin_engine.present?
+    end
   end
 end

--- a/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
@@ -1,5 +1,5 @@
 <%
-if respond_to?(:current_component) && current_component
+if respond_to?(:current_component) && current_component && can_be_managed?(current_component)
   edit_link(
     manage_component_path(current_component),
     :read,

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -47,6 +47,7 @@ Gem::Specification.new do |s|
   s.add_dependency "pg", ">= 0.18", "< 2"
   s.add_dependency "pg_search", "~> 2.1", ">= 2.1.0"
   s.add_dependency "premailer-rails", "~> 1.9"
+  s.add_dependency "rack", "~> 2.0.6"
   s.add_dependency "rack-attack", "~> 5.2"
   s.add_dependency "rails", ">= 5.2", "< 6.0.x"
   s.add_dependency "rails-i18n", "~> 5.0"

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -91,6 +91,7 @@ PATH
       pg (>= 0.18, < 2)
       pg_search (~> 2.1, >= 2.1.0)
       premailer-rails (~> 1.9)
+      rack (~> 2.0.6)
       rack-attack (~> 5.2)
       rails (>= 5.2, < 6.0.x)
       rails-i18n (~> 5.0)
@@ -506,8 +507,8 @@ GEM
       premailer (~> 1.7, >= 1.7.9)
     public_suffix (3.0.2)
     puma (3.11.4)
-    rack (2.0.5)
-    rack-attack (5.4.1)
+    rack (2.0.6)
+    rack-attack (5.4.2)
       rack (>= 1.0, < 3)
     rack-cors (1.0.2)
     rack-test (1.0.0)
@@ -534,7 +535,7 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
-    rails-i18n (5.1.1)
+    rails-i18n (5.1.2)
       i18n (>= 0.7, < 2)
       railties (>= 5.0, < 6)
     railties (5.2.0)
@@ -559,7 +560,7 @@ GEM
       activesupport (>= 4.1.0)
       virtus (~> 1.0.5)
       wisper (>= 1.6.1)
-    redis (4.0.2)
+    redis (4.0.3)
     regexp_parser (1.2.0)
     request_store (1.4.1)
       rack (>= 1.4)
@@ -721,4 +722,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.6
+   1.17.1

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -91,6 +91,7 @@ PATH
       pg (>= 0.18, < 2)
       pg_search (~> 2.1, >= 2.1.0)
       premailer-rails (~> 1.9)
+      rack (~> 2.0.6)
       rack-attack (~> 5.2)
       rails (>= 5.2, < 6.0.x)
       rails-i18n (~> 5.0)
@@ -506,8 +507,8 @@ GEM
       premailer (~> 1.7, >= 1.7.9)
     public_suffix (3.0.2)
     puma (3.11.4)
-    rack (2.0.5)
-    rack-attack (5.4.1)
+    rack (2.0.6)
+    rack-attack (5.4.2)
       rack (>= 1.0, < 3)
     rack-cors (1.0.2)
     rack-test (1.0.0)
@@ -534,7 +535,7 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
-    rails-i18n (5.1.1)
+    rails-i18n (5.1.2)
       i18n (>= 0.7, < 2)
       railties (>= 5.0, < 6)
     railties (5.2.0)
@@ -559,7 +560,7 @@ GEM
       activesupport (>= 4.1.0)
       virtus (~> 1.0.5)
       wisper (>= 1.6.1)
-    redis (4.0.2)
+    redis (4.0.3)
     regexp_parser (1.2.0)
     request_store (1.4.1)
       rack (>= 1.4)
@@ -721,4 +722,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.6
+   1.17.1


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #4318 to `0.14-stable` and fix its CHANGELOG.
