### PR TITLE
Participatory text title bug

### DIFF
--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -6,6 +6,7 @@ module Decidim
     class ProposalsController < Decidim::Proposals::ApplicationController
       helper Decidim::WidgetUrlsHelper
       helper ProposalWizardHelper
+      helper ParticipatoryTextsHelper
       include FormFactory
       include FilterResource
       include Orderable

--- a/decidim-proposals/app/helpers/decidim/proposals/participatory_texts_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/participatory_texts_helper.rb
@@ -13,6 +13,14 @@ module Decidim
         translated = t(proposal.participatory_text_level, scope: "decidim.proposals.admin.participatory_texts.sections", title: proposal.title)
         translated.html_safe
       end
+
+      def render_participatory_text_title(participatory_text)
+        if participatory_text.nil?
+          t("alternative_title", scope: "decidim.proposals.participatory_text_proposal")
+        else
+          translated_attribute(participatory_text.title)
+        end
+      end
     end
   end
 end

--- a/decidim-proposals/app/views/decidim/proposals/proposals/participatory_texts/participatory_text.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/participatory_texts/participatory_text.html.erb
@@ -2,7 +2,7 @@
 
 <div class="row view-header">
   <div class="column medium-9">
-    <h2 class="heading2"><%= translated_attribute(@participatory_text.title) %></h2>
+    <h2 class="heading2"><%= translated_attribute(@participatory_text&.title) %></h2>
   </div>
   <div class="column medium-3 pull-right">
     <%= render partial: "decidim/proposals/proposals/participatory_texts/view_index" %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/participatory_texts/participatory_text.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/participatory_texts/participatory_text.html.erb
@@ -2,7 +2,7 @@
 
 <div class="row view-header">
   <div class="column medium-9">
-    <h2 class="heading2"><%= translated_attribute(@participatory_text&.title) %></h2>
+    <h2 class="heading2"><%= render_participatory_text_title(@participatory_text) %></h2>
   </div>
   <div class="column medium-3 pull-right">
     <%= render partial: "decidim/proposals/proposals/participatory_texts/view_index" %>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -529,6 +529,7 @@ en:
       new:
         limit_reached: You can't create new proposals since you've exceeded the limit.
       participatory_text_proposal:
+        alternative_title: There are no participatory texts at the moment
         buttons:
           comment: Comment
           comments: Comments

--- a/decidim-proposals/spec/system/participatory_texts_spec.rb
+++ b/decidim-proposals/spec/system/participatory_texts_spec.rb
@@ -29,7 +29,7 @@ describe "Proposals", type: :system do
   end
 
   context "when listing proposals in a participatory process as participatory texts" do
-    context "when admin has not yet imported a participatory text" do
+    context "when admin has not yet published a participatory text" do
       let!(:component) do
         create(:proposal_component,
                :with_participatory_texts_enabled,
@@ -41,14 +41,12 @@ describe "Proposals", type: :system do
         visit_component
       end
 
-      it "renders an empty title" do
-        within ".heading2" do
-          expect(page).to have_content("")
-        end
+      it "renders an alternative title" do
+        expect(page).to have_content("There are no participatory texts at the moment")
       end
     end
 
-    context "when admin has imported a participatory text" do
+    context "when admin has published a participatory text" do
       let!(:participatory_text) { create :participatory_text, component: component }
       let!(:proposals) { create_list(:proposal, 3, :published, component: component) }
       let!(:component) do


### PR DESCRIPTION
#### :tophat: What? Why?
When participatory texts are enabled and a user visits the proposals index before the admin has imported any document, the application crashes while trying to render the participatory text title.

#### :clipboard: Subtasks
- [x] Add tests

### :camera: Screenshots (optional)
**NoMethodError in Decidim::Proposals::Proposals#index
undefined method `title' for nil:NilClass**
https://github.com/decidim/decidim/blob/a2d999dc6461991e035150652180688510dba005/decidim-proposals/app/views/decidim/proposals/proposals/participatory_texts/participatory_text.html.erb#L5