### PR TITLE
Add the participatory space to the meeting directory listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@ In order to generate Open Data exports you should add this to your crontab or re
 - **decidim-admin**: Fix image updating in content blocks [\#4549](https://github.com/decidim/decidim/pull/4549)
 - **decidim-proposals**: Fix address toggle in the add proposal form [\#4587](https://github.com/decidim/decidim/pull/4587)
 - **decidim-comments**: Correctly render comments activity with mentions [\#4612](https://github.com/decidim/decidim/pull/4612)
+- **decidim-meetings**: Add the participatory space to the meeting directory listing [\#4620](https://github.com/decidim/decidim/pull/4620)
 
 **Removed**:
 

--- a/decidim-meetings/app/views/decidim/meetings/directory/meetings/_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/directory/meetings/_meetings.html.erb
@@ -14,7 +14,7 @@
 
   <div class="row small-up-1 medium-up-2 card-grid">
     <% meetings.each do |meeting| %>
-      <%= card_for meeting %>
+      <%= card_for meeting, context: { show_space: true } %>
     <% end %>
   </div>
   <%= decidim_paginate meetings, order_start_time: params[:order_start_time], scope_id: params[:scope_id] %>


### PR DESCRIPTION
#### :tophat: What? Why?

Adds the participatory space to the meeting card at the meeting directory.

#### :pushpin: Related Issues
- Fixes #4611

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
