### PR TITLE
Remove current_feature backport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Fixed**:
 
 - **decidim-meetings**: Fix meetings form when only one locale is available [\#4625](https://github.com/decidim/decidim/pull/4625)
+- **decidim-core**: Remove `current_feature` [\#4680](https://github.com/decidim/decidim/pull/4680)
 
 ## [0.15.1](https://github.com/decidim/decidim/tree/v0.15.1)
 

--- a/decidim-core/app/controllers/decidim/components/base_controller.rb
+++ b/decidim-core/app/controllers/decidim/components/base_controller.rb
@@ -37,12 +37,9 @@ module Decidim
         request.env["decidim.current_participatory_space"]
       end
 
-      deprecate current_feature: "current_feature is deprecated and will be removed from Decidim's next release"
-
       def current_component
         request.env["decidim.current_component"]
       end
-      alias current_feature current_component
 
       def current_manifest
         @current_manifest ||= current_component.manifest


### PR DESCRIPTION
#### :tophat: What? Why?

Remove deprecated method since it's not needed and it's making applications crash.

#### :pushpin: Related Issues
- Related to #4624 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

