### PR TITLE
Separate activity search classes

### DIFF
--- a/decidim-core/app/cells/decidim/content_blocks/last_activity_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/last_activity_cell.rb
@@ -46,7 +46,7 @@ module Decidim
       private
 
       def activities
-        @activities ||= ActivitySearch.new(
+        @activities ||= HomeActivitySearch.new(
           organization: current_organization,
           resource_type: "all"
         ).results.limit(activities_to_show * 6)

--- a/decidim-core/app/controllers/decidim/last_activities_controller.rb
+++ b/decidim-core/app/controllers/decidim/last_activities_controller.rb
@@ -32,7 +32,7 @@ module Decidim
     end
 
     def search_klass
-      ActivitySearch
+      HomeActivitySearch
     end
 
     def context_params

--- a/decidim-core/app/services/decidim/activity_search.rb
+++ b/decidim-core/app/services/decidim/activity_search.rb
@@ -4,6 +4,10 @@ module Decidim
   # A class to search for recent activity performed in a Decidim Organization.
   # It is intended to be used in the user profile, to retrieve activity and
   # timeline for that user.
+  #
+  # It will return any action for a given resource, except `create` on resources
+  # that implement the `Decidim::Publicable` concern to avoid leaking private
+  # data.
   class ActivitySearch < Searchlight::Search
     # Needed by Searchlight, this is the base query that will be used to
     # append other criteria to the search.

--- a/decidim-core/app/services/decidim/activity_search.rb
+++ b/decidim-core/app/services/decidim/activity_search.rb
@@ -61,22 +61,19 @@ module Decidim
     end
 
     def scope_for(resource_type)
-      action = if publicable_resource_types.include?(resource_type)
-                 "publish"
-               else
-                 "create"
-               end
-
-      query.where(resource_type: resource_type, action: action)
+      if publicable_resource_types.include?(resource_type)
+        query.where(resource_type: resource_type).where.not(action: "create")
+      else
+        query.where(resource_type: resource_type)
+      end
     end
 
     def all_resources_scope
       query
         .where(
-          "(action = ? AND resource_type IN (?)) OR (action = ? AND resource_type IN (?))",
-          "publish",
-          publicable_resource_types,
+          "(action <> ? AND resource_type IN (?)) OR (resource_type IN (?))",
           "create",
+          publicable_resource_types,
           (resource_types - publicable_resource_types)
         )
     end

--- a/decidim-core/app/services/decidim/activity_search.rb
+++ b/decidim-core/app/services/decidim/activity_search.rb
@@ -2,6 +2,8 @@
 
 module Decidim
   # A class to search for recent activity performed in a Decidim Organization.
+  # It is intended to be used in the user profile, to retrieve activity and
+  # timeline for that user.
   class ActivitySearch < Searchlight::Search
     # Needed by Searchlight, this is the base query that will be used to
     # append other criteria to the search.

--- a/decidim-core/app/services/decidim/home_activity_search.rb
+++ b/decidim-core/app/services/decidim/home_activity_search.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Decidim
+  # A class to search for recent activity performed in a Decidim Organization.
+  # It will only return the `Decidim::ActionLog` rows that have an action as
+  # `created` or `published`.
+  #
+  # This class is thought to be used in the `LastActivityCell` uniquely.
+  class HomeActivitySearch < Searchlight::Search
+    # Needed by Searchlight, this is the base query that will be used to
+    # append other criteria to the search.
+    def base_query
+      ActionLog
+        .where(visibility: %w(public-only all))
+        .where(organization: options.fetch(:organization))
+    end
+
+    # Overwrites the default Searchlight run method since we want to return
+    # activities in an specific order but we need to set it at the end of the chain.
+    def run
+      super.order(created_at: :desc)
+    end
+
+    # Adds a constrain to filter by resource type(s).
+    def search_resource_type
+      if resource_types.include?(resource_type)
+        scope_for(resource_type)
+      else
+        all_resources_scope
+      end
+    end
+
+    # All the resource types that are eligible to be included as an activity.
+    def resource_types
+      @resource_types ||= %w(
+        Decidim::Accountability::Result
+        Decidim::Blogs::Post
+        Decidim::Comments::Comment
+        Decidim::Consultations::Question
+        Decidim::Debates::Debate
+        Decidim::Meetings::Meeting
+        Decidim::Proposals::Proposal
+        Decidim::Surveys::Survey
+        Decidim::Assembly
+        Decidim::Consultation
+        Decidim::Initiative
+        Decidim::ParticipatoryProcess
+      ).select do |klass|
+        klass.safe_constantize.present?
+      end
+    end
+
+    private
+
+    def publicable_resource_types
+      @publicable_resource_types ||= resource_types.select { |klass| klass.constantize.column_names.include?("published_at") }
+    end
+
+    def scope_for(resource_type)
+      action = if publicable_resource_types.include?(resource_type)
+                 "publish"
+               else
+                 "create"
+               end
+
+      query.where(resource_type: resource_type, action: action)
+    end
+
+    def all_resources_scope
+      query
+        .where(
+          "(action = ? AND resource_type IN (?)) OR (action = ? AND resource_type IN (?))",
+          "publish",
+          publicable_resource_types,
+          "create",
+          (resource_types - publicable_resource_types)
+        )
+    end
+  end
+end

--- a/decidim-core/spec/services/decidim/activity_search_spec.rb
+++ b/decidim-core/spec/services/decidim/activity_search_spec.rb
@@ -36,12 +36,12 @@ module Decidim
       it { is_expected.to include(action_log) }
     end
 
-    context "with update actions" do
+    context "with any other actions" do
       let!(:action_log) do
         create(:action_log, action: "update", visibility: "public-only", organization: organization)
       end
 
-      it { is_expected.not_to include(action_log) }
+      it { is_expected.to include(action_log) }
     end
 
     context "when a resource is publicable" do

--- a/decidim-core/spec/services/decidim/home_activity_search_spec.rb
+++ b/decidim-core/spec/services/decidim/home_activity_search_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  HomeActivitySearch.class_eval do
+    def resource_types
+      %w(
+        Decidim::Comments::Comment
+        Decidim::DummyResources::DummyResource
+      )
+    end
+  end
+
+  describe HomeActivitySearch do
+    subject { search.results }
+
+    let(:search) do
+      described_class.new(organization: organization, resource_type: resource_type)
+    end
+    let(:organization) { create(:organization) }
+    let(:resource_type) { "all" }
+
+    context "with admin logs" do
+      let!(:admin_log) { create(:action_log, visibility: "admin-only", organization: organization) }
+
+      it { is_expected.not_to eq(admin_log) }
+    end
+
+    context "when a resource is not publicable" do
+      let(:comment) { create(:comment) }
+      let!(:action_log) do
+        create(:action_log, action: "create", visibility: "public-only", resource: comment, organization: organization)
+      end
+
+      it { is_expected.to include(action_log) }
+    end
+
+    context "with update actions" do
+      let!(:action_log) do
+        create(:action_log, action: "update", visibility: "public-only", organization: organization)
+      end
+
+      it { is_expected.not_to include(action_log) }
+    end
+
+    context "when a resource is publicable" do
+      let!(:action_log) do
+        create(:action_log, action: action, visibility: "all", resource: resource, organization: organization, participatory_space: component.participatory_space)
+      end
+      let(:component) do
+        create(:component, :published, organization: organization)
+      end
+
+      context "and it is not published" do
+        let(:action) { "create" }
+        let(:resource) do
+          create(:dummy_resource, component: component, published_at: nil)
+        end
+
+        it { is_expected.not_to include(action_log) }
+      end
+
+      context "and it is published" do
+        let(:action) { "publish" }
+        let(:resource) do
+          create(:dummy_resource, component: component, published_at: Time.current)
+        end
+
+        it { is_expected.to include(action_log) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR is extracted from #4627. It separates the `ActivitySearch` class into two different and unrelated classes, so we can customize properly what kind of actions we show in the homepage and what actions are shown in the user profile.

#### :pushpin: Related Issues
- Related to #4439, #4627.

#### :clipboard: Subtasks
None