### PR TITLE
Fix assemblies filter by type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 **Fixed**:
 
+- **decidim-assemblies**: Fix assemblies filter by type [\#4778](https://github.com/decidim/decidim/pull/4778)
 - **decidim-proposals** Fix unhideable reported collaborative drafts and mail jobs [\#4706](https://github.com/decidim/decidim/pull/4706)
 - **decidim-assemblies**: Fix parent assemblies children_count counter [\#4718](https://github.com/decidim/decidim/pull/4718/)
 - **decidim-core**: Place `CurrentOrganization` middleware before `WardenManager`. [\#4708](https://github.com/decidim/decidim/pull/4708)

--- a/decidim-assemblies/app/controllers/decidim/assemblies/assemblies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/assemblies_controller.rb
@@ -71,7 +71,7 @@ module Decidim
       end
 
       def parent_assemblies
-        @parent_assemblies ||= assemblies | ParentAssemblies.new | FilteredAssemblies.new(params[:filter])
+        @parent_assemblies ||= assemblies | ParentAssemblies.new | FilteredAssemblies.new(current_filter)
       end
 
       alias collection parent_assemblies
@@ -86,6 +86,10 @@ module Decidim
 
       def assembly_participatory_processes
         @assembly_participatory_processes ||= @current_participatory_space.linked_participatory_space_resources(:participatory_processes, "included_participatory_processes")
+      end
+
+      def current_filter
+        params[:filter] || "all"
       end
     end
   end

--- a/decidim-assemblies/app/helpers/decidim/assemblies/filter_assemblies_helper.rb
+++ b/decidim-assemblies/app/helpers/decidim/assemblies/filter_assemblies_helper.rb
@@ -12,12 +12,16 @@ module Decidim
         link_to t(filter, scope: "decidim.assemblies.filter"), url_for(params.to_unsafe_h.merge(page: nil, filter: filter)), data: { filter: filter }, remote: true
       end
 
-      def label_text
-        t("label", scope: "decidim.assemblies.filter")
+      def help_text
+        t("help", scope: "decidim.assemblies.filter")
       end
 
-      def placeholder_text
-        t("placeholder", scope: "decidim.assemblies.filter")
+      def filter
+        params[:filter] || "all"
+      end
+
+      def current_filter_text
+        t(filter, scope: "decidim.assemblies.filter")
       end
     end
   end

--- a/decidim-assemblies/app/queries/decidim/assemblies/filtered_assemblies.rb
+++ b/decidim-assemblies/app/queries/decidim/assemblies/filtered_assemblies.rb
@@ -8,20 +8,14 @@ module Decidim
         @filter = filter
       end
 
-      def filter
-        return "all" if @filter.nil?
-
-        @filter
-      end
-
       def assemblies
         Decidim::Assembly
       end
 
       def query
-        return assemblies.all if filter == "all"
+        return assemblies.all if @filter == "all"
 
-        assemblies.where(assembly_type: filter)
+        assemblies.where(assembly_type: @filter)
       end
     end
   end

--- a/decidim-assemblies/app/views/decidim/assemblies/_filter_by_type.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/_filter_by_type.html.erb
@@ -1,7 +1,7 @@
-<div class="inline-filters">
+<div id="assemblies-filter" class="inline-filters">
 <label>
-  <span><%= label_text %></span>
-  <button data-toggle="inline-filter-sort"><%= placeholder_text %></button>
+  <span><%= help_text %></span>
+  <button id="button-text" data-toggle="inline-filter-sort"><%= current_filter_text %></button>
   <div id="inline-filter-sort" class="dropdown-pane" data-position="bottom" data-alignment="right" data-dropdown data-auto-focus="true">
     <ul class="list-reset">
       <% available_filters.each do |filter| %>
@@ -10,4 +10,5 @@
     </ul>
   </div>
 </label>
+<script> $(document).foundation(); </script>
 </div>

--- a/decidim-assemblies/app/views/decidim/assemblies/assemblies/_parent_assemblies.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/assemblies/_parent_assemblies.html.erb
@@ -1,0 +1,14 @@
+<section id="parent-assemblies" class="section row collapse">
+  <div class="row column">
+    <div class="flex--sbe">
+      <h2 id="assemblies-count" class="section-heading collapse">
+        <%= render partial: "count" %>
+      </h2>
+      <%= render partial: "decidim/assemblies/filter_by_type" %>
+    </div>
+    <hr class="reset mt-s mb-s" />
+  </div>
+  <div class="row small-up-1 medium-up-2 large-up-3 card-grid">
+    <%= render(collection) %>
+  </div>
+</section>

--- a/decidim-assemblies/app/views/decidim/assemblies/assemblies/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/assemblies/index.html.erb
@@ -16,20 +16,7 @@ edit_link(
     </section>
   <% end %>
 
-  <section id="assemblies-grid" class="section row collapse">
-    <div class="row column">
-      <div class="flex--sbe">
-        <h2 id="assemblies-count" class="section-heading collapse">
-          <%= render partial: "count" %>
-        </h2>
-        <%= render partial: "decidim/assemblies/filter_by_type" %>
-      </div>
-      <hr class="reset mt-s mb-s" />
-    </div>
-    <div class="row small-up-1 medium-up-2 large-up-3 card-grid">
-      <%= render(collection) %>
-    </div>
-  </section>
+  <%= render partial: "parent_assemblies" %>
 
   <section id="assemblies-chart" class="row column section">
     <div class="row column">

--- a/decidim-assemblies/app/views/decidim/assemblies/assemblies/index.js.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/assemblies/index.js.erb
@@ -1,5 +1,7 @@
-var $grid = $('#assemblies-grid');
+var $grid = $('#parent-assemblies');
 var $assembliesCount = $('#assemblies-count');
+var $assembliesFilter = $('#assemblies-filter');
 
 $grid.find('.card-grid').html('<%= j(render(collection)).strip.html_safe %>');
 $assembliesCount.html('<%= j(render partial: "count").strip.html_safe %>');
+$assembliesFilter.html('<%= j(render partial: "decidim/assemblies/filter_by_type") %>');

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -258,15 +258,14 @@ en:
         others: Others
         public: Public
       filter:
-        all: All
+        all: All types of assemblies
         commission: Commission
         consultative_advisory: Consultative/Advisory
         executive: Executive
         government: Government
-        label: 'Show:'
+        help: 'Show:'
         others: Others
         participatory: Participatory
-        placeholder: Filter by type
         working_group: Working group
       index:
         title: Assemblies

--- a/decidim-assemblies/spec/system/assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/assemblies_spec.rb
@@ -104,8 +104,8 @@ describe "Assemblies", type: :system do
     end
 
     it "lists the parent assemblies" do
-      within "#assemblies-grid" do
-        within "#assemblies-grid h2" do
+      within "#parent-assemblies" do
+        within "#parent-assemblies h2" do
           expect(page).to have_content("2")
         end
 
@@ -127,54 +127,54 @@ describe "Assemblies", type: :system do
 
       before do
         visit decidim_assemblies.assemblies_path
-        click_button "Filter by type"
+        click_button "All types of assemblies"
       end
 
       it "filters by All types" do
-        click_link "All"
+        click_link "All types of assemblies"
         expect(page).to have_selector("article.card.card--assembly", count: 7)
       end
 
       it "filters by Government type" do
         click_link "Government"
         expect(page).to have_selector("article.card.card--assembly", count: 1)
-        expect(page).to have_content("Government")
+        expect(page).to have_selector("#button-text", text: "Government")
       end
 
       it "filters by Executive type" do
         click_link "Executive"
         expect(page).to have_selector("article.card.card--assembly", count: 1)
-        expect(page).to have_content("Executive")
+        expect(page).to have_selector("#button-text", text: "Executive")
       end
 
       it "filters by Consultative/Advisory type" do
         click_link "Consultative/Advisory"
         expect(page).to have_selector("article.card.card--assembly", count: 1)
-        expect(page).to have_content("Consultative/Advisory")
+        expect(page).to have_selector("#button-text", text: "Consultative/Advisory")
       end
 
       it "filters by Participatory type" do
         click_link "Participatory"
         expect(page).to have_selector("article.card.card--assembly", count: 1)
-        expect(page).to have_content("Participatory")
+        expect(page).to have_selector("#button-text", text: "Participatory")
       end
 
       it "filters by Working group type" do
         click_link "Working group"
         expect(page).to have_selector("article.card.card--assembly", count: 1)
-        expect(page).to have_content("Working group")
+        expect(page).to have_selector("#button-text", text: "Working group")
       end
 
       it "filters by Commission type" do
         click_link "Commission"
         expect(page).to have_selector("article.card.card--assembly", count: 1)
-        expect(page).to have_content("Commission")
+        expect(page).to have_selector("#button-text", text: "Commission")
       end
 
       it "filters by Others type" do
         click_link "Others"
         expect(page).to have_selector("article.card.card--assembly", count: 1)
-        expect(page).to have_content("Others")
+        expect(page).to have_selector("#button-text", text: "Others")
       end
     end
 

--- a/decidim-assemblies/spec/system/private_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/private_assemblies_spec.rb
@@ -23,8 +23,8 @@ describe "Private Assemblies", type: :system do
         end
 
         it "lists all the assemblies" do
-          within "#assemblies-grid" do
-            within "#assemblies-grid h2" do
+          within "#parent-assemblies" do
+            within "#parent-assemblies h2" do
               expect(page).to have_content("2")
             end
 
@@ -44,8 +44,8 @@ describe "Private Assemblies", type: :system do
         end
 
         it "lists all the assemblies" do
-          within "#assemblies-grid" do
-            within "#assemblies-grid h2" do
+          within "#parent-assemblies" do
+            within "#parent-assemblies h2" do
               expect(page).to have_content("2")
             end
 
@@ -68,8 +68,8 @@ describe "Private Assemblies", type: :system do
         end
 
         it "lists only the not private assembly" do
-          within "#assemblies-grid" do
-            within "#assemblies-grid h2" do
+          within "#parent-assemblies" do
+            within "#parent-assemblies h2" do
               expect(page).to have_content("1")
             end
 
@@ -89,8 +89,8 @@ describe "Private Assemblies", type: :system do
         end
 
         it "lists only the not private assembly" do
-          within "#assemblies-grid" do
-            within "#assemblies-grid h2" do
+          within "#parent-assemblies" do
+            within "#parent-assemblies h2" do
               expect(page).to have_content("1")
             end
 
@@ -109,8 +109,8 @@ describe "Private Assemblies", type: :system do
           end
 
           it "lists private assemblies" do
-            within "#assemblies-grid" do
-              within "#assemblies-grid h2" do
+            within "#parent-assemblies" do
+              within "#parent-assemblies h2" do
                 expect(page).to have_content("2")
               end
 
@@ -137,8 +137,8 @@ describe "Private Assemblies", type: :system do
         end
 
         it "lists private assemblies" do
-          within "#assemblies-grid" do
-            within "#assemblies-grid h2" do
+          within "#parent-assemblies" do
+            within "#parent-assemblies h2" do
               expect(page).to have_content("2")
             end
 


### PR DESCRIPTION
#### :tophat: What? Why?
> The functionality of filtering Assemblies by type has been incorporated. However, when you select an assembly type it does not appear as selected and there is no indicator to show that the filter is being applied.

#### :pushpin: Related Issues
- Fixes #4772

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)

![assemblies_filter](https://user-images.githubusercontent.com/40306853/51485414-491a2800-1d9e-11e9-8a6e-71c12b03714d.gif)