### PR TITLE
Fix voting re-rendering

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/proposal_votes/update_buttons_and_counters.js.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposal_votes/update_buttons_and_counters.js.erb
@@ -1,29 +1,42 @@
 <% @proposals.each do |proposal| %>
-(function() {
-  var $proposalVotesCount = $('#proposal-<%= proposal.id %>-votes-count');
-  var $proposalVoteButton = $('#proposal-<%= proposal.id %>-vote-button');
+  (function() {
+    var $proposalVotesCount = $('#proposal-<%= proposal.id %>-votes-count');
 
-  morphdom($proposalVotesCount[0], '<%= j(render partial: "decidim/proposals/proposals/votes_count", locals: { proposal: proposal, from_proposals_list: @from_proposals_list }).strip.html_safe %>');
-  morphdom($proposalVoteButton[0], '<%= j(render partial: "decidim/proposals/proposals/vote_button", locals: { proposal: proposal, from_proposals_list: @from_proposals_list }).strip.html_safe %>');
-})();
+    if($proposalVotesCount[0]) {
+      morphdom($proposalVotesCount[0], '<%= j(render partial: "decidim/proposals/proposals/votes_count", locals: { proposal: proposal, from_proposals_list: @from_proposals_list }).strip.html_safe %>');
+    }
+
+    var $proposalVoteButton = $('#proposal-<%= proposal.id %>-vote-button');
+
+    if($proposalVoteButton[0]) {
+      morphdom($proposalVoteButton[0], '<%= j(render partial: "decidim/proposals/proposals/vote_button", locals: { proposal: proposal, from_proposals_list: @from_proposals_list }).strip.html_safe %>');
+    }
+  })();
 <% end %>
 
 <% if vote_limit_enabled? %>
-  var $remainingVotesCount = $('#remaining-votes-count');
-  var $notVotedButtons = $('.card__button.button').not('.success');
+  (function() {
+    var $remainingVotesCount = $('#remaining-votes-count');
+    var $notVotedButtons = $('.card__button.button').not('.success');
 
-  morphdom($remainingVotesCount[0], '<%= j(render partial: "decidim/proposals/proposals/remaining_votes_count").strip.html_safe %>');
+    if(!$remainingVotesCount[0]) { return; }
 
-  <% if remaining_votes_count_for(current_user) == 0 %>
-    $notVotedButtons.attr('disabled', true);
-    $notVotedButtons.val('<%= t("decidim.proposals.proposals.vote_button.no_votes_remaining") %>');
-  <% else %>
-    $notVotedButtons.attr('disabled', false);
-    $notVotedButtons.val('<%= t("decidim.proposals.proposals.vote_button.vote") %>');
-  <% end %>
+    morphdom($remainingVotesCount[0], '<%= j(render partial: "decidim/proposals/proposals/remaining_votes_count").strip.html_safe %>');
+
+    <% if remaining_votes_count_for(current_user) == 0 %>
+      $notVotedButtons.attr('disabled', true);
+      $notVotedButtons.val('<%= t("decidim.proposals.proposals.vote_button.no_votes_remaining") %>');
+    <% else %>
+      $notVotedButtons.attr('disabled', false);
+      $notVotedButtons.val('<%= t("decidim.proposals.proposals.vote_button.vote") %>');
+    <% end %>
+  }());
 <% end %>
 
 <% if show_voting_rules? %>
-  var $votingRules = $('.voting-rules');
-  morphdom($votingRules[0], '<%= j(render partial: "decidim/proposals/proposals/voting_rules").strip.html_safe %>');
+  (function() {
+    var $votingRules = $('.voting-rules');
+    if(!$votingRules[0]) { return; }
+    morphdom($votingRules[0], '<%= j(render partial: "decidim/proposals/proposals/voting_rules").strip.html_safe %>');
+  }());
 <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
Re-rendering of votes were failing when voting from a proposal's page. This is due to a bad usage of `morphdom` that was trying to mutate unexisting nodes.

#### :pushpin: Related Issues
- Related to #4556 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
*None*
