### PR TITLE
Fix accepting/declining meeting invitations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - **decidim-initiatives** Add missing dependency for wicked_pdf to initiatives module [\#4813](https://github.com/decidim/decidim/pull/4813)
 - **decidim-participatory_processes**: Shows the short description on processes when displaying a single one on the homepage. [\#4824](https://github.com/decidim/decidim/pull/4824)
 - **decidim-proposals**: Add missing translation key for "Address". [\#4835](https://github.com/decidim/decidim/pull/4835)
+- **decidim-meetings**: Fix accepting/declining meeting invitations [\#4839](https://github.com/decidim/decidim/pull/4839)
 
 **Removed**:
 

--- a/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
@@ -55,7 +55,8 @@ module Decidim
       end
 
       def can_join_meeting?
-        meeting.registrations_enabled? && meeting.has_available_slots?
+        meeting.registrations_enabled? && meeting.has_available_slots? &&
+          !meeting.has_registration_for?(user)
       end
 
       def send_email_confirmation

--- a/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
@@ -102,9 +102,13 @@ module Decidim
       end
 
       def redirect_after_path
-        referer = request.headers["Referer"]
-        return redirect_to(meeting_path(meeting)) if referer =~ /invitation_token/
-        redirect_back fallback_location: meeting_path(meeting)
+        redirect_to meeting_path(meeting)
+      end
+
+      def user_has_no_permission_path
+        return meeting_path(meeting) if user_signed_in?
+
+        decidim.new_user_session_path
       end
     end
   end

--- a/decidim-meetings/spec/commands/join_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/join_meeting_spec.rb
@@ -168,6 +168,16 @@ module Decidim::Meetings
     end
 
     context "when the meeting has not enough available slots" do
+      before do
+        create(:registration, meeting: meeting, user: user)
+      end
+
+      it "broadcasts invalid" do
+        expect { subject.call }.to broadcast(:invalid)
+      end
+    end
+
+    context "when the user has already registered for the meeting" do
       let(:available_slots) { 1 }
 
       before do

--- a/decidim-meetings/spec/commands/join_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/join_meeting_spec.rb
@@ -168,8 +168,10 @@ module Decidim::Meetings
     end
 
     context "when the meeting has not enough available slots" do
+      let(:available_slots) { 1 }
+
       before do
-        create(:registration, meeting: meeting, user: user)
+        create(:registration, meeting: meeting)
       end
 
       it "broadcasts invalid" do
@@ -178,10 +180,8 @@ module Decidim::Meetings
     end
 
     context "when the user has already registered for the meeting" do
-      let(:available_slots) { 1 }
-
       before do
-        create(:registration, meeting: meeting)
+        create(:registration, meeting: meeting, user: user)
       end
 
       it "broadcasts invalid" do


### PR DESCRIPTION
#### :tophat: What? Why?
The meeting invitation functionality works currently OK for users that are already signed in. They either click the "accept" or "decline" button and get to the functionality they need.

However, when the user is not already signed in (the case with most of the users), the user experience is more than confusing. By clicking either of the links in the invitation, "accept" or "decline", the user is redirected to the front page and shown a message "You are not authorized to perform this action", without any link to the meeting.

This fixes the issue by redirecting non-signed in users to the sign in page after which they go to the original "accept" or "decline" URL.

This also fixes an exception thrown when the user is already registered for the event and redirects them back to the meeting page.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [X] Add tests