### PR TITLE
[FIX] Use `simple_format` when rendering Participatory Text.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 **Fixed**:
 
+- **decidim-proposals** Public view of Participatory Text is now preserving new lines. [\#4782](https://github.com/decidim/decidim/pull/4782)
 - **decidim-assemblies**: Fix assemblies filter by type [\#4778](https://github.com/decidim/decidim/pull/4778)
 - **decidim-conferences**: Fix error when visiting a Conference event[\#4776](https://github.com/decidim/decidim/pull/4776)
 - **decidim-proposals** Fix unhideable reported collaborative drafts and mail jobs [\#4706](https://github.com/decidim/decidim/pull/4706)

--- a/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal_cell.rb
@@ -30,7 +30,7 @@ module Decidim
 
       def body
         return unless model.participatory_text_level == "article"
-        present(model).body
+        simple_format present(model).body(links: true)
       end
 
       def current_user

--- a/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal_cell.rb
@@ -10,6 +10,7 @@ module Decidim
       include ProposalCellsHelper
       include Cell::ViewModel::Partial
       include Messaging::ConversationHelper
+      include Decidim::SanitizeHelper
 
       delegate :current_organization, to: :controller
 
@@ -30,7 +31,7 @@ module Decidim
 
       def body
         return unless model.participatory_text_level == "article"
-        simple_format present(model).body(links: true)
+        decidim_sanitize(simple_format(present(model).body(links: true)))
       end
 
       def current_user

--- a/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal_cell.rb
@@ -31,7 +31,8 @@ module Decidim
 
       def body
         return unless model.participatory_text_level == "article"
-        decidim_sanitize(simple_format(present(model).body(links: true)))
+        formatted = simple_format(present(model).body)
+        decidim_sanitize(strip_links(formatted))
       end
 
       def current_user

--- a/decidim-proposals/spec/system/participatory_texts_spec.rb
+++ b/decidim-proposals/spec/system/participatory_texts_spec.rb
@@ -15,6 +15,8 @@ describe "Proposals", type: :system do
     expect(prop_block).to have_link(proposal.emendations.count) if component.settings.amendments_enabled
     expect(prop_block).to have_link("Comment") if component.settings.comments_enabled
     expect(prop_block).to have_link(proposal.comments.count) if component.settings.comments_enabled
+    expect(prop_block).to have_content(proposal.body) if proposal.participatory_text_level == "article"
+    expect(prop_block).not_to have_content(proposal.body) if proposal.participatory_text_level != "article"
   end
 
   shared_examples_for "lists all the proposals ordered" do
@@ -26,6 +28,26 @@ describe "Proposals", type: :system do
       should_have_proposal("#proposals div.hover-section:first-child", proposals.first)
       should_have_proposal("#proposals div.hover-section:nth-child(2)", proposals[1])
       should_have_proposal("#proposals div.hover-section:last-child", proposals.last)
+    end
+
+    context " when participatory text level is not article" do
+      it "not renders the participatory text body" do
+        proposal_section = proposals.first
+        proposal_section.participatory_text_level = "section"
+        proposal_section.save!
+        visit_component
+        should_have_proposal("#proposals div.hover-section:first-child", proposal_section)
+      end
+    end
+
+    context "when participatory text level is article" do
+      it "renders the proposal body" do
+        proposal_article = proposals.last
+        proposal_article.participatory_text_level = "article"
+        proposal_article.save!
+        visit_component
+        should_have_proposal("#proposals div.hover-section:last-child", proposal_article)
+      end
     end
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Public view of Participatory Text is not preserving new lines.

#### :pushpin: Related Issues
- Fixes #4767 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [-] Add documentation regarding the feature 
- [-] Add/modify seeds
- [-] Add tests
- [x] Task

### :camera: Screenshots (optional)
First paragraph is multiline now:
![participatory_text-evols](https://user-images.githubusercontent.com/199462/51741954-9812d680-2098-11e9-98de-397f94d7ef5d.png)

