### PR TITLE
Fix admin proposals manager: show proposal state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 **Added**:
 
+- **decidim-proposals**: Fix admin proposals manager: show proposal state [\#4789](https://github.com/decidim/decidim/pull/4789/)
 - **decidim-core**: User groups can now be disabled per organization. [\#4681](https://github.com/decidim/decidim/pull/4681/)
 - **decidim-initiatives**: Add setting in `Decidim::InitiativesType` to restrict online signatures [\#4668](https://github.com/decidim/decidim/pull/4668)
 

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
@@ -23,7 +23,6 @@
     </td>
   <% end %>
   <td>
-    <%= t("decidim/amendment", scope: "activerecord.models", count: 1) if proposal.emendation? %>
     <strong class="<%= proposal_state_css_class proposal.state %>">
       <%= t("decidim/amendment", scope: "activerecord.models", count: 1) if proposal.emendation? %>
       <%= humanize_proposal_state proposal.state %>


### PR DESCRIPTION
#### :tophat: What? Why?
At some point, this line of code got duplicated in a merge/rebase and *Amendment* type was displaying twice in the proposal state column.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
#### Before
![before](https://user-images.githubusercontent.com/40306853/51691749-a9f26c00-1ffb-11e9-817c-9ada76607998.png)

#### After
![after](https://user-images.githubusercontent.com/40306853/51691747-a8c13f00-1ffb-11e9-954d-f824359fecd8.png)
