### PR TITLE
Use org default locale as fallback on emails

### DIFF
--- a/decidim-core/app/mailers/concerns/decidim/localised_mailer.rb
+++ b/decidim-core/app/mailers/concerns/decidim/localised_mailer.rb
@@ -13,7 +13,7 @@ module Decidim
       #
       # Returns nothing.
       def with_user(user)
-        I18n.with_locale(user.locale || I18n.locale) do
+        I18n.with_locale(user.locale || user.organization.default_locale) do
           yield
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR sets the organization default locale as a fallback for email locales, instead of using `I18n.locale`. The explanation is very thorough in the related issue, refer to the issue for more info.

#### :pushpin: Related Issues
- Fixes #4740

#### :clipboard: Subtasks
None