### PR TITLE
[BACKPORT] MetricResolver filtering correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,7 @@ In order to generate Open Data exports you should add this to your crontab or re
 - **decidim-core**: Update Ransack to work with Rails 5.2.2 [\#4682](https://github.com/decidim/decidim/pull/4682)
 - **decidim-core**: Fix background-size on home page [\#4678](https://github.com/decidim/decidim/pull/4678)
 - **decidim-meetings**: Filter meeting by end time instead of start time [\#4701](https://github.com/decidim/decidim/pull/4701)
+- **decidim-core**: MetricResolver filtering corrected comparison between symbol and string [\#4736](https://github.com/decidim/decidim/pull/4736)
 
 **Removed**:
 

--- a/decidim-core/app/resolvers/decidim/core/metric_resolver.rb
+++ b/decidim-core/app/resolvers/decidim/core/metric_resolver.rb
@@ -47,7 +47,7 @@ module Decidim
       # Only key name attributes in Decidim::Metric will be applied
       def filter
         @filters.each do |key, value|
-          next unless Decidim::Metric.column_names.include? key
+          next unless Decidim::Metric.column_names.include? key.to_s
           @records = @records.where("#{key}": value)
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
MetricResolver was not filtering results by ParticipatorySpace, even when values passed by parameter. Backport for 0.16.X Decidim version

#### :pushpin: Related Issues
- Related to #4733

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

