### PR TITLE
Fix SettingsChangeJob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,9 @@ In order to generate Open Data exports you should add this to your crontab or re
 - **decidim-comments**: Fix GraphQL comments schema [\#4638](https://github.com/decidim/decidim/pull/4638)
 - **decidim-core**: Better handling setting process step position [\#4638](https://github.com/decidim/decidim/pull/4638)
 - **decidim-core**: Don't crash on registration [\#4637](https://github.com/decidim/decidim/pull/4637)
+- **decidim-debates**: Don't crash on settings change [\#4642](https://github.com/decidim/decidim/pull/4642)
+- **decidim-proposals**: Don't crash on settings change [\#4642](https://github.com/decidim/decidim/pull/4642)
+- **decidim-surveys**: Don't crash on settings change [\#4642](https://github.com/decidim/decidim/pull/4642)
 
 **Removed**:
 

--- a/decidim-debates/app/jobs/decidim/debates/settings_change_job.rb
+++ b/decidim-debates/app/jobs/decidim/debates/settings_change_job.rb
@@ -7,6 +7,8 @@ module Decidim
         return if unchanged?(previous_settings, current_settings)
 
         component = Decidim::Component.find(component_id)
+        event = nil
+        event_class = nil
 
         if debate_creation_enabled?(previous_settings, current_settings)
           event = "decidim.events.debates.creation_enabled"
@@ -15,6 +17,8 @@ module Decidim
           event = "decidim.events.debates.creation_disabled"
           event_class = Decidim::Debates::CreationDisabledEvent
         end
+
+        return unless event && event_class
 
         Decidim::EventsManager.publish(
           event: event,

--- a/decidim-debates/app/jobs/decidim/debates/settings_change_job.rb
+++ b/decidim-debates/app/jobs/decidim/debates/settings_change_job.rb
@@ -7,8 +7,6 @@ module Decidim
         return if unchanged?(previous_settings, current_settings)
 
         component = Decidim::Component.find(component_id)
-        event = nil
-        event_class = nil
 
         if debate_creation_enabled?(previous_settings, current_settings)
           event = "decidim.events.debates.creation_enabled"
@@ -34,15 +32,17 @@ module Decidim
         current_settings[:creation_enabled] == previous_settings[:creation_enabled]
       end
 
+      # rubocop:disable Style/DoubleNegation
       def debate_creation_enabled?(previous_settings, current_settings)
         current_settings[:creation_enabled] == true &&
-          previous_settings[:creation_enabled] == false
+          !!previous_settings[:creation_enabled] == false
       end
 
       def debate_creation_disabled?(previous_settings, current_settings)
-        current_settings[:creation_enabled] == false &&
+        !!current_settings[:creation_enabled] == false &&
           previous_settings[:creation_enabled] == true
       end
+      # rubocop:enable Style/DoubleNegation
     end
   end
 end

--- a/decidim-proposals/app/jobs/decidim/proposals/settings_change_job.rb
+++ b/decidim-proposals/app/jobs/decidim/proposals/settings_change_job.rb
@@ -5,8 +5,6 @@ module Decidim
     class SettingsChangeJob < ApplicationJob
       def perform(component_id, previous_settings, current_settings)
         component = Decidim::Component.find(component_id)
-        event = nil
-        event_class = nil
 
         if creation_enabled?(previous_settings, current_settings)
           event = "decidim.events.proposals.creation_enabled"
@@ -31,20 +29,22 @@ module Decidim
 
       private
 
+      # rubocop:disable Style/DoubleNegation
       def creation_enabled?(previous_settings, current_settings)
         current_settings[:creation_enabled] == true &&
-          previous_settings[:creation_enabled] == false
+          !!previous_settings[:creation_enabled] == false
       end
 
       def voting_enabled?(previous_settings, current_settings)
-        (current_settings[:votes_enabled] == true && current_settings[:votes_blocked] == false) &&
-          (previous_settings[:votes_enabled] == false || previous_settings[:votes_blocked] == true)
+        (current_settings[:votes_enabled] == true && !!current_settings[:votes_blocked] == false) &&
+          (!!previous_settings[:votes_enabled] == false || previous_settings[:votes_blocked] == true)
       end
 
       def endorsing_enabled?(previous_settings, current_settings)
-        (current_settings[:endorsements_enabled] == true && current_settings[:endorsements_blocked] == false) &&
-          (previous_settings[:endorsements_enabled] == false || previous_settings[:endorsements_blocked] == true)
+        (current_settings[:endorsements_enabled] == true && !!current_settings[:endorsements_blocked] == false) &&
+          (!!previous_settings[:endorsements_enabled] == false || previous_settings[:endorsements_blocked] == true)
       end
+      # rubocop:enable Style/DoubleNegation
     end
   end
 end

--- a/decidim-proposals/app/jobs/decidim/proposals/settings_change_job.rb
+++ b/decidim-proposals/app/jobs/decidim/proposals/settings_change_job.rb
@@ -5,6 +5,8 @@ module Decidim
     class SettingsChangeJob < ApplicationJob
       def perform(component_id, previous_settings, current_settings)
         component = Decidim::Component.find(component_id)
+        event = nil
+        event_class = nil
 
         if creation_enabled?(previous_settings, current_settings)
           event = "decidim.events.proposals.creation_enabled"

--- a/decidim-surveys/app/jobs/decidim/surveys/settings_change_job.rb
+++ b/decidim-surveys/app/jobs/decidim/surveys/settings_change_job.rb
@@ -7,8 +7,6 @@ module Decidim
         return if unchanged?(previous_settings, current_settings)
 
         component = Decidim::Component.find(component_id)
-        event = nil
-        event_class = nil
 
         if survey_opened?(previous_settings, current_settings)
           event = "decidim.events.surveys.survey_opened"
@@ -33,15 +31,17 @@ module Decidim
         current_settings[:allow_answers] == previous_settings[:allow_answers]
       end
 
+      # rubocop:disable Style/DoubleNegation
       def survey_opened?(previous_settings, current_settings)
         current_settings[:allow_answers] == true &&
-          previous_settings[:allow_answers] == false
+          !!previous_settings[:allow_answers] == false
       end
 
       def survey_closed?(previous_settings, current_settings)
-        current_settings[:allow_answers] == false &&
+        !!current_settings[:allow_answers] == false &&
           previous_settings[:allow_answers] == true
       end
+      # rubocop:enable Style/DoubleNegation
     end
   end
 end

--- a/decidim-surveys/app/jobs/decidim/surveys/settings_change_job.rb
+++ b/decidim-surveys/app/jobs/decidim/surveys/settings_change_job.rb
@@ -7,6 +7,8 @@ module Decidim
         return if unchanged?(previous_settings, current_settings)
 
         component = Decidim::Component.find(component_id)
+        event = nil
+        event_class = nil
 
         if survey_opened?(previous_settings, current_settings)
           event = "decidim.events.surveys.survey_opened"
@@ -16,6 +18,7 @@ module Decidim
           event_class = Decidim::Surveys::ClosedSurveyEvent
         end
 
+        return unless event && event_class
         Decidim::EventsManager.publish(
           event: event,
           event_class: event_class,


### PR DESCRIPTION
#### :tophat: What? Why?
In some cases, the `SettingsChangeJob` could fail if no relevant change was found. This PR fixes it.

#### :pushpin: Related Issues
- Fixes #4146

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
