### PR TITLE
Reenables new issues creation on GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Stacktrace**
+If applicable, add the error stacktrace to help explain your problem.
+
+**Extra data (please complete the following information):**
+ - Device: [e.g. iPhone6, Desktop]
+ - Device OS: [e.g. iOS8.1, Windows 10]
+ - Browser: [e.g. Chrome, Firefox, Safari]
+ - Decidim Version: [e.g. 0.10]
+ - Decidim installation: [e.g. MetaDecidim]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -31,4 +31,4 @@ If applicable, add the error stacktrace to help explain your problem.
  - Decidim installation: [e.g. MetaDecidim]
 
 **Additional context**
-Add any other context about the problem here.
+Add any other context about the problem here. For instance, add Metadecidim link. 

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,14 +1,12 @@
 ---
-name: Issue creation disabled
+name: Feature request creation disabled
 about: Go to MetaDecidim :)
 
 ---
 
-We've disabled the issue creation on this repository. If you want to add a new issue (to report a bug or a feature request) you can do this through MetaDecidim:
+We've disabled the feature request's issue creation on this repository. If you want to discuss about a new feature, you can do this through MetaDecidim:
 
-* [Report a bug](https://meta.decidim.org/processes/bug-report)
 * [Feature Request](https://meta.decidim.org/processes/roadmap)
-* [Support Forum](https://meta.decidim.org/processes/supportforum)
 
 We're doing this because we're trying to eat our own dog food. Once your proposal is collaboratively reviewed and accepted by the Product Comitee, we'll create the new issue on GitHub and notify you through MetaDecidim.
 


### PR DESCRIPTION
#### :tophat: What? Why?

Partially reenable issues on GitHub:

* bug reporting on GitHub
* new feature request and discussion on MetaDecidim

This decision comes by a debate on MetaDecidim itself.

Full discussion regarding this change:
https://meta.decidim.org/processes/supportforum/f/705/proposals/14243

#### :pushpin: Related Issues
- Related to #4810
 
Thanks to @ahukkanen for the feedback. Please review and chime in :) 