### PR TITLE
Add amend button and amendments counter to participatory text proposals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ In order to generate Open Data exports you should add this to your crontab or re
 
 **Added**:
 
+- **decidim-proposals**: Add amend button and amendments counter to participatory text proposals [\#4598](https://github.com/decidim/decidim/pull/4598/)
 - **decidim-core**: Add reject/promote amendments functionalities into Amendment feature. [\#3986](https://github.com/decidim/decidim/pull/3986/)
 - **decidim-core**: Add polymorphic Amendment feature that can be activated in the proposal component with these working functionalities: create/withdraw/accept amendments. [\#3985](https://github.com/decidim/decidim/pull/3985/)
 - **decidim-meetings**: Add registration form answers when exporting meeting registrations.[\#4589](https://github.com/decidim/decidim/pull/4589)

--- a/decidim-core/app/cells/decidim/follow_button/show.erb
+++ b/decidim-core/app/cells/decidim/follow_button/show.erb
@@ -23,7 +23,6 @@
       data: { tooltip: true, disable_hover: false },
       :'aria-haspopup' => true,
       title: t("decidim.shared.follow_button.sign_in_before_follow"),
-      disabled: true,
       remote: true) do %>
       <%= icon "bell", icon_options %>
       <span>

--- a/decidim-core/app/helpers/decidim/amendments_helper.rb
+++ b/decidim-core/app/helpers/decidim/amendments_helper.rb
@@ -20,7 +20,7 @@ module Decidim
     def amendments_for(amendable)
       return unless amendments_enabled? && amendable.emendations.count
       return if amendable.emendation?
-      content = content_tag :h2, class: "section-heading" do
+      content = content_tag :h2, class: "section-heading", id: "amendments" do
         t("section_heading", scope: "decidim.amendments.amendable", count: amendable.emendations.count)
       end
 

--- a/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal/buttons.erb
+++ b/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal/buttons.erb
@@ -1,53 +1,33 @@
 <div class="columns mediumlarge-4 hidden-section p-sm">
   <div class="medium-8">
-    <% if current_settings.votes_enabled? || show_endorsements_card? || current_user || !current_settings.comments_blocked? %>
-      <%= follow_button_for(model, true) %>
-      <% if component_settings.comments_enabled? %>
-        <div class="button-group button-group--collapse mb-s row collapse">
-          <% if current_settings.comments_blocked? %>
-            <%= content_tag :button, class: "column medium-4 button light secondary", title: t("endorse", scope: "decidim.proposals.participatory_text_proposal.buttons") do %>
-              <%= icon "comment-square", class: "icon--small", aria_label: t("comments", scope: "decidim.proposals.participatory_text_proposal.buttons"), role: "img" %>
-              <%= model.comments.count %>
-            <% end %>
-            <%= content_tag :button, t("comment", scope: "decidim.proposals.participatory_text_proposal.buttons"), class: "column button hollow secondary button--sc disabled", disabled: true, title: t("comment", scope: "decidim.proposals.participatory_text_proposal.buttons") %>
-          <% else %>
-            <%= link_to resource_comments_path, class: "column medium-4 button light secondary" do %>
-              <%= icon "comment-square", class: "icon--small", aria_label: t("comments", scope: "decidim.proposals.participatory_text_proposal.buttons"), role: "img" %> <%= model.comments.count %>
-            <% end %>
-            <%= link_to resource_comments_path, class: "column button hollow secondary button--sc" do %>
-              <%= t("comment", scope: "decidim.proposals.participatory_text_proposal.buttons") %>
-            <% end %>
+    <%= follow_button_for(model, true) %>
+    <% if amendments_enabled? %>
+      <div class="button-group button-group--collapse mb-s row collapse">
+        <%= link_to resource_amendments_path, class: "column medium-4 button light secondary" do %>
+        <%= model.emendations.count %>
           <% end %>
-        </div>
-      <% end %>
-      <% if current_settings.votes_enabled? %>
-        <%= content_tag :div, class: "button-group mb-s row collapse #{"button-group--collapse" unless current_settings.votes_hidden?}" do %>
-          <% unless current_settings.votes_hidden? %>
-            <%= votes_count_for(model, true) %>
+          <%= link_to amend_resource_path, class: "column button hollow secondary button--sc" do %>
+            <%= t("amend", scope: "decidim.proposals.participatory_text_proposal.buttons") %>
           <% end %>
-          <%= vote_button_for(model, true) %>
+      </div>
+    <% end %>
+    <% if component_settings.comments_enabled? %>
+      <div class="button-group button-group--collapse row collapse">
+        <% if current_settings.comments_blocked? %>
+          <%= content_tag :button, class: "column medium-4 button light secondary", title: t("endorse", scope: "decidim.proposals.participatory_text_proposal.buttons") do %>
+            <%= icon "comment-square", class: "icon--small", aria_label: t("comments", scope: "decidim.proposals.participatory_text_proposal.buttons"), role: "img" %>
+            <%= model.comments.count %>
+          <% end %>
+          <%= content_tag :button, t("comment", scope: "decidim.proposals.participatory_text_proposal.buttons"), class: "column button hollow secondary button--sc disabled", disabled: true, title: t("comment", scope: "decidim.proposals.participatory_text_proposal.buttons") %>
+        <% else %>
+          <%= link_to resource_comments_path, class: "column medium-4 button light secondary" do %>
+            <%= icon "comment-square", class: "icon--small", aria_label: t("comments", scope: "decidim.proposals.participatory_text_proposal.buttons"), role: "img" %> <%= model.comments.count %>
+          <% end %>
+          <%= link_to resource_comments_path, class: "column button hollow secondary button--sc" do %>
+            <%= t("comment", scope: "decidim.proposals.participatory_text_proposal.buttons") %>
+          <% end %>
         <% end %>
-      <% end %>
-      <% if current_settings.endorsements_enabled? %>
-        <div class="button-group button-group--collapse row collapse">
-          <% endorse_translated = t("decidim.proposals.proposal_endorsements_helper.render_endorsements_button_card_part.endorse") %>
-          <% if current_settings.endorsements_blocked? || !current_component.participatory_space.can_participate?(current_user) %>
-            <%= content_tag :button, class: "column medium-4 button secondary light button--sc button--shadow", title: t("endorse", scope: "decidim.proposals.participatory_text_proposal.buttons") do %>
-              <%= icon "bullhorn", class: "icon--small", aria_label: t("endorsements", scope: "decidim.proposals.participatory_text_proposal.buttons"), role: "img" %>
-              <%= model.proposal_endorsements_count.to_s %>
-            <% end %>
-            <%= content_tag :button, t("endorse", scope: "decidim.proposals.participatory_text_proposal.buttons"), class: "column button secondary light button--sc disabled", disabled: true, title: t("endorse", scope: "decidim.proposals.participatory_text_proposal.buttons") %>
-          <% else %>
-            <%= link_to resource_path, class: "column medium-4 button secondary light button--sc button--shadow" do %>
-              <%= icon "bullhorn", class: "icon--small", aria_label: t("endorsements", scope: "decidim.proposals.participatory_text_proposal.buttons"), role: "img" %>
-              <%= model.proposal_endorsements_count.to_s %>
-            <% end %>
-            <%= link_to resource_path, class: "column button secondary light button--sc" do %>
-              <%= t("endorse", scope: "decidim.proposals.participatory_text_proposal.buttons") %>
-            <% end %>
-          <% end %>
-        </div>
-      <% end %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal_cell.rb
@@ -46,11 +46,11 @@ module Decidim
       end
 
       def resource_comments_path
-        "#{resource_locator(model).path}/#comments"
+        resource_locator(model).path(anchor: "comments")
       end
 
       def resource_amendments_path
-        "#{resource_locator(model).path}/#amendments"
+        resource_locator(model).path(anchor: "amendments")
       end
 
       def current_participatory_space

--- a/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal_cell.rb
@@ -46,11 +46,11 @@ module Decidim
       end
 
       def resource_comments_path
-        resource_locator(model).path(anchor: "#comments")
+        "#{resource_locator(model).path}/#comments"
       end
 
       def resource_amendments_path
-        resource_locator(model).path(anchor: "#amendments")
+        "#{resource_locator(model).path}/#amendments"
       end
 
       def current_participatory_space

--- a/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal_cell.rb
@@ -41,8 +41,16 @@ module Decidim
         resource_locator(model).path
       end
 
+      def amend_resource_path
+        decidim.new_amend_path(amendable_gid: model.to_sgid.to_s)
+      end
+
       def resource_comments_path
         "#{resource_locator(model).path}/#comments"
+      end
+
+      def resource_amendments_path
+        "#{resource_locator(model).path}/#amendments"
       end
 
       def current_participatory_space

--- a/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal_cell.rb
@@ -46,11 +46,11 @@ module Decidim
       end
 
       def resource_comments_path
-        "#{resource_locator(model).path}/#comments"
+        resource_locator(model).path(anchor: "#comments")
       end
 
       def resource_amendments_path
-        "#{resource_locator(model).path}/#amendments"
+        resource_locator(model).path(anchor: "#amendments")
       end
 
       def current_participatory_space

--- a/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
@@ -95,20 +95,7 @@ module Decidim
       end
 
       def follow_button_for(model, large = nil)
-        if current_user
-          render partial: "decidim/shared/follow_button.html", locals: { followable: model, large: large }
-        else
-          content_tag(:p, class: "mt-s mb-none") do
-            if current_organization.sign_up_enabled?
-              t("decidim.proposals.proposals.show.sign_in_or_up",
-                in: link_to(t("decidim.proposals.proposals.show.sign_in"), decidim.new_user_session_path),
-                up: link_to(t("decidim.proposals.proposals.show.sign_up"), decidim.new_user_registration_path)).html_safe
-            else
-              t("decidim.proposals.proposals.show.sign_in_to_participate",
-                in: link_to(t("decidim.proposals.proposals.show.sign_in"), decidim.new_user_session_path)).html_safe
-            end
-          end
-        end
+        render partial: "decidim/shared/follow_button.html", locals: { followable: model, large: large }
       end
 
       def votes_count_for(model, from_proposals_list)

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -532,10 +532,10 @@ en:
       participatory_text_proposal:
         alternative_title: There are no participatory texts at the moment
         buttons:
+          amend: Amend
           comment: Comment
           comments: Comments
           endorse: Endorse
-          endorsements: Endorsements
       proposal_endorsements:
         create:
           error: There's been errors when endorsing the proposal.
@@ -637,10 +637,6 @@ en:
           proposal_in_evaluation_reason: This proposal is being evaluated
           proposal_rejected_reason: 'This proposal has been rejected because:'
           report: Report
-          sign_in: Sign in
-          sign_in_or_up: "%{in} or %{up} to participate"
-          sign_in_to_participate: "%{in} to participate"
-          sign_up: sign up
           withdraw_btn_hint: You can withdraw your proposal if you change your mind, as long as you have not received any support. The proposal is not deleted, it will appear in the list of withdrawn proposals.
           withdraw_confirmation: Are you sure to withdraw this proposal?
           withdraw_proposal: Withdraw proposal

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -196,6 +196,14 @@ FactoryBot.define do
         }
       end
     end
+
+    trait :with_comments_disabled do
+      settings do
+        {
+          comments_enabled: false
+        }
+      end
+    end
   end
 
   factory :proposal, class: "Decidim::Proposals::Proposal" do

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -187,6 +187,15 @@ FactoryBot.define do
         }
       end
     end
+
+    trait :with_amendments_and_participatory_texts_enabled do
+      settings do
+        {
+          participatory_texts_enabled: true,
+          amendments_enabled: true
+        }
+      end
+    end
   end
 
   factory :proposal, class: "Decidim::Proposals::Proposal" do

--- a/decidim-proposals/spec/system/participatory_texts_spec.rb
+++ b/decidim-proposals/spec/system/participatory_texts_spec.rb
@@ -10,15 +10,16 @@ describe "Proposals", type: :system do
     expect(page).to have_tag(selector, text: proposal.title)
     prop_block = page.find(selector)
     prop_block.hover
-    expect(prop_block).to have_link("Sign in")
+    expect(prop_block).to have_button("Follow")
+    expect(prop_block).to have_link("Amend") if component.settings.amendments_enabled
+    expect(prop_block).to have_link(proposal.emendations.count) if component.settings.amendments_enabled
     expect(prop_block).to have_link("Comment")
-    expect(prop_block).to have_button("Vote") if component.step_settings[participatory_process.active_step.id.to_s].votes_enabled?
-    expect(prop_block).to have_link("Endorse")
+    expect(prop_block).to have_link(proposal.comments.count)
   end
 
   shared_examples_for "lists all the proposals ordered" do
     it "by position" do
-      expect(component.settings.participatory_texts_enabled?).to be true
+      expect(component.settings.participatory_texts_enabled).to be true
       visit_component
       count = proposals.count
       expect(page).to have_css(".hover-section", count: count)
@@ -64,11 +65,10 @@ describe "Proposals", type: :system do
         expect(page).to have_content(participatory_text.title)
       end
 
-      context "when voting is enabled" do
+      context "when amendments are enabled" do
         let!(:component) do
           create(:proposal_component,
-                 :with_participatory_texts_enabled,
-                 :with_votes_enabled,
+                 :with_amendments_and_participatory_texts_enabled,
                  manifest: manifest,
                  participatory_space: participatory_process)
         end
@@ -76,10 +76,9 @@ describe "Proposals", type: :system do
         it_behaves_like "lists all the proposals ordered"
       end
 
-      context "when voting is disabled" do
+      context "when amendments are disabled" do
         let(:component) do
           create(:proposal_component,
-                 :with_votes_disabled,
                  :with_participatory_texts_enabled,
                  manifest: manifest,
                  participatory_space: participatory_process)

--- a/decidim-proposals/spec/system/participatory_texts_spec.rb
+++ b/decidim-proposals/spec/system/participatory_texts_spec.rb
@@ -13,8 +13,8 @@ describe "Proposals", type: :system do
     expect(prop_block).to have_button("Follow")
     expect(prop_block).to have_link("Amend") if component.settings.amendments_enabled
     expect(prop_block).to have_link(proposal.emendations.count) if component.settings.amendments_enabled
-    expect(prop_block).to have_link("Comment")
-    expect(prop_block).to have_link(proposal.comments.count)
+    expect(prop_block).to have_link("Comment") if component.settings.comments_enabled
+    expect(prop_block).to have_link(proposal.comments.count) if component.settings.comments_enabled
   end
 
   shared_examples_for "lists all the proposals ordered" do
@@ -79,6 +79,30 @@ describe "Proposals", type: :system do
       context "when amendments are disabled" do
         let(:component) do
           create(:proposal_component,
+                 :with_participatory_texts_enabled,
+                 manifest: manifest,
+                 participatory_space: participatory_process)
+        end
+
+        it_behaves_like "lists all the proposals ordered"
+      end
+
+      context "when comments are enabled" do
+        let!(:component) do
+          create(:proposal_component,
+                 :with_participatory_texts_enabled,
+                 :with_votes_enabled,
+                 manifest: manifest,
+                 participatory_space: participatory_process)
+        end
+
+        it_behaves_like "lists all the proposals ordered"
+      end
+
+      context "when comments are disabled" do
+        let(:component) do
+          create(:proposal_component,
+                 :with_comments_disabled,
                  :with_participatory_texts_enabled,
                  manifest: manifest,
                  participatory_space: participatory_process)


### PR DESCRIPTION
#### :tophat: What? Why?
>The list of buttons and actions should be the following in this order:
Follow
Amend (with counter)
Comment (with counter)

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/issues/3752#issuecomment-439851487

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)
![](https://user-images.githubusercontent.com/40306853/49140468-9f19a480-f2f4-11e8-8a42-bb5aea59d2df.jpg)