### PR TITLE
Check metadata variations based on children scopes in vote_form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ ActiveSupport::Notifications.subscribe "decidim.user.omniauth_registration" do |
 - **decidim-initiatives**: Change initiative creation wizard layout. [\#4888](https://github.com/decidim/decidim/pull/4888)
 - **decidim-initiatives**: Make changes related with initiatives signature and permissions ux. [\#4906](https://github.com/decidim/decidim/pull/4906)
 - **decidim-admin**: Fix inputs of translated attributes in resource permissions options form. [\#4911](https://github.com/decidim/decidim/pull/4911)
+- **decidim-initiatives**: Validate vote_form metadata considering initiative scope and also children scopes. [\#4933](https://github.com/decidim/decidim/pull/4933)
 
 **Fixed**:
 

--- a/decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb
@@ -94,7 +94,9 @@ module Decidim
       def personal_data_consistent_with_metadata
         return if initiative.document_number_authorization_handler.blank?
 
-        errors.add(:base, :invalid) unless authorized? && authorization_handler && authorization.metadata.symbolize_keys == authorization_handler.metadata.symbolize_keys
+        errors.add(:base, :invalid) unless authorized? &&
+                                           authorization_handler &&
+                                           authorization_handler_metadata_variations.any? { |variation| authorization.metadata.symbolize_keys == variation.symbolize_keys }
       end
 
       def author
@@ -130,6 +132,19 @@ module Decidim
                                                                              date_of_birth: date_of_birth,
                                                                              postal_code: postal_code,
                                                                              scope_id: scope&.id)
+      end
+
+      def authorization_handler_metadata_variations
+        return [] unless authorization_handler && scope.present?
+
+        scope.children.map do |child_scope|
+          Decidim::AuthorizationHandler.handler_for(handler_name,
+                                                    document_number: document_number,
+                                                    name_and_surname: name_and_surname,
+                                                    date_of_birth: date_of_birth,
+                                                    postal_code: postal_code,
+                                                    scope_id: child_scope&.id)
+        end.unshift(authorization_handler).map(&:metadata)
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

- Allows voting initiatives when the scope of the initiative is parent of the scope the user belongs to. To do this, the metadata is checked not only for the initiative scope, also for the children scopes

#### :pushpin: Related Issues
- Related to #4644

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
