### PR TITLE
Prevent empty selection in the data picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - **decidim-initiatives** Add missing dependency for wicked_pdf to initiatives module [\#4813](https://github.com/decidim/decidim/pull/4813)
 - **decidim-participatory_processes**: Shows the short description on processes when displaying a single one on the homepage. [\#4824](https://github.com/decidim/decidim/pull/4824)
 - **decidim-proposals**: Add missing translation key for "Address". [\#4835](https://github.com/decidim/decidim/pull/4835)
+- **decidim-core**: Prevent empty selection in the data picker [\#4842](https://github.com/decidim/decidim/pull/4842)
 
 **Removed**:
 

--- a/decidim-core/app/assets/javascripts/decidim/data_picker.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/data_picker.js.es6
@@ -127,6 +127,12 @@
     }
 
     _choose(data, user = true) {
+      // Prevent choosing is nothing has been selected. This would otherwise
+      // cause an empty checkbox to appear in the selected values list.
+      if (!data.value || data.value.length < 1) {
+        return;
+      }
+
       // Add or update value appearance
       if (this.current.div) {
         let link = $("a", this.current.div);


### PR DESCRIPTION
#### :tophat: What? Why?
The data picker allows an empty selection in case the user writes something to the autocomplete field and clicks the "Select" button without selecting any value.

This prevents empty selections in the popup by disabling the "Select" click if nothing is selected.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![decidim-bug-data-picker](https://user-images.githubusercontent.com/864340/52781188-96637f80-3054-11e9-9f70-6c4cd17064a9.png)
