### PR TITLE
[WIP]: Easy demo for Decidim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+#Demo image for decidim
+FROM decidim/decidim-cli
+
+#Instance name
+ARG APP_NAME=${APP_NAME:-DemoApp}
+
+#Database connectivity
+ARG DATABASE_HOST=${DATABASE_HOST:-postgres}
+ARG DATABASE_USERNAME=${DATABASE_USERNAME:-postgres}
+ARG DATABASE_PASSWORD=${DATABASE_PASSWORD:-postgres}
+
+ENV DATABASE_HOST=${DATABASE_HOST}
+ENV DATABASE_USERNAME=${DATABASE_USERNAME}
+ENV DATABASE_PASSWORD=${DATABASE_PASSWORD}
+
+RUN decidim ${APP_NAME}
+
+WORKDIR /code/${APP_NAME}/
+
+COPY ./start-demo ./
+
+CMD ./start-demo

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,0 +1,8 @@
+# Decidim command line image
+FROM ruby:2.5.1-stretch
+
+WORKDIR /code/
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN gem install decidim
+RUN apt-get update && apt-get -y install nodejs

--- a/docker-demo.yml
+++ b/docker-demo.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  decidim:
+    image: decidim/decidim
+    ports:
+      - 3000:3000
+  postgres:
+    image: postgres
+    volumes:
+      - ./data/postgresql:/var/lib/postgresql/data
+  redis:
+    image: redis
+    volumes:
+      - ./data/redis:/data
+

--- a/start-demo
+++ b/start-demo
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -x
+
+if [ ! -f /initialzied ]; then
+    echo "Initializing database..."
+    rails db:create
+    rails db:migrate
+    rails db:seed
+    echo "Done" > /initialzieds
+fi
+
+rails server


### PR DESCRIPTION
#### :tophat: What? Why?
Adds an easy way to setup a Decidim instance for demo purposes so we can lower the entry barrier to test and explore Decidim.

This PR includes 2 changes.

#### decidim/decidim-cli ####
Docker image for the decidim command line application which enables us to use the cli without having to setup the environment and to easily build sub-images for custom decidim instances.

#### decidim/decidim ####
A demo Docker image + compose file ready to be used.

#### :clipboard: Subtasks
- [ ] Add documentation regarding the feature
- [ ] Fixtures for a demo environment
- [ ] Setup CI

#### Questions

- If the idea seems appealing, where should I document this?
- Once the gem is build and publish, we should rebuild the images. How?
- Do we want stable and master images?
- Can anybody provide interesting ready-to-use fixtures? Game of Thrones lore perhaps?
