### PR TITLE
Add missing locales for organization errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,7 @@ In order to generate Open Data exports you should add this to your crontab or re
 - **decidim-core**: Fix nickname generation [\#4615](https://github.com/decidim/decidim/pull/4615)
 - **decidim-initiatives**: Don't eager load polymorphic relations [\#4614](https://github.com/decidim/decidim/pull/4614)
 - **decidim-initiatives**: Fix searching for initiatives with by type [\#4626](https://github.com/decidim/decidim/pull/4626)
+- **decidim-admin**: Add missing locales for organization errors [\#4633](https://github.com/decidim/decidim/pull/4633)
 
 **Removed**:
 

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -99,6 +99,12 @@ en:
           attributes:
             redirect_uri:
               must_be_ssl: The redirect URI must be a SSL URI
+        organization:
+          attributes:
+            official_img_header:
+              allowed_file_content_types: Invalid image file
+            official_img_footer:
+              allowed_file_content_types: Invalid image file
   activerecord:
     attributes:
       decidim/static_page:


### PR DESCRIPTION
#### :tophat: What? Why?

Adds missing locales when there's an error when uploading an organization image.

#### :pushpin: Related Issues

- Fixes #4609

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

