### PR TITLE
[BACKPORT] Skip callbacks on follower counters migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,6 +261,7 @@ In order to generate Open Data exports you should add this to your crontab or re
 - **decidim-meetings**: Filter meeting by end time instead of start time [\#4701](https://github.com/decidim/decidim/pull/4701)
 - **decidim-core**: MetricResolver filtering corrected comparison between symbol and string [\#4736](https://github.com/decidim/decidim/pull/4736)
 - **decidim-meetings**: Fix meeting questionnaire migration [\#4949](https://github.com/decidim/decidim/pull/4949/)
+- **decidim-core**: Speed up `AddFollowingAndFollowersCountersToUsers` migration [\#4955](https://github.com/decidim/decidim/pull/4955/)
 
 **Removed**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## [Unreleased](https://github.com/decidim/decidim/tree/HEAD)
 
+### Upgrade notes
+
+#### User follow counters
+After running the migrations, please run this code from a console:
+
+```ruby
+Decidim::UserBaseEntity.find_each do |entity|
+  follower_count = Decidim::Follow.where(followable: entity).count
+  following_count = Decidim::Follow.where(decidim_user_id: entity.id).count
+  following_users_count = Decidim::Follow.where(decidim_user_id: entity.id, decidim_followable_type: ["Decidim::UserBaseEntity", "Decidim::User", "Decidim::UserGroup"]).count
+
+  # We use `update_columns` to skip Searchable callbacks
+  entity.update_columns(
+    followers_count: follower_count,
+    following_count: following_count,
+    following_users_count: following_users_count
+  )
+end
+```
+
+### Changes
+
 **Added**:
 
 - **decidim-proposals**: Added a button to reset all participatory text drafts. [\#4817](https://github.com/decidim/decidim/pull/4817)

--- a/decidim-core/db/migrate/20181115102958_add_following_and_followers_counters_to_users.rb
+++ b/decidim-core/db/migrate/20181115102958_add_following_and_followers_counters_to_users.rb
@@ -5,17 +5,6 @@ class AddFollowingAndFollowersCountersToUsers < ActiveRecord::Migration[5.2]
     add_column :decidim_users, :following_count, :integer, null: false, default: 0
     add_column :decidim_users, :following_users_count, :integer, null: false, default: 0
     add_column :decidim_users, :followers_count, :integer, null: false, default: 0
-
-    Decidim::UserBaseEntity.find_each do |entity|
-      follower_count = Decidim::Follow.where(followable: entity).count
-      following_count = Decidim::Follow.where(decidim_user_id: entity.id).count
-      following_users_count = Decidim::Follow.where(decidim_user_id: entity.id, decidim_followable_type: ["Decidim::UserBaseEntity", "Decidim::User", "Decidim::UserGroup"]).count
-
-      entity.followers_count = follower_count
-      entity.following_count = following_count
-      entity.following_users_count = following_users_count
-      entity.save
-    end
   end
 
   def down

--- a/decidim-core/lib/decidim/searchable.rb
+++ b/decidim-core/lib/decidim/searchable.rb
@@ -71,7 +71,7 @@ module Decidim
             add_to_index_as_search_resource
           else
             fields = self.class.search_resource_fields_mapper.mapped(self)
-            searchables_in_org.each do |sr|
+            searchables_in_org.find_each do |sr|
               sr.update(contents_to_searchable_resource_attributes(fields, sr.locale))
             end
           end


### PR DESCRIPTION
#### :tophat: What? Why?
When updating apps we found out that the `AddFollowingAndFollowersCountersToUsers` migration takes a lot of time. We dug a little bit and found that the cause of the problem is that `Searchable` concern causes N extra updates (one per organization available_locale) to keep the searchable_resources up to date, and there's no way to skip them. In our case, the updated data is not used in the search, so we don't need those updates.

This PR changes the migration to use `update_columns`, which skips callbacks and thus avoids those extra updates.

**EDIT**: We decided to move the code to an "Upgrade notes" in the changelog, so that it won't block the migrations.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

