### PR TITLE
4661 initiatives answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - **decidim-initiatives**: Add a last step on signature initiatives wizard and use it instead of redirect to initiative after signing. [\#4841](https://github.com/decidim/decidim/pull/4841)
 - **decidim-initiatives**: Change permissions of sign_initiative action. [\#4841](https://github.com/decidim/decidim/pull/4841)
 - **decidim-initiatives**: Allow edition of type, scope and signature type of initiatives depending on state and user. [\#4861](https://github.com/decidim/decidim/pull/4861)
+- **decidim-initiatives**: Move edition of initiatives answer to a separated form in admin panel and shows answer in front if present for any state. [\#4881](https://github.com/decidim/decidim/pull/4881)
 
 **Fixed**:
 

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative.rb
@@ -44,12 +44,8 @@ module Decidim
           attrs = {
             title: form.title,
             description: form.description,
-            hashtag: form.hashtag,
-            answer: form.answer,
-            answer_url: form.answer_url
+            hashtag: form.hashtag
           }
-
-          attrs[:answered_at] = Time.current if form.answer.present?
 
           if form.signature_type_updatable?
             attrs[:signature_type] = form.signature_type

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative_answer.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative_answer.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Initiatives
+    module Admin
+      # A command with all the business logic to answer
+      # initiatives.
+      class UpdateInitiativeAnswer < Rectify::Command
+        # Public: Initializes the command.
+        #
+        # initiative   - Decidim::Initiative
+        # form         - A form object with the params.
+        # current_user - Decidim::User
+        def initialize(initiative, form, current_user)
+          @form = form
+          @initiative = initiative
+          @current_user = current_user
+        end
+
+        # Executes the command. Broadcasts these events:
+        #
+        # - :ok when everything is valid.
+        # - :invalid if the form wasn't valid and we couldn't proceed.
+        #
+        # Returns nothing.
+        def call
+          return broadcast(:invalid) if form.invalid?
+
+          @initiative = Decidim.traceability.update!(
+            initiative,
+            current_user,
+            attributes
+          )
+          notify_initiative_is_extended if @notify_extended
+          broadcast(:ok, initiative)
+        rescue ActiveRecord::RecordInvalid
+          broadcast(:invalid, initiative)
+        end
+
+        private
+
+        attr_reader :form, :initiative, :current_user
+
+        def attributes
+          attrs = {
+            answer: form.answer,
+            answer_url: form.answer_url
+          }
+
+          attrs[:answered_at] = Time.current if form.answer.present?
+
+          if form.signature_dates_required?
+            attrs[:signature_start_date] = form.signature_start_date
+            attrs[:signature_end_date] = form.signature_end_date
+
+            if initiative.published?
+              @notify_extended = true if form.signature_end_date != initiative.signature_end_date &&
+                                         form.signature_end_date > initiative.signature_end_date
+            end
+          end
+
+          attrs
+        end
+
+        def notify_initiative_is_extended
+          Decidim::EventsManager.publish(
+            event: "decidim.events.initiatives.initiative_extended",
+            event_class: Decidim::Initiatives::ExtendInitiativeEvent,
+            resource: initiative,
+            followers: initiative.followers - [initiative.author]
+          )
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/answers_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/answers_controller.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Initiatives
+    module Admin
+      # Controller used to manage the initiatives answers
+      class AnswersController < Decidim::Initiatives::Admin::ApplicationController
+        include Decidim::Initiatives::NeedsInitiative
+
+        helper Decidim::Initiatives::InitiativeHelper
+        layout "decidim/admin/initiatives"
+
+        # GET /admin/initiatives/:id/answer/edit
+        def edit
+          enforce_permission_to :answer, :initiative, initiative: current_initiative
+          @form = form(Decidim::Initiatives::Admin::InitiativeAnswerForm)
+                  .from_model(
+                    current_initiative,
+                    initiative: current_initiative
+                  )
+        end
+
+        # PUT /admin/initiatives/:id/answer
+        def update
+          enforce_permission_to :answer, :initiative, initiative: current_initiative
+
+          params[:id] = params[:slug]
+          @form = form(Decidim::Initiatives::Admin::InitiativeAnswerForm)
+                  .from_params(params, initiative: current_initiative)
+
+          UpdateInitiativeAnswer.call(current_initiative, @form, current_user) do
+            on(:ok) do
+              flash[:notice] = I18n.t("initiatives.update.success", scope: "decidim.initiatives.admin")
+              redirect_to initiatives_path
+            end
+
+            on(:invalid) do
+              flash.now[:alert] = I18n.t("initiatives.update.error", scope: "decidim.initiatives.admin")
+              render :edit
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_answer_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_answer_form.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Initiatives
+    module Admin
+      # A form object used to manage the initiative answer in the
+      # administration panel.
+      class InitiativeAnswerForm < Form
+        include TranslatableAttributes
+
+        mimic :initiative
+
+        translatable_attribute :answer, String
+        attribute :answer_url, String
+        attribute :signature_start_date, Decidim::Attributes::LocalizedDate
+        attribute :signature_end_date, Decidim::Attributes::LocalizedDate
+
+        validates :signature_start_date, :signature_end_date, presence: true, if: :signature_dates_required?
+        validates :signature_end_date, date: { after: :signature_start_date }, if: lambda { |form|
+          form.signature_start_date.present? && form.signature_end_date.present?
+        }
+
+        def signature_dates_required?
+          @signature_dates_required ||= context.initiative.state == "published"
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_form.rb
@@ -21,9 +21,6 @@ module Decidim
         attribute :offline_votes, Integer
         attribute :state, String
 
-        translatable_attribute :answer, String
-        attribute :answer_url, String
-
         validates :title, :description, presence: true
         validates :signature_type, presence: true, if: :signature_type_updatable?
         validates :signature_start_date, presence: true, if: ->(form) { form.context.initiative.published? }
@@ -31,9 +28,6 @@ module Decidim
         validates :signature_end_date, date: { after: :signature_start_date }, if: lambda { |form|
           form.signature_start_date.present? && form.signature_end_date.present?
         }
-
-        validates :answer, translatable_presence: true, if: ->(form) { form.context.initiative.accepted? }
-        validates :answer_url, presence: true, if: ->(form) { form.context.initiative.accepted? }
 
         validates :offline_votes,
                   numericality: {

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/answers/_info_initiative.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/answers/_info_initiative.html.erb
@@ -1,0 +1,23 @@
+<div class="card">
+  <div class="card-divider">
+    <h2 class="card-title">
+      <%= link_to "#{t ".initiatives"} > ", initiatives_path %>
+      <%= decidim_sanitize translated_attribute(initiative.title) %>
+    </h2>
+  </div>
+
+  <div class="card-section">
+    <div class="row column">
+      <strong><%= t ".description" %>: </strong> <%= decidim_sanitize translated_attribute(initiative.description) %>
+    </div>
+    <div class="row column">
+      <strong><%= t ".created_at" %>: </strong> <%= l initiative.created_at, format: :decidim_short %>
+    </div>
+    <div class="row column">
+      <strong><%= t ".state" %>: </strong> <%= I18n.t(initiative.state, scope: "decidim.initiatives.admin_states") %>
+    </div>
+    <div class="row column">
+      <strong><%= t ".initiative_votes_count" %>: </strong> <%= initiative.initiative_votes_count %>
+    </div>
+  </div>
+</div>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/answers/edit.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/answers/edit.html.erb
@@ -1,0 +1,35 @@
+<%= render partial: "info_initiative", locals: { initiative: current_initiative } %>
+
+<%= decidim_form_for(@form, url: initiative_answer_path(current_initiative), html: { class: "form edit_initiative_answer" }) do |f| %>
+  <div class="card">
+    <div class="card-divider">
+      <h2 class="card-title"><%= t ".title", title: translated_attribute(current_initiative.title) %></h2>
+    </div>
+
+    <div class="card-section">
+      <div class="row column">
+        <%= f.translated :editor, :answer, autofocus: true, rows: 15 %>
+      </div>
+
+      <div class="row column">
+        <%= f.text_field :answer_url %>
+      </div>
+
+      <% if @form.signature_dates_required? %>
+        <div class="row">
+          <div class="columns xlarge-6">
+            <%= f.date_field :signature_start_date, disabled: !@form.signature_dates_required? %>
+          </div>
+
+          <div class="columns xlarge-6">
+            <%= f.date_field :signature_end_date, disabled: !@form.signature_dates_required? %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="button--double form-general-submit">
+    <%= f.submit t(".answer") %>
+  </div>
+<% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/_form.html.erb
@@ -71,16 +71,6 @@
         </div>
       </div>
     <% end %>
-
-    <% if current_initiative.accepted? %>
-      <div class="row column">
-        <%= form.translated :editor, :answer %>
-      </div>
-
-      <div class="row column">
-        <%= form.text_field :answer_url %>
-      </div>
-    <% end %>
   </div>
 </div>
 

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
@@ -89,6 +89,12 @@
                                  class: "action-icon--edit" %>
               <% end %>
 
+              <% if allowed_to?(:answer, :initiative, initiative: initiative) %>
+                <%= icon_link_to "comment-square", edit_initiative_answer_path(initiative.slug), t("actions.answer", scope: "decidim.initiatives"), class: "action-icon action-icon--answer" %>
+              <% else %>
+                <%= icon "comment-square", scope: "decidim.admin", class: "action-icon action-icon--disabled" %>
+              <% end %>
+
               <% if allowed_to? :read, :initiative, initiative: initiative %>
                 <%= icon_link_to "print",
                                  decidim_admin_initiatives.initiative_path(initiative.to_param),

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_result.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_result.html.erb
@@ -1,10 +1,10 @@
-<% if initiative.accepted? && initiative.answered? && translated_attribute(initiative.answer).present? %>
+<% if initiative.answered? && translated_attribute(initiative.answer).present? %>
   <br />
   <div class="row column">
     <div class="callout success">
-      <h5><%= t(".initiative_accepted_reason") %>:</h5>
+      <h5><%= t(initiative.state, scope: "decidim.initiatives.initiatives.result.answer_title") %>:</h5>
       <p>
-        <% if initiative.answer_url %>
+        <% if initiative.answer_url.present? %>
           <a href="<%= initiative.answer_url %>" target="_blank">
             <%= decidim_sanitize translated_attribute initiative.answer %>
           </a>

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -136,7 +136,19 @@ en:
           page: "<p>An initiative is a proposal that can be promoted by anyone on their own initiative (independently of other channels or participation spaces) through the collection of (digital) signatures for the organization to carry out a specific action (modify a regulation, initiate a project, change the name of a department or a street, etc.).</p> <p>The promoters of an initiative can define its objectives, gather support, debate, disseminate it and define meeting points where signatures can be collected from the attendees or debates open to other participants.</p> <p>Examples: An initiative can collect signatures to convene a consultation among all the people of an organization, or to create or convene an assembly, or to initiate a process of budget increase for a territory or area of the organization. During the process of collecting signatures, more people can add to this demand and carry it forward in the organization.</p>\n"
           title: What are initiatives?
     initiatives:
+      actions:
+        answer: Answer
       admin:
+        answers:
+          edit:
+            title: Answer for %{title}
+            answer: Answer
+          info_initiative:
+            created_at: Created at
+            description: Description
+            initiative_votes_count: Votes count
+            initiatives: Initiatives
+            state: State
         committee_requests:
           index:
             approve: Approve

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -355,7 +355,13 @@ en:
           random: Random
           recent: Most recent
         result:
-          initiative_accepted_reason: This initiative has been accepted because
+          answer_title:
+            accepted: This proposal has been accepted because
+            created: This proposal has been created
+            discarded: This proposal has been discarded because
+            published: This proposal is published because
+            rejected: This proposal has been rejected because
+            validating: This proposal is being evaluated
           initiative_rejected_reason: This initiative has been rejected due to its lack of supports.
         show:
           any_vote_method: This citizen initiative collects online support as well as face to face.

--- a/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
@@ -39,6 +39,8 @@ module Decidim
               delete :revoke
             end
           end
+
+          resource :answer, only: [:edit, :update]
         end
 
         scope "/initiatives/:initiative_slug" do

--- a/decidim-initiatives/spec/commands/decidim/initiatives/admin/update_initiative_answer_spec.rb
+++ b/decidim-initiatives/spec/commands/decidim/initiatives/admin/update_initiative_answer_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Initiatives
+    module Admin
+      describe UpdateInitiativeAnswer do
+        let(:form_klass) { Decidim::Initiatives::Admin::InitiativeAnswerForm }
+
+        context "when valid data" do
+          it_behaves_like "update an initiative answer" do
+            context "when the user is an admin" do
+              let(:current_user) { create(:user, :admin, organization: initiative.organization) }
+
+              it "notifies the followers" do
+                follower = create(:user, organization: organization)
+                create(:follow, followable: initiative, user: follower)
+
+                expect(Decidim::EventsManager)
+                  .to receive(:publish)
+                  .with(
+                    event: "decidim.events.initiatives.initiative_extended",
+                    event_class: Decidim::Initiatives::ExtendInitiativeEvent,
+                    resource: initiative,
+                    followers: [follower]
+                  )
+
+                command.call
+              end
+
+              context "when the signature end time is not modified" do
+                let(:signature_end_date) { initiative.signature_end_date }
+
+                it "doesn't notify the followers" do
+                  expect(Decidim::EventsManager).not_to receive(:publish)
+
+                  command.call
+                end
+              end
+            end
+          end
+        end
+
+        context "when validation failure" do
+          let(:organization) { create(:organization) }
+          let!(:initiative) { create(:initiative, organization: organization) }
+          let!(:form) do
+            form_klass
+              .from_model(initiative)
+              .with_context(current_organization: organization, initiative: initiative)
+          end
+
+          let(:command) { described_class.new(initiative, form, initiative.author) }
+
+          it "broadcasts invalid" do
+            expect(initiative).to receive(:valid?)
+              .at_least(:once)
+              .and_return(false)
+            expect { command.call }.to broadcast :invalid
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/spec/forms/admin/initiative_answer_form_spec.rb
+++ b/decidim-initiatives/spec/forms/admin/initiative_answer_form_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Initiatives
+    module Admin
+      describe InitiativeAnswerForm do
+        subject { described_class.from_model(initiative).with_context(context) }
+
+        let(:organization) { create(:organization) }
+        let(:initiatives_type) { create(:initiatives_type, organization: organization) }
+        let(:scope) { create(:initiatives_type_scope, type: initiatives_type) }
+
+        let(:state) { "published" }
+
+        let(:initiative) { create(:initiative, organization: organization, state: state, scoped_type: scope) }
+        let(:user) { create(:user, organization: organization) }
+
+        let(:context) do
+          {
+            current_user: user,
+            current_organization: organization,
+            initiative: initiative
+          }
+        end
+
+        context "when everything is OK" do
+          it { is_expected.to be_valid }
+        end
+
+        describe "#signature_dates_required?" do
+          subject { described_class.from_model(initiative).with_context(context).signature_dates_required? }
+
+          context "when created" do
+            let(:state) { "created" }
+
+            it { is_expected.to eq(false) }
+          end
+
+          context "when published" do
+            it { is_expected.to eq(true) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/spec/shared/update_initiative_answer_example.rb
+++ b/decidim-initiatives/spec/shared/update_initiative_answer_example.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+shared_examples "update an initiative answer" do
+  let(:organization) { create(:organization) }
+  let(:initiative) { create(:initiative, organization: organization, state: state) }
+  let(:form) do
+    form_klass.from_params(
+      form_params
+    ).with_context(
+      current_organization: organization,
+      initiative: initiative
+    )
+  end
+  let(:signature_end_date) { Date.current + 500.days }
+  let(:state) { "published" }
+  let(:form_params) do
+    {
+      signature_start_date: Date.current + 10.days,
+      signature_end_date: signature_end_date,
+      answer: { en: "Measured answer" },
+      answer_url: "http://decidim.org"
+    }
+  end
+  let(:administrator) { create(:user, :admin, organization: organization) }
+  let(:current_user) { administrator }
+  let(:command) { described_class.new(initiative, form, current_user) }
+
+  describe "call" do
+    describe "when the form is not valid" do
+      before do
+        expect(form).to receive(:invalid?).and_return(true)
+      end
+
+      it "broadcasts invalid" do
+        expect { command.call }.to broadcast(:invalid)
+      end
+
+      it "doesn't updates the initiative" do
+        command.call
+
+        form_params.each do |key, value|
+          expect(initiative[key]).not_to eq(value)
+        end
+      end
+    end
+
+    describe "when the form is valid" do
+      it "broadcasts ok" do
+        expect { command.call }.to broadcast(:ok)
+      end
+
+      it "updates the initiative" do
+        command.call
+        initiative.reload
+
+        expect(initiative.answer["en"]).to eq(form_params[:answer][:en])
+        expect(initiative.answer_url).to eq(form_params[:answer_url])
+      end
+
+      context "when initiative is not published" do
+        let(:state) { "validating" }
+
+        it "voting interval remains unchanged" do
+          command.call
+          initiative.reload
+
+          [:signature_start_date, :signature_end_date].each do |key|
+            expect(initiative[key]).not_to eq(form_params[key])
+          end
+        end
+      end
+
+      context "when initiative is published" do
+        it "voting interval is updated" do
+          command.call
+          initiative.reload
+
+          [:signature_start_date, :signature_end_date].each do |key|
+            expect(initiative[key]).to eq(form_params[key])
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/spec/shared/update_initiative_example.rb
+++ b/decidim-initiatives/spec/shared/update_initiative_example.rb
@@ -24,8 +24,6 @@ shared_examples "update an initiative" do
       signature_type: "any",
       type_id: initiative.type.id,
       decidim_scope_id: initiative.scope.id,
-      answer: { en: "Measured answer" },
-      answer_url: "http://decidim.org",
       hashtag: "update_initiative_example",
       offline_votes: 1
     }
@@ -64,9 +62,7 @@ shared_examples "update an initiative" do
 
         expect(initiative.title["en"]).to eq(form_params[:title][:en])
         expect(initiative.description["en"]).to eq(form_params[:description][:en])
-        expect(initiative.answer["en"]).to eq(form_params[:answer][:en])
         expect(initiative.type.id).to eq(form_params[:type_id])
-        expect(initiative.answer_url).to eq(form_params[:answer_url])
         expect(initiative.hashtag).to eq(form_params[:hashtag])
       end
 

--- a/decidim-initiatives/spec/system/admin/answer_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/admin/answer_initiative_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "User answers the initiative", type: :system do
+  include_context "when admins initiative"
+
+  def submit_and_validate
+    find("*[type=submit]").click
+
+    within ".callout-wrapper" do
+      expect(page).to have_content("successfully")
+    end
+  end
+
+  context "when user is author" do
+    before do
+      switch_to_host(organization.host)
+      login_as author, scope: :user
+      visit decidim_admin_initiatives.initiatives_path
+    end
+
+    it "answer is forbidden" do
+      expect(page).to have_no_css(".action-icon--answer")
+
+      visit decidim_admin_initiatives.edit_initiative_answer_path(initiative)
+
+      expect(page).to have_content("You are not authorized")
+    end
+  end
+
+  context "when user is admin" do
+    before do
+      switch_to_host(organization.host)
+      login_as user, scope: :user
+      visit decidim_admin_initiatives.initiatives_path
+    end
+
+    it "answer is allowed" do
+      expect(page).to have_css(".action-icon--answer")
+      page.find(".action-icon--answer").click
+
+      within ".edit_initiative_answer" do
+        fill_in_i18n_editor(
+          :initiative_answer,
+          "#initiative-answer-tabs",
+          en: "An answer",
+          es: "Una respuesta",
+          ca: "Una resposta"
+        )
+      end
+
+      submit_and_validate
+    end
+
+    context "when initiative is in published state" do
+      before do
+        initiative.published!
+      end
+
+      it "signature dates can be edited in answer" do
+        page.find(".action-icon--answer").click
+
+        within ".edit_initiative_answer" do
+          fill_in_i18n_editor(
+            :initiative_answer,
+            "#initiative-answer-tabs",
+            en: "An answer",
+            es: "Una respuesta",
+            ca: "Una resposta"
+          )
+          expect(page).to have_css("#initiative_signature_start_date")
+          expect(page).to have_css("#initiative_signature_end_date")
+
+          fill_in :initiative_signature_start_date, with: 1.day.ago
+        end
+
+        submit_and_validate
+      end
+    end
+
+    context "when initiative is in validating state" do
+      before do
+        initiative.validating!
+      end
+
+      it "signature dates are not displayed" do
+        page.find(".action-icon--answer").click
+
+        within ".edit_initiative_answer" do
+          expect(page).to have_no_css("#initiative_signature_start_date")
+          expect(page).to have_no_css("#initiative_signature_end_date")
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/spec/system/admin/update_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/admin/update_initiative_spec.rb
@@ -107,21 +107,6 @@ describe "User prints the initiative", type: :system do
           initiative.accepted!
         end
 
-        it "updates accepted initiative data" do
-          page.find(".action-icon--edit").click
-          within ".edit_initiative" do
-            fill_in_i18n_editor(
-              :initiative_answer,
-              "#initiative-answer-tabs",
-              ca: "Alguna resposta",
-              en: "Some answer",
-              es: "Alguna respuesta"
-            )
-            fill_in :initiative_answer_url, with: "http://meta.decidim.org"
-          end
-          submit_and_validate
-        end
-
         it "update of type, scope and signature type are disabled" do
           page.find(".action-icon--edit").click
 


### PR DESCRIPTION
#### :tophat: What? Why?
- Moves the management of initiatives answer to a separated form.
- Allows only admins to answer or view the initiative answer form fields.
- Allows to admins the edition of the answer (with blank values permitted), regardless the state of the initiative.
- Removes the answer fields from the admin panel initiative edition form.
- Displays the answer in front if the translated response text is present.
- Uses the answer_url attribute only if present.



#### :pushpin: Related Issues
- Related to #4661

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)

#### Before:

<img width="998" alt="screen shot 2019-02-19 at 20 40 51" src="https://user-images.githubusercontent.com/446459/53042890-8bab4f00-3487-11e9-8c23-4eb9d355079c.png">

#### After:
<img width="1164" alt="screen shot 2019-02-19 at 20 38 37" src="https://user-images.githubusercontent.com/446459/53042888-8bab4f00-3487-11e9-8021-b4fe5f7ed74a.png">
<img width="1183" alt="screen shot 2019-02-19 at 20 39 10" src="https://user-images.githubusercontent.com/446459/53042889-8bab4f00-3487-11e9-8d40-bd2739af3e32.png">


