### PR TITLE
Fix stats display for debates when a debate has been moderated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 
 **Fixed**:
 
+- **decidim-debates**: Fix stats display for debates when a debate has been moderated.[\#4903](https://github.com/decidim/decidim/pull/4903)
 - **decidim-core**: Fix AttachmentCreatedEvent email resource_url [#4880](https://github.com/decidim/decidim/pull/4880)
 - **decidim-proposals**: Add participatory texts file format support in admin. [#4819](https://github.com/decidim/decidim/pull/4819)
 - **decidim-proposals**: Fix collaborative draft attachment when attachments are enabled after collaborative draft creation [\#4877](https://github.com/decidim/decidim/pull/4877)

--- a/decidim-debates/lib/decidim/debates/component.rb
+++ b/decidim-debates/lib/decidim/debates/component.rb
@@ -26,7 +26,7 @@ Decidim.register_component(:debates) do |component|
   end
 
   component.register_stat :debates_count, primary: true, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |components, _start_at, _end_at|
-    Decidim::Debates::Debate.where(component: components).count
+    Decidim::Debates::Debate.where(component: components).not_hidden.count
   end
 
   component.register_resource(:debate) do |resource|

--- a/decidim-debates/spec/system/homepage_stats_spec.rb
+++ b/decidim-debates/spec/system/homepage_stats_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Homepage", type: :system do
+  include_context "with a component"
+  let(:manifest_name) { "debates" }
+
+  let!(:debates) { create_list(:debate, 3, component: component) }
+  let!(:moderation) { create :moderation, reportable: debates.first, hidden_at: 1.day.ago }
+
+  before do
+    create :content_block, organization: organization, scope: :homepage, manifest_name: :stats
+    visit decidim.root_path
+  end
+
+  it "display unhidden debates count" do
+    within(".debates_count") do
+      expect(page).to have_content(2)
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Fix stats display for debates
#### :pushpin: Related Issues
- Fixes https://github.com/OpenSourcePolitics/decidim/issues/225

#### :clipboard: Subtasks
- [X] Add `CHANGELOG` entry
- [X] Add tests

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/20232956/49464017-0efac400-f7fa-11e8-8c2a-6fe8b4072f18.png)
