### PR TITLE
Ignore blank permission options in action authorizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - **decidim-core**: Place `CurrentOrganization` middleware before `WardenManager`. [\#4708](https://github.com/decidim/decidim/pull/4708)
 - **decidim-core**: Fix form builder upload field multiple errors display [\#4715](https://github.com/decidim/decidim/pull/4715)
 - **decidim-core**: MetricResolver filtering corrected comparison between symbol and string [\#4733](https://github.com/decidim/decidim/pull/4733)
+- **decidim-core**: Ignore blank permission options in action authorizer [\#4744](https://github.com/decidim/decidim/pull/4744)
 
 **Removed**:
 

--- a/decidim-core/spec/services/decidim/action_authorizer_spec.rb
+++ b/decidim-core/spec/services/decidim/action_authorizer_spec.rb
@@ -154,6 +154,14 @@ module Decidim
                                                                               postal_codes: "2345, 4567" } })
             end
           end
+
+          context "when options are present but empty" do
+            let(:options) { { postal_code: "" } }
+
+            it "returns ok" do
+              expect(response).to be_ok
+            end
+          end
         end
 
         context "when the authorization has expired" do

--- a/decidim-verifications/lib/decidim/verifications/default_action_authorizer.rb
+++ b/decidim-verifications/lib/decidim/verifications/default_action_authorizer.rb
@@ -70,17 +70,23 @@ module Decidim
       attr_reader :authorization, :options, :component, :resource
 
       def unmatched_fields
-        @unmatched_fields ||= (options.keys & authorization.metadata.to_h.keys).each_with_object({}) do |field, unmatched|
+        @unmatched_fields ||= (valid_options_keys & authorization.metadata.to_h.keys).each_with_object({}) do |field, unmatched|
           unmatched[field] = options[field] if authorization.metadata[field] != options[field]
           unmatched
         end
       end
 
       def missing_fields
-        @missing_fields ||= options.keys.each_with_object([]) do |field, missing|
+        @missing_fields ||= valid_options_keys.each_with_object([]) do |field, missing|
           missing << field if authorization.metadata[field].blank?
           missing
         end
+      end
+
+      def valid_options_keys
+        @valid_options_keys ||= options.map do |key, value|
+          key if value.present?
+        end.compact
       end
 
       def authorization_expired?


### PR DESCRIPTION
#### :tophat: What? Why?

When configuring the permissions for a component and with an authorizer that accepts options, if the option was blank it was asking the users for a value.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

