### PR TITLE
Fix nicknames migration in 0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,7 @@ administrators should keep in mind updating the help texts for each step.
 - **decidim-core**: Use custom sanitizer in views instead of the default one [\#3655](https://github.com/decidim/decidim/pull/3655)
 - **decidim-initiatives**: Use custom sanitizer in views instead of the default one [\#3655](https://github.com/decidim/decidim/pull/3655)
 - **decidim-sortitions**: Use custom sanitizer in views instead of the default one [\#3655](https://github.com/decidim/decidim/pull/3655)
+- **decidim-core**: Fix nicknames migration [\#4936](https://github.com/decidim/decidim/pull/4936)
 
 **Removed**:
 

--- a/decidim-core/db/migrate/20180221101934_fix_nickname_index.rb
+++ b/decidim-core/db/migrate/20180221101934_fix_nickname_index.rb
@@ -3,6 +3,8 @@
 class FixNicknameIndex < ActiveRecord::Migration[5.1]
   class User < ApplicationRecord
     self.table_name = :decidim_users
+
+    include Decidim::Nicknamizable
   end
 
   def change


### PR DESCRIPTION
#### :tophat: What? Why?
As reported in #4019, the nicknames migration is broken in 0.11 stable. This PR fixes it.

#### :pushpin: Related Issues
- Fixes #4019

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

