### PR TITLE
4662 px iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - **decidim-initiatives**: Change permissions of sign_initiative action. [\#4841](https://github.com/decidim/decidim/pull/4841)
 - **decidim-initiatives**: Allow edition of type, scope and signature type of initiatives depending on state and user. [\#4861](https://github.com/decidim/decidim/pull/4861)
 - **decidim-initiatives**: Move edition of initiatives answer to a separated form in admin panel and shows answer in front if present for any state. [\#4881](https://github.com/decidim/decidim/pull/4881)
+- **decidim-initiatives**: Change initiative type selection step view to display options using tabs. [\#4884](https://github.com/decidim/decidim/pull/4884)
 
 **Fixed**:
 

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/select_initiative_type.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/select_initiative_type.html.erb
@@ -1,3 +1,4 @@
+<% default_type = available_initiative_types.first %>
 <% content_for :back_link do %>
   <%= link_to initiatives_path do %>
     <%= icon "chevron-left", class: "icon--small" %>
@@ -12,28 +13,42 @@
   </div>
 </div>
 <br />
-<section id="initiative-types-grid" class="section row collapse">
-  <div class="row small-up-1 medium-up-2 large-up-3 card-grid">
-    <% initiative_types_each do |type| %>
-      <div class="column">
-        <article class="card card--initiative-type">
-          <div class="card__content">
-            <div class="card__header">
-              <h5 class="card__title"><%= translated_attribute type.title %></h5>
-            </div>
-            <%= raw translated_attribute type.description %>
-          </div>
-          <div class="card__footer">
-            <div class="card__support">
-              <div class="card__support__data"></div>
-              <%= decidim_form_for(@form, url: next_wizard_path, method: :put, html: { class: "form select-initiative_type-form" }) do |f| %>
-                <%= f.hidden_field :type_id, value: type.id %>
-                <%= f.submit t(".select"), class: "button small secondary card__button" %>
-              <% end %>
-            </div>
-          </div>
-        </article>
+<div class="row column">
+  <div class="main-container">
+    <div class="row collapse main-container--side-panel">
+      <div class="columns medium-4 large-3">
+        <div class="side-panel">
+          <ul class="tabs vertical side-panel__tabs" id="initiatives-tabs" data-tabs>
+            <% initiative_types_each do |type| %>
+              <li class="tabs-title <%= "is-active" if type == default_type %>">
+                <%= link_to "#initiativeType#{type.id}" do %>
+                  <%# Quiero crear un <strong><%= translated_attribute type.title %1></strong> %>
+                  <%= t(".choose_html", title: translated_attribute(type.title)) %>
+                <% end %>
+              </li>
+            <% end %>
+          </ul>
+        </div>
       </div>
-    <% end %>
+      <div class="columns medium-8 large-9">
+        <div class="main-container__content">
+          <div class="tabs-content vertical" data-tabs-content="initiatives-tabs">
+            <% initiative_types_each do |type| %>
+              <div class="tabs-panel <%= "is-active" if type == default_type %>" id="<%= "initiativeType#{type.id}" %>">
+                <h2 class="section-heading"><%= translated_attribute(type.title) %></h2>
+                <div>
+                  <%= raw translated_attribute type.description %>
+                </div>
+                <br />
+                <%= decidim_form_for(@form, url: next_wizard_path, method: :put, html: { id: "new_initiative_#{type.id}", class: "form select-initiative_type-form" }) do |f| %>
+                  <%= f.hidden_field :type_id, value: type.id, id: "initiative_type_id_#{ type.id }" %>
+                  <%= f.submit t(".select"), class: "button" %>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
-</section>
+</div>

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -285,8 +285,9 @@ en:
           more_information: "(More information)"
         select_initiative_type:
           back: Back
+          choose_html: I want to create a <strong>%{title}</strong>
           more_information: "(More information)"
-          select: Choose
+          select: I want to promote this initiative
           select_initiative_type_help: Citizen initiatives are a means by which the citizenship can intervene so that the City Council can undertake actions in defence of the general interest that are within fields of municipal jurisdiction. Which initiative do you want to launch?
         share_committee_link:
           continue: Continue

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -69,7 +69,7 @@ describe "Initiative", type: :system do
 
       context "and fill basic data" do
         before do
-          find_button("Choose").click
+          find_button("I want to promote this initiative").click
         end
 
         it "Has a hidden field with the selected initiative type" do
@@ -93,7 +93,7 @@ describe "Initiative", type: :system do
         let!(:initiative) { create(:initiative, organization: organization) }
 
         before do
-          find_button("Choose").click
+          find_button("I want to promote this initiative").click
           fill_in "Title", with: translated(initiative.title, locale: :en)
           fill_in_editor "initiative_description", with: translated(initiative.description, locale: :en)
           find_button("Continue").click
@@ -122,7 +122,7 @@ describe "Initiative", type: :system do
         let(:initiative) { build(:initiative) }
 
         before do
-          find_button("Choose").click
+          find_button("I want to promote this initiative").click
           fill_in "Title", with: translated(initiative.title, locale: :en)
           fill_in_editor "initiative_description", with: translated(initiative.description, locale: :en)
           find_button("Continue").click
@@ -151,7 +151,7 @@ describe "Initiative", type: :system do
         let(:initiative) { build(:initiative, organization: organization, scoped_type: initiative_type_scope) }
 
         before do
-          find_button("Choose").click
+          find_button("I want to promote this initiative").click
 
           fill_in "Title", with: translated(initiative.title, locale: :en)
           fill_in_editor "initiative_description", with: translated(initiative.description, locale: :en)
@@ -194,7 +194,7 @@ describe "Initiative", type: :system do
         let(:initiative) { build(:initiative) }
 
         before do
-          find_button("Choose").click
+          find_button("I want to promote this initiative").click
 
           fill_in "Title", with: translated(initiative.title, locale: :en)
           fill_in_editor "initiative_description", with: translated(initiative.description, locale: :en)


### PR DESCRIPTION
#### :tophat: What? Why?
- Replaces the current initiative type selection step view using cards for each initiative with one using tabs

#### :pushpin: Related Issues
- Related to #4662

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)

#### Before

<img width="1056" alt="screen shot 2019-02-20 at 13 43 45" src="https://user-images.githubusercontent.com/446459/53092653-97dded80-3515-11e9-85bb-4e59c496f5dd.png">

#### After

<img width="1038" alt="screen shot 2019-02-20 at 13 41 51" src="https://user-images.githubusercontent.com/446459/53092652-97455700-3515-11e9-880c-c707cf8d0508.png">