### PR TITLE
Fix address toggle in the add proposal form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ end
 - **decidim-proposals**: Fix vote-rerendering on a proposal's page [#4557](https://github.com/decidim/decidim/pull/4557)
 - **decidim-core**: Fix tabs with inputs with invalid characters [\#4552](https://github.com/decidim/decidim/pull/4552)
 - **decidim-admin**: Fix image updating in content blocks [\#4549](https://github.com/decidim/decidim/pull/4549)
+- **decidim-proposals**: Fix address toggle in the add proposal form [\#4587](https://github.com/decidim/decidim/pull/4587)
 
 **Removed**:
 

--- a/decidim-proposals/app/assets/javascripts/decidim/proposals/add_proposal.js.es6
+++ b/decidim-proposals/app/assets/javascripts/decidim/proposals/add_proposal.js.es6
@@ -2,7 +2,7 @@ $(() => {
   window.DecidimProposals = window.DecidimProposals || {};
 
   window.DecidimProposals.bindProposalAddress = () => {
-    const $checkbox = $("input:checkbox.has_address");
+    const $checkbox = $("input:checkbox[name$='[has_address]']");
     const $addressInput = $("#address_input");
 
     if ($checkbox.length > 0) {


### PR DESCRIPTION
#### :tophat: What? Why?
The address toggle does not work when creating a new proposal. The address field is always visible even if the "has address" toggle is unchecked.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry