### PR TITLE
4648 - Initiative type minimum comitee members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - **decidim-core**: User groups can now be disabled per organization. [\#4681](https://github.com/decidim/decidim/pull/4681/)
 - **decidim-initiatives**: Add setting in `Decidim::InitiativesType` to restrict online signatures [\#4668](https://github.com/decidim/decidim/pull/4668)
+- **decidim-initiatives**: Add setting in `Decidim::InitiativesType` to set minimum commitee members before sending initiative to technical evaluation [\#4688](https://github.com/decidim/decidim/pull/4688)
 
 **Changed**:
 

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/create_initiative_type.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/create_initiative_type.rb
@@ -40,7 +40,7 @@ module Decidim
             title: form.title,
             description: form.description,
             online_signature_enabled: form.online_signature_enabled,
-            min_committee_members: form.min_committee_members,
+            minimum_committee_members: form.minimum_committee_members,
             banner_image: form.banner_image
           )
 

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/create_initiative_type.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/create_initiative_type.rb
@@ -40,6 +40,7 @@ module Decidim
             title: form.title,
             description: form.description,
             online_signature_enabled: form.online_signature_enabled,
+            min_committee_members: form.min_committee_members,
             banner_image: form.banner_image
           )
 

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative_type.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative_type.rb
@@ -42,7 +42,7 @@ module Decidim
             title: form.title,
             description: form.description,
             online_signature_enabled: form.online_signature_enabled,
-            min_committee_members: form.min_committee_members
+            minimum_committee_members: form.minimum_committee_members
           }
 
           result[:banner_image] = form.banner_image unless form.banner_image.nil?

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative_type.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative_type.rb
@@ -41,7 +41,8 @@ module Decidim
           result = {
             title: form.title,
             description: form.description,
-            online_signature_enabled: form.online_signature_enabled
+            online_signature_enabled: form.online_signature_enabled,
+            min_committee_members: form.min_committee_members
           }
 
           result[:banner_image] = form.banner_image unless form.banner_image.nil?

--- a/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
@@ -29,7 +29,7 @@ module Decidim
 
       def show
         enforce_permission_to :create, :initiative
-        send("#{step}_step", initiative: session[:initiative])
+        send("#{step}_step", initiative: session_initiative)
       end
 
       def update
@@ -71,7 +71,9 @@ module Decidim
       end
 
       def promotal_committee_step(parameters)
-        if session[:initiative].has_key?(:id)
+        skip_step unless promotal_committee_required?
+
+        if session_initiative.has_key?(:id)
           render_wizard
           return
         end
@@ -108,7 +110,7 @@ module Decidim
       def build_form(klass, parameters)
         @form = form(klass).from_params(parameters)
         attributes = @form.attributes_with_values
-        session[:initiative] = session[:initiative].merge(attributes)
+        session[:initiative] = session_initiative.merge(attributes)
         @form.valid? if params[:validate_form]
 
         @form
@@ -119,12 +121,21 @@ module Decidim
       end
 
       def current_initiative
-        initiative = session[:initiative].with_indifferent_access
-        Initiative.find(initiative[:id]) if initiative.has_key?(:id)
+        Initiative.find(session_initiative[:id]) if session_initiative.has_key?(:id)
       end
 
       def initiative_type
         @initiative_type ||= InitiativesType.find(@form&.type_id)
+      end
+
+      def session_initiative
+        session[:initiative]&.with_indifferent_access
+      end
+
+      def promotal_committee_required?
+        min_committee_members = InitiativesType.find(session_initiative[:type_id]).min_committee_members ||
+                                Decidim::Initiatives.minimum_committee_members
+        min_committee_members.present? && min_committee_members.positive?
       end
     end
   end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
@@ -133,9 +133,9 @@ module Decidim
       end
 
       def promotal_committee_required?
-        min_committee_members = InitiativesType.find(session_initiative[:type_id]).min_committee_members ||
-                                Decidim::Initiatives.minimum_committee_members
-        min_committee_members.present? && min_committee_members.positive?
+        minimum_committee_members = InitiativesType.find(session_initiative[:type_id]).minimum_committee_members ||
+                                    Decidim::Initiatives.minimum_committee_members
+        minimum_committee_members.present? && minimum_committee_members.positive?
       end
     end
   end

