### PR TITLE
Allow online/offline ID document verification requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ In order to generate Open Data exports you should add this to your crontab or re
 - **decidim-admin**: Rename "Officializations" section to "Participants" [\#4510](https://github.com/decidim/decidim/pull/4510)
 - **decidim-core**: Improve search results layout. Now results appear grouped by type [\#4537](https://github.com/decidim/decidim/pull/4537)
 - **decidim-core**: Improve propoals serialization [\#4593](https://github.com/decidim/decidim/pull/4593)
+- **decidim-verifications**: The ID documents verification now supports online and offline verification modes [\#4573](https://github.com/decidim/decidim/pull/4573)
 
 **Fixed**:
 

--- a/decidim-core/app/presenters/decidim/admin_log/organization_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/organization_presenter.rb
@@ -19,6 +19,7 @@ module Decidim
           .merge(omnipresent_banner_attributes_mapping)
           .merge(highlighted_content_banner_attributes_mapping)
           .merge(appearance_attributes_mapping)
+          .merge(id_documents_attributes_mapping)
       end
 
       def settings_attributes_mapping
@@ -71,12 +72,24 @@ module Decidim
         }
       end
 
+      def id_documents_attributes_mapping
+        {
+          id_documents_methods: :string,
+          id_documents_explanation_text: :i18n
+        }
+      end
+
       def action_string
+        return "decidim.admin_log.organization.update_id_documents_config" if action == "update_id_documents_config"
         "decidim.admin_log.organization.update"
       end
 
       def i18n_labels_scope
         "activemodel.attributes.organization"
+      end
+
+      def has_diff?
+        action == "update_id_documents_config" || super
       end
     end
   end

--- a/decidim-core/app/presenters/decidim/admin_log/user_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/user_presenter.rb
@@ -16,7 +16,7 @@ module Decidim
 
       def action_string
         case action
-        when "invite", "officialize", "remove_from_admin", "unofficialize"
+        when "grant_id_documents_offline_verification", "invite", "officialize", "remove_from_admin", "unofficialize"
           "decidim.admin_log.user.#{action}"
         else
           super

--- a/decidim-core/db/migrate/20181126145142_add_id_documents_fields_to_org.rb
+++ b/decidim-core/db/migrate/20181126145142_add_id_documents_fields_to_org.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddIdDocumentsFieldsToOrg < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_organizations, :id_documents_methods, :string, array: true, default: ["online"]
+    add_column :decidim_organizations, :id_documents_explanation_text, :jsonb, default: {}
+
+    # rubocop:disable Rails/SkipsModelValidations
+    Decidim::Organization.reset_column_information
+    Decidim::Organization.update_all(id_documents_methods: ["online"])
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+end

--- a/decidim-verifications/app/commands/decidim/verifications/id_documents/admin/confirm_user_offline_authorization.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/id_documents/admin/confirm_user_offline_authorization.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Verifications
+    module IdDocuments
+      module Admin
+        # A command to confirm a previous partial offline authorization.
+        class ConfirmUserOfflineAuthorization < Rectify::Command
+          # Public: Initializes the command.
+          #
+          # form - A form object with the verification data to confirm it.
+          def initialize(form)
+            @form = form
+          end
+
+          # Executes the command. Broadcasts these events:
+          #
+          # - :ok when everything is valid.
+          # - :invalid if the handler wasn't valid and we couldn't proceed.
+          #
+          # Returns nothing.
+          def call
+            return broadcast(:invalid) unless form.valid?
+            return broadcast(:invalid) unless authorization
+
+            if confirmation_successful?
+              grant_authorization
+              broadcast(:ok)
+            else
+              broadcast(:invalid)
+            end
+          end
+
+          protected
+
+          def confirmation_successful?
+            form.verification_metadata.all? do |key, value|
+              authorization.verification_metadata[key] == value
+            end
+          end
+
+          private
+
+          attr_reader :form
+
+          def grant_authorization
+            Decidim.traceability.perform_action!(
+              :grant_id_documents_offline_verification,
+              authorization_user,
+              form.current_user
+            ) do
+              authorization.grant!
+            end
+          end
+
+          def authorization
+            @authorization ||= Authorizations
+                               .new(organization: form.current_organization, name: "id_documents", granted: false)
+                               .query
+                               .where("verification_metadata->'rejected' IS NULL")
+                               .where("verification_metadata->>'verification_type' = 'offline'")
+                               .find_by(user: authorization_user)
+          end
+
+          def authorization_user
+            @authorization_user ||= Decidim::User
+                                    .where(organization: form.current_organization)
+                                    .find_by(email: form.email)
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-verifications/app/commands/decidim/verifications/id_documents/admin/update_config.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/id_documents/admin/update_config.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Verifications
+    module IdDocuments
+      module Admin
+        class UpdateConfig < Rectify::Command
+          def initialize(form)
+            @form = form
+          end
+
+          def call
+            return broadcast(:invalid) if form.invalid?
+
+            update_config
+
+            broadcast(:ok)
+          end
+
+          private
+
+          attr_reader :form
+
+          def update_config
+            form.current_organization.id_documents_methods = form.selected_methods
+            form.current_organization.id_documents_explanation_text = form.offline_explanation
+            form.current_organization.save!
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-verifications/app/commands/decidim/verifications/id_documents/admin/update_config.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/id_documents/admin/update_config.rb
@@ -22,9 +22,15 @@ module Decidim
           attr_reader :form
 
           def update_config
-            form.current_organization.id_documents_methods = form.selected_methods
-            form.current_organization.id_documents_explanation_text = form.offline_explanation
-            form.current_organization.save!
+            Decidim.traceability.perform_action!(
+              :update_id_documents_config,
+              form.current_organization,
+              form.current_user
+            ) do
+              form.current_organization.id_documents_methods = form.selected_methods
+              form.current_organization.id_documents_explanation_text = form.offline_explanation
+              form.current_organization.save!
+            end
           end
         end
       end

--- a/decidim-verifications/app/controllers/decidim/verifications/id_documents/admin/config_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/id_documents/admin/config_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Verifications
+    module IdDocuments
+      module Admin
+        #
+        # Handles the configuration for the ID documents verification
+        #
+        class ConfigController < Decidim::Admin::ApplicationController
+          layout "decidim/admin/users"
+
+          def edit
+            enforce_permission_to :update, :organization, organization: current_organization
+
+            @form = form(ConfigForm).from_model(current_organization)
+          end
+
+          def update
+            enforce_permission_to :update, :organization, organization: current_organization
+
+            @form = form(ConfigForm).from_params(params)
+
+            UpdateConfig.call(@form) do
+              on(:ok) do
+                flash[:notice] = t("config.update.success", scope: "decidim.verifications.id_documents.admin")
+                redirect_to pending_authorizations_path
+              end
+
+              on(:invalid) do
+                flash.now[:alert] = t("config.update.error", scope: "decidim.verifications.id_documents.admin")
+                render action: :edit
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-verifications/app/controllers/decidim/verifications/id_documents/admin/offline_confirmations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/id_documents/admin/offline_confirmations_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Verifications
+    module IdDocuments
+      module Admin
+        #
+        # Handles confirmations for offline verification by identity document.
+        #
+        class OfflineConfirmationsController < Decidim::Admin::ApplicationController
+          layout "decidim/admin/users"
+
+          def new
+            enforce_permission_to :update, :authorization
+
+            @form = form(OfflineConfirmationForm).instance
+          end
+
+          def create
+            enforce_permission_to :update, :authorization
+
+            @form = form(OfflineConfirmationForm).from_params(params)
+
+            ConfirmUserOfflineAuthorization.call(@form) do
+              on(:ok) do
+                flash[:notice] = t("offline_confirmations.create.success", scope: "decidim.verifications.id_documents.admin")
+                redirect_to pending_authorizations_path
+              end
+
+              on(:invalid) do
+                flash.now[:alert] = t("offline_confirmations.create.error", scope: "decidim.verifications.id_documents.admin")
+                render action: :new
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-verifications/app/controllers/decidim/verifications/id_documents/admin/pending_authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/id_documents/admin/pending_authorizations_controller.rb
@@ -7,6 +7,8 @@ module Decidim
         class PendingAuthorizationsController < Decidim::Admin::ApplicationController
           layout "decidim/admin/users"
 
+          helper_method :has_offline_method?
+
           def index
             enforce_permission_to :index, :authorization
 
@@ -20,6 +22,14 @@ module Decidim
               .new(organization: current_organization, name: "id_documents", granted: false)
               .query
               .where("verification_metadata->'rejected' IS NULL")
+          end
+
+          def has_offline_method?
+            available_methods.include?("offline")
+          end
+
+          def available_methods
+            @available_methods ||= current_organization.id_documents_methods
           end
         end
       end

--- a/decidim-verifications/app/controllers/decidim/verifications/id_documents/admin/pending_authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/id_documents/admin/pending_authorizations_controller.rb
@@ -12,16 +12,17 @@ module Decidim
           def index
             enforce_permission_to :index, :authorization
 
-            @pending_authorizations = pending_authorizations
+            @pending_online_authorizations = pending_online_authorizations
           end
 
           private
 
-          def pending_authorizations
+          def pending_online_authorizations
             Authorizations
               .new(organization: current_organization, name: "id_documents", granted: false)
               .query
               .where("verification_metadata->'rejected' IS NULL")
+              .where("verification_metadata->>'verification_type' = 'online'")
           end
 
           def has_offline_method?

--- a/decidim-verifications/app/controllers/decidim/verifications/id_documents/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/id_documents/authorizations_controller.rb
@@ -11,6 +11,11 @@ module Decidim
 
         before_action :load_authorization
 
+        def choose
+          return redirect_to action: :new, using: verification_type if current_organization.id_documents_methods.count == 1
+          render :choose
+        end
+
         def new
           enforce_permission_to :create, :authorization, authorization: @authorization
 
@@ -80,7 +85,7 @@ module Decidim
         end
 
         def verification_type
-          params[:using]
+          params[:using] || current_organization.id_documents_methods.first
         end
 
         def using_online?

--- a/decidim-verifications/app/controllers/decidim/verifications/id_documents/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/id_documents/authorizations_controller.rb
@@ -7,14 +7,14 @@ module Decidim
       # Handles verification by identity document upload
       #
       class AuthorizationsController < ApplicationController
-        helper_method :authorization
+        helper_method :authorization, :verification_type, :using_offline?, :using_online?
 
         before_action :load_authorization
 
         def new
           enforce_permission_to :create, :authorization, authorization: @authorization
 
-          @form = UploadForm.new
+          @form = UploadForm.from_params(id_document_upload: { verification_type: verification_type })
         end
 
         def create
@@ -77,6 +77,18 @@ module Decidim
             user: current_user,
             name: "id_documents"
           )
+        end
+
+        def verification_type
+          params[:using]
+        end
+
+        def using_online?
+          verification_type == "online"
+        end
+
+        def using_offline?
+          verification_type == "offline"
         end
       end
     end

--- a/decidim-verifications/app/controllers/decidim/verifications/id_documents/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/id_documents/authorizations_controller.rb
@@ -7,7 +7,7 @@ module Decidim
       # Handles verification by identity document upload
       #
       class AuthorizationsController < ApplicationController
-        helper_method :authorization, :verification_type, :using_offline?, :using_online?
+        helper_method :authorization, :verification_type, :using_offline?, :using_online?, :available_methods
 
         before_action :load_authorization
 
@@ -53,6 +53,7 @@ module Decidim
           @form = UploadForm.from_params(
             params.merge(
               user: current_user,
+              verification_type: verification_type,
               verification_attachment: params[:id_document_upload][:verification_attachment] || @authorization.verification_attachment
             )
           )
@@ -86,7 +87,12 @@ module Decidim
         end
 
         def verification_type
-          params[:using] || available_methods.first
+          params[:using] || authorization_verification_type || available_methods.first
+        end
+
+        def authorization_verification_type
+          return unless @authorization
+          @authorization.verification_metadata["verification_type"]
         end
 
         def using_online?

--- a/decidim-verifications/app/forms/decidim/verifications/id_documents/admin/config_form.rb
+++ b/decidim-verifications/app/forms/decidim/verifications/id_documents/admin/config_form.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Verifications
+    module IdDocuments
+      # A form object to be used as the base for identity document verification
+      module Admin
+        class ConfigForm < Decidim::Form
+          include TranslatableAttributes
+          mimic :config
+
+          attribute :offline, Boolean
+          attribute :online, Boolean
+          translatable_attribute :offline_explanation, String
+
+          validates :offline_explanation, translatable_presence: true, if: :offline
+          validate :has_some_method_selected?
+
+          def map_model(model)
+            self.online = model.id_documents_methods.include?("online")
+            self.offline = model.id_documents_methods.include?("offline")
+            self.offline_explanation = model.id_documents_explanation_text
+          end
+
+          def has_some_method_selected?
+            return if online || offline
+
+            errors.add(:online, :invalid)
+            errors.add(:offline, :invalid)
+          end
+
+          def selected_methods
+            methods = []
+            methods << "offline" if offline
+            methods << "online" if online
+            methods
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-verifications/app/forms/decidim/verifications/id_documents/admin/offline_confirmation_form.rb
+++ b/decidim-verifications/app/forms/decidim/verifications/id_documents/admin/offline_confirmation_form.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Verifications
+    module IdDocuments
+      # A form object to be used as the base for identity document verification
+      module Admin
+        class OfflineConfirmationForm < InformationForm
+          attribute :email, String
+
+          validates :email, presence: true
+        end
+      end
+    end
+  end
+end

--- a/decidim-verifications/app/forms/decidim/verifications/id_documents/information_form.rb
+++ b/decidim-verifications/app/forms/decidim/verifications/id_documents/information_form.rb
@@ -11,6 +11,7 @@ module Decidim
 
         attribute :document_number, String
         attribute :document_type, String
+        attribute :verification_type, String
 
         validates :document_type,
                   inclusion: { in: DOCUMENT_TYPES },
@@ -20,6 +21,10 @@ module Decidim
                   format: { with: /\A[A-Z0-9]*\z/, message: I18n.t("errors.messages.uppercase_only_letters_numbers") },
                   presence: true
 
+        validates :verification_type,
+                  presence: true,
+                  inclusion: { in: %w(offline online) }
+
         def handler_name
           "id_documents"
         end
@@ -27,12 +32,14 @@ module Decidim
         def map_model(model)
           self.document_type = model.verification_metadata["document_type"]
           self.document_number = model.verification_metadata["document_number"]
+          self.verification_type = model.verification_metadata["verification_type"].presence || "online"
         end
 
         def verification_metadata
           {
             "document_type" => document_type,
-            "document_number" => document_number
+            "document_number" => document_number,
+            "verification_type" => verification_type
           }
         end
 
@@ -43,6 +50,10 @@ module Decidim
               type
             ]
           end
+        end
+
+        def uses_online_method?
+          verification_type == "online"
         end
       end
     end

--- a/decidim-verifications/app/forms/decidim/verifications/id_documents/upload_form.rb
+++ b/decidim-verifications/app/forms/decidim/verifications/id_documents/upload_form.rb
@@ -13,7 +13,8 @@ module Decidim
         validates :verification_attachment,
                   file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } },
                   file_content_type: { allow: ["image/jpeg", "image/png"] },
