### PR TITLE
Replaced 'Suplantar' by 'Impersonar' 

### DIFF
--- a/decidim-admin/config/locales/ca.yml
+++ b/decidim-admin/config/locales/ca.yml
@@ -267,7 +267,7 @@ ca:
             managed: Gestionat
             not_managed: No gestionat
           filter_by: Filtra per
-          impersonate: Suplantar
+          impersonate: Impersonar
           impersonate_new_managed_user: Substitueix un nou usuari administrat
           managed: Gestionat
           name: Nom
@@ -279,8 +279,8 @@ ca:
           view_logs: Veure registres
       impersonations:
         close_session:
-          error: S'ha produït un error en tancar la sessió de suplantació actual.
-          success: La sessió de suplantació actual s'ha finalitzat amb èxit.
+          error: S'ha produït un error en tancar la sessió d'impersonació actual.
+          success: La sessió d'impersonació actual s'ha finalitzat amb èxit.
         create:
           error: S'ha produït un error en impersonar l'usuari.
           success: L'usuari gestionat s'ha creat correctament.
@@ -289,7 +289,7 @@ ca:
           name: Nom
           reason: Raó
         new:
-          impersonate: Suplantar
+          impersonate: Impersonar
           impersonate_existing_managed_user: Impersonar l'usuari gestionat "%{name}"
           impersonate_existing_user: Impersona l'usuari "%{name}"
           impersonate_new_managed_user: Impersona un nou usuari administrat
@@ -302,7 +302,7 @@ ca:
           success: S'ha promogut amb èxit l'usuari gestionat.
         promotions:
           new:
-            explanation: Els usuaris gestionats es poden promocionar a usuaris estàndard. Significa que seran convidats al sistema i no podreu tornar a suplantar-los. L'usuari convidat rebrà un correu electrònic per acceptar la vostra invitació.
+            explanation: Els usuaris gestionats es poden promocionar a usuaris estàndard. Significa que seran convidats al sistema i no podreu tornar a impersonar-los. L'usuari convidat rebrà un correu electrònic per acceptar la vostra invitació.
             new_managed_user_promotion: Nova promoció d'usuari gestionat
             promote: Promocionar
       menu:
@@ -607,7 +607,7 @@ ca:
         authorization_workflows: Mètodes de verificació
         dashboard: Tauler de control
         impersonatable_users: Usuaris impersonables
-        impersonations: Suplantacions
+        impersonations: Impersonacions
         participants: Participants
         scope_types: Tipus d'àmbit
         scopes: Àmbits

--- a/decidim-admin/config/locales/es.yml
+++ b/decidim-admin/config/locales/es.yml
@@ -267,7 +267,7 @@ es:
             managed: Administrado
             not_managed: No gestionado
           filter_by: Filtrado por
-          impersonate: Suplantar
+          impersonate: Impersonar
           impersonate_new_managed_user: Impersonar a un nuevo usuario administrado
           managed: Administrado
           name: Nombre
@@ -279,8 +279,8 @@ es:
           view_logs: Ver los registros
       impersonations:
         close_session:
-          error: Se ha producido un error al cerrar la sesión de suplantación actual.
-          success: Se ha finalizado con éxito la sesión de suplantación actual.
+          error: Se ha producido un error al cerrar la sesión de impersonación actual.
+          success: Se ha finalizado con éxito la sesión de impersonación actual.
         create:
           error: Se ha producido un error al promocionar el usuario gestionado.
           success: El usuario gestionado se ha creado correctamente.
@@ -289,7 +289,7 @@ es:
           name: Nombre
           reason: Razón
         new:
-          impersonate: Suplantar
+          impersonate: Impersonar
           impersonate_existing_managed_user: Impersonar al usuario administrado "%{name}"
           impersonate_existing_user: Impersonar usuario "%{name}"
           impersonate_new_managed_user: Impersonar a un nuevo usuario administrado
@@ -302,7 +302,7 @@ es:
           success: El usuario gestionado se ha promocionado correctamente.
         promotions:
           new:
-            explanation: Los usuarios gestionados pueden ser promovidos a usuarios estándar. Esto significa que serán invitados a la aplicación y no será capaz de suplantarlos de nuevo. El usuario invitado recibirá un correo electrónico para aceptar su invitación.
+            explanation: Los usuarios gestionados pueden ser promovidos a usuarios estándar. Esto significa que serán invitados a la aplicación y no será capaz de impersonarlos de nuevo. El usuario invitado recibirá un correo electrónico para aceptar su invitación.
             new_managed_user_promotion: Nueva promoción de usuarios gestionados
             promote: Promocionar
       menu:
@@ -607,7 +607,7 @@ es:
         authorization_workflows: Métodos de verificación
         dashboard: Panel de control
         impersonatable_users: Usuarios impersonables
-        impersonations: Suplantaciones
+        impersonations: Impersonaciones
         participants: Participantes
         scope_types: Tipos de ámbito
         scopes: Ámbitos


### PR DESCRIPTION
Replaced 'Suplantar' by 'Impersonar' as it has no negative implications in Catalan and Spanish

#### :tophat: What? Why?
Thw word "Suplantar" both in catan and spanish languages means to become another person "unloyaly". This is not the intention of the "impersonate" action, so the word should be changed in the strings files by the word "Impersonar"

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
