### PR TITLE
4656 document number verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - **decidim-initiatives**: Implement a mechanism to store encrytped personal data of users on votes and decrypt it exporting to PDF [\#4716](https://github.com/decidim/decidim/pull/4716)
 - **decidim-initiatives**: Add setting to initiatives types to enable a step to allow initiative signature after passing SMS verification mechanism [\#4792](https://github.com/decidim/decidim/pull/4792)
 - **decidim-initiatives**: Allow integration of services to add timestamps and sign PDFs, define example services and use in application generator [\#4805](https://github.com/decidim/decidim/pull/4805)
+- **decidim-initiatives**: Add setting to initiatives types to verify document number provided on votes and avoid duplicated votes with the same document [\#4794](https://github.com/decidim/decidim/pull/4794)
 
 **Changed**:
 

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/create_initiative_type.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/create_initiative_type.rb
@@ -44,7 +44,8 @@ module Decidim
             banner_image: form.banner_image,
             collect_user_extra_fields: form.collect_user_extra_fields,
             extra_fields_legal_information: form.extra_fields_legal_information,
-            validate_sms_code_on_votes: form.validate_sms_code_on_votes
+            validate_sms_code_on_votes: form.validate_sms_code_on_votes,
+            document_number_authorization_handler: form.document_number_authorization_handler
           )
 
           return initiative_type unless initiative_type.valid?

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative_type.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative_type.rb
@@ -45,7 +45,8 @@ module Decidim
             minimum_committee_members: form.minimum_committee_members,
             collect_user_extra_fields: form.collect_user_extra_fields,
             extra_fields_legal_information: form.extra_fields_legal_information,
-            validate_sms_code_on_votes: form.validate_sms_code_on_votes
+            validate_sms_code_on_votes: form.validate_sms_code_on_votes,
+            document_number_authorization_handler: form.document_number_authorization_handler
           }
 
           result[:banner_image] = form.banner_image unless form.banner_image.nil?

--- a/decidim-initiatives/app/commands/decidim/initiatives/vote_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/vote_initiative.rb
@@ -45,7 +45,8 @@ module Decidim
         @vote = @initiative.votes.build(
           author: @current_user,
           decidim_user_group_id: form.group_id,
-          encrypted_metadata: form.encrypted_metadata
+          encrypted_metadata: form.encrypted_metadata,
+          hash_id: form.hash_id
         )
       end
 

--- a/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_type_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_type_form.rb
@@ -17,6 +17,7 @@ module Decidim
         attribute :collect_user_extra_fields, Boolean
         translatable_attribute :extra_fields_legal_information, String
         attribute :validate_sms_code_on_votes, Boolean
+        attribute :document_number_authorization_handler, String
 
         validates :title, :description, translatable_presence: true
         validates :online_signature_enabled, inclusion: { in: [true, false] }

--- a/decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb
@@ -23,6 +23,8 @@ module Decidim
       validates :initiative_id, presence: true
       validates :author_id, presence: true
 
+      validate :document_number_authorized, if: :required_personal_data?
+
       def initiative
         @initiative ||= Decidim::Initiative.find_by(id: initiative_id)
       end
@@ -62,6 +64,42 @@ module Decidim
         return unless required_personal_data?
 
         encryptor.encrypt(metadata)
+      end
+
+      def document_number_authorized
+        return if initiative.document_number_authorization_handler.blank?
+
+        errors.add(:document_number, :invalid) unless authorized? && authorization_handler && authorization.unique_id == authorization_handler.unique_id
+      end
+
+      def author
+        @author ||= current_organization.users.find_by(id: author_id)
+      end
+
+      def authorization
+        return unless author && handler_name
+
+        @authorization ||= Verifications::Authorizations.new(organization: author.organization, user: author, name: handler_name).first
+      end
+
+      def authorization_status
+        return unless authorization
+
+        Decidim::Verifications::Adapter.from_element(handler_name).authorize(authorization, {}, nil, nil)
+      end
+
+      def authorized?
+        authorization_status&.first == :ok
+      end
+
+      def handler_name
+        initiative.document_number_authorization_handler
+      end
+
+      def authorization_handler
+        return unless document_number && handler_name
+
+        @authorization_handler ||= Decidim::AuthorizationHandler.handler_for(handler_name, document_number: document_number)
       end
     end
   end

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -175,6 +175,8 @@ module Decidim
     # RETURNS string
     delegate :banner_image, to: :type
 
+    delegate :document_number_authorization_handler, to: :type
+
     def votes_enabled?
       published? &&
         signature_start_date <= Date.current &&

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_form.html.erb
@@ -34,6 +34,16 @@
       </div>
     <% end %>
 
+    <div class="row column">
+      <%=
+        form.select(
+          :document_number_authorization_handler,
+          current_organization.available_authorizations.map { |name| [t("#{name}.name", scope: "decidim.authorization_handlers"), name] },
+          include_blank: true
+        )
+      %>
+    </div>
+
     <div class="row">
       <div class="columns xlarge-6">
         <%= form.upload :banner_image %>

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -28,6 +28,7 @@ en:
         banner_image: Banner image
         collect_user_extra_fields: Collect user personal data on signature
         description: Description
+        document_number_authorization_handler: Authorization to verify document number on votes
         extra_fields_legal_information: Legal information about the collection of
           personal data
         minimum_committee_members: Minimum of committee members

--- a/decidim-initiatives/db/migrate/20190125131847_add_document_number_authorization_handler_to_initiatives_types.rb
+++ b/decidim-initiatives/db/migrate/20190125131847_add_document_number_authorization_handler_to_initiatives_types.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDocumentNumberAuthorizationHandlerToInitiativesTypes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_initiatives_types, :document_number_authorization_handler, :string
+  end
+end

--- a/decidim-initiatives/spec/shared/update_initiative_type_example.rb
+++ b/decidim-initiatives/spec/shared/update_initiative_type_example.rb
@@ -21,7 +21,8 @@ shared_examples "update an initiative type" do
         minimum_committee_members: 7,
         banner_image: Decidim::Dev.test_file("city2.jpeg", "image/jpeg"),
         collect_user_extra_fields: true,
-        extra_fields_legal_information: Decidim::Faker::Localized.sentence(25)
+        extra_fields_legal_information: Decidim::Faker::Localized.sentence(25),
+        document_number_authorization_handler: ""
       }
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

* Adds a `document_number_authorization_handler` attribute to initiatives types to set an authorization handler to check if the document number provided in personal information of signatures is verified for the user.
* Adds management of this attribute in the admin panel. The options for this field are taken from the available authorizations of the organization. The authorization handler must accept a `document_number` attribute and use a `unique_id` to perform verification. 
* A hash_id is generated on signatures including the document number to avoid initiatives signatures with the same document number.

#### :pushpin: Related Issues
- Related to #4656
- Related to #4644

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