-                  presence: true
+                  presence: true,
+                  if: :uses_online_method?
       end
     end
   end

--- a/decidim-verifications/app/views/decidim/verifications/id_documents/admin/config/edit.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/id_documents/admin/config/edit.html.erb
@@ -1,0 +1,26 @@
+<%= decidim_form_for(@form, url: { action: :update },
+                            html: { class: "form" }) do |form| %>
+  <div class="card">
+    <div class="card-divider">
+      <h2 class="card-title">
+        <%= t(".title") %>
+      </h2>
+    </div>
+
+    <div class="card-section">
+      <div class="row column">
+      <%= label_tag(:available_methods) %>
+        <%= form.check_box :online %>
+        <%= form.check_box :offline %>
+      </div>
+
+      <div class="row column">
+        <%= form.translated :editor, :offline_explanation, lines: 10 %>
+      </div>
+    </div>
+  </div>
+
+  <div class="button--double form-general-submit">
+    <%= form.submit t(".update") %>
+  </div>
+<% end %>

--- a/decidim-verifications/app/views/decidim/verifications/id_documents/admin/confirmations/new.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/id_documents/admin/confirmations/new.html.erb
@@ -16,6 +16,7 @@
       <div class="row column">
         <%= form.select :document_type, @form.document_types_for_select, prompt: true, selected: nil %>
         <%= form.text_field :document_number, value: nil %>
