### PR TITLE
Add missing dependency for wicked_pdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - **decidim-core**: MetricResolver filtering corrected comparison between symbol and string [\#4733](https://github.com/decidim/decidim/pull/4733)
 - **decidim-core**: Ignore blank permission options in action authorizer [\#4744](https://github.com/decidim/decidim/pull/4744)
 - **decidim-proposals** Lock proposals on voting to avoid race conditions to vote over the limit [\#4763](https://github.com/decidim/decidim/pull/4763)
+- **decidim-initiatives** Add missing dependency for wicked_pdf to initiatives module [\#4813](https://github.com/decidim/decidim/pull/4813)
 
 **Removed**:
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,6 +158,7 @@ PATH
       social-share-button (~> 1.0)
       wicked (~> 1.3)
       wicked_pdf
+      wkhtmltopdf-binary
     decidim-meetings (0.17.0.dev)
       cells-erb (~> 0.1.0)
       cells-rails (~> 0.0.9)

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -153,6 +153,7 @@ PATH
       social-share-button (~> 1.0)
       wicked (~> 1.3)
       wicked_pdf
+      wkhtmltopdf-binary
     decidim-meetings (0.17.0.dev)
       cells-erb (~> 0.1.0)
       cells-rails (~> 0.0.9)
@@ -739,6 +740,7 @@ GEM
     wicked_pdf (1.1.0)
     wisper (2.0.0)
     wisper-rspec (1.1.0)
+    wkhtmltopdf-binary (0.12.4)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 

--- a/decidim-initiatives/decidim-initiatives.gemspec
+++ b/decidim-initiatives/decidim-initiatives.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency "social-share-button", "~> 1.0"
   s.add_dependency "wicked", "~> 1.3"
   s.add_dependency "wicked_pdf"
+  s.add_dependency "wkhtmltopdf-binary"
 
   s.add_development_dependency "decidim-dev", Decidim::Initiatives.version
 end

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -158,6 +158,7 @@ PATH
       social-share-button (~> 1.0)
       wicked (~> 1.3)
       wicked_pdf
+      wkhtmltopdf-binary
     decidim-meetings (0.17.0.dev)
       cells-erb (~> 0.1.0)
       cells-rails (~> 0.0.9)


### PR DESCRIPTION
#### :tophat: What? Why?
Adds dependency for wicked_pdf gem to decidim-initiatives module

#### :pushpin: Related Issues
- Related to #4644

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
