### PR TITLE
Fix AttachmentCreatedEvent email resource_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 **Fixed**:
 
+- **decidim-core**: Fix AttachmentCreatedEvent email resource_url [#4880](https://github.com/decidim/decidim/pull/4880)
 - **decidim-proposals**: Add participatory texts file format support in admin. [#4819](https://github.com/decidim/decidim/pull/4819)
 - **decidim-proposals**: Fix collaborative draft attachment when attachments are enabled after collaborative draft creation [\#4877](https://github.com/decidim/decidim/pull/4877)
 - **decidim-assemblies**: Fix parent assemblies children_count counter (add migration) [\#4852](https://github.com/decidim/decidim/pull/4852/)

--- a/decidim-admin/app/events/decidim/attachment_created_event.rb
+++ b/decidim-admin/app/events/decidim/attachment_created_event.rb
@@ -2,14 +2,14 @@
 
 module Decidim
   class AttachmentCreatedEvent < Decidim::Events::SimpleEvent
-    i18n_attributes :resource_url
+    i18n_attributes :attached_to_url
 
     def resource_path
       @resource.url
     end
 
     def resource_url
-      resource_locator.url
+      attached_to_url
     end
 
     def resource_text
@@ -20,6 +20,10 @@ module Decidim
     end
 
     private
+
+    def attached_to_url
+      resource_locator.url
+    end
 
     def resource
       @resource.attached_to

--- a/decidim-admin/app/events/decidim/attachment_created_event.rb
+++ b/decidim-admin/app/events/decidim/attachment_created_event.rb
@@ -2,14 +2,14 @@
 
 module Decidim
   class AttachmentCreatedEvent < Decidim::Events::SimpleEvent
-    i18n_attributes :attached_to_url
+    i18n_attributes :resource_url
 
     def resource_path
       @resource.url
     end
 
     def resource_url
-      @resource.url
+      resource_locator.url
     end
 
     def resource_text
@@ -20,10 +20,6 @@ module Decidim
     end
 
     private
-
-    def attached_to_url
-      resource_locator.url
-    end
 
     def resource
       @resource.attached_to

--- a/decidim-admin/spec/events/decidim/attachment_created_event_spec.rb
+++ b/decidim-admin/spec/events/decidim/attachment_created_event_spec.rb
@@ -30,6 +30,12 @@ describe Decidim::AttachmentCreatedEvent do
     end
   end
 
+  describe "resource_url" do
+    it "is generated correctly" do
+      expect(subject.resource_url).to eq(attached_to_url)
+    end
+  end
+
   describe "email_outro" do
     it "is generated correctly" do
       expect(subject.email_outro)

--- a/decidim-core/app/views/decidim/notification_mailer/event_received.html.erb
+++ b/decidim-core/app/views/decidim/notification_mailer/event_received.html.erb
@@ -10,7 +10,7 @@
   </blockquote>
 <% end %>
 
-<% if @event_instance.resource_url.present? && @event_instance.resource_title.present? %>
+<% if @event_instance.resource_path.present? && @event_instance.resource_title.present? %>
   <p>
     <%= link_to @event_instance.resource_title, @event_instance.resource_url %>
   </p>

--- a/decidim-core/app/views/decidim/notification_mailer/event_received.html.erb
+++ b/decidim-core/app/views/decidim/notification_mailer/event_received.html.erb
@@ -10,9 +10,9 @@
   </blockquote>
 <% end %>
 
-<% if @event_instance.resource_path.present? && @event_instance.resource_title.present? %>
+<% if @event_instance.resource_url.present? && @event_instance.resource_title.present? %>
   <p>
-    <%= link_to @event_instance.resource_url, @event_instance.resource_url %>
+    <%= link_to @event_instance.resource_title, @event_instance.resource_url %>
   </p>
 <% end %>
 


### PR DESCRIPTION
#### :tophat: What? Why?
> Han trobat un problema amb els emails que envia el Decidim als seguidors d'un procés quan es puja un arxiu adjunt. Sembla que no calcula bé la URL del recurs que es col·loca al mail i hi falta la part corresponent al servidor.

Changed `resource_url` so it calls `attached_to_url`. This fixes the issue because `attached_to_url` makes use of `ResourceLocatorPresenter` and handles the host part. Besides, I think it makes more sense now that the link points to the object that holds the attachment because the **email outro** says:

>You can stop receiving notifications following the previous link.

I also changed the link text to `resource_title`, but this is a matter of opinion.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)
#### Before
![before](https://user-images.githubusercontent.com/40306853/53026799-ef238580-3463-11e9-9bb1-126b5f90cb09.png)
#### After
![after2](https://user-images.githubusercontent.com/40306853/53034820-55180900-3474-11e9-887a-1223755f6110.png)
#### After with changed link text
![after](https://user-images.githubusercontent.com/40306853/53026796-ed59c200-3463-11e9-9408-d6513bf86e51.png)