+        <%= form.hidden_field :verification_type, value: :online %>
       </div>
     </div>
   </div>

--- a/decidim-verifications/app/views/decidim/verifications/id_documents/admin/offline_confirmations/new.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/id_documents/admin/offline_confirmations/new.html.erb
@@ -1,0 +1,24 @@
+<%= decidim_form_for(@form, url: offline_confirmation_path,
+                            html: { class: "form" }) do |form| %>
+  <div class="card">
+    <div class="card-divider">
+      <h2 class="card-title">
+        <%= t(".introduce_user_data") %>
+      </h2>
+    </div>
+
+    <div class="card-section">
+      <div class="row column">
+        <%= form.text_field :email %>
+        <%= form.select :document_type, @form.document_types_for_select, prompt: true %>
+        <%= form.text_field :document_number %>
+        <%= form.hidden_field :verification_type, value: :offline %>
+      </div>
+    </div>
+  </div>
+
+  <div class="button--double form-general-submit">
+    <%= form.submit t(".verify") %>
+    <%= link_to t(".cancel"), root_path, class: "button hollow" %>
+  </div>
+<% end %>

--- a/decidim-verifications/app/views/decidim/verifications/id_documents/admin/pending_authorizations/index.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/id_documents/admin/pending_authorizations/index.html.erb
@@ -3,7 +3,7 @@
     <h2 class="card-title">
       <%= t(".title") %>
         <%= link_to t(".config"), edit_config_path, class: "button tiny button--title" %>
