### PR TITLE
Fix meeting questionnaire migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@ ActiveSupport::Notifications.subscribe "decidim.user.omniauth_registration" do |
 - **decidim-consultations**: Allow admins to manage components [\#4942](https://github.com/decidim/decidim/pull/4942)
 - **decidim-comments**: Fix comments on IE11 [\#4946](https://github.com/decidim/decidim/pull/4946)
 - **decidim-surveys**: Ensure the user has authorization to render the survey [\#4943](https://github.com/decidim/decidim/pull/4943)
+- **decidim-meetings**: Fix meeting questionnaire migration [\#4950](https://github.com/decidim/decidim/pull/4950/)
 
 **Removed**:
 

--- a/decidim-meetings/db/migrate/20181107175558_add_questionnaire_to_existing_meetings.rb
+++ b/decidim-meetings/db/migrate/20181107175558_add_questionnaire_to_existing_meetings.rb
@@ -4,7 +4,7 @@ class AddQuestionnaireToExistingMeetings < ActiveRecord::Migration[5.2]
   def change
     Decidim::Meetings::Meeting.transaction do
       Decidim::Meetings::Meeting.find_each do |meeting|
-        if meeting.questionnaire.blank?
+        if meeting.component.present? && meeting.questionnaire.blank?
           meeting.update!(
             questionnaire: Decidim::Forms::Questionnaire.new
           )


### PR DESCRIPTION
#### :tophat: What? Why?
Fix migration to skip orphaned meetings. See #4949

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
