### PR TITLE
Fix user activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 - **decidim-core**: Prevent empty selection in the data picker [\#4842](https://github.com/decidim/decidim/pull/4842)
 - **decidim-forms**: Fix free text fields exporting. [\#4846](https://github.com/decidim/decidim/pull/4846)
 - **decidim-initiatives** Fix admin layout of some subsections of initiatives participatory spaces. [\#4849](https://github.com/decidim/decidim/pull/4849)
+- **decidim-core**: Fix user activities list [\#4853](https://github.com/decidim/decidim/pull/4853)
 
 **Removed**:
 

--- a/decidim-core/app/controllers/decidim/user_activities_controller.rb
+++ b/decidim-core/app/controllers/decidim/user_activities_controller.rb
@@ -12,7 +12,7 @@ module Decidim
     private
 
     def user
-      @user ||= Decidim::User.find_by(nickname: params[:nickname])
+      @user ||= current_organization.users.find_by(nickname: params[:nickname])
     end
 
     def activities


### PR DESCRIPTION
#### :tophat: What? Why?

When two users had the same nickname in different organizations we could be loading the wrong user.

#### :pushpin: Related Issues

- Fixes #4757

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
