### PR TITLE
Fix autoloading error

### DIFF
--- a/decidim-core/app/controllers/decidim/application_controller.rb
+++ b/decidim-core/app/controllers/decidim/application_controller.rb
@@ -75,7 +75,7 @@ module Decidim
 
     def track_continuity_badge
       return unless current_user
-      ContinuityBadgeTracker.new(current_user).track!(Time.zone.today)
+      Decidim::ContinuityBadgeTracker.new(current_user).track!(Time.zone.today)
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Ever encountered an error like "A copy of Decidim::ApplicationController has been removed from the module tree but is still active" while developing Decidim? This PR fixes it.

#### :pushpin: Related Issues
Solved it while investigating #4202.

#### :clipboard: Subtasks
None
