### PR TITLE
Fix cells translations

### DIFF
--- a/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_cell.rb
+++ b/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_cell.rb
@@ -4,7 +4,6 @@ module Decidim
   module Assemblies
     module ContentBlocks
       class HighlightedAssembliesCell < Decidim::ViewModel
-        delegate :current_organization, to: :controller
         delegate :current_user, to: :controller
 
         def show

--- a/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_cell.rb
+++ b/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_cell.rb
@@ -4,7 +4,6 @@ module Decidim
   module Conferences
     module ContentBlocks
       class HighlightedConferencesCell < Decidim::ViewModel
-        delegate :current_organization, to: :controller
         delegate :current_user, to: :controller
 
         def show

--- a/decidim-consultations/app/cells/decidim/consultations/content_blocks/highlighted_consultations_cell.rb
+++ b/decidim-consultations/app/cells/decidim/consultations/content_blocks/highlighted_consultations_cell.rb
@@ -4,7 +4,6 @@ module Decidim
   module Consultations
     module ContentBlocks
       class HighlightedConsultationsCell < Decidim::ViewModel
-        delegate :current_organization, to: :controller
         delegate :current_user, to: :controller
 
         def show

--- a/decidim-core/app/cells/decidim/activities_cell.rb
+++ b/decidim-core/app/cells/decidim/activities_cell.rb
@@ -8,8 +8,6 @@ module Decidim
     include Decidim::IconHelper
     include Decidim::Core::Engine.routes.url_helpers
 
-    delegate :current_organization, to: :controller
-
     # Since we're rendering each activity separatedly we need to trigger
     # BatchLoader in order to accumulate all the ids to be found later.
     def show

--- a/decidim-core/app/cells/decidim/content_blocks/footer_sub_hero_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/footer_sub_hero_cell.rb
@@ -5,7 +5,6 @@ module Decidim
     class FooterSubHeroCell < Decidim::ViewModel
       include Decidim::IconHelper
 
-      delegate :current_organization, to: :controller
       delegate :current_user, to: :controller
     end
   end

--- a/decidim-core/app/cells/decidim/content_blocks/hero_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/hero_cell.rb
@@ -6,8 +6,6 @@ module Decidim
       include Decidim::CtaButtonHelper
       include Decidim::SanitizeHelper
 
-      delegate :current_organization, to: :controller
-
       # Needed so that the `CtaButtonHelper` can work.
       def decidim_participatory_processes
         Decidim::ParticipatoryProcesses::Engine.routes.url_helpers

--- a/decidim-core/app/cells/decidim/content_blocks/highlighted_content_banner_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/highlighted_content_banner_cell.rb
@@ -9,8 +9,6 @@ module Decidim
         return unless current_organization.highlighted_content_banner_enabled
         render
       end
-
-      delegate :current_organization, to: :controller
     end
   end
 end

--- a/decidim-core/app/cells/decidim/content_blocks/last_activity_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/last_activity_cell.rb
@@ -7,8 +7,6 @@ module Decidim
     class LastActivityCell < Decidim::ViewModel
       include Decidim::Core::Engine.routes.url_helpers
 
-      delegate :current_organization, to: :controller
-
       def show
         return if activities.empty?
         render

--- a/decidim-core/app/cells/decidim/content_blocks/metrics_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/metrics_cell.rb
@@ -3,8 +3,6 @@
 module Decidim
   module ContentBlocks
     class MetricsCell < Decidim::ViewModel
-      delegate :current_organization, to: :controller
-
       def show
         return unless current_organization.show_statistics?
         render

--- a/decidim-core/app/cells/decidim/content_blocks/stats_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/stats_cell.rb
@@ -3,8 +3,6 @@
 module Decidim
   module ContentBlocks
     class StatsCell < Decidim::ViewModel
-      delegate :current_organization, to: :controller
-
       def show
         return unless current_organization.show_statistics?
         render

--- a/decidim-core/app/cells/decidim/content_blocks/sub_hero_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/sub_hero_cell.rb
@@ -10,8 +10,6 @@ module Decidim
         return if translated_attribute(current_organization.description).blank?
         render
       end
-
-      delegate :current_organization, to: :controller
     end
   end
 end

--- a/decidim-core/app/cells/decidim/follow_button_cell.rb
+++ b/decidim-core/app/cells/decidim/follow_button_cell.rb
@@ -12,10 +12,6 @@ module Decidim
 
     private
 
-    def current_user
-      context[:current_user]
-    end
-
     def button_classes
       return "card__button secondary text-uppercase follow-button mb-none" if inline?
       return "button secondary hollow expanded button--icon button--sc" if large?

