### PR TITLE
Don't crash when a log is in an unavailable locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,7 @@ In order to generate Open Data exports you should add this to your crontab or re
 - **decidim-core**: Fix nickname generation [\#4615](https://github.com/decidim/decidim/pull/4615)
 - **decidim-initiatives**: Don't eager load polymorphic relations [\#4614](https://github.com/decidim/decidim/pull/4614)
 - **decidim-initiatives**: Fix searching for initiatives with by type [\#4626](https://github.com/decidim/decidim/pull/4626)
+- **decidim-core**: Don't crash when a log is in an unavailable locale [\#4632](https://github.com/decidim/decidim/pull/4632)
 
 **Removed**:
 

--- a/decidim-core/app/services/decidim/log/diff_changeset_calculator.rb
+++ b/decidim-core/app/services/decidim/log/diff_changeset_calculator.rb
@@ -127,7 +127,9 @@ module Decidim
                 end
         return label unless locale
 
-        locale_name = I18n.t("locale.name", locale: locale)
+        locale_name = I18n.t("locale.name", locale: locale) if I18n.available_locales.include?(locale.to_sym)
+        locale_name ||= locale
+
         "#{label} (#{locale_name})"
       end
     end

--- a/decidim-core/spec/services/decidim/log/diff_changeset_calculator_spec.rb
+++ b/decidim-core/spec/services/decidim/log/diff_changeset_calculator_spec.rb
@@ -95,6 +95,23 @@ describe Decidim::Log::DiffChangesetCalculator do
           expect(subject.first).to include(label: "My field (English)", previous_value: "Foo", new_value: nil)
           expect(subject.last).to include(label: "My field (Català)", previous_value: nil, new_value: "Bar")
         end
+
+        context "when a changeset has an unexisting locale" do
+          let(:changeset) do
+            {
+              field: [
+                { "en" => "Foo", "zn" => "Bar" },
+                { "en" => "Doe", "zn" => "Doe" }
+              ]
+            }
+          end
+
+          it "doesn't try to generate a nice label" do
+            expect(subject.count).to eq 2
+            expect(subject.first).to include(label: "My field (English)", previous_value: "Foo", new_value: "Doe")
+            expect(subject.last).to include(label: "My field (zn)", previous_value: "Bar", new_value: "Doe")
+          end
+        end
       end
 
       context "when i18n labels scope is not set" do


### PR DESCRIPTION
#### :tophat: What? Why?

Use the locale name instead of trying to generate a label.

#### :pushpin: Related Issues

- Fixes #4373

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