-        <%= link_to t(".offline_verification"), "#", class: "button tiny button--title" if has_offline_method? %>
+        <%= link_to t(".offline_verification"), new_offline_confirmation_path, class: "button tiny button--title" if has_offline_method? %>
     </h2>
   </div>
   <div class="card-section">
@@ -16,7 +16,7 @@
       </thead>
       <tbody>
         <tr>
-          <% @pending_authorizations.each do |authorization| %>
+          <% @pending_online_authorizations.each do |authorization| %>
             <td>
               <%= link_to t(".verification_number", n: authorization.id),
                           new_pending_authorization_confirmation_path(authorization.id) %>

--- a/decidim-verifications/app/views/decidim/verifications/id_documents/admin/pending_authorizations/index.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/id_documents/admin/pending_authorizations/index.html.erb
@@ -2,6 +2,8 @@
   <div class="card-divider">
     <h2 class="card-title">
       <%= t(".title") %>
+        <%= link_to t(".config"), edit_config_path, class: "button tiny button--title" %>
+        <%= link_to t(".offline_verification"), "#", class: "button tiny button--title" if has_offline_method? %>
     </h2>
   </div>
   <div class="card-section">

--- a/decidim-verifications/app/views/decidim/verifications/id_documents/authorizations/_form.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/id_documents/authorizations/_form.html.erb
@@ -1,0 +1,17 @@
+<div class="card-section">
+  <div class="field">
+    <%= form.select :document_type, @form.document_types_for_select, prompt: true %>
+  </div>
+
+  <div class="field">
+    <%= form.text_field :document_number %>
+  </div>
+
+  <% if using_online? %>
+    <div class="field">
+      <%= form.upload :verification_attachment %>
+    </div>
+  <% end %>
+
+  <%= form.hidden_field :verification_type, value: verification_type %>
+</div>

--- a/decidim-verifications/app/views/decidim/verifications/id_documents/authorizations/choose.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/id_documents/authorizations/choose.html.erb
@@ -1,0 +1,21 @@
+<div class="wrapper">
+  <div class="row collapse">
+    <div class="row collapse">
+      <div class="columns large-8 large-centered text-center page-title">
+        <h1><%= t(".title") %></h1>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="columns large-6 medium-centered">
+        <div class="card">
+          <div class="card__content">
+            <p><%= t(".choose_a_type") %></p>
+            <%= link_to t(".offline"), { action: :new, using: :offline }, class: "button button--sc expanded hollow" %>
+            <%= link_to t(".online"), { action: :new, using: :online }, class: "button button--sc expanded" %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/decidim-verifications/app/views/decidim/verifications/id_documents/authorizations/edit.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/id_documents/authorizations/edit.html.erb
@@ -22,6 +22,7 @@
       <div class="row column">
         <div class="card">
           <div class="card__content">
+            <%= translated_attribute(current_organization.id_documents_explanation_text).html_safe unless using_online? %>
             <%= decidim_form_for(@form, url: authorization_path, method: :put) do |form| %>
               <%= render partial: "form", locals: { form: form } %>
 

--- a/decidim-verifications/app/views/decidim/verifications/id_documents/authorizations/edit.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/id_documents/authorizations/edit.html.erb
@@ -36,6 +36,8 @@
                 <div class="field">
                   <%= form.upload :verification_attachment, optional: false %>
                 </div>
+
+                <%= form.hidden_field :verification_type %>
               </div>
 
               <div class="card-section">

--- a/decidim-verifications/app/views/decidim/verifications/id_documents/authorizations/edit.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/id_documents/authorizations/edit.html.erb
@@ -17,39 +17,27 @@
     </div>
   </div>
 
-  <% if authorization.rejected? %>
-    <div class="row">
-      <div class="columns large-6 medium-centered">
-        <div class="row column">
-          <div class="card">
-            <div class="card__content">
-              <%= decidim_form_for(@form, url: authorization_path, method: :put) do |form| %>
-              <div class="card-section">
-                <div class="field">
-                  <%= form.select :document_type, @form.document_types_for_select, prompt: true %>
-                </div>
-
-                <div class="field">
-                  <%= form.text_field :document_number %>
-                </div>
-
-                <div class="field">
-                  <%= form.upload :verification_attachment, optional: false %>
-                </div>
-
-                <%= form.hidden_field :verification_type %>
-              </div>
+  <div class="row">
+    <div class="columns large-6 medium-centered">
+      <div class="row column">
+        <div class="card">
+          <div class="card__content">
+            <%= decidim_form_for(@form, url: authorization_path, method: :put) do |form| %>
+              <%= render partial: "form", locals: { form: form } %>
 
               <div class="card-section">
                 <div class="actions">
                   <%= form.submit t(".send"), class: "button expanded", "data-disable-with" => "#{t('.send')}..." %>
+                  <% if available_methods.count > 1 %>
+                    <%= link_to t(".offline"), { action: :edit, using: :offline }, class: "button expanded hollow" if using_online? %>
+                    <%= link_to t(".online"), { action: :edit, using: :online }, class: "button expanded hollow" if using_offline? %>
+                  <% end %>
                 </div>
               </div>
-              <% end %>
-            </div>
+            <% end %>
           </div>
         </div>
       </div>
     </div>
-  <% end %>
+  </div>
 </div>

--- a/decidim-verifications/app/views/decidim/verifications/id_documents/authorizations/new.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/id_documents/authorizations/new.html.erb
@@ -10,6 +10,7 @@
       <div class="columns large-6 medium-centered">
         <div class="card">
           <div class="card__content">
+            <%= translated_attribute(current_organization.id_documents_explanation_text).html_safe unless using_online? %>
             <%= decidim_form_for(@form, url: authorization_path) do |form| %>
               <div class="field">
                 <%= form.select :document_type, @form.document_types_for_select, prompt: true %>

