### PR TITLE
Let users define their interests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ In order to generate Open Data exports you should add this to your crontab or re
 - **decidim-meetings**: Export meetings [\#4597](https://github.com/decidim/decidim/pull/4597)
 - **decidim-core**: User groups can now confirm their email [\#4603](https://github.com/decidim/decidim/pull/4603)
 - **decidim-core**: Admins can verify batches of user groups that have the email confirmed by uploading a CSV file [\#4613](https://github.com/decidim/decidim/pull/4613)
+- **decidim-core**: Let users select their interests (scopes/areas). They will see relevant activity in the Timeline tab in their profile [\#4621](https://github.com/decidim/decidim/pull/4621)
 
 **Changed**:
 

--- a/decidim-core/app/commands/decidim/update_user_interests.rb
+++ b/decidim-core/app/commands/decidim/update_user_interests.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This command updates the user's interests.
+  class UpdateUserInterests < Rectify::Command
+    # Updates a user's intersts.
+    #
+    # user - The user to be updated.
+    # form - The form with the data.
+    def initialize(user, form)
+      @user = user
+      @form = form
+    end
+
+    def call
+      return broadcast(:invalid) unless @form.valid?
+
+      update_interests
+      @user.save!
+
+      broadcast(:ok)
+    end
+
+    private
+
+    def update_interests
+      @user.extended_data ||= {}
+      @user.extended_data["interested_scopes"] = selected_scopes_ids
+    end
+
+    def selected_scopes_ids
+      @form.scopes.select(&:checked).map(&:id)
+    end
+  end
+end

--- a/decidim-core/app/commands/decidim/update_user_interests.rb
+++ b/decidim-core/app/commands/decidim/update_user_interests.rb
@@ -26,10 +26,15 @@ module Decidim
     def update_interests
       @user.extended_data ||= {}
       @user.extended_data["interested_scopes"] = selected_scopes_ids
+      @user.extended_data["interested_areas"] = selected_areas_ids
     end
 
     def selected_scopes_ids
       @form.scopes.select(&:checked).map(&:id)
+    end
+
+    def selected_areas_ids
+      @form.areas.select(&:checked).map(&:id)
     end
   end
 end

--- a/decidim-core/app/controllers/decidim/user_interests_controller.rb
+++ b/decidim-core/app/controllers/decidim/user_interests_controller.rb
@@ -18,21 +18,15 @@ module Decidim
 
       UpdateUserInterests.call(current_user, @user_interests) do
         on(:ok) do
-          flash.now[:notice] = t("user_interests.update.success", scope: "decidim")
+          flash.keep[:notice] = t("user_interests.update.success", scope: "decidim")
         end
 
         on(:invalid) do
-          flash.now[:alert] = t("user_interests.update.error", scope: "decidim")
+          flash.keep[:alert] = t("user_interests.update.error", scope: "decidim")
         end
       end
 
       redirect_to action: :show
-    end
-
-    private
-
-    def scopes
-      @scopes ||= current_organization.scopes.top_level.limit(1)
     end
   end
 end

--- a/decidim-core/app/controllers/decidim/user_interests_controller.rb
+++ b/decidim-core/app/controllers/decidim/user_interests_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Decidim
+  # The controller to handle the user's interests page.
+  class UserInterestsController < Decidim::ApplicationController
+    include Decidim::UserProfile
+
+    helper_method :scopes
+
+    def show
+      enforce_permission_to :read, :user, current_user: current_user
+      @user_interests = form(UserInterestsForm).from_model(current_user)
+    end
+
+    def update
+      enforce_permission_to :update, :user, current_user: current_user
+      @user_interests = form(UserInterestsForm).from_params(params)
+
+      UpdateUserInterests.call(current_user, @user_interests) do
+        on(:ok) do
+          flash.now[:notice] = t("user_interests.update.success", scope: "decidim")
+        end
+
+        on(:invalid) do
+          flash.now[:alert] = t("user_interests.update.error", scope: "decidim")
+        end
+      end
+
+      redirect_to action: :show
+    end
+
+    private
+
+    def scopes
+      @scopes ||= current_organization.scopes.top_level.limit(1)
+    end
+  end
+end

--- a/decidim-core/app/forms/decidim/user_interest_area_form.rb
+++ b/decidim-core/app/forms/decidim/user_interest_area_form.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Decidim
+  # The form object that handles the data behind updating a user's
+  # interests in her profile page.
+  class UserInterestAreaForm < Form
+    mimic :area
+
+    attribute :name, String
+    attribute :checked, Boolean
+
+    def map_model(model_hash)
+      area = model_hash[:area]
+      user = model_hash[:user]
+
+      self.id = area.id
+      self.name = area.name
+      self.checked = user.interested_areas_ids.include?(area.id)
+    end
+  end
+end

--- a/decidim-core/app/forms/decidim/user_interest_scope_form.rb
+++ b/decidim-core/app/forms/decidim/user_interest_scope_form.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Decidim
+  # The form object that handles the data behind updating a user's
+  # interests in her profile page.
+  class UserInterestScopeForm < Form
+    mimic :scope
+
+    attribute :name, String
+    attribute :checked, Boolean
+    attribute :children, Array[UserInterestScopeForm]
+
+    def map_model(model_hash)
+      scope = model_hash[:scope]
+      user = model_hash[:user]
+
+      self.id = scope.id
+      self.name = scope.name
+      self.checked = user.interested_scopes_ids.include?(scope.id)
+      self.children = scope.children.map do |children_scope|
+        UserInterestScopeForm.from_model(scope: children_scope, user: user)
+      end
+    end
+  end
+end

--- a/decidim-core/app/forms/decidim/user_interests_form.rb
+++ b/decidim-core/app/forms/decidim/user_interests_form.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Decidim
+  # The form object that handles the data behind updating a user's
+  # interests in her profile page.
+  class UserInterestsForm < Form
+    mimic :user
+
+    attribute :scopes, Array[UserInterestScopeForm]
+
+    def newsletter_notifications_at
+      return nil unless newsletter_notifications
+      Time.current
+    end
+
+    def map_model(user)
+      self.scopes = user.organization.scopes.top_level.map do |scope|
+        UserInterestScopeForm.from_model(scope: scope, user: user)
+      end
+    end
+  end
+end

--- a/decidim-core/app/forms/decidim/user_interests_form.rb
+++ b/decidim-core/app/forms/decidim/user_interests_form.rb
@@ -7,6 +7,7 @@ module Decidim
     mimic :user
 
     attribute :scopes, Array[UserInterestScopeForm]
+    attribute :areas, Array[UserInterestAreaForm]
 
     def newsletter_notifications_at
       return nil unless newsletter_notifications
@@ -14,6 +15,9 @@ module Decidim
     end
 
     def map_model(user)
+      self.areas = user.organization.areas.map do |area|
+        UserInterestAreaForm.from_model(area: area, user: user)
+      end
       self.scopes = user.organization.scopes.top_level.map do |scope|
         UserInterestScopeForm.from_model(scope: scope, user: user)
       end

--- a/decidim-core/app/models/decidim/action_log.rb
+++ b/decidim-core/app/models/decidim/action_log.rb
@@ -5,6 +5,8 @@ module Decidim
   # for transparency reasons, to log all actions so all other users can
   # see the actions being performed.
   class ActionLog < ApplicationRecord
+    include Decidim::Scopable
+
     belongs_to :organization,
                foreign_key: :decidim_organization_id,
                class_name: "Decidim::Organization"

--- a/decidim-core/app/models/decidim/action_log.rb
+++ b/decidim-core/app/models/decidim/action_log.rb
@@ -32,6 +32,11 @@ module Decidim
                optional: true,
                class_name: "PaperTrail::Version"
 
+    belongs_to :area,
+               foreign_key: "decidim_area_id",
+               class_name: "Decidim::Area",
+               optional: true
+
     validates :organization, :user, :action, presence: true
     validates :resource, presence: true, if: ->(log) { log.action != "delete" }
     validates :visibility, presence: true, inclusion: { in: %w(admin-only public-only all) }

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -157,11 +157,19 @@ module Decidim
     end
 
     def interested_scopes_ids
-      extended_data["interested_scopes"]
+      extended_data["interested_scopes"] || []
+    end
+
+    def interested_areas_ids
+      extended_data["interested_areas"] || []
     end
 
     def interested_scopes
       organization.scopes.where(id: interested_scopes_ids)
+    end
+
+    def interested_areas
+      organization.areas.where(id: interested_areas_ids)
     end
 
     protected

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -165,11 +165,11 @@ module Decidim
     end
 
     def interested_scopes
-      organization.scopes.where(id: interested_scopes_ids)
+      @interested_scopes ||= organization.scopes.where(id: interested_scopes_ids)
     end
 
     def interested_areas
-      organization.areas.where(id: interested_areas_ids)
+      @interested_areas ||= organization.areas.where(id: interested_areas_ids)
     end
 
     protected

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -156,6 +156,14 @@ module Decidim
       ImpersonationLog.active.where(user: self).exists?
     end
 
+    def interested_scopes_ids
+      extended_data["interested_scopes"]
+    end
+
+    def interested_scopes
+      organization.scopes.where(id: interested_scopes_ids)
+    end
+
     protected
 
     # Overrides devise email required validation.

--- a/decidim-core/app/services/decidim/action_logger.rb
+++ b/decidim-core/app/services/decidim/action_logger.rb
@@ -53,6 +53,7 @@ module Decidim
         resource_type: resource.class.name,
         participatory_space: participatory_space,
         component: component,
+        scope: scope,
         version_id: version_id,
         extra: extra_data,
         visibility: visibility
@@ -74,6 +75,10 @@ module Decidim
     def participatory_space
       return component.participatory_space if component.respond_to?(:participatory_space)
       resource.participatory_space if resource.respond_to?(:participatory_space)
+    end
+
+    def scope
+      resource.try(:scope) || participatory_space.try(:scope)
     end
 
     def title_for(resource)

--- a/decidim-core/app/services/decidim/action_logger.rb
+++ b/decidim-core/app/services/decidim/action_logger.rb
@@ -53,6 +53,7 @@ module Decidim
         resource_type: resource.class.name,
         participatory_space: participatory_space,
         component: component,
+        area: area,
         scope: scope,
         version_id: version_id,
         extra: extra_data,
@@ -75,6 +76,10 @@ module Decidim
     def participatory_space
       return component.participatory_space if component.respond_to?(:participatory_space)
       resource.participatory_space if resource.respond_to?(:participatory_space)
+    end
+
+    def area
+      resource.try(:area) || participatory_space.try(:area)
     end
 
     def scope

--- a/decidim-core/app/services/decidim/activity_search.rb
+++ b/decidim-core/app/services/decidim/activity_search.rb
@@ -18,6 +18,8 @@ module Decidim
   #   contained in any of them as spaces.
   # :scopes - a collection of `Decidim::Scope`. It will return any activity that
   #   took place in any of those scopes.
+  # :areas - a collection of `Decidim::Area`. It will return any activity that
+  #   took place in any of those areas.
   class ActivitySearch < Searchlight::Search
     # Needed by Searchlight, this is the base query that will be used to
     # append other criteria to the search.
@@ -94,7 +96,8 @@ module Decidim
 
     def filter_follows(query)
       follows = options[:follows]
-      followed_scopes = options[:scopes]
+      interesting_scopes = options[:scopes]
+      interesting_areas = options[:areas]
       conditions = []
 
       if follows.present?
@@ -108,7 +111,8 @@ module Decidim
         conditions += followed_spaces_conditions(follows)
       end
 
-      conditions += followed_scopes_conditions(followed_scopes)
+      conditions += interesting_scopes_conditions(interesting_scopes)
+      conditions += interesting_areas_conditions(interesting_areas)
 
       return query if conditions.empty?
 
@@ -138,10 +142,16 @@ module Decidim
       end
     end
 
-    def followed_scopes_conditions(followed_scopes)
-      return [] if followed_scopes.blank?
+    def interesting_scopes_conditions(interesting_scopes)
+      return [] if interesting_scopes.blank?
 
-      [Decidim::ActionLog.arel_table[:decidim_scope_id].in(followed_scopes.map(&:id))]
+      [Decidim::ActionLog.arel_table[:decidim_scope_id].in(interesting_scopes.map(&:id))]
+    end
+
+    def interesting_areas_conditions(interesting_areas)
+      return [] if interesting_areas.blank?
+
+      [Decidim::ActionLog.arel_table[:decidim_area_id].in(interesting_areas.map(&:id))]
     end
 
     def participatory_space_classes

--- a/decidim-core/app/services/decidim/activity_search.rb
+++ b/decidim-core/app/services/decidim/activity_search.rb
@@ -8,6 +8,16 @@ module Decidim
   # It will return any action for a given resource, except `create` on resources
   # that implement the `Decidim::Publicable` concern to avoid leaking private
   # data.
+  #
+  # Possible options:
+  #
+  # :organization - the `Decidim::Organization` to scope to search. Required.
+  # :user - an optional `Decidim::USer` that performed the activites
+  # :follows - a collection of `Decidim::Follow` resources. It will return any
+  #   activity affecting any of these resources, performed by any of them or
+  #   contained in any of them as spaces.
+  # :scopes - a collection of `Decidim::Scope`. It will return any activity that
+  #   took place in any of those scopes.
   class ActivitySearch < Searchlight::Search
     # Needed by Searchlight, this is the base query that will be used to
     # append other criteria to the search.
@@ -84,16 +94,23 @@ module Decidim
 
     def filter_follows(query)
       follows = options[:follows]
-      return query if follows.blank?
+      followed_scopes = options[:scopes]
+      conditions = []
 
-      conditions = follows.group_by(&:decidim_followable_type).map do |type, grouped_follows|
-        Decidim::ActionLog.arel_table[:resource_type].eq(type).and(
-          Decidim::ActionLog.arel_table[:resource_id].in(grouped_follows.map(&:decidim_followable_id))
-        )
+      if follows.present?
+        conditions += follows.group_by(&:decidim_followable_type).map do |type, grouped_follows|
+          Decidim::ActionLog.arel_table[:resource_type].eq(type).and(
+            Decidim::ActionLog.arel_table[:resource_id].in(grouped_follows.map(&:decidim_followable_id))
+          )
+        end
+
+        conditions += followed_users_conditions(follows)
+        conditions += followed_spaces_conditions(follows)
       end
 
-      conditions += followed_users_conditions(follows)
-      conditions += followed_spaces_conditions(follows)
+      conditions += followed_scopes_conditions(followed_scopes)
+
+      return query if conditions.empty?
 
       chained_conditions = conditions.inject do |previous_condition, condition|
         next condition unless previous_condition
@@ -119,6 +136,12 @@ module Decidim
           Decidim::ActionLog.arel_table[:participatory_space_id].in(grouped_follows.map(&:decidim_followable_id))
         )
       end
+    end
+
+    def followed_scopes_conditions(followed_scopes)
+      return [] if followed_scopes.blank?
+
+      [Decidim::ActionLog.arel_table[:decidim_scope_id].in(followed_scopes.map(&:id))]
     end
 
     def participatory_space_classes

--- a/decidim-core/app/views/decidim/user_interests/_areas.html.erb
+++ b/decidim-core/app/views/decidim/user_interests/_areas.html.erb
@@ -1,0 +1,14 @@
+<ul>
+  <% areas.each do |area| %>
+    <li class="switch tiny switch-with-label">
+      <%= f.fields_for "areas[]", area do |form| %>
+        <label>
+          <%= form.check_box "checked", label: false, class: "switch-input" %>
+          <span class="switch-paddle"></span>
+          <span class="switch-label"><%= translated_attribute area.name %></span>
+        </label>
+        <%= form.hidden_field "id", value: area.id %>
+      <% end %>
+    </li>
+  <% end %>
+</ul>

--- a/decidim-core/app/views/decidim/user_interests/_scopes.html.erb
+++ b/decidim-core/app/views/decidim/user_interests/_scopes.html.erb
@@ -1,0 +1,15 @@
+<ul>
+  <% scopes.each do |scope| %>
+    <li class="switch tiny switch-with-label email_on_notification">
+      <%= f.fields_for "scopes[]", scope do |form| %>
+        <label>
+          <%= form.check_box "checked", label: false, class: "switch-input" %>
+          <span class="switch-paddle"></span>
+          <span class="switch-label"><%= translated_attribute scope.name %></span>
+        </label>
+        <%= form.hidden_field "id", value: scope.id %>
+      <% end %>
+    </li>
+    <%= render partial: "scopes", locals: { scopes: scope.children, f: f } %>
+  <% end %>
+</ul>

--- a/decidim-core/app/views/decidim/user_interests/_scopes.html.erb
+++ b/decidim-core/app/views/decidim/user_interests/_scopes.html.erb
@@ -1,6 +1,6 @@
 <ul>
   <% scopes.each do |scope| %>
-    <li class="switch tiny switch-with-label email_on_notification">
+    <li class="switch tiny switch-with-label">
       <%= f.fields_for "scopes[]", scope do |form| %>
         <label>
           <%= form.check_box "checked", label: false, class: "switch-input" %>

--- a/decidim-core/app/views/decidim/user_interests/show.html.erb
+++ b/decidim-core/app/views/decidim/user_interests/show.html.erb
@@ -7,7 +7,15 @@
     <% else %>
       <p><%= t(".no_scopes") %></p>
     <% end %>
-    <% if @user_interests.scopes.any? %>
+
+    <p><strong><%= t(".areas") %></strong></p>
+    <% if @user_interests.areas.any? %>
+      <%= render partial: "areas", locals: { areas: @user_interests.areas, f: f } %>
+    <% else %>
+      <p><%= t(".no_areas") %></p>
+    <% end %>
+
+    <% if @user_interests.scopes.any? || @user_interests.areas.any? %>
       <%= f.submit t(".update_my_interests"), disable_with: true %>
     <% end %>
   <% end %>

--- a/decidim-core/app/views/decidim/user_interests/show.html.erb
+++ b/decidim-core/app/views/decidim/user_interests/show.html.erb
@@ -1,0 +1,14 @@
+<div class="row">
+  <p><%= t(".select_your_interests") %></p>
+  <%= form_for(@user_interests, url: user_interests_path, method: :put, class: "user-form") do |f| %>
+    <p><strong><%= t(".scopes") %></strong></p>
+    <% if @user_interests.scopes.any? %>
+      <%= render partial: "scopes", locals: { scopes: @user_interests.scopes, f: f } %>
+    <% else %>
+      <p><%= t(".no_scopes") %></p>
+    <% end %>
+    <% if @user_interests.scopes.any? %>
+      <%= f.submit t(".update_my_interests"), disable_with: true %>
+    <% end %>
+  <% end %>
+</div>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -965,10 +965,15 @@ en:
         no_activities_warning: This user hasn't had any activity yet.
     user_interests:
       show:
+        areas: Areas
+        no_areas: This organization doesn't have any area yet!
         no_scopes: This organization doesn't have any scope yet!
         scopes: Scopes
         select_your_interests: Select the topics you're interested in to receive events related to them in your profile Timeline tab.
         update_my_interests: Update my interests
+      update:
+        error: There was an erorr while updating your interests.
+        success: Your interests have been successfully updated.
     welcome_notification:
       default_body: <p>Hi {{name}}, thanks for joining {{organization}} and welcome!</p><ul><li>If you want to get a quick idea of what you can do here, have a look at the <a href="{{help_url}}">Help</a> section.</li><li>Once you have read it you will get your first badge. Here's a <a href="{{badges_url}}">list of all the badges</a> you can get as you participate in {{organization}}</li><li>Last but not least, join other people, share with them the experience of being engaged and participating in {{organization}}. Make proposals, comments, debate, think about how to contribute to the common good, provide arguments to convince, listen and read to be convinced, express your ideas in a concrete and direct way, respond with patience and decision, defend your ideas and keep an open mind to collaborate and join other people's ideas.</li></ul>
       default_subject: Thanks for joining {{organization}}!

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1168,6 +1168,7 @@ en:
         authorizations: Authorizations
         delete_my_account: Delete my account
         my_data: My data
+        my_interests: My interests
         notifications_settings: Notifications settings
         title: User settings
         user_groups: Groups

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -963,6 +963,12 @@ en:
     user_activity:
       index:
         no_activities_warning: This user hasn't had any activity yet.
+    user_interests:
+      show:
+        no_scopes: This organization doesn't have any scope yet!
+        scopes: Scopes
+        select_your_interests: Select the topics you're interested in to receive events related to them in your profile Timeline tab.
+        update_my_interests: Update my interests
     welcome_notification:
       default_body: <p>Hi {{name}}, thanks for joining {{organization}} and welcome!</p><ul><li>If you want to get a quick idea of what you can do here, have a look at the <a href="{{help_url}}">Help</a> section.</li><li>Once you have read it you will get your first badge. Here's a <a href="{{badges_url}}">list of all the badges</a> you can get as you participate in {{organization}}</li><li>Last but not least, join other people, share with them the experience of being engaged and participating in {{organization}}. Make proposals, comments, debate, think about how to contribute to the common good, provide arguments to convince, listen and read to be convinced, express your ideas in a concrete and direct way, respond with patience and decision, defend your ideas and keep an open mind to collaborate and join other people's ideas.</li></ul>
       default_subject: Thanks for joining {{organization}}!

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -64,6 +64,8 @@ Decidim::Core::Engine.routes.draw do
       end
     end
 
+    resources :user_interests, only: [:index, :create]
+
     get "/authorization_modals/:authorization_action/f/:component_id(/:resource_name/:resource_id)", to: "authorization_modals#show", as: :authorization_modal
 
     resources :groups, except: [:destroy, :index, :show] do

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -64,7 +64,7 @@ Decidim::Core::Engine.routes.draw do
       end
     end
 
-    resources :user_interests, only: [:index, :create]
+    resource :user_interests, only: [:show, :update]
 
     get "/authorization_modals/:authorization_action/f/:component_id(/:resource_name/:resource_id)", to: "authorization_modals#show", as: :authorization_modal
 

--- a/decidim-core/db/migrate/20181211080834_add_scope_to_action_logs.rb
+++ b/decidim-core/db/migrate/20181211080834_add_scope_to_action_logs.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddScopeToActionLogs < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_action_logs, :decidim_scope_id, :integer
+  end
+end

--- a/decidim-core/db/migrate/20181211090933_add_area_to_action_logs.rb
+++ b/decidim-core/db/migrate/20181211090933_add_area_to_action_logs.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddAreaToActionLogs < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_action_logs, :decidim_area_id, :integer
+  end
+end

--- a/decidim-core/db/migrate/20181211090933_add_area_to_action_logs.rb
+++ b/decidim-core/db/migrate/20181211090933_add_area_to_action_logs.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class AddAreaToActionLogs < ActiveRecord::Migration[5.2]
   def change
     add_column :decidim_action_logs, :decidim_area_id, :integer

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -166,9 +166,13 @@ module Decidim
                       position: 1.3
           end
 
+          menu.item t("my_interests", scope: "layouts.decidim.user_profile"),
+                    decidim.user_interests_path,
+                    position: 1.4
+
           menu.item t("my_data", scope: "layouts.decidim.user_profile"),
                     decidim.data_portability_path,
-                    position: 1.4
+                    position: 1.5
 
           menu.item t("delete_my_account", scope: "layouts.decidim.user_profile"),
                     decidim.delete_account_path,

--- a/decidim-core/spec/commands/decidim/update_user_interests_spec.rb
+++ b/decidim-core/spec/commands/decidim/update_user_interests_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe UpdateUserInterests do
+    let(:command) { described_class.new(user, form) }
+    let(:user) { create(:user) }
+    let(:interested_scope) { create :scope, organization: user.organization }
+    let(:ignored_scope) { create :scope, organization: user.organization }
+    let(:data) do
+      {
+        scopes: {
+          ignored_scope.id.to_s => {
+            "checked": "0",
+            "id": ignored_scope.id.to_s
+          },
+          interested_scope.id.to_s => {
+            "checked": "1",
+            "id": interested_scope.id.to_s
+          }
+        }
+      }
+    end
+
+    let(:form) do
+      Decidim::UserInterestsForm.from_params(user: data)
+    end
+
+    context "when invalid" do
+      before do
+        allow(form).to receive(:valid?).and_return(false)
+      end
+
+      it "broadcasts invalid" do
+        expect { command.call }.to broadcast(:invalid)
+      end
+    end
+
+    context "when valid" do
+      it "updates the users's interested scopes" do
+        expect { command.call }.to broadcast(:ok)
+        user.reload
+        expect(user.interested_scopes).to eq [interested_scope]
+      end
+    end
+  end
+end

--- a/decidim-core/spec/commands/decidim/update_user_interests_spec.rb
+++ b/decidim-core/spec/commands/decidim/update_user_interests_spec.rb
@@ -8,6 +8,8 @@ module Decidim
     let(:user) { create(:user) }
     let(:interested_scope) { create :scope, organization: user.organization }
     let(:ignored_scope) { create :scope, organization: user.organization }
+    let(:interested_area) { create :area, organization: user.organization }
+    let(:ignored_area) { create :area, organization: user.organization }
     let(:data) do
       {
         scopes: {
@@ -18,6 +20,16 @@ module Decidim
           interested_scope.id.to_s => {
             "checked": "1",
             "id": interested_scope.id.to_s
+          }
+        },
+        areas: {
+          ignored_area.id.to_s => {
+            "checked": "0",
+            "id": ignored_area.id.to_s
+          },
+          interested_area.id.to_s => {
+            "checked": "1",
+            "id": interested_area.id.to_s
           }
         }
       }
@@ -42,6 +54,7 @@ module Decidim
         expect { command.call }.to broadcast(:ok)
         user.reload
         expect(user.interested_scopes).to eq [interested_scope]
+        expect(user.interested_areas).to eq [interested_area]
       end
     end
   end

--- a/decidim-core/spec/lib/traceable_spec.rb
+++ b/decidim-core/spec/lib/traceable_spec.rb
@@ -26,7 +26,7 @@ module Decidim
 
       describe "last_editor" do
         context "when last editor is a user" do
-          let(:user) { create :user }
+          let(:user) { create :user, organization: resource.organization }
 
           it "returns the user" do
             Decidim.traceability.update!(subject, user, title: "My new title 3")

--- a/decidim-core/spec/services/decidim/action_logger_spec.rb
+++ b/decidim-core/spec/services/decidim/action_logger_spec.rb
@@ -114,9 +114,40 @@ describe Decidim::ActionLogger do
         expect(action_log.participatory_space).to be_nil
         expect(action_log.user).to eq user
         expect(action_log.action).to eq action
+        expect(action_log.scope).to be_nil
         expect(action_log.extra["component"]).to be_empty
         expect(action_log.extra["participatory_space"]).to be_empty
         expect(action_log.extra["resource"]).not_to be_empty
+      end
+    end
+
+    describe "scope" do
+      context "when the resource has scope" do
+        it "saves the resource scope" do
+          subject
+          expect(action_log.scope).to eq resource.scope
+        end
+      end
+
+      context "when the resource has no scope" do
+        let(:resource) { create :dummy_resource, component: component, scope: nil }
+
+        context "when the space has a scope" do
+          let(:participatory_space) { create :participatory_process, organization: organization, scope: scope }
+          let(:scope) { create :scope, organization: organization }
+
+          it "saves the participatory_space scope" do
+            subject
+            expect(action_log.scope).to eq participatory_space.scope
+          end
+        end
+
+        context "when the space has no scope" do
+          it "saves the participatory_space scope" do
+            subject
+            expect(action_log.scope).to be_nil
+          end
+        end
       end
     end
   end

--- a/decidim-core/spec/services/decidim/action_logger_spec.rb
+++ b/decidim-core/spec/services/decidim/action_logger_spec.rb
@@ -143,9 +143,30 @@ describe Decidim::ActionLogger do
         end
 
         context "when the space has no scope" do
-          it "saves the participatory_space scope" do
+          it "doesn't save any scope" do
             subject
             expect(action_log.scope).to be_nil
+          end
+        end
+      end
+    end
+
+    describe "area" do
+      context "when the resource has no area" do
+        context "when the space has an area" do
+          let(:participatory_space) { create :assembly, organization: organization, area: area }
+          let(:area) { create :area, organization: organization }
+
+          it "saves the participatory_space area" do
+            subject
+            expect(action_log.area).to eq participatory_space.area
+          end
+        end
+
+        context "when the space has no area" do
+          it "doesn't save any area" do
+            subject
+            expect(action_log.area).to be_nil
           end
         end
       end

--- a/decidim-core/spec/services/decidim/activity_search_spec.rb
+++ b/decidim-core/spec/services/decidim/activity_search_spec.rb
@@ -95,8 +95,16 @@ module Decidim
           create(:dummy_resource, component: component2, published_at: Time.current)
         end
 
+        let(:scoped_resource) do
+          create(:dummy_resource, component: component3, published_at: Time.current)
+        end
+
         let!(:uninteresting_resource) do
           create(:dummy_resource, component: component3, published_at: Time.current)
+        end
+
+        let(:interesting_scope) do
+          scoped_resource.scope
         end
 
         let!(:action_log) do
@@ -111,6 +119,10 @@ module Decidim
           create(:action_log, action: "publish", visibility: "all", resource: resource2, organization: organization)
         end
 
+        let!(:scoped_resource_action_log) do
+          create(:action_log, action: "publish", visibility: "all", resource: scoped_resource, organization: organization, scope: scoped_resource.scope)
+        end
+
         let!(:uninteresting_resource_action_log) do
           create(:action_log, action: "publish", visibility: "all", resource: uninteresting_resource, organization: organization)
         end
@@ -119,7 +131,8 @@ module Decidim
           described_class.new(
             organization: organization,
             resource_type: resource_type,
-            follows: user.following_follows
+            follows: user.following_follows,
+            scopes: [interesting_scope]
           )
         end
 
@@ -135,6 +148,10 @@ module Decidim
 
         it "includes results from followed spaces" do
           expect(subject).to include(action_log_2)
+        end
+
+        it "includes results from followed scopes" do
+          expect(subject).to include(scoped_resource_action_log)
         end
 
         it "includes results from followed resources" do

--- a/decidim-core/spec/services/decidim/activity_search_spec.rb
+++ b/decidim-core/spec/services/decidim/activity_search_spec.rb
@@ -71,7 +71,7 @@ module Decidim
       end
     end
 
-    context "for followed resources" do
+    context "with followed resources and interesting scopes/areas" do
       let(:comment) { create(:comment) }
       let(:user) { create(:user, organization: organization) }
       let(:user2) { create(:user, organization: organization) }

--- a/decidim-core/spec/services/decidim/activity_search_spec.rb
+++ b/decidim-core/spec/services/decidim/activity_search_spec.rb
@@ -69,6 +69,82 @@ module Decidim
 
         it { is_expected.to include(action_log) }
       end
+
+      context "for followed resources" do
+        let(:comment) { create(:comment) }
+        let(:user) { create(:user, organization: organization) }
+        let(:user2) { create(:user, organization: organization) }
+
+        let(:component) do
+          create(:component, :published, organization: organization)
+        end
+
+        let(:component2) do
+          create(:component, :published, organization: organization)
+        end
+
+        let(:component3) do
+          create(:component, :published, organization: organization)
+        end
+
+        let(:resource) do
+          create(:dummy_resource, component: component, published_at: Time.current)
+        end
+
+        let(:resource2) do
+          create(:dummy_resource, component: component2, published_at: Time.current)
+        end
+
+        let!(:uninteresting_resource) do
+          create(:dummy_resource, component: component3, published_at: Time.current)
+        end
+
+        let!(:action_log) do
+          create(:action_log, action: "create", visibility: "public-only", resource: comment, organization: organization, user: user2)
+        end
+
+        let!(:action_log_2) do
+          create(:action_log, action: "publish", visibility: "all", resource: resource, organization: organization, participatory_space: component.participatory_space)
+        end
+
+        let!(:action_log_3) do
+          create(:action_log, action: "publish", visibility: "all", resource: resource2, organization: organization)
+        end
+
+        let!(:uninteresting_resource_action_log) do
+          create(:action_log, action: "publish", visibility: "all", resource: uninteresting_resource, organization: organization)
+        end
+
+        let(:search) do
+          described_class.new(
+            organization: organization,
+            resource_type: resource_type,
+            follows: user.following_follows
+          )
+        end
+
+        before do
+          Decidim::Follow.create!(user: user, followable: user2)
+          Decidim::Follow.create!(user: user, followable: action_log_2.participatory_space)
+          Decidim::Follow.create!(user: user, followable: resource2)
+        end
+
+        it "includes results from followed resources" do
+          expect(subject).to include(action_log)
+        end
+
+        it "includes results from followed spaces" do
+          expect(subject).to include(action_log_2)
+        end
+
+        it "includes results from followed resources" do
+          expect(subject).to include(action_log)
+        end
+
+        it "does not include results from uninteresting resources" do
+          expect(subject).not_to include(uninteresting_resource_action_log)
+        end
+      end
     end
   end
 end

--- a/decidim-core/spec/services/decidim/traceability_spec.rb
+++ b/decidim-core/spec/services/decidim/traceability_spec.rb
@@ -5,9 +5,10 @@ require "spec_helper"
 describe Decidim::Traceability, versioning: true do
   subject { described_class.new }
 
-  let!(:user) { create :user }
+  let!(:organization) { dummy_resource.organization }
+  let!(:user) { create :user, organization: organization }
   let(:klass) { Decidim::DummyResources::DummyResource }
-  let(:params) { attributes_for(:dummy_resource) }
+  let(:params) { attributes_for(:dummy_resource, scope: nil) }
   let(:dummy_resource) { create :dummy_resource }
 
   describe "create" do

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/admin/initiatives_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/admin/initiatives_controller_spec.rb
@@ -375,7 +375,7 @@ module Decidim
           end
 
           context "and Administrator" do
-            let!(:admin) { create(:user, :confirmed, :admin) }
+            let!(:admin) { create(:user, :confirmed, :admin, organization: organization) }
 
             before do
               sign_in admin, scope: :user
@@ -408,7 +408,7 @@ module Decidim
           end
 
           context "and Administrator" do
-            let(:admin) { create(:user, :confirmed, :admin) }
+            let(:admin) { create(:user, :confirmed, :admin, organization: organization) }
 
             before do
               sign_in admin, scope: :user
@@ -442,7 +442,7 @@ module Decidim
           end
 
           context "and Administrator" do
-            let(:admin) { create(:user, :confirmed, :admin) }
+            let(:admin) { create(:user, :confirmed, :admin, organization: organization) }
 
             before do
               sign_in admin, scope: :user
@@ -475,7 +475,7 @@ module Decidim
           end
 
           context "when Administrator" do
-            let!(:admin) { create(:user, :confirmed, :admin) }
+            let!(:admin) { create(:user, :confirmed, :admin, organization: organization) }
 
             before do
               sign_in admin, scope: :user
@@ -507,7 +507,7 @@ module Decidim
           end
 
           context "when Administrator" do
-            let!(:admin) { create(:user, :confirmed, :admin) }
+            let!(:admin) { create(:user, :confirmed, :admin, organization: organization) }
 
             before do
               sign_in admin, scope: :user

--- a/decidim-meetings/spec/commands/admin/update_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/admin/update_meeting_spec.rb
@@ -29,7 +29,7 @@ module Decidim::Meetings
     let(:services_to_persist) do
       services.map { |service| Admin::MeetingServiceForm.from_params(service) }
     end
-    let(:user) { create :user, :admin }
+    let(:user) { create :user, :admin, organization: organization }
     let(:organizer) { create :user, organization: organization }
     let(:private_meeting) { false }
     let(:transparent) { true }


### PR DESCRIPTION
#### :tophat: What? Why?
Implements #4439.

#### :pushpin: Related Issues
- Related to #4439

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add scopes to action logs
- [x] Add areas to action logs
- [x] Let `ActivitySearch` return ActionLogs affecting a given scope/area
- [x] Add a way for users to declare their interest in a scope/area
- [x] Show action logs related to the user interests in the Timeline

#### Screenshots
![localhost_3000_user_interests](https://user-images.githubusercontent.com/491891/49867648-648f2c00-fe0b-11e8-9917-fafadb2399fd.png)

