### PR TITLE
Correctly set the category in the admin debate form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
 - **decidim-debates** Fix debates card and ordering [\#4879](https://github.com/decidim/decidim/pull/4879)
 - **decidim-proposals** Don't count withdrawn proposals when publishing one [\#4875](https://github.com/decidim/decidim/pull/4875)
 - **decidim-initiatives** Fix author duplicated appearance in some initiatives authors lists. [\#4885](https://github.com/decidim/decidim/pull/4885)
+- **decidim-debates** Correctly set the category in the admin debate form [\#4894](https://github.com/decidim/decidim/pull/4894)
 
 **Removed**:
 

--- a/decidim-debates/app/forms/decidim/debates/admin/debate_form.rb
+++ b/decidim-debates/app/forms/decidim/debates/admin/debate_form.rb
@@ -23,6 +23,10 @@ module Decidim
 
         validates :category, presence: true, if: ->(form) { form.decidim_category_id.present? }
 
+        def map_model(model)
+          self.decidim_category_id = model.category.try(:id)
+        end
+
         def category
           return unless current_component
           @category ||= current_component.categories.find_by(id: decidim_category_id)

--- a/decidim-debates/spec/forms/decidim/debates/admin/debate_form_spec.rb
+++ b/decidim-debates/spec/forms/decidim/debates/admin/debate_form_spec.rb
@@ -100,4 +100,16 @@ describe Decidim::Debates::Admin::DebateForm do
 
     it { is_expected.not_to be_valid }
   end
+
+  describe "from model" do
+    subject { described_class.from_model(debate).with_context(context) }
+
+    let(:component) { create :debates_component }
+    let(:category) { create :category, participatory_space: component.participatory_space }
+    let(:debate) { create :debate, category: category, component: component }
+
+    it "sets the form category id correctly" do
+      expect(subject.decidim_category_id).to eq category.id
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
We were not getting the category ID correctly in the admin debate form, so it was being overwritten every time.

This PR fixes this problem.

#### :pushpin: Related Issues
- Fixes #4795

#### :clipboard: Subtasks
None