### PR TITLE
Add migration reset_negative_children_count_counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 **Changed**:
 
+- **decidim-assemblies** Allow to change participatory texts title without uploading file. [\#4761](https://github.com/decidim/decidim/pull/4761)
 - **decidim-proposals** Allow to change participatory texts title without uploading file. [\#4761](https://github.com/decidim/decidim/pull/4761)
 - **decidim-proposals** Change collaborative draft contributors permissions [\#4712](https://github.com/decidim/decidim/pull/4712)
 - **decidim-admin**: Change admin moderations manager [\#4717](https://github.com/decidim/decidim/pull/4717)
@@ -43,7 +44,7 @@
 
 **Fixed**:
 
-- **decidim-proposals**: Fix Proposals Last Activity feed [\#4828](https://github.com/decidim/decidim/pull/4828)
+- **decidim-assemblies**: Fix parent assemblies children_count counter (add migration) [\#4852](https://github.com/decidim/decidim/pull/4852/)
 - **decidim-proposals**: Fix attachments not being inherited from collaborative draft when published as proposal. [\#4811](https://github.com/decidim/decidim/pull/4811)
 - **decidim-core**: Add set_locale method to prevent users be redirected to unexpected locale[#4809](https://github.com/decidim/decidim/pull/4809)
 - **decidim-core**: Fix inconsistent dataviz [\#4787](https://github.com/decidim/decidim/pull/4787)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@
 
 **Changed**:
 
-- **decidim-assemblies** Allow to change participatory texts title without uploading file. [\#4761](https://github.com/decidim/decidim/pull/4761)
 - **decidim-proposals** Allow to change participatory texts title without uploading file. [\#4761](https://github.com/decidim/decidim/pull/4761)
 - **decidim-proposals** Change collaborative draft contributors permissions [\#4712](https://github.com/decidim/decidim/pull/4712)
 - **decidim-admin**: Change admin moderations manager [\#4717](https://github.com/decidim/decidim/pull/4717)
@@ -45,6 +44,7 @@
 **Fixed**:
 
 - **decidim-assemblies**: Fix parent assemblies children_count counter (add migration) [\#4852](https://github.com/decidim/decidim/pull/4852/)
+- **decidim-proposals**: Fix Proposals Last Activity feed [\#4828](https://github.com/decidim/decidim/pull/4828)
 - **decidim-proposals**: Fix attachments not being inherited from collaborative draft when published as proposal. [\#4811](https://github.com/decidim/decidim/pull/4811)
 - **decidim-core**: Add set_locale method to prevent users be redirected to unexpected locale[#4809](https://github.com/decidim/decidim/pull/4809)
 - **decidim-core**: Fix inconsistent dataviz [\#4787](https://github.com/decidim/decidim/pull/4787)

--- a/decidim-assemblies/db/migrate/20190215093700_reset_negative_children_count_counters.rb
+++ b/decidim-assemblies/db/migrate/20190215093700_reset_negative_children_count_counters.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ResetNegativeChildrenCountCounters < ActiveRecord::Migration[5.2]
+  def change
+    ids = Decidim::Assembly.where("children_count < 0").pluck(:id)
+    ids.each { |id| Decidim::Assembly.reset_counters(id, :children_count) }
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
>check the database for assemblies that have a negative children_count counter and reset their counters.

#### :pushpin: Related Issues
- Related to #https://github.com/decidim/decidim/pull/4847#issuecomment-463964554

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry