### PR TITLE
Feature filter by type amendments proposals on proposals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,8 +67,9 @@ In order to generate Open Data exports you should add this to your crontab or re
 
 **Added**:
 
-- **decidim-core**: Add version control functionality into Amendment feature. [\#4567](https://github.com/decidim/decidim/pull/4567/)
-- **decidim-core**: Add reject/promote amendments functionalities into Amendment feature. [\#3986](https://github.com/decidim/decidim/pull/3986/)
+- **decidim-proposals**: Add filter by type functionality to Amendments on proposals. [\#4567](https://github.com/decidim/decidim/pull/4567/)
+- **decidim-proposals**: Add version control functionality to Amendments on proposals. [\#4567](https://github.com/decidim/decidim/pull/4567/)
+- **decidim-core**: Add reject/promote amendments functionalities to the Amendment feature. [\#3986](https://github.com/decidim/decidim/pull/3986/)
 - **decidim-core**: Add polymorphic Amendment feature that can be activated in the proposal component with these working functionalities: create/withdraw/accept amendments. [\#3985](https://github.com/decidim/decidim/pull/3985/)
 - **decidim-meetings**: Add registration form answers when exporting meeting registrations.[\#4589](https://github.com/decidim/decidim/pull/4589)
 - **decidim-core**: Trigger an ActiveSupport::Notification after registering via OmniAuth. [\#4565](https://github.com/decidim/decidim/pull/4565)

--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -226,7 +226,8 @@ module Decidim
           category_id: "",
           state: "except_rejected",
           scope_id: nil,
-          related_to: ""
+          related_to: "",
+          type: "all"
         }
       end
 

--- a/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
@@ -168,6 +168,15 @@ module Decidim
           ["all", t("decidim.proposals.application_helper.filter_state_values.all")]
         ]
       end
+
+      def filter_type_values
+        [
+          ["all", t("decidim.proposals.application_helper.filter_type_values.all")],
+          ["proposals", t("decidim.proposals.application_helper.filter_type_values.proposals")],
+          ["amendments", t("decidim.proposals.application_helper.filter_type_values.amendments")]
+
+        ]
+      end
     end
   end
 end

--- a/decidim-proposals/app/services/decidim/proposals/proposal_search.rb
+++ b/decidim-proposals/app/services/decidim/proposals/proposal_search.rb
@@ -80,6 +80,18 @@ module Decidim
         end
       end
 
+      # Handle the amendment type filter
+      def search_type
+        case type
+        when "proposals"
+          query.where.not(id: query.joins(:amendable).pluck(:id))
+        when "amendments"
+          query.where(id: query.joins(:amendable).pluck(:id))
+        else
+          query
+        end
+      end
+
       # Filters Proposals by the name of the classes they are linked to. By default,
       # returns all Proposals. When a `related_to` param is given, then it camelcases item
       # to find the real class name and checks the links for the Proposals.

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
@@ -12,6 +12,9 @@
     </div>
   </div>
 
+  <% if component_settings.amendments_enabled %>
+    <%= form.collection_radio_buttons :type, filter_type_values, :first, :last, legend_title: t(".amendment_type") %>
+  <% end %>
   <% if component_settings.official_proposals_enabled %>
     <%= form.collection_radio_buttons :origin, filter_origin_values, :first, :last, legend_title: t(".origin") %>
   <% end %>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -386,6 +386,10 @@ en:
           evaluating: Evaluating
           except_rejected: All except rejected
           rejected: Rejected
+        filter_type_values:
+          all: All
+          amendments: Amendments
+          proposals: Proposals
       collaborative_drafts:
         collaborative_draft:
           publish:
@@ -428,6 +432,7 @@ en:
           title: Edit collaborative draft
         filters:
           all: All
+          amendment: Amendments
           category: Category
           category_prompt: Category Prompt
           open: Open
@@ -587,6 +592,7 @@ en:
           search: Search
           state: State
           voted: Voted
+          amendment_type: Type
         filters_small_view:
           close_modal: Close modal
           filter: Filter

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -658,5 +658,58 @@ describe "Proposals", type: :system do
 
       it_behaves_like "a paginated resource"
     end
+
+    context "when amendments_enabled setting is enabled" do
+      before do
+        component.update!(settings: { amendments_enabled: true })
+      end
+
+      context "with 'proposals' type" do
+        it "lists the filtered proposals" do
+          create_list(:proposal, 2, component: component, scope: scope)
+          visit_component
+
+          within ".filters" do
+            choose "Proposals"
+          end
+
+          expect(page).to have_css(".card.card--proposal", count: 2)
+          expect(page).to have_content("2 PROPOSALS")
+        end
+      end
+
+      context "with 'amendments' type" do
+        let!(:proposal) { create(:proposal, component: component, scope: scope) }
+        let!(:emendation) { create(:proposal, component: component, scope: scope) }
+        let!(:amendment) { create(:amendment, amendable: proposal, emendation: emendation) }
+
+        it "lists the filtered proposals" do
+          visit_component
+
+          within ".filters" do
+            choose "Amendments"
+          end
+
+          expect(page).to have_css(".card.card--proposal", count: 1)
+          expect(page).to have_content("1 PROPOSAL")
+          expect(page).to have_content("AMENDMENT")
+        end
+      end
+
+      context "with 'all' type" do
+        let!(:proposal) { create(:proposal, component: component, scope: scope) }
+        let!(:emendation) { create(:proposal, component: component, scope: scope) }
+        let!(:amendment) { create(:amendment, amendable: proposal, emendation: emendation) }
+
+        it "lists the filtered proposals" do
+          visit_component
+
+          find('input[id="filter_type_all"]').click
+          expect(page).to have_content("2 PROPOSALS")
+          expect(page).to have_content("AMENDMENT", count: 1)
+          expect(page).to have_css(".card.card--proposal", count: 2)
+        end
+      end
+    end
   end
 end

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -660,54 +660,46 @@ describe "Proposals", type: :system do
     end
 
     context "when amendments_enabled setting is enabled" do
+      let!(:proposal) { create(:proposal, component: component, scope: scope) }
+      let!(:emendation) { create(:proposal, component: component, scope: scope) }
+      let!(:amendment) { create(:amendment, amendable: proposal, emendation: emendation) }
+
       before do
         component.update!(settings: { amendments_enabled: true })
+        visit_component
+      end
+
+      context "with 'all' type" do
+        it "lists the filtered proposals" do
+          find('input[id="filter_type_all"]').click
+
+          expect(page).to have_css(".card.card--proposal", count: 2)
+          expect(page).to have_content("2 PROPOSALS")
+          expect(page).to have_content("AMENDMENT", count: 1)
+        end
       end
 
       context "with 'proposals' type" do
         it "lists the filtered proposals" do
-          create_list(:proposal, 2, component: component, scope: scope)
-          visit_component
-
           within ".filters" do
             choose "Proposals"
           end
 
-          expect(page).to have_css(".card.card--proposal", count: 2)
-          expect(page).to have_content("2 PROPOSALS")
+          expect(page).to have_css(".card.card--proposal", count: 1)
+          expect(page).to have_content("1 PROPOSAL")
+          expect(page).to have_content("AMENDMENT", count: 0)
         end
       end
 
       context "with 'amendments' type" do
-        let!(:proposal) { create(:proposal, component: component, scope: scope) }
-        let!(:emendation) { create(:proposal, component: component, scope: scope) }
-        let!(:amendment) { create(:amendment, amendable: proposal, emendation: emendation) }
-
         it "lists the filtered proposals" do
-          visit_component
-
           within ".filters" do
             choose "Amendments"
           end
 
           expect(page).to have_css(".card.card--proposal", count: 1)
           expect(page).to have_content("1 PROPOSAL")
-          expect(page).to have_content("AMENDMENT")
-        end
-      end
-
-      context "with 'all' type" do
-        let!(:proposal) { create(:proposal, component: component, scope: scope) }
-        let!(:emendation) { create(:proposal, component: component, scope: scope) }
-        let!(:amendment) { create(:amendment, amendable: proposal, emendation: emendation) }
-
-        it "lists the filtered proposals" do
-          visit_component
-
-          find('input[id="filter_type_all"]').click
-          expect(page).to have_content("2 PROPOSALS")
           expect(page).to have_content("AMENDMENT", count: 1)
-          expect(page).to have_css(".card.card--proposal", count: 2)
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Add **Filter by type** Functionality to Amendments (proposals)

Include
- Create & withdraw amendments | from #3985 
- Accept amendments | from #3985
- Reject amendments | from #3986 
- Promote rejected amendments | from #3986 
- Publishing a proposal creates a version | from #4567  
- Accepting an amendment creates a new version | from #4567  

New
* If Amendments are enabled the proposal index can be filtered by type:
  * All (default)
  * Proposals
  * Amendments


#### :pushpin: Related Issues
- Related to #2292  

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)
![all_type](https://user-images.githubusercontent.com/40306853/49147625-764ddb00-f305-11e8-9598-6cab729696c3.png)
![proposal_type](https://user-images.githubusercontent.com/40306853/49147631-78179e80-f305-11e8-9862-721ab74f4290.png)
![amendment_type](https://user-images.githubusercontent.com/40306853/49147632-7948cb80-f305-11e8-9230-5de94678b929.png)