### PR TITLE
[BACKPORT] Don't render profile URL if user has no nickname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,6 +262,7 @@ In order to generate Open Data exports you should add this to your crontab or re
 - **decidim-core**: MetricResolver filtering corrected comparison between symbol and string [\#4736](https://github.com/decidim/decidim/pull/4736)
 - **decidim-meetings**: Fix meeting questionnaire migration [\#4949](https://github.com/decidim/decidim/pull/4949/)
 - **decidim-core**: Speed up `AddFollowingAndFollowersCountersToUsers` migration [\#4955](https://github.com/decidim/decidim/pull/4955/)
+- **decidim-admin**: Do not generate profile URL in officializations view if nickname is missing [\#4962](https://github.com/decidim/decidim/pull/4962/)
 
 **Removed**:
 

--- a/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
@@ -55,8 +55,13 @@
         <tbody>
           <% @users.each do |user| %>
             <tr data-user-id="<%= user.id %>">
-              <td><%= link_to user.name, decidim.profile_path(user.nickname) %></td>
-              <td><%= link_to user.nickname, decidim.profile_path(user.nickname) %></td>
+              <% if user.nickname.present? %>
+                <td><%= link_to user.name, decidim.profile_path(user.nickname) %></td>
+                <td><%= link_to user.nickname, decidim.profile_path(user.nickname) %></td>
+              <% else %>
+                <td><%= user.name %></td>
+                <td><%= user.nickname %></td>
+              <% end %>
               <td><%= l user.created_at, format: :short %></td>
               <td><%= user.officialized? ? t(".officialized") : t(".not_officialized") %></td>
               <td><%= translated_attribute(user.officialized_as) %></td>


### PR DESCRIPTION
#### :tophat: What? Why?
If the nickname is not present, the URL generation fails.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry