### PR TITLE
add set_locale method before action to prevent broken links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 **Fixed**:
 
 - **decidim-proposals**: Fix attachments not being inherited from collaborative draft when published as proposal. [\#4811](https://github.com/decidim/decidim/pull/4811)
+- **decidim-core**: Add set_locale method to prevent users be redirected to unexpected locale[#4809](https://github.com/decidim/decidim/pull/4809)
 - **decidim-core**: Fix inconsistent dataviz [\#4787](https://github.com/decidim/decidim/pull/4787)
 - **decidim-proposals**: Fix participatory texts error uploading files with accents and special characters. [\#4788](https://github.com/decidim/decidim/pull/4788)
 - **decidim-meetings**: Fix form when duplicating meetings [\#4750](https://github.com/decidim/decidim/pull/4750)

--- a/decidim-core/app/controllers/concerns/decidim/locale_switcher.rb
+++ b/decidim-core/app/controllers/concerns/decidim/locale_switcher.rb
@@ -11,7 +11,7 @@ module Decidim
       around_action :switch_locale
       helper_method :current_locale, :available_locales, :default_locale
       before_action :set_locale
-      
+
       # Sets the locale for the current session.
       #
       # Returns nothing.
@@ -61,16 +61,16 @@ module Decidim
       # to prevent unnecessary redirects
       def set_locale
         logger.debug "* Actual locale: #{I18n.locale}"
-        logger.debug "* Accept-Language: #{request.env['HTTP_ACCEPT_LANGUAGE']}"
+        logger.debug "* Accept-Language: #{request.env["HTTP_ACCEPT_LANGUAGE"]}"
         logger.debug "* params[:locale]: #{params[:locale]}"
-        session[:user_locale]= params[:locale] if params[:locale].present?
-        locale= session[:user_locale] || extract_locale_from_accept_language_header
+        session[:user_locale] = params[:locale] if params[:locale].present?
+        locale = session[:user_locale] || extract_locale_from_accept_language_header
         I18n.locale = available_locales.include?(locale) ? locale : I18n.default_locale
         logger.debug "* Locale set to '#{I18n.locale}'"
       end
 
       def extract_locale_from_accept_language_header
-        lang= request.env['HTTP_ACCEPT_LANGUAGE'] || I18n.locale.to_s
+        lang = request.env["HTTP_ACCEPT_LANGUAGE"] || I18n.locale.to_s
         lang.scan(/\A^[a-z]{2}\z/).first
       end
     end

--- a/decidim-core/app/controllers/concerns/decidim/locale_switcher.rb
+++ b/decidim-core/app/controllers/concerns/decidim/locale_switcher.rb
@@ -60,13 +60,9 @@ module Decidim
       # Save current locale in session variable
       # to prevent unnecessary redirects
       def set_locale
-        logger.debug "* Actual locale: #{I18n.locale}"
-        logger.debug "* Accept-Language: #{request.env["HTTP_ACCEPT_LANGUAGE"]}"
-        logger.debug "* params[:locale]: #{params[:locale]}"
         session[:user_locale] = params[:locale] if params[:locale].present?
         locale = session[:user_locale] || extract_locale_from_accept_language_header
         I18n.locale = available_locales.include?(locale) ? locale : I18n.default_locale
-        logger.debug "* Locale set to '#{I18n.locale}'"
       end
 
       def extract_locale_from_accept_language_header


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds a set_locale method that check the params[:locale] and save it to a session variable to prevent unexpected redirection between pages.

#### :pushpin: Related Issues
- Related to #4802 
- Fixes #4798

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add set_locale method 

### :camera: Screenshots (optional)
![Description](URL)
