### PR TITLE
[FEATURE] Make `MarkdownToProposals` parse links.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 **Added**:
 
+- **decidim-proposals**: Add Participatory Text support for links in Markdown. [\#4790](https://github.com/decidim/decidim/pull/4790)
 - **decidim-core**: User groups can now be disabled per organization. [\#4681](https://github.com/decidim/decidim/pull/4681/)
 - **decidim-initiatives**: Add setting in `Decidim::InitiativesType` to restrict online signatures [\#4668](https://github.com/decidim/decidim/pull/4668)
 

--- a/decidim-proposals/lib/decidim/proposals/markdown_to_proposals.rb
+++ b/decidim-proposals/lib/decidim/proposals/markdown_to_proposals.rb
@@ -60,6 +60,12 @@ module Decidim
         text
       end
 
+      def link(link, title, content)
+        attrs = %(href="#{link}")
+        attrs += %( title="#{title}") if title.present?
+        "<a #{attrs}>#{content}</a>"
+      end
+
       # ignore images
       def image(_link, _title, _alt_text)
         ""

--- a/decidim-proposals/spec/lib/decidim/proposals/markdown_to_proposals_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/markdown_to_proposals_spec.rb
@@ -79,8 +79,29 @@ module Decidim
 
           proposal = Proposal.last
           # proposal titled with its numbering (position)
-          # the paragraph ans proposal's body
           expect(proposal.title).to eq("1")
+          expect(proposal.body).to eq(paragraph)
+          expect(proposal.position).to eq(1)
+          expect(proposal.participatory_text_level).to eq(ParticipatoryTextSection::LEVELS[:article])
+          should_have_expected_states(proposal)
+        end
+      end
+
+      describe "links are parsed" do
+        let(:text_w_link) { %[This text links to [Meta Decidim](https://meta.decidim.org "Community's meeting point").] }
+
+        before do
+          items << "#{text_w_link}\n"
+        end
+
+        it "contains the link as an html anchor" do
+          should_parse_and_produce_proposals(1)
+
+          proposal = Proposal.last
+          # proposal titled with its numbering (position)
+          # the paragraph and proposal's body
+          expect(proposal.title).to eq("1")
+          paragraph = %q(This text links to <a href="https://meta.decidim.org" title="Community's meeting point">Meta Decidim</a>.)
           expect(proposal.body).to eq(paragraph)
           expect(proposal.position).to eq(1)
           expect(proposal.participatory_text_level).to eq(ParticipatoryTextSection::LEVELS[:article])


### PR DESCRIPTION
#### :tophat: What? Why?
`MarkdownToProposals` should parse links to html anchors.

#### :pushpin: Related Issues
- Related to #4767 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [-] Add documentation regarding the feature 
- [-] Add/modify seeds
- [x] Add tests
- [x] Task

### :camera: Screenshots (optional)
Parsed text with link in it results in an anchor as seen in the following capture:
![imatge](https://user-images.githubusercontent.com/199462/51741441-3dc54600-2097-11e9-8fcf-1e9032b6cd85.png)