--- a/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_type_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_type_form.rb
@@ -13,16 +13,16 @@ module Decidim
         translatable_attribute :description, String
         attribute :banner_image, String
         attribute :online_signature_enabled, Boolean
-        attribute :min_committee_members, Integer
+        attribute :minimum_committee_members, Integer
 
         validates :title, :description, translatable_presence: true
         validates :online_signature_enabled, inclusion: { in: [true, false] }
-        validates :min_committee_members, numericality: { only_integer: true }, allow_nil: true
+        validates :minimum_committee_members, numericality: { only_integer: true }, allow_nil: true
         validates :banner_image, presence: true, if: lambda { |form|
           form.context.initiative_type.nil?
         }
 
-        def min_committee_members=(value)
+        def minimum_committee_members=(value)
           super(value.presence)
         end
       end

--- a/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_type_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_type_form.rb
@@ -13,12 +13,18 @@ module Decidim
         translatable_attribute :description, String
         attribute :banner_image, String
         attribute :online_signature_enabled, Boolean
+        attribute :min_committee_members, Integer
 
         validates :title, :description, translatable_presence: true
         validates :online_signature_enabled, inclusion: { in: [true, false] }
+        validates :min_committee_members, numericality: { only_integer: true }, allow_nil: true
         validates :banner_image, presence: true, if: lambda { |form|
           form.context.initiative_type.nil?
         }
+
+        def min_committee_members=(value)
+          super(value.presence)
+        end
       end
     end
   end

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -284,6 +284,14 @@ module Decidim
         published?
     end
 
+    def min_committee_members
+      type.min_committee_members || Decidim::Initiatives.minimum_committee_members
+    end
+
+    def enough_committee_members?
+      committee_members.approved.count >= min_committee_members
+    end
+
     private
 
     def signature_type_allowed

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -284,12 +284,12 @@ module Decidim
         published?
     end
 
-    def min_committee_members
-      type.min_committee_members || Decidim::Initiatives.minimum_committee_members
+    def minimum_committee_members
+      type.minimum_committee_members || Decidim::Initiatives.minimum_committee_members
     end
 
     def enough_committee_members?
-      committee_members.approved.count >= min_committee_members
+      committee_members.approved.count >= minimum_committee_members
     end
 
     private

--- a/decidim-initiatives/app/permissions/decidim/initiatives/admin/permissions.rb
+++ b/decidim-initiatives/app/permissions/decidim/initiatives/admin/permissions.rb
@@ -171,8 +171,8 @@ module Decidim
             toggle_allow(initiative.created?)
           when :send_to_technical_validation
             allowed = initiative.created? && (
-                        !initiative.decidim_user_group_id.nil? ||
-                          initiative.committee_members.approved.count >= Decidim::Initiatives.minimum_committee_members
+                        !initiative.created_by_individual? ||
+                        initiative.enough_committee_members?
                       )
 
             toggle_allow(allowed)

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/edit.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/edit.html.erb
@@ -8,8 +8,8 @@
                   send_to_technical_validation_initiative_path(current_initiative),
                   class: "button muted",
                   data: { confirm: t(".confirm") } %>
-    <% else %>
-      <%= link_to t(".send_to_technical_validation"), "#", class: "button muted disabled" if current_initiative.created? %>
+    <% elsif current_initiative.created? %>
+      <%= link_to t(".send_to_technical_validation"), "#", class: "button muted disabled" %>
     <% end %>
 
     <% if allowed_to? :publish, :initiative, initiative: current_initiative %>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_form.html.erb
@@ -17,7 +17,7 @@
     </div>
 
     <div class="row column">
-      <%= form.number_field :min_committee_members, min: 0, step: 1 %>
+      <%= form.number_field :minimum_committee_members, min: 0, step: 1 %>
     </div>
 
     <div class="row">

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_form.html.erb
@@ -16,6 +16,10 @@
       <%= form.check_box :online_signature_enabled %>
     </div>
 
+    <div class="row column">
+      <%= form.number_field :min_committee_members, min: 0, step: 1 %>
+    </div>
+
     <div class="row">
       <div class="columns xlarge-6">
         <%= form.upload :banner_image %>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/promotal_committee.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/promotal_committee.html.erb
