### PR TITLE
Fix form when duplicating meetings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - **decidim-assemblies**: Fix assemblies filter by type [\#4778](https://github.com/decidim/decidim/pull/4778)
 - **decidim-conferences**: Fix error when visiting a Conference event[\#4776](https://github.com/decidim/decidim/pull/4776)
+- **decidim-meetings**: Fix form when duplicating meetings [\#4750](https://github.com/decidim/decidim/pull/4750)
 - **decidim-proposals** Fix unhideable reported collaborative drafts and mail jobs [\#4706](https://github.com/decidim/decidim/pull/4706)
 - **decidim-assemblies**: Fix parent assemblies children_count counter [\#4718](https://github.com/decidim/decidim/pull/4718/)
 - **decidim-core**: Place `CurrentOrganization` middleware before `WardenManager`. [\#4708](https://github.com/decidim/decidim/pull/4708)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@
 
 **Fixed**:
 
+- **decidim-meetings**: Fix form when duplicating meetings [\#4750](https://github.com/decidim/decidim/pull/4750)
 - **decidim-assemblies**: Fix assemblies filter by type [\#4778](https://github.com/decidim/decidim/pull/4778)
 - **decidim-conferences**: Fix error when visiting a Conference event[\#4776](https://github.com/decidim/decidim/pull/4776)
-- **decidim-meetings**: Fix form when duplicating meetings [\#4750](https://github.com/decidim/decidim/pull/4750)
 - **decidim-proposals** Fix unhideable reported collaborative drafts and mail jobs [\#4706](https://github.com/decidim/decidim/pull/4706)
 - **decidim-assemblies**: Fix parent assemblies children_count counter [\#4718](https://github.com/decidim/decidim/pull/4718/)
 - **decidim-core**: Place `CurrentOrganization` middleware before `WardenManager`. [\#4708](https://github.com/decidim/decidim/pull/4708)

--- a/decidim-meetings/app/commands/decidim/meetings/admin/copy_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/copy_meeting.rb
@@ -38,8 +38,8 @@ module Decidim
         attr_reader :form, :meeting
 
         def copy_meeting!
-          parsed_title = Decidim::ContentProcessor.parse_with_processor(:hashtag, @form.title, current_organization: @form.current_organization).rewrite
-          parsed_description = Decidim::ContentProcessor.parse_with_processor(:hashtag, @form.description, current_organization: @form.current_organization).rewrite
+          parsed_title = Decidim::ContentProcessor.parse_with_processor(:hashtag, @form.title, current_organization: @meeting.organization).rewrite
+          parsed_description = Decidim::ContentProcessor.parse_with_processor(:hashtag, @form.description, current_organization: @meeting.organization).rewrite
 
           @copied_meeting = Decidim.traceability.create!(
             Meeting,

--- a/decidim-meetings/app/commands/decidim/meetings/admin/copy_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/copy_meeting.rb
@@ -38,13 +38,16 @@ module Decidim
         attr_reader :form, :meeting
 
         def copy_meeting!
+          parsed_title = Decidim::ContentProcessor.parse_with_processor(:hashtag, @form.title, current_organization: @form.current_organization).rewrite
+          parsed_description = Decidim::ContentProcessor.parse_with_processor(:hashtag, @form.description, current_organization: @form.current_organization).rewrite
+
           @copied_meeting = Decidim.traceability.create!(
             Meeting,
             @form.current_user,
             scope: @meeting.scope,
             category: @meeting.category,
-            title: @form.title,
-            description: @form.description,
+            title: parsed_title,
+            description: parsed_description,
             end_time: @form.end_time,
             start_time: @form.start_time,
             address: @form.address,

--- a/decidim-meetings/app/views/decidim/meetings/admin/meeting_copies/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meeting_copies/_form.html.erb
@@ -4,12 +4,12 @@
   </div>
 
   <div class="card-section">
-    <div class="row column">
-      <%= form.translated :text_field, :title, autofocus: true, value: present(@meeting).title %>
+    <div class="row column  hashtags__container">
+      <%= form.translated :text_field, :title, autofocus: true, class: "js-hashtags", hashtaggable: true, value: @meeting.present? ? present(@meeting).title(all_locales: true) : @form.title.with_indifferent_access %>
     </div>
 
-    <div class="row column">
-      <%= form.translated :editor, :description, value: present(@meeting).description %>
+    <div class="row column hashtags__container">
+      <%= form.translated :editor, :description, class: "js-hashtags", hashtaggable: true, value: @meeting.present? ? present(@meeting).description(all_locales: true) : @form.description.with_indifferent_access %>
     </div>
 
     <div class="row column">

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
@@ -4,11 +4,12 @@
   </div>
   <div class="card-section">
     <div class="row column  hashtags__container">
-      <%= form.translated :text_field, :title, autofocus: true, class: "js-hashtags", hashtaggable: true, value: @meeting.present? ? present(@meeting).title(all_locales: true) : "" %>
+      <%= form.translated :text_field, :title, autofocus: true, class: "js-hashtags", hashtaggable: true, value: @meeting.present? ? present(@meeting).title(all_locales: true) : @form.title.with_indifferent_access %>
+      <%#raise%>
     </div>
 
     <div class="row column hashtags__container">
-      <%= form.translated :editor, :description, class: "js-hashtags", hashtaggable: true, value: @meeting.present? ? present(@meeting).description(all_locales: true) : "" %>
+      <%= form.translated :editor, :description, class: "js-hashtags", hashtaggable: true, value: @meeting.present? ? present(@meeting).description(all_locales: true) : @form.description.with_indifferent_access %>
     </div>
 
     <div class="row column">

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
@@ -5,7 +5,6 @@
   <div class="card-section">
     <div class="row column  hashtags__container">
       <%= form.translated :text_field, :title, autofocus: true, class: "js-hashtags", hashtaggable: true, value: @meeting.present? ? present(@meeting).title(all_locales: true) : @form.title.with_indifferent_access %>
-      <%#raise%>
     </div>
 
     <div class="row column hashtags__container">


### PR DESCRIPTION
#### :tophat: What? Why?
This PR solves problems when duplicating a meeting. Fields title and description, doesn't maintained the different languages ​​enabled on the platform. All languages ​​are displayed in the same language as the one you use to navigate the platform.

#### :pushpin: Related Issues
- Fixes #4711

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Fix form meeting when some error on validations
- [x] Fix form when duplicationg meeting

### :camera: Screenshots (optional)
![Description](URL)
