### PR TITLE
Fix background-size on home page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,7 @@ In order to generate Open Data exports you should add this to your crontab or re
 - **decidim-debates**: Don't crash on settings change [\#4642](https://github.com/decidim/decidim/pull/4642)
 - **decidim-proposals**: Don't crash on settings change [\#4642](https://github.com/decidim/decidim/pull/4642)
 - **decidim-surveys**: Don't crash on settings change [\#4642](https://github.com/decidim/decidim/pull/4642)
+- **decidim-core**: Fix background-size on home page [\#4678](https://github.com/decidim/decidim/pull/4678)
 
 **Removed**:
 

--- a/decidim-core/app/assets/stylesheets/decidim/layouts/_home.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/layouts/_home.scss
@@ -178,7 +178,7 @@
 }
 
 .home-section:nth-of-type(2n+1){
-  background: $light-gray-dark;
+  background-color: $light-gray-dark;
 }
 
 .subhero{


### PR DESCRIPTION
#### :tophat: What? Why?

The `.hero` class defines a `background-size: cover` element which was
reseted few lines later by the `.home-section` class. In consequence,
the background images didn't look great on big screens.

#### :pushpin: Related Issues

None

#### :clipboard: Subtasks

- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

From https://decidim.barcelona, before:
![capture d ecran de 2018-12-19 11-45-40](https://user-images.githubusercontent.com/1436309/50215583-bf80d000-0383-11e9-9425-47df5df5c770.png)

After:
![capture d ecran de 2018-12-19 11-46-01](https://user-images.githubusercontent.com/1436309/50215591-c7407480-0383-11e9-91db-b5b92346dbe2.png)
