### PR TITLE
Avoid author duplication from authors lists including committee members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
 - **decidim-core**: Fix process filters [\#4872](https://github.com/decidim/decidim/pull/4872)
 - **decidim-debates** Fix debates card and ordering [\#4879](https://github.com/decidim/decidim/pull/4879)
 - **decidim-proposals** Don't count withdrawn proposals when publishing one [\#4875](https://github.com/decidim/decidim/pull/4875)
+- **decidim-initiatives** Fix author duplicated appearance in some initiatives authors lists. [\#4885](https://github.com/decidim/decidim/pull/4885)
 
 **Removed**:
 

--- a/decidim-initiatives/app/cells/decidim/initiatives/initiative_m_cell.rb
+++ b/decidim-initiatives/app/cells/decidim/initiatives/initiative_m_cell.rb
@@ -38,7 +38,7 @@ module Decidim
 
       def authors
         [present(model).author] +
-          model.committee_members.approved.non_deleted.map { |member| present(member.user) }
+          model.committee_members.approved.non_deleted.excluding_author.map { |member| present(member.user) }
       end
     end
   end

--- a/decidim-initiatives/app/models/decidim/initiatives_committee_member.rb
+++ b/decidim-initiatives/app/models/decidim/initiatives_committee_member.rb
@@ -19,5 +19,6 @@ module Decidim
 
     scope :approved, -> { where(state: :accepted) }
     scope :non_deleted, -> { includes(:user).where(decidim_users: { deleted_at: nil }) }
+    scope :excluding_author, -> { joins(:initiative).where.not("decidim_users_id = decidim_author_id") }
   end
 end

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_author.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_author.html.erb
@@ -15,7 +15,7 @@
       </span>
     </div>
 
-    <% initiative.committee_members.approved.each do |m| %>
+    <% initiative.committee_members.excluding_author.approved.each do |m| %>
       <% unless m.user.deleted? %>
         <div class="author author--inline">
           <span class="author__avatar author__avatar--small">

--- a/decidim-initiatives/spec/system/initiative_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_spec.rb
@@ -40,6 +40,12 @@ describe "Initiative", type: :system do
       end
     end
 
+    it "shows the author name once in the authors list" do
+      within ".initiative-authors" do
+        expect(page).to have_content(initiative.author_name, count: 1)
+      end
+    end
+
     it_behaves_like "has attachments"
   end
 end

--- a/decidim-initiatives/spec/system/initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/initiatives_spec.rb
@@ -50,6 +50,7 @@ describe "Initiatives", type: :system do
 
       within "#initiatives" do
         expect(page).to have_content(translated(initiative.title, locale: :en))
+        expect(page).to have_content(initiative.author_name, count: 1)
         expect(page).not_to have_content(translated(unpublished_initiative.title, locale: :en))
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
- Avoids the appearance of the author of an initiative in authors list when the author belongs to committee

#### :pushpin: Related Issues
- Related to #4661

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)

#### Before

<img width="388" alt="screen shot 2019-02-20 at 14 34 34" src="https://user-images.githubusercontent.com/446459/53096200-dd52e880-351e-11e9-8154-46fd0cf97b67.png">

#### After

<img width="362" alt="screen shot 2019-02-20 at 14 34 04" src="https://user-images.githubusercontent.com/446459/53096198-dd52e880-351e-11e9-83dd-0a38a170740b.png">
