### PR TITLE
Add email validations and confirmations to user groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ In order to generate Open Data exports you should add this to your crontab or re
 - **decidim-core**: Adds a user timeline tab on the public profile. [\#4574](https://github.com/decidim/decidim/pull/4574)
 - **decidim-core**: Open Data export [\#4578](https://github.com/decidim/decidim/pull/4578)
 - **decidim-meetings**: Export meetings [\#4597](https://github.com/decidim/decidim/pull/4597)
+- **decidim-core**: User groups can now confirm their email [\#4603](https://github.com/decidim/decidim/pull/4603)
 
 **Changed**:
 

--- a/decidim-core/app/cells/decidim/profile_sidebar/show.erb
+++ b/decidim-core/app/cells/decidim/profile_sidebar/show.erb
@@ -107,6 +107,16 @@
     <% end %>
 
     <% if can_edit_user_group_profile? %>
+      <% if user_group_email_to_be_confirmed? %>
+        <div class="text-center">
+          <%= link_to decidim.group_email_confirmation_path(model.nickname), method: :post, class: "button secondary light expanded" do %>
+            <span>
+              <%= t("decidim.profiles.user.resend_email_confirmation_instructions") %>
+            </span>
+          <% end %>
+        </div>
+      <% end %>
+
       <div class="text-center">
         <%= link_to t("decidim.profiles.user.edit_user_group"), edit_group_path(profile_holder.nickname) %>
       </div>

--- a/decidim-core/app/cells/decidim/profile_sidebar_cell.rb
+++ b/decidim-core/app/cells/decidim/profile_sidebar_cell.rb
@@ -61,5 +61,11 @@ module Decidim
       return false if model.is_a?(Decidim::User)
       Decidim::UserGroupMembership.where(user: current_user, user_group: model).where.not(role: :creator).any?
     end
+
+    def user_group_email_to_be_confirmed?
+      return false unless current_user
+      return false if model.is_a?(Decidim::User)
+      !model.confirmed?
+    end
   end
 end

--- a/decidim-core/app/controllers/decidim/devise/confirmations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/confirmations_controller.rb
@@ -6,6 +6,8 @@ module Decidim
     class ConfirmationsController < ::Devise::ConfirmationsController
       include Decidim::DeviseControllers
 
+      helper_method :new_user_group_session_path
+
       # Since we're using a single Devise installation for multiple
       # organizations, and user emails can be repeated across organizations,
       # we need to identify the user by both the email and the organization.
@@ -17,6 +19,13 @@ module Decidim
       # `decidim_organization_id` attribute.
       def resource_params
         super.merge(decidim_organization_id: current_organization.id)
+      end
+
+      # Overwrites the default method to handle user groups confirmations.
+      def after_confirmation_path_for(resource_name, resource)
+        return profile_path(resource.nickname) if resource_name == :user_group
+
+        super
       end
     end
   end

--- a/decidim-core/app/controllers/decidim/group_email_confirmations_controller.rb
+++ b/decidim-core/app/controllers/decidim/group_email_confirmations_controller.rb
@@ -25,9 +25,5 @@ module Decidim
     def user_group
       @user_group ||= Decidim::UserGroups::ManageableUserGroups.for(current_user).find_by(nickname: params[:group_id])
     end
-
-    def membership
-      user_group.memberships.find(params[:id])
-    end
   end
 end

--- a/decidim-core/app/controllers/decidim/group_email_confirmations_controller.rb
+++ b/decidim-core/app/controllers/decidim/group_email_confirmations_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Decidim
+  # The controller to manage email confirmations for user groups.
+  class GroupEmailConfirmationsController < Decidim::ApplicationController
+    include FormFactory
+
+    helper_method :user_group
+
+    def create
+      enforce_permission_to :manage, :user_group, user_group: user_group
+      if user_group.email.blank?
+        flash.keep[:alert] = t("decidim.profiles.user.fill_in_email_to_confirm_it")
+        redirect_to edit_group_path(user_group.nickname) and return
+      end
+
+      user_group.send_confirmation_instructions
+
+      flash.keep[:notice] = t("decidim.profiles.user.confirmation_instructions_sent")
+      redirect_back(fallback_location: decidim.profile_path(user_group.nickname))
+    end
+
+    private
+
+    def user_group
+      @user_group ||= Decidim::UserGroups::ManageableUserGroups.for(current_user).find_by(nickname: params[:group_id])
+    end
+
+    def membership
+      user_group.memberships.find(params[:id])
+    end
+  end
+end

--- a/decidim-core/app/controllers/decidim/group_email_confirmations_controller.rb
+++ b/decidim-core/app/controllers/decidim/group_email_confirmations_controller.rb
@@ -11,7 +11,7 @@ module Decidim
       enforce_permission_to :manage, :user_group, user_group: user_group
       if user_group.email.blank?
         flash.keep[:alert] = t("decidim.profiles.user.fill_in_email_to_confirm_it")
-        redirect_to edit_group_path(user_group.nickname) and return
+        redirect_to(edit_group_path(user_group.nickname)) && return
       end
 
       user_group.send_confirmation_instructions

--- a/decidim-core/app/models/decidim/user_group.rb
+++ b/decidim-core/app/models/decidim/user_group.rb
@@ -17,7 +17,7 @@ module Decidim
     validate :correct_state
     validate :unique_document_number, if: :has_document_number?
 
-    devise :confirmable, :decidim_validatable
+    devise :confirmable, :decidim_validatable, confirmation_keys: [:decidim_organization_id, :email]
 
     scope :verified, -> { where.not("extended_data->>'verified_at' IS ?", nil) }
     scope :rejected, -> { where.not("extended_data->>'rejected_at' IS ?", nil) }

--- a/decidim-core/app/models/decidim/user_group.rb
+++ b/decidim-core/app/models/decidim/user_group.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_dependency "devise/models/decidim_validatable"
+require "valid_email2"
+
 module Decidim
   # A UserGroup is an organization of citizens
   class UserGroup < UserBaseEntity
@@ -13,6 +16,8 @@ module Decidim
 
     validate :correct_state
     validate :unique_document_number, if: :has_document_number?
+
+    devise :confirmable, :decidim_validatable
 
     scope :verified, -> { where.not("extended_data->>'verified_at' IS ?", nil) }
     scope :rejected, -> { where.not("extended_data->>'rejected_at' IS ?", nil) }
@@ -97,6 +102,18 @@ module Decidim
 
     def has_document_number?
       document_number.present?
+    end
+
+    # Overwites method in `Decidim::Validatable`, as user groups don't have a
+    # password.
+    def password_required?
+      false
+    end
+
+    # Overwites method in `Decidim::Validatable`, as user groups don't have a
+    # password.
+    def password
+      nil
     end
   end
 end

--- a/decidim-core/app/views/decidim/devise/shared/_links.html.erb
+++ b/decidim-core/app/views/decidim/devise/shared/_links.html.erb
@@ -1,4 +1,4 @@
-<%- if controller_name != "sessions" %>
+<%- if controller_name != "sessions" && resource_class != Decidim::UserGroup %>
   <p class="text-center">
     <%= link_to t("devise.shared.links.sign_in"), new_session_path(resource_name) %>
   </p>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -853,14 +853,17 @@ en:
           info: Badges are earned by performing specific activity in the platform.
           title: Badges
       user:
+        confirmation_instructions_sent: Email confirmation instructions sent
         create_user_group: Create group
         edit_profile: Edit profile
         edit_user_group: Edit group profile
+        fill_in_email_to_confirm_it: Please, fill in your group's email to confirm it
         invite_user: Invite user
         join_user_group: Request to join group
         leave_user_group: Leave group
         manage_user_group_admins: Manage admins
         manage_user_group_users: Manage members
+        resend_email_confirmation_instructions: Resend email confirmation instructions
     reported_mailer:
       hide:
         hello: Hello %{name},

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -16,6 +16,14 @@ Decidim::Core::Engine.routes.draw do
                omniauth_callbacks: "decidim/devise/omniauth_registrations"
              }
 
+  devise_for :user_groups,
+             class_name: "Decidim::UserGroup",
+             module: :devise,
+             router_name: :decidim,
+             controllers: {
+               confirmations: "decidim/devise/user_group_confirmations"
+             }
+
   devise_scope :user do
     post "omniauth_registrations" => "devise/omniauth_registrations#create"
   end

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -21,7 +21,7 @@ Decidim::Core::Engine.routes.draw do
              module: :devise,
              router_name: :decidim,
              controllers: {
-               confirmations: "decidim/devise/user_group_confirmations"
+               confirmations: "decidim/devise/confirmations"
              }
 
   devise_scope :user do
@@ -79,6 +79,7 @@ Decidim::Core::Engine.routes.draw do
           post :demote
         end
       end
+      resource :email_confirmation, only: [:create], controller: "group_email_confirmations"
 
       member do
         delete :leave

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -142,6 +142,7 @@ if !Rails.env.production? || ENV["SEED"]
       user_group = Decidim::UserGroup.create!(
         name: Faker::Company.unique.name,
         nickname: Faker::Twitter.unique.screen_name,
+        email: Faker::Internet.email,
         extended_data: {
           document_number: Faker::Number.number(10),
           phone: Faker::PhoneNumber.phone_number,
@@ -149,6 +150,7 @@ if !Rails.env.production? || ENV["SEED"]
         },
         decidim_organization_id: user.organization.id
       )
+      user_group.confirm
 
       Decidim::UserGroupMembership.create!(
         user: user,

--- a/decidim-core/spec/models/decidim/user_group_spec.rb
+++ b/decidim-core/spec/models/decidim/user_group_spec.rb
@@ -42,6 +42,12 @@ module Decidim
     end
 
     describe "validations", processing_uploads_for: Decidim::AvatarUploader do
+      context "without an email" do
+        let(:user_group) { build(:user_group, email: nil) }
+
+        it { is_expected.not_to be_valid }
+      end
+
       context "without a document number" do
         subject { another_user_group }
 

--- a/decidim-core/spec/system/user_group_email_confirmation_spec.rb
+++ b/decidim-core/spec/system/user_group_email_confirmation_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "User group email confirmation", type: :system do
+  let!(:creator) { create(:user, :confirmed) }
+  let!(:user_group) { create(:user_group, users: [creator], organization: creator.organization) }
+
+  before do
+    switch_to_host(user_group.organization.host)
+  end
+
+  context "when trying to access by a basic member" do
+    before do
+      member = create(:user_group_membership, user_group: user_group, role: :member).user
+      login_as member, scope: :user
+      visit decidim.profile_path(user_group.nickname)
+    end
+
+    it "does not show the link to edit" do
+      expect(page).to have_no_content("Resend email confirmation instructions")
+    end
+  end
+
+  context "when requesting by a manager" do
+    before do
+      login_as creator, scope: :user
+      visit decidim.profile_path(user_group.nickname)
+    end
+
+    it "allows demoting a user" do
+      clear_emails
+      click_link "Resend email confirmation instructions"
+      expect(page).to have_content("Email confirmation instructions sent")
+
+      visit last_email_link
+      expect(page).to have_content("Your email address has been successfully confirmed")
+      user_group.reload
+      expect(user_group).to be_confirmed
+    end
+  end
+end

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -216,6 +216,7 @@ Decidim.register_component(:proposals) do |component|
         group = Decidim::UserGroup.create!(
           name: Faker::Name.name,
           nickname: Faker::Twitter.unique.screen_name,
+          email: Faker::Internet.email,
           extended_data: {
             document_number: Faker::Code.isbn,
             phone: Faker::PhoneNumber.phone_number,
@@ -223,6 +224,7 @@ Decidim.register_component(:proposals) do |component|
           },
           decidim_organization_id: component.organization.id
         )
+        group.confirm
         Decidim::UserGroupMembership.create!(
           user: author,
           role: "creator",
@@ -303,6 +305,7 @@ Decidim.register_component(:proposals) do |component|
             group = Decidim::UserGroup.create!(
               name: Faker::Name.name,
               nickname: Faker::Twitter.unique.screen_name,
+              email: Faker::Internet.email,
               extended_data: {
                 document_number: Faker::Code.isbn,
                 phone: Faker::PhoneNumber.phone_number,
@@ -310,6 +313,7 @@ Decidim.register_component(:proposals) do |component|
               },
               decidim_organization_id: component.organization.id
             )
+            group.confirm
             Decidim::UserGroupMembership.create!(
               user: author,
               role: "creator",


### PR DESCRIPTION
#### :tophat: What? Why?
As per #3837, user groups must have a confirmed email. This PR adds validations and confirmation system for them.

#### :pushpin: Related Issues
- Related to #3837

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry