### PR TITLE
Adds environment to open data export task to avoid errors

### DIFF
--- a/decidim-core/lib/tasks/decidim_open_data_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_open_data_tasks.rake
@@ -3,7 +3,7 @@
 namespace :decidim do
   namespace :open_data do
     desc "Generates the Open Data export files for each organization."
-    task :export do
+    task export: :environment do
       Decidim::Organization.find_each do |organization|
         Decidim::OpenDataJob.perform_later(organization)
       end


### PR DESCRIPTION
#### :tophat: What? Why?
When running the open data export task, I receive the following error, that can be fixed adding the environment to the task:
```bash
$ RAILS_ENV=production bundle exec rails decidim:open_data:export
from (path)/bundle/ruby/2.5.0/gems/bootsnap-1.3.2/lib/bootsnap.rb:22:in `setup': The 'disable_trace' method is not allowed with this Ruby version. current: 2.5.1, allowed version: < 2.5.0
rails aborted!
NameError: uninitialized constant Decidim::Organization
(path)/bundle/ruby/2.5.0/gems/bootsnap-1.3.2/lib/bootsnap/load_path_cache/core_ext/active_support.rb:74:in `block in load_missing_constant'
(path)/bundle/ruby/2.5.0/gems/bootsnap-1.3.2/lib/bootsnap/load_path_cache/core_ext/active_support.rb:8:in `without_bootsnap_cache'
(path)/bundle/ruby/2.5.0/gems/bootsnap-1.3.2/lib/bootsnap/load_path_cache/core_ext/active_support.rb:74:in `rescue in load_missing_constant'
(path)/bundle/ruby/2.5.0/gems/bootsnap-1.3.2/lib/bootsnap/load_path_cache/core_ext/active_support.rb:56:in `load_missing_constant'
(path)/bundle/ruby/2.5.0/gems/decidim-core-0.16.0/lib/tasks/decidim_open_data_tasks.rake:7:in `block (3 levels) in <top (required)>'
(path)/bundle/ruby/2.5.0/gems/airbrake-7.4.0/lib/airbrake/rake.rb:17:in `execute'
(path)/bundle/ruby/2.5.0/gems/railties-5.2.2/lib/rails/commands/rake/rake_command.rb:23:in `block in perform'
(path)/bundle/ruby/2.5.0/gems/railties-5.2.2/lib/rails/commands/rake/rake_command.rb:20:in `perform'
(path)/bundle/ruby/2.5.0/gems/railties-5.2.2/lib/rails/command.rb:48:in `invoke'
(path)/bundle/ruby/2.5.0/gems/railties-5.2.2/lib/rails/commands.rb:18:in `<top (required)>'
(path)/bundle/ruby/2.5.0/gems/bootsnap-1.3.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:21:in `require'
(path)/bundle/ruby/2.5.0/gems/bootsnap-1.3.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:21:in `block in require_with_bootsnap_lfi'
(path)/bundle/ruby/2.5.0/gems/bootsnap-1.3.2/lib/bootsnap/load_path_cache/loaded_features_index.rb:65:in `register'
(path)/bundle/ruby/2.5.0/gems/bootsnap-1.3.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:20:in `require_with_bootsnap_lfi'
(path)/bundle/ruby/2.5.0/gems/bootsnap-1.3.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:29:in `require'
bin/rails:4:in `<main>'

Caused by:
NameError: uninitialized constant Decidim::Organization
(path)/bundle/ruby/2.5.0/gems/bootsnap-1.3.2/lib/bootsnap/load_path_cache/core_ext/active_support.rb:58:in `block in load_missing_constant'
(path)/bundle/ruby/2.5.0/gems/bootsnap-1.3.2/lib/bootsnap/load_path_cache/core_ext/active_support.rb:16:in `allow_bootsnap_retry'
(path)/bundle/ruby/2.5.0/gems/bootsnap-1.3.2/lib/bootsnap/load_path_cache/core_ext/active_support.rb:57:in `load_missing_constant'
(path)/bundle/ruby/2.5.0/gems/decidim-core-0.16.0/lib/tasks/decidim_open_data_tasks.rake:7:in `block (3 levels) in <top (required)>'
(path)/bundle/ruby/2.5.0/gems/airbrake-7.4.0/lib/airbrake/rake.rb:17:in `execute'
(path)/bundle/ruby/2.5.0/gems/railties-5.2.2/lib/rails/commands/rake/rake_command.rb:23:in `block in perform'
(path)/bundle/ruby/2.5.0/gems/railties-5.2.2/lib/rails/commands/rake/rake_command.rb:20:in `perform'
(path)/bundle/ruby/2.5.0/gems/railties-5.2.2/lib/rails/command.rb:48:in `invoke'
(path)/bundle/ruby/2.5.0/gems/railties-5.2.2/lib/rails/commands.rb:18:in `<top (required)>'
(path)/bundle/ruby/2.5.0/gems/bootsnap-1.3.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:21:in `require'
(path)/bundle/ruby/2.5.0/gems/bootsnap-1.3.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:21:in `block in require_with_bootsnap_lfi'
(path)/bundle/ruby/2.5.0/gems/bootsnap-1.3.2/lib/bootsnap/load_path_cache/loaded_features_index.rb:65:in `register'
(path)/bundle/ruby/2.5.0/gems/bootsnap-1.3.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:20:in `require_with_bootsnap_lfi'
(path)/bundle/ruby/2.5.0/gems/bootsnap-1.3.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:29:in `require'
bin/rails:4:in `<main>'
Tasks: TOP => decidim:open_data:export
(See full trace by running task with --trace)
```


#### :pushpin: Related Issues

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
