### PR TITLE
Initiatives admin fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@
 - **decidim-proposals**: Let admins keep orirignal authors when importing proposals from another component [\#4902](https://github.com/decidim/decidim/pull/4902)
 - **decidim-proposals**: Don't let users vote/follow withdrawn proposals [\#4909](https://github.com/decidim/decidim/pull/4909)
 - **decidim-participatory_processes**: Fix collaborator permissions so they can't `:read` anything [\#4899](https://github.com/decidim/decidim/pull/4899)
+- **decidim-initiatives** Add some small fixes in admin panel of initiatives [\#4912](https://github.com/decidim/decidim/pull/4912)
 
 **Removed**:
 

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative.rb
@@ -55,7 +55,7 @@ module Decidim
           if current_user.admin?
             attrs[:signature_start_date] = form.signature_start_date
             attrs[:signature_end_date] = form.signature_end_date
-            attrs[:offline_votes] = form.offline_votes
+            attrs[:offline_votes] = form.offline_votes if form.offline_votes
             attrs[:state] = form.state if form.state
 
             if initiative.published?

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
@@ -74,7 +74,7 @@ module Decidim
 
           PublishInitiative.call(current_initiative, current_user) do
             on(:ok) do
-              redirect_to decidim_admin_initiatives.initiatives_path
+              redirect_to decidim_admin_initiatives.edit_initiative_path(current_initiative)
             end
           end
         end
@@ -85,7 +85,7 @@ module Decidim
 
           UnpublishInitiative.call(current_initiative, current_user) do
             on(:ok) do
-              redirect_to decidim_admin_initiatives.initiatives_path
+              redirect_to decidim_admin_initiatives.edit_initiative_path(current_initiative)
             end
           end
         end
@@ -94,21 +94,21 @@ module Decidim
         def discard
           enforce_permission_to :discard, :initiative, initiative: current_initiative
           current_initiative.discarded!
-          redirect_to decidim_admin_initiatives.initiatives_path
+          redirect_to decidim_admin_initiatives.edit_initiative_path(current_initiative)
         end
 
         # POST /admin/initiatives/:id/accept
         def accept
           enforce_permission_to :accept, :initiative, initiative: current_initiative
           current_initiative.accepted!
-          redirect_to decidim_admin_initiatives.initiatives_path
+          redirect_to decidim_admin_initiatives.edit_initiative_path(current_initiative)
         end
 
         # DELETE /admin/initiatives/:id/reject
         def reject
           enforce_permission_to :reject, :initiative, initiative: current_initiative
           current_initiative.rejected!
-          redirect_to decidim_admin_initiatives.initiatives_path
+          redirect_to decidim_admin_initiatives.edit_initiative_path(current_initiative)
         end
 
         # GET /admin/initiatives/:id/send_to_technical_validation

--- a/decidim-initiatives/app/permissions/decidim/initiatives/admin/permissions.rb
+++ b/decidim-initiatives/app/permissions/decidim/initiatives/admin/permissions.rb
@@ -138,7 +138,7 @@ module Decidim
           when :discard
             toggle_allow(initiative.validating?)
           when :export_pdf_signatures
-            toggle_allow(initiative.published?)
+            toggle_allow(initiative.published? || initiative.accepted? || initiative.rejected?)
           when :export_votes
             toggle_allow(initiative.offline? || initiative.any?)
           when :accept


### PR DESCRIPTION
#### :tophat: What? Why?
Adds some fixes on initiatives administration:
- Fixes deletion of offline votes editing an initiative. The change of offline count of votes will only allowed if the initiative is in published status.
- After an admin clicks on publish, unpublish, discard, accept and reject actions the admin is redirected to initiative edition path instead of index of initiatives.
- Makes available the "Export PDF of signatures" button an action when the initiative is accepted, rejected or published (previously only in published status was available)

#### :pushpin: Related Issues
- Related to #4644

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

