### PR TITLE
Remove etiquette validator at admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - **decidim-comments** Fix author display in comments [\#4851](https://github.com/decidim/decidim/pull/4851)
 - **decidim-debates** Allow HTML content at debates page [\#4850](https://github.com/decidim/decidim/pull/4850)
 - **decidim-proposals** Fix proposals search indexes [\#4857](https://github.com/decidim/decidim/pull/4857)
+- **decidim-proposals** Remove etiquette validation from proposals admin [\#4856](https://github.com/decidim/decidim/pull/4856)
 
 **Removed**:
 

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
@@ -21,7 +21,7 @@ module Decidim
         attribute :meeting_id, Integer
         attribute :suggested_hashtags, Array[String]
 
-        validates :title, :body, presence: true, etiquette: true
+        validates :title, :body, presence: true
         validates :title, length: { maximum: 150 }
         validates :address, geocoding: true, if: -> { current_component.settings.geocoding_enabled? }
         validates :category, presence: true, if: ->(form) { form.category_id.present? }

--- a/decidim-proposals/spec/forms/decidim/proposals/admin_proposal_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/admin_proposal_form_spec.rb
@@ -6,8 +6,8 @@ module Decidim
   module Proposals
     module Admin
       describe ProposalForm do
-        it_behaves_like "a proposal form"
-        it_behaves_like "a proposal form with meeting as author"
+        it_behaves_like "a proposal form", skip_etiquette_validation: true
+        it_behaves_like "a proposal form with meeting as author", skip_etiquette_validation: true
       end
     end
   end

--- a/decidim-proposals/spec/shared/proposal_form_examples.rb
+++ b/decidim-proposals/spec/shared/proposal_form_examples.rb
@@ -61,15 +61,17 @@ shared_examples "a proposal form" do |options|
   end
 
   context "when the title is too long" do
-    let(:body) { "A" * 200 }
+    let(:title) { "A" * 200 }
 
     it { is_expected.to be_invalid }
   end
 
-  context "when the body is not etiquette-compliant" do
-    let(:body) { "A" }
+  unless options[:skip_etiquette_validation]
+    context "when the body is not etiquette-compliant" do
+      let(:body) { "A" }
 
-    it { is_expected.to be_invalid }
+      it { is_expected.to be_invalid }
+    end
   end
 
   context "when there's no body" do
@@ -270,7 +272,7 @@ shared_examples "a proposal form" do |options|
   end
 end
 
-shared_examples "a proposal form with meeting as author" do |_options|
+shared_examples "a proposal form with meeting as author" do |options|
   subject { form }
 
   let(:organization) { create(:organization, available_locales: [:en]) }
@@ -312,15 +314,17 @@ shared_examples "a proposal form with meeting as author" do |_options|
   end
 
   context "when the title is too long" do
-    let(:body) { "A" * 200 }
+    let(:title) { "A" * 200 }
 
     it { is_expected.to be_invalid }
   end
 
-  context "when the body is not etiquette-compliant" do
-    let(:body) { "A" }
+  unless options[:skip_etiquette_validation]
+    context "when the body is not etiquette-compliant" do
+      let(:body) { "A" }
 
-    it { is_expected.to be_invalid }
+      it { is_expected.to be_invalid }
+    end
   end
 
   context "when there's no body" do

--- a/decidim-proposals/spec/system/admin_edits_proposal_spec.rb
+++ b/decidim-proposals/spec/system/admin_edits_proposal_spec.rb
@@ -58,22 +58,6 @@ describe "Admin edits proposals", type: :system do
         expect(page).to have_content("not authorized")
       end
     end
-
-    context "when updating with wrong data" do
-      let(:component) { create(:proposal_component, :with_creation_enabled, :with_attachments_allowed, participatory_space: participatory_process) }
-
-      it "returns an error message" do
-        visit_component_admin
-
-        find("a.action-icon--edit-proposal").click
-        expect(page).to have_content "UPDATE PROPOSAL"
-
-        fill_in "Body", with: "A"
-        click_button "Update"
-
-        expect(page).to have_content("is using too many capital letters (over 25% of the text), is too short (under 15 characters)")
-      end
-    end
   end
 
   describe "editing a non-official proposal" do


### PR DESCRIPTION
#### :tophat: What? Why?

Allow admins to create proposals without the etiquette validator.

#### :pushpin: Related Issues
- Fixes #4766

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
