### PR TITLE
Improve Searchable docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,19 @@ Decidim::Organization.find_each do |organization|
 end
 ```
 
+- **Searchable resources**
+
+As per #4537, if you have a custom module with a resource that uses the `Decidim::Searchable`
+concern, you'll need to make the resource searchable from its manifest, otherwise it won't
+appear under the global search results:
+
+```ruby
+Decidim.register_resource(:my_resource) do |resource|
+  resource.searchable = true
+  # ...
+end
+```
+
 **Added**:
 
 - **decidim-core**: Trigger an ActiveSupport::Notification after registering via OmniAuth. [\#4565](https://github.com/decidim/decidim/pull/4565)

--- a/decidim-core/lib/decidim/searchable.rb
+++ b/decidim-core/lib/decidim/searchable.rb
@@ -7,6 +7,8 @@ module Decidim
   # A concern with the features needed when you want a model to be searchable.
   #
   # A Searchable should include this concern and declare its `searchable_fields`.
+  # You'll also need to define it as `searchable` in its resource manifest,
+  # otherwise it won't appear as possible results.
   #
   # The indexing of Searchables is managed through:
   # - after_create callback configurable via `index_on_create`.


### PR DESCRIPTION
#### :tophat: What? Why?
After #4537, resources need to declare themselves as `searchable` in their resource manifest, otherwise they won't be considered as possible results.

This PR adds a note to the `Searchable` concern docs clarifying this point.

#### :pushpin: Related Issues
- Related to #4537

#### :clipboard: Subtasks
None