### PR TITLE
Wrap large url links

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_margins.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_margins.scss
@@ -7,6 +7,7 @@ $margin-l: $global-margin * 5;
 //Sections
 .section{
   margin-bottom: $margin-sm;
+  word-wrap: break-word;
 
   @include breakpoint(large){
     margin-bottom: $margin-m;


### PR DESCRIPTION
#### :tophat: What? Why?
Apply a break-word on sections, therefore, large url links will be chopped.

#### :pushpin: Related Issues
- Fixes #4672 

### :camera: Screenshots (optional)
![imagen](https://user-images.githubusercontent.com/817526/50079471-fcb15a80-01e9-11e9-8b46-f5646e6fc6bb.png)

