### PR TITLE
Fix admin initiatives participatory space layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - **decidim-meetings**: Fix accepting/declining meeting invitations [\#4839](https://github.com/decidim/decidim/pull/4839)
 - **decidim-budgets**: Allow only to attach published proposals to budgeting projects [\#4840](https://github.com/decidim/decidim/pull/4840)
 - **decidim-core**: Prevent empty selection in the data picker [\#4842](https://github.com/decidim/decidim/pull/4842)
+- **decidim-initiatives** Fix admin layout of some subsections of initiatives participatory spaces. [\#4849](https://github.com/decidim/decidim/pull/4849)
 
 **Removed**:
 

--- a/decidim-initiatives/app/controllers/concerns/decidim/initiatives/needs_initiative.rb
+++ b/decidim-initiatives/app/controllers/concerns/decidim/initiatives/needs_initiative.rb
@@ -13,7 +13,7 @@ module Decidim
         include NeedsOrganization
         include InitiativeSlug
 
-        helper_method :current_initiative, :signature_has_steps?
+        helper_method :current_initiative, :current_participatory_space, :signature_has_steps?
 
         # Public: Finds the current Initiative given this controller's
         # context.

--- a/decidim-initiatives/app/controllers/decidim/initiatives/application_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/application_controller.rb
@@ -4,8 +4,6 @@ module Decidim
   module Initiatives
     # The main admin application controller for initiatives
     class ApplicationController < Decidim::ApplicationController
-      layout "decidim/admin/initiatives"
-
       include NeedsPermission
 
       def permissions_context

--- a/decidim-initiatives/app/views/layouts/decidim/admin/initiative.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/admin/initiative.html.erb
@@ -1,24 +1,24 @@
 <% content_for :secondary_nav do %>
   <div class="secondary-nav secondary-nav--subnav">
     <ul>
-      <%= public_page_link decidim_initiatives.initiative_path(current_initiative) %>
-      <% if allowed_to? :edit, :initiative, initiative: current_initiative %>
-        <li <% if is_active_link?(decidim_admin_initiatives.edit_initiative_path(current_initiative)) %> class="is-active" <% end %>>
-          <%= aria_selected_link_to t(".information"), decidim_admin_initiatives.edit_initiative_path(current_initiative) %>
+      <%= public_page_link decidim_initiatives.initiative_path(current_participatory_space) %>
+      <% if allowed_to? :edit, :initiative, initiative: current_participatory_space %>
+        <li <% if is_active_link?(decidim_admin_initiatives.edit_initiative_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t(".information"), decidim_admin_initiatives.edit_initiative_path(current_participatory_space) %>
         </li>
       <% end %>
 
-      <% if allowed_to? :manage_membership, :initiative, initiative: current_initiative %>
-        <li <% if is_active_link?(decidim_admin_initiatives.initiative_committee_requests_path(current_initiative)) %> class="is-active" <% end %>>
-          <%= aria_selected_link_to t(".committee_members"), decidim_admin_initiatives.initiative_committee_requests_path(current_initiative) %>
+      <% if allowed_to? :manage_membership, :initiative, initiative: current_participatory_space %>
+        <li <% if is_active_link?(decidim_admin_initiatives.initiative_committee_requests_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t(".committee_members"), decidim_admin_initiatives.initiative_committee_requests_path(current_participatory_space) %>
         </li>
       <% end %>
 
-      <% if allowed_to? :read, :component, initiative: current_initiative %>
-        <li <% if is_active_link?(decidim_admin_initiatives.components_path(current_initiative)) %> class="is-active" <% end %>>
-          <%= aria_selected_link_to t(".components"), decidim_admin_initiatives.components_path(current_initiative) %>
+      <% if allowed_to? :read, :component, initiative: current_participatory_space %>
+        <li <% if is_active_link?(decidim_admin_initiatives.components_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t(".components"), decidim_admin_initiatives.components_path(current_participatory_space) %>
           <ul>
-            <% current_initiative.components.each do |component| %>
+            <% current_participatory_space.components.each do |component| %>
               <% if component.manifest.admin_engine %>
                 <li <% if is_active_link?(manage_component_path(component)) %> class="is-active" <% end %>>
                   <%= link_to manage_component_path(component) do %>
@@ -36,9 +36,9 @@
         </li>
       <% end %>
 
-      <% if allowed_to? :read, :attachment, initiative: current_initiative %>
-        <li <% if is_active_link?(decidim_admin_initiatives.initiative_attachments_path(current_initiative)) %> class="is-active" <% end %>>
-          <%= aria_selected_link_to t(".attachments"), decidim_admin_initiatives.initiative_attachments_path(current_initiative) %>
+      <% if allowed_to? :read, :attachment, initiative: current_participatory_space %>
+        <li <% if is_active_link?(decidim_admin_initiatives.initiative_attachments_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t(".attachments"), decidim_admin_initiatives.initiative_attachments_path(current_participatory_space) %>
         </li>
       <% end %>
     </ul>
@@ -48,7 +48,7 @@
 <%= render "layouts/decidim/admin/application" do %>
   <div class="process-title">
     <div class="process-title-content">
-      <%= link_to translated_attribute(current_initiative.title), decidim_initiatives.initiative_path(current_initiative), target: "_blank" %>
+      <%= link_to translated_attribute(current_participatory_space.title), decidim_initiatives.initiative_path(current_participatory_space), target: "_blank" %>
     </div>
   </div>
 

--- a/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
@@ -11,7 +11,7 @@ Decidim.register_participatory_space(:initiatives) do |participatory_space|
 
   participatory_space.context(:admin) do |context|
     context.engine = Decidim::Initiatives::AdminEngine
-    context.layout = "layouts/decidim/admin/initiatives"
+    context.layout = "layouts/decidim/admin/initiative"
   end
 
   participatory_space.participatory_spaces do |organization|


### PR DESCRIPTION
#### :tophat: What? Why?
- Uses the initiative admin layout for initiatives and committee members, attachments and components subsections.
- Replaces `current_initiative` with `current_participatory_space` in admin/initiative layout to avoid errors in components subsections.
- Removes an unused reference to admin layout in front

#### :pushpin: Related Issues
- Related to #4661

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)

#### Before

Committee members:

<img width="1274" alt="screen shot 2019-02-15 at 00 17 58" src="https://user-images.githubusercontent.com/446459/52824021-5681b400-30b7-11e9-829e-a57fca817305.png">

Components subsections:

<img width="1279" alt="screen shot 2019-02-15 at 00 18 17" src="https://user-images.githubusercontent.com/446459/52824022-5681b400-30b7-11e9-965b-03684afe4431.png">

Attachments:

<img width="1277" alt="screen shot 2019-02-15 at 00 18 44" src="https://user-images.githubusercontent.com/446459/52824024-5681b400-30b7-11e9-9b49-48535b20eb19.png">

#### After

Committee members:

<img width="1275" alt="screen shot 2019-02-15 at 00 12 09" src="https://user-images.githubusercontent.com/446459/52823909-f854d100-30b6-11e9-84ca-d5e884604cb4.png">

Components subsections:

<img width="1277" alt="screen shot 2019-02-15 at 00 12 32" src="https://user-images.githubusercontent.com/446459/52823919-00147580-30b7-11e9-835e-6e40f574004a.png">

Attachments:

<img width="1278" alt="screen shot 2019-02-15 at 00 12 50" src="https://user-images.githubusercontent.com/446459/52823928-073b8380-30b7-11e9-9aa3-702e6ddec0d0.png">