### PR TITLE
[REFACTOR] Article cards open by default (participatory texts).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 **Added**:
 
+- **decidim-proposals**: In participatory texts it is better to render Article cards open by default. [\#4806](https://github.com/decidim/decidim/pull/4806)
 - **decidim-proposals**: Add Participatory Text support for links in Markdown. [\#4790](https://github.com/decidim/decidim/pull/4790)
 - **decidim-core**: User groups can now be disabled per organization. [\#4681](https://github.com/decidim/decidim/pull/4681/)
 - **decidim-initiatives**: Add setting in `Decidim::InitiativesType` to restrict online signatures [\#4668](https://github.com/decidim/decidim/pull/4668)

--- a/decidim-proposals/app/views/decidim/proposals/admin/participatory_texts/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/participatory_texts/index.html.erb
@@ -15,7 +15,7 @@
         data-allow-all-closed="true">
         <%= form.fields_for(:proposals) do |prop_form| %>
         <% proposal= @drafts[prop_form.index] %>
-          <li class="accordion-item" data-accordion-item>
+          <li class="accordion-item <%= proposal.article? ? "is-active" : nil %>" data-accordion-item>
             <a href="#" class="accordion-title flex--sbc"><%= preview_participatory_text_section_title(proposal) %><span class="mr-m"><%= icon "menu", class: "icon--small" %></span></a>
             <div class="accordion-content" data-tab-content>
               <%= render "article-preview", { form: prop_form, proposal: proposal } %>


### PR DESCRIPTION
#### :tophat: What? Why?
In participatory texts it is better to render Article cards open by default.

#### :pushpin: Related Issues
- Related to #4770 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [-] Add documentation regarding the feature 
- [-] Add/modify seeds
- [-] Add tests
- [x] Task

### :camera: Screenshots (optional)
![Description](URL)