@@ -8,7 +8,7 @@
 <div class="row column">
   <div class="column large-6 medium-centered">
     <div class="callout secondary">
-      <%= t ".individual_help_text" %>
+      <%= t ".individual_help_text", committee_size: current_initiative.min_committee_members %>
       <%= link_to t(".more_information"), decidim.page_path("initiatives"), target: "_blank" %>.
     </div>
   </div>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/promotal_committee.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/promotal_committee.html.erb
@@ -8,7 +8,7 @@
 <div class="row column">
   <div class="column large-6 medium-centered">
     <div class="callout secondary">
-      <%= t ".individual_help_text", committee_size: current_initiative.min_committee_members %>
+      <%= t ".individual_help_text", committee_size: current_initiative.minimum_committee_members %>
       <%= link_to t(".more_information"), decidim.page_path("initiatives"), target: "_blank" %>.
     </div>
   </div>

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -27,7 +27,7 @@ en:
       initiatives_type:
         banner_image: Banner image
         description: Description
-        min_committee_members: Minimum of committee members
+        minimum_committee_members: Minimum of committee members
         online_signature_enabled: Online signature enabled
         title: Title
       organization_data:

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -27,6 +27,7 @@ en:
       initiatives_type:
         banner_image: Banner image
         description: Description
+        min_committee_members: Minimum of committee members
         online_signature_enabled: Online signature enabled
         title: Title
       organization_data:
@@ -242,7 +243,7 @@ en:
           more_information: "(More information)"
         promotal_committee:
           back: Back
-          individual_help_text: Citizen initiatives require a Promoting Commission consisting of at least three people (attestors). You must share the following link with the other people that are part of this initiative. When your contacts receive this link they will have to follow the indicated steps.
+          individual_help_text: This kind of citizen initiative requires a Promoting Commission consisting of at least %{committee_size} people (attestors). You must share the following link with the other people that are part of this initiative. When your contacts receive this link they will have to follow the indicated steps.
           more_information: "(More information)"
         select_initiative_type:
           back: Back

--- a/decidim-initiatives/db/migrate/20181213184712_add_min_committee_members_to_initiative_type.rb
+++ b/decidim-initiatives/db/migrate/20181213184712_add_min_committee_members_to_initiative_type.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMinCommitteeMembersToInitiativeType < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_initiatives_types, :min_committee_members, :integer, null: true, default: nil
+  end
+end

--- a/decidim-initiatives/db/migrate/20181213184712_add_min_committee_members_to_initiative_type.rb
+++ b/decidim-initiatives/db/migrate/20181213184712_add_min_committee_members_to_initiative_type.rb
@@ -2,6 +2,6 @@
 
 class AddMinCommitteeMembersToInitiativeType < ActiveRecord::Migration[5.2]
   def change
-    add_column :decidim_initiatives_types, :min_committee_members, :integer, null: true, default: nil
+    add_column :decidim_initiatives_types, :minimum_committee_members, :integer, null: true, default: nil
   end
 end

--- a/decidim-initiatives/lib/decidim/initiatives/test/factories.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/test/factories.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     banner_image { Decidim::Dev.test_file("city2.jpeg", "image/jpeg") }
     organization
     online_signature_enabled { true }
+    min_committee_members { 3 }
 
     trait :online_signature_enabled do
       online_signature_enabled { true }

--- a/decidim-initiatives/lib/decidim/initiatives/test/factories.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/test/factories.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     banner_image { Decidim::Dev.test_file("city2.jpeg", "image/jpeg") }
     organization
     online_signature_enabled { true }
-    min_committee_members { 3 }
+    minimum_committee_members { 3 }
 
     trait :online_signature_enabled do
       online_signature_enabled { true }

