### PR TITLE
Send welcome email by default on seeds

### DIFF
--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -34,7 +34,7 @@ if !Rails.env.production? || ENV["SEED"]
     users_registration_mode: :enabled,
     tos_version: Time.current,
     badges_enabled: true,
-    send_welcome_email: true
+    send_welcome_notification: true
   )
 
   if organization.top_scopes.none?

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -33,7 +33,8 @@ if !Rails.env.production? || ENV["SEED"]
     available_authorizations: Decidim.authorization_workflows.map(&:name),
     users_registration_mode: :enabled,
     tos_version: Time.current,
-    badges_enabled: true
+    badges_enabled: true,
+    send_welcome_email: true
   )
 
   if organization.top_scopes.none?


### PR DESCRIPTION
#### :tophat: What? Why?
Sets the `send_welcome_email` variable by default on the app's seeds.

#### :pushpin: Related Issues
- Related to #4304 

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*
