### PR TITLE
Don't mix omniauth notifications with `Decidim::EventManager` events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 **Upgrade notes**:
 
+- **Actions on omniauth registrations**: Due to [#4895](https://github.com/decidim/decidim/pull/4895), if there are [actions registered to be performed when a user registers throught OAuth](https://github.com/decidim/decidim/blob/master/docs/customization/oauth.md#performing-more-actions-on-omniauth-registration), the name of the event must be changed to keep them working. The subscription to the notification should be changed from:
+
+```ruby
+ActiveSupport::Notifications.subscribe "decidim.events.user.omniauth_registration" do |name, started, finished, unique_id, data|
+```
+
+to
+
+```ruby
+ActiveSupport::Notifications.subscribe "decidim.user.omniauth_registration" do |name, started, finished, unique_id, data|
+```
+
+
+- **decidim-core**: Don't mix omniauth notifications with `Decidim::EventManager` events
+
 **Added**:
 
 - **decidim-proposals**: Added a button to reset all participatory text drafts. [\#4814](https://github.com/decidim/decidim/pull/4814)
@@ -54,6 +69,7 @@
 
 **Fixed**:
 
+- **decidim-core**: Don't mix omniauth notifications with `Decidim::EventManager` events [#4895](https://github.com/decidim/decidim/pull/4895)
 - **decidim-core**: Hide comments on cards when deactivated on a component. [\#4904](https://github.com/decidim/decidim/pull/4904)
 - **decidim-debates**: Fix stats display for debates when a debate has been moderated. [\#4903](https://github.com/decidim/decidim/pull/4903)
 - **decidim-core**: Fix comments count when a comment has been moderated [\#4901](https://github.com/decidim/decidim/pull/4901)

--- a/decidim-core/app/commands/decidim/create_omniauth_registration.rb
+++ b/decidim-core/app/commands/decidim/create_omniauth_registration.rb
@@ -95,7 +95,7 @@ module Decidim
 
     def trigger_omniauth_registration
       ActiveSupport::Notifications.publish(
-        "decidim.events.user.omniauth_registration",
+        "decidim.user.omniauth_registration",
         user_id: @user.id,
         identity_id: @identity.id,
         provider: form.provider,

--- a/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
@@ -94,7 +94,7 @@ module Decidim
             expect(ActiveSupport::Notifications)
               .to receive(:publish)
               .with(
-                "decidim.events.user.omniauth_registration",
+                "decidim.user.omniauth_registration",
                 user_id: user.id,
                 identity_id: 1234,
                 provider: provider,

--- a/docs/customization/oauth.md
+++ b/docs/customization/oauth.md
@@ -24,7 +24,7 @@ Check [omniauth-decidim](https://github.com/decidim/omniauth-decidim) in order t
 
 ## Performing more actions on omniauth registration
 
-Some times, there is the need to perform more actions than just ceating a user on registration, this is why `CreateOmniauthRegistration` command publishes a `"decidim.events.user.omniauth_registration` event after registration so that developers can subscribe to it and perform other actions like user verification or alike.
+Some times, there is the need to perform more actions than just ceating a user on registration, this is why `CreateOmniauthRegistration` command publishes a `"decidim.user.omniauth_registration` event after registration so that developers can subscribe to it and perform other actions like user verification or alike.
 
 This event comes with the following payload:
 
@@ -41,7 +41,7 @@ This event comes with the following payload:
 To be notified after a registration one should subscribe to the event, in the passed block the after registration code should be implemented:
 
 ```ruby
-ActiveSupport::Notifications.subscribe "decidim.events.user.omniauth_registration" do |name, started, finished, unique_id, data|
+ActiveSupport::Notifications.subscribe "decidim.user.omniauth_registration" do |name, started, finished, unique_id, data|
   puts "the data: #{data.inspect}"
   IdCatMobilVerificationJob.perform_later(data[:raw_data])
 end

--- a/docs/customization/oauth.md
+++ b/docs/customization/oauth.md
@@ -24,7 +24,7 @@ Check [omniauth-decidim](https://github.com/decidim/omniauth-decidim) in order t
 
 ## Performing more actions on omniauth registration
 
-Some times, there is the need to perform more actions than just ceating a user on registration, this is why `CreateOmniauthRegistration` command publishes a `"decidim.user.omniauth_registration` event after registration so that developers can subscribe to it and perform other actions like user verification or alike.
+Some times, there is the need to perform more actions than just creating a user on registration, this is why `CreateOmniauthRegistration` command publishes a `"decidim.user.omniauth_registration` event after registration so that developers can subscribe to it and perform other actions like user verification or alike.
 
 This event comes with the following payload:
 


### PR DESCRIPTION
#### :tophat: What? Why?
Decidim [subscribes every notification starting with `"decidim.events."` to be processed by `EmailNotificationGeneratorJob` and `NotificationGeneratorJob`](https://github.com/decidim/decidim/blob/master/decidim-core/lib/decidim/core/engine.rb#L185). To work properly, these classes need to receive an `event_class`.

On the other hand, the omniauth creation command [publish a `decidim.events.user.omniauth_registration` notification](https://github.com/decidim/decidim/blob/master/decidim-core/app/commands/decidim/create_omniauth_registration.rb#L98) that it doesn't seem to be defined to be processed by the referred jobs.

As the omniauth notification starts with `"decidim.events."`, my background jobs worker raises a lot of errors. This PR changes the name for the omniauth notification, to avoid the messages mixing and the related errors.

#### :pushpin: Related Issues
- Related to #4539

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
