### PR TITLE
Prevent change password field to be autocompleted

### DIFF
--- a/decidim-core/app/views/decidim/account/show.html.erb
+++ b/decidim-core/app/views/decidim/account/show.html.erb
@@ -1,5 +1,6 @@
 <div class="row">
-  <%= decidim_form_for(@account, url: account_path, method: :put, class: "user-form", autocomplete: "nope") do |f| %>
+  <%= decidim_form_for(@account, url: account_path, method: :put, html: { autocomplete: "nope" }) do |f| %>
+    <input autocomplete="off" name="hidden" type="password" style="display:none;" />
     <div class="columns large-4">
       <%= f.upload :avatar %>
     </div>


### PR DESCRIPTION
#### :tophat: What? Why?
Changes done in #2529 weren't being taken into account. I'm pretty sure that those changes were working when they were applied, but currently I can't find any evidence of that. :face_with_head_bandage: 

I've tested the `autocomplete: nope` and it wasn't working in my Firefox 64.

I think this problem could be very annoying for users, so we should do anything to prevent it. I've added a fake password field and now it works in my browser, but I guess that we should test in other browsers. :cry: 

#### :pushpin: Related Issues
- Related to #2529

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
