### PR TITLE
Ensure collaborators can only preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@
 - **decidim-core** Fix elements with non-unique ID on filtering pages [\#4897](https://github.com/decidim/decidim/pull/4897)
 - **decidim-debates** Correctly set the category in the admin debate form [\#4894](https://github.com/decidim/decidim/pull/4894)
 - **decidim-proposals**: Let admins keep orirignal authors when importing proposals from another component [\#4902](https://github.com/decidim/decidim/pull/4902)
+- **decidim-participatory_processes**: Fix collaborator permissions so they can't `:read` anything [\#4899](https://github.com/decidim/decidim/pull/4899)
 
 **Removed**:
 

--- a/decidim-admin/app/controllers/decidim/admin/components/base_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/components/base_controller.rb
@@ -30,7 +30,10 @@ module Decidim
         end
 
         def permissions_context
-          super.merge(participatory_space: current_participatory_space)
+          super.merge(
+            current_participatory_space: current_participatory_space,
+            participatory_space: current_participatory_space
+          )
         end
 
         def permission_class_chain

--- a/decidim-participatory_processes/app/permissions/decidim/participatory_processes/permissions.rb
+++ b/decidim-participatory_processes/app/permissions/decidim/participatory_processes/permissions.rb
@@ -191,11 +191,11 @@ module Decidim
         allow! if permission_action.subject == :moderation
       end
 
-      # Collaborators can read/preview everything inside their process.
+      # Collaborators can only preview their own processes.
       def collaborator_action?
         return unless can_manage_process?(role: :collaborator)
 
-        allow! if permission_action.action == :read || permission_action.action == :preview
+        allow! if permission_action.action == :preview
       end
 
       # Process admins can eprform everything *inside* that process. They cannot

--- a/decidim-participatory_processes/spec/permissions/decidim/participatory_processes/permissions_spec.rb
+++ b/decidim-participatory_processes/spec/permissions/decidim/participatory_processes/permissions_spec.rb
@@ -233,14 +233,6 @@ describe Decidim::ParticipatoryProcesses::Permissions do
     context "when user is a collaborator" do
       let(:user) { process_collaborator }
 
-      context "when action is :read" do
-        let(:action) do
-          { scope: :admin, action: :read, subject: :dummy }
-        end
-
-        it { is_expected.to eq true }
-      end
-
       context "when action is :preview" do
         let(:action) do
           { scope: :admin, action: :preview, subject: :dummy }


### PR DESCRIPTION
#### :tophat: What? Why?
Collaborators could `:read` things, which allowed them to access some components where in theory they shouldn't. This PR removes the permission to `:read`, so now they can only `:preview` things.

~~I'm 👍 on removing this role, since I don't think it's used at all, its permissions are not clear and have never been, at least in my case (see https://github.com/decidim/decidim/issues/2023#issuecomment-336370826)~~ (we won't be removing this role as of now)

#### :pushpin: Related Issues
- Related to #4748
- Fixes #4749

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
