### PR TITLE
Add start and end times to debates card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 - **decidim-proposals** Fix proposals search indexes [\#4857](https://github.com/decidim/decidim/pull/4857)
 - **decidim-proposals** Remove etiquette validation from proposals admin [\#4856](https://github.com/decidim/decidim/pull/4856)
 - **decidim-core**: Fix process filters [\#4872](https://github.com/decidim/decidim/pull/4872)
+- **decidim-debates** Fix debates card and ordering [\#4879](https://github.com/decidim/decidim/pull/4879)
 
 **Removed**:
 

--- a/decidim-debates/app/cells/decidim/debates/debate_m/data.erb
+++ b/decidim-debates/app/cells/decidim/debates/debate_m/data.erb
@@ -1,0 +1,8 @@
+<div class="card__icondata">
+  <ul class="card-data">
+    <li class="card-data__item">
+      <%= icon "datetime", class: "icon--big" %>
+    </li>
+    <%= debate_date %>
+  </ul>
+</div>

--- a/decidim-debates/app/cells/decidim/debates/debate_m/multiple_dates.erb
+++ b/decidim-debates/app/cells/decidim/debates/debate_m/multiple_dates.erb
@@ -1,0 +1,17 @@
+<li class="card-data__item">
+  <div class="card-data__item--multiple">
+    <div>
+      <strong>
+        <%= l start_date, format: :decidim_with_month_name %>
+      </strong>
+      <%= formatted_start_time %>
+    </div>
+    <%= icon "arrow-thin-right", class: "icon--big muted" %>
+    <div>
+      <strong>
+        <%= l end_date, format: :decidim_with_month_name %>
+      </strong>
+      <%= formatted_end_time %>
+    </div>
+  </div>
+</li>

--- a/decidim-debates/app/cells/decidim/debates/debate_m/single_date.erb
+++ b/decidim-debates/app/cells/decidim/debates/debate_m/single_date.erb
@@ -1,0 +1,9 @@
+<li class="card-data__item">
+  <div>
+    <strong>
+      <%= l start_date, format: :decidim_with_month_name %>
+    </strong>
+    &nbsp;·&nbsp;
+    <%= formatted_start_time %> - <%= formatted_end_time %>
+  </div>
+</li>

--- a/decidim-debates/app/cells/decidim/debates/debate_m_cell.rb
+++ b/decidim-debates/app/cells/decidim/debates/debate_m_cell.rb
@@ -7,6 +7,10 @@ module Decidim
     class DebateMCell < Decidim::CardMCell
       include DebateCellsHelper
 
+      def date
+        render
+      end
+
       private
 
       def resource_icon

--- a/decidim-debates/app/services/decidim/debates/debate_search.rb
+++ b/decidim-debates/app/services/decidim/debates/debate_search.rb
@@ -32,6 +32,16 @@ module Decidim
           query
         end
       end
+
+      def search_order_start_time
+        if order_start_time == "asc"
+          query.order("start_time ASC")
+        elsif order_start_time == "desc"
+          query.order("start_time DESC")
+        else
+          query.order("start_time ASC")
+        end
+      end
     end
   end
 end

--- a/decidim-debates/spec/services/decidim/debates/debate_search_spec.rb
+++ b/decidim-debates/spec/services/decidim/debates/debate_search_spec.rb
@@ -110,5 +110,23 @@ describe Decidim::Debates::DebateSearch do
         end
       end
     end
+
+    describe "order_start_time" do
+      context "when ordering ascending" do
+        let(:params) { default_params.merge(order_start_time: "asc") }
+
+        it "shows the upcoming debates first" do
+          expect(subject).to eq([debate1, debate2])
+        end
+      end
+
+      context "when ordering descending" do
+        let(:params) { default_params.merge(order_start_time: "desc") }
+
+        it "shows the latest debates first" do
+          expect(subject).to eq([debate2, debate1])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Shows the start and end time at debates card. The date at the footer will still show the creation date since it's how other cards work and how the design sets it: https://decidim-design.herokuapp.com/public/debates (although I'm not sure what's the value of showing the creation date).

#### :pushpin: Related Issues

- Fixes #4866

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/5254/53002966-3c850000-342e-11e9-84e2-c5642ff8a67f.png)