### PR TITLE
Add Sublime Text 3 .tags file to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ schema.json
 .yardoc
 .rspec-failures
 .rbenv-vars
+# Sublime Text 3 indexing file: .tags
+.tags


### PR DESCRIPTION
#### :tophat: What? Why?
Gitignore .tags file that is used by Sublime Text 3 for temporal indexing.

#### :pushpin: Related Issues
Not realted to any Issue/Bug.

#### :clipboard: Subtasks
- [-] Add `CHANGELOG` entry
- [-] Add documentation regarding the feature 
- [-] Add/modify seeds
- [-] Add tests
- [-] Another subtask
