### PR TITLE
Fix Proposals Last Activity feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 **Fixed**:
 
+- **decidim-proposals**: Fix Proposals Last Activity feed [\#4828](https://github.com/decidim/decidim/pull/4828)
 - **decidim-proposals**: Fix attachments not being inherited from collaborative draft when published as proposal. [\#4811](https://github.com/decidim/decidim/pull/4811)
 - **decidim-core**: Add set_locale method to prevent users be redirected to unexpected locale[#4809](https://github.com/decidim/decidim/pull/4809)
 - **decidim-core**: Fix inconsistent dataviz [\#4787](https://github.com/decidim/decidim/pull/4787)

--- a/decidim-core/app/commands/decidim/amendable/create.rb
+++ b/decidim-core/app/commands/decidim/amendable/create.rb
@@ -55,7 +55,7 @@ module Decidim
 
       def create_emendation!
         @emendation = Decidim.traceability.perform_action!(
-          :create,
+          "publish",
           form.amendable_type.constantize,
           form.current_user,
           visibility: "public-only"

--- a/decidim-core/lib/decidim/core/test/shared_examples/amendable/create_amendment_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/amendable/create_amendment_examples.rb
@@ -18,7 +18,7 @@ shared_examples "create amendment" do
       expect(Decidim.traceability)
         .to receive(:perform_action!)
         .with(
-          :create,
+          "publish",
           form.amendable_type.constantize,
           form.current_user,
           kind_of(Hash)

--- a/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
@@ -56,7 +56,7 @@ module Decidim
       # Prevent PaperTrail from creating an additional version
       # in the proposal multi-step creation process (step 1: create)
       #
-      # A final version will be created in step 4: publish
+      # A first version will be created in step 4: publish
       # for diff rendering in the proposal version control
       def create_proposal
         PaperTrail.request(enabled: false) do

--- a/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
@@ -59,16 +59,18 @@ module Decidim
       # A final version will be created in step 4: publish
       # for diff rendering in the proposal version control
       def create_proposal
-        @proposal = Decidim.traceability.perform_action!(
-          :create,
-          Decidim::Proposals::Proposal,
-          @current_user,
-          visibility: "public-only"
-        ) do
-          proposal = Proposal.new(proposal_attributes)
-          proposal.add_coauthor(@current_user, user_group: user_group)
-          proposal.save!
-          proposal
+        PaperTrail.request(enabled: false) do
+          @proposal = Decidim.traceability.perform_action!(
+            :create,
+            Decidim::Proposals::Proposal,
+            @current_user,
+            visibility: "public-only"
+          ) do
+            proposal = Proposal.new(proposal_attributes)
+            proposal.add_coauthor(@current_user, user_group: user_group)
+            proposal.save!
+            proposal
+          end
         end
       end
 

--- a/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
@@ -53,8 +53,11 @@ module Decidim
         fields
       end
 
-      # This will be the PaperTrail version that is
-      # shown in the version control feature (1 of 1)
+      # Prevent PaperTrail from creating an additional version
+      # in the proposal multi-step creation process (step 1: create)
+      #
+      # A final version will be created in step 4: publish
+      # for diff rendering in the proposal version control
       def create_proposal
         @proposal = Decidim.traceability.perform_action!(
           :create,

--- a/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
@@ -43,16 +43,6 @@ module Decidim
 
       attr_reader :form, :proposal, :attachment
 
-      def proposal_attributes
-        fields = {}
-
-        fields[:title] = title_with_hashtags
-        fields[:body] = body_with_hashtags
-        fields[:component] = form.component
-
-        fields
-      end
-
       # Prevent PaperTrail from creating an additional version
       # in the proposal multi-step creation process (step 1: create)
       #
@@ -66,7 +56,11 @@ module Decidim
             @current_user,
             visibility: "public-only"
           ) do
-            proposal = Proposal.new(proposal_attributes)
+            proposal = Proposal.new(
+              title: title_with_hashtags,
+              body: body_with_hashtags,
+              component: form.component
+            )
             proposal.add_coauthor(@current_user, user_group: user_group)
             proposal.save!
             proposal

--- a/decidim-proposals/app/commands/decidim/proposals/publish_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/publish_proposal.rb
@@ -37,11 +37,8 @@ module Decidim
       # This will be the PaperTrail version that is
       # shown in the version control feature (1 of 1)
       #
-      # But first, we need to reset the proposal attributes
-      # as PaperTrail only keeps track of changes made to a model.
-      # If we don't, the new version will not show the state
-      # of title and body, because they are not modified in
-      # the process of publishing.
+      # For an attribute to appear in the new version it has to be reset
+      # and reassigned, as PaperTrail only keeps track of object CHANGES.
       def publish_proposal
         title = reset(:title)
         body = reset(:body)
@@ -56,7 +53,7 @@ module Decidim
         end
       end
 
-      # Reset the attribute so the definitive version will recieve new changes
+      # Reset the attribute to an empty string and return the old value
       def reset(attribute)
         attribute_value = @proposal[attribute]
         PaperTrail.request(enabled: false) do

--- a/decidim-proposals/app/commands/decidim/proposals/update_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/update_proposal.rb
@@ -70,7 +70,7 @@ module Decidim
       # Prevent PaperTrail from creating an additional version
       # in the proposal multi-step creation process (step 3: complete)
       #
-      # A final version will be created in step 4: publish
+      # A first version will be created in step 4: publish
       # for diff rendering in the proposal control version
       def update_draft
         PaperTrail.request(enabled: false) do

--- a/decidim-proposals/app/commands/decidim/proposals/update_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/update_proposal.rb
@@ -69,11 +69,12 @@ module Decidim
 
       # Prevent PaperTrail from creating an additional version
       # in the proposal multi-step creation process (step 3: complete)
+      #
+      # A final version will be created in step 4: publish
+      # for diff rendering in the proposal control version
       def update_draft
         PaperTrail.request(enabled: false) do
           @proposal.update(proposal_attributes)
-          @proposal.coauthorships.clear
-          @proposal.add_coauthor(current_user, user_group: user_group)
         end
       end
 

--- a/decidim-proposals/app/commands/decidim/proposals/update_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/update_proposal.rb
@@ -75,6 +75,8 @@ module Decidim
       def update_draft
         PaperTrail.request(enabled: false) do
           @proposal.update(proposal_attributes)
+          @proposal.coauthorships.clear
+          @proposal.add_coauthor(current_user, user_group: user_group)
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
>Last Activity module stopped recording activity in the platform
> It's specific for proposals (they're not showing on t he last activity feed).
> This bug was introduced with the removal of a relevant part of the code which created the Activity on the #4567 PR

#### :pushpin: Related Issues
- Related to #4567
- Fixes #4769

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests