### PR TITLE
Fix searching for initiatives by type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,7 @@ In order to generate Open Data exports you should add this to your crontab or re
 - **decidim-meetings**: Add the participatory space to the meeting directory listing [\#4620](https://github.com/decidim/decidim/pull/4620)
 - **decidim-core**: Fix nickname generation [\#4615](https://github.com/decidim/decidim/pull/4615)
 - **decidim-initiatives**: Don't eager load polymorphic relations [\#4614](https://github.com/decidim/decidim/pull/4614)
+- **decidim-initiatives**: Fix searching for initiatives with by type [\#4626](https://github.com/decidim/decidim/pull/4626)
 
 **Removed**:
 

--- a/decidim-initiatives/app/services/decidim/initiatives/initiative_search.rb
+++ b/decidim-initiatives/app/services/decidim/initiatives/initiative_search.rb
@@ -15,7 +15,7 @@ module Decidim
 
       def base_query
         Decidim::Initiative
-          .includes(:author, scoped_type: [:scope])
+          .includes(scoped_type: [:scope])
           .where(organization: options[:organization])
       end
 
@@ -44,12 +44,9 @@ module Decidim
       def search_type
         return query if type == "all"
 
-        query
-          .joins(:scoped_type)
-          .where(
-            "decidim_initiatives_type_scopes.decidim_initiatives_types_id IN (?)",
-            type
-          )
+        types = InitiativesTypeScope.where(decidim_initiatives_types_id: type).pluck(:id)
+
+        query.where(scoped_type: types)
       end
 
       def search_author


### PR DESCRIPTION
#### :tophat: What? Why?

Don't crash when filtering initiatives with a type.

#### :pushpin: Related Issues

- Fixes #4426

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
