### PR TITLE
WIP: Documentation for i18n on multitenant

### DIFF
--- a/docs/customization/texts.md
+++ b/docs/customization/texts.md
@@ -13,3 +13,30 @@ en:
 ```
 
 You need to create a file for this translation as [Ruby on Rails i18n documentation](http://guides.rubyonrails.org/i18n.html) says, for instance config/locales/home.en.yml
+
+## By organization
+
+To have different translations by organization on a multitenant (for instance, if an organization would want to call *Councils* instead of *Assemblies*), you'll need to make these steps:
+
+* Add a new file to `config/locales/` with a new regional. For instance we'll call it **"es-CST"**
+
+* Add a new file for datepicker locales on `vendor/assets/javascripts/datepicker-locales/foundation-datepicker.es-CST.js`, based on availables languages.
+
+* Change your available locales on `config/initializers/decidim.rb`:
+
+```ruby
+  config.available_locales = [:en, :ca, :es, :"es-CST"]
+```
+
+* Add the fallback language on `config/application.rb`:
+
+```ruby
+  config.i18n.fallbacks = { 'es-CST' => 'es' }
+```
+
+* Create the organization on System panel with the new language.
+
+At the moment this solution has two handicaps:
+
+* It's only possible to do it with new Organizations
+* It's ugly at the URL level (?locale=es-CST)


### PR DESCRIPTION
#### :tophat: What? Why?
Adds documentation on how to customize the terminology for every Tenant/Organization. 

Also we found [this gem](https://github.com/ElMassimo/i18n_multitenant) that seems to do the same, although we didn't try it yet. 

We need to keep investigating what could be the best way on doing this feature, the proposed solution isn't as clean as it could be.

#### :pushpin: Related Issues
- Fixes #4697 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [x] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

