### PR TITLE
Keep hashtag casing

### DIFF
--- a/decidim-core/app/presenters/decidim/hashtag_presenter.rb
+++ b/decidim-core/app/presenters/decidim/hashtag_presenter.rb
@@ -8,11 +8,16 @@ module Decidim
     include Rails.application.routes.mounted_helpers
     include ActionView::Helpers::UrlHelper
 
+    def initialize(hashtag, cased_name: nil)
+      super(hashtag)
+      @cased_name = cased_name if cased_name&.downcase == hashtag.name
+    end
+
     #
-    # name presented in a twitter-like style
+    # hashtag presented in a twitter-like style
     #
     def name
-      "##{super}"
+      "##{@cased_name || super}"
     end
 
     delegate :url, to: :hashtag, prefix: true

--- a/decidim-core/lib/decidim/content_parsers/hashtag_parser.rb
+++ b/decidim-core/lib/decidim/content_parsers/hashtag_parser.rb
@@ -25,7 +25,7 @@ module Decidim
       # @return [String] the content with the hashtags replaced by global ids
       def rewrite
         content.gsub(HASHTAG_REGEX) do |match|
-          hashtag(match[1..-1]).to_global_id.to_s
+          hashtag(match[1..-1]).to_global_id.to_s + "/" + match[1..-1]
         end
       end
 

--- a/decidim-core/lib/decidim/content_renderers/hashtag_renderer.rb
+++ b/decidim-core/lib/decidim/content_renderers/hashtag_renderer.rb
@@ -10,39 +10,40 @@ module Decidim
     # @see BaseRenderer Examples of how to use a content renderer
     class HashtagRenderer < BaseRenderer
       # Matches a global id representing a Decidim::Hashtag
-      GLOBAL_ID_REGEX = %r{gid:\/\/[\w-]*\/Decidim::Hashtag\/(\d+)}
+      GLOBAL_ID_REGEX = %r{(gid:\/\/[\w-]*\/Decidim::Hashtag\/(?:\d+))\/?([[:alnum:]](?:[[:alnum:]]|_)*)?\b}
 
       # Replaces found Global IDs matching an existing hashtag with
       # a link to their detail page. The Global IDs representing an
       # invalid Decidim::Hashtag are replaced with an empty string.
       #
       # @return [String] the content ready to display (contains HTML)
-      def render
-        content.gsub(GLOBAL_ID_REGEX) do |hashtag_gid|
-          begin
-            hashtag = GlobalID::Locator.locate(hashtag_gid)
-            Decidim::HashtagPresenter.new(hashtag).display_hashtag
-          rescue ActiveRecord::RecordNotFound => _ex
-            ""
+      def render(with_link: true)
+        if content.is_a?(Hash)
+          content.each_with_object({}) do |(locale, string), parsed_content|
+            parsed_content[locale] = replace_hashtags(string, with_link)
           end
+        else
+          replace_hashtags(content, with_link)
         end
       end
 
       def render_without_link
-        if content.is_a?(Hash)
-          content.each_with_object({}) do |(locale, string), parsed_content|
-            parsed_content[locale] = replace_hashtag_gid_with_hashtag_name(string)
-          end
-        else
-          replace_hashtag_gid_with_hashtag_name(content)
-        end
+        render(with_link: false)
       end
 
-      def replace_hashtag_gid_with_hashtag_name(content)
+      private
+
+      def replace_hashtags(content, with_link)
         content.gsub(GLOBAL_ID_REGEX) do |hashtag_gid|
           begin
-            hashtag = GlobalID::Locator.locate(hashtag_gid)
-            Decidim::HashtagPresenter.new(hashtag).display_hashtag_name
+            gid, cased_name = hashtag_gid.scan(GLOBAL_ID_REGEX).flatten
+            hashtag = GlobalID::Locator.locate(gid)
+            presenter = Decidim::HashtagPresenter.new(hashtag, cased_name: cased_name)
+            if with_link
+              presenter.display_hashtag
+            else
+              presenter.display_hashtag_name
+            end
           rescue ActiveRecord::RecordNotFound => _ex
             ""
           end

--- a/decidim-core/spec/content_parsers/decidim/hashtag_parser_spec.rb
+++ b/decidim-core/spec/content_parsers/decidim/hashtag_parser_spec.rb
@@ -11,7 +11,7 @@ module Decidim
     let(:parser) { described_class.new(content, context) }
 
     let(:content) { "This text contains a hashtag present on DB: ##{hashtag.name}" }
-    let(:parsed_content) { "This text contains a hashtag present on DB: #{hashtag.to_global_id}" }
+    let(:parsed_content) { "This text contains a hashtag present on DB: #{hashtag.to_global_id}/#{hashtag.name}" }
     let(:metadata_hashtags) { [hashtag] }
 
     shared_examples "find and stores the hashtags references" do
@@ -29,6 +29,7 @@ module Decidim
 
     context "when content hashtag doesn't match existing case" do
       let(:content) { "This text contains a hashtag present on DB: ##{hashtag.name.upcase}" }
+      let(:parsed_content) { "This text contains a hashtag present on DB: #{hashtag.to_global_id}/#{hashtag.name.upcase}" }
 
       it_behaves_like "find and stores the hashtags references"
     end
@@ -36,7 +37,7 @@ module Decidim
     context "when contents has a new hashtag" do
       let(:hashtag) { Decidim::Hashtag.find_by(organization: organization, name: name) }
       let(:content) { "This text contains a hashtag not present on DB: ##{name}" }
-      let(:parsed_content) { "This text contains a hashtag not present on DB: #{hashtag.to_global_id}" }
+      let(:parsed_content) { "This text contains a hashtag not present on DB: #{hashtag.to_global_id}/#{hashtag.name}" }
 
       it_behaves_like "find and stores the hashtags references"
     end
@@ -45,7 +46,7 @@ module Decidim
       let(:new_hashtag) { Decidim::Hashtag.find_by(organization: organization, name: "a_new_one") }
       let(:hashtag2) { create(:hashtag, organization: organization) }
       let(:content) { "This text contains multiple hashtag presents: #a_new_one, ##{hashtag.name} and ##{hashtag2.name}" }
-      let(:parsed_content) { "This text contains multiple hashtag presents: #{new_hashtag.to_global_id}, #{hashtag.to_global_id} and #{hashtag2.to_global_id}" }
+      let(:parsed_content) { "This text contains multiple hashtag presents: #{new_hashtag.to_global_id}/#{new_hashtag.name}, #{hashtag.to_global_id}/#{hashtag.name} and #{hashtag2.to_global_id}/#{hashtag2.name}" }
       let(:metadata_hashtags) { [new_hashtag, hashtag, hashtag2] }
 
       it_behaves_like "find and stores the hashtags references"
@@ -60,12 +61,13 @@ module Decidim
     context "when content contains the same new hashtag twice" do
       let(:hashtag) { Decidim::Hashtag.find_by(organization: organization, name: name) }
       let(:content) { "This text contains a hashtag not present on DB twice: ##{name} and ##{name}" }
-      let(:parsed_content) { "This text contains a hashtag not present on DB twice: #{hashtag.to_global_id} and #{hashtag.to_global_id}" }
+      let(:parsed_content) { "This text contains a hashtag not present on DB twice: #{hashtag.to_global_id}/#{hashtag.name} and #{hashtag.to_global_id}/#{hashtag.name}" }
 
       it_behaves_like "find and stores the hashtags references"
 
       context "when written with different case" do
         let(:content) { "This text contains a hashtag not present on DB twice: ##{name.downcase} and ##{name.upcase}" }
+        let(:parsed_content) { "This text contains a hashtag not present on DB twice: #{hashtag.to_global_id}/#{hashtag.name.downcase} and #{hashtag.to_global_id}/#{hashtag.name.upcase}" }
 
         it_behaves_like "find and stores the hashtags references"
       end
@@ -73,7 +75,7 @@ module Decidim
 
     context "when content contains non-hash characters next to the hashtag name" do
       let(:content) { "You can't add some characters to hashtags: ##{hashtag.name}+extra" }
-      let(:parsed_content) { "You can't add some characters to hashtags: #{hashtag.to_global_id}+extra" }
+      let(:parsed_content) { "You can't add some characters to hashtags: #{hashtag.to_global_id}/#{hashtag.name}+extra" }
 
       it_behaves_like "find and stores the hashtags references"
     end

--- a/decidim-core/spec/content_renderers/decidim/hashtag_renderer_spec.rb
+++ b/decidim-core/spec/content_renderers/decidim/hashtag_renderer_spec.rb
@@ -6,13 +6,36 @@ module Decidim
   describe ContentRenderers::HashtagRenderer do
     let(:hashtag) { create(:hashtag) }
     let(:renderer) { described_class.new(content) }
-    let(:presenter) { Decidim::HashtagPresenter.new(hashtag) }
+    let(:presenter) { Decidim::HashtagPresenter.new(hashtag, cased_name: name) }
+    let(:name) { hashtag.name }
+    let(:content) { "This text contains a valid Decidim::Hashtag Global ID: #{hashtag.to_global_id}/#{name}" }
+    let(:result) { %(This text contains a valid Decidim::Hashtag Global ID: <a target="_blank" class="hashtag-mention" href="/search?term=%23#{name}">##{name}</a>) }
 
-    context "when content has a valid Decidim::Hashtag Global ID" do
+    it "renders the hashtagging" do
+      expect(renderer.render).to eq(result)
+    end
+
+    context "when cased_name is not received" do
+      let(:presenter) { Decidim::HashtagPresenter.new(hashtag) }
+
+      it "renders the hashtagging" do
+        expect(renderer.render).to eq(result)
+      end
+    end
+
+    context "when parsed hashtag doesn't include the casing part" do
       let(:content) { "This text contains a valid Decidim::Hashtag Global ID: #{hashtag.to_global_id}" }
 
       it "renders the hashtagging" do
-        expect(renderer.render).to eq(%(This text contains a valid Decidim::Hashtag Global ID: <a target="_blank" class="hashtag-mention" href="/search?term=%23#{hashtag.name}">##{hashtag.name}</a>))
+        expect(renderer.render).to eq(result)
+      end
+    end
+
+    context "when hashtag has upper case letters" do
+      let(:name) { hashtag.name.capitalize }
+
+      it "renders the hashtagging" do
+        expect(renderer.render).to eq(result)
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
I guess that we are downcasing all hashtags for technical reasons, but I think this isn't nice for users. Sometimes, hashtags look like [#HashtagWithCase](#HashtagWithCase), and reading [#hashtagwithcase](#hashtagwithcase) can be difficult to read or understand.

This PR stills saves the hashtag name downcased, but also saves the case information within the parsed hashtag GlobalId in the resource content, in the form `gid://<APP_NAME>/Decidim::Hashtag/<ID>/<HashtagWithCase>`. Then, when retrieving the content, it can access to the original casing to use it when rendering.

#### :pushpin: Related Issues
- I based this PR in #4548, so my idea is to rebase this after it is merged.

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![imagen](https://user-images.githubusercontent.com/453545/48903444-dbb05080-ee5b-11e8-92e2-7eb3824c82ae.png)
