### PR TITLE
Add notification to conferences and meetings registrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ In order to generate Open Data exports you should add this to your crontab or re
 
 **Added**:
 
+- **decidim-meetings**: Add notification to conferences and meetings registrations [\#4636](https://github.com/decidim/decidim/pull/4636/)
 - **decidim-proposals**: Add amend button and amendments counter to participatory text proposals [\#4598](https://github.com/decidim/decidim/pull/4598/)
 - **decidim-proposals**: Add filter by type functionality to Amendments on proposals. [\#4567](https://github.com/decidim/decidim/pull/4567/)
 - **decidim-proposals**: Add version control functionality to Amendments on proposals. [\#4567](https://github.com/decidim/decidim/pull/4567/)

--- a/decidim-conferences/app/commands/decidim/conferences/admin/confirm_conference_registration.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/confirm_conference_registration.rb
@@ -54,8 +54,11 @@ module Decidim
         end
 
         def send_email_confirmation
-          Decidim::Conferences::ConferenceRegistrationMailer.confirmation(@conference_registration.user,
-                                                                          @conference_registration.conference, @conference_registration.registration_type).deliver_later
+          Decidim::Conferences::ConferenceRegistrationMailer.confirmation(
+            @conference_registration.user,
+            @conference_registration.conference,
+            @conference_registration.registration_type
+          ).deliver_later
         end
 
         def send_notification_confirmation

--- a/decidim-conferences/app/commands/decidim/conferences/admin/confirm_conference_registration.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/confirm_conference_registration.rb
@@ -22,6 +22,7 @@ module Decidim
             return broadcast(:invalid) unless can_join_conference?
             confirm_registration
             send_email_confirmation
+            send_notification_confirmation
           end
           broadcast(:ok)
         end
@@ -55,6 +56,15 @@ module Decidim
         def send_email_confirmation
           Decidim::Conferences::ConferenceRegistrationMailer.confirmation(@conference_registration.user,
                                                                           @conference_registration.conference, @conference_registration.registration_type).deliver_later
+        end
+
+        def send_notification_confirmation
+          Decidim::EventsManager.publish(
+            event: "decidim.events.conferences.conference_registration_confirmed",
+            event_class: Decidim::Conferences::ConferenceRegistrationNotificationEvent,
+            resource: @conference_registration.conference,
+            recipient_ids: [@conference_registration.user.id]
+          )
         end
       end
     end

--- a/decidim-conferences/app/commands/decidim/conferences/join_conference.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/join_conference.rb
@@ -26,7 +26,8 @@ module Decidim
           create_meetings_registrations
           accept_invitation
           send_email_pending_validation
-          send_notification
+          send_notification_pending_validation
+          notify_admin_over_percentage
         end
         broadcast(:ok)
       end
@@ -60,11 +61,20 @@ module Decidim
         Decidim::Conferences::ConferenceRegistrationMailer.pending_validation(user, conference, @registration_type).deliver_later
       end
 
+      def send_notification_pending_validation
+        Decidim::EventsManager.publish(
+          event: "decidim.events.conferences.conference_registration_validation_pending",
+          event_class: Decidim::Conferences::ConferenceRegistrationNotificationEvent,
+          resource: @conference,
+          recipient_ids: [@user.id]
+        )
+      end
+
       def participatory_space_admins
         @conference.admins
       end
 
-      def send_notification
+      def notify_admin_over_percentage
         return send_notification_over(0.5) if occupied_slots_over?(0.5)
         return send_notification_over(0.8) if occupied_slots_over?(0.8)
         send_notification_over(1.0) if occupied_slots_over?(1.0)

--- a/decidim-conferences/app/events/decidim/conferences/conference_registration_notification_event.rb
+++ b/decidim-conferences/app/events/decidim/conferences/conference_registration_notification_event.rb
@@ -1,0 +1,21 @@
+# frozen-string_literal: true
+
+module Decidim
+  module Conferences
+    class ConferenceRegistrationNotificationEvent < Decidim::Events::BaseEvent
+      include Decidim::Events::NotificationEvent
+
+      def notification_title
+        I18n.t("notification_title", i18n_options).html_safe
+      end
+
+      def i18n_options
+        {
+          resource_title: resource_title,
+          resource_url: resource_url,
+          scope: event_name
+        }
+      end
+    end
+  end
+end

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -507,6 +507,10 @@ en:
         votes_count: Votes
     events:
       conferences:
+        conference_registration_validation_pending:
+          notification_title: Your registration for the conference <a href="%{resource_url}">%{resource_title}</a> is pending to be confirmed.
+        conference_registration_confirmed:
+          notification_title: Your registration for the conference <a href="%{resource_url}">%{resource_title}</a> has been confirmed.
         conference_registrations_over_percentage:
           email_intro: The "%{resource_title}" conference occupied slots are over %{percentage}%.
           email_outro: You have received this notification because you are an admin of the conference's participatory space.

--- a/decidim-conferences/spec/commands/confirm_conference_registration_spec.rb
+++ b/decidim-conferences/spec/commands/confirm_conference_registration_spec.rb
@@ -41,6 +41,19 @@ module Decidim::Conferences
         expect(attachment.mime_type).to eq("text/calendar")
         expect(attachment.filename).to match(/conference-calendar-info.ics/)
       end
+
+      it "sends a notification to the user with the pending validation" do
+        expect(Decidim::EventsManager)
+          .to receive(:publish)
+          .with(
+            event: "decidim.events.conferences.conference_registration_confirmed",
+            event_class: Decidim::Conferences::ConferenceRegistrationNotificationEvent,
+            resource: conference,
+            recipient_ids: [user.id]
+          )
+
+        subject.call
+      end
     end
   end
 end

--- a/decidim-conferences/spec/commands/join_conference_spec.rb
+++ b/decidim-conferences/spec/commands/join_conference_spec.rb
@@ -15,16 +15,16 @@ module Decidim::Conferences
     let(:user) { create :user, :confirmed, organization: organization }
     let(:participatory_space_admins) { conference.admins }
 
-    let(:user_notification_params) do
+    let(:user_notification) do
       {
         event: "decidim.events.conferences.conference_registration_validation_pending",
-        event_class: Decidim::Conferences::ConferenceRegistrationNotificationEvent,
+        event_class: ConferenceRegistrationNotificationEvent,
         resource: conference,
         recipient_ids: [user.id]
       }
     end
 
-    let(:admin_notification_params) do
+    let(:admin_notification) do
       {
         event: "decidim.events.conferences.conference_registrations_over_percentage",
         event_class: ConferenceRegistrationsOverPercentageEvent,
@@ -56,7 +56,7 @@ module Decidim::Conferences
       end
 
       it "sends a notification to the user with the pending validation" do
-        expect(Decidim::EventsManager).to receive(:publish).with(user_notification_params)
+        expect(Decidim::EventsManager).to receive(:publish).with(user_notification)
 
         subject.call
       end
@@ -77,9 +77,8 @@ module Decidim::Conferences
         end
 
         it "also sends a notification to the process admins" do
-          expect(Decidim::EventsManager).to receive(:publish).with(user_notification_params)
-
-          expect(Decidim::EventsManager).to receive(:publish).with(admin_notification_params)
+          expect(Decidim::EventsManager).to receive(:publish).with(user_notification)
+          expect(Decidim::EventsManager).to receive(:publish).with(admin_notification)
 
           subject.call
         end
@@ -90,7 +89,7 @@ module Decidim::Conferences
           end
 
           it "doesn't notify it twice to the process admins" do
-            expect(Decidim::EventsManager).not_to receive(:publish).with(admin_notification_params)
+            expect(Decidim::EventsManager).not_to receive(:publish).with(admin_notification)
 
             subject.call
           end
@@ -105,9 +104,8 @@ module Decidim::Conferences
         end
 
         it "also sends a notification to the process admins" do
-          expect(Decidim::EventsManager).to receive(:publish).with(user_notification_params)
-
-          expect(Decidim::EventsManager).to receive(:publish).with(admin_notification_params)
+          expect(Decidim::EventsManager).to receive(:publish).with(user_notification)
+          expect(Decidim::EventsManager).to receive(:publish).with(admin_notification)
 
           subject.call
         end
@@ -118,7 +116,7 @@ module Decidim::Conferences
           end
 
           it "doesn't notify it twice to the process admins" do
-            expect(Decidim::EventsManager).not_to receive(:publish).with(admin_notification_params)
+            expect(Decidim::EventsManager).not_to receive(:publish).with(admin_notification)
 
             subject.call
           end
@@ -133,9 +131,8 @@ module Decidim::Conferences
         end
 
         it "also sends a notification to the process admins" do
-          expect(Decidim::EventsManager).to receive(:publish).with(user_notification_params)
-
-          expect(Decidim::EventsManager).to receive(:publish).with(admin_notification_params)
+          expect(Decidim::EventsManager).to receive(:publish).with(user_notification)
+          expect(Decidim::EventsManager).to receive(:publish).with(admin_notification)
 
           subject.call
         end

--- a/decidim-conferences/spec/commands/join_conference_spec.rb
+++ b/decidim-conferences/spec/commands/join_conference_spec.rb
@@ -15,6 +15,25 @@ module Decidim::Conferences
     let(:user) { create :user, :confirmed, organization: organization }
     let(:participatory_space_admins) { conference.admins }
 
+    let(:user_notification_params) do
+      {
+        event: "decidim.events.conferences.conference_registration_validation_pending",
+        event_class: Decidim::Conferences::ConferenceRegistrationNotificationEvent,
+        resource: conference,
+        recipient_ids: [user.id]
+      }
+    end
+
+    let(:admin_notification_params) do
+      {
+        event: "decidim.events.conferences.conference_registrations_over_percentage",
+        event_class: ConferenceRegistrationsOverPercentageEvent,
+        resource: conference,
+        recipient_ids: participatory_space_admins.pluck(:id),
+        extra: extra
+      }
+    end
+
     context "when everything is ok" do
       it "broadcasts ok" do
         expect { subject.call }.to broadcast(:ok)
@@ -36,6 +55,12 @@ module Decidim::Conferences
         expect(email.body.encoded).to include(translated(registration_type.title))
       end
 
+      it "sends a notification to the user with the pending validation" do
+        expect(Decidim::EventsManager).to receive(:publish).with(user_notification_params)
+
+        subject.call
+      end
+
       context "and exists and invite for the user" do
         let!(:conference_invite) { create(:conference_invite, conference: conference, user: user) }
 
@@ -45,22 +70,16 @@ module Decidim::Conferences
       end
 
       context "when the conference available slots are occupied over the 50%" do
+        let(:extra) { { percentage: 0.5 } }
+
         before do
           create_list :conference_registration, (available_slots * 0.5).round - 1, conference: conference
         end
 
-        it "notifies it to the process admins" do
-          expect(Decidim::EventsManager)
-            .to receive(:publish)
-            .with(
-              event: "decidim.events.conferences.conference_registrations_over_percentage",
-              event_class: ConferenceRegistrationsOverPercentageEvent,
-              resource: conference,
-              recipient_ids: participatory_space_admins.pluck(:id),
-              extra: {
-                percentage: 0.5
-              }
-            )
+        it "also sends a notification to the process admins" do
+          expect(Decidim::EventsManager).to receive(:publish).with(user_notification_params)
+
+          expect(Decidim::EventsManager).to receive(:publish).with(admin_notification_params)
 
           subject.call
         end
@@ -70,9 +89,8 @@ module Decidim::Conferences
             create :conference_registration, conference: conference
           end
 
-          it "doesn't notify it twice" do
-            expect(Decidim::EventsManager)
-              .not_to receive(:publish)
+          it "doesn't notify it twice to the process admins" do
+            expect(Decidim::EventsManager).not_to receive(:publish).with(admin_notification_params)
 
             subject.call
           end
@@ -80,22 +98,16 @@ module Decidim::Conferences
       end
 
       context "when the conference available slots are occupied over the 80%" do
+        let(:extra) { { percentage: 0.8 } }
+
         before do
           create_list :conference_registration, (available_slots * 0.8).round - 1, conference: conference
         end
 
-        it "notifies it to the process admins" do
-          expect(Decidim::EventsManager)
-            .to receive(:publish)
-            .with(
-              event: "decidim.events.conferences.conference_registrations_over_percentage",
-              event_class: ConferenceRegistrationsOverPercentageEvent,
-              resource: conference,
-              recipient_ids: participatory_space_admins.pluck(:id),
-              extra: {
-                percentage: 0.8
-              }
-            )
+        it "also sends a notification to the process admins" do
+          expect(Decidim::EventsManager).to receive(:publish).with(user_notification_params)
+
+          expect(Decidim::EventsManager).to receive(:publish).with(admin_notification_params)
 
           subject.call
         end
@@ -105,9 +117,8 @@ module Decidim::Conferences
             create_list :conference_registration, (available_slots * 0.8).round, conference: conference
           end
 
-          it "doesn't notify it twice" do
-            expect(Decidim::EventsManager)
-              .not_to receive(:publish)
+          it "doesn't notify it twice to the process admins" do
+            expect(Decidim::EventsManager).not_to receive(:publish).with(admin_notification_params)
 
             subject.call
           end
@@ -115,22 +126,16 @@ module Decidim::Conferences
       end
 
       context "when the conference available slots are occupied over the 100%" do
+        let(:extra) { { percentage: 1 } }
+
         before do
           create_list :conference_registration, available_slots - 1, conference: conference
         end
 
-        it "notifies it to the process admins" do
-          expect(Decidim::EventsManager)
-            .to receive(:publish)
-            .with(
-              event: "decidim.events.conferences.conference_registrations_over_percentage",
-              event_class: ConferenceRegistrationsOverPercentageEvent,
-              resource: conference,
-              recipient_ids: participatory_space_admins.pluck(:id),
-              extra: {
-                percentage: 1
-              }
-            )
+        it "also sends a notification to the process admins" do
+          expect(Decidim::EventsManager).to receive(:publish).with(user_notification_params)
+
+          expect(Decidim::EventsManager).to receive(:publish).with(admin_notification_params)
 
           subject.call
         end

--- a/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
@@ -73,7 +73,7 @@ module Decidim
           resource: @meeting,
           recipient_ids: [@user.id],
           extra: {
-            registration: Decidim::Meetings::Registration.last
+            registration_code: Decidim::Meetings::Registration.last.code
           }
         )
       end

--- a/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
@@ -51,7 +51,7 @@ module Decidim
       end
 
       def create_registration
-        Decidim::Meetings::Registration.create!(meeting: meeting, user: user)
+        @registration = Decidim::Meetings::Registration.create!(meeting: meeting, user: user)
       end
 
       def can_join_meeting?
@@ -62,7 +62,7 @@ module Decidim
         Decidim::Meetings::RegistrationMailer.confirmation(
           @user,
           @meeting,
-          Decidim::Meetings::Registration.last
+          @registration
         ).deliver_now
       end
 
@@ -73,7 +73,7 @@ module Decidim
           resource: @meeting,
           recipient_ids: [@user.id],
           extra: {
-            registration_code: Decidim::Meetings::Registration.last.code
+            registration_code: @registration.code
           }
         )
       end

--- a/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
@@ -50,7 +50,7 @@ module Decidim
       end
 
       def create_registration
-        @registration = Decidim::Meetings::Registration.create!(meeting: meeting, user: user)
+        Decidim::Meetings::Registration.create!(meeting: meeting, user: user)
       end
 
       def can_join_meeting?
@@ -58,6 +58,7 @@ module Decidim
       end
 
       def send_email_confirmation
+        registration = Decidim::Meetings::Registration.last
         Decidim::Meetings::RegistrationMailer.confirmation(user, meeting, registration).deliver_later
       end
 

--- a/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
@@ -31,7 +31,8 @@ module Decidim
           create_registration
           accept_invitation
           send_email_confirmation
-          send_notification
+          send_notification_confirmation
+          notify_admin_over_percentage
           increment_score
         end
         broadcast(:ok)
@@ -58,15 +59,30 @@ module Decidim
       end
 
       def send_email_confirmation
-        registration = Decidim::Meetings::Registration.last
-        Decidim::Meetings::RegistrationMailer.confirmation(user, meeting, registration).deliver_later
+        Decidim::Meetings::RegistrationMailer.confirmation(
+          @user,
+          @meeting,
+          Decidim::Meetings::Registration.last
+        ).deliver_now
+      end
+
+      def send_notification_confirmation
+        Decidim::EventsManager.publish(
+          event: "decidim.events.meetings.meeting_registration_confirmed",
+          event_class: Decidim::Meetings::MeetingRegistrationNotificationEvent,
+          resource: @meeting,
+          recipient_ids: [@user.id],
+          extra: {
+            registration: Decidim::Meetings::Registration.last
+          }
+        )
       end
 
       def participatory_space_admins
         @meeting.component.participatory_space.admins
       end
 
-      def send_notification
+      def notify_admin_over_percentage
         return send_notification_over(0.5) if occupied_slots_over?(0.5)
         return send_notification_over(0.8) if occupied_slots_over?(0.8)
         send_notification_over(1.0) if occupied_slots_over?(1.0)

--- a/decidim-meetings/app/events/decidim/meetings/meeting_registration_notification_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/meeting_registration_notification_event.rb
@@ -14,7 +14,7 @@ module Decidim
           resource_title: resource_title,
           resource_url: resource_url,
           scope: event_name,
-          registration_code: extra["registration"]["code"]
+          registration_code: extra["registration_code"]
         }
       end
     end

--- a/decidim-meetings/app/events/decidim/meetings/meeting_registration_notification_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/meeting_registration_notification_event.rb
@@ -1,0 +1,22 @@
+# frozen-string_literal: true
+
+module Decidim
+  module Meetings
+    class MeetingRegistrationNotificationEvent < Decidim::Events::BaseEvent
+      include Decidim::Events::NotificationEvent
+
+      def notification_title
+        I18n.t("notification_title", i18n_options).html_safe
+      end
+
+      def i18n_options
+        {
+          resource_title: resource_title,
+          resource_url: resource_url,
+          scope: event_name,
+          registration_code: extra["registration"]["code"]
+        }
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/helpers/decidim/meetings/meetings_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/meetings_helper.rb
@@ -87,6 +87,16 @@ module Decidim
         end
         html.html_safe
       end
+
+      def registration
+        @registration ||= Decidim::Meetings::Registration
+                          .where(decidim_user_id: current_user)
+                          .find_by(decidim_meeting_id: @meeting.id)
+      end
+
+      def registration_validation_state
+        @registration.validated_at ? "VALIDATED" : "VALIDATION PENDING"
+      end
     end
   end
 end

--- a/decidim-meetings/app/helpers/decidim/meetings/meetings_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/meetings_helper.rb
@@ -94,8 +94,16 @@ module Decidim
                           .find_by(decidim_meeting_id: @meeting.id)
       end
 
+      def registration_code_help_text
+        t("registration_code_help_text", scope: "decidim.meetings.meetings.show")
+      end
+
       def registration_validation_state
-        @registration.validated_at ? "VALIDATED" : "VALIDATION PENDING"
+        if @registration.validated_at
+          t("validated", scope: "decidim.meetings.meetings.show.registration_state")
+        else
+          t("validation_pending", scope: "decidim.meetings.meetings.show.registration_state")
+        end
       end
     end
   end

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -61,15 +61,15 @@ edit_link(
     </div>
 
     <% if registration %>
-    <div class="card extra">
-      <div class="card__content">
-          <div class="registration_code">
-            <span>Your registration code</span>
-            <span><strong><%= registration.code %></strong></span>
-            <div class="text-small"><%= registration_validation_state %></div>
-          </div>
+      <div class="card extra">
+        <div class="card__content">
+            <div class="registration_code">
+              <span><%= registration_code_help_text %></span>
+              <span><strong><%= registration.code %></strong></span>
+              <div class="text-small"><%= registration_validation_state %></div>
+            </div>
+        </div>
       </div>
-    </div>
     <% end %>
 
     <% if meeting.services.any? %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -60,6 +60,18 @@ edit_link(
       <% end %>
     </div>
 
+    <% if registration %>
+    <div class="card extra">
+      <div class="card__content">
+          <div class="registration_code">
+            <span>Your registration code</span>
+            <span><strong><%= registration.code %></strong></span>
+            <div class="text-small"><%= registration_validation_state %></div>
+          </div>
+      </div>
+    </div>
+    <% end %>
+
     <% if meeting.services.any? %>
       <div class="card card--list">
         <% meeting.services.each do |service| %>

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -112,7 +112,7 @@ en:
           email_subject: The "%{resource_title}" meeting was updated
           notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting was updated.
         registration_code_validated:
-          email_intro: Your registration code %{registration_code} for the "%{resource_title}" meeting has been validated.
+          email_intro: Your registration code "%{registration_code}" for the "%{resource_title}" meeting has been validated.
           email_outro: You have received this notification because your registration code for the "%{resource_title}" meeting has been validated.
           email_subject: Your registration code "%{registration_code}" for the "%{resource_title}" meeting has been validated
           notification_title: Your registration code "%{registration_code}" for the <a href="%{resource_path}">%{resource_title}</a> meeting has been validated.

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -112,7 +112,7 @@ en:
           email_subject: The "%{resource_title}" meeting was updated
           notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting was updated.
         registration_code_validated:
-          email_intro: Your registration code "%{registration_code}" for the "%{resource_title}" meeting has been validated.
+          email_intro: Your registration code %{registration_code} for the "%{resource_title}" meeting has been validated.
           email_outro: You have received this notification because your registration code for the "%{resource_title}" meeting has been validated.
           email_subject: Your registration code "%{registration_code}" for the "%{resource_title}" meeting has been validated
           notification_title: Your registration code "%{registration_code}" for the <a href="%{resource_path}">%{resource_title}</a> meeting has been validated.

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -364,6 +364,10 @@ en:
           meeting_report: Meeting report
           no_slots_available: No slots available
           organizations: Attending organizations
+          registration_code_help_text: Your registration code
+          registration_state:
+            validated: VALIDATED
+            validation_pending: VALIDATION PENDING
           remaining_slots:
             one: "%{count} slot remaining"
             other: "%{count} slots remaining"

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -99,6 +99,8 @@ en:
           email_outro: You have received this notification because you are following "%{participatory_space_title}". You can unfollow it from the previous link.
           email_subject: New meeting added to %{participatory_space_title}
           notification_title: The meeting <a href="%{resource_path}">%{resource_title}</a> has been added to %{participatory_space_title}
+        meeting_registration_confirmed:
+          notification_title: Your registration for the meeting <a href="%{resource_url}">%{resource_title}</a> has been confirmed. Your registration code is %{registration_code}.
         meeting_registrations_over_percentage:
           email_intro: The "%{resource_title}" meeting occupied slots are over %{percentage}%.
           email_outro: You have received this notification because you are an admin of the meeting's participatory space.

--- a/decidim-meetings/spec/commands/join_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/join_meeting_spec.rb
@@ -17,6 +17,28 @@ module Decidim::Meetings
     let(:meeting) { create :meeting, component: component, registrations_enabled: registrations_enabled, available_slots: available_slots, questionnaire: questionnaire }
     let(:user) { create :user, :confirmed, organization: organization, email_on_notification: false }
 
+    let(:user_notification) do
+      {
+        event: "decidim.events.meetings.meeting_registration_confirmed",
+        event_class: MeetingRegistrationNotificationEvent,
+        resource: meeting,
+        recipient_ids: [user.id],
+        extra: { registration_code: kind_of(String) }
+      }
+    end
+
+    let(:badge_earned) { hash_including(event: "decidim.events.gamification.badge_earned") }
+
+    let(:admin_notification) do
+      {
+        event: "decidim.events.meetings.meeting_registrations_over_percentage",
+        event_class: MeetingRegistrationsOverPercentageEvent,
+        resource: meeting,
+        recipient_ids: [process_admin.id],
+        extra: extra
+      }
+    end
+
     context "when everything is ok" do
       it "broadcasts ok" do
         expect { subject.call }.to broadcast(:ok)
@@ -45,6 +67,13 @@ module Decidim::Meetings
         expect(attachment.filename).to match(/meeting-calendar-info.ics/)
       end
 
+      it "sends a notification to the user with the registration confirmed" do
+        expect(Decidim::EventsManager).to receive(:publish).with(user_notification)
+        expect(Decidim::EventsManager).to receive(:publish).with(badge_earned)
+
+        subject.call
+      end
+
       it "increases the user's score" do
         expect { subject.call }.to change { Decidim::Gamification.status_for(user, :attended_meetings).score }.from(0).to(1)
       end
@@ -58,28 +87,16 @@ module Decidim::Meetings
       end
 
       context "when the meeting available slots are occupied over the 50%" do
+        let(:extra) { { percentage: 0.5 } }
+
         before do
           create_list :registration, (available_slots * 0.5).round - 1, meeting: meeting
         end
 
-        it "notifies it to the process admins" do
-          expect(Decidim::EventsManager)
-            .to receive(:publish)
-            .with(
-              event: "decidim.events.meetings.meeting_registrations_over_percentage",
-              event_class: MeetingRegistrationsOverPercentageEvent,
-              resource: meeting,
-              recipient_ids: [process_admin.id],
-              extra: {
-                percentage: 0.5
-              }
-            ).ordered
-
-          expect(Decidim::EventsManager)
-            .to receive(:publish)
-            .with(
-              hash_including(event: "decidim.events.gamification.badge_earned")
-            ).ordered
+        it "also sends a notification to the process admins" do
+          expect(Decidim::EventsManager).to receive(:publish).with(user_notification)
+          expect(Decidim::EventsManager).to receive(:publish).with(badge_earned)
+          expect(Decidim::EventsManager).to receive(:publish).with(admin_notification)
 
           subject.call
         end
@@ -90,11 +107,7 @@ module Decidim::Meetings
           end
 
           it "doesn't notify it twice" do
-            expect(Decidim::EventsManager)
-              .not_to receive(:publish)
-              .with(
-                hash_including(event: "decidim.events.meetings.meeting_registrations_over_percentage")
-              )
+            expect(Decidim::EventsManager).not_to receive(:publish).with(admin_notification)
 
             subject.call
           end
@@ -102,28 +115,16 @@ module Decidim::Meetings
       end
 
       context "when the meeting available slots are occupied over the 80%" do
+        let(:extra) { { percentage: 0.8 } }
+
         before do
           create_list :registration, (available_slots * 0.8).round - 1, meeting: meeting
         end
 
-        it "notifies it to the process admins" do
-          expect(Decidim::EventsManager)
-            .to receive(:publish)
-            .with(
-              event: "decidim.events.meetings.meeting_registrations_over_percentage",
-              event_class: MeetingRegistrationsOverPercentageEvent,
-              resource: meeting,
-              recipient_ids: [process_admin.id],
-              extra: {
-                percentage: 0.8
-              }
-            )
-
-          expect(Decidim::EventsManager)
-            .to receive(:publish)
-            .with(
-              hash_including(event: "decidim.events.gamification.badge_earned")
-            ).ordered
+        it "also sends a notification to the process admins" do
+          expect(Decidim::EventsManager).to receive(:publish).with(user_notification)
+          expect(Decidim::EventsManager).to receive(:publish).with(badge_earned)
+          expect(Decidim::EventsManager).to receive(:publish).with(admin_notification)
 
           subject.call
         end
@@ -134,11 +135,7 @@ module Decidim::Meetings
           end
 
           it "doesn't notify it twice" do
-            expect(Decidim::EventsManager)
-              .not_to receive(:publish)
-              .with(
-                hash_including(event: "decidim.events.meetings.meeting_registrations_over_percentage")
-              )
+            expect(Decidim::EventsManager).not_to receive(:publish).with(admin_notification)
 
             subject.call
           end
@@ -146,28 +143,16 @@ module Decidim::Meetings
       end
 
       context "when the meeting available slots are occupied over the 100%" do
+        let(:extra) { { percentage: 1 } }
+
         before do
           create_list :registration, available_slots - 1, meeting: meeting
         end
 
-        it "notifies it to the process admins" do
-          expect(Decidim::EventsManager)
-            .to receive(:publish)
-            .with(
-              event: "decidim.events.meetings.meeting_registrations_over_percentage",
-              event_class: MeetingRegistrationsOverPercentageEvent,
-              resource: meeting,
-              recipient_ids: [process_admin.id],
-              extra: {
-                percentage: 1
-              }
-            )
-
-          expect(Decidim::EventsManager)
-            .to receive(:publish)
-            .with(
-              hash_including(event: "decidim.events.gamification.badge_earned")
-            ).ordered
+        it "also sends a notification to the process admins" do
+          expect(Decidim::EventsManager).to receive(:publish).with(user_notification)
+          expect(Decidim::EventsManager).to receive(:publish).with(badge_earned)
+          expect(Decidim::EventsManager).to receive(:publish).with(admin_notification)
 
           subject.call
         end

--- a/decidim-meetings/spec/shared/manage_invites_examples.rb
+++ b/decidim-meetings/spec/shared/manage_invites_examples.rb
@@ -83,10 +83,7 @@ shared_examples "manage invites" do
           end
 
           expect(page).to have_content "successfully"
-
-          within ".card.extra" do
-            expect(page).to have_css(".button", text: "GOING")
-          end
+          expect(page).to have_css(".button", text: "GOING")
         end
 
         it "the invited user sign up into the application and declines the invitation" do
@@ -105,10 +102,7 @@ shared_examples "manage invites" do
           end
 
           expect(page).to have_content "declined the invitation successfully"
-
-          within ".card.extra" do
-            expect(page).to have_css(".button", text: "JOIN MEETING")
-          end
+          expect(page).to have_css(".button", text: "JOIN MEETING")
         end
       end
 
@@ -122,9 +116,7 @@ shared_examples "manage invites" do
 
           visit last_email_link
 
-          within ".card.extra" do
-            expect(page).to have_css(".button", text: "GOING")
-          end
+          expect(page).to have_css(".button", text: "GOING")
         end
 
         it "the invited user declines the invitation" do
@@ -134,9 +126,7 @@ shared_examples "manage invites" do
 
           visit last_email_first_link
 
-          within ".card.extra" do
-            expect(page).to have_css(".button", text: "JOIN MEETING")
-          end
+          expect(page).to have_css(".button", text: "JOIN MEETING")
         end
       end
 
@@ -150,9 +140,7 @@ shared_examples "manage invites" do
 
           visit last_email_link
 
-          within ".card.extra" do
-            expect(page).to have_css(".button", text: "GOING")
-          end
+          expect(page).to have_css(".button", text: "GOING")
         end
 
         it "the invited user declines the invitation" do
@@ -162,9 +150,7 @@ shared_examples "manage invites" do
 
           visit last_email_first_link
 
-          within ".card.extra" do
-            expect(page).to have_css(".button", text: "JOIN MEETING")
-          end
+          expect(page).to have_css(".button", text: "JOIN MEETING")
         end
       end
     end

--- a/decidim-meetings/spec/system/meeting_spec.rb
+++ b/decidim-meetings/spec/system/meeting_spec.rb
@@ -33,36 +33,4 @@ describe "Meeting", type: :system do
       end
     end
   end
-
-  context "when the user is logged in and is registered to the meeting" do
-    let!(:registration) { create(:registration, meeting: meeting, user: user) }
-
-    before do
-      login_as user, scope: :user
-    end
-
-    it "shows the registration code" do
-      visit_meeting
-
-      expect(page).to have_css(".registration_code")
-      expect(page).to have_content(registration.code)
-    end
-
-    context "when showing the registration code validation state" do
-      it "shows validation pending if not validated" do
-        visit_meeting
-
-        expect(registration.validated_at).to be(nil)
-        expect(page).to have_content("VALIDATION PENDING")
-      end
-
-      it "shows validated if validated" do
-        registration.update validated_at: Time.current
-        visit_meeting
-
-        expect(registration.validated_at).not_to be(nil)
-        expect(page).to have_content("VALIDATED")
-      end
-    end
-  end
 end

--- a/decidim-meetings/spec/system/meeting_spec.rb
+++ b/decidim-meetings/spec/system/meeting_spec.rb
@@ -33,4 +33,36 @@ describe "Meeting", type: :system do
       end
     end
   end
+
+  context "when the user is logged in and is registered to the meeting" do
+    let!(:registration) { create(:registration, meeting: meeting, user: user) }
+
+    before do
+      login_as user, scope: :user
+    end
+
+    it "shows the registration code" do
+      visit_meeting
+
+      expect(page).to have_css(".registration_code")
+      expect(page).to have_content(registration.code)
+    end
+
+    context "when showing the registration code validation state" do
+      it "shows validation pending if not validated" do
+        visit_meeting
+
+        expect(registration.validated_at).to be(nil)
+        expect(page).to have_content("VALIDATION PENDING")
+      end
+
+      it "shows validated if validated" do
+        registration.update validated_at: Time.current
+        visit_meeting
+
+        expect(registration.validated_at).not_to be(nil)
+        expect(page).to have_content("VALIDATED")
+      end
+    end
+  end
 end

--- a/decidim-meetings/spec/system/private_meetings_spec.rb
+++ b/decidim-meetings/spec/system/private_meetings_spec.rb
@@ -112,9 +112,7 @@ describe "Private meetings", type: :system do
 
             expect(page).to have_current_path resource_locator(private_meeting).path
             expect(page).to have_content "Private"
-            within ".card.extra" do
-              expect(page).to have_css(".button", text: "GOING")
-            end
+            expect(page).to have_css(".button", text: "GOING")
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
> When I register for a meeting and I have "email notifications" de-activated on my account I don't receive an email with the registration code for the conference. [...] I should receive a notification. [...] It is otherwise impossible to access it. [...] My code should/could also be displayed under the registration button once I am registered [...]

Apart from adding registration notifications, I opted for displaying the registrarion code in the meeting's page as @xabier suggested.
 
#### :pushpin: Related Issues
- Fixes #4607

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)

**Conference registration pending notification:**

![conference_pending_notification](https://user-images.githubusercontent.com/40306853/49647088-9a09d300-fa21-11e8-86e4-29e74da0895f.png)

**Conference registration confirmed notification:**

![conference_confirmed_notification](https://user-images.githubusercontent.com/40306853/49647282-40ee6f00-fa22-11e8-8ff3-c0175fd007e5.png)

**Meeting registration notification:**

![notification](https://user-images.githubusercontent.com/40306853/49647111-af7efd00-fa21-11e8-99d2-48787a99cf55.png)

**Before joining a meeting:**

![join_meeting](https://user-images.githubusercontent.com/40306853/49593414-cd8e2400-f973-11e8-9c2f-c630557f3c59.png)

**After joining a meeting:**

![going_pending](https://user-images.githubusercontent.com/40306853/49593419-cebf5100-f973-11e8-9d96-c158a9ea864b.png)

**After admin validates the registration code for a meeting:**

![going_validated](https://user-images.githubusercontent.com/40306853/49593421-cff07e00-f973-11e8-966f-48dcbd4dd916.png)