### PR TITLE
Fix dates in Catalan

### DIFF
--- a/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.ca.js
+++ b/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.ca.js
@@ -2,13 +2,13 @@
  * Catalan translation for foundation-datepicker, language file from bootstrap-datepicker
  * J. Garcia <jogaco.en@gmail.com>
  */
-;(function($){
+; (function ($) {
 	$.fn.fdatepicker.dates['ca'] = {
-		days: ["Diumenge", "Dilluns", "Dimarts", "Dimecres", "Dijous", "Divendres", "Dissabte"],
-		daysShort: ["Diu",  "Dil", "Dmt", "Dmc", "Dij", "Div", "Dis"],
-		daysMin: ["dg", "dl", "dt", "dc", "dj", "dv", "ds"],
-		months: ["Gener", "Febrer", "Març", "Abril", "Maig", "Juny", "Juliol", "Agost", "Setembre", "Octubre", "Novembre", "Desembre"],
-		monthsShort: ["Gen", "Feb", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Oct", "Nov", "Des"],
+		days: ["diumenge", "dilluns", "dimarts", "dimecres", "dijous", "divendres", "dissabte"],
+		daysShort: ["dg.", "dl.", "dt.", "dc.", "dj.", "dv.", "ds."],
+		daysMin: ["dg.", "dl.", "dt.", "dc.", "dj.", "dv.", "ds."],
+		months: ["gener", "febrer", "març", "abril", "maig", "juny", "juliol", "agost", "setembre", "octubre", "novembre", "desembre"],
+		monthsShort: ["gen.", "febr.", "març", "abr.", "maig", "juny", "jul.", "ag.", "set.", "oct.", "nov.", "des."],
 		today: "Avui",
 		clear: "Esborrar",
 		weekStart: 1


### PR DESCRIPTION
#### :tophat: What? Why?
Fix days and months abbreviations in Catalan.

Taken from [this source](https://aplicacions.llengua.gencat.cat/llc/AppJava/index.html?action=Principal&method=detall&input_cercar=abreviatures+mesos&numPagina=1&database=FITXES_PUB&idFont=8402&idHit=8402&tipusFont=Fitxes+de+l%2527Optimot&numeroResultat=1&databases_avansada=&categories_avansada=&clickLink=detall&titol=abreviatures+dels+mesos+de+l%2527any&tematica=&tipusCerca=cerca.normes).

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None