### PR TITLE
[Backport] Fix authorization workflows index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,6 +262,7 @@ In order to generate Open Data exports you should add this to your crontab or re
 - **decidim-core**: MetricResolver filtering corrected comparison between symbol and string [\#4736](https://github.com/decidim/decidim/pull/4736)
 - **decidim-meetings**: Fix meeting questionnaire migration [\#4949](https://github.com/decidim/decidim/pull/4949/)
 - **decidim-core**: Speed up `AddFollowingAndFollowersCountersToUsers` migration [\#4955](https://github.com/decidim/decidim/pull/4955/)
+- **decidim-admin**: Let admins visit the autrhorization workflows index page [\#4963](https://github.com/decidim/decidim/pull/4963/)
 
 **Removed**:
 

--- a/decidim-admin/app/controllers/decidim/admin/authorization_workflows_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/authorization_workflows_controller.rb
@@ -6,7 +6,7 @@ module Decidim
       layout "decidim/admin/users"
 
       def index
-        enforce_permission_to :index, :authorization_workflows
+        enforce_permission_to :index, :authorization_workflow
 
         @workflows = Decidim::Verifications.admin_workflows
       end

--- a/decidim-verifications/spec/system/admin_lists_authorizations_spec.rb
+++ b/decidim-verifications/spec/system/admin_lists_authorizations_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin lists authorizations", type: :system do
+  let!(:organization) do
+    create(:organization, available_authorizations: ["id_documents"])
+  end
+
+  let(:admin) { create(:user, :admin, :confirmed, organization: organization) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as admin, scope: :user
+    visit decidim_admin.root_path
+    click_link "Users"
+    click_link "Verifications"
+  end
+
+  it "allows the user to list all available authorization methods" do
+    within ".container" do
+      expect(page).to have_content("Identity documents")
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
There was a bug in the permissions system that didn't allow admins to visit the authorization workflows page and this wasn't being tested by any system spec.

This PR solves this and adds the missing specs.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
