### PR TITLE
Fix #4669

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - **decidim-proposals** Lock proposals on voting to avoid race conditions to vote over the limit [\#4763](https://github.com/decidim/decidim/pull/4763)
 - **decidim-initiatives** Add missing dependency for wicked_pdf to initiatives module [\#4813](https://github.com/decidim/decidim/pull/4813)
 - **decidim-participatory_processes**: Shows the short description on processes when displaying a single one on the homepage. [\#4824](https://github.com/decidim/decidim/pull/4824)
+- **decidim-core** Fix redirect to static map view after login. [\#4830](https://github.com/decidim/decidim/pull/4830)
 
 **Removed**:
 

--- a/decidim-core/app/controllers/decidim/static_map_controller.rb
+++ b/decidim-core/app/controllers/decidim/static_map_controller.rb
@@ -2,6 +2,8 @@
 
 module Decidim
   class StaticMapController < Decidim::ApplicationController
+    skip_before_action :store_current_location
+
     def show
       send_data StaticMapGenerator.new(resource).data, type: "image/jpeg", disposition: "inline"
     end

--- a/decidim-core/spec/controllers/static_map_controller_spec.rb
+++ b/decidim-core/spec/controllers/static_map_controller_spec.rb
@@ -29,6 +29,7 @@ module Decidim
         expect(StaticMapGenerator).to receive(:new).with(resource).and_return(generator)
         expect(generator).to receive(:data).and_return(data)
         expect(controller).to receive(:send_data).with(data, type: "image/jpeg", disposition: "inline")
+        expect(controller).not_to receive(:store_current_location)
 
         get :show, format: "image/jpeg", params: params
       end


### PR DESCRIPTION
#### :tophat: What? Why?
Fix redirect to the static map when user needs to sign in on page where the static map is visible.


#### :pushpin: Related Issues
- Fixes #4669

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry