### PR TITLE
Fix comments count when a comment has been moderated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 
 **Fixed**:
 
+- **decidim-core**: Fix comments count when a comment has been moderated [\#4901](https://github.com/decidim/decidim/pull/4901)
 - **decidim-core**: Fix AttachmentCreatedEvent email resource_url [#4880](https://github.com/decidim/decidim/pull/4880)
 - **decidim-proposals**: Add participatory texts file format support in admin. [#4819](https://github.com/decidim/decidim/pull/4819)
 - **decidim-proposals**: Fix collaborative draft attachment when attachments are enabled after collaborative draft creation [\#4877](https://github.com/decidim/decidim/pull/4877)

--- a/decidim-core/app/cells/decidim/card_m_cell.rb
+++ b/decidim-core/app/cells/decidim/card_m_cell.rb
@@ -97,6 +97,8 @@ module Decidim
     end
 
     def comments_count
+      return model.comments.not_hidden.count if model.comments.respond_to? :not_hidden
+
       model.comments.count
     end
 

--- a/decidim-meetings/spec/system/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/system/explore_meetings_spec.rb
@@ -21,6 +21,24 @@ describe "Explore meetings", type: :system do
       end
     end
 
+    context "when comments have been moderated" do
+      let(:meeting) { create(:meeting, component: component) }
+      let!(:comments) { create_list(:comment, 3, commentable: meeting) }
+      let!(:moderation) { create :moderation, reportable: comments.first, hidden_at: 1.day.ago }
+
+      it "displays unhidden comments count" do
+        visit_component
+
+        within("#meeting_#{meeting.id}") do
+          within(".card__status") do
+            within(".card-data__item:last-child") do
+              expect(page).to have_content(2)
+            end
+          end
+        end
+      end
+    end
+
     context "when filtering" do
       it "allows searching by text" do
         visit_component

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -289,7 +289,6 @@ describe "Proposals", type: :system do
       end
     end
 
-
     describe "default ordering" do
       it_behaves_like "a random proposal ordering"
     end

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -272,6 +272,24 @@ describe "Proposals", type: :system do
       it_behaves_like "editable content for admins"
     end
 
+    context "when comments have been moderated" do
+      let(:proposal) { create(:proposal, component: component) }
+      let(:author) { create(:user, :confirmed, organization: component.organization) }
+      let!(:comments) { create_list(:comment, 3, commentable: proposal) }
+      let!(:moderation) { create :moderation, reportable: comments.first, hidden_at: 1.day.ago }
+
+      it "displays unhidden comments count" do
+        visit_component
+
+        within("#proposal_#{proposal.id}") do
+          within(".card-data__item:last-child") do
+            expect(page).to have_content(2)
+          end
+        end
+      end
+    end
+
+
     describe "default ordering" do
       it_behaves_like "a random proposal ordering"
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Fix comments count when a comment has been moderated

#### :pushpin: Related Issues
- Fixes : #3651

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add system test for proposals
- [x] Add system test for meetings