### PR TITLE
Fix attachments not being inherited from collaborative draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 **Fixed**:
 
+- **decidim-proposals**: Fix attachments not being inherited from collaborative draft when published as proposal. [\#4811](https://github.com/decidim/decidim/pull/4811)
 - **decidim-core**: Fix inconsistent dataviz [\#4787](https://github.com/decidim/decidim/pull/4787)
 - **decidim-proposals**: Fix participatory texts error uploading files with accents and special characters. [\#4788](https://github.com/decidim/decidim/pull/4788)
 - **decidim-meetings**: Fix form when duplicating meetings [\#4750](https://github.com/decidim/decidim/pull/4750)

--- a/decidim-proposals/app/commands/decidim/proposals/publish_collaborative_draft.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/publish_collaborative_draft.rb
@@ -79,6 +79,7 @@ module Decidim
           new_proposal = Proposal.new(proposal_attributes)
           new_proposal.coauthorships = @collaborative_draft.coauthorships
           new_proposal.category = @collaborative_draft.category
+          new_proposal.attachments = @collaborative_draft.attachments
           new_proposal.save!
           new_proposal
         end

--- a/decidim-proposals/spec/commands/decidim/proposals/publish_collaborative_draft_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/publish_collaborative_draft_spec.rb
@@ -8,6 +8,14 @@ module Decidim
       let(:component) { create(:proposal_component) }
       let(:state) { :open }
       let!(:collaborative_draft) { create(:collaborative_draft, component: component, state: state) }
+      let!(:attachment) { Decidim::Attachment.create(attachment_params) }
+      let(:attachment_params) do
+        {
+          title: "My attachment",
+          file: Decidim::Dev.test_file("city.jpeg", "image/jpeg"),
+          attached_to: collaborative_draft
+        }
+      end
       let(:current_user) { collaborative_draft.creator_author }
       let(:command) { described_class.new(collaborative_draft, current_user) }
 
@@ -55,6 +63,7 @@ module Decidim
             expect(proposal.category).to eq(collaborative_draft.category)
             expect(proposal.scope).to eq(collaborative_draft.scope)
             expect(proposal.address).to eq(collaborative_draft.address)
+            expect(proposal.attachments).to eq(collaborative_draft.attachments)
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
>When a collaborative draft is published as proposal the attachment image is lost.

#### :pushpin: Related Issues
- Fixes #4799

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
