### PR TITLE
Ensure email is downcased when authenticating a user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ ActiveSupport::Notifications.subscribe "decidim.user.omniauth_registration" do |
 - **decidim-proposals**: Don't let users vote/follow withdrawn proposals [\#4909](https://github.com/decidim/decidim/pull/4909)
 - **decidim-participatory_processes**: Fix collaborator permissions so they can't `:read` anything [\#4899](https://github.com/decidim/decidim/pull/4899)
 - **decidim-initiatives** Add some small fixes in admin panel of initiatives [\#4912](https://github.com/decidim/decidim/pull/4912)
+- **decidim-core**: Ensure email is downcased when authenticating a user [\#4926](https://github.com/decidim/decidim/pull/4926)
 
 **Removed**:
 

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -120,7 +120,7 @@ module Decidim
     def self.find_for_authentication(warden_conditions)
       organization = warden_conditions.dig(:env, "decidim.current_organization")
       find_by(
-        email: warden_conditions[:email].downcase,
+        email: warden_conditions[:email].to_s.downcase,
         decidim_organization_id: organization.id
       )
     end

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -120,7 +120,7 @@ module Decidim
     def self.find_for_authentication(warden_conditions)
       organization = warden_conditions.dig(:env, "decidim.current_organization")
       find_by(
-        email: warden_conditions[:email],
+        email: warden_conditions[:email].downcase,
         decidim_organization_id: organization.id
       )
     end

--- a/decidim-core/spec/models/decidim/user_spec.rb
+++ b/decidim-core/spec/models/decidim/user_spec.rb
@@ -235,5 +235,22 @@ module Decidim
         end
       end
     end
+
+    describe "#find_for_authentication" do
+      let(:user) { create(:user, organization: organization) }
+
+      let(:conditions) do
+        {
+          env: {
+            "decidim.current_organization" => organization,
+          },
+          email: user.email.upcase
+        }
+      end
+
+      it "finds the user even with weird casing in email" do
+        expect(described_class.find_for_authentication(conditions)).to eq user
+      end
+    end
   end
 end

--- a/decidim-core/spec/models/decidim/user_spec.rb
+++ b/decidim-core/spec/models/decidim/user_spec.rb
@@ -242,7 +242,7 @@ module Decidim
       let(:conditions) do
         {
           env: {
-            "decidim.current_organization" => organization,
+            "decidim.current_organization" => organization
           },
           email: user.email.upcase
         }


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes a bug when authenticating users where email was not being downcased.

#### :pushpin: Related Issues
- Fixes #4915

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
