### PR TITLE
MetricResolver filtering corrected comparison between symbol and string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@
 
 **Upgrade notes**:
 
-
 **Added**:
-
 
 **Changed**:
 
@@ -15,9 +13,9 @@
 **Fixed**:
 
 - **decidim-core**: Fix form builder upload field multiple errors display [\#4715](https://github.com/decidim/decidim/pull/4715)
+- **decidim-core**: MetricResolver filtering corrected comparison between symbol and string [\#4733](https://github.com/decidim/decidim/pull/4733)
 
 **Removed**:
-
 
 ## Previous versions
 

--- a/decidim-core/app/resolvers/decidim/core/metric_resolver.rb
+++ b/decidim-core/app/resolvers/decidim/core/metric_resolver.rb
@@ -47,7 +47,7 @@ module Decidim
       # Only key name attributes in Decidim::Metric will be applied
       def filter
         @filters.each do |key, value|
-          next unless Decidim::Metric.column_names.include? key
+          next unless Decidim::Metric.column_names.include? key.to_s
           @records = @records.where("#{key}": value)
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
MetricResolver was not filtering results by `ParticipatorySpace`, even when values passed by parameter. This correction solves it.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

