### PR TITLE
Redirect after SMS verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@ ActiveSupport::Notifications.subscribe "decidim.user.omniauth_registration" do |
 - **decidim-participatory_processes**: Fix collaborator permissions so they can't `:read` anything [\#4899](https://github.com/decidim/decidim/pull/4899)
 - **decidim-initiatives** Add some small fixes in admin panel of initiatives [\#4912](https://github.com/decidim/decidim/pull/4912)
 - **decidim-core**: Ensure email is downcased when authenticating a user [\#4926](https://github.com/decidim/decidim/pull/4926)
+- **decidim-verifications**: Redirect to previous url after verifying your mobile number via SMS. [\#4929](https://github.com/decidim/decidim/pull/4929)
 
 **Removed**:
 

--- a/decidim-verifications/app/controllers/decidim/verifications/sms/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/sms/authorizations_controller.rb
@@ -21,7 +21,7 @@ module Decidim
             on(:ok) do
               flash[:notice] = t("authorizations.create.success", scope: "decidim.verifications.sms")
               authorization_method = Decidim::Verifications::Adapter.from_element(authorization.name)
-              redirect_to authorization_method.resume_authorization_path
+              redirect_to authorization_method.resume_authorization_path(redirect_url: params[:redirect_url])
             end
             on(:invalid) do
               flash.now[:alert] = t("authorizations.create.error", scope: "decidim.verifications.sms")
@@ -44,7 +44,12 @@ module Decidim
           ConfirmUserAuthorization.call(authorization, @form) do
             on(:ok) do
               flash[:notice] = t("authorizations.update.success", scope: "decidim.verifications.sms")
-              redirect_to decidim_verifications.authorizations_path
+
+              if params[:redirect_url]
+                redirect_to params[:redirect_url]
+              else
+                redirect_to decidim_verifications.authorizations_path
+              end
             end
 
             on(:invalid) do

--- a/decidim-verifications/app/views/decidim/verifications/sms/authorizations/edit.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/sms/authorizations/edit.html.erb
@@ -10,7 +10,7 @@
       <div class="columns large-6 medium-centered">
         <div class="card">
           <div class="card__content">
-            <%= decidim_form_for(@form, url: authorization_path, method: :put) do |form| %>
+            <%= decidim_form_for(@form, url: authorization_path(redirect_url: params[:redirect_url]), method: :put) do |form| %>
               <div class="field">
                 <%= form.text_field :verification_code %>
               </div>

--- a/decidim-verifications/app/views/decidim/verifications/sms/authorizations/new.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/sms/authorizations/new.html.erb
@@ -10,7 +10,7 @@
       <div class="columns large-6 medium-centered">
         <div class="card">
           <div class="card__content">
-            <%= decidim_form_for(@form, url: authorization_path) do |form| %>
+            <%= decidim_form_for(@form, url: authorization_path(redirect_url: params[:redirect_url])) do |form| %>
               <div class="field">
                 <%= form.text_field :mobile_phone_number %>
               </div>


### PR DESCRIPTION
#### :tophat: What? Why?

Fixes the SMS verification by redirecting to the URL that triggered the verification (if any).

#### :pushpin: Related Issues
- Related to #4429 
