### PR TITLE
Fix show published child assemblies only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ end
 
 **Fixed**:
 
+- **decidim-assemblies**: Fix only show published children assemblies in public view [#4969](https://github.com/decidim/decidim/pull/4969)
 - **decidim-core**: Fix wrong check of avatar_url in `/oauth/me` controller  [#4917](https://github.com/decidim/decidim/pull/4917)
 - **decidim-core**: Don't mix omniauth notifications with `Decidim::EventManager` events [#4895](https://github.com/decidim/decidim/pull/4895)
 - **decidim-core**: Hide comments on cards when deactivated on a component. [\#4904](https://github.com/decidim/decidim/pull/4904)

--- a/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
@@ -84,7 +84,7 @@ edit_link(
         <section id="assemblies-grid" class="section row collapse">
           <h4 class="section-heading"><%= t("assemblies.show.children", scope: "decidim") %></h4>
           <div class="row small-up-1 medium-up-2 large-up-2 card-grid">
-            <%= render partial: "decidim/assemblies/assembly", collection: current_participatory_space.children %>
+            <%= render partial: "decidim/assemblies/assembly", collection: current_participatory_space.children.published %>
           </div>
         </section>
       <% end %>

--- a/decidim-assemblies/spec/system/assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/assemblies_spec.rb
@@ -255,7 +255,7 @@ describe "Assemblies", type: :system do
       end
     end
 
-    context "when the assembly has a child" do
+    context "when the assembly has children assemblies" do
       let!(:child_assembly) { create :assembly, organization: organization, parent: assembly }
       let!(:unpublished_child_assembly) { create :assembly, :unpublished, organization: organization, parent: assembly }
 
@@ -263,7 +263,7 @@ describe "Assemblies", type: :system do
         visit decidim_assemblies.assembly_path(assembly)
       end
 
-      it "shows the published children assemblies_path" do
+      it "shows only the published children assemblies" do
         within("#assemblies-grid") do
           expect(page).to have_link translated(child_assembly.title)
           expect(page).not_to have_link translated(unpublished_child_assembly.title)

--- a/decidim-assemblies/spec/system/assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/assemblies_spec.rb
@@ -257,14 +257,16 @@ describe "Assemblies", type: :system do
 
     context "when the assembly has a child" do
       let!(:child_assembly) { create :assembly, organization: organization, parent: assembly }
+      let!(:unpublished_child_assembly) { create :assembly, :unpublished, organization: organization, parent: assembly }
 
       before do
         visit decidim_assemblies.assembly_path(assembly)
       end
 
-      it "shows the children" do
+      it "shows the published children assemblies_path" do
         within("#assemblies-grid") do
           expect(page).to have_link translated(child_assembly.title)
+          expect(page).not_to have_link translated(unpublished_child_assembly.title)
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
>Despite unpublishing them, child assemblies are still visible on the parent assembly home page

#### :pushpin: Related Issues
- Fixes #4952

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
