### PR TITLE
Lock proposal on vote creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - **decidim-core**: Fix form builder upload field multiple errors display [\#4715](https://github.com/decidim/decidim/pull/4715)
 - **decidim-core**: MetricResolver filtering corrected comparison between symbol and string [\#4733](https://github.com/decidim/decidim/pull/4733)
 - **decidim-core**: Ignore blank permission options in action authorizer [\#4744](https://github.com/decidim/decidim/pull/4744)
+- **decidim-proposals** Lock proposals on voting to avoid race conditions to vote over the limit [\#4763](https://github.com/decidim/decidim/pull/4763)
 
 **Removed**:
 

--- a/decidim-proposals/app/commands/decidim/proposals/vote_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/vote_proposal.rb
@@ -26,7 +26,7 @@ module Decidim
         return broadcast(:invalid) unless vote.valid?
 
         ActiveRecord::Base.transaction do
-          proposal.with_lock do
+          @proposal.with_lock do
             vote.save!
             update_temporary_votes
           end

--- a/decidim-proposals/app/commands/decidim/proposals/vote_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/vote_proposal.rb
@@ -26,8 +26,10 @@ module Decidim
         return broadcast(:invalid) unless vote.valid?
 
         ActiveRecord::Base.transaction do
-          vote.save!
-          update_temporary_votes
+          proposal.with_lock do
+            vote.save!
+            update_temporary_votes
+          end
         end
 
         Decidim::Gamification.increment_score(@current_user, :proposal_votes)


### PR DESCRIPTION
#### :tophat: What? Why?
Lock proposal on vote creation to avoid race conditions that could allow a user to vote over the limit.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
