### PR TITLE
Fix .card--list__data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ end
 
 **Fixed**:
 
+- **decidim-meetings**: Fix card list data displays. [#4972](https://github.com/decidim/decidim/pull/4972)
 - **decidim-assemblies**: Fix only show published children assemblies in public view [#4969](https://github.com/decidim/decidim/pull/4969)
 - **decidim-core**: Fix wrong check of avatar_url in `/oauth/me` controller  [#4917](https://github.com/decidim/decidim/pull/4917)
 - **decidim-core**: Don't mix omniauth notifications with `Decidim::EventManager` events [#4895](https://github.com/decidim/decidim/pull/4895)

--- a/decidim-accountability/app/assets/stylesheets/decidim/accountability/accountability/_cards.scss
+++ b/decidim-accountability/app/assets/stylesheets/decidim/accountability/accountability/_cards.scss
@@ -3,10 +3,6 @@
     display: block;
   }
 
-  .card--list__data{
-    min-width: 7rem;
-  }
-
   .card--meta{
     span{
       margin-right: .5rem;

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
@@ -501,6 +501,7 @@ $datetime-bg: var(--primary);
   text-align: center;
   text-transform: uppercase;
   font-size: 85%;
+  min-width: 7rem;
   line-height: 1;
   color: $muted;
   padding: $card-padding-small;


### PR DESCRIPTION
#### :tophat: What? Why?
Fix card list data displays on meetings.
Move css from accountability to core to ensure this doesn't happen anymore.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
Before : 
<img width="615" alt="Capture d’écran 2019-03-14 à 18 58 46" src="https://user-images.githubusercontent.com/20232956/54380606-29133080-468c-11e9-897d-5963ea9aba45.png">
After : 
<img width="615" alt="Capture d’écran 2019-03-14 à 18 57 47" src="https://user-images.githubusercontent.com/20232956/54380605-29133080-468c-11e9-8770-d184b8728df9.png">