--- a/decidim-core/app/cells/decidim/pad_iframe_cell.rb
+++ b/decidim-core/app/cells/decidim/pad_iframe_cell.rb
@@ -42,10 +42,6 @@ module Decidim
       model
     end
 
-    def current_user
-      context[:current_user]
-    end
-
     def current_organization
       current_user.organization
     end

--- a/decidim-core/lib/decidim/view_model.rb
+++ b/decidim-core/lib/decidim/view_model.rb
@@ -11,6 +11,8 @@ module Decidim
     include Decidim::ActionAuthorizationHelper
     include Decidim::ReplaceButtonsHelper
 
+    delegate :current_organization, to: :controller
+
     def current_user
       context[:current_user]
     end

--- a/decidim-core/spec/cells/decidim/tags_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/tags_cell_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 describe Decidim::TagsCell, type: :cell do
+  controller Decidim::PagesController
+
   let(:organization) { create(:organization) }
   let(:participatory_space) { create(:participatory_process, organization: organization) }
   let(:component_proposals) { create(:proposal_component, participatory_space: participatory_space) }

--- a/decidim-initiatives/spec/cells/decidim/initiatives_votes/vote_cell_spec.rb
+++ b/decidim-initiatives/spec/cells/decidim/initiatives_votes/vote_cell_spec.rb
@@ -5,6 +5,8 @@ require "spec_helper"
 describe Decidim::InitiativesVotes::VoteCell, type: :cell do
   subject { cell("decidim/initiatives_votes/vote", vote).call }
 
+  controller Decidim::PagesController
+
   let(:vote) do
     create(:initiative_user_vote,
            initiative: create(:initiative, :with_user_extra_fields_collection),

--- a/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_events_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_events_cell.rb
@@ -6,8 +6,6 @@ module Decidim
       class UpcomingEventsCell < Decidim::ViewModel
         include Decidim::CardHelper
 
-        delegate :current_organization, to: :controller
-
         def show
           return if upcoming_events.blank?
           render

--- a/decidim-meetings/spec/cells/decidim/meetings/content_blocks/upcoming_events_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/content_blocks/upcoming_events_cell_spec.rb
@@ -12,7 +12,7 @@ module Decidim
         let(:organization) { create(:organization) }
 
         before do
-          expect(controller).to receive(:current_organization).and_return(organization)
+          expect(controller).to receive(:current_organization).at_least(:once).and_return(organization)
         end
 
         context "with events" do

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_cell.rb
@@ -6,7 +6,6 @@ module Decidim
       class HighlightedProcessesCell < Decidim::ViewModel
         include Decidim::SanitizeHelper
 
-        delegate :current_organization, to: :controller
         delegate :current_user, to: :controller
 
         def show

--- a/decidim-proposals/app/cells/decidim/proposals/collaborative_draft_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/collaborative_draft_cell.rb
@@ -17,10 +17,6 @@ module Decidim
 
       private
 
-      def current_user
-        context[:current_user]
-      end
-
       def card_size
         "decidim/proposals/collaborative_draft_m"
       end

--- a/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal_cell.rb
@@ -12,8 +12,6 @@ module Decidim
       include Messaging::ConversationHelper
       include Decidim::SanitizeHelper
 
-      delegate :current_organization, to: :controller
-
       def show
         render
       end

--- a/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal_cell.rb
@@ -33,10 +33,6 @@ module Decidim
         decidim_sanitize(strip_links(formatted))
       end
 
-      def current_user
-        context[:current_user]
-      end
-
       def resource_path
         resource_locator(model).path
       end

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_cell.rb
@@ -17,10 +17,6 @@ module Decidim
 
       private
 
-      def current_user
-        context[:current_user]
-      end
-
       def card_size
         "decidim/proposals/proposal_m"
       end


### PR DESCRIPTION
#### :tophat: What? Why?
In a Decidim instance with many languages, participatory processes cells doesn't work well when content is not translated to the user locale. Instead of showing the content in the organization's default locale, it uses the first locale, even when there is no translation for that language neither. This bug can be solved easily adding `delegate :current_organization, to: :controller` to the cell class.

But, instead of adding that line to fix this problem, this PR adds it to the base class (`Decidim::ViewModel`), that would probably fix a lot of potencial problems and allow to remove a lot of duplicated lines of code. It also deletes duplicated code defining the `current_user` method when it is exactly as already defined on the base class.

@decidim/developers I understand that every cell is rendered in the context of a controller with a `current_organization` method. If you know that it doesn't or if you are not sure, I can add the `allow_nil: true` modifier to be sure that doesn't raise errors on those cases.

#### :pushpin: Related Issues

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
