### PR TITLE
Fix proposals ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 - **decidim-core**: Prevent empty selection in the data picker [\#4842](https://github.com/decidim/decidim/pull/4842)
 - **decidim-forms**: Fix free text fields exporting. [\#4846](https://github.com/decidim/decidim/pull/4846)
 - **decidim-initiatives** Fix admin layout of some subsections of initiatives participatory spaces. [\#4849](https://github.com/decidim/decidim/pull/4849)
+- **decidim-proposals** Fix recent proposals order [\#4854](https://github.com/decidim/decidim/pull/4854)
 
 **Removed**:
 

--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
@@ -59,7 +59,7 @@ module Decidim
           when "most_voted"
             proposals.order(proposal_votes_count: :desc)
           when "recent"
-            proposals.order(created_at: :desc)
+            proposals.order(published_at: :desc)
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

The display date on the proposal card is the publish date but we were ordering by created at.

#### :pushpin: Related Issues
- Fixes #4768

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