--- a/decidim-verifications/app/views/decidim/verifications/id_documents/authorizations/new.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/id_documents/authorizations/new.html.erb
@@ -12,24 +12,12 @@
           <div class="card__content">
             <%= translated_attribute(current_organization.id_documents_explanation_text).html_safe unless using_online? %>
             <%= decidim_form_for(@form, url: authorization_path) do |form| %>
-              <div class="field">
-                <%= form.select :document_type, @form.document_types_for_select, prompt: true %>
-              </div>
+              <%= render partial: "form", locals: { form: form } %>
 
-              <div class="field">
-                <%= form.text_field :document_number %>
-              </div>
-
-              <% if using_online? %>
-                <div class="field">
-                  <%= form.upload :verification_attachment %>
+              <div class="card-section">
+                <div class="actions">
+                  <%= form.submit t(".send"), class: "button expanded", "data-disable-with" => "#{t('.send')}..." %>
                 </div>
-              <% end %>
-
-              <%= form.hidden_field :verification_type %>
-
-              <div class="actions">
-                <%= form.submit t(".send"), class: "button expanded", "data-disable-with" => "#{t('.send')}..." %>
               </div>
             <% end %>
           </div>

--- a/decidim-verifications/app/views/decidim/verifications/id_documents/authorizations/new.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/id_documents/authorizations/new.html.erb
@@ -19,9 +19,13 @@
                 <%= form.text_field :document_number %>
               </div>
 
-              <div class="field">
-                <%= form.upload :verification_attachment %>
-              </div>
+              <% if using_online? %>
+                <div class="field">
+                  <%= form.upload :verification_attachment %>
+                </div>
+              <% end %>
+
+              <%= form.hidden_field :verification_type %>
 
               <div class="actions">
                 <%= form.submit t(".send"), class: "button expanded", "data-disable-with" => "#{t('.send')}..." %>

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -118,6 +118,8 @@ en:
             success: Document uploaded successfully
           edit:
             being_reviewed: We're reviewing your documents. You'll be verified shortly
+            offline: Use offline verification
+            online: Use online verification
             rejection_clarity: Make sure the information is clearly visible in the uploaded image
             rejection_correctness: Make sure the information entered is correct
             rejection_notice: There was a problem with your verification. Please try again

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -20,6 +20,9 @@ en:
     admin:
       menu:
         authorization_workflows: Verifications
+    admin_log:
+      organization:
+        update_id_documents_config: "%{user_name} updated the Identity Documents verification configuration"
     authorization_handlers:
       admin:
         id_documents:

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -109,7 +109,7 @@ en:
               success: Verification rejected. User will be prompted to amend her documents
         authorizations:
           choose:
-            choose_a_type: CHOOSE A TYPE PLEASE
+            choose_a_type: "Please select how you want to be verified:"
             offline: Offline
             online: Online
             title: Verify yourself using your identity document

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -70,6 +70,13 @@ en:
           other: 'Participation is restricted to users with any of the following postal codes: %{postal_codes}.'
       id_documents:
         admin:
+          config:
+            edit:
+              title: Identity documents configuration
+              update: Update
+            update:
+              error: There was an error updating the configuration.
+              success: Configuration successfully updated
           confirmations:
             create:
               error: Verification doesn't match. Try again or reject the verification so the user can amend it
@@ -80,7 +87,9 @@ en:
               verify: Verify
           pending_authorizations:
             index:
-              title: Pending verifications
+              config: Config
+              offline_verification: Offline verification
+              title: Pending online verifications
               verification_number: 'Verification #%{n}'
           rejections:
             create:

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -86,6 +86,11 @@ en:
             create:
               success: Verification rejected. User will be prompted to amend her documents
         authorizations:
+          choose:
+            choose_a_type: CHOOSE A TYPE PLEASE
+            offline: Offline
+            online: Online
+            title: Verify yourself using your identity document
           create:
             error: There was a problem uploading your document
             success: Document uploaded successfully

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -23,6 +23,8 @@ en:
     admin_log:
       organization:
         update_id_documents_config: "%{user_name} updated the Identity Documents verification configuration"
+      user:
+        grant_id_documents_offline_verification: "%{user_name} verified %{resource_name} using an offline Identity Documents verification"
     authorization_handlers:
       admin:
         id_documents:
@@ -87,6 +89,14 @@ en:
             new:
               introduce_user_data: Introduce the data in the picture
               reject: Reject
+              verify: Verify
+          offline_confirmations:
+            create:
+              error: Verification doesn't match. Try again or tell the user to amend it
+              success: User successfully verified
+            new:
+              cancel: Cancel
+              introduce_user_data: Introduce the user email and the document data
               verify: Verify
           pending_authorizations:
             index:

--- a/decidim-verifications/lib/decidim/verifications/id_documents/admin_engine.rb
+++ b/decidim-verifications/lib/decidim/verifications/id_documents/admin_engine.rb
@@ -16,6 +16,8 @@ module Decidim
             resource :rejections, only: :create, as: :rejection
           end
 
+          resource :config, only: [:edit, :update], controller: "config"
+
           root to: "pending_authorizations#index"
         end
       end

--- a/decidim-verifications/lib/decidim/verifications/id_documents/admin_engine.rb
+++ b/decidim-verifications/lib/decidim/verifications/id_documents/admin_engine.rb
@@ -15,6 +15,7 @@ module Decidim
             resource :confirmations, only: [:new, :create], as: :confirmation
             resource :rejections, only: :create, as: :rejection
           end
+          resource :offline_confirmations, only: [:new, :create], as: :offline_confirmation
 
           resource :config, only: [:edit, :update], controller: "config"
 

--- a/decidim-verifications/lib/decidim/verifications/id_documents/engine.rb
+++ b/decidim-verifications/lib/decidim/verifications/id_documents/engine.rb
@@ -11,9 +11,13 @@ module Decidim
         paths["lib/tasks"] = nil
 
         routes do
-          resource :authorizations, only: [:new, :create, :edit, :update], as: :authorization
+          resource :authorizations, only: [:new, :create, :edit, :update], as: :authorization do
+            collection do
+              get :choose
+            end
+          end
 
-          root to: "authorizations#new"
+          root to: "authorizations#choose"
         end
       end
     end

--- a/decidim-verifications/spec/commmands/decidim/verifications/id_documents/admin/confirm_user_offline_authorization_spec.rb
+++ b/decidim-verifications/spec/commmands/decidim/verifications/id_documents/admin/confirm_user_offline_authorization_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Verifications::IdDocuments::Admin::ConfirmUserOfflineAuthorization do
+  subject { described_class.new(form) }
+
+  let(:authorization) do
+    create(
+      :authorization,
+      :pending,
+      name: "id_documents",
+      verification_metadata: verification_metadata
+    )
+  end
+
+  let(:verification_type) { "offline" }
+  let(:verification_metadata) do
+    { secret_code: "XX42YY", verification_type: verification_type }
+  end
+
+  let(:form_class) do
+    Class.new(Decidim::Form) do
+      mimic :authorization
+
+      attribute :email
+      attribute :secret_code
+
+      validates :secret_code, presence: true
+
+      def verification_metadata
+        { "secret_code" => secret_code }
+      end
+    end
+  end
+
+  let(:email) { user.email }
+  let(:form) do
+    form_class.new(
+      secret_code: secret_code,
+      email: email
+    ).with_context(
+      current_user: admin,
+      current_organization: user.organization
+    )
+  end
+
+  let(:granted_authorizations) do
+    Decidim::Verifications::Authorizations.new(organization: user.organization, user: user, granted: true)
+  end
+
+  let(:user) { authorization.user }
+  let(:admin) { create :user, :admin, organization: user.organization }
+
+  context "when the form is not valid" do
+    let(:secret_code) { nil }
+
+    it "is not valid" do
+      expect { subject.call }.to broadcast(:invalid)
+    end
+  end
+
+  context "when the authorization is not found" do
+    let(:email) { "this@doesnt.exist" }
+    let(:secret_code) { "XX42YY" }
+
+    it "broadcasts invalid" do
+      expect { subject.call }.to broadcast(:invalid)
+    end
+  end
+
+  context "when the authorization is not offline" do
+    let(:verification_type) { :online }
+    let(:secret_code) { "XX42YY" }
+
+    it "broadcasts invalid" do
+      expect { subject.call }.to broadcast(:invalid)
+    end
+  end
+
+  context "when the authorization is already confirmed" do
+    let(:secret_code) { "XX42YY" }
+
+    before { authorization.grant! }
+
+    it "broadcasts already confirmed" do
+      expect { subject.call }.to broadcast(:invalid)
+    end
+  end
+
+  context "when everything is ok" do
+    let(:secret_code) { "XX42YY" }
+
+    it "broadcasts ok" do
+      expect { subject.call }.to broadcast(:ok)
+    end
+
+    it "confirms the authorization for the user" do
+      expect { subject.call }.to change(granted_authorizations, :count).by(1)
+    end
+
+    it "traces the action", versioning: true do
+      expect(Decidim.traceability)
+        .to receive(:perform_action!)
+        .with(:grant_id_documents_offline_verification, user, admin)
+        .and_call_original
+      expect { subject.call }.to change(Decidim::ActionLog, :count)
+      action_log = Decidim::ActionLog.last
+      expect(action_log.version).not_to be_present
+    end
+  end
+end

--- a/decidim-verifications/spec/commmands/decidim/verifications/id_documents/admin/update_config_spec.rb
+++ b/decidim-verifications/spec/commmands/decidim/verifications/id_documents/admin/update_config_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Verifications::IdDocuments::Admin
+  describe UpdateConfig do
+    subject { described_class.new(form) }
+
+    let(:form) do
+      ConfigForm.from_params(
+        online: online,
+        offline: offline,
+        offline_explanation: offline_explanation
+      ).with_context(current_organization: organization)
+    end
+    let(:organization) { create :organization }
+    let(:online) { true }
+    let(:offline) { true }
+    let(:offline_explanation) { { en: "Blah" } }
+
+    context "when the form is not authorized" do
+      before do
+        expect(form).to receive(:valid?).and_return(false)
+      end
+
+      it "is not valid" do
+        expect { subject.call }.to broadcast(:invalid)
+      end
+    end
+
+    context "when everything is ok" do
+      it "updates the organization" do
+        subject.call
+        organization.reload
+        expect(organization.id_documents_methods).to match_array(%w(online offline))
+        expect(translated(organization.id_documents_explanation_text)).to eq "Blah"
+      end
+    end
+  end
+end

--- a/decidim-verifications/spec/commmands/decidim/verifications/id_documents/admin/update_config_spec.rb
+++ b/decidim-verifications/spec/commmands/decidim/verifications/id_documents/admin/update_config_spec.rb
@@ -11,9 +11,10 @@ module Decidim::Verifications::IdDocuments::Admin
         online: online,
         offline: offline,
         offline_explanation: offline_explanation
-      ).with_context(current_organization: organization)
+      ).with_context(current_organization: organization, current_user: user)
     end
     let(:organization) { create :organization }
+    let(:user) { create :user, organization: organization }
     let(:online) { true }
     let(:offline) { true }
     let(:offline_explanation) { { en: "Blah" } }
@@ -34,6 +35,18 @@ module Decidim::Verifications::IdDocuments::Admin
         organization.reload
         expect(organization.id_documents_methods).to match_array(%w(online offline))
         expect(translated(organization.id_documents_explanation_text)).to eq "Blah"
+      end
+
+      it "traces the action", versioning: true do
+        expect(Decidim.traceability)
+          .to receive(:perform_action!)
+          .with(:update_id_documents_config, organization, user)
+          .and_call_original
+
+        expect { subject.call }.to change(Decidim::ActionLog, :count)
+        action_log = Decidim::ActionLog.last
+        expect(action_log.version).to be_present
+        expect(action_log.version.event).to eq "update"
       end
     end
   end

