### PR TITLE
Fix newsletter rendering when locale content is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,7 @@ In order to generate Open Data exports you should add this to your crontab or re
 - **decidim-core**: Fix nickname generation [\#4615](https://github.com/decidim/decidim/pull/4615)
 - **decidim-initiatives**: Don't eager load polymorphic relations [\#4614](https://github.com/decidim/decidim/pull/4614)
 - **decidim-initiatives**: Fix searching for initiatives with by type [\#4626](https://github.com/decidim/decidim/pull/4626)
+- **decidim-core**: Fix newsletter rendering when locale content is missing [\#4629](https://github.com/decidim/decidim/pull/4629)
 
 **Removed**:
 

--- a/decidim-core/app/mailers/decidim/newsletter_mailer.rb
+++ b/decidim-core/app/mailers/decidim/newsletter_mailer.rb
@@ -16,9 +16,13 @@ module Decidim
 
       @custom_url_for_mail_root = custom_url_for_mail_root(@organization, @newsletter.id) if Decidim.config.track_newsletter_links
       @encrypted_token = Decidim::NewsletterEncryptor.sent_at_encrypted(@user.id, @newsletter.sent_at)
+
       with_user(user) do
-        @subject = parse_interpolations(@newsletter.subject[I18n.locale.to_s], user, @newsletter.id)
-        @body = parse_interpolations(@newsletter.body[I18n.locale.to_s], user, @newsletter.id)
+        subject = @newsletter.subject[I18n.locale.to_s].presence || @newsletter.subject[@organization.default_locale]
+        body = @newsletter.body[I18n.locale.to_s].presence || @newsletter.body[@organization.default_locale]
+
+        @subject = parse_interpolations(subject, user, @newsletter.id)
+        @body = parse_interpolations(body, user, @newsletter.id)
 
         mail(to: "#{user.name} <#{user.email}>", subject: @subject)
       end

--- a/decidim-core/spec/mailers/newsletter_mailer_spec.rb
+++ b/decidim-core/spec/mailers/newsletter_mailer_spec.rb
@@ -32,6 +32,43 @@ module Decidim
       it "parses the body" do
         expect(email_body(mail)).to include("Content for Sarah Connor")
       end
+
+      context "when the user has a different locale" do
+        before do
+          user.locale = "ca"
+          user.save!
+        end
+
+        it "parses the subject in the user's locale" do
+          expect(mail.subject).to eq("Email per Sarah Connor")
+        end
+
+        it "parses the body in the user's locale" do
+          expect(email_body(mail)).to include("Contingut per Sarah Connor")
+        end
+
+        context "when there's no content in the user's locale" do
+          let(:newsletter) do
+            create(:newsletter,
+                   organization: organization,
+                   subject: {
+                     en: "Email for %{name}",
+                     ca: "",
+                     es: "Email para %{name}"
+                   },
+                   body: {
+                     en: "Content for %{name}",
+                     ca: "",
+                     es: "Contenido para %{name}"
+                   })
+          end
+
+          it "fallbacks to the default one" do
+            expect(mail.subject).to eq("Email for Sarah Connor")
+            expect(email_body(mail)).to include("Content for Sarah Connor")
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Fallback to default locale if we can't find content for the user's locale in a newsletter.

#### :pushpin: Related Issues
- Fixes #4527

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
