### PR TITLE
Fix locale names on Crowdin

### DIFF
--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -12,6 +12,7 @@ files:
         fr: fr
         gl: gl
         hu: hu
+        id-ID: id
         it: it
         nl: nl
         pl: pl
@@ -19,4 +20,5 @@ files:
         pt-PT: pt
         rumany: ru
         sv-SE: sv
+        tr-TR: tr
         ukmany: uk


### PR DESCRIPTION
#### :tophat: What? Why?
Crowdin exports the locale names in a wrong format. for example, both Turkish and Indonesian are exported in `tr.yml` and `id.yml` files, but the main key for the files are `tr-TR:` and `id-ID:`, which shouldn't be happening and breaks the comments translations.


#### :pushpin: Related Issues
- Related to #4728

#### :clipboard: Subtasks
None