--- a/decidim-verifications/spec/forms/decidim/verifications/id_documents/admin/config_form_spec.rb
+++ b/decidim-verifications/spec/forms/decidim/verifications/id_documents/admin/config_form_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Verifications::IdDocuments::Admin
+  describe ConfigForm do
+    subject { described_class.from_params(attributes).with_context(current_organization: organization) }
+
+    let(:attributes) do
+      {
+        online: online,
+        offline: offline,
+        offline_explanation: offline_explanation
+      }
+    end
+    let(:organization) { create :organization }
+    let(:online) { true }
+    let(:offline) { false }
+    let(:offline_explanation) { {} }
+
+    context "when the information is valid" do
+      it "is valid" do
+        expect(subject).to be_valid
+      end
+    end
+
+    context "when both modes are false" do
+      let(:online) { false }
+      let(:offline) { false }
+
+      it "is not valid" do
+        expect(subject).not_to be_valid
+      end
+    end
+
+    context "when offline is true" do
+      let(:offline) { true }
+
+      it "is not valid without an explanation" do
+        expect(subject).not_to be_valid
+        expect(subject.errors[:offline_explanation_en])
+          .to include("can't be blank")
+      end
+    end
+  end
+end

--- a/decidim-verifications/spec/forms/decidim/verifications/id_documents/information_form_spec.rb
+++ b/decidim-verifications/spec/forms/decidim/verifications/id_documents/information_form_spec.rb
@@ -6,6 +6,7 @@ module Decidim::Verifications::IdDocuments
   describe InformationForm do
     subject do
       described_class.new(
+        verification_type: verification_type,
         document_type: document_type,
         document_number: document_number
       )
@@ -13,12 +14,22 @@ module Decidim::Verifications::IdDocuments
 
     let(:user) { create(:user) }
 
+    let(:verification_type) { "online" }
     let(:document_type) { "DNI" }
     let(:document_number) { "XXXXXXXXY" }
 
     context "when the information is valid" do
       it "is valid" do
         expect(subject).to be_valid
+      end
+    end
+
+    context "when verification type is invalid" do
+      let(:verification_type) { "invalid type" }
+
+      it "is not valid" do
+        expect(subject).not_to be_valid
+        expect(subject.errors[:verification_type]).to include("is not included in the list")
       end
     end
 

--- a/decidim-verifications/spec/system/id_documents/id_document_offline_review_spec.rb
+++ b/decidim-verifications/spec/system/id_documents/id_document_offline_review_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Identity document offline review", type: :system do
+  let!(:organization) do
+    create(
+      :organization,
+      available_authorizations: ["id_documents"],
+      id_documents_methods: ["offline"],
+      id_documents_explanation_text: { en: "Foobar" }
+    )
+  end
+
+  let(:user) { create(:user, :confirmed, organization: organization) }
+
+  let!(:authorization) do
+    create(
+      :authorization,
+      :pending,
+      id: 1,
+      name: "id_documents",
+      user: user,
+      verification_metadata: {
+        "verification_type" => "offline",
+        "document_type" => "DNI",
+        "document_number" => "XXXXXXXX"
+      }
+    )
+  end
+
+  let(:admin) { create(:user, :admin, :confirmed, organization: organization) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as admin, scope: :user
+    visit decidim_admin_id_documents.root_path
+    click_link "Offline verification"
+  end
+
+  it "allows the user to verify an identity document" do
+    submit_verification_form(doc_type: "DNI", doc_number: "XXXXXXXX")
+
+    expect(page).to have_content("User successfully verified")
+  end
+
+  it "shows an error when there's no authorization for the given email" do
+    submit_verification_form(doc_type: "DNI", doc_number: "XXXXXXXX", user_email: "this@doesnt.exist")
+
+    expect(page).to have_content("Verification doesn't match")
+    expect(page).to have_content("INTRODUCE THE USER EMAIL AND THE DOCUMENT DATA")
+  end
+
+  it "shows an error when information doesn't match" do
+    submit_verification_form(doc_type: "NIE", doc_number: "XXXXXXXY")
+
+    expect(page).to have_content("Verification doesn't match")
+    expect(page).to have_content("INTRODUCE THE USER EMAIL AND THE DOCUMENT DATA")
+  end
+
+  private
+
+  def submit_verification_form(doc_type:, doc_number:, user_email: user.email)
+    fill_in "Email", with: user_email
+    select doc_type, from: "Type of the document"
+    fill_in "Document number (with letter)", with: doc_number
+
+    click_button "Verify"
+  end
+end

--- a/decidim-verifications/spec/system/id_documents/id_document_online_review_spec.rb
+++ b/decidim-verifications/spec/system/id_documents/id_document_online_review_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Identity document review", type: :system do
+describe "Identity document online review", type: :system do
   let!(:organization) do
     create(:organization, available_authorizations: ["id_documents"])
   end

--- a/decidim-verifications/spec/system/id_documents/id_document_online_upload_spec.rb
+++ b/decidim-verifications/spec/system/id_documents/id_document_online_upload_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Identity document online upload", type: :system do
+  let!(:organization) do
+    create(:organization, available_authorizations: ["id_documents"])
+  end
+
+  let!(:user) { create(:user, :confirmed, organization: organization) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim_id_documents.root_path
+  end
+
+  it "redirects to verification after login" do
+    expect(page).to have_content("Upload your identity document")
+  end
+
+  it "allows the user to upload her identity document" do
+    submit_upload_form(
+      doc_type: "DNI",
+      doc_number: "XXXXXXXX",
+      file_name: "id.jpg"
+    )
+
+    expect(page).to have_content("Document uploaded successfully")
+  end
+
+  it "shows an error when upload failed" do
+    submit_upload_form(
+      doc_type: "DNI",
+      doc_number: "XXXXXXXX",
+      file_name: "Exampledocument.pdf"
+    )
+
+    expect(page).to have_content("There was a problem uploading your document")
+  end
+
+  private
+
+  def submit_upload_form(doc_type:, doc_number:, file_name:)
+    select doc_type, from: "Type of your document"
+    fill_in "Document number (with letter)", with: doc_number
+    attach_file "Scanned copy of your document", Decidim::Dev.asset(file_name)
+
+    click_button "Request verification"
+  end
+end

--- a/decidim-verifications/spec/system/id_documents/id_document_request_edition_spec.rb
+++ b/decidim-verifications/spec/system/id_documents/id_document_request_edition_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Identity document request edition", type: :system do
+  let(:organization) do
+    create(
+      :organization,
+      available_authorizations: ["id_documents"],
+      id_documents_methods: [:online]
+    )
+  end
+
+  let(:verification_method) { :online }
+  let!(:authorization) do
+    create(
+      :authorization,
+      :pending,
+      name: "id_documents",
+      user: user,
+      verification_metadata: {
+        "verification_type" => verification_method,
+        "document_type" => "DNI",
+        "document_number" => "XXXXXXXX"
+      },
+      verification_attachment: Decidim::Dev.test_file("id.jpg", "image/jpg")
+    )
+  end
+
+  let!(:user) { create(:user, :confirmed, organization: organization) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim_verifications.authorizations_path
+    click_link "Identity documents"
+  end
+
+  context "when the organization only has online method active" do
+    it "allows the user to change the data" do
+      expect(page).to have_selector("form", text: "Request verification again")
+
+      submit_upload_form(
+        doc_type: "DNI",
+        doc_number: "XXXXXXXY",
+        file_name: "dni.jpg"
+      )
+      expect(page).to have_content("Document reuploaded successfully")
+      authorization.reload
+      expect(authorization.verification_metadata["verification_type"]).to eq "online"
+      expect(authorization.verification_metadata["document_number"]).to eq "XXXXXXXY"
+    end
+  end
+
+  context "when the organization only has offline method active" do
+    let!(:organization) do
+      create(
+        :organization,
+        available_authorizations: ["id_documents"],
+        id_documents_methods: [:offline],
+        id_documents_explanation_text: { en: "This is my explanation text" }
+      )
+    end
+    let(:verification_method) { :offline }
+
+    it "allows the user to change the data" do
+      expect(page).to have_selector("form", text: "Request verification again")
+      expect(page).not_to have_content("Scanned copy of your document")
+      expect(page).to have_content("This is my explanation text")
+
+      submit_upload_form(
+        doc_type: "DNI",
+        doc_number: "XXXXXXXY"
+      )
+      expect(page).to have_content("Document reuploaded successfully")
+      authorization.reload
+      expect(authorization.verification_metadata["verification_type"]).to eq "offline"
+      expect(authorization.verification_metadata["document_number"]).to eq "XXXXXXXY"
+    end
+  end
+
+  context "when the organization has both online and offline methods active" do
+    let!(:organization) do
+      create(
+        :organization,
+        available_authorizations: ["id_documents"],
+        id_documents_methods: [:offline, :online],
+        id_documents_explanation_text: { en: "This is my explanation text" }
+      )
+    end
+
+    context "when the authorization is offline" do
+      let(:verification_method) { :offline }
+
+      it "allows the user to change the verification method" do
+        expect(page).to have_selector("form", text: "Request verification again")
+        expect(page).not_to have_content("Scanned copy of your document")
+        click_link "Use online verification"
+
+        submit_upload_form(
+          doc_type: "DNI",
+          doc_number: "XXXXXXXY",
+          file_name: "dni.jpg"
+        )
+
+        expect(page).to have_content("Document reuploaded successfully")
+        authorization.reload
+        expect(authorization.verification_metadata["verification_type"]).to eq "online"
+        expect(authorization.verification_metadata["document_number"]).to eq "XXXXXXXY"
+        expect(authorization.verification_attachment).to be_present
+      end
+    end
+
+    context "when the authorization is online" do
+      let(:verification_method) { :online }
+
+      it "allows the user to change the verification method" do
+        expect(page).to have_selector("form", text: "Request verification again")
+        click_link "Use offline verification"
+        expect(page).not_to have_content("Scanned copy of your document")
+
+        submit_upload_form(
+          doc_type: "DNI",
+          doc_number: "XXXXXXXY"
+        )
+
+        expect(page).to have_content("Document reuploaded successfully")
+        authorization.reload
+        expect(authorization.verification_metadata["verification_type"]).to eq "offline"
+        expect(authorization.verification_metadata["document_number"]).to eq "XXXXXXXY"
+        expect(authorization.verification_attachment).to be_present
+      end
+    end
+  end
+
+  private
+
+  def submit_upload_form(doc_type:, doc_number:, file_name: nil)
+    select doc_type, from: "Type of your document"
+    fill_in "Document number (with letter)", with: doc_number
+    attach_file "Scanned copy of your document", Decidim::Dev.asset(file_name) if file_name
+
+    click_button "Request verification again"
+  end
+end

--- a/decidim-verifications/spec/system/id_documents/id_document_review_spec.rb
+++ b/decidim-verifications/spec/system/id_documents/id_document_review_spec.rb
@@ -17,6 +17,7 @@ describe "Identity document review", type: :system do
       name: "id_documents",
       user: user,
       verification_metadata: {
+        "verification_type" => "online",
         "document_type" => "DNI",
         "document_number" => "XXXXXXXX"
       },


### PR DESCRIPTION
#### :tophat: What? Why?
This PR implements #4122 by modifying only the ID Documents verification.

It lets admins configure the verification methods:
- Online: just like before, the user uploads a picture of their document and fills the document type and number. The admin receives the submission, sees the picture and fills the document type and number. If both submissions match, the user is verified.
- Offline: The user doesn't upload any picture, only fills the document type and number. Then visits the admin. The admin needs to fill the user email, document type and number. If all data match, the user is verified.

#### :pushpin: Related Issues
- Fixes #4122

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Let users fill the form in both online/offline methods
- [x] Allow admins to enable online/offline verification methods for ID documents
- [x] Let admins add explanation text for offline verification
- [x] Trace when admins enable/disable online/offline methods
- [x] Let admins verify users using offline verification and trace the action
- [x] Let users edit submissions and change the verification method
- [x] ensure online verification works as before
- [ ] fix locales

### :camera: Screenshots (optional)
![Description](URL)
