### PR TITLE
Add registration form questionnaire answers to export meeting registrations file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ end
 
 **Added**:
 
+- **decidim-meetings**: Add registration form answers when exporting meeting registrations.[\#4589](https://github.com/decidim/decidim/pull/4589)
 - **decidim-proposals**: Specific public view rendering of participatory texts. [\#4316](https://github.com/decidim/decidim/pull/4316)
 - **decidim-proposals**: Admin can create proposals from the admin panel, with a meeting as an author.[\#4382](https://github.com/decidim/decidim/pull/4382)
 - **decidim-conferences**: Add diplomas functionallity in an automated way for those users that has their registration confirmed. [\#4443](https://github.com/decidim/decidim/pull/4443)

--- a/decidim-meetings/app/serializers/decidim/meetings/registration_serializer.rb
+++ b/decidim-meetings/app/serializers/decidim/meetings/registration_serializer.rb
@@ -3,6 +3,7 @@
 module Decidim
   module Meetings
     class RegistrationSerializer < Decidim::Exporters::Serializer
+      include Decidim::TranslationsHelper
       # Serializes a registration
       def serialize
         {
@@ -11,8 +12,25 @@ module Decidim
           user: {
             name: resource.user.name,
             email: resource.user.email
-          }
+          },
+          registration_form_answers: serialize_answers
         }
+      end
+
+      private
+
+      def serialize_answers
+        questions = resource.meeting.questionnaire.questions
+        answers = resource.meeting.questionnaire.answers.where(user: resource.user)
+        questions.each_with_index.inject({}) do |serialized, (question, idx)|
+          answer = answers.find_by(question: question)
+          serialized.update("#{idx + 1}. #{translated_attribute(question.body)}" => normalize_body(answer))
+        end
+      end
+
+      def normalize_body(answer)
+        return "" unless answer
+        answer.body || answer.choices.pluck(:body)
       end
     end
   end

--- a/decidim-meetings/spec/serializers/registration_serializer_spec.rb
+++ b/decidim-meetings/spec/serializers/registration_serializer_spec.rb
@@ -4,25 +4,80 @@ require "spec_helper"
 
 module Decidim::Meetings
   describe RegistrationSerializer do
-    let(:registration) { create(:registration) }
-    let(:subject) { described_class.new(registration) }
-
     describe "#serialize" do
-      it "includes the id" do
-        expect(subject.serialize).to include(id: registration.id)
+      let!(:registration) { create(:registration) }
+      let!(:subject) { described_class.new(registration) }
+
+      context "when there are not a questionnaire" do
+        it "includes the id" do
+          expect(subject.serialize).to include(id: registration.id)
+        end
+
+        it "includes the registration code" do
+          expect(subject.serialize).to include(code: registration.code)
+        end
+
+        it "includes the user" do
+          expect(subject.serialize[:user]).to(
+            include(name: registration.user.name)
+          )
+          expect(subject.serialize[:user]).to(
+            include(email: registration.user.email)
+          )
+        end
       end
 
-      it "includes the registration code" do
-        expect(subject.serialize).to include(code: registration.code)
-      end
+      context "when questtionaire enabled" do
+        let(:meeting) { create :meeting, :with_registrations_enabled }
+        let!(:user) { create(:user, organization: meeting.organization) }
+        let!(:registration) { create(:registration, meeting: meeting, user: user) }
 
-      it "includes the user" do
-        expect(subject.serialize[:user]).to(
-          include(name: registration.user.name)
-        )
-        expect(subject.serialize[:user]).to(
-          include(email: registration.user.email)
-        )
+        let!(:questions) { create_list :questionnaire_question, 3, questionnaire: meeting.questionnaire }
+        let!(:answers) do
+          questions.map do |question|
+            create :answer, questionnaire: meeting.questionnaire, question: question, user: user
+          end
+        end
+
+        let!(:multichoice_question) { create :questionnaire_question, questionnaire: meeting.questionnaire, question_type: "multiple_option" }
+        let!(:multichoice_answer_options) { create_list :answer_option, 2, question: multichoice_question }
+        let!(:multichoice_answer) do
+          create :answer, questionnaire: meeting.questionnaire, question: multichoice_question, user: user, body: nil
+        end
+        let!(:multichoice_answer_choices) do
+          multichoice_answer_options.map do |answer_option|
+            create :answer_choice, answer: multichoice_answer, answer_option: answer_option, body: answer_option.body[I18n.locale.to_s]
+          end
+        end
+
+        let!(:singlechoice_question) { create :questionnaire_question, questionnaire: meeting.questionnaire, question_type: "single_option" }
+        let!(:singlechoice_answer_options) { create_list :answer_option, 2, question: multichoice_question }
+        let!(:singlechoice_answer) do
+          create :answer, questionnaire: meeting.questionnaire, question: singlechoice_question, user: user, body: nil
+        end
+        let!(:singlechoice_answer_choice) do
+          answer_option = singlechoice_answer_options.first
+          create :answer_choice, answer: singlechoice_answer, answer_option: answer_option, body: answer_option.body[I18n.locale.to_s]
+        end
+
+        let!(:subject) { described_class.new(registration) }
+        let(:serialized) { subject.serialize }
+
+        it "includes the answer for each question" do
+          expect(serialized[:registration_form_answers]).to include(
+            "1. #{translated(questions.first.body, locale: I18n.locale)}" => answers.first.body
+          )
+          expect(serialized[:registration_form_answers]).to include(
+            "3. #{translated(questions.last.body, locale: I18n.locale)}" => answers.last.body
+          )
+          expect(serialized[:registration_form_answers]).to include(
+            "4. #{translated(multichoice_question.body, locale: I18n.locale)}" => multichoice_answer_choices.map(&:body)
+          )
+
+          expect(serialized[:registration_form_answers]).to include(
+            "5. #{translated(singlechoice_question.body, locale: I18n.locale)}" => [singlechoice_answer_choice.body]
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds the answers to the Questionnaire for meeting registration forms to the exported file.

#### :pushpin: Related Issues
- Related to #4419 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
- [x] Add fields to the serializer

### :camera: Screenshots (optional)
![Description](URL)
