### PR TITLE
Use short description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - **decidim-core**: MetricResolver filtering corrected comparison between symbol and string [\#4733](https://github.com/decidim/decidim/pull/4733)
 - **decidim-core**: Ignore blank permission options in action authorizer [\#4744](https://github.com/decidim/decidim/pull/4744)
 - **decidim-proposals** Lock proposals on voting to avoid race conditions to vote over the limit [\#4763](https://github.com/decidim/decidim/pull/4763)
+- **decidim-participatory_processes**: Shows the short description on processes when displaying a single one on the homepage. [\#4824](https://github.com/decidim/decidim/pull/4824)
 
 **Removed**:
 

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes/single_process.erb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes/single_process.erb
@@ -10,7 +10,7 @@
               <%= link_to decidim_participatory_processes.participatory_process_path(process), class: "card__link" do %>
                 <h2 class="card__title"><%= translated_attribute process.title %></h2>
               <% end %>
-              <%= decidim_sanitize translated_attribute(process.description) %>
+              <%= decidim_sanitize translated_attribute(process.short_description) %>
               <%= link_to t("more_information", scope: i18n_scope), decidim_participatory_processes.participatory_process_path(process), class: "button secondary small hollow" %>
             </div>
           </div>


### PR DESCRIPTION
#### :tophat: What? Why?
Use short description on processes when showing a single one on the homepage.

#### :pushpin: Related Issues
- Fixes #4797

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
*None*
