### PR TITLE
Fixes card small break words

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
@@ -408,10 +408,6 @@ $datetime-bg: $primary;
 .card__link{
   color: $anchor-color;
 
-  @include breakpoint(small only){
-    word-break: break-all;
-  }
-
   &:hover{
     color: $anchor-color;
   }


### PR DESCRIPTION
* Fixes break words on card title on small screens

#### :tophat: What? Why?
On small screens the words on a card title are breaking. 

#### :pushpin: Related Issues
- Fixes #4786 