### PR TITLE
Fix action authorizer with blank permissions 0.15 backport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 **Fixed**:
 
+- **decidim-core**: Ignore blank permission options in action authorizer [\#4745](https://github.com/decidim/decidim/pull/4745)
+
+## [0.15.2](https://github.com/decidim/decidim/tree/v0.15.2)
+
+**Fixed**:
+
 - **decidim-meetings**: Fix meetings form when only one locale is available [\#4625](https://github.com/decidim/decidim/pull/4625)
 - **decidim-core**: Update Ransack to make it work with Rails 5.2.2 [\#4683](https://github.com/decidim/decidim/pull/4683)
 - **decidim-core**: Remove `current_feature` [\#4680](https://github.com/decidim/decidim/pull/4680)

--- a/decidim-core/spec/services/decidim/action_authorizer_spec.rb
+++ b/decidim-core/spec/services/decidim/action_authorizer_spec.rb
@@ -154,6 +154,14 @@ module Decidim
                                                                               postal_codes: "2345, 4567" } })
             end
           end
+
+          context "when options are present but empty" do
+            let(:options) { { postal_code: "" } }
+
+            it "returns ok" do
+              expect(response).to be_ok
+            end
+          end
         end
 
         context "when the authorization has expired" do

--- a/decidim-verifications/lib/decidim/verifications/default_action_authorizer.rb
+++ b/decidim-verifications/lib/decidim/verifications/default_action_authorizer.rb
@@ -70,17 +70,23 @@ module Decidim
       attr_reader :authorization, :options, :component, :resource
 
       def unmatched_fields
-        @unmatched_fields ||= (options.keys & authorization.metadata.to_h.keys).each_with_object({}) do |field, unmatched|
+        @unmatched_fields ||= (valid_options_keys & authorization.metadata.to_h.keys).each_with_object({}) do |field, unmatched|
           unmatched[field] = options[field] if authorization.metadata[field] != options[field]
           unmatched
         end
       end
 
       def missing_fields
-        @missing_fields ||= options.keys.each_with_object([]) do |field, missing|
+        @missing_fields ||= valid_options_keys.each_with_object([]) do |field, missing|
           missing << field if authorization.metadata[field].blank?
           missing
         end
+      end
+
+      def valid_options_keys
+        @valid_options_keys ||= options.map do |key, value|
+          key if value.present?
+        end.compact
       end
 
       def authorization_expired?


### PR DESCRIPTION
#### :tophat: What? Why?

Backports #4744 to `0.15-stable`
