### PR TITLE
Add options to attribute settings manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - **decidim-initiatives**: Display state of initiative on edition form inside a disabled select. [\#4861](https://github.com/decidim/decidim/pull/4861)
 - **decidim-initiatives**: Allow users report comments on initiatives and admins moderate reports from initiative admin panel. [\#4878](https://github.com/decidim/decidim/pull/4878)
 - **decidim-admin**: Add css variables for multitenant custom colors. [\#4882](https://github.com/decidim/decidim/pull/4882)
+- **decidim-verifications**: Allow definition of attributes in settings manifest to be required always on authorizations. [\#4911](https://github.com/decidim/decidim/pull/4911)
 
 **Changed**:
 
@@ -51,6 +52,7 @@
 - **decidim-initiatives**: Change design of column containing signatures progress and actions buttons in initiative show. [\#4887](https://github.com/decidim/decidim/pull/4887)
 - **decidim-initiatives**: Change initiative creation wizard layout. [\#4888](https://github.com/decidim/decidim/pull/4888)
 - **decidim-initiatives**: Make changes related with initiatives signature and permissions ux. [\#4906](https://github.com/decidim/decidim/pull/4906)
+- **decidim-admin**: Fix inputs of translated attributes in resource permissions options form. [\#4911](https://github.com/decidim/decidim/pull/4911)
 
 **Fixed**:
 

--- a/decidim-admin/app/views/decidim/admin/resource_permissions/_options_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/resource_permissions/_options_form.html.erb
@@ -5,12 +5,14 @@
 %>
 
 <%= form.fields_for(:authorization_handlers_options) do |options_form| %>
-  <% attributes.each do |name, attribute| %>
-    <%= options_form.fields_for(handler_name, schema) do |attribute_options_form| %>
-      <%= attribute_options_form.send(
-            form_method_for_attribute(attribute),
+  <%= options_form.fields_for(handler_name, schema) do |attribute_options_form| %>
+    <% attributes.each do |name, attribute| %>
+      <%= settings_attribute_input(
+            attribute_options_form,
+            attribute,
             name,
-            label: t("authorization_handlers.#{handler_name}.fields.#{name}", scope: "decidim")#,
+            label: t("authorization_handlers.#{handler_name}.fields.#{name}", scope: "decidim"),
+            tabs_prefix: "#{name}_tabs_prefix"
           ) %>
     <% end %>
   <% end %>

--- a/decidim-core/lib/decidim/settings_manifest.rb
+++ b/decidim-core/lib/decidim/settings_manifest.rb
@@ -67,6 +67,10 @@ module Decidim
       @schema
     end
 
+    def required_attributes_for_authorization
+      attributes.select { |_, attribute| attribute.required_for_authorization? }
+    end
+
     # Semi-private: Attributes are an abstraction used by SettingsManifest
     # to encapsulate behavior related to each individual settings field. Shouldn't
     # be used from the outside.
@@ -87,6 +91,7 @@ module Decidim
       attribute :translated, Boolean, default: false
       attribute :editor, Boolean, default: false
       attribute :required, Boolean, default: true
+      attribute :required_for_authorization, Boolean, default: false
 
       validates :type, inclusion: { in: TYPES.keys }
 

--- a/decidim-core/spec/services/decidim/action_authorizer_spec.rb
+++ b/decidim-core/spec/services/decidim/action_authorizer_spec.rb
@@ -219,6 +219,50 @@ module Decidim
               expect(response).to be_ok
             end
           end
+
+          context "when attribute is defined in manifest with required_for_authorization" do
+            before do
+              Verifications.find_workflow_manifest(name).options do |opts|
+                opts.attribute :location, type: :string, required: false, required_for_authorization: required_for_authorization
+              end
+            end
+
+            context "when options are empty" do
+              let(:options) { {} }
+
+              context "and required_for_authorization is true" do
+                let(:required_for_authorization) { true }
+
+                context "and metadata is empty" do
+                  let(:metadata) { {} }
+
+                  it "returns incomplete" do
+                    expect(response.codes).to include(:incomplete)
+                  end
+                end
+
+                context "and metadata contains a value for the attribute" do
+                  let(:metadata) { { location: "Tomorrowland" } }
+
+                  it "returns ok" do
+                    expect(response).to be_ok
+                  end
+                end
+              end
+
+              context "and required_for_authorization is false" do
+                let(:required_for_authorization) { false }
+
+                context "and metadata is empty" do
+                  let(:metadata) { {} }
+
+                  it "returns ok" do
+                    expect(response).to be_ok
+                  end
+                end
+              end
+            end
+          end
         end
 
         context "when the authorization has expired" do

--- a/decidim-verifications/lib/decidim/verifications/adapter.rb
+++ b/decidim-verifications/lib/decidim/verifications/adapter.rb
@@ -84,7 +84,7 @@ module Decidim
       # Returns the result of authorization handler check. Check Decidim::Verifications::DefaultActionAuthorizer class docs.
       #
       def authorize(authorization, options, component, resource)
-        @action_authorizer = @manifest.action_authorizer_class.new(authorization, options, component, resource)
+        @action_authorizer = @manifest.action_authorizer_class.new(authorization, options_for_authorizer_class(options), component, resource)
         @action_authorizer.authorize
       end
 
@@ -99,6 +99,18 @@ module Decidim
       def redirect_params(params = {})
         # Could add redirect params if a ActionAuthorizer object was previously set.
         params.merge(@action_authorizer&.redirect_params || {})
+      end
+
+      def options_for_authorizer_class(options)
+        options = options.present? ? options.stringify_keys : {}
+
+        attributes_required_for_authorization.inject(options) do |options_for_authorizer_class, (key, _)|
+          options_for_authorizer_class.update(key => OpenStruct.new(required_for_authorization?: true, value: options[key]))
+        end
+      end
+
+      def attributes_required_for_authorization
+        @attributes_required_for_authorization ||= manifest.options.attributes.stringify_keys.select { |_, attribute| attribute.required_for_authorization? }
       end
     end
   end

--- a/decidim-verifications/lib/decidim/verifications/default_action_authorizer.rb
+++ b/decidim-verifications/lib/decidim/verifications/default_action_authorizer.rb
@@ -70,8 +70,9 @@ module Decidim
       attr_reader :authorization, :options, :component, :resource
 
       def unmatched_fields
-        @unmatched_fields ||= (valid_options_keys & authorization.metadata.to_h.keys).each_with_object({}) do |field, unmatched|
-          unmatched[field] = options[field] if authorization.metadata[field] != options[field]
+        @unmatched_fields ||= (valued_options_keys & authorization.metadata.to_h.keys).each_with_object({}) do |field, unmatched|
+          required_value = options[field].respond_to?(:value) ? options[field].value : options[field]
+          unmatched[field] = required_value if authorization.metadata[field] != required_value
           unmatched
         end
       end
@@ -85,7 +86,13 @@ module Decidim
 
       def valid_options_keys
         @valid_options_keys ||= options.map do |key, value|
-          key if value.present?
+          key if value.present? || value.try(:required_for_authorization?)
+        end.compact
+      end
+
+      def valued_options_keys
+        @valued_options_keys ||= options.map do |key, value|
+          key if value.respond_to?(:value) ? value.value.present? : value.present?
         end.compact
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

- Adds a new attribute option in settings manifest named `required_for_authorization` of type boolean to allow definition of attributes in a manifest which can be required to user in an authorization process regardless the authorization for. This can be useful for example, if a new minimum age requirement has to be added to a permission and the date of birth wasn't being stored in authorizations metadata. If a new `date_of_birth` attribute is declared in manifest and `required_for_authorization` is set as true, the authorization will generate an incomplete status, regardless the resource permission options have or not a value for `date_of_birth`
- Replaces form_method_for_attribute with settings_attribute_input in options_form of resource permissions. This fixes form elements of translated attributes. 

#### :pushpin: Related Issues

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
