### PR TITLE
Fix update content block image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ end
 - **decidim-participatory_processes**: Don't filter highlighted processes by state [\#4502](https://github.com/decidim/decidim/pull/4502)
 - **decidim-participatory_processes**: Don't show grouped processes in the process list[\#4503](https://github.com/decidim/decidim/pull/4503)
 - **decidim-core**: Fix notification settings form [\#4528](https://github.com/decidim/decidim/pull/4528)
+- **decidim-admin**: Fix image updating in content blocks [\#4549](https://github.com/decidim/decidim/pull/4549)
 
 **Removed**:
 

--- a/decidim-admin/app/commands/decidim/admin/update_content_block.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_content_block.rb
@@ -43,10 +43,10 @@ module Decidim
         content_block.manifest.images.each do |image_config|
           image_name = image_config[:name]
 
-          if form.images["remove_#{image_name}".to_sym]
-            content_block.images_container.send("remove_#{image_name}=", true)
-          elsif form.images[image_name]
+          if form.images[image_name]
             content_block.images_container.send("#{image_name}=", form.images[image_name])
+          elsif form.images["remove_#{image_name}".to_sym] == "1"
+            content_block.images_container.send("remove_#{image_name}=", true)
           end
         end
       end

--- a/decidim-admin/spec/commands/decidim/admin/update_content_block_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/update_content_block_spec.rb
@@ -21,6 +21,7 @@ module Decidim::Admin
     end
     let(:images) do
       {
+        "remove_background_image" => "0",
         "background_image" => uploaded_image
       }.with_indifferent_access
     end
@@ -88,8 +89,7 @@ module Decidim::Admin
         context "when removing the image" do
           let(:images) do
             {
-              "remove_background_image" => "1",
-              "background_image" => uploaded_image
+              "remove_background_image" => "1"
             }.with_indifferent_access
           end
 


### PR DESCRIPTION
#### :tophat: What? Why?

When an image existed ina content block and you tried to update it it was deleting the old one (the form was sending `"0"` as a value for `remove_image`).

#### :pushpin: Related Issues
- Related to #3968, #4545

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