--- a/decidim-initiatives/spec/forms/initiative_type_form_spec.rb
+++ b/decidim-initiatives/spec/forms/initiative_type_form_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Initiatives
+    module Admin
+      describe InitiativeTypeForm do
+        subject { described_class.from_params(attributes).with_context(context) }
+
+        let(:organization) { create :organization }
+        let(:initiatives_type) { create(:initiatives_type, organization: organization) }
+        let(:title) { Decidim::Faker::Localized.sentence(5) }
+        let(:min_committee_members) { 5 }
+        let(:attributes) do
+          {
+            title: title,
+            description: Decidim::Faker::Localized.sentence(25),
+            online_signature_enabled: false,
+            min_committee_members: min_committee_members,
+            banner_image: Decidim::Dev.test_file("city2.jpeg", "image/jpeg")
+          }
+        end
+        let(:context) do
+          {
+            current_organization: initiatives_type.organization,
+            current_component: nil
+          }
+        end
+
+        context "when everything is OK" do
+          it { is_expected.to be_valid }
+        end
+
+        context "when min_committee_members is blank" do
+          let(:min_committee_members) { " " }
+
+          it "is nullified" do
+            expect(subject.min_committee_members).to be_nil
+          end
+        end
+
+        context "when title is missing" do
+          let(:title) { nil }
+
+          it { is_expected.to be_invalid }
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/spec/forms/initiative_type_form_spec.rb
+++ b/decidim-initiatives/spec/forms/initiative_type_form_spec.rb
@@ -11,13 +11,13 @@ module Decidim
         let(:organization) { create :organization }
         let(:initiatives_type) { create(:initiatives_type, organization: organization) }
         let(:title) { Decidim::Faker::Localized.sentence(5) }
-        let(:min_committee_members) { 5 }
+        let(:minimum_committee_members) { 5 }
         let(:attributes) do
           {
             title: title,
             description: Decidim::Faker::Localized.sentence(25),
             online_signature_enabled: false,
-            min_committee_members: min_committee_members,
+            minimum_committee_members: minimum_committee_members,
             banner_image: Decidim::Dev.test_file("city2.jpeg", "image/jpeg")
           }
         end
@@ -32,11 +32,11 @@ module Decidim
           it { is_expected.to be_valid }
         end
 
-        context "when min_committee_members is blank" do
-          let(:min_committee_members) { " " }
+        context "when minimum_committee_members is blank" do
+          let(:minimum_committee_members) { " " }
 
           it "is nullified" do
-            expect(subject.min_committee_members).to be_nil
+            expect(subject.minimum_committee_members).to be_nil
           end
         end
 

--- a/decidim-initiatives/spec/helpers/decidim/initiatives/create_initiative_helper_spec.rb
+++ b/decidim-initiatives/spec/helpers/decidim/initiatives/create_initiative_helper_spec.rb
@@ -71,6 +71,18 @@ module Decidim
           expect(signature_type_options).to match_array(all)
         end
       end
+
+      context "when signature setting changed" do
+        let(:signature_type) { "online" }
+        let(:initiative_state) { "published" }
+        let(:signature_type_options) { helper.signature_type_options(form) }
+
+        before { initiative_type.update!(online_signature_enabled: false) }
+
+        it "contains all signature type options" do
+          expect(signature_type_options).to match_array(all)
+        end
+      end
     end
   end
 end

--- a/decidim-initiatives/spec/models/decidim/initiative_spec.rb
+++ b/decidim-initiatives/spec/models/decidim/initiative_spec.rb
@@ -9,12 +9,12 @@ module Decidim
     let(:organization) { create(:organization) }
     let(:initiative) { build :initiative }
 
-    let(:initiatives_type_min_committee_members) { 2 }
+    let(:initiatives_type_minimum_committee_members) { 2 }
     let(:initiatives_type) do
       create(
         :initiatives_type,
         organization: organization,
-        min_committee_members: initiatives_type_min_committee_members
+        minimum_committee_members: initiatives_type_minimum_committee_members
       )
     end
     let(:scoped_type) { create(:initiatives_type_scope, type: initiatives_type) }
@@ -217,8 +217,8 @@ module Decidim
       end
     end
 
-    describe "#min_committee_members" do
-      subject { initiative.min_committee_members }
+    describe "#minimum_committee_members" do
+      subject { initiative.minimum_committee_members }
 
       let(:committee_members_fallback_setting) { 1 }
       let(:initiative) { create(:initiative, organization: organization, scoped_type: scoped_type) }
@@ -230,11 +230,11 @@ module Decidim
       end
 
       context "when setting defined in type" do
-        it { is_expected.to eq initiatives_type_min_committee_members }
+        it { is_expected.to eq initiatives_type_minimum_committee_members }
       end
 
       context "when setting not set" do
