### PR TITLE
Crop long words

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
@@ -446,6 +446,16 @@ $datetime-bg: $primary;
   @include breakpoint(medium){
     padding-left: $card-padding;
   }
+
+  svg{
+    flex-basis: 15%;
+    flex-shrink: 0;
+  }
+
+  svg + div{
+    max-width: calc(85% - #{$global-margin});
+    overflow-wrap: break-word;
+  }
 }
 
 .card--list__icon{


### PR DESCRIPTION
#### :tophat: What? Why?
When sidebar descriptions contains long word as url or mails, layout become broken.

Fixes #4118 
