### PR TITLE
Fixes description when there's a single process on the homepage

### DIFF
--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes/single_process.erb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes/single_process.erb
@@ -10,7 +10,7 @@
               <%= link_to decidim_participatory_processes.participatory_process_path(process), class: "card__link" do %>
                 <h2 class="card__title"><%= translated_attribute process.title %></h2>
               <% end %>
-              <%= decidim_sanitize translated_attribute(process.description) %>
+              <%= decidim_sanitize translated_attribute(process.short_description) %>
               <%= link_to t("more_information", scope: i18n_scope), decidim_participatory_processes.participatory_process_path(process), class: "button secondary small hollow" %>
             </div>
           </div>


### PR DESCRIPTION
Uses the short_description instead of the full description.

#### :tophat: What? Why?
For having consistency when there's one or multiple process on the homepage. 

#### :pushpin: Related Issues
- Fixes #4797
