### PR TITLE
Fix a potential error 500 in _wrapper.html.erb

### DIFF
--- a/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
@@ -107,7 +107,9 @@ end
               <ul class="footer-nav">
                 <% if current_organization.static_pages.any? %>
                   <% current_organization.static_page_topics.where(show_in_footer: true).each do |page_topic| %>
-                    <li><%= link_to translated_attribute(page_topic.title), decidim.page_path(page_topic.pages.first) %></li>
+                    <% if page_topic.pages.any? %>
+                      <li><%= link_to translated_attribute(page_topic.title), decidim.page_path(page_topic.pages.first) %></li>
+                    <% end %>
                   <% end %>
 
                   <% current_organization.static_pages.where(show_in_footer: true).each do |page| %>


### PR DESCRIPTION
Check if a page topic has any pages before try to print it in the in the `_wrapper.html.erb` view.

#### :tophat: What? Why?

When and admin creates a topic under the pages admin module and has no pages associated but (probably inadvertently) checks the "Show in footer" option, the view `_wrapper.html.erb` tries to render the first page which causes an exception (500 error to the browser).

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/1401520/53358956-f6e69c80-3931-11e9-80d6-455a7d113679.png)
![image](https://user-images.githubusercontent.com/1401520/53359011-18478880-3932-11e9-91a5-1832eb44cb51.png)
