### PR TITLE
Fix/collaborative draft attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 
 **Fixed**:
 
+- **decidim-proposals**: Fix collaborative draft attachment when attachments are enabled after collaborative draft creation [\#4877](https://github.com/decidim/decidim/pull/4877)
 - **decidim-assemblies**: Fix parent assemblies children_count counter (add migration) [\#4852](https://github.com/decidim/decidim/pull/4852/)
 - **decidim-proposals**: Fix Proposals Last Activity feed [\#4828](https://github.com/decidim/decidim/pull/4828)
 - **decidim-proposals**: Fix attachments not being inherited from collaborative draft when published as proposal. [\#4811](https://github.com/decidim/decidim/pull/4811)

--- a/decidim-proposals/app/controllers/decidim/proposals/collaborative_drafts_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/collaborative_drafts_controller.rb
@@ -98,6 +98,7 @@ module Decidim
         enforce_permission_to :edit, :collaborative_draft, collaborative_draft: @collaborative_draft
 
         @form = form(CollaborativeDraftForm).from_model(@collaborative_draft)
+        @form.attachment = form(AttachmentForm).from_model(@collaborative_draft.attachments.first)
       end
 
       def update

--- a/decidim-proposals/spec/system/edit_collaborative_draft_spec.rb
+++ b/decidim-proposals/spec/system/edit_collaborative_draft_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Edit collaborative_drafts", type: :system do
+  include_context "with a component"
+  let!(:component) { create(:proposal_component, :with_collaborative_drafts_enabled, organization: organization) }
+  let(:manifest_name) { "proposals" }
+
+  let!(:user) { create :user, :confirmed, organization: participatory_process.organization }
+  let!(:another_user) { create :user, :confirmed, organization: participatory_process.organization }
+  let!(:collaborative_draft) { create :collaborative_draft, users: [user], component: component }
+
+  before do
+    switch_to_host user.organization.host
+  end
+
+  describe "editing my own collaborative draft" do
+    let(:new_title) { "This is my collaborative_draft new title" }
+    let(:new_body) { "This is my collaborative_draft new body" }
+
+    before do
+      login_as user, scope: :user
+    end
+
+    it "can be updated" do
+      visit_component
+
+      click_link "Access collaborative drafts"
+      click_link collaborative_draft.title
+      click_link "Edit collaborative draft"
+
+      expect(page).to have_content "EDIT COLLABORATIVE DRAFT"
+
+      within "form.edit_collaborative_draft" do
+        fill_in :collaborative_draft_title, with: new_title
+        fill_in :collaborative_draft_body, with: new_body
+        click_button "Send"
+      end
+
+      expect(page).to have_content(new_title)
+      expect(page).to have_content(new_body)
+    end
+
+    context "when attachment is enabled" do
+      context "and after collaborative draft creation" do
+        let!(:component) do
+          create(:proposal_component,
+                 :with_attachments_allowed_and_collaborative_drafts_enabled,
+                 manifest: manifest,
+                 participatory_space: participatory_process)
+        end
+
+        it "can be updated" do
+          visit_component
+
+          click_link "Access collaborative drafts"
+          click_link collaborative_draft.title
+          click_link "Edit collaborative draft"
+
+          expect(page).to have_css "#collaborative_draft_attachment_file"
+
+          within "form.edit_collaborative_draft" do
+            fill_in :collaborative_draft_attachment_title, with: "My attachment"
+            attach_file :collaborative_draft_attachment_file, Decidim::Dev.asset("city.jpeg")
+            find("*[type=submit]").click
+          end
+
+          expect(page).to have_content("successfully")
+        end
+      end
+    end
+
+    context "when updating with wrong data" do
+      it "returns an error message" do
+        visit_component
+
+        click_link "Access collaborative drafts"
+        click_link collaborative_draft.title
+        click_link "Edit collaborative draft"
+
+        within "form.edit_collaborative_draft" do
+          fill_in :collaborative_draft_body, with: "A"
+          click_button "Send"
+        end
+
+        expect(page).to have_content("is using too many capital letters (over 25% of the text), is too short (under 15 characters)")
+      end
+
+      it "keeps the submitted values" do
+        visit_component
+
+        click_link "Access collaborative drafts"
+        click_link collaborative_draft.title
+        click_link "Edit collaborative draft"
+
+        within "form.edit_collaborative_draft" do
+          fill_in :collaborative_draft_title, with: "A title with a #hashtag"
+          fill_in :collaborative_draft_body, with: "Ỳü"
+        end
+        click_button "Send"
+
+        expect(page).to have_selector("input[value='A title with a #hashtag']")
+        expect(page).to have_content("Ỳü")
+      end
+    end
+  end
+
+  describe "editing someone else's proposal" do
+    before do
+      login_as another_user, scope: :user
+    end
+
+    it "renders an error" do
+      visit_component
+
+      click_link "Access collaborative drafts"
+      click_link collaborative_draft.title
+      expect(page).to have_no_content("Edit collaborative draft")
+      visit current_path + "/edit"
+
+      expect(page).to have_content("not authorized")
+    end
+  end
+
+  describe "editing my proposal outside the time limit" do
+    let!(:collaborative_draft) { create :collaborative_draft, users: [user], component: component, created_at: 1.hour.ago }
+
+    before do
+      login_as another_user, scope: :user
+    end
+
+    it "renders an error" do
+      visit_component
+
+      click_link "Access collaborative drafts"
+      click_link collaborative_draft.title
+      expect(page).to have_no_content("Edit collaborative draft")
+      visit current_path + "/edit"
+
+      expect(page).to have_content("not authorized")
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
When editing a collaborative draft after enabling attachment, it raises an error.
A method was missing on the edit method from controller collaborative drafts.
This is now fixed.
Also, there were no tests for collaborative drafts editing, I add it by the way.

#### :pushpin: Related Issues
- Related to https://github.com/OpenSourcePolitics/decidim/issues/463
- Submitted here : https://meta.decidim.org/processes/bug-report/f/210/proposals/14266

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [X] Add tests

### :camera: Screenshots (optional)
<img width="1680" alt="capture d ecran 2019-02-18 a 19 33 17" src="https://user-images.githubusercontent.com/20232956/52970446-13278e00-33b4-11e9-88fe-88832b63473e.png">