### PR TITLE
Increase timeout for download specs

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/download_helper.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/download_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module DownloadHelper
-  TIMEOUT = 20
+  TIMEOUT = 60
   PATH = Rails.root.join("tmp", "downloads").freeze
 
   def downloads

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/download_helper.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/download_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module DownloadHelper
-  TIMEOUT = 10
+  TIMEOUT = 20
   PATH = Rails.root.join("tmp", "downloads").freeze
 
   def downloads


### PR DESCRIPTION
#### :tophat: What? Why?
After merging #4578, some tests started failing with timeouts. This PR increases the timeout time so that tests don't fail.

#### :pushpin: Related Issues
- Related to #4578