### PR TITLE
Fixes highlighted banner row

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/layouts/_highlighted_banner.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/layouts/_highlighted_banner.scss
@@ -31,8 +31,5 @@
       padding: 6rem 0;
     }
 
-    .row{
-      max-width: 100rem;
-    }
   }
 }

--- a/decidim-core/app/assets/stylesheets/decidim/layouts/_highlighted_banner.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/layouts/_highlighted_banner.scss
@@ -30,6 +30,5 @@
     @include breakpoint(large){
       padding: 6rem 0;
     }
-
   }
 }


### PR DESCRIPTION
#### :tophat: What? Why?

Removes the max-width row on highlighted banner on homepage, because it wasn't consistent with the design.

Pair programmed with @carolromero 

### :camera: Screenshots (optional)

#### Before

![imagen](https://user-images.githubusercontent.com/717367/51110124-b73b7980-17f7-11e9-980a-cb05420b96e3.png)

#### After

![imagen](https://user-images.githubusercontent.com/717367/51110129-bb679700-17f7-11e9-8b78-39281768fa42.png)
