### PR TITLE
Fix meeting form when only one locale is available (backported to 0.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## [0.15.1](https://github.com/decidim/decidim/tree/v0.15.1)
 
-- **decidim-meetings**: Fix meetings form when only one locale is available [\#4623](https://github.com/decidim/decidim/pull/4623)
+- **decidim-meetings**: Fix meetings form when only one locale is available [\#4625](https://github.com/decidim/decidim/pull/4625)
 - **decidim-meetings**: Change title to description in meetings admin form. [\#4484](https://github.com/decidim/decidim/pull/4484)
 - **decidim-meetings**: Fix title and description fields in admin form. [\#4547](https://github.com/decidim/decidim/pull/4547)
 - **decidim-proposals**: Fix vote-rerendering on a proposal's page [\#4558](https://github.com/decidim/decidim/pull/4558)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [0.15.1](https://github.com/decidim/decidim/tree/v0.15.1)
 
+**Fixed**:
+
 - **decidim-meetings**: Fix meetings form when only one locale is available [\#4625](https://github.com/decidim/decidim/pull/4625)
 - **decidim-meetings**: Change title to description in meetings admin form. [\#4484](https://github.com/decidim/decidim/pull/4484)
 - **decidim-meetings**: Fix title and description fields in admin form. [\#4547](https://github.com/decidim/decidim/pull/4547)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 
 **Fixed**:
 
+- **decidim-meeting**: Fix admin update meeting with only one locale [\#4625](https://github.com/decidim/decidim/pull/4625)
 - **decidim-assemblies**: Add parent when duplicating child assembly. [\#4371](https://github.com/decidim/decidim/pull/4371)
 - **decidim-assemblies**: Add paginate on admin site assembly members. [\#4369](https://github.com/decidim/decidim/pull/4369)
 - **decidim-admin**: Adds traceability when creating and deleting Participatory Space private user [\#4332](https://github.com/decidim/decidim/pull/4332)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,6 @@ Decidim::User.where(**search for old subscribed users**).update(newsletter_notif
 
 **Fixed**:
 
-- **decidim-meeting**: Fix admin update meeting with only one locale [\#4625](https://github.com/decidim/decidim/pull/4625)
 - **decidim-assemblies**: Add parent when duplicating child assembly. [\#4371](https://github.com/decidim/decidim/pull/4371)
 - **decidim-assemblies**: Add paginate on admin site assembly members. [\#4369](https://github.com/decidim/decidim/pull/4369)
 - **decidim-admin**: Adds traceability when creating and deleting Participatory Space private user [\#4332](https://github.com/decidim/decidim/pull/4332)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## [0.15.1](https://github.com/decidim/decidim/tree/v0.15.1)
 
+- **decidim-meetings**: Fix meetings form when only one locale is available [\#4623](https://github.com/decidim/decidim/pull/4623)
 - **decidim-meetings**: Change title to description in meetings admin form. [\#4484](https://github.com/decidim/decidim/pull/4484)
 - **decidim-meetings**: Fix title and description fields in admin form. [\#4547](https://github.com/decidim/decidim/pull/4547)
 - **decidim-proposals**: Fix vote-rerendering on a proposal's page [\#4558](https://github.com/decidim/decidim/pull/4558)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## [Unreleased](https://github.com/decidim/decidim/tree/0.15-stable)
 
+**Fixed**:
+
+- **decidim-meetings**: Fix meetings form when only one locale is available [\#4625](https://github.com/decidim/decidim/pull/4625)
+
 ## [0.15.1](https://github.com/decidim/decidim/tree/v0.15.1)
 
 **Fixed**:
 
-- **decidim-meetings**: Fix meetings form when only one locale is available [\#4625](https://github.com/decidim/decidim/pull/4625)
 - **decidim-meetings**: Change title to description in meetings admin form. [\#4484](https://github.com/decidim/decidim/pull/4484)
 - **decidim-meetings**: Fix title and description fields in admin form. [\#4547](https://github.com/decidim/decidim/pull/4547)
 - **decidim-proposals**: Fix vote-rerendering on a proposal's page [\#4558](https://github.com/decidim/decidim/pull/4558)

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -36,13 +36,7 @@ module Decidim
     #
     # Renders form fields for each locale.
     def translated(type, name, options = {})
-      if locales.count == 1
-        return send(
-          type,
-          "#{name}_#{locales.first.to_s.gsub("-", "__")}",
-          options.merge(label: options[:label] || label_for(name))
-        )
-      end
+      return translated_one_locale(type, name, locales.first, options.merge(label: (options[:label] || label_for(name)))) if locales.count == 1
 
       tabs_id = sanitize_tabs_selector(options[:tabs_id] || "#{object_name}-#{name}-tabs")
 
@@ -72,7 +66,7 @@ module Decidim
           tab_content_id = "#{tabs_id}-#{name}-panel-#{index}"
           string + content_tag(:div, class: tab_element_class_for("panel", index), id: tab_content_id) do
             if options[:hashtaggable]
-              hashtaggable_text_field(type, name, locale, options)
+              hashtaggable_text_field(type, name, locale, options.merge(label: false))
             else
               send(type, name_with_locale(name, locale), options.merge(label: false))
             end
@@ -81,6 +75,15 @@ module Decidim
       end
 
       safe_join [label_tabs, tabs_content]
+    end
+
+    def translated_one_locale(type, name, locale, options = {})
+      return hashtaggable_text_field(type, name, locale, options.merge(value: options[:value])) if options[:hashtaggable]
+      send(
+        type,
+        "#{name}_#{locale.to_s.gsub("-", "__")}",
+        options.merge(label: options[:label] || label_for(name))
+      )
     end
 
     # Public: Generates a field for hashtaggable type.
@@ -93,9 +96,9 @@ module Decidim
     def hashtaggable_text_field(type, name, locale, options = {})
       content_tag(:div, class: "hashtags__container") do
         if options[:value]
-          send(type, name_with_locale(name, locale), options.merge(label: false, value: options[:value][locale]))
+          send(type, name_with_locale(name, locale), options.merge(label: options[:label], value: options[:value][locale]))
         else
-          send(type, name_with_locale(name, locale), options.merge(label: false))
+          send(type, name_with_locale(name, locale), options.merge(label: options[:label]))
         end
       end
     end

--- a/decidim-core/spec/lib/form_builder_spec.rb
+++ b/decidim-core/spec/lib/form_builder_spec.rb
@@ -131,6 +131,38 @@ module Decidim
           end
         end
       end
+
+      context "with an editor field hashtaggable" do
+        let(:output) do
+          builder.translated :editor, :short_description, hashtaggable: true
+        end
+
+        it "renders a tabbed input hidden for each field and a container for the editor" do
+          expect(parsed.css("label[for='resource_short_description']")).not_to be_empty
+
+          expect(parsed.css("li.tabs-title a").count).to eq 3
+          expect(parsed.css(".editor.hashtags__container").count).to eq 3
+
+          expect(parsed.css(".editor label[for='resource_short_description_en']").first).to be_nil
+
+          expect(parsed.css(".tabs-panel .editor input[type='hidden'][name='resource[short_description_ca]']")).not_to be_empty
+          expect(parsed.css(".tabs-panel .editor input[type='hidden'][name='resource[short_description_en]']")).not_to be_empty
+          expect(parsed.css(".tabs-panel .editor input[type='hidden'][name='resource[short_description_de__CH]']")).not_to be_empty
+
+          expect(parsed.css(".tabs-panel .editor .editor-container").count).to eq 3
+        end
+
+        context "with a single locale" do
+          let(:available_locales) { %w(en) }
+
+          it "renders a single input and a container for the editor" do
+            expect(parsed.css(".editor-container.js-hashtags").count).to eq 1
+            expect(parsed.css(".editor input[type='hidden'][name='resource[short_description_en]']")).not_to be_empty
+            expect(parsed.css(".editor label[for='resource_short_description_en']")).not_to be_empty
+            expect(parsed.css(".editor .editor-container")).not_to be_empty
+          end
+        end
+      end
     end
 
     describe "categories_for_select" do

--- a/decidim-meetings/spec/shared/manage_meetings_examples.rb
+++ b/decidim-meetings/spec/shared/manage_meetings_examples.rb
@@ -12,6 +12,71 @@ shared_examples "manage meetings" do
     stub_geocoding(address, [latitude, longitude])
   end
 
+  describe "when rendering the text in the update page" do
+    context "when there are multiple locales" do
+      before do
+        click_link "Edit"
+      end
+
+      it "shows the title correctly in all available locales" do
+        within "#meeting-title-tabs" do
+          click_link "English"
+        end
+        expect(page).to have_css("input", text: meeting.title[:en], visible: true)
+
+        within "#meeting-title-tabs" do
+          click_link "Català"
+        end
+        expect(page).to have_css("input", text: meeting.title[:ca], visible: true)
+
+        within "#meeting-title-tabs" do
+          click_link "Castellano"
+        end
+        expect(page).to have_css("input", text: meeting.title[:es], visible: true)
+      end
+
+      it "shows the description correctly in all available locales" do
+        within "#meeting-description-tabs" do
+          click_link "English"
+        end
+        expect(page).to have_css("input", text: meeting.description[:en], visible: true)
+
+        within "#meeting-description-tabs" do
+          click_link "Català"
+        end
+        expect(page).to have_css("input", text: meeting.description[:ca], visible: true)
+
+        within "#meeting-description-tabs" do
+          click_link "Castellano"
+        end
+        expect(page).to have_css("input", text: meeting.description[:es], visible: true)
+      end
+    end
+
+    context "when there is only one locale" do
+      let(:organization) { create :organization, available_locales: [:en] }
+      let(:component) { create(:component, manifest_name: manifest_name, organization: organization) }
+      let!(:meeting) do
+        create(:meeting, scope: scope, services: [], component: component,
+                         title: { en: "Title" }, description: { en: "Description" })
+      end
+
+      before do
+        click_link "Edit"
+      end
+
+      it "shows the title correctly" do
+        expect(page).not_to have_css("#meeting-title-tabs")
+        expect(page).to have_css("input", text: meeting.title[:en], visible: true)
+      end
+
+      it "shows the description correctly" do
+        expect(page).not_to have_css("#meeting-description-tabs")
+        expect(page).to have_css("input", text: meeting.description[:en], visible: true)
+      end
+    end
+  end
+
   it "updates a meeting" do
     within find("tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title) do
       click_link "Edit"


### PR DESCRIPTION
#### :tophat: What? Why?
>This PR solves a bug when editing a meeting with an organization with only one locale, the form isn't rendering correctly the hashtaggable attributes.

Backport #4623 to 0.15

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests