### PR TITLE
fix wrong check of avatar_url in /oauth/me controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ ActiveSupport::Notifications.subscribe "decidim.user.omniauth_registration" do |
 
 **Fixed**:
 
+- **decidim-core**: Fix wrong check of avatar_url in `/oauth/me` controller  [#4917](https://github.com/decidim/decidim/pull/4917)
 - **decidim-core**: Don't mix omniauth notifications with `Decidim::EventManager` events [#4895](https://github.com/decidim/decidim/pull/4895)
 - **decidim-core**: Hide comments on cards when deactivated on a component. [\#4904](https://github.com/decidim/decidim/pull/4904)
 - **decidim-debates**: Fix stats display for debates when a debate has been moderated. [\#4903](https://github.com/decidim/decidim/pull/4903)

--- a/decidim-core/app/controllers/decidim/doorkeeper/credentials_controller.rb
+++ b/decidim-core/app/controllers/decidim/doorkeeper/credentials_controller.rb
@@ -31,7 +31,7 @@ module Decidim
         avatar_url = current_resource_owner.avatar_url
         return unless avatar_url
 
-        unless (%r{^https?://}).match? avatar_url
+        unless %r{^https?://}.match? avatar_url
           request_uri = URI.parse(request.url)
           request_uri.path = avatar_url
           request_uri.query = nil

--- a/decidim-core/app/controllers/decidim/doorkeeper/credentials_controller.rb
+++ b/decidim-core/app/controllers/decidim/doorkeeper/credentials_controller.rb
@@ -31,7 +31,7 @@ module Decidim
         avatar_url = current_resource_owner.avatar_url
         return unless avatar_url
 
-        unless avatar_url.match?(%r{/https?://})
+        unless (%r{^https?://}).match? avatar_url
           request_uri = URI.parse(request.url)
           request_uri.path = avatar_url
           request_uri.query = nil


### PR DESCRIPTION
#### :tophat: What? Why?

A 500 error caused if the user tries to authenticate using OAuth, Decidim is configured to use S3 and user has and avatar uploaded.

Users in this situation cannot authenticate using Decidim as OAuth provider (for instance, from meta.decidim using decidim.barcelona).

In Decidim installations configured to use external services as file provider
(such as AWS-S3), if a user has an avatar cannot authenticate using the builtin
OAuth server due an error checking the url in the credentials_controller


#### :pushpin: Related Issues
- Fixes #4133 

