### PR TITLE
Filter meetings by end time instead of start time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,7 @@ In order to generate Open Data exports you should add this to your crontab or re
 - **decidim-surveys**: Don't crash on settings change [\#4642](https://github.com/decidim/decidim/pull/4642)
 - **decidim-core**: Update Ransack to work with Rails 5.2.2 [\#4682](https://github.com/decidim/decidim/pull/4682)
 - **decidim-core**: Fix background-size on home page [\#4678](https://github.com/decidim/decidim/pull/4678)
+- **decidim-meetings**: Filter meeting by end time instead of start time [\#4701](https://github.com/decidim/decidim/pull/4701)
 
 **Removed**:
 

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -35,7 +35,7 @@ module Decidim
       geocoded_by :address, http_headers: ->(proposal) { { "Referer" => proposal.component.organization.host } }
 
       scope :past, -> { where(arel_table[:end_time].lteq(Time.current)) }
-      scope :upcoming, -> { where(arel_table[:start_time].gt(Time.current)) }
+      scope :upcoming, -> { where(arel_table[:end_time].gteq(Time.current)) }
 
       scope :visible_meeting_for, lambda { |user|
                                     joins("LEFT JOIN decidim_meetings_registrations ON

--- a/decidim-meetings/app/services/decidim/meetings/meeting_search.rb
+++ b/decidim-meetings/app/services/decidim/meetings/meeting_search.rb
@@ -25,9 +25,9 @@ module Decidim
       # Handle the date filter
       def search_date
         if options[:date] == "upcoming"
-          query.where("start_time >= ? ", Time.current).order(start_time: :asc)
+          query.where("end_time >= ? ", Time.current).order(start_time: :asc)
         elsif options[:date] == "past"
-          query.where("start_time <= ? ", Time.current).order(start_time: :desc)
+          query.where("end_time <= ? ", Time.current).order(start_time: :desc)
         end
       end
 

--- a/decidim-meetings/spec/services/meeting_search_spec.rb
+++ b/decidim-meetings/spec/services/meeting_search_spec.rb
@@ -25,7 +25,8 @@ module Decidim::Meetings
       create(
         :meeting,
         component: current_component,
-        start_time: 2.days.from_now,
+        start_time: 1.day.ago,
+        end_time: 2.days.from_now,
         category: subcategory,
         scope: scope2,
         description: Decidim::Faker::Localized.literal("Curabitur arcu erat, accumsan id imperdiet et.")
@@ -59,7 +60,7 @@ module Decidim::Meetings
       context "with date" do
         let(:params) { default_params.merge(date: date) }
         let!(:past_meeting) do
-          create(:meeting, component: current_component, start_time: 1.day.ago)
+          create(:meeting, component: current_component, start_time: 10.days.ago, end_time: 1.day.ago)
         end
 
         context "when upcoming" do


### PR DESCRIPTION
#### :tophat: What? Why?

If a meeting lasts multiple days we would show it as past instead of upcoming. With these changes current meetings are included in upcoming ones.

#### :pushpin: Related Issues
- Fixes #4691

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
