### PR TITLE
Areachart number overlaps in mobile

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/vizzs/_areachart.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/vizzs/_areachart.scss
@@ -62,10 +62,6 @@
   &.small{
     .sum{
       font-size: rem-calc(map-get(map-get(map-get($header-styles, medium), 'h3'), 'font-size'));
-
-      @include breakpoint(medium down){
-        font-size: rem-calc(map-get(map-get(map-get($header-styles, medium), 'h1'), 'font-size')) * 1.5;
-      }
     }
   }
 }


### PR DESCRIPTION
#### :tophat: What? Why?
Highlighted number font size too big on mobile

#### :pushpin: Related Issues
- Fixes #4754 

### :camera: Screenshots (optional)
![imagen](https://user-images.githubusercontent.com/817526/51186745-a4e63c00-18da-11e9-97cb-e9b9435207df.png)

