### PR TITLE
Corrected resource links in notification emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
 - **decidim-core**: Fix process filters [\#4872](https://github.com/decidim/decidim/pull/4872)
 - **decidim-debates** Fix debates card and ordering [\#4879](https://github.com/decidim/decidim/pull/4879)
 - **decidim-proposals** Don't count withdrawn proposals when publishing one [\#4875](https://github.com/decidim/decidim/pull/4875)
+- **decidim-initiatives** Fix author duplicated appearance in some initiatives authors lists. [\#4885](https://github.com/decidim/decidim/pull/4885)
 
 **Removed**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - **decidim-initiatives**: Change permissions of sign_initiative action. [\#4841](https://github.com/decidim/decidim/pull/4841)
 - **decidim-initiatives**: Allow edition of type, scope and signature type of initiatives depending on state and user. [\#4861](https://github.com/decidim/decidim/pull/4861)
 - **decidim-initiatives**: Move edition of initiatives answer to a separated form in admin panel and shows answer in front if present for any state. [\#4881](https://github.com/decidim/decidim/pull/4881)
+- **decidim-initiatives**: Change initiative type selection step view to display options using tabs. [\#4884](https://github.com/decidim/decidim/pull/4884)
 
 **Fixed**:
 

--- a/decidim-admin/app/events/decidim/attachment_created_event.rb
+++ b/decidim-admin/app/events/decidim/attachment_created_event.rb
@@ -19,13 +19,9 @@ module Decidim
       )
     end
 
-    def url_host=(host)
-      @url_host = host
-    end
+    attr_writer :url_host
 
-    def url_host
-      @url_host
-    end
+    attr_reader :url_host
 
     private
 

--- a/decidim-admin/app/events/decidim/attachment_created_event.rb
+++ b/decidim-admin/app/events/decidim/attachment_created_event.rb
@@ -19,6 +19,14 @@ module Decidim
       )
     end
 
+    def set_url_host(host)
+      @url_host = host
+    end
+
+    def get_url_host
+      @url_host
+    end
+
     private
 
     def attached_to_url

--- a/decidim-admin/app/events/decidim/attachment_created_event.rb
+++ b/decidim-admin/app/events/decidim/attachment_created_event.rb
@@ -19,10 +19,6 @@ module Decidim
       )
     end
 
-    attr_writer :url_host
-
-    attr_reader :url_host
-
     private
 
     def attached_to_url

--- a/decidim-admin/app/events/decidim/attachment_created_event.rb
+++ b/decidim-admin/app/events/decidim/attachment_created_event.rb
@@ -19,11 +19,11 @@ module Decidim
       )
     end
 
-    def set_url_host(host)
+    def url_host=(host)
       @url_host = host
     end
 
-    def get_url_host
+    def url_host
       @url_host
     end
 

--- a/decidim-core/app/events/decidim/welcome_notification_event.rb
+++ b/decidim-core/app/events/decidim/welcome_notification_event.rb
@@ -43,6 +43,10 @@ module Decidim
       nil
     end
 
+    attr_writer :url_host
+
+    attr_reader :url_host
+
     private
 
     def interpolate(template)

--- a/decidim-core/app/mailers/decidim/notification_mailer.rb
+++ b/decidim-core/app/mailers/decidim/notification_mailer.rb
@@ -13,6 +13,7 @@ module Decidim
         @organization = user.organization
         event_class = event_class_name.constantize
         @event_instance = event_class.new(resource: resource, event_name: event, user: user, extra: extra, user_role: user_role)
+        @event_instance.set_url_host("https://"+@organization.host)
         subject = @event_instance.email_subject
 
         mail(to: user.email, subject: subject)

--- a/decidim-core/app/mailers/decidim/notification_mailer.rb
+++ b/decidim-core/app/mailers/decidim/notification_mailer.rb
@@ -13,7 +13,7 @@ module Decidim
         @organization = user.organization
         event_class = event_class_name.constantize
         @event_instance = event_class.new(resource: resource, event_name: event, user: user, extra: extra, user_role: user_role)
-        @event_instance.set_url_host("https://" + @organization.host)
+        @event_instance.url_host = "https://" + @organization.host
         subject = @event_instance.email_subject
 
         mail(to: user.email, subject: subject)

--- a/decidim-core/app/mailers/decidim/notification_mailer.rb
+++ b/decidim-core/app/mailers/decidim/notification_mailer.rb
@@ -13,7 +13,7 @@ module Decidim
         @organization = user.organization
         event_class = event_class_name.constantize
         @event_instance = event_class.new(resource: resource, event_name: event, user: user, extra: extra, user_role: user_role)
-        @event_instance.set_url_host("https://"+@organization.host)
+        @event_instance.set_url_host("https://" + @organization.host)
         subject = @event_instance.email_subject
 
         mail(to: user.email, subject: subject)

--- a/decidim-core/app/views/decidim/notification_mailer/event_received.html.erb
+++ b/decidim-core/app/views/decidim/notification_mailer/event_received.html.erb
@@ -12,7 +12,7 @@
 
 <% if @event_instance.resource_path.present? && @event_instance.resource_title.present? %>
   <p>
-    <%= link_to @event_instance.resource_title, @event_instance.resource_url %>
+    <%= link_to @event_instance.resource_title, (@event_instance.get_url_host+@event_instance.resource_url) %>
   </p>
 <% end %>
 

--- a/decidim-core/app/views/decidim/notification_mailer/event_received.html.erb
+++ b/decidim-core/app/views/decidim/notification_mailer/event_received.html.erb
@@ -12,7 +12,7 @@
 
 <% if @event_instance.resource_path.present? && @event_instance.resource_title.present? %>
   <p>
-    <%= link_to @event_instance.resource_title, (@event_instance.get_url_host+@event_instance.resource_url) %>
+    <%= link_to @event_instance.resource_title, (@event_instance.url_host + @event_instance.resource_url) %>
   </p>
 <% end %>
 

--- a/decidim-core/lib/decidim/events/simple_event.rb
+++ b/decidim-core/lib/decidim/events/simple_event.rb
@@ -97,6 +97,10 @@ module Decidim
         nil
       end
 
+      attr_writer :url_host
+
+      attr_reader :url_host
+
       private
 
       def event_interpolations

--- a/decidim-initiatives/app/cells/decidim/initiatives/initiative_m_cell.rb
+++ b/decidim-initiatives/app/cells/decidim/initiatives/initiative_m_cell.rb
@@ -38,7 +38,7 @@ module Decidim
 
       def authors
         [present(model).author] +
-          model.committee_members.approved.non_deleted.map { |member| present(member.user) }
+          model.committee_members.approved.non_deleted.excluding_author.map { |member| present(member.user) }
       end
     end
   end

--- a/decidim-initiatives/app/models/decidim/initiatives_committee_member.rb
+++ b/decidim-initiatives/app/models/decidim/initiatives_committee_member.rb
@@ -19,5 +19,6 @@ module Decidim
 
     scope :approved, -> { where(state: :accepted) }
     scope :non_deleted, -> { includes(:user).where(decidim_users: { deleted_at: nil }) }
+    scope :excluding_author, -> { joins(:initiative).where.not("decidim_users_id = decidim_author_id") }
   end
 end

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/select_initiative_type.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/select_initiative_type.html.erb
@@ -1,3 +1,4 @@
+<% default_type = available_initiative_types.first %>
 <% content_for :back_link do %>
   <%= link_to initiatives_path do %>
     <%= icon "chevron-left", class: "icon--small" %>
@@ -12,28 +13,42 @@
   </div>
 </div>
 <br />
-<section id="initiative-types-grid" class="section row collapse">
-  <div class="row small-up-1 medium-up-2 large-up-3 card-grid">
-    <% initiative_types_each do |type| %>
-      <div class="column">
-        <article class="card card--initiative-type">
-          <div class="card__content">
-            <div class="card__header">
-              <h5 class="card__title"><%= translated_attribute type.title %></h5>
-            </div>
-            <%= raw translated_attribute type.description %>
-          </div>
-          <div class="card__footer">
-            <div class="card__support">
-              <div class="card__support__data"></div>
-              <%= decidim_form_for(@form, url: next_wizard_path, method: :put, html: { class: "form select-initiative_type-form" }) do |f| %>
-                <%= f.hidden_field :type_id, value: type.id %>
-                <%= f.submit t(".select"), class: "button small secondary card__button" %>
-              <% end %>
-            </div>
-          </div>
-        </article>
+<div class="row column">
+  <div class="main-container">
+    <div class="row collapse main-container--side-panel">
+      <div class="columns medium-4 large-3">
+        <div class="side-panel">
+          <ul class="tabs vertical side-panel__tabs" id="initiatives-tabs" data-tabs>
+            <% initiative_types_each do |type| %>
+              <li class="tabs-title <%= "is-active" if type == default_type %>">
+                <%= link_to "#initiativeType#{type.id}" do %>
+                  <%# Quiero crear un <strong><%= translated_attribute type.title %1></strong> %>
+                  <%= t(".choose_html", title: translated_attribute(type.title)) %>
+                <% end %>
+              </li>
+            <% end %>
+          </ul>
+        </div>
       </div>
-    <% end %>
+      <div class="columns medium-8 large-9">
+        <div class="main-container__content">
+          <div class="tabs-content vertical" data-tabs-content="initiatives-tabs">
+            <% initiative_types_each do |type| %>
+              <div class="tabs-panel <%= "is-active" if type == default_type %>" id="<%= "initiativeType#{type.id}" %>">
+                <h2 class="section-heading"><%= translated_attribute(type.title) %></h2>
+                <div>
+                  <%= raw translated_attribute type.description %>
+                </div>
+                <br />
+                <%= decidim_form_for(@form, url: next_wizard_path, method: :put, html: { id: "new_initiative_#{type.id}", class: "form select-initiative_type-form" }) do |f| %>
+                  <%= f.hidden_field :type_id, value: type.id, id: "initiative_type_id_#{ type.id }" %>
+                  <%= f.submit t(".select"), class: "button" %>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
-</section>
+</div>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_author.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_author.html.erb
@@ -15,7 +15,7 @@
       </span>
     </div>
 
-    <% initiative.committee_members.approved.each do |m| %>
+    <% initiative.committee_members.excluding_author.approved.each do |m| %>
       <% unless m.user.deleted? %>
         <div class="author author--inline">
           <span class="author__avatar author__avatar--small">

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -285,8 +285,9 @@ en:
           more_information: "(More information)"
         select_initiative_type:
           back: Back
+          choose_html: I want to create a <strong>%{title}</strong>
           more_information: "(More information)"
-          select: Choose
+          select: I want to promote this initiative
           select_initiative_type_help: Citizen initiatives are a means by which the citizenship can intervene so that the City Council can undertake actions in defence of the general interest that are within fields of municipal jurisdiction. Which initiative do you want to launch?
         share_committee_link:
           continue: Continue

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -69,7 +69,7 @@ describe "Initiative", type: :system do
 
       context "and fill basic data" do
         before do
-          find_button("Choose").click
+          find_button("I want to promote this initiative").click
         end
 
         it "Has a hidden field with the selected initiative type" do
@@ -93,7 +93,7 @@ describe "Initiative", type: :system do
         let!(:initiative) { create(:initiative, organization: organization) }
 
         before do
-          find_button("Choose").click
+          find_button("I want to promote this initiative").click
           fill_in "Title", with: translated(initiative.title, locale: :en)
           fill_in_editor "initiative_description", with: translated(initiative.description, locale: :en)
           find_button("Continue").click
@@ -122,7 +122,7 @@ describe "Initiative", type: :system do
         let(:initiative) { build(:initiative) }
 
         before do
-          find_button("Choose").click
+          find_button("I want to promote this initiative").click
           fill_in "Title", with: translated(initiative.title, locale: :en)
           fill_in_editor "initiative_description", with: translated(initiative.description, locale: :en)
           find_button("Continue").click
@@ -151,7 +151,7 @@ describe "Initiative", type: :system do
         let(:initiative) { build(:initiative, organization: organization, scoped_type: initiative_type_scope) }
 
         before do
-          find_button("Choose").click
+          find_button("I want to promote this initiative").click
 
           fill_in "Title", with: translated(initiative.title, locale: :en)
           fill_in_editor "initiative_description", with: translated(initiative.description, locale: :en)
@@ -194,7 +194,7 @@ describe "Initiative", type: :system do
         let(:initiative) { build(:initiative) }
 
         before do
-          find_button("Choose").click
+          find_button("I want to promote this initiative").click
 
           fill_in "Title", with: translated(initiative.title, locale: :en)
           fill_in_editor "initiative_description", with: translated(initiative.description, locale: :en)

--- a/decidim-initiatives/spec/system/initiative_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_spec.rb
@@ -40,6 +40,12 @@ describe "Initiative", type: :system do
       end
     end
 
+    it "shows the author name once in the authors list" do
+      within ".initiative-authors" do
+        expect(page).to have_content(initiative.author_name, count: 1)
+      end
+    end
+
     it_behaves_like "has attachments"
   end
 end

--- a/decidim-initiatives/spec/system/initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/initiatives_spec.rb
@@ -50,6 +50,7 @@ describe "Initiatives", type: :system do
 
       within "#initiatives" do
         expect(page).to have_content(translated(initiative.title, locale: :en))
+        expect(page).to have_content(initiative.author_name, count: 1)
         expect(page).not_to have_content(translated(unpublished_initiative.title, locale: :en))
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Notification emails on new file attachment had a worng url link in multitenant environments. These links had not the servername.
This PR corrects this problem.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
