### PR TITLE
Refactor private space checks

### DIFF
--- a/decidim-assemblies/app/models/decidim/assembly.rb
+++ b/decidim-assemblies/app/models/decidim/assembly.rb
@@ -112,8 +112,9 @@ module Decidim
 
     def can_participate?(user)
       return true unless private_space?
-      return true if private_space? && users.include?(user)
-      return false if private_space? && is_transparent?
+      return false unless user
+
+      users.include?(user)
     end
 
     def translated_title

--- a/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
+++ b/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
@@ -82,15 +82,17 @@ module Decidim
                       [:assembly, :participatory_space].include?(permission_action.subject) &&
                       assembly
 
-        return disallow! if cannot_view_private_space
+        return disallow! unless can_view_private_space?
         return allow! if user&.admin?
         return allow! if assembly.published?
         toggle_allow(can_manage_assembly?)
       end
 
-      def cannot_view_private_space
-        return unless assembly.private_space && !assembly.is_transparent
-        !user || !user.admin && !assembly.users.include?(user)
+      def can_view_private_space?
+        return true unless assembly.private_space && !assembly.is_transparent?
+        return false unless user
+
+        user.admin || assembly.users.include?(user)
       end
 
       def public_list_members_action?

--- a/decidim-core/app/controllers/concerns/decidim/participatory_space_context.rb
+++ b/decidim-core/app/controllers/concerns/decidim/participatory_space_context.rb
@@ -63,12 +63,11 @@ module Decidim
 
     # Method for current user can visit the space (assembly or proces)
     def current_user_can_visit_space?
-      current_user&.admin ||
-        (current_participatory_space.try(:private_space?) &&
-         current_participatory_space.users.include?(current_user)) ||
-        !current_participatory_space.try(:private_space?) ||
-        (current_participatory_space.try(:private_space?) &&
-         current_participatory_space.try(:is_transparent?))
+      return true unless current_participatory_space.try(:private_space?) &&
+                         !current_participatory_space.try(:is_transparent?)
+      return false unless current_user
+
+      current_user.admin || current_participatory_space.users.include?(current_user)
     end
 
     def check_current_user_can_visit_space

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -111,17 +111,9 @@ module Decidim
         followers
       end
 
-      # rubocop:disable Metrics/PerceivedComplexity,Metrics/CyclomaticComplexity
       def can_participate?(user)
-        return true unless participatory_space.try(:private_space?) || private_meeting?
-        return true if (participatory_space.try(:private_space?) &&
-                        participatory_space.users.include?(user)) ||
-                       (private_meeting? && registrations.exists?(decidim_user_id: user.try(:id)))
-        return false if (participatory_space.try(:private_space?) &&
-                        participatory_space.try(:transparent?)) ||
-                        (private_meeting? && transparent?)
+        can_participate_in_space?(user) && can_participate_in_meeting?(user)
       end
-      # rubocop:enable Metrics/PerceivedComplexity,Metrics/CyclomaticComplexity
 
       def organizer_belongs_to_organization
         return if !organizer || !organization
@@ -160,6 +152,22 @@ module Decidim
         return false unless pad_is_visible?
 
         (Time.current - end_time) < 72.hours
+      end
+
+      private
+
+      def can_participate_in_space?(user)
+        return true unless participatory_space.try(:private_space?)
+        return false unless user
+
+        participatory_space.users.include?(user)
+      end
+
+      def can_participate_in_meeting?(user)
+        return true unless private_meeting?
+        return false unless user
+
+        registrations.exists?(decidim_user_id: user.id)
       end
     end
   end

--- a/decidim-participatory_processes/app/models/decidim/participatory_process.rb
+++ b/decidim-participatory_processes/app/models/decidim/participatory_process.rb
@@ -101,8 +101,9 @@ module Decidim
 
     def can_participate?(user)
       return true unless private_space?
-      return true if private_space? && users.include?(user)
-      false
+      return false unless user
+
+      users.include?(user)
     end
 
     # Overrides the method from `Participable`.

--- a/decidim-participatory_processes/app/permissions/decidim/participatory_processes/permissions.rb
+++ b/decidim-participatory_processes/app/permissions/decidim/participatory_processes/permissions.rb
@@ -101,15 +101,17 @@ module Decidim
                       [:process, :participatory_space].include?(permission_action.subject) &&
                       process
 
-        return disallow! if cannot_view_private_space
+        return disallow! unless can_view_private_space?
         return allow! if user&.admin?
         return allow! if process.published?
         toggle_allow(can_manage_process?)
       end
 
-      def cannot_view_private_space
-        return unless process.private_space
-        !user || !user.admin && !process.users.include?(user)
+      def can_view_private_space?
+        return true unless process.private_space
+        return false unless user
+
+        user.admin || process.users.include?(user)
       end
 
       def public_report_content_action?


### PR DESCRIPTION
#### :tophat: What? Why?
When working with private spaces, is very difficult to follow the code that perform checks for visibility and participation for an specific user on a participatory process, assembly or meeting. The code is complex and there is a lack of coherence between methods that perform the same type of comparison. 

IMHO, this methods can be simplified very much with the following pattern, and that is what I do in this PR:

```ruby
def can_view?(user)
  return true unless private?¹
  return false unless user
  user.admin? || in_list_of_users?(user)
end

def can_participate?(user)
  return true unless private?
  return false unless user
  in_list_of_users?(user)
end
```
¹ In case of an assembly, this condition should also check if it's not transparent.

#### :pushpin: Related Issues
- Related to #3438
- Related to #4591

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
