### PR TITLE
fix wrong check of avatar_url in /oauth/me 0.15 backport (#4917)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 **Fixed**:
 
+- **decidim-core**: Fix wrong check of avatar_url in `/oauth/me` controller  [#4917](https://github.com/decidim/decidim/pull/4917)
 - **decidim-meetings**: Change title to description in meetings admin form. [\#4484](https://github.com/decidim/decidim/pull/4484)
 - **decidim-meetings**: Fix title and description fields in admin form. [\#4547](https://github.com/decidim/decidim/pull/4547)
 - **decidim-proposals**: Fix vote-rerendering on a proposal's page [\#4558](https://github.com/decidim/decidim/pull/4558)

--- a/decidim-core/app/controllers/decidim/doorkeeper/credentials_controller.rb
+++ b/decidim-core/app/controllers/decidim/doorkeeper/credentials_controller.rb
@@ -31,7 +31,7 @@ module Decidim
         avatar_url = current_resource_owner.avatar_url
         return unless avatar_url
 
-        unless avatar_url.match?(%r{/https?://})
+        unless %r{^https?://}.match? avatar_url
           request_uri = URI.parse(request.url)
           request_uri.path = avatar_url
           request_uri.query = nil


### PR DESCRIPTION
* fix wrong check of avatar_url in /oauth/me controller that leads to a 500 error

In Decidim intallations configured to use external services as file provider
(such as AWS-S3), if a user has an avatar cannot authenticate using the builtin
OAuth server due an error checking the url in the credentials_controller

* fix rubocop complain

* [ci_skip] Changelog fix entry

#### :tophat: What? Why?


#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
