### PR TITLE
Allow managing components inside a consultation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@ ActiveSupport::Notifications.subscribe "decidim.user.omniauth_registration" do |
 - **decidim-budgets**: Fix button updates [\#4941](https://github.com/decidim/decidim/pull/4941)
 - **decidim-comments**: Fix comment reply when comments blocked [\#4939](https://github.com/decidim/decidim/pull/4939)
 - **decidim-forms**: Keep correct answers of sinlge-choice question when there are errors [\#4934](https://github.com/decidim/decidim/pull/4934)
+- **decidim-consultations**: Allow admins to manage components [\#4942](https://github.com/decidim/decidim/pull/4942)
 
 **Removed**:
 

--- a/decidim-consultations/app/permissions/decidim/consultations/admin/permissions.rb
+++ b/decidim-consultations/app/permissions/decidim/consultations/admin/permissions.rb
@@ -8,9 +8,7 @@ module Decidim
           return permission_action unless user
           return permission_action unless permission_action.scope == :admin
 
-          if consultation && (!consultation.is_a?(Decidim::Consultation) && !consultation.is_a?(Decidim::Consultations::Question))
-            return permission_action
-          end
+          return permission_action if consultation && (!consultation.is_a?(Decidim::Consultation) && !consultation.is_a?(Decidim::Consultations::Question))
 
           unless user.admin?
             disallow!

--- a/decidim-consultations/app/permissions/decidim/consultations/admin/permissions.rb
+++ b/decidim-consultations/app/permissions/decidim/consultations/admin/permissions.rb
@@ -7,7 +7,10 @@ module Decidim
         def permissions
           return permission_action unless user
           return permission_action unless permission_action.scope == :admin
-          return permission_action if consultation && !consultation.is_a?(Decidim::Consultation)
+
+          if consultation && (!consultation.is_a?(Decidim::Consultation) && !consultation.is_a?(Decidim::Consultations::Question))
+            return permission_action
+          end
 
           unless user.admin?
             disallow!
@@ -22,6 +25,7 @@ module Decidim
           end
 
           allowed_read_participatory_space?
+          allowed_action_on_component?
           allowed_consultation_action?
           allowed_question_action?
           allowed_response_action?
@@ -41,6 +45,12 @@ module Decidim
 
         def response
           @response ||= context.fetch(:response, nil)
+        end
+
+        def allowed_action_on_component?
+          return unless permission_action.subject == :component
+
+          allow!
         end
 
         def allowed_consultation_action?

--- a/decidim-consultations/app/permissions/decidim/consultations/permissions.rb
+++ b/decidim-consultations/app/permissions/decidim/consultations/permissions.rb
@@ -6,10 +6,9 @@ module Decidim
       def permissions
         allowed_public_anonymous_action?
 
-        permission_action unless user
+        return permission_action unless user
         allowed_public_action?
 
-        permission_action unless permission_action.scope == :admin
         return Decidim::Consultations::Admin::Permissions.new(user, permission_action, context).permissions if permission_action.scope == :admin
 
         permission_action

--- a/decidim-consultations/spec/permissions/decidim/consultations/admin/permissions_spec.rb
+++ b/decidim-consultations/spec/permissions/decidim/consultations/admin/permissions_spec.rb
@@ -240,4 +240,21 @@ describe Decidim::Consultations::Admin::Permissions do
       end
     end
   end
+
+  describe "participatory spaces" do
+    let(:action_subject) { :participatory_space }
+    let(:action_name) { :read }
+
+    it { is_expected.to eq true }
+  end
+
+  describe "components" do
+    let(:action_subject) { :component }
+    let(:action_name) { :manage }
+    let(:extra_context) do
+      { consultation: nil, participatory_space: question }
+    end
+
+    it { is_expected.to eq true }
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Components were not working as expected inside a consultation. This PR allows users to manage them.

#### :pushpin: Related Issues
- Fixes #4865 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/491891/53878285-c4146680-400b-11e9-85e1-e296e1721e06.png)