-        let(:initiatives_type_min_committee_members) { nil }
+        let(:initiatives_type_minimum_committee_members) { nil }
 
         it { is_expected.to eq committee_members_fallback_setting }
       end
@@ -243,19 +243,19 @@ module Decidim
     describe "#enough_committee_members?" do
       subject { initiative.enough_committee_members? }
 
-      let(:initiatives_type_min_committee_members) { 2 }
+      let(:initiatives_type_minimum_committee_members) { 2 }
       let(:initiative) { create(:initiative, organization: organization, scoped_type: scoped_type) }
 
       before { initiative.committee_members.destroy_all }
 
       context "when enough members" do
-        before { create_list(:initiatives_committee_member, initiatives_type_min_committee_members, initiative: initiative) }
+        before { create_list(:initiatives_committee_member, initiatives_type_minimum_committee_members, initiative: initiative) }
 
         it { is_expected.to eq true }
       end
 
       context "when not enough members" do
-        before { create_list(:initiatives_committee_member, initiatives_type_min_committee_members - 1, initiative: initiative) }
+        before { create_list(:initiatives_committee_member, initiatives_type_minimum_committee_members - 1, initiative: initiative) }
 
         it { is_expected.to eq false }
       end

--- a/decidim-initiatives/spec/models/decidim/initiative_spec.rb
+++ b/decidim-initiatives/spec/models/decidim/initiative_spec.rb
@@ -9,6 +9,16 @@ module Decidim
     let(:organization) { create(:organization) }
     let(:initiative) { build :initiative }
 
+    let(:initiatives_type_min_committee_members) { 2 }
+    let(:initiatives_type) do
+      create(
+        :initiatives_type,
+        organization: organization,
+        min_committee_members: initiatives_type_min_committee_members
+      )
+    end
+    let(:scoped_type) { create(:initiatives_type_scope, type: initiatives_type) }
+
     include_examples "has reference"
 
     context "when created initiative" do
@@ -204,6 +214,50 @@ module Decidim
           initiative.update(offline_votes: offline_votes, initiative_votes_count: online_votes)
           expect(initiative.percentage).to eq(100)
         end
+      end
+    end
+
+    describe "#min_committee_members" do
+      subject { initiative.min_committee_members }
+
+      let(:committee_members_fallback_setting) { 1 }
+      let(:initiative) { create(:initiative, organization: organization, scoped_type: scoped_type) }
+
+      before do
+        allow(Decidim::Initiatives).to(
+          receive(:minimum_committee_members).and_return(committee_members_fallback_setting)
+        )
+      end
+
+      context "when setting defined in type" do
+        it { is_expected.to eq initiatives_type_min_committee_members }
+      end
+
+      context "when setting not set" do
+        let(:initiatives_type_min_committee_members) { nil }
+
+        it { is_expected.to eq committee_members_fallback_setting }
+      end
+    end
+
+    describe "#enough_committee_members?" do
+      subject { initiative.enough_committee_members? }
+
+      let(:initiatives_type_min_committee_members) { 2 }
+      let(:initiative) { create(:initiative, organization: organization, scoped_type: scoped_type) }
+
+      before { initiative.committee_members.destroy_all }
+
+      context "when enough members" do
+        before { create_list(:initiatives_committee_member, initiatives_type_min_committee_members, initiative: initiative) }
+
+        it { is_expected.to eq true }
+      end
+
+      context "when not enough members" do
+        before { create_list(:initiatives_committee_member, initiatives_type_min_committee_members - 1, initiative: initiative) }
+
+        it { is_expected.to eq false }
       end
     end
   end

--- a/decidim-initiatives/spec/permissions/decidim/initiatives/admin/permissions_spec.rb
+++ b/decidim-initiatives/spec/permissions/decidim/initiatives/admin/permissions_spec.rb
@@ -198,10 +198,18 @@ describe Decidim::Initiatives::Admin::Permissions do
 
           context "when initiative has enough approved members" do
             before do
-              allow(Decidim::Initiatives).to receive(:minimum_committee_members).and_return(1)
+              allow(initiative).to receive(:enough_committee_members?).and_return(true)
             end
 
             it { is_expected.to eq true }
+          end
+
+          context "when initiative has not enough approved members" do
+            before do
+              allow(initiative).to receive(:enough_committee_members?).and_return(false)
+            end
+
+            it { is_expected.to eq false }
           end
         end
       end

