### PR TITLE
Disable space deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,10 @@ In order to generate Open Data exports you should add this to your crontab or re
 - **decidim-verifications**: The ID documents verification now supports online and offline verification modes [\#4573](https://github.com/decidim/decidim/pull/4573)
 - **decidim-core**: "Follows" section in user profiles now show every resource they follow [\#4616](https://github.com/decidim/decidim/pull/4616)
 - **decidim-core**: Remove `current_feature` method [\#4624](https://github.com/decidim/decidim/pull/4624)
+- **decidim-participatory-processes**: Disable deleting participatory processes [\#4640](https://github.com/decidim/decidim/pull/4640)
+- **decidim-assemblies**: Disable deleting assemblies [\#4640](https://github.com/decidim/decidim/pull/4640)
+- **decidim-conferences**: Disable deleting conferences [\#4640](https://github.com/decidim/decidim/pull/4640)
+- **decidim-consultations**: Disable deleting consultations[\#4640](https://github.com/decidim/decidim/pull/4640)
 
 **Fixed**:
 

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
@@ -9,7 +9,7 @@ module Decidim
         helper_method :current_assembly, :parent_assembly, :parent_assemblies, :current_participatory_space
         layout "decidim/admin/assemblies"
 
-        before_action :set_all_assemblies, except: [:index, :destroy]
+        before_action :set_all_assemblies, except: [:index]
 
         def index
           enforce_permission_to :read, :assembly_list
@@ -63,15 +63,6 @@ module Decidim
               render :edit, layout: "decidim/admin/assembly"
             end
           end
-        end
-
-        def destroy
-          enforce_permission_to :destroy, :assembly, assembly: current_assembly
-          current_assembly.destroy!
-
-          flash[:notice] = I18n.t("assemblies.destroy.success", scope: "decidim.admin")
-
-          redirect_to assemblies_path
         end
 
         def copy

--- a/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
+++ b/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
@@ -31,7 +31,6 @@ module Decidim
         user_can_read_assembly_list?
         user_can_read_current_assembly?
         user_can_create_assembly?
-        user_can_destroy_assembly?
 
         # org admins and space admins can do everything in the admin section
         org_admin_action?
@@ -143,14 +142,6 @@ module Decidim
         toggle_allow(user.admin?)
       end
 
-      # Only organization admins can destroy a assembly
-      def user_can_destroy_assembly?
-        return unless permission_action.action == :destroy &&
-                      permission_action.subject == :assembly
-
-        toggle_allow(user.admin?)
-      end
-
       # Everyone can read the assembly list
       def user_can_read_assembly_list?
         return unless read_assembly_list_permission_action?
@@ -180,13 +171,11 @@ module Decidim
 
       # Process admins can eprform everything *inside* that assembly. They cannot
       # create a assembly or perform actions on assembly groups or other
-      # assemblies. They cannot destroy their assembly either.
+      # assemblies.
       def assembly_admin_action?
         return unless can_manage_assembly?(role: :admin)
         return if user.admin?
         return disallow! if permission_action.action == :create &&
-                            permission_action.subject == :assembly
-        return disallow! if permission_action.action == :destroy &&
                             permission_action.subject == :assembly
 
         is_allowed = [

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/edit.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/edit.html.erb
@@ -10,9 +10,5 @@
         <%= link_to t("actions.publish", scope: "decidim.admin"), assembly_publish_path(current_assembly), method: :post, class: "button hollow" %>
       <% end %>
     <% end %>
-
-    <% if allowed_to? :destroy, :assembly, assembly: current_assembly %>
-      <%= link_to t("decidim.admin.actions.destroy"), current_assembly, method: :delete, class: "alert button", data: { confirm: t("decidim.admin.actions.confirm_destroy") } %>
-    <% end %>
   </div>
 <% end %>

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -82,8 +82,6 @@ en:
         create:
           error: There was an error creating a new assembly.
           success: Assembly created successfully.
-        destroy:
-          success: Assembly deleted successfully.
         edit:
           update: Update
         form:

--- a/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
@@ -15,7 +15,7 @@ module Decidim
       paths["lib/tasks"] = nil
 
       routes do
-        resources :assemblies, param: :slug, except: :show do
+        resources :assemblies, param: :slug, except: [:show, :destroy] do
           resource :publish, controller: "assembly_publications", only: [:create, :destroy]
           resources :copies, controller: "assembly_copies", only: [:new, :create]
           resources :members, controller: "assembly_members"

--- a/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
+++ b/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
@@ -203,14 +203,6 @@ describe Decidim::Assemblies::Permissions do
     it_behaves_like "access for roles", org_admin: true, admin: false, collaborator: false, moderator: false
   end
 
-  context "when destroying a assembly" do
-    let(:action) do
-      { scope: :admin, action: :destroy, subject: :assembly }
-    end
-
-    it_behaves_like "access for roles", org_admin: true, admin: false, collaborator: false, moderator: false
-  end
-
   context "with a assembly" do
     let(:context) { { assembly: assembly } }
 
@@ -269,14 +261,6 @@ describe Decidim::Assemblies::Permissions do
         it { is_expected.to eq false }
       end
 
-      context "when destroying a assembly" do
-        let(:action) do
-          { scope: :admin, action: :destroy, subject: :assembly }
-        end
-
-        it { is_expected.to eq false }
-      end
-
       shared_examples "allows any action on subject" do |action_subject|
         context "when action subject is #{action_subject}" do
           let(:action) do
@@ -302,14 +286,6 @@ describe Decidim::Assemblies::Permissions do
       context "when creating a assembly" do
         let(:action) do
           { scope: :admin, action: :create, subject: :assembly }
-        end
-
-        it { is_expected.to eq true }
-      end
-
-      context "when destroying a assembly" do
-        let(:action) do
-          { scope: :admin, action: :destroy, subject: :assembly }
         end
 
         it { is_expected.to eq true }

--- a/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
@@ -64,22 +64,6 @@ describe "Admin manages assemblies", type: :system do
     end
   end
 
-  shared_examples "deleting an assembly" do
-    before do
-      click_link translated(assembly.title)
-    end
-
-    it "deletes an assembly" do
-      accept_confirm { click_link "Delete" }
-
-      expect(page).to have_admin_callout("successfully")
-
-      within "table" do
-        expect(page).not_to have_content(translated(assembly.title))
-      end
-    end
-  end
-
   context "when managing parent assemblies" do
     let(:parent_assembly) { nil }
 
@@ -91,7 +75,6 @@ describe "Admin manages assemblies", type: :system do
 
     it_behaves_like "manage assemblies"
     it_behaves_like "creating an assembly"
-    it_behaves_like "deleting an assembly"
   end
 
   context "when managing child assemblies" do
@@ -110,6 +93,5 @@ describe "Admin manages assemblies", type: :system do
 
     it_behaves_like "manage assemblies"
     it_behaves_like "creating an assembly"
-    it_behaves_like "deleting an assembly"
   end
 end

--- a/decidim-conferences/app/controllers/decidim/conferences/admin/conferences_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/admin/conferences_controller.rb
@@ -62,15 +62,6 @@ module Decidim
           end
         end
 
-        def destroy
-          enforce_permission_to :destroy, :conference, conference: current_conference
-          current_conference.destroy!
-
-          flash[:notice] = I18n.t("conferences.destroy.success", scope: "decidim.admin")
-
-          redirect_to conferences_path
-        end
-
         def copy
           enforce_permission_to :create, :conference
         end

--- a/decidim-conferences/app/permissions/decidim/conferences/permissions.rb
+++ b/decidim-conferences/app/permissions/decidim/conferences/permissions.rb
@@ -42,7 +42,6 @@ module Decidim
         user_can_export_conference_registrations?
         user_can_confirm_conference_registration?
         user_can_create_conference?
-        user_can_destroy_conference?
 
         # org admins and space admins can do everything in the admin section
         org_admin_action?
@@ -197,14 +196,6 @@ module Decidim
         toggle_allow(user.admin?)
       end
 
-      # Only organization admins can destroy a conference
-      def user_can_destroy_conference?
-        return unless permission_action.action == :destroy &&
-                      permission_action.subject == :conference
-
-        toggle_allow(user.admin?)
-      end
-
       # Only organization admins can read a conference registrations
       def user_can_read_conference_registrations?
         return unless permission_action.action == :read_conference_registrations &&
@@ -257,13 +248,11 @@ module Decidim
 
       # Process admins can eprform everything *inside* that conference. They cannot
       # create a conference or perform actions on conference groups or other
-      # conferences. They cannot destroy their conference either.
+      # conferences.
       def conference_admin_action?
         return unless can_manage_conference?(role: :admin)
         return if user.admin?
         return disallow! if permission_action.action == :create &&
-                            permission_action.subject == :conference
-        return disallow! if permission_action.action == :destroy &&
                             permission_action.subject == :conference
 
         is_allowed = [

--- a/decidim-conferences/app/views/decidim/conferences/admin/conferences/edit.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conferences/edit.html.erb
@@ -10,9 +10,5 @@
         <%= link_to t("actions.publish", scope: "decidim.admin"), conference_publish_path(current_conference), method: :post, class: "button hollow" %>
       <% end %>
     <% end %>
-
-    <% if allowed_to? :destroy, :conference, conference: current_conference %>
-      <%= link_to t("decidim.admin.actions.destroy"), current_conference, method: :delete, class: "alert button", data: { confirm: t("decidim.admin.actions.confirm_destroy") } %>
-    <% end %>
   </div>
 <% end %>

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -105,8 +105,6 @@ en:
         create:
           error: There was an error creating a new conference.
           success: Conference created successfully.
-        destroy:
-          success: Conference deleted successfully.
         edit:
           update: Update
         exports:

--- a/decidim-conferences/lib/decidim/conferences/admin_engine.rb
+++ b/decidim-conferences/lib/decidim/conferences/admin_engine.rb
@@ -14,7 +14,7 @@ module Decidim
       paths["lib/tasks"] = nil
 
       routes do
-        resources :conferences, param: :slug, except: :show do
+        resources :conferences, param: :slug, except: [:show, :destroy] do
           resource :publish, controller: "conference_publications", only: [:create, :destroy]
           resources :copies, controller: "conference_copies", only: [:new, :create]
           resources :speakers, controller: "conference_speakers"

--- a/decidim-conferences/spec/permissions/decidim/conferences/permissions_spec.rb
+++ b/decidim-conferences/spec/permissions/decidim/conferences/permissions_spec.rb
@@ -219,14 +219,6 @@ describe Decidim::Conferences::Permissions do
     it_behaves_like "access for roles", org_admin: true, admin: false, collaborator: false, moderator: false
   end
 
-  context "when destroying a conference" do
-    let(:action) do
-      { scope: :admin, action: :destroy, subject: :conference }
-    end
-
-    it_behaves_like "access for roles", org_admin: true, admin: false, collaborator: false, moderator: false
-  end
-
   context "with a conference" do
     let(:context) { { conference: conference } }
 
@@ -285,14 +277,6 @@ describe Decidim::Conferences::Permissions do
         it { is_expected.to eq false }
       end
 
-      context "when destroying a conference" do
-        let(:action) do
-          { scope: :admin, action: :destroy, subject: :conference }
-        end
-
-        it { is_expected.to eq false }
-      end
-
       shared_examples "allows any action on subject" do |action_subject|
         context "when action subject is #{action_subject}" do
           let(:action) do
@@ -319,14 +303,6 @@ describe Decidim::Conferences::Permissions do
       context "when creating a conference" do
         let(:action) do
           { scope: :admin, action: :create, subject: :conference }
-        end
-
-        it { is_expected.to eq true }
-      end
-
-      context "when destroying a conference" do
-        let(:action) do
-          { scope: :admin, action: :destroy, subject: :conference }
         end
 
         it { is_expected.to eq true }

--- a/decidim-conferences/spec/shared/manage_conferences_examples.rb
+++ b/decidim-conferences/spec/shared/manage_conferences_examples.rb
@@ -63,22 +63,6 @@ shared_examples "manage conferences" do
     end
   end
 
-  describe "deleting a conference" do
-    before do
-      click_link translated(conference.title)
-    end
-
-    it "deletes a conference" do
-      accept_confirm { click_link "Delete" }
-
-      expect(page).to have_admin_callout("successfully")
-
-      within "table" do
-        expect(page).not_to have_content(translated(conference.title))
-      end
-    end
-  end
-
   describe "updating a conference" do
     let(:image3_filename) { "city3.jpeg" }
     let(:image3_path) { Decidim::Dev.asset(image3_filename) }

--- a/decidim-consultations/app/controllers/decidim/consultations/admin/consultations_controller.rb
+++ b/decidim-consultations/app/controllers/decidim/consultations/admin/consultations_controller.rb
@@ -64,15 +64,6 @@ module Decidim
           end
         end
 
-        def destroy
-          enforce_permission_to :destroy, :consultation, consultation: current_consultation
-          current_consultation.destroy!
-
-          flash[:notice] = I18n.t("consultations.destroy.success", scope: "decidim.admin")
-
-          redirect_to consultations_path
-        end
-
         private
 
         def current_consultation

--- a/decidim-consultations/app/permissions/decidim/consultations/admin/permissions.rb
+++ b/decidim-consultations/app/permissions/decidim/consultations/admin/permissions.rb
@@ -49,7 +49,7 @@ module Decidim
           case permission_action.action
           when :create, :read, :publish
             allow!
-          when :update, :destroy, :preview
+          when :update, :preview
             toggle_allow(consultation.present?)
           when :publish_results
             toggle_allow(consultation.finished? && !consultation.results_published?)

--- a/decidim-consultations/config/locales/en.yml
+++ b/decidim-consultations/config/locales/en.yml
@@ -76,8 +76,6 @@ en:
         create:
           error: There was an error creating a new consultation.
           success: Consultation successfully created.
-        destroy:
-          success: Consultation successfully deleted.
         edit:
           update: Update
         form:

--- a/decidim-consultations/lib/decidim/consultations/admin_engine.rb
+++ b/decidim-consultations/lib/decidim/consultations/admin_engine.rb
@@ -14,7 +14,7 @@ module Decidim
       paths["lib/tasks"] = nil
 
       routes do
-        resources :consultations, param: :slug, except: :show do
+        resources :consultations, param: :slug, except: [:show, :destroy] do
           resource :publish, controller: "consultation_publications", only: [:create, :destroy]
           resource :publish_results, controller: "consultation_results_publications", only: [:create, :destroy]
           resources :questions, param: :slug, except: :show, shallow: true do

--- a/decidim-consultations/spec/permissions/decidim/consultations/admin/permissions_spec.rb
+++ b/decidim-consultations/spec/permissions/decidim/consultations/admin/permissions_spec.rb
@@ -63,21 +63,6 @@ describe Decidim::Consultations::Admin::Permissions do
       end
     end
 
-    context "when destroying a consultation" do
-      let(:action_name) { :destroy }
-
-      context "when consultation is present" do
-        it { is_expected.to eq true }
-      end
-
-      context "when consultation is not present" do
-        let(:consultation) { nil }
-        let(:question) { nil }
-
-        it { is_expected.to eq false }
-      end
-    end
-
     context "when previewing a consultation" do
       let(:action_name) { :preview }
 

--- a/decidim-consultations/spec/system/admin/admin_manages_consultations_spec.rb
+++ b/decidim-consultations/spec/system/admin/admin_manages_consultations_spec.rb
@@ -181,25 +181,6 @@ describe "Admin manages consultations", type: :system do
     end
   end
 
-  describe "deleting a consultation" do
-    let!(:consultation2) { create(:consultation, organization: organization) }
-
-    before do
-      visit decidim_admin_consultations.consultations_path
-    end
-
-    it "deletes a consultation" do
-      click_link translated(consultation2.title)
-      accept_confirm { click_link "Delete" }
-
-      expect(page).to have_admin_callout("successfully")
-
-      within "table" do
-        expect(page).not_to have_content(translated(consultation2.title))
-      end
-    end
-  end
-
   describe "previewing consultations" do
     let!(:consultation) { create(:consultation, :unpublished, organization: organization) }
 

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_processes_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_processes_controller.rb
@@ -68,15 +68,6 @@ module Decidim
           end
         end
 
-        def destroy
-          enforce_permission_to :destroy, :process, process: current_participatory_process
-          current_participatory_process.destroy!
-
-          flash[:notice] = I18n.t("participatory_processes.destroy.success", scope: "decidim.admin")
-
-          redirect_to participatory_processes_path
-        end
-
         def copy
           enforce_permission_to :create, Decidim::ParticipatoryProcess
         end

--- a/decidim-participatory_processes/app/permissions/decidim/participatory_processes/permissions.rb
+++ b/decidim-participatory_processes/app/permissions/decidim/participatory_processes/permissions.rb
@@ -35,7 +35,6 @@ module Decidim
         user_can_read_process_list?
         user_can_read_current_process?
         user_can_create_process?
-        user_can_destroy_process?
 
         # org admins and space admins can do everything in the admin section
         org_admin_action?
@@ -170,14 +169,6 @@ module Decidim
         toggle_allow(user.admin?)
       end
 
-      # Only organization admins can destroy a process
-      def user_can_destroy_process?
-        return unless permission_action.action == :destroy &&
-                      permission_action.subject == :process
-
-        toggle_allow(user.admin?)
-      end
-
       # Everyone can read the process list
       def user_can_read_process_list?
         return unless read_process_list_permission_action?
@@ -207,13 +198,11 @@ module Decidim
 
       # Process admins can eprform everything *inside* that process. They cannot
       # create a process or perform actions on process groups or other
-      # processes. They cannot destroy their process either.
+      # processes.
       def process_admin_action?
         return unless can_manage_process?(role: :admin)
         return if user.admin?
         return disallow! if permission_action.action == :create &&
-                            permission_action.subject == :process
-        return disallow! if permission_action.action == :destroy &&
                             permission_action.subject == :process
 
         is_allowed = [

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/edit.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/edit.html.erb
@@ -10,9 +10,5 @@
         <%= link_to t("actions.publish", scope: "decidim.admin"), participatory_process_publish_path(current_participatory_process), method: :post, class: "button hollow" %>
       <% end %>
     <% end %>
-
-    <% if allowed_to? :destroy, :process, process: current_participatory_process %>
-      <%= link_to t("decidim.admin.actions.destroy"), current_participatory_process, method: :delete, class: "alert button", data: { confirm: t("decidim.admin.actions.confirm_destroy") } %>
-    <% end %>
   </div>
 <% end %>

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -196,8 +196,6 @@ en:
         create:
           error: There was an error creating a new participatory process.
           success: Participatory process created successfully. Configure now its steps.
-        destroy:
-          success: Participatory process deleted successfully.
         edit:
           update: Update
         form:

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
@@ -16,7 +16,7 @@ module Decidim
 
       routes do
         resources :participatory_process_groups
-        resources :participatory_processes, param: :slug, except: :show do
+        resources :participatory_processes, param: :slug, except: [:show, :destroy] do
           resource :publish, controller: "participatory_process_publications", only: [:create, :destroy]
           resources :copies, controller: "participatory_process_copies", only: [:new, :create]
 

--- a/decidim-participatory_processes/spec/permissions/decidim/participatory_processes/permissions_spec.rb
+++ b/decidim-participatory_processes/spec/permissions/decidim/participatory_processes/permissions_spec.rb
@@ -211,14 +211,6 @@ describe Decidim::ParticipatoryProcesses::Permissions do
     it_behaves_like "access for roles", org_admin: true, admin: false, collaborator: false, moderator: false
   end
 
-  context "when destroying a process" do
-    let(:action) do
-      { scope: :admin, action: :destroy, subject: :process }
-    end
-
-    it_behaves_like "access for roles", org_admin: true, admin: false, collaborator: false, moderator: false
-  end
-
   context "with a process" do
     let(:context) { { process: process } }
 
@@ -277,14 +269,6 @@ describe Decidim::ParticipatoryProcesses::Permissions do
         it { is_expected.to eq false }
       end
 
-      context "when destroying a process" do
-        let(:action) do
-          { scope: :admin, action: :destroy, subject: :process }
-        end
-
-        it { is_expected.to eq false }
-      end
-
       shared_examples "allows any action on subject" do |action_subject|
         context "when action subject is #{action_subject}" do
           let(:action) do
@@ -309,14 +293,6 @@ describe Decidim::ParticipatoryProcesses::Permissions do
       context "when creating a process" do
         let(:action) do
           { scope: :admin, action: :create, subject: :process }
-        end
-
-        it { is_expected.to eq true }
-      end
-
-      context "when destroying a process" do
-        let(:action) do
-          { scope: :admin, action: :destroy, subject: :process }
         end
 
         it { is_expected.to eq true }

--- a/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_processes_spec.rb
@@ -98,23 +98,4 @@ describe "Admin manages participatory processes", versioning: true, type: :syste
       expect(page).to have_css("img[src*='#{participatory_process3.banner_image.url}']")
     end
   end
-
-  context "when deleting a participatory process" do
-    let!(:participatory_process2) { create(:participatory_process, organization: organization) }
-
-    before do
-      visit decidim_admin_participatory_processes.participatory_processes_path
-    end
-
-    it "deletes a participatory_process" do
-      click_link translated(participatory_process2.title)
-      accept_confirm { click_link "Delete" }
-
-      expect(page).to have_admin_callout("successfully")
-
-      within "table" do
-        expect(page).to have_no_content(translated(participatory_process2.title))
-      end
-    end
-  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

The current implementation to delete a participatory space makes no sense and it's quite dangerous:

- An admin can delete a published space
- There's no traceability when an admin deletes a space

Also, it creates data integrity issues since when a space is deleted all its components aren't deleted. We could delete all components in cascade, but this has other implications, what if there's data from the users? Should we actually allow an admin to delete a space?

I think the best solution for now is to disable space deletion (an admin could always unpublish it), and rethink all this.

#### :pushpin: Related Issues
- Related to #4583
- Fixes #4147

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
