### PR TITLE
Remove card-spaces footer background

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
@@ -200,12 +200,6 @@ $datetime-bg: var(--primary);
   .card__content{
     display: flex;
   }
-
-  &.card__footer--spaces{
-    background: rgba($card-spaces, .2);
-    border-top-color: rgba($card-spaces, .6);
-    border-top-width: .25rem;
-  }
 }
 
 .card__footer--transparent{


### PR DESCRIPTION
#### :tophat: What? Why?
This remove the rgba function to `card__footer--spaces` class, because is not posible to use rgba with css custom properties using hex colors. 

#### :pushpin: Related Issues
- Related to #4882 


### :camera: Screenshots (optional)
#### Before
![Before](https://user-images.githubusercontent.com/1911813/54277017-105c2b00-4565-11e9-8518-d4894e9d905a.png)

#### After
![After](https://user-images.githubusercontent.com/1911813/54277055-2833af00-4565-11e9-96c0-3a2f8d631c66.png)

