### PR TITLE
Allow only to attach published proposals to budgeting projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - **decidim-initiatives** Add missing dependency for wicked_pdf to initiatives module [\#4813](https://github.com/decidim/decidim/pull/4813)
 - **decidim-participatory_processes**: Shows the short description on processes when displaying a single one on the homepage. [\#4824](https://github.com/decidim/decidim/pull/4824)
 - **decidim-proposals**: Add missing translation key for "Address". [\#4835](https://github.com/decidim/decidim/pull/4835)
+- **decidim-budgets**: Allow only to attach published proposals to budgeting projects [\#4840](https://github.com/decidim/decidim/pull/4840)
 
 **Removed**:
 

--- a/decidim-budgets/app/forms/decidim/budgets/admin/project_form.rb
+++ b/decidim-budgets/app/forms/decidim/budgets/admin/project_form.rb
@@ -38,6 +38,7 @@ module Decidim
 
         def proposals
           @proposals ||= Decidim.find_resource_manifest(:proposals).try(:resource_scope, current_component)
+                         &.published
                          &.order(title: :asc)
                          &.map { |proposal| [present(proposal).title, proposal.id] }
         end

--- a/decidim-budgets/spec/forms/project_form_spec.rb
+++ b/decidim-budgets/spec/forms/project_form_spec.rb
@@ -92,6 +92,13 @@ module Decidim::Budgets
           expect(subject.proposals)
             .to eq([[proposal.title, proposal.id]])
         end
+
+        it "does not return the draft proposals" do
+          create_list(:proposal, 10, :draft, component: proposals_component)
+
+          expect(subject.proposals)
+            .to eq([[proposal.title, proposal.id]])
+        end
       end
 
       describe "#map_model" do


### PR DESCRIPTION
#### :tophat: What? Why?
The budgeting project proposal selector allows selecting draft proposals which should not be the case.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [X] Add tests