### PR TITLE
4656 metadata verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - **decidim-initiatives**: Add setting to initiatives types to enable a step to allow initiative signature after passing SMS verification mechanism [\#4792](https://github.com/decidim/decidim/pull/4792)
 - **decidim-initiatives**: Allow integration of services to add timestamps and sign PDFs, define example services and use in application generator [\#4805](https://github.com/decidim/decidim/pull/4805)
 - **decidim-initiatives**: Add setting to initiatives types to verify document number provided on votes and avoid duplicated votes with the same document [\#4794](https://github.com/decidim/decidim/pull/4794)
+- **decidim-initiatives**: Add validation using metadata of authorization for handler defined to validate document mumber [\#4838](https://github.com/decidim/decidim/pull/4838)
 
 **Changed**:
 

--- a/decidim-initiatives/app/controllers/decidim/initiatives/initiative_signatures_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/initiative_signatures_controller.rb
@@ -72,9 +72,17 @@ module Decidim
       end
 
       def sms_phone_number_step(parameters)
-        check_session_personal_data unless parameters.has_key? :initiatives_vote
+        if parameters.has_key? :initiatives_vote
+          build_vote_form(parameters)
+        else
+          check_session_personal_data
+        end
         clear_session_sms_code
-        build_vote_form(parameters)
+
+        if @vote_form.invalid?
+          flash[:alert] = I18n.t("personal_data.invalid", scope: "decidim.initiatives.initiative_votes")
+          jump_to(:fill_personal_data)
+        end
 
         @form = Decidim::Verifications::Sms::MobilePhoneForm.new
         render_wizard

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -313,6 +313,8 @@ en:
           error: There's been errors when signing the initiative.
           invalid: The data provided to sign the initiative is not valid
           success: Congratulations! The initiative has been signed correctly
+        personal_data:
+          invalid: Personal data is not consistent with data provided for authorization.
         sms_code:
           invalid: Your verification code doesn't match ours. Please double-check the SMS we sent you.
         sms_phone:


### PR DESCRIPTION
#### :tophat: What? Why?
- Adds a validation to votes form to check if the personal data provided by the user together with the initiative scope is compatible with the authorization metadata used to check document number
- Includes a redirect in vote wizard to personal data step from sms number step if personal data is invalid

#### :pushpin: Related Issues
- Related to #4656
- Related to #4644

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
