### PR TITLE
Keep original authors when importing from component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@
 - **decidim-initiatives** Fix author duplicated appearance in some initiatives authors lists. [\#4885](https://github.com/decidim/decidim/pull/4885)
 - **decidim-core** Fix elements with non-unique ID on filtering pages [\#4897](https://github.com/decidim/decidim/pull/4897)
 - **decidim-debates** Correctly set the category in the admin debate form [\#4894](https://github.com/decidim/decidim/pull/4894)
+- **decidim-proposals**: Let admins keep orirignal authors when importing proposals from another component [\#4902](https://github.com/decidim/decidim/pull/4902)
 
 **Removed**:
 

--- a/decidim-proposals/app/commands/decidim/proposals/admin/import_proposals.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/import_proposals.rb
@@ -35,7 +35,7 @@ module Decidim
 
             Decidim::Proposals::ProposalBuilder.copy(
               original_proposal,
-              author: form.current_organization,
+              author: proposal_author,
               action_user: form.current_user,
               extra_attributes: {
                 "component" => target_component
@@ -73,6 +73,10 @@ module Decidim
           original_proposal.linked_resources(:proposals, "copied_from_component").any? do |proposal|
             proposal.component == target_component
           end
+        end
+
+        def proposal_author
+          form.keep_authors ? nil : @form.current_organization
         end
       end
     end

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposals_import_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposals_import_form.rb
@@ -10,6 +10,7 @@ module Decidim
 
         attribute :origin_component_id, Integer
         attribute :import_proposals, Boolean
+        attribute :keep_authors, Boolean
         attribute :states, Array
 
         validates :origin_component_id, :origin_component, :states, :current_component, presence: true

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals_imports/new.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals_imports/new.html.erb
@@ -14,6 +14,9 @@
           <%= f.collection_check_boxes :states, @form.states_collection, :value, :name %>
         </div>
         <div class="row column">
+          <%= f.check_box :keep_authors %>
+        </div>
+        <div class="row column">
           <%= f.check_box :import_proposals %>
         </div>
       </div>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -28,6 +28,9 @@ en:
       proposals_copy:
         copy_proposals: I understand that this will import all proposals from the selected component to the current one and that this action can't be reversed.
         origin_component_id: Component to copy the proposals from
+      proposals_import:
+        import_proposals: Import proposals
+        keep_authors: Keep original authors
     errors:
       models:
         participatory_text:

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/import_proposals_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/import_proposals_spec.rb
@@ -8,6 +8,7 @@ module Decidim
       describe ImportProposals do
         describe "call" do
           let!(:proposal) { create(:proposal, :accepted) }
+          let(:keep_authors) { false }
           let(:current_component) do
             create(
               :proposal_component,
@@ -20,6 +21,7 @@ module Decidim
               origin_component: proposal.component,
               current_component: current_component,
               current_organization: current_component.organization,
+              keep_authors: keep_authors,
               states: states,
               current_user: create(:user),
               valid?: valid
@@ -95,6 +97,19 @@ module Decidim
               expect(new_proposal.answer).to be_nil
               expect(new_proposal.answered_at).to be_nil
               expect(new_proposal.reference).not_to eq(proposal.reference)
+            end
+
+            describe "when keep_authors is true" do
+              let(:keep_authors) { true }
+
+              it "only keeps the proposal authors" do
+                command.call
+
+                new_proposal = Proposal.where(component: current_component).last
+                expect(new_proposal.title).to eq(proposal.title)
+                expect(new_proposal.body).to eq(proposal.body)
+                expect(new_proposal.creator_author).to eq(proposal.creator_author)
+              end
             end
 
             describe "proposal states" do

--- a/decidim-proposals/spec/forms/decidim/proposals/admin/proposals_import_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/admin/proposals_import_form_spec.rb
@@ -16,6 +16,7 @@ module Decidim
         let(:params) do
           {
             states: states,
+            keep_authors: false,
             origin_component_id: origin_component.try(:id),
             import_proposals: import_proposals
           }

--- a/decidim-proposals/spec/shared/import_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/import_proposals_examples.rb
@@ -7,22 +7,47 @@ shared_examples "import proposals" do
   include Decidim::ComponentPathHelper
 
   it "imports proposals from one component to another" do
-    click_link "Import from another component"
+    fill_form
 
-    within ".import_proposals" do
-      select origin_component.name["en"], from: :proposals_import_origin_component_id
-      check "Accepted"
-      check :proposals_import_import_proposals
-    end
-
-    click_button "Import proposals"
-
-    expect(page).to have_content("3 proposals successfully imported")
+    confirm_flash_message
 
     proposals.each do |proposal|
       expect(page).to have_content(proposal.title["en"])
     end
 
+    confirm_current_path
+  end
+
+  it "imports proposals from one component to another by keeping the authors" do
+    fill_form(keep_authors: true)
+
+    confirm_flash_message
+
+    proposals.each do |proposal|
+      expect(page).to have_content(proposal.title["en"])
+    end
+
+    confirm_current_path
+  end
+
+  def fill_form(keep_authors: false)
+    click_link "Import from another component"
+
+    within ".import_proposals" do
+      select origin_component.name["en"], from: "Origin component"
+      check "Accepted"
+      check "Keep original authors" if keep_authors
+      check "Import proposals"
+    end
+
+    click_button "Import proposals"
+  end
+
+  def confirm_flash_message
+    expect(page).to have_content("3 proposals successfully imported")
+  end
+
+  def confirm_current_path
     expect(page).to have_current_path(manage_component_path(current_component))
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR lets admins decide whether they want to keep the original authors or not when importing proposals from another component.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/491891/53342525-6ea2d000-390e-11e9-8f86-b2003eca2266.png)

