### PR TITLE
Use bigint instead of int for projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,7 @@ In order to generate Open Data exports you should add this to your crontab or re
 - **decidim-core**: Fix nickname generation [\#4615](https://github.com/decidim/decidim/pull/4615)
 - **decidim-initiatives**: Don't eager load polymorphic relations [\#4614](https://github.com/decidim/decidim/pull/4614)
 - **decidim-initiatives**: Fix searching for initiatives with by type [\#4626](https://github.com/decidim/decidim/pull/4626)
+- **decidim-budgets**: Use bigint instead of int for projects [\#4628](https://github.com/decidim/decidim/pull/4628)
 
 **Removed**:
 

--- a/decidim-budgets/db/migrate/20181205141115_use_big_ints_for_budgets.rb
+++ b/decidim-budgets/db/migrate/20181205141115_use_big_ints_for_budgets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UseBigIntsForBudgets < ActiveRecord::Migration[5.2]
   def change
     change_column :decidim_budgets_projects, :budget, :bigint

--- a/decidim-budgets/db/migrate/20181205141115_use_big_ints_for_budgets.rb
+++ b/decidim-budgets/db/migrate/20181205141115_use_big_ints_for_budgets.rb
@@ -1,0 +1,5 @@
+class UseBigIntsForBudgets < ActiveRecord::Migration[5.2]
+  def change
+    change_column :decidim_budgets_projects, :budget, :bigint
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Use bigint instead of int for the budget of a project.

#### :pushpin: Related Issues

- Fixes #4546

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
