### PR TITLE
Do not notify comment authors about their comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,7 @@ In order to generate Open Data exports you should add this to your crontab or re
 - **decidim-budgets**: Use bigint instead of int for projects [\#4628](https://github.com/decidim/decidim/pull/4628)
 - **decidim-comments**: Fix GraphQL comments schema [\#4638](https://github.com/decidim/decidim/pull/4638)
 - **decidim-core**: Better handling setting process step position [\#4638](https://github.com/decidim/decidim/pull/4638)
+- **decidim-core**: Comment authors won't be notified about their own comments [\#4643](https://github.com/decidim/decidim/pull/4643)
 - **decidim-core**: Don't crash on registration [\#4637](https://github.com/decidim/decidim/pull/4637)
 
 **Removed**:


### PR DESCRIPTION
#### :tophat: What? Why?
If a user mentions herself on a comment, she gets a notification. This PR prevents this from happening.

#### :pushpin: Related Issues
- Fixes #3900

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
