### PR TITLE
Better handling setting process step position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,7 @@ In order to generate Open Data exports you should add this to your crontab or re
 - **decidim-initiatives**: Provide a fallback when an initative scope is missing [\#4634](https://github.com/decidim/decidim/pull/4634)
 - **decidim-accountability**: Return a 404 when a result doesn't exist. [\#4630](https://github.com/decidim/decidim/pull/4630)
 - **decidim-budgets**: Use bigint instead of int for projects [\#4628](https://github.com/decidim/decidim/pull/4628)
+- **decidim-core**: Better handling setting process step position [\#4638](https://github.com/decidim/decidim/pull/4638)
 
 **Removed**:
 

--- a/decidim-participatory_processes/app/models/decidim/participatory_process_step.rb
+++ b/decidim-participatory_processes/app/models/decidim/participatory_process_step.rb
@@ -21,7 +21,7 @@ module Decidim
     validates :position, numericality: { greater_than_or_equal_to: 0, only_integer: true }, allow_blank: true
     validates :position, uniqueness: { scope: :decidim_participatory_process_id }
 
-    before_create :set_position
+    before_validation :set_position, on: :create
 
     def self.log_presenter_class_for(_log)
       Decidim::ParticipatoryProcesses::AdminLog::StepPresenter
@@ -42,7 +42,7 @@ module Decidim
       return if position.present?
       return self.position = 0 if participatory_process.steps.select(&:persisted?).empty?
 
-      self.position = participatory_process.steps.pluck(:position).last + 1
+      self.position = participatory_process.steps.maximum(:position) + 1
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

The `position` was set after the validation instead of before, which could cause some race condition errors.

#### :pushpin: Related Issues
- Fixes #4175

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
