### PR TITLE
Added a new button to the editor's toolbar: "image"

### DIFF
--- a/decidim-core/app/assets/javascripts/decidim/editor.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/editor.js.es6
@@ -24,7 +24,7 @@
     } else if (toolbar === "basic") {
       quillToolbar = [
         ...quillToolbar,
-        ["video"].
+        ["video"],
         ["image"]
       ];
     }

--- a/decidim-core/app/assets/javascripts/decidim/editor.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/editor.js.es6
@@ -2,7 +2,7 @@
 // = require_self
 
 ((exports) => {
-  const quillFormats = ["bold", "italic", "link", "underline", "header", "list", "video"];
+  const quillFormats = ["bold", "italic", "link", "underline", "header", "list", "video", "image"];
 
   const createQuillEditor = (container) => {
     const toolbar = $(container).data("toolbar");
@@ -18,12 +18,14 @@
       quillToolbar = [
         [{ header: [1, 2, 3, 4, 5, 6, false] }],
         ...quillToolbar,
-        ["video"]
+        ["video"],
+        ["image"]
       ];
     } else if (toolbar === "basic") {
       quillToolbar = [
         ...quillToolbar,
-        ["video"]
+        ["video"].
+        ["image"]
       ];
     }
 


### PR DESCRIPTION
Added a new button to the editor's toolbar: "image". This button allows users to embed images inside the editor,

#### :tophat: What? Why?
Minimal changes on javascript assets to ensure the quilleditor has a button to embed images. It appears next to the embed video button

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
