### PR TITLE
4661 initiative administration fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 - **decidim-meetings**: Order meetings at admin [\#4844](https://github.com/decidim/decidim/pull/4844)
 - **decidim-proposals** Add admin edit link for proposals [\#4843](https://github.com/decidim/decidim/pull/4843)
 - **decidim-initiatives**: Add setting in `Decidim::InitiativesType` to enable users to undo their initiatives signatures. [\#4841](https://github.com/decidim/decidim/pull/4841)
+- **decidim-initiatives**: Add author of initiative to committee members on creation. [\#4861](https://github.com/decidim/decidim/pull/4861)
+- **decidim-initiatives**: Display state of initiative on edition form inside a disabled select. [\#4861](https://github.com/decidim/decidim/pull/4861)
 
 **Changed**:
 
@@ -40,6 +42,7 @@
 - **decidim-initiatives**: Change logic of online sign initiative buttons. [\#4841](https://github.com/decidim/decidim/pull/4841)
 - **decidim-initiatives**: Add a last step on signature initiatives wizard and use it instead of redirect to initiative after signing. [\#4841](https://github.com/decidim/decidim/pull/4841)
 - **decidim-initiatives**: Change permissions of sign_initiative action. [\#4841](https://github.com/decidim/decidim/pull/4841)
+- **decidim-initiatives**: Allow edition of type, scope and signature type of initiatives depending on state and user. [\#4861](https://github.com/decidim/decidim/pull/4861)
 
 **Fixed**:
 

--- a/decidim-initiatives/app/assets/javascripts/decidim/initiatives/scoped_type.js
+++ b/decidim-initiatives/app/assets/javascripts/decidim/initiatives/scoped_type.js
@@ -1,12 +1,9 @@
 /* eslint-disable camelcase */
-
-$(document).ready(function () {
-  let typeSelector = $("[data-scope-selector]");
-
-  if (typeSelector.length) {
-    let currentValue = typeSelector.data("scope-id"),
-        searchUrl = typeSelector.data("scope-search-url"),
-        targetElement = $(`#${typeSelector.data("scope-selector")}`);
+let controlSelector = function(source, prefix, currentValueKey) {
+  if (source.length) {
+    let currentValue = source.data(currentValueKey),
+        searchUrl = source.data(`${prefix}-search-url`),
+        targetElement = $(`#${source.data(`${prefix}-selector`)}`);
 
     if (targetElement.length) {
       let refresh = function () {
@@ -15,7 +12,7 @@ $(document).ready(function () {
           cache: false,
           dataType: "html",
           data: {
-            type_id: typeSelector.val(),
+            type_id: source.val(),
             selected: currentValue
           },
           success: function (data) {
@@ -24,8 +21,14 @@ $(document).ready(function () {
         });
       };
 
-      typeSelector.change(refresh);
+      source.change(refresh);
       refresh();
     }
   }
+};
+
+$(document).ready(function () {
+  let typeSelector = $("[data-scope-selector]");
+  controlSelector(typeSelector, "scope", "scope-id");
+  controlSelector(typeSelector, "signature-types", "signature-type");
 });

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative.rb
@@ -60,6 +60,7 @@ module Decidim
             attrs[:signature_start_date] = form.signature_start_date
             attrs[:signature_end_date] = form.signature_end_date
             attrs[:offline_votes] = form.offline_votes
+            attrs[:state] = form.state if form.state
 
             if initiative.published?
               @notify_extended = true if form.signature_end_date != initiative.signature_end_date &&

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative.rb
@@ -49,8 +49,12 @@ module Decidim
             answer_url: form.answer_url
           }
 
-          attrs[:signature_type] = form.signature_type if initiative.created?
           attrs[:answered_at] = Time.current if form.answer.present?
+
+          if form.signature_type_updatable?
+            attrs[:signature_type] = form.signature_type
+            attrs[:scoped_type_id] = form.scoped_type_id if form.scoped_type_id
+          end
 
           if current_user.admin?
             attrs[:signature_start_date] = form.signature_start_date

--- a/decidim-initiatives/app/commands/decidim/initiatives/create_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/create_initiative.rb
@@ -46,6 +46,7 @@ module Decidim
           create_components_for(initiative)
           send_notification(initiative)
           add_author_as_follower(initiative)
+          add_author_as_committee_member(initiative)
         end
 
         initiative
@@ -108,6 +109,17 @@ module Decidim
                )
 
         Decidim::CreateFollow.new(form, current_user).call
+      end
+
+      def add_author_as_committee_member(initiative)
+        form = Decidim::Initiatives::CommitteeMemberForm
+               .from_params(initiative_id: initiative.id, user_id: initiative.decidim_author_id, state: "accepted")
+               .with_context(
+                 current_organization: initiative.organization,
+                 current_user: current_user
+               )
+
+        Decidim::Initiatives::SpawnCommitteeRequest.new(form, current_user).call
       end
     end
   end

--- a/decidim-initiatives/app/commands/decidim/initiatives/spawn_committee_request.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/spawn_committee_request.rb
@@ -7,10 +7,10 @@ module Decidim
     class SpawnCommitteeRequest < Rectify::Command
       # Public: Initializes the command.
       #
-      # initiative - Decidim::Initiative
+      # form - Decidim::Initiative::CommitteeMemberForm
       # current_user - Decidim::User
-      def initialize(initiative, current_user)
-        @initiative = initiative
+      def initialize(form, current_user)
+        @form = form
         @current_user = current_user
       end
 
@@ -21,6 +21,7 @@ module Decidim
       #
       # Returns nothing.
       def call
+        return broadcast(:invalid) if form.invalid?
         request = create_request
 
         if request.persisted?
@@ -32,13 +33,13 @@ module Decidim
 
       private
 
-      attr_reader :initiative, :current_user
+      attr_reader :form, :current_user
 
       def create_request
         request = InitiativesCommitteeMember.new(
-          decidim_initiatives_id: initiative&.id,
-          decidim_users_id: current_user&.id,
-          state: "requested"
+          decidim_initiatives_id: form.initiative_id,
+          decidim_users_id: form.user_id,
+          state: form.state
         )
         return request unless request.valid?
 

--- a/decidim-initiatives/app/controllers/decidim/initiatives/committee_requests_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/committee_requests_controller.rb
@@ -20,7 +20,10 @@ module Decidim
       def spawn
         enforce_permission_to :request_membership, :initiative, initiative: current_initiative
 
-        SpawnCommitteeRequest.call(current_initiative, current_user) do
+        form = Decidim::Initiatives::CommitteeMemberForm
+               .from_params(initiative_id: current_initiative.id, user_id: current_user.id, state: "requested")
+
+        SpawnCommitteeRequest.call(form, current_user) do
           on(:ok) do
             redirect_to initiatives_path, flash: {
               notice: I18n.t(

--- a/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_type_signature_types_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_type_signature_types_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Initiatives
+    class InitiativesTypeSignatureTypesController < Decidim::Initiatives::ApplicationController
+      helper_method :allowed_signature_types_for_initiatives
+
+      # GET /initiative_type_signature_types/search
+      def search
+        enforce_permission_to :search, :initiative_type_signature_types
+        render layout: false
+      end
+
+      private
+
+      def allowed_signature_types_for_initiatives
+        @allowed_signature_types_for_initiatives ||= InitiativesType.find(params[:type_id]).allowed_signature_types_for_initiatives
+      end
+    end
+  end
+end

--- a/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_form.rb
@@ -53,6 +53,10 @@ module Decidim
                                         end
         end
 
+        def state_updatable?
+          false
+        end
+
         def scoped_type_id
           return unless type && decidim_scope_id
 

--- a/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_form.rb
@@ -25,7 +25,7 @@ module Decidim
         attribute :answer_url, String
 
         validates :title, :description, presence: true
-        validates :signature_type, presence: true
+        validates :signature_type, presence: true, if: :signature_type_updatable?
         validates :signature_start_date, presence: true, if: ->(form) { form.context.initiative.published? }
         validates :signature_end_date, presence: true, if: ->(form) { form.context.initiative.published? }
         validates :signature_end_date, date: { after: :signature_start_date }, if: lambda { |form|
@@ -47,7 +47,22 @@ module Decidim
         end
 
         def signature_type_updatable?
-          state == "created"
+          @signature_type_updatable ||= begin
+                                          state ||= context.initiative.state
+                                          state == "validating" && context.current_user.admin? || state == "created"
+                                        end
+        end
+
+        def scoped_type_id
+          return unless type && decidim_scope_id
+
+          type.scopes.find_by!(decidim_scopes_id: decidim_scope_id).id
+        end
+
+        private
+
+        def type
+          @type ||= type_id ? Decidim::InitiativesType.find(type_id) : context.initiative.type
         end
       end
     end

--- a/decidim-initiatives/app/forms/decidim/initiatives/committee_member_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/committee_member_form.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Initiatives
+    # A form object used to collect the data for a new initiative committee
+    # member.
+    class CommitteeMemberForm < Form
+      mimic :initiatives_committee_member
+
+      attribute :initiative_id, Integer
+      attribute :user_id, Integer
+      attribute :state, String
+
+      validates :initiative_id, presence: true
+      validates :user_id, presence: true
+      validates :state, inclusion: { in: %w(requested rejected accepted) }, unless: :user_is_author?
+      validates :state, inclusion: { in: %w(rejected accepted) }, if: :user_is_author?
+
+      def user_is_author?
+        initiative&.decidim_author_id == user_id
+      end
+
+      private
+
+      def initiative
+        @initiative ||= Decidim::Initiative.find_by(id: initiative_id)
+      end
+    end
+  end
+end

--- a/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
+++ b/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
@@ -52,7 +52,7 @@ module Decidim
 
       def search_initiative_types_and_scopes?
         return unless permission_action.action == :search
-        return unless [:initiative_type, :initiative_type_scope].include?(permission_action.subject)
+        return unless [:initiative_type, :initiative_type_scope, :initiative_type_signature_types].include?(permission_action.subject)
 
         allow!
       end

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/_form.html.erb
@@ -4,6 +4,15 @@
   </div>
 
   <div class="card-section">
+    <div class="row">
+      <div class="columns xlarge-6">
+        <%= form.select :state,
+                        Decidim::Initiative.states.keys.map { |state| [I18n.t(state, scope: "decidim.initiatives.admin_states"), state] },
+                        {},
+                        { disabled: !@form.state_updatable? } %>
+      </div>
+    </div>
+
     <div class="row column">
       <%= form.translated :text_field, :title, autofocus: true, disabled: !allowed_to?(:update, :initiative, initiative: current_initiative) %>
     </div>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/_form.html.erb
@@ -18,7 +18,7 @@
                         initiative_type_options,
                         {},
                         {
-                          disabled: true,
+                          disabled: !@form.signature_type_updatable?,
                           "data-scope-selector": "initiative_decidim_scope_id",
                           "data-scope-id": current_initiative.scope.id,
                           "data-scope-search-url": decidim_initiatives.initiative_type_scopes_search_url
@@ -26,7 +26,7 @@
       </div>
 
       <div class="columns xlarge-6">
-        <%= form.select :decidim_scope_id, [], {}, { disabled: true } %>
+        <%= form.select :decidim_scope_id, [], {}, { disabled: !@form.signature_type_updatable? } %>
       </div>
     </div>
 

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/_form.html.erb
@@ -20,8 +20,11 @@
                         {
                           disabled: !@form.signature_type_updatable?,
                           "data-scope-selector": "initiative_decidim_scope_id",
-                          "data-scope-id": current_initiative.scope.id,
-                          "data-scope-search-url": decidim_initiatives.initiative_type_scopes_search_url
+                          "data-scope-id": current_initiative.scoped_type.id,
+                          "data-scope-search-url": decidim_initiatives.initiative_type_scopes_search_url,
+                          "data-signature-types-selector": "initiative_signature_type",
+                          "data-signature-type": current_initiative.signature_type,
+                          "data-signature-types-search-url": decidim_initiatives.initiative_type_signature_types_search_url
                         } %>
       </div>
 
@@ -48,8 +51,7 @@
       </div>
 
       <div class="columns xlarge-6">
-        <%= form.hidden_field :signature_type %>
-        <%= form.select :signature_type, signature_type_options(form.object), {}, { disabled: !current_initiative.created? } %>
+        <%= form.select :signature_type, [], {}, { disabled: !@form.signature_type_updatable? } %>
       </div>
     </div>
 

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives_type_signature_types/search.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives_type_signature_types/search.html.erb
@@ -1,0 +1,1 @@
+<%= options_for_select allowed_signature_types_for_initiatives.map { |type| [t(type, scope: "activemodel.attributes.initiative.signature_type_values"), type] }, params[:selected] %>

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -13,6 +13,7 @@ en:
           any: Mixed
           offline: Face to face
           online: OnLine
+        state: State
         title: Title
       initiative_author:
         address: Address

--- a/decidim-initiatives/lib/decidim/initiatives/engine.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/engine.rb
@@ -16,6 +16,7 @@ module Decidim
       routes do
         get "/initiative_types/search", to: "initiative_types#search", as: :initiative_types_search
         get "/initiative_type_scopes/search", to: "initiatives_type_scopes#search", as: :initiative_type_scopes_search
+        get "/initiative_type_signature_types/search", to: "initiatives_type_signature_types#search", as: :initiative_type_signature_types_search
 
         resources :create_initiative
 

--- a/decidim-initiatives/spec/commands/decidim/initiatives/spawn_committee_request_spec.rb
+++ b/decidim-initiatives/spec/commands/decidim/initiatives/spawn_committee_request_spec.rb
@@ -7,7 +7,16 @@ module Decidim
     describe SpawnCommitteeRequest do
       let(:initiative) { create(:initiative, :created) }
       let(:current_user) { create(:user, organization: initiative.organization) }
-      let(:command) { described_class.new(initiative, current_user) }
+      let(:state) { "requested" }
+      let(:form) do
+        Decidim::Initiatives::CommitteeMemberForm
+          .from_params(initiative_id: initiative.id, user_id: current_user.id, state: state)
+          .with_context(
+            current_organization: initiative.organization,
+            current_user: current_user
+          )
+      end
+      let(:command) { described_class.new(form, current_user) }
 
       context "when duplicated request" do
         let!(:committee_request) { create(:initiatives_committee_member, user: current_user, initiative: initiative) }

--- a/decidim-initiatives/spec/forms/admin/initiative_form_spec.rb
+++ b/decidim-initiatives/spec/forms/admin/initiative_form_spec.rb
@@ -11,15 +11,33 @@ module Decidim
         let(:organization) { create(:organization) }
         let(:initiatives_type) { create(:initiatives_type, organization: organization) }
         let(:scope) { create(:initiatives_type_scope, type: initiatives_type) }
+        let(:other_scope) { create(:initiatives_type_scope, type: initiatives_type) }
 
-        let(:state) { "validating" }
+        let(:state) { "published" }
+
         let(:initiative) { create(:initiative, organization: organization, state: state, scoped_type: scope) }
+        let(:user) { create(:user, organization: organization) }
 
         let(:context) do
           {
+            current_user: user,
             current_organization: organization,
             current_component: nil,
             initiative: initiative
+          }
+        end
+
+        let(:type_id) { initiatives_type.id }
+        let(:decidim_scope_id) { scope.scope.id }
+
+        let(:attributes) do
+          {
+            type_id: type_id,
+            decidim_scope_id: decidim_scope_id,
+            title: Decidim::Faker::Localized.sentence(2),
+            description: Decidim::Faker::Localized.sentence(5),
+            state: "created",
+            signature_type: "online"
           }
         end
 
@@ -36,8 +54,63 @@ module Decidim
             it { is_expected.to eq(true) }
           end
 
+          context "when validating" do
+            let(:state) { "validating" }
+
+            context "and user current_user is admin" do
+              let(:user) { create(:user, :admin, organization: organization) }
+
+              it { is_expected.to eq(true) }
+            end
+
+            context "and current_user is not addmin" do
+              it { is_expected.to eq(false) }
+            end
+          end
+
           context "when any other state" do
             it { is_expected.to eq(false) }
+          end
+        end
+
+        describe "#scoped_type_id" do
+          context "when created from attributes" do
+            subject { described_class.from_params(attributes).with_context(context).scoped_type_id }
+
+            context "when type_id and decidim_scope_id from initiative are provided" do
+              it { is_expected.to eq(initiative.scoped_type.id) }
+            end
+
+            context "when other decidim_scope_id is provided" do
+              let(:decidim_scope_id) { other_scope.scope.id }
+
+              it { is_expected.to eq(other_scope.id) }
+            end
+
+            context "when decidim_scope_id is blank" do
+              let(:decidim_scope_id) { nil }
+
+              it { is_expected.to be_nil }
+            end
+
+            context "when no type or decidim_scope_id are provided" do
+              let(:attributes) do
+                {
+                  title: Decidim::Faker::Localized.sentence(2),
+                  description: Decidim::Faker::Localized.sentence(5),
+                  state: "created",
+                  signature_type: "online"
+                }
+              end
+
+              it { is_expected.to be_nil }
+            end
+          end
+
+          context "when created from model" do
+            subject { described_class.from_model(initiative).with_context(context).scoped_type_id }
+
+            it { is_expected.to eq(initiative.scoped_type.id) }
           end
         end
       end

--- a/decidim-initiatives/spec/shared/create_initiative_example.rb
+++ b/decidim-initiatives/spec/shared/create_initiative_example.rb
@@ -82,6 +82,13 @@ shared_examples "create an initiative" do
           end
         end
       end
+
+      it "adds the author as committee member in accepted state" do
+        command.call
+        initiative = Decidim::Initiative.last
+
+        expect(initiative.committee_members.accepted.where(user: author)).to exist
+      end
     end
   end
 end

--- a/decidim-initiatives/spec/shared/initiative_administration.rb
+++ b/decidim-initiatives/spec/shared/initiative_administration.rb
@@ -3,8 +3,11 @@
 shared_context "when admins initiative" do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+  let(:author) { create(:user, :confirmed, organization: organization) }
+  let!(:other_initiatives_type) { create(:initiatives_type, organization: organization) }
+  let!(:other_initiatives_type_scope) { create(:initiatives_type_scope, type: other_initiatives_type) }
 
-  let!(:initiative) { create(:initiative, organization: organization) }
+  let!(:initiative) { create(:initiative, organization: organization, author: author) }
 
   let(:image1_filename) { "city.jpeg" }
   let(:image1_path) { Decidim::Dev.asset(image1_filename) }

--- a/decidim-initiatives/spec/system/admin/update_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/admin/update_initiative_spec.rb
@@ -14,38 +14,123 @@ describe "User prints the initiative", type: :system do
   end
 
   context "when initiative update" do
-    before do
-      switch_to_host(organization.host)
-      login_as user, scope: :user
-      visit decidim_admin_initiatives.initiatives_path
-    end
-
-    it "Updates published initiative data" do
-      page.find(".action-icon--edit").click
-      within ".edit_initiative" do
-        fill_in :initiative_hashtag, with: "#hashtag"
-      end
-      submit_and_validate
-    end
-
-    context "when initiative is in accepted state" do
+    context "and user is author" do
       before do
-        initiative.accepted!
+        switch_to_host(organization.host)
+        login_as author, scope: :user
+        visit decidim_admin_initiatives.initiatives_path
       end
 
-      it "updates accepted initiative data" do
+      context "when initiative is in created state" do
+        before do
+          initiative.created!
+        end
+
+        it "updates type, scope and signature type" do
+          page.find(".action-icon--edit").click
+          within ".edit_initiative" do
+            select translated(other_initiatives_type.title), from: "initiative_type_id"
+            select translated(other_initiatives_type_scope), from: "initiative_decidim_scope_id"
+            select "Face to face", from: "initiative_signature_type"
+          end
+          submit_and_validate
+        end
+      end
+
+      context "when initiative is in validating state" do
+        before do
+          initiative.validating!
+        end
+
+        it "update of type, scope and signature type are disabled" do
+          page.find(".action-icon--edit").click
+
+          within ".edit_initiative" do
+            expect(page).to have_css("#initiative_type_id[disabled]")
+            expect(page).to have_css("#initiative_decidim_scope_id[disabled]")
+            expect(page).to have_css("#initiative_signature_type[disabled]")
+          end
+          expect(page).to have_no_css("*[type=submit]")
+        end
+      end
+    end
+
+    context "and user is admin" do
+      before do
+        switch_to_host(organization.host)
+        login_as user, scope: :user
+        visit decidim_admin_initiatives.initiatives_path
+      end
+
+      it "Updates published initiative data" do
         page.find(".action-icon--edit").click
         within ".edit_initiative" do
-          fill_in_i18n_editor(
-            :initiative_answer,
-            "#initiative-answer-tabs",
-            ca: "Alguna resposta",
-            en: "Some answer",
-            es: "Alguna respuesta"
-          )
-          fill_in :initiative_answer_url, with: "http://meta.decidim.org"
+          fill_in :initiative_hashtag, with: "#hashtag"
         end
         submit_and_validate
+      end
+
+      context "when initiative is in created state" do
+        before do
+          initiative.created!
+        end
+
+        it "updates type, scope and signature type" do
+          page.find(".action-icon--edit").click
+          within ".edit_initiative" do
+            select translated(other_initiatives_type.title), from: "initiative_type_id"
+            select translated(other_initiatives_type_scope), from: "initiative_decidim_scope_id"
+            select "Face to face", from: "initiative_signature_type"
+          end
+          submit_and_validate
+        end
+      end
+
+      context "when initiative is in validating state" do
+        before do
+          initiative.validating!
+        end
+
+        it "updates type, scope and signature type" do
+          page.find(".action-icon--edit").click
+          within ".edit_initiative" do
+            select translated(other_initiatives_type.title), from: "initiative_type_id"
+            select translated(other_initiatives_type_scope), from: "initiative_decidim_scope_id"
+            select "Face to face", from: "initiative_signature_type"
+          end
+          submit_and_validate
+        end
+      end
+
+      context "when initiative is in accepted state" do
+        before do
+          initiative.accepted!
+        end
+
+        it "updates accepted initiative data" do
+          page.find(".action-icon--edit").click
+          within ".edit_initiative" do
+            fill_in_i18n_editor(
+              :initiative_answer,
+              "#initiative-answer-tabs",
+              ca: "Alguna resposta",
+              en: "Some answer",
+              es: "Alguna respuesta"
+            )
+            fill_in :initiative_answer_url, with: "http://meta.decidim.org"
+          end
+          submit_and_validate
+        end
+
+        it "update of type, scope and signature type are disabled" do
+          page.find(".action-icon--edit").click
+
+          within ".edit_initiative" do
+            expect(page).to have_css("#initiative_type_id[disabled]")
+            expect(page).to have_css("#initiative_decidim_scope_id[disabled]")
+            expect(page).to have_css("#initiative_signature_type[disabled]")
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Adds some fixes to initiatives administration:
- Allows the edition of Initative type, Decidim scope and Signature collection type from admin panel when the initiative is in created or validating states for admins and when the initiative is in created state for users.
- Changes the available signature types select options depending on initiatives type selection.
- After creation adds the author of an initiative to the committee members with accepted request
- Displays the state of initiative in admin edition form in a disabled select field. This select can be enabled for admins but won't work for all state changes.

#### :pushpin: Related Issues
- Related to #4661

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)

Initiative state on admin edition form:
<img width="964" alt="screen shot 2019-02-17 at 23 09 36" src="https://user-images.githubusercontent.com/446459/52920083-2c273500-3309-11e9-8bc9-2291f65d5d67.png">
