### PR TITLE
Removes card--title__strong on blog posts titles

### DIFF
--- a/decidim-blogs/app/views/decidim/blogs/posts/_posts.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/posts/_posts.html.erb
@@ -4,7 +4,7 @@
       <div class="card__content">
         <div class="card__header">
           <%= link_to post, class: "card__link" do %>
-          <h5 class="card__title card__title--strong">
+          <h5 class="card__title">
             <%= translated_attribute post.title %>
           </h5>
           <% end %>

--- a/decidim-blogs/spec/system/explore_posts_spec.rb
+++ b/decidim-blogs/spec/system/explore_posts_spec.rb
@@ -13,8 +13,8 @@ describe "Explore posts", type: :system do
     it "shows all posts for the given process" do
       visit_component
       expect(page).to have_selector("article.card", count: 2)
-      expect(page).to have_selector(".card--post", text: translated(new_post.title).upcase)
-      expect(page).to have_selector(".card--post", text: translated(old_post.title).upcase)
+      expect(page).to have_selector(".card--post", text: translated(new_post.title))
+      expect(page).to have_selector(".card--post", text: translated(old_post.title))
     end
 
     context "when paginating" do

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
@@ -77,11 +77,6 @@ $datetime-bg: $primary;
   @extend .heading5;
 }
 
-.card__title--strong{
-  font-weight: bold;
-  text-transform: uppercase;
-}
-
 .card__header{
   margin-bottom: $card-padding / 2;
 

--- a/decidim_app-design/app/views/public/blog/blog.html.erb
+++ b/decidim_app-design/app/views/public/blog/blog.html.erb
@@ -78,7 +78,7 @@
           <div class="card__content">
             <div class="card__header">
               <%= link_to page_path("blog/blog-view"), class: "card__link" do %>
-              <h5 class="card__title card__title--strong">
+              <h5 class="card__title">
                 Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ratione fugit, ipsam ex omnis eos dicta modi adipisci, debitis harum?
               </h5>
               <% end %>
@@ -105,7 +105,7 @@
           <div class="card__content">
             <div class="card__header">
               <%= link_to page_path("blog/blog-view"), class: "card__link" do %>
-              <h5 class="card__title card__title--strong">
+              <h5 class="card__title">
                 Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ratione fugit, ipsam ex omnis eos dicta modi adipisci, debitis harum?
               </h5>
               <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

Removes the uppercase and bold on blog posts titles, because it wasn't consistent with the rest of the design.

Pair programmed with @carolromero

### :camera: Screenshots (optional)

#### Before

![imagen](https://user-images.githubusercontent.com/717367/51111320-01265e80-17fc-11e9-8a27-2597895089e6.png)

#### After

![imagen](https://user-images.githubusercontent.com/717367/51111324-04214f00-17fc-11e9-81fa-f990186368ab.png)