--- a/decidim-initiatives/spec/shared/create_initiative_type_example.rb
+++ b/decidim-initiatives/spec/shared/create_initiative_type_example.rb
@@ -18,6 +18,7 @@ shared_examples "create an initiative type" do
         title: Decidim::Faker::Localized.sentence(5),
         description: Decidim::Faker::Localized.sentence(25),
         online_signature_enabled: true,
+        min_committee_members: 7,
         banner_image: Decidim::Dev.test_file("city2.jpeg", "image/jpeg")
       }
     end

--- a/decidim-initiatives/spec/shared/create_initiative_type_example.rb
+++ b/decidim-initiatives/spec/shared/create_initiative_type_example.rb
@@ -18,7 +18,7 @@ shared_examples "create an initiative type" do
         title: Decidim::Faker::Localized.sentence(5),
         description: Decidim::Faker::Localized.sentence(25),
         online_signature_enabled: true,
-        min_committee_members: 7,
+        minimum_committee_members: 7,
         banner_image: Decidim::Dev.test_file("city2.jpeg", "image/jpeg")
       }
     end

--- a/decidim-initiatives/spec/shared/update_initiative_type_example.rb
+++ b/decidim-initiatives/spec/shared/update_initiative_type_example.rb
@@ -3,7 +3,6 @@
 shared_examples "update an initiative type" do
   let(:organization) { create(:organization) }
   let(:initiative_type) { create(:initiatives_type, :online_signature_enabled, organization: organization) }
-
   let(:form) do
     form_klass.from_params(
       form_params
@@ -19,6 +18,7 @@ shared_examples "update an initiative type" do
         title: Decidim::Faker::Localized.sentence(5),
         description: Decidim::Faker::Localized.sentence(25),
         online_signature_enabled: false,
+        min_committee_members: 7,
         banner_image: Decidim::Dev.test_file("city2.jpeg", "image/jpeg")
       }
     end
@@ -39,6 +39,7 @@ shared_examples "update an initiative type" do
         expect(initiative_type.title).not_to eq(form_params[:title])
         expect(initiative_type.description).not_to eq(form_params[:description])
         expect(initiative_type.online_signature_enabled).not_to eq(form_params[:online_signature_enabled])
+        expect(initiative_type.min_committee_members).not_to eq(form_params[:min_committee_members])
       end
     end
 
@@ -55,6 +56,7 @@ shared_examples "update an initiative type" do
         expect(initiative_type.title).to eq(form_params[:title])
         expect(initiative_type.description).to eq(form_params[:description])
         expect(initiative_type.online_signature_enabled).to eq(form_params[:online_signature_enabled])
+        expect(initiative_type.min_committee_members).to eq(form_params[:min_committee_members])
       end
 
       it "propagates signature type to created initiatives" do

--- a/decidim-initiatives/spec/shared/update_initiative_type_example.rb
+++ b/decidim-initiatives/spec/shared/update_initiative_type_example.rb
@@ -18,7 +18,7 @@ shared_examples "update an initiative type" do
         title: Decidim::Faker::Localized.sentence(5),
         description: Decidim::Faker::Localized.sentence(25),
         online_signature_enabled: false,
-        min_committee_members: 7,
+        minimum_committee_members: 7,
         banner_image: Decidim::Dev.test_file("city2.jpeg", "image/jpeg")
       }
     end
@@ -39,7 +39,7 @@ shared_examples "update an initiative type" do
         expect(initiative_type.title).not_to eq(form_params[:title])
         expect(initiative_type.description).not_to eq(form_params[:description])
         expect(initiative_type.online_signature_enabled).not_to eq(form_params[:online_signature_enabled])
-        expect(initiative_type.min_committee_members).not_to eq(form_params[:min_committee_members])
+        expect(initiative_type.minimum_committee_members).not_to eq(form_params[:minimum_committee_members])
       end
     end
 
@@ -56,7 +56,7 @@ shared_examples "update an initiative type" do
         expect(initiative_type.title).to eq(form_params[:title])
         expect(initiative_type.description).to eq(form_params[:description])
         expect(initiative_type.online_signature_enabled).to eq(form_params[:online_signature_enabled])
