### PR TITLE
backport when editing meeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 
 **Fixed**:
 
+ **decidim-meetings**: Fix title and description fields in admin form. [\#4547](https://github.com/decidim/decidim/pull/4547)
 - **decidim-assemblies**: Add parent when duplicating child assembly. [\#4371](https://github.com/decidim/decidim/pull/4371)
 - **decidim-assemblies**: Add paginate on admin site assembly members. [\#4369](https://github.com/decidim/decidim/pull/4369)
 - **decidim-admin**: Adds traceability when creating and deleting Participatory Space private user [\#4332](https://github.com/decidim/decidim/pull/4332)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/decidim/decidim/tree/0.15-stable)
 
 - **decidim-meetings**: Change title to description in meetings admin form. [\#4484](https://github.com/decidim/decidim/pull/4484)
+- **decidim-meetings**: Fix title and description fields in admin form. [\#4547](https://github.com/decidim/decidim/pull/4547)
 
 ## [0.15.0](https://github.com/decidim/decidim/tree/v0.15.0)
 
@@ -75,7 +76,6 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 
 **Fixed**:
 
- **decidim-meetings**: Fix title and description fields in admin form. [\#4547](https://github.com/decidim/decidim/pull/4547)
 - **decidim-assemblies**: Add parent when duplicating child assembly. [\#4371](https://github.com/decidim/decidim/pull/4371)
 - **decidim-assemblies**: Add paginate on admin site assembly members. [\#4369](https://github.com/decidim/decidim/pull/4369)
 - **decidim-admin**: Adds traceability when creating and deleting Participatory Space private user [\#4332](https://github.com/decidim/decidim/pull/4332)

--- a/decidim-core/lib/decidim/content_renderers/hashtag_renderer.rb
+++ b/decidim-core/lib/decidim/content_renderers/hashtag_renderer.rb
@@ -29,6 +29,16 @@ module Decidim
       end
 
       def render_without_link
+        if content.is_a?(Hash)
+          content.each_with_object({}) do |(locale, string), parsed_content|
+            parsed_content[locale] = replace_hashtag_gid_with_hashtag_name(string)
+          end
+        else
+          replace_hashtag_gid_with_hashtag_name(content)
+        end
+      end
+
+      def replace_hashtag_gid_with_hashtag_name(content)
         content.gsub(GLOBAL_ID_REGEX) do |hashtag_gid|
           begin
             hashtag = GlobalID::Locator.locate(hashtag_gid)

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -72,9 +72,7 @@ module Decidim
           tab_content_id = "#{tabs_id}-#{name}-panel-#{index}"
           string + content_tag(:div, class: tab_element_class_for("panel", index), id: tab_content_id) do
             if options[:hashtaggable]
-              content_tag(:div, class: "hashtags__container") do
-                send(type, name_with_locale(name, locale), options.merge(label: false))
-              end
+              hashtaggable_text_field(type, name, locale, options)
             else
               send(type, name_with_locale(name, locale), options.merge(label: false))
             end
@@ -83,6 +81,23 @@ module Decidim
       end
 
       safe_join [label_tabs, tabs_content]
+    end
+
+    # Public: Generates a field for hashtaggable type.
+    # type - The form field's type, like `text_area` or `text_input`
+    # name - The name of the field
+    # handlers - The social handlers to be created
+    # options - The set of options to send to the field
+    #
+    # Renders form fields for each locale.
+    def hashtaggable_text_field(type, name, locale, options = {})
+      content_tag(:div, class: "hashtags__container") do
+        if options[:value]
+          send(type, name_with_locale(name, locale), options.merge(label: false, value: options[:value][locale]))
+        else
+          send(type, name_with_locale(name, locale), options.merge(label: false))
+        end
+      end
     end
 
     # Public: Generates an form field for each social.

--- a/decidim-core/spec/content_renderers/decidim/hashtag_renderer_spec.rb
+++ b/decidim-core/spec/content_renderers/decidim/hashtag_renderer_spec.rb
@@ -23,5 +23,47 @@ module Decidim
         expect(renderer.render).to eq(content)
       end
     end
+
+    context "when content has more than one Decidim::Hashtag Global ID" do
+      let(:content) { "This text contains two valid Decidim::Hashtag Global ID: #{hashtag.to_global_id} #{hashtag.to_global_id}" }
+
+      it "renders the two mentions" do
+        rendered = renderer.render
+        hashtag_rendered = %(<a target="_blank" class="hashtag-mention" href="/search?term=%23#{hashtag.name}">##{hashtag.name}</a>)
+        expect(rendered.scan(hashtag_rendered).length).to eq(2)
+      end
+    end
+
+    context "when content has an invalid Decidim::Hashtag Global ID" do
+      let(:content) { "This text contains a invalid gid for removed hashtag: #{hashtag.to_global_id}" }
+
+      before { hashtag.destroy }
+
+      it "removes the Global ID" do
+        expect(renderer.render).to eq("This text contains a invalid gid for removed hashtag: ")
+      end
+
+      it "does not raises an exception" do
+        expect { renderer.render }.not_to raise_error
+      end
+    end
+
+    context "when render without link" do
+      context "when content is hash" do
+        let(:content) { "{'en'=>'This text contains a valid Decidim::Hashtag Global ID: #{hashtag.to_global_id}','ca'=>'Aquest text conté un Decidim::Hashtag Global ID valid: #{hashtag.to_global_id}'}" }
+
+        it "renders the hash with hashtags without_link" do
+          expect(renderer.render_without_link).to eq(%({'en'=>'This text contains a valid Decidim::Hashtag Global ID: ##{hashtag.name}','ca'=>'Aquest text conté un Decidim::Hashtag Global ID valid: ##{hashtag.name}'}))
+        end
+      end
+
+      context "when content is a string" do
+        let(:content) { "This text contains a valid Decidim::Hashtag Global ID: #{hashtag.to_global_id}" }
+
+        it "renders the hashtag without_link" do
+          expect(renderer.render_without_link).to eq(%(This text contains a valid Decidim::Hashtag Global ID: ##{hashtag.name}))
+        end
+      end
+    end
   end
 end

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -35,6 +35,18 @@ module Decidim
         renderer = Decidim::ContentRenderers::HashtagRenderer.new(translated_attribute(meeting.description))
         renderer.render.html_safe
       end
+
+      def title_with_locales
+        return unless meeting
+        renderer = Decidim::ContentRenderers::HashtagRenderer.new(meeting.title)
+        renderer.render_without_link
+      end
+
+      def description_with_locales
+        return unless meeting
+        renderer = Decidim::ContentRenderers::HashtagRenderer.new(meeting.description)
+        renderer.render_without_link
+      end
     end
   end
 end

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
@@ -4,11 +4,11 @@
   </div>
   <div class="card-section">
     <div class="row column  hashtags__container">
-      <%= form.translated :text_field, :title, autofocus: true, class: "js-hashtags", hashtaggable: true, value: @meeting.present? ? present(@meeting).title : "" %>
+      <%= form.translated :text_field, :title, autofocus: true, class: "js-hashtags", hashtaggable: true, value: @meeting.present? ? present(@meeting).title_with_locales : "" %>
     </div>
 
     <div class="row column hashtags__container">
-      <%= form.translated :editor, :description, class: "js-hashtags", hashtaggable: true, value: @meeting.present? ? present(@meeting).description : "" %>
+      <%= form.translated :editor, :description, class: "js-hashtags", hashtaggable: true, value: @meeting.present? ? present(@meeting).description_with_locales : "" %>
     </div>
 
     <div class="row column">


### PR DESCRIPTION
#### :tophat: What? Why?
When Editing a meeting description or title with multiple locales causes the meeting to write the same content to all the locales (using the current one).

#### :pushpin: Related Issues
- Related to #2458 #4080
- Fixes #4532

#### :clipboard: Subtasks
- [ ] Add CHANGELOG entry
- [x]   Fix meeting values for hashtags
- [x]   Add specs

### :camera: Screenshots (optional)
![Description](URL)
