### PR TITLE
Fix form builder upload field multiple errors display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 **Fixed**:
 
+- **decidim-core**: Fix form builder upload field multiple errors display [\#4715](https://github.com/decidim/decidim/pull/4715)
 
 **Removed**:
 

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -354,7 +354,7 @@ module Decidim
 
       if object.errors[attribute].any?
         template += content_tag :p, class: "is-invalid-label" do
-          safe_join object.errors[attribute], "<br/>"
+          safe_join object.errors[attribute], "<br/>".html_safe
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
The upload field prints `<br/>` as a string in case there is multiple errors related to the upload field.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry