### PR TITLE
force graphql and graphiql versions to prevent errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,8 +45,8 @@ PATH
       sassc (~> 1.12, >= 1.12.1)
       sassc-rails (~> 1.3)
     decidim-api (0.16.0.dev)
-      graphiql-rails (~> 1.4)
-      graphql (~> 1.6)
+      graphiql-rails (~> 1.4, < 1.5)
+      graphql (~> 1.6, < 1.8.11)
       rack-cors (~> 1.0)
       sprockets-es6 (~> 0.9.2)
     decidim-assemblies (0.16.0.dev)
@@ -397,10 +397,10 @@ GEM
     geocoder (1.5.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    graphiql-rails (1.5.0)
+    graphiql-rails (1.4.11)
       railties
       sprockets-rails
-    graphql (1.8.11)
+    graphql (1.8.8)
     hashdiff (0.3.7)
     hashie (3.5.7)
     highline (2.0.0)

--- a/decidim-api/decidim-api.gemspec
+++ b/decidim-api/decidim-api.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib,vendor}/**/*", "Rakefile", "README.md"]
 
-  s.add_dependency "graphiql-rails", "~> 1.4"
-  s.add_dependency "graphql", "~> 1.6"
+  s.add_dependency "graphiql-rails", "~> 1.4", "< 1.5"
+  s.add_dependency "graphql", "~> 1.6", "< 1.8.11"
   s.add_dependency "rack-cors", "~> 1.0"
   s.add_dependency "sprockets-es6", "~> 0.9.2"
 

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -36,8 +36,8 @@ PATH
       sassc (~> 1.12, >= 1.12.1)
       sassc-rails (~> 1.3)
     decidim-api (0.16.0.dev)
-      graphiql-rails (~> 1.4)
-      graphql (~> 1.6)
+      graphiql-rails (~> 1.4, < 1.5)
+      graphql (~> 1.6, < 1.8.11)
       rack-cors (~> 1.0)
       sprockets-es6 (~> 0.9.2)
     decidim-assemblies (0.16.0.dev)
@@ -389,7 +389,7 @@ GEM
     graphiql-rails (1.4.11)
       railties
       sprockets-rails
-    graphql (1.8.11)
+    graphql (1.8.10)
     hashdiff (0.3.7)
     hashie (3.5.7)
     highline (2.0.0)

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -45,8 +45,8 @@ PATH
       sassc (~> 1.12, >= 1.12.1)
       sassc-rails (~> 1.3)
     decidim-api (0.16.0.dev)
-      graphiql-rails (~> 1.4)
-      graphql (~> 1.6)
+      graphiql-rails (~> 1.4, < 1.5)
+      graphql (~> 1.6, < 1.8.11)
       rack-cors (~> 1.0)
       sprockets-es6 (~> 0.9.2)
     decidim-assemblies (0.16.0.dev)
@@ -400,7 +400,7 @@ GEM
     graphiql-rails (1.4.11)
       railties
       sprockets-rails
-    graphql (1.8.11)
+    graphql (1.8.10)
     hashdiff (0.3.7)
     hashie (3.5.7)
     highline (2.0.0)


### PR DESCRIPTION
#### :tophat: What? Why?
When trying to upgrade an application from version to version, I found a graphql error when I visited the url "api/graphiql"

The browser console gives this error:
```
Uncaught Error: Cannot use e "__Schema" from another module or realm.

Ensure that there is only one instance of "graphql" in the node_modules
directory. If different versions of "graphql" are the dependencies of other
relied on modules, use "resolutions" to ensure only one version is installed.

https://yarnpkg.com/en/docs/selective-version-resolutions

Duplicate "graphql" modules cannot be used at the same time since different
versions may have different capabilities and behavior. The data from one
version used in the function from another could produce confusing and
spurious results.
```

To solve it, it is necessary to return to the previous version of the gems `graphql` and `graphiql-rails`

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [x] Forece graphql version
- [x] Forece graphiql-rails version

### :camera: Screenshots (optional)
![Description](URL)
