### PR TITLE
Correctly render comments activity with mentions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@ In order to generate Open Data exports you should add this to your crontab or re
 - **decidim-core**: Fix tabs with inputs with invalid characters [\#4552](https://github.com/decidim/decidim/pull/4552)
 - **decidim-admin**: Fix image updating in content blocks [\#4549](https://github.com/decidim/decidim/pull/4549)
 - **decidim-proposals**: Fix address toggle in the add proposal form [\#4587](https://github.com/decidim/decidim/pull/4587)
+- **decidim-comments**: Correctly render comments activity with mentions [\#4612](https://github.com/decidim/decidim/pull/4612)
 
 **Removed**:
 

--- a/decidim-comments/app/cells/decidim/comments/comment_activity_cell.rb
+++ b/decidim-comments/app/cells/decidim/comments/comment_activity_cell.rb
@@ -11,7 +11,7 @@ module Decidim
       end
 
       def resource_link_text
-        comment.body
+        comment.formatted_body
       end
 
       def resource_link_path

--- a/decidim-comments/spec/cells/decidim/comments/comment_activity_cell_spec.rb
+++ b/decidim-comments/spec/cells/decidim/comments/comment_activity_cell_spec.rb
@@ -25,6 +25,21 @@ module Decidim::Comments
         expect(html).to have_content(comment.body)
       end
 
+      context "when the comment has mentions" do
+        before do
+          body = "Comment mentioning some user, @#{comment.author.nickname}"
+          parsed_body = Decidim::ContentProcessor.parse(body, current_organization: comment.organization)
+          comment.body = parsed_body.rewrite
+          comment.save
+        end
+
+        it "correctly renders comments with mentions" do
+          html = cell("decidim/comments/comment_activity", action_log).call
+          expect(html).to have_no_content("gid://")
+          expect(html).to have_content("@#{comment.author.nickname}")
+        end
+      end
+
       context "when the commentable is missing" do
         before do
           comment.root_commentable.delete


### PR DESCRIPTION
#### :tophat: What? Why?

Use the formatted body instead of the regular one to render content for comments.

#### :pushpin: Related Issues
- Fixes #4606

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

