### PR TITLE
Keep correct answers of single-choice questions when errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ ActiveSupport::Notifications.subscribe "decidim.user.omniauth_registration" do |
 - **decidim-proposals**: Allow reporting official proposals [\#4930](https://github.com/decidim/decidim/pull/4930)
 - **decidim-participatory_processes**: Fix past processes filter [\#4932](https://github.com/decidim/decidim/pull/4932)
 - **decidim-verifications**: Redirect to previous url after verifying your mobile number via SMS. [\#4929](https://github.com/decidim/decidim/pull/4929)
+- **decidim-forms**: Keep correct answers of sinlge-choice question when there are errors [\#4934](https://github.com/decidim/decidim/pull/4934)
 
 **Removed**:
 

--- a/decidim-forms/app/views/decidim/forms/questionnaires/_answer.html.erb
+++ b/decidim-forms/app/views/decidim/forms/questionnaires/_answer.html.erb
@@ -22,7 +22,7 @@
       <%= label_tag "#{choice_id}_body" do %>
         <%= radio_button_tag "questionnaire[answers][#{answer_idx}][choices][][body]",
                              translated_attribute(answer_option.body),
-                             choice.try(:body),
+                             answer_option.id == choice.try(:answer_option_id),
                              id: "#{choice_id}_body", disabled: disabled %>
 
         <%= translated_attribute(answer_option.body) %>


### PR DESCRIPTION
#### :tophat: What? Why?
When using single-option questions on a survey, and there's an error answering it, the single-option answers get scrambled. Actually, the last option is selected (see gifs). This PR fixes this problem.

#### :pushpin: Related Issues
- Fixes #3686

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
Without this PR:
![screenrecording20190305at1 2](https://user-images.githubusercontent.com/491891/53801526-c14c3f80-3f3f-11e9-9d20-77ff8366bc5f.gif)

With this PR:
![screenrecording20190305at1 1](https://user-images.githubusercontent.com/491891/53801432-72060f00-3f3f-11e9-940b-c100730f5248.gif)

