### PR TITLE
Add "address" translation key for proposals/collaborative drafts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - **decidim-proposals** Lock proposals on voting to avoid race conditions to vote over the limit [\#4763](https://github.com/decidim/decidim/pull/4763)
 - **decidim-initiatives** Add missing dependency for wicked_pdf to initiatives module [\#4813](https://github.com/decidim/decidim/pull/4813)
 - **decidim-participatory_processes**: Shows the short description on processes when displaying a single one on the homepage. [\#4824](https://github.com/decidim/decidim/pull/4824)
+- **decidim-proposals**: Add missing translation key for "Address". [\#4835](https://github.com/decidim/decidim/pull/4835)
 
 **Removed**:
 

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -2,6 +2,7 @@ en:
   activemodel:
     attributes:
       collaborative_draft:
+        address: Address
         body: Body
         category_id: Category
         decidim_scope_id: Scope
@@ -10,6 +11,7 @@ en:
         title: Title
         user_group_id: Create collaborative draft as
       proposal:
+        address: Address
         answer: Answer
         answered_at: Answered at
         automatic_hashtags: Hashtags automatically added


### PR DESCRIPTION
#### :tophat: What? Why?
The "Address" field is missing the translation key in the source translations (English).

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry