### PR TITLE
4662 create initiative wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - **decidim-initiatives**: Allow edition of type, scope and signature type of initiatives depending on state and user. [\#4861](https://github.com/decidim/decidim/pull/4861)
 - **decidim-initiatives**: Move edition of initiatives answer to a separated form in admin panel and shows answer in front if present for any state. [\#4881](https://github.com/decidim/decidim/pull/4881)
 - **decidim-initiatives**: Change initiative type selection step view to display options using tabs. [\#4884](https://github.com/decidim/decidim/pull/4884)
+- **decidim-initiatives**: Change initiative creation wizard layout. [\#4888](https://github.com/decidim/decidim/pull/4888)
 
 **Fixed**:
 

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 
 <div class="row column">
-  <div class="column large-6 medium-centered">
+  <div class="medium-centered">
     <div class="callout secondary">
       <%== t ".fill_data_help" %>
       <%= link_to t(".more_information"), decidim.page_path("initiatives"), target: "_blank" %>.
@@ -15,7 +15,7 @@
 </div>
 <br />
 <div class="row">
-  <div class="columns large-6 medium-centered">
+  <div class="medium-centered">
     <div class="card">
       <div class="card__content">
         <%= decidim_form_for(@form, url: next_wizard_path, method: :put, html: { class: "form new_initiative_form" }) do |f| %>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/finish.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/finish.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 
 <div class="row column">
-  <div class="column large-6 medium-centered">
+  <div class="medium-centered">
     <div class="callout secondary">
       <%= t ".callout_text" %>
       <%= link_to t(".more_information"), decidim.page_path("initiatives"), target: "_blank" %>
@@ -15,7 +15,7 @@
 </div>
 <br />
 <div class="row">
-    <div class="columns large-6 small-12 medium-centered">
+    <div class="small-12 medium-centered">
       <div class="card">
         <div class="card__content">
           <%= render partial: "finish_help" %>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/previous_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/previous_form.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 
 <div class="row">
-  <div class="column large-6 medium-centered">
+  <div class="medium-centered">
     <div class="callout secondary">
       <%= t ".help" %>
       <%= link_to t(".more_information"), decidim.page_path("initiatives"), target: "_blank" %>.
@@ -15,7 +15,7 @@
 </div>
 <br />
 <div class="row">
-  <div class="columns large-6 medium-centered">
+  <div class="medium-centered">
     <div class="card">
       <div class="card__content">
         <%= decidim_form_for(@form, url: next_wizard_path, method: :put, html: { class: "form new_initiative_previous_form" }) do |f| %>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/promotal_committee.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/promotal_committee.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 
 <div class="row column">
-  <div class="column large-6 medium-centered">
+  <div class="medium-centered">
     <div class="callout secondary">
       <%= t ".individual_help_text", committee_size: current_initiative.minimum_committee_members %>
       <%= link_to t(".more_information"), decidim.page_path("initiatives"), target: "_blank" %>.
@@ -15,7 +15,7 @@
 </div>
 <br />
 <div class="row">
-  <div class="columns large-6 small-12 medium-centered">
+  <div class="small-12 medium-centered">
     <%= render partial: "share_committee_link" %>
   </div>
 </div>

--- a/decidim-initiatives/app/views/layouts/decidim/_initiative_creation_header.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/_initiative_creation_header.html.erb
@@ -1,37 +1,27 @@
-<div class="process-header">
-  <div class="process-header__inner">
-    <div class="row column process-header__main">
-    </div>
-    <div class="process-header__container initiative-creation-header__container row collapse column">
-      <div class="columns mediumlarge-8 process-header__info">
-        <% if content_for? :back_link %>
-          <%= content_for :back_link %>
+<div class="columns large-3">
+  <div class="m-bottom">
+    <%= link_to :back do %>
+      <%= icon "chevron-left", class: "icon--small" %> <%= t(".back") %>
+    <% end %>
+  </div>
+  <div class="section">
+    <p>
+      <%= t(".title") %>
+    </p>
+  </div>
+  <div class="show-for-large">
+    <ol class="wizard__steps">
+      <% wizard_steps.each do |wizard_step| %>
+        <% if step == wizard_step %>
+          <li class="step--active">
+            <%= t(".#{wizard_step}") %>
+          </li>
+        <% else %>
+          <li>
+            <%= t(".#{wizard_step}") %>
+          </li>
         <% end %>
-
-        <h1 class="text-highlight heading2"><%= t(".title") %></h1>
-      </div>
-      <div class="columns mediumlarge-4">
-        <div class="process-header__phase initiative-creation-header__phase">
-          <div class="process-header__progress show-for-medium">
-            <ol>
-              <% wizard_steps.each do |wizard_step| %>
-                <% unless future_step? wizard_step %>
-                  <li class="phase-item--past">
-                    <span></span>
-                  </li>
-                <% else %>
-                  <li>
-                    <span></span>
-                  </li>
-                <% end %>
-              <% end %>
-              <% step_index = wizard_steps.index(step) %>
-            </ol>
-            <span class="phase-current"><%= t(".step", current: (step_index + 1), total: wizard_steps.length) %></span>
-            <span class="phase-title"><%= t(".#{step}") %></span>
-          </div>
-        </div>
-      </div>
-    </div>
+      <% end %>
+    </ol>
   </div>
 </div>

--- a/decidim-initiatives/app/views/layouts/decidim/initiative_creation.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/initiative_creation.html.erb
@@ -1,7 +1,19 @@
 <%= render "layouts/decidim/application" do %>
-  <%= render partial: "layouts/decidim/initiative_creation_header" %>
-  <div class="wrapper">
+  <% if wizard_steps.first == step %>
+    <div class="wrapper">
     <%= yield %>
-  </div>
+    </div>
+    </div>
+  <% else %>
+    <div class="wrapper">
+      <div class="row">
+        <%= render partial: "layouts/decidim/initiative_creation_header" %>
+        <div class="columns large-6">
+          <%= yield %>
+        </div>
+        <div class="columns large-3"></div>
+      </div>
+    </div>
+  <% end %>
   <%= javascript_include_tag "decidim/initiatives/application" %>
 <% end %>

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -441,6 +441,7 @@ en:
           components: Components
           information: Information
       initiative_creation_header:
+        back: Back
         fill_data: Create
         finish: Finish
         previous_form: Start

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -184,8 +184,10 @@ describe "Initiative", type: :system do
           let(:initiative_type_minimum_committee_members) { 0 }
 
           it "skips to next step" do
-            expect(page).not_to have_content("Promoter committee")
-            expect(page).to have_content("Finish")
+            within(".step--active") do
+              expect(page).not_to have_content("Promoter committee")
+              expect(page).to have_content("Finish")
+            end
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
- Replaces the layout of create initiative wizard displaying steps in a column at the left of the page
- The steps are not shown for the first wizard step, the initiative type selection

#### :pushpin: Related Issues
- Related to #4662

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)

#### Before

<img width="1089" alt="screen shot 2019-02-21 at 09 06 14" src="https://user-images.githubusercontent.com/446459/53153306-42a6e800-35b8-11e9-9516-a0b787e73d3f.png">
<img width="1033" alt="screen shot 2019-02-21 at 09 06 34" src="https://user-images.githubusercontent.com/446459/53153308-42a6e800-35b8-11e9-8c81-4520dcc0d16f.png">
<img width="1028" alt="screen shot 2019-02-21 at 09 06 45" src="https://user-images.githubusercontent.com/446459/53153309-433f7e80-35b8-11e9-90a1-5f7c481eca4e.png">
<img width="1065" alt="screen shot 2019-02-21 at 09 07 13" src="https://user-images.githubusercontent.com/446459/53153310-433f7e80-35b8-11e9-8451-bec6c58e97ca.png">
<img width="1050" alt="screen shot 2019-02-21 at 09 07 28" src="https://user-images.githubusercontent.com/446459/53153311-433f7e80-35b8-11e9-821c-443797db4b90.png">
<img width="1033" alt="screen shot 2019-02-21 at 09 07 38" src="https://user-images.githubusercontent.com/446459/53153312-433f7e80-35b8-11e9-8785-07be6ac2b4aa.png">

#### After

<img width="1167" alt="screen shot 2019-02-21 at 09 03 53" src="https://user-images.githubusercontent.com/446459/53153336-55b9b800-35b8-11e9-919f-bef9e4e0c40a.png">
<img width="1098" alt="screen shot 2019-02-21 at 09 04 08" src="https://user-images.githubusercontent.com/446459/53153338-56524e80-35b8-11e9-85f0-0a17d22138a2.png">
<img width="960" alt="screen shot 2019-02-21 at 09 04 31" src="https://user-images.githubusercontent.com/446459/53153339-56524e80-35b8-11e9-886b-b48071cb5835.png">
<img width="1034" alt="screen shot 2019-02-21 at 09 05 00" src="https://user-images.githubusercontent.com/446459/53153340-56524e80-35b8-11e9-89ab-53aea9d15435.png">
<img width="1022" alt="screen shot 2019-02-21 at 09 05 18" src="https://user-images.githubusercontent.com/446459/53153341-56eae500-35b8-11e9-9eac-036b25b11621.png">
<img width="1084" alt="screen shot 2019-02-21 at 09 05 30" src="https://user-images.githubusercontent.com/446459/53153342-57837b80-35b8-11e9-9a7a-a7dac21bdb18.png">