-        expect(initiative_type.min_committee_members).to eq(form_params[:min_committee_members])
+        expect(initiative_type.minimum_committee_members).to eq(form_params[:minimum_committee_members])
       end
 
       it "propagates signature type to created initiatives" do

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -32,7 +32,8 @@ describe "Initiative", type: :system do
     end
 
     context "without validation" do
-      let(:initiative_type) { create(:initiatives_type, organization: organization) }
+      let(:initiative_type_min_committee_members) { 2 }
+      let(:initiative_type) { create(:initiatives_type, organization: organization, min_committee_members: initiative_type_min_committee_members) }
       let!(:other_initiative_type) { create(:initiatives_type, organization: organization) }
       let!(:initiative_type_scope) { create(:initiatives_type_scope, type: initiative_type) }
 
@@ -147,7 +148,7 @@ describe "Initiative", type: :system do
       end
 
       context "when Promotal committee" do
-        let(:initiative) { build(:initiative) }
+        let(:initiative) { build(:initiative, organization: organization, scoped_type: initiative_type_scope) }
 
         before do
           find_button("Choose").click
@@ -167,7 +168,7 @@ describe "Initiative", type: :system do
 
         it "Offers contextual help" do
           within ".callout.secondary" do
-            expect(page).to have_content("Citizen initiatives require a Promoting Commission consisting of at least three people (attestors). You must share the following link with the other people that are part of this initiative. When your contacts receive this link they will have to follow the indicated steps.")
+            expect(page).to have_content("This kind of citizen initiative requires a Promoting Commission consisting of at least #{initiative_type_min_committee_members} people (attestors). You must share the following link with the other people that are part of this initiative. When your contacts receive this link they will have to follow the indicated steps.")
           end
         end
 
@@ -177,6 +178,15 @@ describe "Initiative", type: :system do
 
         it "Contains a button to continue with next step" do
           expect(page).to have_content("Continue")
+        end
+
+        context "when minimum committee size is zero" do
+          let(:initiative_type_min_committee_members) { 0 }
+
+          it "skips to next step" do
+            expect(page).not_to have_content("Promoter committee")
+            expect(page).to have_content("Finish")
+          end
         end
       end
 

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -32,8 +32,8 @@ describe "Initiative", type: :system do
     end
 
     context "without validation" do
-      let(:initiative_type_min_committee_members) { 2 }
-      let(:initiative_type) { create(:initiatives_type, organization: organization, min_committee_members: initiative_type_min_committee_members) }
+      let(:initiative_type_minimum_committee_members) { 2 }
+      let(:initiative_type) { create(:initiatives_type, organization: organization, minimum_committee_members: initiative_type_minimum_committee_members) }
       let!(:other_initiative_type) { create(:initiatives_type, organization: organization) }
       let!(:initiative_type_scope) { create(:initiatives_type_scope, type: initiative_type) }
 
@@ -168,7 +168,7 @@ describe "Initiative", type: :system do
 
         it "Offers contextual help" do
           within ".callout.secondary" do
-            expect(page).to have_content("This kind of citizen initiative requires a Promoting Commission consisting of at least #{initiative_type_min_committee_members} people (attestors). You must share the following link with the other people that are part of this initiative. When your contacts receive this link they will have to follow the indicated steps.")
+            expect(page).to have_content("This kind of citizen initiative requires a Promoting Commission consisting of at least #{initiative_type_minimum_committee_members} people (attestors). You must share the following link with the other people that are part of this initiative. When your contacts receive this link they will have to follow the indicated steps.")
           end
         end
 
@@ -181,7 +181,7 @@ describe "Initiative", type: :system do
         end
 
         context "when minimum committee size is zero" do
-          let(:initiative_type_min_committee_members) { 0 }
+          let(:initiative_type_minimum_committee_members) { 0 }
 
           it "skips to next step" do
             expect(page).not_to have_content("Promoter committee")


### PR DESCRIPTION
#### :tophat: What? Why?

Adds setting in `Decidim::InitiativesType` to set minimum number of committee members needed by an initiative before it can be sent to technical evaluation.

#### :pushpin: Related Issues

- Fixes #4648 

#### :clipboard: Subtasks

- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)

![image](https://user-images.githubusercontent.com/9287468/50233399-a5f77c80-03b3-11e9-919b-5b6d7d890f05.png)

