### PR TITLE
4644 initiatives signatures improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - **decidim-initiatives**: Add validation using metadata of authorization for handler defined to validate document mumber [\#4838](https://github.com/decidim/decidim/pull/4838)
 - **decidim-meetings**: Order meetings at admin [\#4844](https://github.com/decidim/decidim/pull/4844)
 - **decidim-proposals** Add admin edit link for proposals [\#4843](https://github.com/decidim/decidim/pull/4843)
+- **decidim-initiatives**: Add setting in `Decidim::InitiativesType` to enable users to undo their initiatives signatures. [\#4841](https://github.com/decidim/decidim/pull/4841)
 
 **Changed**:
 
@@ -35,6 +36,9 @@
 - **decidim-admin**: Change admin moderations manager [\#4717](https://github.com/decidim/decidim/pull/4717)
 - **decidim-core**: Change action_authorization and modals to manage multiple authorization handlers instead of one [\#4747](https://github.com/decidim/decidim/pull/4747)
 - **decidim-admin**: Change interface to manage multiple authorizations for components and resources [\#4747](https://github.com/decidim/decidim/pull/4747)
+- **decidim-initiatives**: Change logic of online sign initiative buttons. [\#4841](https://github.com/decidim/decidim/pull/4841)
+- **decidim-initiatives**: Add a last step on signature initiatives wizard and use it instead of redirect to initiative after signing. [\#4841](https://github.com/decidim/decidim/pull/4841)
+- **decidim-initiatives**: Change permissions of sign_initiative action. [\#4841](https://github.com/decidim/decidim/pull/4841)
 
 **Fixed**:
 

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/create_initiative_type.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/create_initiative_type.rb
@@ -40,6 +40,7 @@ module Decidim
             title: form.title,
             description: form.description,
             online_signature_enabled: form.online_signature_enabled,
+            undo_online_signatures_enabled: form.undo_online_signatures_enabled,
             minimum_committee_members: form.minimum_committee_members,
             banner_image: form.banner_image,
             collect_user_extra_fields: form.collect_user_extra_fields,

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative_type.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative_type.rb
@@ -42,6 +42,7 @@ module Decidim
             title: form.title,
             description: form.description,
             online_signature_enabled: form.online_signature_enabled,
+            undo_online_signatures_enabled: form.undo_online_signatures_enabled,
             minimum_committee_members: form.minimum_committee_members,
             collect_user_extra_fields: form.collect_user_extra_fields,
             extra_fields_legal_information: form.extra_fields_legal_information,

--- a/decidim-initiatives/app/controllers/decidim/initiatives/initiative_signatures_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/initiative_signatures_controller.rb
@@ -107,7 +107,7 @@ module Decidim
         end
       end
 
-      def wicked_finish_step(parameters)
+      def finish_step(parameters)
         if parameters.has_key? :initiatives_vote
           build_vote_form(parameters)
         else
@@ -131,16 +131,15 @@ module Decidim
         VoteInitiative.call(@vote_form, current_user) do
           on(:ok) do
             session[:initiative_vote_form] = {}
-            flash[:notice] = I18n.t("create.success", scope: "decidim.initiatives.initiative_votes")
-            redirect_to initiative_path(current_initiative)
           end
 
           on(:invalid) do |vote|
             logger.fatal "Failed creating signature: #{vote.errors.full_messages.join(", ")}" if vote
             flash[:alert] = I18n.t("create.invalid", scope: "decidim.initiatives.initiative_votes")
-            redirect_to wizard_path(steps.last)
+            jump_to previous_step
           end
         end
+        render_wizard
       end
 
       def build_vote_form(parameters)
@@ -193,7 +192,7 @@ module Decidim
       end
 
       def set_wizard_steps
-        self.steps = sms_step? ? [:fill_personal_data, :sms_phone_number, :sms_code] : [:fill_personal_data]
+        self.steps = sms_step? ? [:fill_personal_data, :sms_phone_number, :sms_code, :finish] : [:fill_personal_data, :finish]
       end
     end
   end

--- a/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_type_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_type_form.rb
@@ -13,6 +13,7 @@ module Decidim
         translatable_attribute :description, String
         attribute :banner_image, String
         attribute :online_signature_enabled, Boolean
+        attribute :undo_online_signatures_enabled, Boolean
         attribute :minimum_committee_members, Integer
         attribute :collect_user_extra_fields, Boolean
         translatable_attribute :extra_fields_legal_information, String
@@ -21,6 +22,7 @@ module Decidim
 
         validates :title, :description, translatable_presence: true
         validates :online_signature_enabled, inclusion: { in: [true, false] }
+        validates :undo_online_signatures_enabled, inclusion: { in: [true, false] }
         validates :minimum_committee_members, numericality: { only_integer: true }, allow_nil: true
         validates :banner_image, presence: true, if: lambda { |form|
           form.context.initiative_type.nil?

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -183,6 +183,13 @@ module Decidim
         signature_end_date >= Date.current
     end
 
+    # Public: Check if the user has voted the question.
+    #
+    # Returns Boolean.
+    def voted_by?(user)
+      votes.where(author: user).any?
+    end
+
     # Public: Checks if the organization has given an answer for the initiative.
     #
     # Returns Boolean.

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -299,6 +299,10 @@ module Decidim
         votes_enabled?
     end
 
+    def accepts_online_unvotes?
+      accepts_online_votes? && type.undo_online_signatures_enabled?
+    end
+
     def minimum_committee_members
       type.minimum_committee_members || Decidim::Initiatives.minimum_committee_members
     end

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -286,6 +286,12 @@ module Decidim
         published?
     end
 
+    def accepts_online_votes?
+      Decidim::Initiatives.online_voting_allowed &&
+        (online? || any?) &&
+        votes_enabled?
+    end
+
     def minimum_committee_members
       type.minimum_committee_members || Decidim::Initiatives.minimum_committee_members
     end

--- a/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
+++ b/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
@@ -105,13 +105,7 @@ module Decidim
         return unless permission_action.action == :vote &&
                       permission_action.subject == :initiative
 
-        can_vote = initiative.votes_enabled? &&
-                   initiative.organization&.id == user.organization&.id &&
-                   initiative.votes.where(decidim_author_id: user.id, decidim_user_group_id: decidim_user_group_id).empty? &&
-                   (can_user_support?(initiative) || Decidim::UserGroups::ManageableUserGroups.for(user).verified.any?) &&
-                   authorized?(:vote, resource: initiative, permissions_holder: initiative.type)
-
-        toggle_allow(can_vote)
+        toggle_allow(can_vote?)
       end
 
       def authorized?(permission_action, resource: nil, permissions_holder: nil)
@@ -137,11 +131,22 @@ module Decidim
         return unless permission_action.action == :sign_initiative &&
                       permission_action.subject == :initiative
 
-        toggle_allow(context.fetch(:signature_has_steps, false))
+        can_sign = can_vote? &&
+                   context.fetch(:signature_has_steps, false)
+
+        toggle_allow(can_sign)
       end
 
       def decidim_user_group_id
         context.fetch(:group_id, nil)
+      end
+
+      def can_vote?
+        initiative.votes_enabled? &&
+          initiative.organization&.id == user.organization&.id &&
+          initiative.votes.where(decidim_author_id: user.id, decidim_user_group_id: decidim_user_group_id).empty? &&
+          (can_user_support?(initiative) || Decidim::UserGroups::ManageableUserGroups.for(user).verified.any?) &&
+          authorized?(:vote, resource: initiative, permissions_holder: initiative.type)
       end
 
       def can_user_support?(initiative)

--- a/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
+++ b/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
@@ -124,7 +124,7 @@ module Decidim
         return unless permission_action.action == :unvote &&
                       permission_action.subject == :initiative
 
-        can_unvote = initiative.votes_enabled? &&
+        can_unvote = initiative.accepts_online_unvotes? &&
                      initiative.organization&.id == user.organization&.id &&
                      initiative.votes.where(decidim_author_id: user.id, decidim_user_group_id: decidim_user_group_id).any? &&
                      (can_user_support?(initiative) || Decidim::UserGroups::ManageableUserGroups.for(user).verified.any?) &&

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_form.html.erb
@@ -17,6 +17,10 @@
     </div>
 
     <div class="row column">
+      <%= form.check_box :undo_online_signatures_enabled %>
+    </div>
+
+    <div class="row column">
       <%= form.number_field :minimum_committee_members, min: 0, step: 1 %>
     </div>
 

--- a/decidim-initiatives/app/views/decidim/initiatives/initiative_signatures/_wizard_steps.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiative_signatures/_wizard_steps.html.erb
@@ -1,0 +1,19 @@
+<div class="hide-for-large m-bottom">
+  <span class="text-small">
+    <%= t("step", scope: "layouts.decidim.initiative_signature_creation_header", current: (wizard_steps.index(step) + 1), total: wizard_steps.length) %>
+    (<a data-toggle="steps"><%= t("see_steps", scope: "layouts.decidim.initiative_signature_creation_header") %></a>)
+  </span>
+  <ol id="steps" class="wizard__steps steps-toggle is-hidden" data-toggler=".is-hidden">
+    <% wizard_steps.each do |wizard_step| %>
+      <% if step == wizard_step %>
+        <li class="step--active">
+          <%= t(wizard_step, scope: "layouts.decidim.initiative_signature_creation_header") %>
+        </li>
+      <% else %>
+        <li>
+          <%= t(wizard_step, scope: "layouts.decidim.initiative_signature_creation_header") %>
+        </li>
+      <% end %>
+    <% end %>
+  </ol>
+</div>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiative_signatures/fill_personal_data.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiative_signatures/fill_personal_data.html.erb
@@ -1,43 +1,43 @@
-      <div class="callout secondary mb-sm">
-        <p>
-      <%= t ".help" %>
-        </p>
-      </div>
-      <h2 class="section-heading"><%= t(step, scope: "layouts.decidim.initiative_signature_creation_header") %></h2>
+<div class="callout secondary mb-sm">
+  <p>
+<%= t ".help" %>
+  </p>
+</div>
+<h2 class="section-heading"><%= t(step, scope: "layouts.decidim.initiative_signature_creation_header") %></h2>
 
-      <%= render partial: "wizard_steps" %>
+<%= render partial: "wizard_steps" %>
 
-      <div class="card">
-        <div class="card__content">
-          <%= decidim_form_for(@form, url: next_wizard_path, method: :put, html: { class: "form user_personal_data_signature_form" }) do |f| %>
-            <%= f.hidden_field :group_id %>
-            <div>
-              <div class="field">
-                <%= f.text_field :name_and_surname, autofocus: true, required: true %>
-              </div>
+<div class="card">
+  <div class="card__content">
+    <%= decidim_form_for(@form, url: next_wizard_path, method: :put, html: { class: "form user_personal_data_signature_form" }) do |f| %>
+      <%= f.hidden_field :group_id %>
+      <div>
+        <div class="field">
+          <%= f.text_field :name_and_surname, autofocus: true, required: true %>
+        </div>
 
-              <div class="field">
-                <%= f.text_field :document_number, required: true %>
-              </div>
+        <div class="field">
+          <%= f.text_field :document_number, required: true %>
+        </div>
 
-              <div class="field">
-                <%= f.date_field :date_of_birth, required: true %>
-              </div>
+        <div class="field">
+          <%= f.date_field :date_of_birth, required: true %>
+        </div>
 
-              <div class="field">
-                <%= f.text_field :postal_code, required: true %>
-              </div>
+        <div class="field">
+          <%= f.text_field :postal_code, required: true %>
+        </div>
 
-              <div class="pb-s">
-                <small class="text-small">
-                <%= strip_tags(translated_attribute(extra_data_legal_information)) %>
-                </small>
-              </div>
-            </div>
-
-            <div class="actions">
-              <%= f.submit t(".continue"), class: "button expanded" %>
-            </div>
-          <% end %>
+        <div class="pb-s">
+          <small class="text-small">
+          <%= strip_tags(translated_attribute(extra_data_legal_information)) %>
+          </small>
         </div>
       </div>
+
+      <div class="actions">
+        <%= f.submit t(".continue"), class: "button expanded" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiative_signatures/fill_personal_data.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiative_signatures/fill_personal_data.html.erb
@@ -5,25 +5,7 @@
       </div>
       <h2 class="section-heading"><%= t(step, scope: "layouts.decidim.initiative_signature_creation_header") %></h2>
 
-      <div class="hide-for-large m-bottom">
-        <span class="text-small">
-          <%= t("step", scope: "layouts.decidim.initiative_signature_creation_header", current: (wizard_steps.index(step) + 1), total: wizard_steps.length) %>
-          (<a data-toggle="steps"><%= t("see_steps", scope: "layouts.decidim.initiative_signature_creation_header") %></a>)
-        </span>
-        <ol id="steps" class="wizard__steps steps-toggle is-hidden" data-toggler=".is-hidden">
-          <% wizard_steps.each do |wizard_step| %>
-            <% if step == wizard_step %>
-              <li class="step--active">
-                <%= t(wizard_step, scope: "layouts.decidim.initiative_signature_creation_header") %>
-              </li>
-            <% else %>
-              <li>
-                <%= t(wizard_step, scope: "layouts.decidim.initiative_signature_creation_header") %>
-              </li>
-            <% end %>
-          <% end %>
-        </ol>
-      </div>
+      <%= render partial: "wizard_steps" %>
 
       <div class="card">
         <div class="card__content">

--- a/decidim-initiatives/app/views/decidim/initiatives/initiative_signatures/finish.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiative_signatures/finish.html.erb
@@ -1,1 +1,17 @@
-OK!!!!
+<div class="callout secondary mb-sm">
+  <p>
+    <%= t("create.success_html",
+          scope: "decidim.initiatives.initiative_votes",
+          title: translated_attribute(current_initiative.title)) %>
+  </p>
+</div>
+<h2 class="section-heading"><%= t("finished", scope: "layouts.decidim.initiative_signature_creation_header") %></h2>
+
+<%= render partial: "wizard_steps" %>
+
+<div class="card">
+  <br />
+  <div class="column actions">
+    <%= link_to t(".back_to_initiative"), initiative_path(current_initiative), class: "button white-button expanded" %>
+  </div>
+</div>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiative_signatures/sms_code.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiative_signatures/sms_code.html.erb
@@ -5,25 +5,7 @@
 </div>
 <h2 class="section-heading"><%= t(step, scope: "layouts.decidim.initiative_signature_creation_header") %></h2>
 
-<div class="hide-for-large m-bottom">
-  <span class="text-small">
-    <%= t("step", scope: "layouts.decidim.initiative_signature_creation_header", current: (wizard_steps.index(step) + 1), total: wizard_steps.length) %>
-    (<a data-toggle="steps"><%= t("see_steps", scope: "layouts.decidim.initiative_signature_creation_header") %></a>)
-  </span>
-  <ol id="steps" class="wizard__steps steps-toggle is-hidden" data-toggler=".is-hidden">
-    <% wizard_steps.each do |wizard_step| %>
-      <% if step == wizard_step %>
-        <li class="step--active">
-          <%= t(wizard_step, scope: "layouts.decidim.initiative_signature_creation_header") %>
-        </li>
-      <% else %>
-        <li>
-          <%= t(wizard_step, scope: "layouts.decidim.initiative_signature_creation_header") %>
-        </li>
-      <% end %>
-    <% end %>
-  </ol>
-</div>
+<%= render partial: "wizard_steps" %>
 
 <div class="card">
   <div class="card__content">

--- a/decidim-initiatives/app/views/decidim/initiatives/initiative_signatures/sms_phone_number.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiative_signatures/sms_phone_number.html.erb
@@ -5,25 +5,7 @@
 </div>
 <h2 class="section-heading"><%= t(step, scope: "layouts.decidim.initiative_signature_creation_header") %></h2>
 
-<div class="hide-for-large m-bottom">
-  <span class="text-small">
-    <%= t("step", scope: "layouts.decidim.initiative_signature_creation_header", current: (wizard_steps.index(step) + 1), total: wizard_steps.length) %>
-    (<a data-toggle="steps"><%= t("see_steps", scope: "layouts.decidim.initiative_signature_creation_header") %></a>)
-  </span>
-  <ol id="steps" class="wizard__steps steps-toggle is-hidden" data-toggler=".is-hidden">
-    <% wizard_steps.each do |wizard_step| %>
-      <% if step == wizard_step %>
-        <li class="step--active">
-          <%= t(wizard_step, scope: "layouts.decidim.initiative_signature_creation_header") %>
-        </li>
-      <% else %>
-        <li>
-          <%= t(wizard_step, scope: "layouts.decidim.initiative_signature_creation_header") %>
-        </li>
-      <% end %>
-    <% end %>
-  </ol>
-</div>
+<%= render partial: "wizard_steps" %>
 
 <div class="card">
   <div class="card__content">

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_vote_button.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_vote_button.html.erb
@@ -15,18 +15,27 @@
     ) %>
   <% end %>
 <% else %>
-  <%= authorized_vote_modal_button(initiative, remote: true, class: "card_button button expanded button--sc") do %>
-    <%= verification_label %>
+  <% if initiative.voted_by?(current_user) %>
+    <% if allowed_to? :unvote, :initiative, initiative: initiative %>
+      <%= button_to(
+        initiative_initiative_vote_path(initiative_slug: current_initiative.slug),
+        method: :delete,
+        remote: true,
+        data: { disable: true },
+        class: "card__button button expanded button--sc success light"
+      ) do %>
+        <%= icon("check", class: "icon--small") %>
+        <%= unvote_label %>
+      <% end %>
+    <% else %>
+      <button class='card__button button expanded button--sc success light disabled' disabled>
+        <%= icon("check", class: "icon--small") %>
+        <%= unvote_label %>
+      </button>
+    <% end %>
+  <% else %>
+    <%= authorized_vote_modal_button(initiative, remote: true, class: "card_button button expanded button--sc") do %>
+      <%= verification_label %>
+    <% end %>
   <% end %>
-<% end %>
-
-<% if allowed_to? :unvote, :initiative, initiative: initiative %>
-  <%= button_to(
-    vote_label,
-    initiative_initiative_vote_path(initiative_slug: current_initiative.slug),
-    method: :delete,
-    remote: true,
-    data: { disable: true },
-    class: "card__button button expanded button--sc success"
-  ) %>
 <% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_vote_cabin.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_vote_cabin.html.erb
@@ -8,7 +8,7 @@
        id="user-identities"
        data-reveal data-refresh-url="<%= signature_identities_initiative_url(slug: initiative.slug) %>">
   </div>
-<% else %>
+<% elsif initiative.accepts_online_votes? %>
     <%= render partial: "decidim/initiatives/initiatives/vote_button",
                locals: {
                    initiative: initiative,
@@ -16,10 +16,8 @@
                    unvote_label: t(".already_voted"),
                    verification_label: t(".verification_required"),
                    steps: signature_has_steps?
-               } if Decidim::Initiatives.online_voting_allowed %>
-<% end %>
-
-<% if !allowed_to?(:vote, :initiative, initiative: initiative) && !allowed_to?(:unvote, :initiative, initiative: initiative) %>
+               } %>
+<% else %>
   <button class='card__button button expanded button--sc disabled' disabled>
     <%= t(".votes_blocked") %>
   </button>

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -302,6 +302,8 @@ en:
           continue: Continue
           help: Please, fill the following fields with your personal data to sign
             the initiative
+        finish:
+          back_to_initiative: Back to initiative
         sms_phone_number:
           continue: Send me an SMS
           help: Fill the form with your verified phone number to request
@@ -313,7 +315,7 @@ en:
         create:
           error: There's been errors when signing the initiative.
           invalid: The data provided to sign the initiative is not valid
-          success: Congratulations! The initiative has been signed correctly
+          success_html: Congratulations! The <strong> %{title}</strong> initiative has been signed correctly
         personal_data:
           invalid: Personal data is not consistent with data provided for authorization.
         sms_code:
@@ -435,6 +437,8 @@ en:
       initiative_signature_creation_header:
         back: Back
         fill_personal_data: Complete your data
+        finish: Finish
+        finished: Initiative signature created
         select_identity: Select identity
         see_steps: see steps
         sms_code: SMS code verification

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
         minimum_committee_members: Minimum of committee members
         online_signature_enabled: Online signature enabled
         title: Title
+        undo_online_signatures_enabled: Enable users to undo their online signatures
         validate_sms_code_on_votes: Add SMS code validation step to signature process
       initiatives_vote:
         name_and_surname: Name and surname

--- a/decidim-initiatives/db/migrate/20190213184301_add_undo_online_signatures_enabled_to_initiatives_types.rb
+++ b/decidim-initiatives/db/migrate/20190213184301_add_undo_online_signatures_enabled_to_initiatives_types.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUndoOnlineSignaturesEnabledToInitiativesTypes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_initiatives_types, :undo_online_signatures_enabled, :boolean, null: false, default: true
+  end
+end

--- a/decidim-initiatives/lib/decidim/initiatives/test/factories.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/test/factories.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     banner_image { Decidim::Dev.test_file("city2.jpeg", "image/jpeg") }
     organization
     online_signature_enabled { true }
+    undo_online_signatures_enabled { true }
     minimum_committee_members { 3 }
 
     trait :online_signature_enabled do
@@ -18,6 +19,14 @@ FactoryBot.define do
 
     trait :online_signature_disabled do
       online_signature_enabled { false }
+    end
+
+    trait :undo_online_signatures_enabled do
+      undo_online_signatures_enabled { true }
+    end
+
+    trait :undo_online_signatures_disabled do
+      undo_online_signatures_enabled { false }
     end
 
     trait :with_user_extra_fields_collection do

--- a/decidim-initiatives/spec/forms/initiative_type_form_spec.rb
+++ b/decidim-initiatives/spec/forms/initiative_type_form_spec.rb
@@ -17,6 +17,7 @@ module Decidim
             title: title,
             description: Decidim::Faker::Localized.sentence(25),
             online_signature_enabled: false,
+            undo_online_signatures_enabled: false,
             minimum_committee_members: minimum_committee_members,
             banner_image: Decidim::Dev.test_file("city2.jpeg", "image/jpeg")
           }

--- a/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
+++ b/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
@@ -11,6 +11,84 @@ describe Decidim::Initiatives::Permissions do
   let(:context) { {} }
   let(:permission_action) { Decidim::PermissionAction.new(action) }
 
+  shared_examples "votes permissions" do
+    let(:organization) { create(:organization, available_authorizations: authorizations) }
+    let(:authorizations) { %w(dummy_authorization_handler another_dummy_authorization_handler) }
+    let(:initiative) { create :initiative, organization: organization }
+    let(:context) do
+      { initiative: initiative }
+    end
+    let(:votes_enabled?) { true }
+
+    before do
+      allow(initiative).to receive(:votes_enabled?).and_return(votes_enabled?)
+    end
+
+    context "when initiative has votes disabled" do
+      let(:votes_enabled?) { false }
+
+      it { is_expected.to eq false }
+    end
+
+    context "when user belongs to another organization" do
+      let(:user) { create :user }
+
+      it { is_expected.to eq false }
+    end
+
+    context "when user has already voted the initiative" do
+      before do
+        create :initiative_user_vote, initiative: initiative, author: user
+      end
+
+      it { is_expected.to eq false }
+    end
+
+    context "when user has verified user groups" do
+      before do
+        create :user_group, :verified, users: [user], organization: user.organization
+      end
+
+      it { is_expected.to eq true }
+    end
+
+    context "when the initiative type has permissions to vote" do
+      before do
+        initiative.type.create_resource_permission(
+          permissions: {
+            "vote" => {
+              "authorization_handlers" => {
+                "dummy_authorization_handler" => { "options" => {} },
+                "another_dummy_authorization_handler" => { "options" => {} }
+              }
+            }
+          }
+        )
+      end
+
+      context "when user is not verified" do
+        it { is_expected.to eq false }
+      end
+
+      context "when user is not fully verified" do
+        before do
+          create(:authorization, name: "dummy_authorization_handler", user: user, granted_at: 2.seconds.ago)
+        end
+
+        it { is_expected.to eq false }
+      end
+
+      context "when user is fully verified" do
+        before do
+          create(:authorization, name: "dummy_authorization_handler", user: user, granted_at: 2.seconds.ago)
+          create(:authorization, name: "another_dummy_authorization_handler", user: user, granted_at: 2.seconds.ago)
+        end
+
+        it { is_expected.to eq true }
+      end
+    end
+  end
+
   context "when reading the admin dashboard" do
     let(:action) do
       { scope: :admin, action: :read, subject: :admin_dashboard }
@@ -206,82 +284,71 @@ describe Decidim::Initiatives::Permissions do
   end
 
   context "when voting an initiative" do
-    let(:organization) { create(:organization, available_authorizations: authorizations) }
-    let(:authorizations) { %w(dummy_authorization_handler another_dummy_authorization_handler) }
-    let(:action) do
-      { scope: :public, action: :vote, subject: :initiative }
+    it_behaves_like "votes permissions" do
+      let(:action) do
+        { scope: :public, action: :vote, subject: :initiative }
+      end
     end
-    let(:initiative) { create :initiative, organization: organization }
-    let(:context) do
-      { initiative: initiative }
-    end
-    let(:votes_enabled?) { true }
+  end
 
-    before do
-      allow(initiative).to receive(:votes_enabled?).and_return(votes_enabled?)
-    end
-
-    context "when initiative has votes disabled" do
-      let(:votes_enabled?) { false }
-
-      it { is_expected.to eq false }
+  context "when signing an initiative" do
+    context "when initiative signature has steps" do
+      it_behaves_like "votes permissions" do
+        let(:action) do
+          { scope: :public, action: :sign_initiative, subject: :initiative }
+        end
+        let(:context) do
+          { initiative: initiative, signature_has_steps: true }
+        end
+      end
     end
 
-    context "when user belongs to another organization" do
-      let(:user) { create :user }
-
-      it { is_expected.to eq false }
-    end
-
-    context "when user has already voted the initiative" do
-      before do
-        create :initiative_user_vote, initiative: initiative, author: user
+    context "when initiative signature doesn't have steps" do
+      let(:organization) { create(:organization, available_authorizations: authorizations) }
+      let(:authorizations) { %w(dummy_authorization_handler another_dummy_authorization_handler) }
+      let(:initiative) { create :initiative, organization: organization }
+      let(:votes_enabled?) { true }
+      let(:action) do
+        { scope: :public, action: :sign_initiative, subject: :initiative }
+      end
+      let(:context) do
+        { initiative: initiative, signature_has_steps: false }
       end
 
-      it { is_expected.to eq false }
-    end
-
-    context "when user has verified user groups" do
       before do
-        create :user_group, :verified, users: [user], organization: user.organization
+        allow(initiative).to receive(:votes_enabled?).and_return(votes_enabled?)
       end
 
-      it { is_expected.to eq true }
-    end
+      context "when user has verified user groups" do
+        before do
+          create :user_group, :verified, users: [user], organization: user.organization
+        end
 
-    context "when the initiative type has permissions to vote" do
-      before do
-        initiative.type.create_resource_permission(
-          permissions: {
-            "vote" => {
-              "authorization_handlers" => {
-                "dummy_authorization_handler" => { "options" => {} },
-                "another_dummy_authorization_handler" => { "options" => {} }
+        it { is_expected.to eq false }
+      end
+
+      context "when the initiative type has permissions to vote" do
+        before do
+          initiative.type.create_resource_permission(
+            permissions: {
+              "vote" => {
+                "authorization_handlers" => {
+                  "dummy_authorization_handler" => { "options" => {} },
+                  "another_dummy_authorization_handler" => { "options" => {} }
+                }
               }
             }
-          }
-        )
-      end
-
-      context "when user is not verified" do
-        it { is_expected.to eq false }
-      end
-
-      context "when user is not fully verified" do
-        before do
-          create(:authorization, name: "dummy_authorization_handler", user: user, granted_at: 2.seconds.ago)
+          )
         end
 
-        it { is_expected.to eq false }
-      end
+        context "when user is fully verified" do
+          before do
+            create(:authorization, name: "dummy_authorization_handler", user: user, granted_at: 2.seconds.ago)
+            create(:authorization, name: "another_dummy_authorization_handler", user: user, granted_at: 2.seconds.ago)
+          end
 
-      context "when user is fully verified" do
-        before do
-          create(:authorization, name: "dummy_authorization_handler", user: user, granted_at: 2.seconds.ago)
-          create(:authorization, name: "another_dummy_authorization_handler", user: user, granted_at: 2.seconds.ago)
+          it { is_expected.to eq false }
         end
-
-        it { is_expected.to eq true }
       end
     end
   end

--- a/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
+++ b/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
@@ -295,13 +295,21 @@ describe Decidim::Initiatives::Permissions do
       { initiative: initiative }
     end
     let(:votes_enabled?) { true }
+    let(:accepts_online_unvotes?) { true }
 
     before do
       allow(initiative).to receive(:votes_enabled?).and_return(votes_enabled?)
+      allow(initiative).to receive(:accepts_online_unvotes?).and_return(accepts_online_unvotes?)
     end
 
     context "when initiative has votes disabled" do
       let(:votes_enabled?) { false }
+
+      it { is_expected.to eq false }
+    end
+
+    context "when initiative has unvotes disabled" do
+      let(:accepts_online_unvotes?) { false }
 
       it { is_expected.to eq false }
     end

--- a/decidim-initiatives/spec/shared/create_initiative_type_example.rb
+++ b/decidim-initiatives/spec/shared/create_initiative_type_example.rb
@@ -18,6 +18,7 @@ shared_examples "create an initiative type" do
         title: Decidim::Faker::Localized.sentence(5),
         description: Decidim::Faker::Localized.sentence(25),
         online_signature_enabled: true,
+        undo_online_signatures_enabled: true,
         minimum_committee_members: 7,
         banner_image: Decidim::Dev.test_file("city2.jpeg", "image/jpeg"),
         collect_user_extra_fields: true,

--- a/decidim-initiatives/spec/shared/update_initiative_type_example.rb
+++ b/decidim-initiatives/spec/shared/update_initiative_type_example.rb
@@ -2,7 +2,7 @@
 
 shared_examples "update an initiative type" do
   let(:organization) { create(:organization) }
-  let(:initiative_type) { create(:initiatives_type, :online_signature_enabled, organization: organization) }
+  let(:initiative_type) { create(:initiatives_type, :online_signature_enabled, :undo_online_signatures_enabled, organization: organization) }
   let(:form) do
     form_klass.from_params(
       form_params
@@ -18,6 +18,7 @@ shared_examples "update an initiative type" do
         title: Decidim::Faker::Localized.sentence(5),
         description: Decidim::Faker::Localized.sentence(25),
         online_signature_enabled: false,
+        undo_online_signatures_enabled: false,
         minimum_committee_members: 7,
         banner_image: Decidim::Dev.test_file("city2.jpeg", "image/jpeg"),
         collect_user_extra_fields: true,
@@ -42,6 +43,7 @@ shared_examples "update an initiative type" do
         expect(initiative_type.title).not_to eq(form_params[:title])
         expect(initiative_type.description).not_to eq(form_params[:description])
         expect(initiative_type.online_signature_enabled).not_to eq(form_params[:online_signature_enabled])
+        expect(initiative_type.undo_online_signatures_enabled).not_to eq(form_params[:undo_online_signatures_enabled])
         expect(initiative_type.minimum_committee_members).not_to eq(form_params[:minimum_committee_members])
       end
     end
@@ -59,6 +61,7 @@ shared_examples "update an initiative type" do
         expect(initiative_type.title).to eq(form_params[:title])
         expect(initiative_type.description).to eq(form_params[:description])
         expect(initiative_type.online_signature_enabled).to eq(form_params[:online_signature_enabled])
+        expect(initiative_type.undo_online_signatures_enabled).to eq(form_params[:undo_online_signatures_enabled])
         expect(initiative_type.minimum_committee_members).to eq(form_params[:minimum_committee_members])
       end
 

--- a/decidim-initiatives/spec/system/admin/initiative_types_controller_spec.rb
+++ b/decidim-initiatives/spec/system/admin/initiative_types_controller_spec.rb
@@ -50,7 +50,7 @@ describe "InitiativeTypesController", type: :system do
   end
 
   context "when updating an initiative type" do
-    let(:initiatives_type) { create(:initiatives_type, :online_signature_enabled, organization: organization) }
+    let(:initiatives_type) { create(:initiatives_type, :online_signature_enabled, :undo_online_signatures_enabled, organization: organization) }
 
     it "Updates the initiative type" do
       visit decidim_admin_initiatives.edit_initiatives_type_path(initiatives_type)
@@ -62,6 +62,7 @@ describe "InitiativeTypesController", type: :system do
       )
 
       uncheck "Online signature enabled"
+      uncheck "Enable users to undo their online signatures"
 
       click_button "Update"
 

--- a/decidim-initiatives/spec/system/initiative_signing_sms_verification_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_signing_sms_verification_spec.rb
@@ -43,7 +43,9 @@ describe "Initiative signing", type: :system do
   context "when initiative type personal data collection is disabled" do
     let(:initiatives_type) { create(:initiatives_type, :with_sms_code_validation, organization: organization) }
 
-    it "The vote is created" do
+    it "The vote is created without wizard steps" do
+      expect(page).to have_no_content("initiative has been signed correctly")
+
       within ".view-side" do
         expect(page).to have_content("1\nSIGNATURE")
       end
@@ -56,6 +58,9 @@ describe "Initiative signing", type: :system do
         let(:authorizations) { [] }
 
         it "The vote is created" do
+          expect(page).to have_content("initiative has been signed correctly")
+          click_on "Back to initiative"
+
           within ".view-side" do
             expect(page).to have_content("1\nSIGNATURE")
             expect(initiative.reload.initiative_votes_count).to eq(1)
@@ -121,6 +126,9 @@ describe "Initiative signing", type: :system do
             context "and inserts the correct code number" do
               it "the vote is created" do
                 fill_sms_code
+
+                expect(page).to have_content("initiative has been signed correctly")
+                click_on "Back to initiative"
 
                 expect(page).to have_content("1\nSIGNATURE")
                 expect(initiative.reload.initiative_votes_count).to eq(1)

--- a/decidim-initiatives/spec/system/initiative_signing_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_signing_spec.rb
@@ -84,7 +84,7 @@ describe "Initiative signing", type: :system do
 
       within ".view-side" do
         expect(page).to have_content("1\nSIGNATURE")
-        click_button "Sign"
+        click_button "Already signed"
         expect(page).to have_content("0\nSIGNATURE")
       end
     end
@@ -140,10 +140,11 @@ describe "Initiative signing", type: :system do
             visit decidim_initiatives.initiative_path(initiative)
 
             within ".view-side" do
-              expect(page).to have_content("VERIFY YOUR IDENTITY")
+              expect(page).to have_content("1\nSIGNATURE")
+              expect(page).to have_button("Already signed", disabled: true)
+              click_button "Already signed", disabled: true
+              expect(page).to have_content("1\nSIGNATURE")
             end
-            click_button "Verify your identity"
-            expect(page).to have_content("Authorization required")
           end
         end
       end
@@ -205,10 +206,11 @@ describe "Initiative signing", type: :system do
             visit decidim_initiatives.initiative_path(initiative)
 
             within ".view-side" do
-              expect(page).to have_content("VERIFY YOUR IDENTITY")
+              expect(page).to have_content("1\nSIGNATURE")
+              expect(page).to have_button("Already signed", disabled: true)
+              click_button "Already signed", disabled: true
+              expect(page).to have_content("1\nSIGNATURE")
             end
-            click_button "Verify your identity"
-            expect(page).to have_content("Authorization required")
           end
         end
       end

--- a/decidim-initiatives/spec/system/initiative_signing_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_signing_spec.rb
@@ -65,6 +65,23 @@ describe "Initiative signing", type: :system do
   end
 
   context "when the user has signed the initiative and unsigns it" do
+    context "when initiative type has unvotes disabled" do
+      let(:initiatives_type) { create(:initiatives_type, :undo_online_signatures_disabled, organization: organization) }
+      let(:scope) { create(:initiatives_type_scope, type: initiatives_type) }
+      let(:initiative) { create(:initiative, :published, organization: organization, scoped_type: scope) }
+
+      it "unsigning initiative is disabled" do
+        vote_initiative
+
+        within ".view-side" do
+          expect(page).to have_content("1\nSIGNATURE")
+          expect(page).to have_button("Already signed", disabled: true)
+          click_button "Already signed", disabled: true
+          expect(page).to have_content("1\nSIGNATURE")
+        end
+      end
+    end
+
     context "when the user has a verified user group" do
       let!(:user_group) { create :user_group, :verified, users: [confirmed_user], organization: confirmed_user.organization }
 

--- a/decidim-initiatives/spec/system/initiative_signing_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_signing_spec.rb
@@ -18,6 +18,34 @@ describe "Initiative signing", type: :system do
     login_as confirmed_user, scope: :user
   end
 
+  context "when the user has not signed the initiative" do
+    context "when online signatures are disabled for site" do
+      before do
+        allow(Decidim::Initiatives)
+          .to receive(:online_voting_allowed)
+          .and_return(false)
+      end
+
+      it "voting disabled message is shown" do
+        visit decidim_initiatives.initiative_path(initiative)
+
+        expect(page).to have_content("SIGNING DISABLED")
+      end
+    end
+
+    context "when online signatures are enabled for site" do
+      context "when initative type only allows face to face signatures" do
+        let(:initiative) { create(:initiative, :published, organization: organization, signature_type: "offline") }
+
+        it "voting disabled message is shown" do
+          visit decidim_initiatives.initiative_path(initiative)
+
+          expect(page).to have_content("SIGNING DISABLED")
+        end
+      end
+    end
+  end
+
   context "when the user has not signed the initiative yet and signs it" do
     context "when the user has a verified user group" do
       let!(:user_group) { create :user_group, :verified, users: [confirmed_user], organization: confirmed_user.organization }
@@ -83,7 +111,6 @@ describe "Initiative signing", type: :system do
             visit decidim_initiatives.initiative_path(initiative)
 
             within ".view-side" do
-              expect(page).to have_content("SIGNING DISABLED")
               expect(page).to have_content("VERIFY YOUR IDENTITY")
             end
             click_button "Verify your identity"
@@ -113,7 +140,6 @@ describe "Initiative signing", type: :system do
             visit decidim_initiatives.initiative_path(initiative)
 
             within ".view-side" do
-              expect(page).to have_content("SIGNING DISABLED")
               expect(page).to have_content("VERIFY YOUR IDENTITY")
             end
             click_button "Verify your identity"
@@ -146,7 +172,7 @@ describe "Initiative signing", type: :system do
 
             within ".view-side" do
               expect(page).to have_content("0\nSIGNATURE")
-              expect(page).to have_content("SIGNING DISABLED")
+              expect(page).to have_content("VERIFY YOUR IDENTITY")
             end
             click_button "Verify your identity"
             expect(page).to have_content("Authorization required")
@@ -179,7 +205,6 @@ describe "Initiative signing", type: :system do
             visit decidim_initiatives.initiative_path(initiative)
 
             within ".view-side" do
-              expect(page).to have_content("SIGNING DISABLED")
               expect(page).to have_content("VERIFY YOUR IDENTITY")
             end
             click_button "Verify your identity"

--- a/decidim-initiatives/spec/system/initiative_signing_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_signing_spec.rb
@@ -297,6 +297,9 @@ describe "Initiative signing", type: :system do
       fill_in :initiatives_vote_postal_code, with: "01234"
 
       click_button "Continue"
+
+      expect(page).to have_content("initiative has been signed correctly")
+      click_on "Back to initiative"
     end
 
     within ".view-side" do


### PR DESCRIPTION
#### :tophat: What? Why?

Adds improvements to initiatives signatures:
- Doesn't display signature disabled message if online signature has pending permissions
- Fixes button text in initiative show when initiative is already signed
- If initiative is voted by user but signature undo is not allowed a disabled unvote button is shown
- Adds an attribute to initiatives types to enable initiatives signatures undo
- Adds a finish sign initiative wizard step to be shown instead of redirect to initiative with a flash message after signature creation
- Makes an improvement in `sign_initative` action permissions to act like `vote` action when the initiative signature process has wizard steps

#### :pushpin: Related Issues
- Related to #4644 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)
#### Before
When already signed:
<img width="240" alt="screen shot 2019-02-14 at 22 55 25" src="https://user-images.githubusercontent.com/446459/52820204-a6f31480-30ab-11e9-81b6-410c9f819283.png">

When online signature has permissions pending:
<img width="244" alt="screen shot 2019-02-14 at 22 56 28" src="https://user-images.githubusercontent.com/446459/52820257-cf7b0e80-30ab-11e9-8130-f64dc8826953.png">

When online signature is allowed:
<img width="237" alt="screen shot 2019-02-14 at 22 55 54" src="https://user-images.githubusercontent.com/446459/52820271-d570ef80-30ab-11e9-87fc-81bab15d663d.png">

When initiative is published but online signature is not allowed
<img width="241" alt="screen shot 2019-02-14 at 22 53 13" src="https://user-images.githubusercontent.com/446459/52820105-6398a600-30ab-11e9-8c43-d123a5496445.png">

After signature creation:
<img width="1280" alt="screen shot 2019-02-14 at 22 59 48" src="https://user-images.githubusercontent.com/446459/52820445-47e1cf80-30ac-11e9-9d52-fcbcd45e6a5a.png">


#### After
When undo online signature is not allowed:
<img width="251" alt="screen shot 2019-02-14 at 01 42 01" src="https://user-images.githubusercontent.com/446459/52754184-e8c38280-2ff9-11e9-8109-2dcdf3fe8698.png">
When undo online signature is allowed:
<img width="255" alt="screen shot 2019-02-14 at 01 42 55" src="https://user-images.githubusercontent.com/446459/52754185-e8c38280-2ff9-11e9-9186-a11fb4540dd3.png">
When online signature has permissions pending:
<img width="231" alt="screen shot 2019-02-14 at 22 40 17" src="https://user-images.githubusercontent.com/446459/52819586-ee78a100-30a9-11e9-9f20-385e168ca6ff.png">

When online signature is allowed:
<img width="256" alt="screen shot 2019-02-14 at 22 38 49" src="https://user-images.githubusercontent.com/446459/52819591-f33d5500-30a9-11e9-8403-859423ab6f1b.png">

When initiative is published but online signature is not allowed:
<img width="266" alt="screen shot 2019-02-14 at 22 50 28" src="https://user-images.githubusercontent.com/446459/52819994-0e5c9480-30ab-11e9-90be-7d1c82fb8693.png">

After signature creation:
<img width="984" alt="screen shot 2019-02-14 at 22 34 28" src="https://user-images.githubusercontent.com/446459/52820463-53cd9180-30ac-11e9-92d0-6845bb1a00b0.png">

