### PR TITLE
Fix comment reply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ ActiveSupport::Notifications.subscribe "decidim.user.omniauth_registration" do |
 - **decidim-proposals**: Allow reporting official proposals [\#4930](https://github.com/decidim/decidim/pull/4930)
 - **decidim-participatory_processes**: Fix past processes filter [\#4932](https://github.com/decidim/decidim/pull/4932)
 - **decidim-verifications**: Redirect to previous url after verifying your mobile number via SMS. [\#4929](https://github.com/decidim/decidim/pull/4929)
+- **decidim-comments**: Fix comment reply when comments blocked [\#4939](https://github.com/decidim/decidim/pull/4939)
 
 **Removed**:
 

--- a/decidim-comments/app/models/decidim/comments/comment.rb
+++ b/decidim-comments/app/models/decidim/comments/comment.rb
@@ -50,7 +50,7 @@ module Decidim
 
       # Public: Override Commentable concern method `accepts_new_comments?`
       def accepts_new_comments?
-        depth < MAX_DEPTH
+        root_commentable.accepts_new_comments? && depth < MAX_DEPTH
       end
 
       # Public: Override Commentable concern method `users_to_notify_on_comment_created`.
@@ -96,7 +96,7 @@ module Decidim
       # Private: Check if commentable can have comments and if not adds
       # a validation error to the model
       def commentable_can_have_comments
-        errors.add(:commentable, :cannot_have_comments) unless commentable.accepts_new_comments?
+        errors.add(:commentable, :cannot_have_comments) unless root_commentable.accepts_new_comments?
       end
 
       # Private: Compute comment depth inside the current comment tree

--- a/decidim-comments/lib/decidim/comments/api/comment_type.rb
+++ b/decidim-comments/lib/decidim/comments/api/comment_type.rb
@@ -65,7 +65,7 @@ module Decidim
 
       field :hasComments, !types.Boolean, "Check if the commentable has comments" do
         resolve lambda { |obj, _args, _ctx|
-          obj.accepts_new_comments? && obj.comment_threads.size.positive?
+          obj.comment_threads.size.positive?
         }
       end
 

--- a/decidim-comments/spec/models/comment_spec.rb
+++ b/decidim-comments/spec/models/comment_spec.rb
@@ -41,7 +41,7 @@ module Decidim
       end
 
       it "is not valid if its parent is a comment and cannot accept new comments" do
-        expect(comment).to receive(:accepts_new_comments?).and_return false
+        expect(comment.root_commentable).to receive(:accepts_new_comments?).and_return false
         expect(replies[0]).not_to be_valid
       end
 

--- a/decidim-comments/spec/types/comment_type_spec.rb
+++ b/decidim-comments/spec/types/comment_type_spec.rb
@@ -65,12 +65,6 @@ module Decidim
           FactoryBot.create(:comment, commentable: model)
           expect(response).to include("hasComments" => true)
         end
-
-        it "returns false if the comment depth is equal to MAX_DEPTH" do
-          FactoryBot.create(:comment, commentable: model)
-          model.update!(depth: Comment::MAX_DEPTH)
-          expect(response).to include("hasComments" => false)
-        end
       end
 
       describe "acceptsNewComments" do


### PR DESCRIPTION
#### :tophat: What? Why?

Users shouldn't be able to reply comments when they're blocked.

#### :pushpin: Related Issues
- Fixes #4003

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
