### PR TITLE
Fix user presenter for user groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,7 @@ end
 - **decidim-core**: Speed up `AddFollowingAndFollowersCountersToUsers` migration [\#4955](https://github.com/decidim/decidim/pull/4955/)
 - **decidim-admin**: Let admins visit the autrhorization workflows index page [\#4964](https://github.com/decidim/decidim/pull/4964/)
 - **decidim-admin**: Do not generate profile URL in officializations view if nickname is missing [\#4964](https://github.com/decidim/decidim/pull/4964/)
+- **decidim-core**: Fix user presenter for user groups breaking notifications views [\#4973](https://github.com/decidim/decidim/pull/4973/)
 
 **Removed**:
 

--- a/decidim-core/app/presenters/decidim/user_presenter.rb
+++ b/decidim-core/app/presenters/decidim/user_presenter.rb
@@ -25,13 +25,13 @@ module Decidim
     delegate :url, to: :avatar, prefix: true
 
     def profile_url
-      return "" if deleted?
+      return "" if respond_to?(:deleted?) && deleted?
 
       decidim.profile_url(__getobj__.nickname, host: __getobj__.organization.host)
     end
 
     def profile_path
-      return "" if deleted?
+      return "" if respond_to?(:deleted?) && deleted?
 
       decidim.profile_path(__getobj__.nickname)
     end

--- a/decidim-core/spec/presenters/decidim/user_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/user_presenter_spec.rb
@@ -55,5 +55,23 @@ module Decidim
           have_selector(".user-mention")
       end
     end
+
+    context "when user is a group" do
+      let(:user) { build(:user_group) }
+
+      describe "#profile_path" do
+        subject { described_class.new(user).profile_path }
+
+        it { is_expected.to eq("/profiles/#{user.nickname}") }
+      end
+
+      describe "#profile_url" do
+        subject { described_class.new(user).profile_url }
+
+        let(:host) { user.organization.host }
+
+        it { is_expected.to eq("http://#{host}/profiles/#{user.nickname}") }
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

The user groups do not have a `.deleted?` method defined for them which caused the user presenter to break the notifications view in case the notification was linking to a group user.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry