### PR TITLE
[FEATURE] Add text formatting capabilities to MarkdownToProposals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 **Added**:
 
+- **decidim-proposals** Add text formatting capabilities to MarkdownToProposals. [\#4837](https://github.com/decidim/decidim/pull/4837)
 - **decidim-docs** Update dependencies and ruby version. [\#4812](https://github.com/decidim/decidim/pull/4812)
 - **decidim-proposals** Lists are imported as a single proposal. [\#4780](https://github.com/decidim/decidim/pull/4780)
 - **decidim-proposals**: Allow to persist participatory text drafts before publishing. [\#4808](https://github.com/decidim/decidim/pull/4808)

--- a/decidim-proposals/lib/decidim/proposals/markdown_to_proposals.rb
+++ b/decidim-proposals/lib/decidim/proposals/markdown_to_proposals.rb
@@ -27,7 +27,9 @@ module Decidim
         extensions = {
           # no lax_spacing so that it is easier to group paragraphs in articles.
           lax_spacing: false,
-          fenced_code_blocks: true
+          fenced_code_blocks: true,
+          autolink: true,
+          underline: true
         }
         parser = ::Redcarpet::Markdown.new(renderer, extensions)
         parser.render(document)
@@ -108,6 +110,18 @@ module Decidim
         attrs += %( alt="#{alt_text}") if alt_text.present?
         attrs += %( title="#{title}") if title.present?
         "<img #{attrs}/>"
+      end
+
+      def emphasis(text)
+        "<em>#{text}</em>"
+      end
+
+      def double_emphasis(text)
+        "<strong>#{text}</strong>"
+      end
+
+      def underline(text)
+        "<u>#{text}</u>"
       end
 
       private


### PR DESCRIPTION
#### :tophat: What? Why?
Add text formatting capabilities to MarkdownToProposals. It now supports:
- underline: \_underlined text\_
- emphasis: \*emphasized text\*
- double emphasis: \*\*text with strong emphasis\*\*

#### :pushpin: Related Issues
- Related to #3583

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [-] Add documentation regarding the feature 
- [-] Add/modify seeds
- [x] Add tests
- [x] Task

### :camera: Screenshots (optional)
![Description](URL)
