### PR TITLE
4661 initiatives moderation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - **decidim-initiatives**: Add setting in `Decidim::InitiativesType` to enable users to undo their initiatives signatures. [\#4841](https://github.com/decidim/decidim/pull/4841)
 - **decidim-initiatives**: Add author of initiative to committee members on creation. [\#4861](https://github.com/decidim/decidim/pull/4861)
 - **decidim-initiatives**: Display state of initiative on edition form inside a disabled select. [\#4861](https://github.com/decidim/decidim/pull/4861)
+- **decidim-initiatives**: Allow users report comments on initiatives and admins moderate reports from initiative admin panel. [\#4878](https://github.com/decidim/decidim/pull/4878)
 
 **Changed**:
 

--- a/decidim-core/app/commands/decidim/create_report.rb
+++ b/decidim-core/app/commands/decidim/create_report.rb
@@ -85,7 +85,7 @@ module Decidim
     end
 
     def participatory_space
-      @participatory_space ||= @reportable.component.participatory_space
+      @participatory_space ||= @reportable.component&.participatory_space || @reportable.try(:participatory_space)
     end
   end
 end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/moderations_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/moderations_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Initiatives
+    module Admin
+      # This controller allows admins to manage moderations in an conference.
+      class ModerationsController < Decidim::Admin::ModerationsController
+        include InitiativeAdmin
+
+        def permissions_context
+          super.merge(current_participatory_space: current_participatory_space)
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/app/permissions/decidim/initiatives/admin/permissions.rb
+++ b/decidim-initiatives/app/permissions/decidim/initiatives/admin/permissions.rb
@@ -35,6 +35,7 @@ module Decidim
           initiative_type_scope_action?
           initiative_committee_action?
           initiative_admin_user_action?
+          moderator_action?
           allow! if permission_action.subject == :attachment
 
           permission_action
@@ -153,6 +154,12 @@ module Decidim
           else
             allow!
           end
+        end
+
+        def moderator_action?
+          return unless permission_action.subject == :moderation
+
+          allow!
         end
 
         def read_initiative_list_action?

--- a/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
+++ b/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
@@ -14,6 +14,7 @@ module Decidim
         return permission_action if permission_action.scope != :public
 
         # Non-logged users permissions
+        public_report_content_action?
         list_public_initiatives?
         read_public_initiative?
         search_initiative_types_and_scopes?
@@ -125,6 +126,13 @@ module Decidim
                      authorized?(:vote, resource: initiative, permissions_holder: initiative.type)
 
         toggle_allow(can_unvote)
+      end
+
+      def public_report_content_action?
+        return unless permission_action.action == :create &&
+                      permission_action.subject == :moderation
+
+        allow!
       end
 
       def sign_initiative?

--- a/decidim-initiatives/app/queries/decidim/initiatives/admin/admin_users.rb
+++ b/decidim-initiatives/app/queries/decidim/initiatives/admin/admin_users.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Initiatives
+    module Admin
+      # A class used to find the admins for an initiative.
+      class AdminUsers < Rectify::Query
+        # Syntactic sugar to initialize the class and return the queried objects.
+        #
+        # initiative - Decidim::Initiative
+        def self.for(initiative)
+          new(initiative).query
+        end
+
+        # Initializes the class.
+        #
+        # initiative - Decidim::Initiative
+        def initialize(initiative)
+          @initiative = initiative
+        end
+
+        # Finds organization admins and the users with role admin for the given initiative.
+        #
+        # Returns an ActiveRecord::Relation.
+        def query
+          Decidim::User.where(id: organization_admins)
+        end
+
+        private
+
+        attr_reader :initiative
+
+        def organization_admins
+          initiative.organization.admins
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/app/views/layouts/decidim/admin/initiative.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/admin/initiative.html.erb
@@ -41,6 +41,13 @@
           <%= aria_selected_link_to t(".attachments"), decidim_admin_initiatives.initiative_attachments_path(current_participatory_space) %>
         </li>
       <% end %>
+
+      <% if allowed_to? :read, :moderation %>
+        <li <% if is_active_link?(decidim_admin_initiatives.moderations_path(current_participatory_space)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("moderations", scope: "decidim.admin.menu.participatory_processes_submenu"), decidim_admin_initiatives.moderations_path(current_participatory_space) %>
+        </li>
+      <% end %>
+
     </ul>
   </div>
 <% end %>

--- a/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
@@ -50,6 +50,14 @@ module Decidim
             end
             resources :exports, only: :create
           end
+
+          resources :moderations do
+            member do
+              put :unreport
+              put :hide
+              put :unhide
+            end
+          end
         end
 
         scope "/initiatives/:initiative_slug/components/:component_id/manage" do

--- a/decidim-initiatives/spec/queries/decidim/initiatives/admin/admin_users_spec.rb
+++ b/decidim-initiatives/spec/queries/decidim/initiatives/admin/admin_users_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Initiatives
+  describe Admin::AdminUsers do
+    subject { described_class.new(initiative) }
+
+    let(:organization) { create :organization }
+    let(:initiative) { create :initiative, :published, organization: organization }
+    let!(:admin) { create(:user, :admin, :confirmed, organization: organization) }
+    let!(:initiative_admin) do
+      create(:user, :admin, :confirmed, organization: organization)
+    end
+
+    it "returns the organization admins and initiative admins" do
+      expect(subject.query).to match_array([admin, initiative_admin])
+    end
+  end
+end

--- a/decidim-initiatives/spec/system/admin/admin_manages_comments_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_comments_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin manages comments", type: :system do
+  let!(:reportables) do
+    create_list(:comment, 3, commentable: commentable)
+  end
+
+  let(:participatory_space_path) do
+    decidim_admin_initiatives.edit_initiative_path(commentable)
+  end
+
+  let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+  let(:organization) { create(:organization) }
+  let(:commentable) { create(:initiative, organization: organization) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim_admin_initiatives.initiatives_path
+  end
+
+  it_behaves_like "manage moderations" do
+    let!(:moderations) do
+      reportables.first(reportables.length - 1).map do |reportable|
+        moderation = create(:moderation, reportable: reportable, participatory_space: commentable, report_count: 1)
+        create(:report, moderation: moderation)
+        moderation
+      end
+    end
+
+    let!(:hidden_moderations) do
+      reportables.last(1).map do |reportable|
+        moderation = create(:moderation, reportable: reportable, participatory_space: commentable, report_count: 3, hidden_at: Time.current)
+        create_list(:report, 3, moderation: moderation, reason: :spam)
+        moderation
+      end
+    end
+  end
+end

--- a/decidim-initiatives/spec/system/report_comment_spec.rb
+++ b/decidim-initiatives/spec/system/report_comment_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+describe "Report Comment", type: :system do
+  let!(:organization) { create(:organization) }
+  let(:user) { create :user, :confirmed, organization: organization }
+  let(:participatory_space) { commentable }
+  let(:participatory_process) { commentable }
+  let!(:commentable) { create(:initiative, organization: organization) }
+  let!(:reportable) { create(:comment, commentable: commentable) }
+  let(:reportable_path) { decidim_initiatives.initiative_path(commentable) }
+
+  before do
+    switch_to_host(organization.host)
+  end
+
+  include_examples "reports"
+end


### PR DESCRIPTION
#### :tophat: What? Why?
- Allows users to report comments on initiatives.
- Allows admins to moderate reports from initiative admin panel.

#### :pushpin: Related Issues
- Related to #4661

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)
#### Before:
Report modal is opened
<img width="1105" alt="screen shot 2019-02-18 at 20 44 26" src="https://user-images.githubusercontent.com/446459/52973372-36573b00-33be-11e9-963a-aa6b52ec6ee7.png">

But report can't be created
<img width="1175" alt="screen shot 2019-02-18 at 20 44 43" src="https://user-images.githubusercontent.com/446459/52973373-36573b00-33be-11e9-9290-5ffdda7b3691.png">

Also the admin panel doesn't have moderations entry
<img width="1123" alt="screen shot 2019-02-18 at 20 45 24" src="https://user-images.githubusercontent.com/446459/52973374-36efd180-33be-11e9-8d8f-0d926eec08a3.png">

#### After:

Report modal is opened
<img width="1051" alt="screen shot 2019-02-18 at 20 38 55" src="https://user-images.githubusercontent.com/446459/52973193-8e417200-33bd-11e9-94b2-1a9ede7cf5f1.png">

Report is created
<img width="1279" alt="screen shot 2019-02-18 at 20 39 15" src="https://user-images.githubusercontent.com/446459/52973211-9699ad00-33bd-11e9-9281-ab92673b7991.png">

Reports can be moderated from admin panel
<img width="1152" alt="screen shot 2019-02-18 at 20 40 15" src="https://user-images.githubusercontent.com/446459/52973225-a1544200-33bd-11e9-810a-53797c41404c.png">


