### PR TITLE
Don't count withdrawn proposals when publishing one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 - **decidim-proposals** Fix proposals search indexes [\#4857](https://github.com/decidim/decidim/pull/4857)
 - **decidim-proposals** Remove etiquette validation from proposals admin [\#4856](https://github.com/decidim/decidim/pull/4856)
 - **decidim-core**: Fix process filters [\#4872](https://github.com/decidim/decidim/pull/4872)
+- **decidim-proposals** Don't count withdrawn proposals when publishing one [\#4875](https://github.com/decidim/decidim/pull/4875)
 
 **Removed**:
 

--- a/decidim-proposals/app/commands/decidim/proposals/update_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/update_proposal.rb
@@ -105,11 +105,11 @@ module Decidim
       end
 
       def current_user_proposals
-        Proposal.from_author(current_user).where(component: form.current_component).published.where.not(id: proposal.id)
+        Proposal.from_author(current_user).where(component: form.current_component).published.where.not(id: proposal.id).except_withdrawn
       end
 
       def user_group_proposals
-        Proposal.from_user_group(user_group).where(component: form.current_component).published.where.not(id: proposal.id)
+        Proposal.from_user_group(user_group).where(component: form.current_component).published.where.not(id: proposal.id).except_withdrawn
       end
     end
   end

--- a/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
@@ -91,10 +91,6 @@ module Decidim
         ).count
       end
 
-      def current_user_proposals
-        Proposal.where(component: current_component, author: current_user)
-      end
-
       def follow_button_for(model, large = nil)
         render partial: "decidim/shared/follow_button.html", locals: { followable: model, large: large }
       end


### PR DESCRIPTION
#### :tophat: What? Why?

Withdrawn proposals shouldn't count as the limit when publihsing one.

#### :pushpin: Related Issues
- Fixes #4867

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
