### PR TITLE
Hide comments on cards when deactivated on a component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 
 **Fixed**:
 
+- **decidim-core**: Hide comments on cards when deactivated on a component. [\#4904](https://github.com/decidim/decidim/pull/4904)
 - **decidim-core**: Fix AttachmentCreatedEvent email resource_url [#4880](https://github.com/decidim/decidim/pull/4880)
 - **decidim-proposals**: Add participatory texts file format support in admin. [#4819](https://github.com/decidim/decidim/pull/4819)
 - **decidim-proposals**: Fix collaborative draft attachment when attachments are enabled after collaborative draft creation [\#4877](https://github.com/decidim/decidim/pull/4877)

--- a/decidim-core/app/cells/decidim/card_m_cell.rb
+++ b/decidim-core/app/cells/decidim/card_m_cell.rb
@@ -103,7 +103,7 @@ module Decidim
     def statuses
       collection = [:creation_date]
       collection << :follow if model.is_a?(Decidim::Followable) && model != try(:current_user)
-      collection << :comments_count if model.is_a?(Decidim::Comments::Commentable)
+      collection << :comments_count if model.is_a?(Decidim::Comments::Commentable) && model.commentable?
       collection
     end
 

--- a/decidim-core/lib/decidim/core/test.rb
+++ b/decidim-core/lib/decidim/core/test.rb
@@ -38,3 +38,4 @@ require "decidim/core/test/shared_examples/amendable/amendment_created_event_exa
 require "decidim/core/test/shared_examples/amendable/amendment_accepted_event_examples"
 require "decidim/core/test/shared_examples/amendable/amendment_rejected_event_examples"
 require "decidim/core/test/shared_examples/amendable/amendment_promoted_event_examples"
+require "decidim/core/test/shared_examples/uncommentable_component_examples"

--- a/decidim-core/lib/decidim/core/test/shared_examples/uncommentable_component_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/uncommentable_component_examples.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+shared_examples "an uncommentable component" do
+  let!(:component) do
+    create(:component,
+           manifest: manifest,
+           participatory_space: participatory_space)
+  end
+
+  it "doesn't displays comments count" do
+    component.update!(settings: { comments_enabled: false })
+
+    visit_component
+
+    ressources.each do |ressource|
+      expect(page).not_to have_link(resource_locator(ressource).path)
+    end
+  end
+end

--- a/decidim-debates/spec/system/explore_debates_spec.rb
+++ b/decidim-debates/spec/system/explore_debates_spec.rb
@@ -159,6 +159,12 @@ describe "Explore debates", type: :system do
     end
   end
 
+  context "when component is not commentable" do
+    let(:ressources) { create_list(:debate, 3, component: current_component) }
+
+    it_behaves_like "an uncommentable component"
+  end
+
   describe "show" do
     let(:path) do
       decidim_participatory_process_debates.debate_path(

--- a/decidim-meetings/spec/system/meeting_spec.rb
+++ b/decidim-meetings/spec/system/meeting_spec.rb
@@ -33,4 +33,10 @@ describe "Meeting", type: :system do
       end
     end
   end
+
+  context "when component is not commentable" do
+    let!(:ressources) { create_list(:meeting, 3, services: services, component: component) }
+
+    it_behaves_like "an uncommentable component"
+  end
 end

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -659,6 +659,12 @@ describe "Proposals", type: :system do
       it_behaves_like "a paginated resource"
     end
 
+    context "when component is not commentable" do
+      let!(:ressources) { create_list(:proposal, 3, component: component) }
+
+      it_behaves_like "an uncommentable component"
+    end
+
     context "when amendments_enabled setting is enabled" do
       let!(:proposal) { create(:proposal, component: component, scope: scope) }
       let!(:emendation) { create(:proposal, component: component, scope: scope) }


### PR DESCRIPTION
#### :tophat: What? Why?
Hide comments on cards when deactivated on a component.

#### :pushpin: Related Issues
- Fixes https://github.com/OpenSourcePolitics/decidim/issues/300

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add test

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/20232956/49533632-d2919b80-f8bf-11e8-81d4-f483d0c2e134.png)
