### PR TITLE
Fix Issue #4827: Counter intuitive verification Lock icons

### DIFF
--- a/decidim-verifications/app/views/decidim/verifications/authorizations/_granted_authorization.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/authorizations/_granted_authorization.html.erb
@@ -1,6 +1,6 @@
 <div class="card--list__item">
   <div class="card--list__text">
-    <%= icon "lock-unlocked", class: "card--list__icon" %>
+    <%= icon "lock-locked", class: "card--list__icon" %>
     <div>
       <h5 class="card--list__heading">
         <%= t("#{authorization.name}.name", scope: "decidim.authorization_handlers") %>

--- a/decidim-verifications/app/views/decidim/verifications/authorizations/index.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/authorizations/index.html.erb
@@ -49,7 +49,7 @@
           <%= link_to unauthorized_method.root_path do %>
             <div class="card--list__item">
               <div class="card--list__text">
-                <%= icon "lock-locked", class: "card--list__icon" %>
+                <%= icon "lock-unlocked", class: "card--list__icon" %>
                 <div>
                   <h5 class="card--list__heading">
                     <%= t("#{unauthorized_method.key}.name", scope: "decidim.authorization_handlers") %>


### PR DESCRIPTION
#### :tophat: What? Why?
All security related features uses the lock icon status as opposite of what currently is implemented. This PR contains the display of proper lock icon status. 

#### :pushpin: Related Issues
- Fixes #4827 