### PR TITLE
Fix comment author

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 - **decidim-core**: Prevent empty selection in the data picker [\#4842](https://github.com/decidim/decidim/pull/4842)
 - **decidim-forms**: Fix free text fields exporting. [\#4846](https://github.com/decidim/decidim/pull/4846)
 - **decidim-initiatives** Fix admin layout of some subsections of initiatives participatory spaces. [\#4849](https://github.com/decidim/decidim/pull/4849)
+- **decidim-comments** Fix author display in comments [\#4851](https://github.com/decidim/decidim/pull/4851)
 
 **Removed**:
 

--- a/decidim-comments/app/queries/decidim/comments/sorted_comments.rb
+++ b/decidim-comments/app/queries/decidim/comments/sorted_comments.rb
@@ -33,7 +33,7 @@ module Decidim
         scope = Comment
                 .where(commentable: commentable)
                 .not_hidden
-                .includes(:author, :up_votes, :down_votes)
+                .includes(:author, :user_group, :up_votes, :down_votes)
 
         scope = case @options[:order_by]
                 when "older"

--- a/decidim-comments/lib/decidim/comments/api/comment_type.rb
+++ b/decidim-comments/lib/decidim/comments/api/comment_type.rb
@@ -13,7 +13,7 @@ module Decidim
 
       field :author, !Decidim::Core::AuthorInterface, "The resource author" do
         resolve lambda { |obj, _args, _ctx|
-          obj.author
+          obj.user_group || obj.author
         }
       end
 

--- a/decidim-comments/spec/types/comment_type_spec.rb
+++ b/decidim-comments/spec/types/comment_type_spec.rb
@@ -8,8 +8,34 @@ module Decidim
     describe CommentType do
       include_context "with a graphql type"
 
-      let(:model) { FactoryBot.create(:comment) }
+      let(:model) { create(:comment) }
       let(:sgid) { double("sgid", to_s: "1234") }
+
+      describe "author" do
+        let(:query) { "{ author { name } }" }
+        let(:commentable) { build(:dummy_resource) }
+        let(:model) do
+          create(:comment, author: author, user_group: user_group, commentable: commentable)
+        end
+
+        context "when the author is a user" do
+          let(:author) { create(:user, organization: commentable.organization) }
+          let(:user_group) { nil }
+
+          it "returns the user" do
+            expect(response).to include("author" => { "name" => author.name })
+          end
+        end
+
+        context "when the author is a user group" do
+          let(:user_group) { create(:user_group, :verified, organization: commentable.organization, users: [create(:user, organization: commentable.organization)]) }
+          let(:author) { user_group.managers.first }
+
+          it "returns the user" do
+            expect(response).to include("author" => { "name" => user_group.name })
+          end
+        end
+      end
 
       describe "sgid" do
         let(:query) { "{ sgid }" }


### PR DESCRIPTION
#### :tophat: What? Why?

We should return the user group as author if it's present in a comment.

#### :pushpin: Related Issues
- Fixes #4796

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
