### PR TITLE
Show everything being followed on the profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ In order to generate Open Data exports you should add this to your crontab or re
 - **decidim-core**: Improve search results layout. Now results appear grouped by type [\#4537](https://github.com/decidim/decidim/pull/4537)
 - **decidim-core**: Improve propoals serialization [\#4593](https://github.com/decidim/decidim/pull/4593)
 - **decidim-verifications**: The ID documents verification now supports online and offline verification modes [\#4573](https://github.com/decidim/decidim/pull/4573)
+- **decidim-core**: "Follows" section in user profiles now show every resource they follow [\#4616](https://github.com/decidim/decidim/pull/4616)
 
 **Fixed**:
 

--- a/decidim-core/app/cells/decidim/author/profile_minicard.erb
+++ b/decidim-core/app/cells/decidim/author/profile_minicard.erb
@@ -17,7 +17,7 @@
     <% if model.can_follow? %>
       <div>
         <%= link_to decidim.profile_following_path(raw_model.nickname), class: "card__link" do %>
-          <strong><%= model.following_users_count %></strong> <%= t("decidim.profiles.show.following") %>
+          <strong><%= model.following_count %></strong> <%= t("decidim.profiles.show.following") %>
         <% end %>
       </div>
     <% end %>

--- a/decidim-core/app/cells/decidim/card_cell.rb
+++ b/decidim-core/app/cells/decidim/card_cell.rb
@@ -30,13 +30,11 @@ module Decidim
     end
 
     def title
-      return if model.respond_to? :title
-      model.name
+      model.try(:title) || model.try(:name) || ""
     end
 
     def body
-      return if model.respond_to? :body
-      model.about
+      model.try(:body) || model.try(:about) || ""
     end
   end
 end

--- a/decidim-core/app/cells/decidim/following/show.erb
+++ b/decidim-core/app/cells/decidim/following/show.erb
@@ -3,7 +3,7 @@
 </div>
 <div class="row small-up-1 medium-up-2 card-grid">
   <% followings.each do |following| %>
-    <%= card_for following %>
+    <%= card_for following, context: { label: true, show_space: true } %>
   <% end %>
 </div>
 <%= decidim_paginate followings %>

--- a/decidim-core/app/cells/decidim/following_cell.rb
+++ b/decidim-core/app/cells/decidim/following_cell.rb
@@ -12,7 +12,7 @@ module Decidim
     end
 
     def followings
-      @followings ||= Kaminari.paginate_array(model.following_users).page(params[:page]).per(20)
+      @followings ||= Kaminari.paginate_array(model.following).page(params[:page]).per(20)
     end
   end
 end

--- a/decidim-core/app/cells/decidim/profile_sidebar/show.erb
+++ b/decidim-core/app/cells/decidim/profile_sidebar/show.erb
@@ -40,7 +40,7 @@
         <div class="ml-s">
           <%= link_to profile_following_path(nickname: profile_holder.nickname) do %>
             <%= t("decidim.profiles.show.following") %>
-            <h2 class="heading2"><strong><%= profile_user.following_users_count %></strong></h2>
+            <h2 class="heading2"><strong><%= profile_user.following_count %></strong></h2>
           <% end %>
         </div>
       <% else %>

--- a/decidim-core/app/models/decidim/follow.rb
+++ b/decidim-core/app/models/decidim/follow.rb
@@ -27,7 +27,6 @@ module Decidim
 
     # rubocop:disable Rails/SkipsModelValidations
     def increase_following_counters
-      user.increment!(:following_users_count) if decidim_followable_type == "Decidim::UserBaseEntity"
       user.increment!(:following_count)
     end
 
@@ -38,7 +37,6 @@ module Decidim
 
     def decrease_following_counters
       return unless user
-      user.decrement!(:following_users_count) if decidim_followable_type == "Decidim::UserBaseEntity"
       user.decrement!(:following_count)
     end
 

--- a/decidim-core/app/models/decidim/user_base_entity.rb
+++ b/decidim-core/app/models/decidim/user_base_entity.rb
@@ -42,11 +42,5 @@ module Decidim
                        end
                      end
     end
-
-    def following_users
-      @following_users ||= following.select do |f|
-        f.is_a?(Decidim::User) || f.is_a?(Decidim::UserGroup)
-      end
-    end
   end
 end

--- a/decidim-core/db/migrate/20181204110723_remove_following_users_count_from_users.rb
+++ b/decidim-core/db/migrate/20181204110723_remove_following_users_count_from_users.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class RemoveFollowingUsersCountFromUsers < ActiveRecord::Migration[5.2]
+  def up
+    remove_column :decidim_users, :following_users_count
+  end
+
+  def down
+    add_column :decidim_users, :following_users_count, :integer, null: false, default: 0
+
+    Decidim::UserBaseEntity.find_each do |entity|
+      following_users_count = Decidim::Follow.where(decidim_user_id: entity.id, decidim_followable_type: ["Decidim::UserBaseEntity", "Decidim::User", "Decidim::UserGroup"]).count
+      entity.following_users_count = following_users_count
+      entity.save
+    end
+  end
+end

--- a/decidim-core/spec/models/decidim/follow_spec.rb
+++ b/decidim-core/spec/models/decidim/follow_spec.rb
@@ -43,13 +43,6 @@ describe Decidim::Follow do
           user.reload
         end.to change(user, :following_count).by(1)
       end
-
-      it "does not increase the following users count" do
-        expect do
-          create :follow, user: user
-          user.reload
-        end.not_to change(user, :following_users_count)
-      end
     end
 
     context "when following a user" do
@@ -58,13 +51,6 @@ describe Decidim::Follow do
           create :follow, user: user, followable: another_user
           user.reload
         end.to change(user, :following_count).by(1)
-      end
-
-      it "increases the following users count" do
-        expect do
-          create :follow, user: user, followable: another_user
-          user.reload
-        end.to change(user, :following_users_count).by(1)
       end
     end
 
@@ -90,14 +76,6 @@ describe Decidim::Follow do
           user.reload
         end.to change(user, :following_count).by(-1)
       end
-
-      it "does not decrease the following users count" do
-        follow = create :follow, user: user
-        expect do
-          follow.destroy!
-          user.reload
-        end.not_to change(user, :following_users_count)
-      end
     end
 
     context "when unfollowing a user" do
@@ -107,14 +85,6 @@ describe Decidim::Follow do
           follow.destroy!
           user.reload
         end.to change(user, :following_count).by(-1)
-      end
-
-      it "decreases the following users count" do
-        follow = create :follow, user: user, followable: another_user
-        expect do
-          follow.destroy!
-          user.reload
-        end.to change(user, :following_users_count).by(-1)
       end
     end
 

--- a/decidim-core/spec/system/user_profile_spec.rb
+++ b/decidim-core/spec/system/user_profile_spec.rb
@@ -71,7 +71,7 @@ describe "Profile", type: :system do
     context "when displaying followers and following" do
       let(:other_user) { create(:user, organization: user.organization) }
       let(:user_to_follow) { create(:user, organization: user.organization) }
-      let!(:something_that_should_not_be_counted) { create(:follow, user: user, followable: build(:dummy_resource)) }
+      let!(:followed_resource) { create(:follow, user: user, followable: build(:dummy_resource)).followable }
 
       before do
         create(:follow, user: user, followable: other_user)
@@ -82,7 +82,7 @@ describe "Profile", type: :system do
 
       it "shows the number of followers and following" do
         expect(page).to have_link("Followers 1")
-        expect(page).to have_link("Follows 2")
+        expect(page).to have_link("Follows 3")
       end
 
       it "lists the followers" do
@@ -96,6 +96,7 @@ describe "Profile", type: :system do
 
         expect(page).to have_content(other_user.name)
         expect(page).to have_content(user_to_follow.name)
+        expect(page).to have_content(followed_resource.title)
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
This PR implements part of #4439.

The "Follows" section in the profile now shows every resource the user follows, not just users and user groups. Resources can be unfollowed from there.

#### :pushpin: Related Issues
- Related to #4439

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/gChTII3.png)
