### PR TITLE
Fix meeting form when only one locale is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ In order to generate Open Data exports you should add this to your crontab or re
 
 **Changed**:
 
+- **decidim-meetings**: Fix meeting form when only one locale is available [\#4623](https://github.com/decidim/decidim/pull/4623)
 - **decidim-core**: Show hashtags with original case [\#4554](https://github.com/decidim/decidim/pull/4554)
 - **decidim-conferences**: Remove right sidebar completely from the frontend [\#4480](https://github.com/decidim/decidim/pull/4480)
 - **decidim-core**: Allow to configure OmniAuth provider icons [\#4440](https://github.com/decidim/decidim/pull/4440)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,6 @@ In order to generate Open Data exports you should add this to your crontab or re
 
 **Changed**:
 
-- **decidim-meetings**: Fix meeting form when only one locale is available [\#4623](https://github.com/decidim/decidim/pull/4623)
 - **decidim-core**: Show hashtags with original case [\#4554](https://github.com/decidim/decidim/pull/4554)
 - **decidim-conferences**: Remove right sidebar completely from the frontend [\#4480](https://github.com/decidim/decidim/pull/4480)
 - **decidim-core**: Allow to configure OmniAuth provider icons [\#4440](https://github.com/decidim/decidim/pull/4440)
@@ -124,6 +123,7 @@ In order to generate Open Data exports you should add this to your crontab or re
 
 **Fixed**:
 
+- **decidim-meetings**: Fix meetings form when only one locale is available [\#4625](https://github.com/decidim/decidim/pull/4625)
 - **decidim-participatory_processes**: Fix admin cannot access public view of private processes by default [\#4591](https://github.com/decidim/decidim/pull/4591)
 - **decidim-proposals** Index admin-created proposals. [\#4601](https://github.com/decidim/decidim/pull/4601)
 - **decidim-proposals** Fix proposals created from collaborative drafts inherited attributes [\#4605](https://github.com/decidim/decidim/pull/4605)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,7 +123,7 @@ In order to generate Open Data exports you should add this to your crontab or re
 
 **Fixed**:
 
-- **decidim-meetings**: Fix meetings form when only one locale is available [\#4625](https://github.com/decidim/decidim/pull/4625)
+- **decidim-meetings**: Fix meetings form when only one locale is available [\#4623](https://github.com/decidim/decidim/pull/4623)
 - **decidim-participatory_processes**: Fix admin cannot access public view of private processes by default [\#4591](https://github.com/decidim/decidim/pull/4591)
 - **decidim-proposals** Index admin-created proposals. [\#4601](https://github.com/decidim/decidim/pull/4601)
 - **decidim-proposals** Fix proposals created from collaborative drafts inherited attributes [\#4605](https://github.com/decidim/decidim/pull/4605)

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -36,13 +36,7 @@ module Decidim
     #
     # Renders form fields for each locale.
     def translated(type, name, options = {})
-      if locales.count == 1
-        return send(
-          type,
-          "#{name}_#{locales.first.to_s.gsub("-", "__")}",
-          options.merge(label: options[:label] || label_for(name))
-        )
-      end
+      return translated_one_locale(type, name, locales.first, options.merge(label: (options[:label] || label_for(name)))) if locales.count == 1
 
       tabs_id = sanitize_tabs_selector(options[:tabs_id] || "#{object_name}-#{name}-tabs")
 
@@ -72,7 +66,7 @@ module Decidim
           tab_content_id = "#{tabs_id}-#{name}-panel-#{index}"
           string + content_tag(:div, class: tab_element_class_for("panel", index), id: tab_content_id) do
             if options[:hashtaggable]
-              hashtaggable_text_field(type, name, locale, options)
+              hashtaggable_text_field(type, name, locale, options.merge(label: false))
             else
               send(type, name_with_locale(name, locale), options.merge(label: false))
             end
@@ -81,6 +75,15 @@ module Decidim
       end
 
       safe_join [label_tabs, tabs_content]
+    end
+
+    def translated_one_locale(type, name, locale, options = {})
+      return hashtaggable_text_field(type, name, locale, options.merge(value: options[:value])) if options[:hashtaggable]
+      send(
+        type,
+        "#{name}_#{locale.to_s.gsub("-", "__")}",
+        options.merge(label: options[:label] || label_for(name))
+      )
     end
 
     # Public: Generates a field for hashtaggable type.
@@ -93,9 +96,9 @@ module Decidim
     def hashtaggable_text_field(type, name, locale, options = {})
       content_tag(:div, class: "hashtags__container") do
         if options[:value]
-          send(type, name_with_locale(name, locale), options.merge(label: false, value: options[:value][locale]))
+          send(type, name_with_locale(name, locale), options.merge(label: options[:label], value: options[:value][locale]))
         else
-          send(type, name_with_locale(name, locale), options.merge(label: false))
+          send(type, name_with_locale(name, locale), options.merge(label: options[:label]))
         end
       end
     end

--- a/decidim-core/spec/lib/form_builder_spec.rb
+++ b/decidim-core/spec/lib/form_builder_spec.rb
@@ -131,6 +131,38 @@ module Decidim
           end
         end
       end
+
+      context "with an editor field hashtaggable" do
+        let(:output) do
+          builder.translated :editor, :short_description, hashtaggable: true
+        end
+
+        it "renders a tabbed input hidden for each field and a container for the editor" do
+          expect(parsed.css("label[for='resource_short_description']")).not_to be_empty
+
+          expect(parsed.css("li.tabs-title a").count).to eq 3
+          expect(parsed.css(".editor.hashtags__container").count).to eq 3
+
+          expect(parsed.css(".editor label[for='resource_short_description_en']").first).to be_nil
+
+          expect(parsed.css(".tabs-panel .editor input[type='hidden'][name='resource[short_description_ca]']")).not_to be_empty
+          expect(parsed.css(".tabs-panel .editor input[type='hidden'][name='resource[short_description_en]']")).not_to be_empty
+          expect(parsed.css(".tabs-panel .editor input[type='hidden'][name='resource[short_description_de__CH]']")).not_to be_empty
+
+          expect(parsed.css(".tabs-panel .editor .editor-container").count).to eq 3
+        end
+
+        context "with a single locale" do
+          let(:available_locales) { %w(en) }
+
+          it "renders a single input and a container for the editor" do
+            expect(parsed.css(".editor-container.js-hashtags").count).to eq 1
+            expect(parsed.css(".editor input[type='hidden'][name='resource[short_description_en]']")).not_to be_empty
+            expect(parsed.css(".editor label[for='resource_short_description_en']")).not_to be_empty
+            expect(parsed.css(".editor .editor-container")).not_to be_empty
+          end
+        end
+      end
     end
 
     describe "categories_for_select" do

--- a/decidim-meetings/spec/shared/manage_meetings_examples.rb
+++ b/decidim-meetings/spec/shared/manage_meetings_examples.rb
@@ -22,7 +22,6 @@ shared_examples "manage meetings" do
         within "#meeting-title-tabs" do
           click_link "English"
         end
-
         expect(page).to have_css("input", text: meeting.title[:en], visible: true)
 
         within "#meeting-title-tabs" do
@@ -40,7 +39,6 @@ shared_examples "manage meetings" do
         within "#meeting-description-tabs" do
           click_link "English"
         end
-
         expect(page).to have_css("input", text: meeting.description[:en], visible: true)
 
         within "#meeting-description-tabs" do

--- a/decidim-meetings/spec/shared/manage_meetings_examples.rb
+++ b/decidim-meetings/spec/shared/manage_meetings_examples.rb
@@ -12,6 +12,73 @@ shared_examples "manage meetings" do
     stub_geocoding(address, [latitude, longitude])
   end
 
+  describe "when rendering the text in the update page" do
+    context "when there are multiple locales" do
+      before do
+        click_link "Edit"
+      end
+
+      it "shows the title correctly in all available locales" do
+        within "#meeting-title-tabs" do
+          click_link "English"
+        end
+
+        expect(page).to have_css("input", text: meeting.title[:en], visible: true)
+
+        within "#meeting-title-tabs" do
+          click_link "Català"
+        end
+        expect(page).to have_css("input", text: meeting.title[:ca], visible: true)
+
+        within "#meeting-title-tabs" do
+          click_link "Castellano"
+        end
+        expect(page).to have_css("input", text: meeting.title[:es], visible: true)
+      end
+
+      it "shows the description correctly in all available locales" do
+        within "#meeting-description-tabs" do
+          click_link "English"
+        end
+
+        expect(page).to have_css("input", text: meeting.description[:en], visible: true)
+
+        within "#meeting-description-tabs" do
+          click_link "Català"
+        end
+        expect(page).to have_css("input", text: meeting.description[:ca], visible: true)
+
+        within "#meeting-description-tabs" do
+          click_link "Castellano"
+        end
+        expect(page).to have_css("input", text: meeting.description[:es], visible: true)
+      end
+    end
+
+    context "when there is only one locale" do
+      let(:organization) { create :organization, available_locales: [:en] }
+      let(:component) { create(:component, manifest_name: manifest_name, organization: organization) }
+      let!(:meeting) do
+        create(:meeting, scope: scope, services: [], component: component,
+                         title: { en: "Title" }, description: { en: "Description" })
+      end
+
+      before do
+        click_link "Edit"
+      end
+
+      it "shows the title correctly" do
+        expect(page).not_to have_css("#meeting-title-tabs")
+        expect(page).to have_css("input", text: meeting.title[:en], visible: true)
+      end
+
+      it "shows the description correctly" do
+        expect(page).not_to have_css("#meeting-description-tabs")
+        expect(page).to have_css("input", text: meeting.description[:en], visible: true)
+      end
+    end
+  end
+
   it "updates a meeting" do
     within find("tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title) do
       click_link "Edit"


### PR DESCRIPTION
#### :tophat: What? Why?
This PR solves a bug when editing a meeting with an organization with only one locale, the form isn't rendering correctly the hashtaggable attributes. 

#### :pushpin: Related Issues
- Related to #4535 
- Fixes #4619 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [x] Change translated_form
- [ ] Add tests

### :camera: Screenshots (optional)
![Description](URL)
