### PR TITLE
Revert Catalan and Spanish locales normalization

### DIFF
--- a/decidim-accountability/config/locales/ca.yml
+++ b/decidim-accountability/config/locales/ca.yml
@@ -1,4 +1,3 @@
----
 ca:
   activemodel:
     attributes:

--- a/decidim-accountability/config/locales/es.yml
+++ b/decidim-accountability/config/locales/es.yml
@@ -1,4 +1,3 @@
----
 es:
   activemodel:
     attributes:
@@ -33,7 +32,7 @@ es:
   decidim:
     accountability:
       actions:
-        confirm_destroy: "¿Está seguro de que quiere eliminar este %{name}?"
+        confirm_destroy: '¿Está seguro de que quiere eliminar este %{name}?'
         destroy: Borrar
         edit: Editar
         new: Nuevo/a %{name}

--- a/decidim-admin/config/locales/ca.yml
+++ b/decidim-admin/config/locales/ca.yml
@@ -1,4 +1,3 @@
----
 ca:
   activemodel:
     attributes:
@@ -108,9 +107,9 @@ ca:
               must_be_ssl: L'URL de redirecció ha de ser SSL
         organization:
           attributes:
-            official_img_footer:
-              allowed_file_content_types: Fitxer d'imatge no vàlid
             official_img_header:
+              allowed_file_content_types: Fitxer d'imatge no vàlid
+            official_img_footer:
               allowed_file_content_types: Fitxer d'imatge no vàlid
   activerecord:
     attributes:

--- a/decidim-admin/config/locales/es.yml
+++ b/decidim-admin/config/locales/es.yml
@@ -1,4 +1,3 @@
----
 es:
   activemodel:
     attributes:
@@ -108,9 +107,9 @@ es:
               must_be_ssl: El URI de redirección debe ser un URI SSL
         organization:
           attributes:
-            official_img_footer:
-              allowed_file_content_types: Archivo de imagen no válido
             official_img_header:
+              allowed_file_content_types: Archivo de imagen no válido
+            official_img_footer:
               allowed_file_content_types: Archivo de imagen no válido
   activerecord:
     attributes:
@@ -434,13 +433,13 @@ es:
         form:
           interpolations_hint: 'Sugerencia: Puede utilizar "%{name}" en cualquier parte del cuerpo o asunto y será reemplazado por el nombre del destinatario.'
         index:
-          confirm_delete: "¿Estás seguro de que quieres eliminar este boletín?"
+          confirm_delete: '¿Estás seguro de que quieres eliminar este boletín?'
           title: Boletines
         new:
           save: Guardar
           title: Nuevo boletín
         show:
-          confirm_deliver: "¿Estás seguro de que quieres enviar este boletín? Esta acción no se puede deshacer."
+          confirm_deliver: '¿Estás seguro de que quieres enviar este boletín? Esta acción no se puede deshacer.'
           deliver: Enviar boletín
           preview: Previsualizar
           subject: Asunto
@@ -458,7 +457,7 @@ es:
           save: Guardar
           title: Editar aplicación
         index:
-          confirm_delete: "¿Estás seguro que quieres eliminar esta aplicación?"
+          confirm_delete: '¿Estás seguro que quieres eliminar esta aplicación?'
           title: Aplicaciones OAuth
         new:
           save: Guardar

--- a/decidim-assemblies/config/locales/ca.yml
+++ b/decidim-assemblies/config/locales/ca.yml
@@ -1,4 +1,3 @@
----
 ca:
   activemodel:
     attributes:

--- a/decidim-assemblies/config/locales/es.yml
+++ b/decidim-assemblies/config/locales/es.yml
@@ -1,4 +1,3 @@
----
 es:
   activemodel:
     attributes:
@@ -333,7 +332,7 @@ es:
         assemblies:
           contextual: "<p>Una asamblea es un grupo formado por miembros de una organización que se reúnen periódicamente para tomar decisiones sobre un ámbito o área específica de la misma.</p> <p>Las asambleas realizan encuentros, algunas son privadas y otras son abiertas. Si son abiertas se puede participar en ellas (por ejemplo: asistiendo si el aforo lo permite, añadiendo puntos al orden del día, o comentando las propuestas y decisiones tomadas por dicho órgano).</p> <p>Ejemplos: Una asamblea general (que se reúne una vez al año para definir las líneas principales de acción de la organización así como a sus órganos ejecutivos por votación), una consejo asesor de igualdad (que se reúne cada dos meses para realizar propuestas de cómo mejorar las relaciones de género en la organización), una comisión de evaluación (que se reúne cada mes para realizar el seguimiento de un proceso) o una órgano de garantías (que recoge las incidencias, abusos o propuestas de mejora de los procedimientos de toma de decisiones) son todo ejemplos de asambleas.</p>\n"
           page: "<p>Una asamblea es un grupo formado por miembros de una organización que se reúnen periódicamente para tomar decisiones sobre un ámbito o área específica de la misma.</p> <p>Las asambleas realizan encuentros, algunas son privadas y otras son abiertas. Si son abiertas se puede participar en ellas (por ejemplo: asistiendo si el aforo lo permite, añadiendo puntos al orden del día, o comentando las propuestas y decisiones tomadas por dicho órgano).</p> <p>Ejemplos: Una asamblea general (que se reúne una vez al año para definir las líneas principales de acción de la organización así como a sus órganos ejecutivos por votación), una consejo asesor de igualdad (que se reúne cada dos meses para realizar propuestas de cómo mejorar las relaciones de género en la organización), una comisión de evaluación (que se reúne cada mes para realizar el seguimiento de un proceso) o una órgano de garantías (que recoge las incidencias, abusos o propuestas de mejora de los procedimientos de toma de decisiones) son todo ejemplos de asambleas.</p>\n"
-          title: "¿Qué son las asambleas?"
+          title: '¿Qué son las asambleas?'
     log:
       value_types:
         assembly_presenter:

--- a/decidim-blogs/config/locales/ca.yml
+++ b/decidim-blogs/config/locales/ca.yml
@@ -1,4 +1,3 @@
----
 ca:
   activemodel:
     models:

--- a/decidim-blogs/config/locales/es.yml
+++ b/decidim-blogs/config/locales/es.yml
@@ -1,4 +1,3 @@
----
 es:
   activemodel:
     models:
@@ -11,7 +10,7 @@ es:
   decidim:
     blogs:
       actions:
-        confirm_destroy: "¿Seguro que quieres eliminar esta publicación?"
+        confirm_destroy: '¿Seguro que quieres eliminar esta publicación?'
         destroy: Borrar
         edit: Editar
         new: Nueva publicación

--- a/decidim-budgets/config/locales/ca.yml
+++ b/decidim-budgets/config/locales/ca.yml
@@ -1,4 +1,3 @@
----
 ca:
   activemodel:
     attributes:
@@ -52,7 +51,7 @@ ca:
         proposals_imports:
           create:
             invalid: S'ha produït un error en importar les propostes en projectes
-            success: S'ha importat amb èxit %{number} propostes en projectes
+            success: "S'ha importat amb èxit %{number} propostes en projectes"
           new:
             create: Importa propostes a projectes
             no_components: No hi ha cap component de propostes en aquest espai participatiu per importar les propostes a projectes.

--- a/decidim-budgets/config/locales/es.yml
+++ b/decidim-budgets/config/locales/es.yml
@@ -1,4 +1,3 @@
----
 es:
   activemodel:
     attributes:
@@ -19,7 +18,7 @@ es:
       actions:
         attachment_collections: Carpetas
         attachments: Archivos adjuntos
-        confirm_destroy: "¿Estás seguro de que deseas eliminar este proyecto?"
+        confirm_destroy: '¿Estás seguro de que deseas eliminar este proyecto?'
         destroy: Borrar
         edit: Editar
         import: Importar propuestas a proyectos
@@ -68,7 +67,7 @@ es:
             title: Título
       projects:
         budget_confirm:
-          are_you_sure: "¿Estás de acuerdo? Una vez que hayas confirmado tu voto, no puedes cambiarlo."
+          are_you_sure: '¿Estás de acuerdo? Una vez que hayas confirmado tu voto, no puedes cambiarlo.'
           cancel: Cancelar
           confirm: Confirmar
           description: Estos son los proyectos que has elegido para formar parte del presupuesto.
@@ -79,13 +78,13 @@ es:
           ok: De acuerdo
           title: Presupuesto excedido
         budget_summary:
-          are_you_sure: "¿Estás seguro de que deseas cancelar tu voto?"
+          are_you_sure: '¿Estás seguro de que deseas cancelar tu voto?'
           assigned: 'Asignado:'
           cancel_order: eliminar tu voto y empezar de nuevo
           checked_out:
             description: Ya has votado para el presupuesto. Si has cambiado de idea, puedes %{cancel_link}.
             title: Voto enviado correctamente
-          description: "¿Qué proyectos crees que deberíamos asignar el presupuesto? Asigna por lo menos %{minimum_budget} a los proyectos que desees y vota para definir el presupuesto."
+          description: '¿Qué proyectos crees que deberíamos asignar el presupuesto? Asigna por lo menos %{minimum_budget} a los proyectos que desees y vota para definir el presupuesto.'
           title: Tú decides el presupuesto
         count:
           projects_count:

--- a/decidim-comments/config/locales/ca.yml
+++ b/decidim-comments/config/locales/ca.yml
@@ -1,4 +1,3 @@
----
 ca:
   activemodel:
     models:
@@ -35,8 +34,8 @@ ca:
             label: Comentar com a
         opinion:
           neutral: Neutral
-        remaining_characters: Queden %{count} caràcters
-        remaining_characters_1: Queda %{count} caràcter
+        remaining_characters: "Queden %{count} caràcters"
+        remaining_characters_1: "Queda %{count} caràcter"
         title: Deixa el teu comentari
       comment:
         alignment:
@@ -76,7 +75,7 @@ ca:
           email_subject: Hi ha un nou comentari de %{author_name} en %{resource_title}
           notification_title: Hi ha un nou comentari per <a href="%{author_path}">%{author_name} %{author_nickname}</a> a <a href="%{resource_path}">%{resource_title}</a>.
         comment_created:
-          email_intro: 'S''ha comentat %{resource_title}. Pots llegir el comentari d''aquesta pàgina:'
+          email_intro: "S'ha comentat %{resource_title}. Pots llegir el comentari d'aquesta pàgina:"
           email_outro: Has rebut aquesta notificació perquè estàs seguint "%{resource_title}" o el seu autor. Pots deixar de seguir-lo des de l'enllaç anterior.
           email_subject: Hi ha un nou comentari de %{author_name} a %{resource_title}
           notification_title: Hi ha un nou comentari de <a href="%{author_path}">%{author_name} %{author_nickname}</a> en <a href="%{resource_path}">%{resource_title}</a>

--- a/decidim-comments/config/locales/es.yml
+++ b/decidim-comments/config/locales/es.yml
@@ -1,4 +1,3 @@
----
 es:
   activemodel:
     models:
@@ -28,15 +27,15 @@ es:
         form:
           body:
             label: Comentario
-            placeholder: "¿Qué piensas sobre esto?"
+            placeholder: '¿Qué piensas sobre esto?'
           form_error: El texto es necesario y no puede ser más de caracteres %{length}.
           submit: Enviar
           user_group_id:
             label: Comentar como
         opinion:
           neutral: Neutral
-        remaining_characters: Quedan %{count} caracteres
-        remaining_characters_1: Queda %{count} carácter
+        remaining_characters: "Quedan %{count} caracteres"
+        remaining_characters_1: "Queda %{count} carácter"
         title: Deje su comentario
       comment:
         alignment:
@@ -48,7 +47,7 @@ es:
           action: Denunciar
           already_reported: Este contenido ya fue denunciado y será revisado por un administrador.
           close: Cerrar
-          description: "¿Es inapropiado este contenido?"
+          description: '¿Es inapropiado este contenido?'
           details: Comentarios adicionales
           reasons:
             does_not_belong: Contiene actividad ilegal, amenazas de suicidio, información personal o cualquier otra cosa que usted piense que no pertenece en %{organization_name}.

--- a/decidim-conferences/config/locales/ca.yml
+++ b/decidim-conferences/config/locales/ca.yml
@@ -1,4 +1,3 @@
----
 ca:
   activemodel:
     attributes:
@@ -506,10 +505,10 @@ ca:
         votes_count: Suports
     events:
       conferences:
-        conference_registration_confirmed:
-          notification_title: S'ha confirmat el teu registre a la conferència <a href="%{resource_url}">%{resource_title}</a>.
         conference_registration_validation_pending:
           notification_title: El registre de la conferència <a href="%{resource_url}">%{resource_title}</a> està pendent de confirmació.
+        conference_registration_confirmed:
+          notification_title: S'ha confirmat el teu registre a la conferència <a href="%{resource_url}">%{resource_title}</a>.
         conference_registrations_over_percentage:
           email_intro: Les places ocupades per a la conferència "%{resource_title}" ocupen més del %{percentage}%.
           email_outro: Has rebut aquesta notificació perquè ets administrador de la conferència.

--- a/decidim-conferences/config/locales/es.yml
+++ b/decidim-conferences/config/locales/es.yml
@@ -1,4 +1,3 @@
----
 es:
   activemodel:
     attributes:
@@ -476,8 +475,8 @@ es:
           title: Tipos de inscripción
       shared:
         conference_user_login:
-          already_account: "¿Ya tienes una cuenta en decidim?"
-          new_user: "¿Eres nuevo?"
+          already_account: '¿Ya tienes una cuenta en decidim?'
+          new_user: '¿Eres nuevo?'
           sign_in: Inicia sesión para inscribirte en la conferencia
           sign_up: Crea una cuenta de usuario para inscribirte en la conferencia
       show:
@@ -506,10 +505,10 @@ es:
         votes_count: Votos
     events:
       conferences:
-        conference_registration_confirmed:
-          notification_title: Su registro para la conferencia <a href="%{resource_url}">%{resource_title}</a> ha sido confirmado.
         conference_registration_validation_pending:
           notification_title: Su inscripción para la conferencia <a href="%{resource_url}">%{resource_title}</a> está pendiente de confirmación.
+        conference_registration_confirmed:
+          notification_title: Su registro para la conferencia <a href="%{resource_url}">%{resource_title}</a> ha sido confirmado.
         conference_registrations_over_percentage:
           email_intro: Las plazas ocupadas para la conferencia "%{resource_title}" superan el %{percentage}%.
           email_outro: Recibes esta notificación porque eres administrador del espacio participativo de la conferencia.
@@ -528,7 +527,7 @@ es:
         upcoming_conference:
           email_intro: 'La conferencia "%{resource_title}" se lleva a cabo en 2 días. Puedes leer la descripción de su página:'
           email_outro: Ha recibido esta notificación porque está siguiendo la conferencia "%{resource_title}". Puedes dejar de seguirlo desde el enlace anterior.
-          email_subject: ¡Se acerca la conferencia "%{resource_title}"!
+          email_subject: '¡Se acerca la conferencia "%{resource_title}"!'
           notification_title: La conferencia <a href="%{resource_path}">%{resource_title}</a> llegará en 2 días.
     log:
       value_types:

--- a/decidim-consultations/config/locales/ca.yml
+++ b/decidim-consultations/config/locales/ca.yml
@@ -1,4 +1,3 @@
----
 ca:
   activemodel:
     attributes:

--- a/decidim-consultations/config/locales/es.yml
+++ b/decidim-consultations/config/locales/es.yml
@@ -1,4 +1,3 @@
----
 es:
   activemodel:
     attributes:
@@ -250,7 +249,7 @@ es:
         consultations:
           contextual: "<p>Las consultas son un espacio que permite realizar una pregunta clara a todas las personas que forman una organización, hacer un llamamiento a participar en la consulta, suscitar y ordenar el debate a favor o encontra de una respuesta. Llegada la fecha de la consulta permite votar y publicar los resultados de las votaciones.</p> <p>Ejemplos: Las consultas puede versar sobre casi cualquier aspecto que afecte a una organización: algunos ejemplos son cambiar el nombre o logotipo de la organización ofreciendo varias alternativas, decidir Sí o No a formar parte de una organización más grande, validar o rechazar un nuevo plan estratégico o el resultado de un grupo de trabajo, o definir si los cargos deben permanecer un máximo de 1, 2 ó 3 mandatos.</p>\n"
           page: "<p>consultas son un espacio que le permite hacer una pregunta clara a todas las personas que forman una organización, hacer una llamada para participar en la consulta, provocar y ordenar el debate a favor o en contra de una respuesta. Cuando llega la fecha de consulta, puede votar y publicar los resultados de los votos.</p> <p>Ejemplos: las consultas pueden ser sobre casi cualquier aspecto que afecte a una organización: algunos ejemplos están cambiando el nombre o el logotipo de la organización que ofrece varias alternativas, decidiendo Sí o No para formar parte de una organización más grande, validando o rechazando una nueva estrategia plan o el resultado de un grupo de trabajo, o definir si los puestos deben permanecer como máximo de 1, 2 o 3 mandatos en la organización.</p>\n"
-          title: "¿Qué son las consultas?"
+          title: '¿Qué son las consultas?'
     menu:
       consultations: Consultas
     pages:

--- a/decidim-core/config/locales/ca.yml
+++ b/decidim-core/config/locales/ca.yml
@@ -1,4 +1,3 @@
----
 ca:
   activemodel:
     attributes:
@@ -47,7 +46,7 @@ ca:
         other: Grups
   booleans:
     'false': 'No'
-    'true': Sí
+    'true': 'Sí'
   carrierwave:
     errors:
       image_too_big: La imatge és massa gran
@@ -137,12 +136,12 @@ ca:
       amendable:
         amended_by: Esmenat per
         button: Esmenar %{model_name}
+        promote_button: Publicar com una nova %{model_name}
         error: S'ha produït un error en modificar aquest recurs.
         help_text: Milloreu aquest %{model_name} modificant la seva %{amendable_fields}
+        promote_help_text: Pots publicar aquesta esmena com una proposta independent %{model_name}
         no_amenders: No hi ha cap esmenador
         no_amendments: No hi ha cap esmena
-        promote_button: Publicar com una nova %{model_name}
-        promote_help_text: Pots publicar aquesta esmena com una proposta independent %{model_name}
         section_heading: Esmenes (%{count})
       created:
         error: S'ha produït un error en crear aquesta esmena, si us plau torna-ho a provar més tard
@@ -156,7 +155,8 @@ ca:
           accepted: |-
             Aquesta modificació per al %{amendable_type} %{amendable_link} ha estat
             acceptada a <strong>%{announcement_date}</strong>.
-          evaluating: S'està avaluant aquesta esmena del %{amendable_type} %{amendable_link}.
+          evaluating: |-
+            S'està avaluant aquesta esmena del %{amendable_type} %{amendable_link}.
           rejected: |-
             Aquesta esmena de la %{amendable_type} %{amendable_link}
             ha estat rebutjada el <strong>%{announcement_date}</strong>.
@@ -169,12 +169,12 @@ ca:
         heading: Crea la teva esmena
         help_text: Estàs modificant el %{model_name}
         send: Enviar esmena
-      promoted:
-        error: S'ha produït un error en publicar l'esmena com una nova proposta
-        success: L'esmena s'ha publicat com una nova proposta correctament
       rejected:
         error: S'ha produït un error en rebutjar aquesta esmena, si us plau torna-ho a provar més tard
         success: L'esmena s'ha rebutjat correctament
+      promoted:
+        success: L'esmena s'ha publicat com una nova proposta correctament
+        error: S'ha produït un error en publicar l'esmena com una nova proposta
       review:
         back: Tornar
         heading: Revisa l'esmena
@@ -383,17 +383,6 @@ ca:
         title: No s'ha trobat la pàgina que busques
     events:
       amendments:
-        amendment_accepted:
-          affected_user:
-            email_intro: 'S''ha acceptat una modificació per a %{amendable_title}. Podeu veure-ho des d''aquesta pàgina:'
-            email_outro: Has rebut aquesta notificació perquè ets autor/a de %{amendable_title}.
-            email_subject: Una esmena acceptada per %{amendable_title} de %{emendation_author_nickname}
-            notification_title: S'ha acceptat la <a href="%{emendation_path}">esmena</a> creada per <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> per a <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'S''ha acceptat una esmena per %{amendable_title}. Pots veure-ho en aquesta pàgina:'
-            email_outro: Has rebut aquesta notificació perquè estàs seguint %{amendable_title}. Pots deixar de rebre notificacions seguint l'enllaç anterior.
-            email_subject: Una esmena acceptada per %{amendable_title} de %{emendation_author_nickname}
-            notification_title: S'ha acceptat la <a href="%{emendation_path}">esmena</a> creada per <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> per a <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
         amendment_created:
           affected_user:
             email_intro: 'S''ha creat una nova esmena per a %{amendable_title}. La pots veure des d''aquesta pàgina:'
@@ -405,17 +394,6 @@ ca:
             email_outro: Has rebut aquesta notificació perquè estàs seguint %{amendable_title}. Pots deixar de rebre notificacions seguint l'enllaç anterior.
             email_subject: Nova esmena per a %{amendable_title} de %{emendation_author_nickname}
             notification_title: <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> ha creat una <a href="%{emendation_path}">nova esmena</a> per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_promoted:
-          affected_user:
-            email_intro: 'Una esmena rebutjada per %{amendable_title} ha estat publicada com una nova %{amendable_type}. La pots veure des d''aquesta pàgina:'
-            email_outro: Heu rebut aquesta notificació perquè n'ets l'autor/a de %{amendable_title}.
-            email_subject: S'ha publicat una esmena de %{emendation_author_nickname} com una nova proposta
-            notification_title: S'ha publicat una <a href="%{emendation_path}">esmena refusada</a> per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} com una nova proposta de <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
-          follower:
-            email_intro: 'Una esmena rebutjada per %{amendable_title} ha estat promoguda a una d''independent %{amendable_type}. Pots veure-ho des d''aquesta pàgina:'
-            email_outro: Has rebut aquesta notificació perquè estàs seguint %{amendable_title}. Pots deixar de rebre notificacions seguint l'enllaç anterior.
-            email_subject: S'ha promogut una esmena de %{emendation_author_nickname}
-            notification_title: S'ha promogut una esmena de <a href="%{emendation_path}">rebuig</a> per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} per part de <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
         amendment_rejected:
           affected_user:
             email_intro: 'S''ha rebutjat una esmena per %{amendable_title}. La pots veure des d''aquesta pàgina:'
@@ -427,6 +405,28 @@ ca:
             email_outro: Has rebut aquesta notificació perquè estàs seguint %{amendable_title}. Pots deixar de rebre notificacions seguint l'enllaç anterior.
             email_subject: Esmena rebutjada per %{amendable_title} a %{emendation_author_nickname}
             notification_title: L' <a href="%{emendation_path}">esmena</a> creada per <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> ha estat rebutjada per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_promoted:
+          affected_user:
+            email_intro: 'Una esmena rebutjada per %{amendable_title} ha estat publicada com una nova %{amendable_type}. La pots veure des d''aquesta pàgina:'
+            email_outro: Heu rebut aquesta notificació perquè n'ets l'autor/a de %{amendable_title}.
+            email_subject: S'ha publicat una esmena de %{emendation_author_nickname} com una nova proposta
+            notification_title: S'ha publicat una <a href="%{emendation_path}">esmena refusada</a> per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} com una nova proposta de <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+          follower:
+            email_intro: 'Una esmena rebutjada per %{amendable_title} ha estat promoguda a una d''independent %{amendable_type}. Pots veure-ho des d''aquesta pàgina:'
+            email_outro: Has rebut aquesta notificació perquè estàs seguint %{amendable_title}. Pots deixar de rebre notificacions seguint l'enllaç anterior.
+            email_subject: S'ha promogut una esmena de %{emendation_author_nickname}
+            notification_title: S'ha promogut una esmena de <a href="%{emendation_path}">rebuig</a> per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} per part de <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+        amendment_accepted:
+          affected_user:
+            email_intro: 'S''ha acceptat una modificació per a %{amendable_title}. Podeu veure-ho des d''aquesta pàgina:'
+            email_outro: Has rebut aquesta notificació perquè ets autor/a de %{amendable_title}.
+            email_subject: Una esmena acceptada per %{amendable_title} de %{emendation_author_nickname}
+            notification_title: S'ha acceptat la <a href="%{emendation_path}">esmena</a> creada per <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> per a <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'S''ha acceptat una esmena per %{amendable_title}. Pots veure-ho en aquesta pàgina:'
+            email_outro: Has rebut aquesta notificació perquè estàs seguint %{amendable_title}. Pots deixar de rebre notificacions seguint l'enllaç anterior.
+            email_subject: Una esmena acceptada per %{amendable_title} de %{emendation_author_nickname}
+            notification_title: S'ha acceptat la <a href="%{emendation_path}">esmena</a> creada per <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> per a <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
       attachments:
         attachment_created:
           email_intro: 'S''ha afegit un nou document a %{resource_title}. Pots veure-ho des d''aquesta pàgina:'
@@ -497,7 +497,7 @@ ca:
         profile_updated:
           email_intro: El <a href="%{resource_url}">perfil</a> d'en/na %{name} (%{nickname}), a qui estàs seguint, s'ha actualitzat.
           email_outro: Has rebut aquesta notificació perquè estàs seguint en/na %{nickname}. Pots deixar de rebre notificacions seguint l'enllaç anterior.
-          email_subject: En/na %{nickname} ha actualitzat el seu perfil
+          email_subject: "En/na %{nickname} ha actualitzat el seu perfil"
           notification_title: El <a href="%{resource_path}">perfil</a> d'en/na %{name} (%{nickname}), a qui estàs seguint, s'ha actualitzat.
     export_mailer:
       data_portability_export:
@@ -546,7 +546,7 @@ ca:
       badges:
         continuity:
           conditions:
-          - Vine aquí sovint
+            - Vine aquí sovint
           description: Aquest distintiu es concedeix al visitar la plataforma de forma regular. Ens agrada tenir-te per aquí!
           description_another: Aquesta usuària s'ha connectat durant %{score} dies consecutius en algun moment.
           description_own: T'has connectat durant %{score} dies consecutius en algun moment.
@@ -556,7 +556,7 @@ ca:
           unearned_own: No t'has connectat més d'un dia consecutiu.
         followers:
           conditions:
-          - Ser activa i seguir a altres persones segurament farà que altres persones et segueixin.
+            - Ser activa i seguir a altres persones segurament farà que altres persones et segueixin.
           description: Aquesta distinció es concedeix quan arribis a un cert nombre de seguidors. %{organization_name} és una xarxa social i política, teixeix la teva web per comunicar-te amb altres persones a la plataforma.
           description_another: Aquesta usuària té %{score} seguidors.
           description_own: "%{score} usuàries et segueixen."
@@ -571,9 +571,9 @@ ca:
           title: Distintius
         invitations:
           conditions:
-          - Utilitza l'enllaç "convidar amics/gues" a la teva pàgina d'usuari per convidar a les teves amistats.
-          - Personalitza, si vols, el missatge que envies
-          - Pujaràs per mitjà de l'enviament d'invitacions i de registrar-les.
+            - Utilitza l'enllaç "convidar amics/gues" a la teva pàgina d'usuari per convidar a les teves amistats.
+            - Personalitza, si vols, el missatge que envies
+            - Pujaràs per mitjà de l'enviament d'invitacions i de registrar-les.
           description: Aquest distintiu es concedeix quan has convidat a algunes persones i que passen una mica de temps per registrar-se a %{organization_name} i es converteixen en participants. Gràcies per donar a conèixer %{organization_name} als altres i ajudar a ampliar la comunitat!
           description_another: Aquest usuari ha convidat a %{score} usuaris.
           description_own: Has convidat %{score} usuaris.
@@ -783,8 +783,8 @@ ca:
       show:
         email_on_notification: Vull rebre un correu electrònic cada vegada que rebi una notificació.
         everything_followed: Tot el que segueixo
-        newsletter_notifications: Vull rebre butlletins
         newsletters: Butlletins informatius
+        newsletter_notifications: Vull rebre butlletins
         own_activity: La meva pròpia activitat, com quan algú fa comentaris a la meva proposta o em menciona
         receive_notifications_about: Vull rebre notificacions
         send_notifications_by_email: Enviar notificacions per correu electrònic
@@ -989,8 +989,8 @@ ca:
         no_activities_warning: Aquesta participant encara no ha tingut cap activitat.
     user_interests:
       show:
-        my_interests: Els meus interessos
         no_scopes: Aquesta organització encara no té cap abast!
+        my_interests: Els meus interessos
         select_your_interests: Seleccioneu els temes dels quals t'interessa rebre esdeveniments relacionats amb ells a la pestanya Timeline del perfil.
         update_my_interests: Actualitza els meus interessos
       update:
@@ -1170,9 +1170,7 @@ ca:
   layouts:
     decidim:
       cookie_warning:
-        description_html: |-
-          Aquest lloc web fa servir cookies pròpies i de tercers per millorar l’experiència de navegació, i oferir continguts i serveis d’interès.
-          En continuar la navegació entenem que s’accepta la nostra política de cookies. Per a més informació consulta %{link}.
+        description_html: "Aquest lloc web fa servir cookies pròpies i de tercers per millorar l’experiència de navegació, i oferir continguts i serveis d’interès.\nEn continuar la navegació entenem que s’accepta la nostra política de cookies. Per a més informació consulta %{link}."
         link_label: aquí
         ok: Hi estic d'acord
       edit_link:

--- a/decidim-core/config/locales/es.yml
+++ b/decidim-core/config/locales/es.yml
@@ -1,4 +1,3 @@
----
 es:
   activemodel:
     attributes:
@@ -47,7 +46,7 @@ es:
         other: Grupos
   booleans:
     'false': 'No'
-    'true': Sí
+    'true': 'Sí'
   carrierwave:
     errors:
       image_too_big: La imagen es demasiado grande
@@ -70,7 +69,7 @@ es:
         confirm:
           close: Cerrar ventana
           ok: Sí, quiero eliminar mi cuenta
-          question: "¿Seguro que quieres eliminar tu cuenta?"
+          question: '¿Seguro que quieres eliminar tu cuenta?'
           title: Eliminar mi cuenta
         explanation: Por favor, rellena el motivo por el que deseas eliminar tu cuenta (opcional).
       destroy:
@@ -137,12 +136,12 @@ es:
       amendable:
         amended_by: Enmendado por
         button: Enmendar %{model_name}
+        promote_button: Promocionar a %{model_name}
         error: Se ha producido un error al modificar este recurso.
         help_text: Mejora este %{model_name} modificando su %{amendable_fields}
+        promote_help_text: Puedes promocionar esta enmienda y publicarla como un %{model_name}independiente.
         no_amenders: No hay enmendadores
         no_amendments: No hay enmiendas
-        promote_button: Promocionar a %{model_name}
-        promote_help_text: Puedes promocionar esta enmienda y publicarla como un %{model_name}independiente.
         section_heading: Enmiendas (%{count})
       created:
         error: Se ha producido un error creando esta enmienda, inténtalo de nuevo más tarde
@@ -171,12 +170,12 @@ es:
         heading: Crea tu enmienda
         help_text: Estás modificando el %{model_name}
         send: Enviar enmienda
-      promoted:
-        error: Ha habido errores al promocionar la enmienda.
-        success: La enmienda se promociona con éxito.
       rejected:
         error: Se ha producido un error al rechazar esta enmienda. Inténtalo de nuevo más tarde.
         success: La enmienda ha sido rechazada con éxito.
+      promoted:
+        success: La enmienda se promociona con éxito.
+        error: Ha habido errores al promocionar la enmienda.
       review:
         back: Volver
         heading: Revisar la enmienda
@@ -325,7 +324,7 @@ es:
           username_help: Nombre público que aparece en tus mensajes. Con el objetivo de garantizar el anonimato, puede ser cualquier nombre.
       registrations:
         new:
-          already_have_an_account?: "¿Ya tienes una cuenta?"
+          already_have_an_account?: '¿Ya tienes una cuenta?'
           newsletter: Quiero recibir un boletín ocasional con información relevante
           newsletter_title: Permiso de contacto
           nickname_help: Su identificador corto y único en %{organization}
@@ -340,7 +339,7 @@ es:
           username_help: Nombre público que aparecerá en tus publicaciones. Con el objetivo de garantizar el anonimato puede ser cualquier nombre.
       sessions:
         new:
-          are_you_new?: "¿Eres nuevo en la plataforma?"
+          are_you_new?: '¿Eres nuevo en la plataforma?'
           register: Créate una cuenta
           sign_in_disabled: Puedes acceder con una cuenta externa
           sign_up_disabled: El registro está deshabilitado, puedes usar un usuario existente para acceder
@@ -385,17 +384,6 @@ es:
         title: No se ha encontrado la página que buscas
     events:
       amendments:
-        amendment_accepted:
-          affected_user:
-            email_intro: 'Se ha aceptado una enmienda para %{amendable_title}. Puedes verlo desde esta página:'
-            email_outro: Has recibido esta notificación porque eres un autor de %{amendable_title}.
-            email_subject: Una enmienda aceptada para %{amendable_title} de %{emendation_author_nickname}
-            notification_title: El <a href="%{emendation_path}">enmienda</a> creado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> ha sido aceptado para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Se ha aceptado una enmienda para %{amendable_title}. Puedes verlo desde esta página:'
-            email_outro: Has recibido esta notificación porque estás siguiendo a %{amendable_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
-            email_subject: Una enmienda aceptada para %{amendable_title} de %{emendation_author_nickname}
-            notification_title: El <a href="%{emendation_path}">enmienda</a> creado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> ha sido aceptado para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
         amendment_created:
           affected_user:
             email_intro: 'Se ha creado una nueva enmienda para %{amendable_title}. Puedes verlo desde esta página:'
@@ -407,17 +395,6 @@ es:
             email_outro: Has recibido esta notificación porque estás siguiendo a %{amendable_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
             email_subject: Una nueva enmienda para %{amendable_title} de %{emendation_author_nickname}
             notification_title: A <a href="%{emendation_path}">nueva enmienda</a> ha sido creado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_promoted:
-          affected_user:
-            email_intro: 'Una enmienda rechazada por %{amendable_title} ha sido promovida a %{amendable_type}independiente. Puedes verlo desde esta página:'
-            email_outro: Has recibido esta notificación porque eres un autor de %{amendable_title}.
-            email_subject: Se ha promocionado una enmienda de %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">rechazaron enmienda</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} ha sido promovida por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
-          follower:
-            email_intro: 'Una enmienda rechazada por %{amendable_title} ha sido promovida a %{amendable_type}independiente. Puedes verlo desde esta página:'
-            email_outro: Has recibido esta notificación porque estás siguiendo a %{amendable_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
-            email_subject: Se ha promocionado una enmienda de %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">rechazaron enmienda</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} ha sido promovida por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
         amendment_rejected:
           affected_user:
             email_intro: 'Una enmienda ha sido rechazada por %{amendable_title}. Puedes verlo desde esta página:'
@@ -429,6 +406,28 @@ es:
             email_outro: Has recibido esta notificación porque estás siguiendo a %{amendable_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
             email_subject: Una enmienda rechazada por %{amendable_title} de %{emendation_author_nickname}
             notification_title: El <a href="%{emendation_path}">enmienda</a> creado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> ha sido rechazada por <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_promoted:
+          affected_user:
+            email_intro: 'Una enmienda rechazada por %{amendable_title} ha sido promovida a %{amendable_type}independiente. Puedes verlo desde esta página:'
+            email_outro: Has recibido esta notificación porque eres un autor de %{amendable_title}.
+            email_subject: Se ha promocionado una enmienda de %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">rechazaron enmienda</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} ha sido promovida por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+          follower:
+            email_intro: 'Una enmienda rechazada por %{amendable_title} ha sido promovida a %{amendable_type}independiente. Puedes verlo desde esta página:'
+            email_outro: Has recibido esta notificación porque estás siguiendo a %{amendable_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
+            email_subject: Se ha promocionado una enmienda de %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">rechazaron enmienda</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} ha sido promovida por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+        amendment_accepted:
+          affected_user:
+            email_intro: 'Se ha aceptado una enmienda para %{amendable_title}. Puedes verlo desde esta página:'
+            email_outro: Has recibido esta notificación porque eres un autor de %{amendable_title}.
+            email_subject: Una enmienda aceptada para %{amendable_title} de %{emendation_author_nickname}
+            notification_title: El <a href="%{emendation_path}">enmienda</a> creado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> ha sido aceptado para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'Se ha aceptado una enmienda para %{amendable_title}. Puedes verlo desde esta página:'
+            email_outro: Has recibido esta notificación porque estás siguiendo a %{amendable_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
+            email_subject: Una enmienda aceptada para %{amendable_title} de %{emendation_author_nickname}
+            notification_title: El <a href="%{emendation_path}">enmienda</a> creado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> ha sido aceptado para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
       attachments:
         attachment_created:
           email_intro: 'Se ha agregado un nuevo documento a %{resource_title}. Puedes verlo desde esta página:'
@@ -448,15 +447,15 @@ es:
         email_subject: Una actualización de %{resource_title}
       gamification:
         badge_earned:
-          email_intro: ¡Gran trabajo! Has obtenido la insignia "<a href="%{resource_url}">%{badge_name}</a>" (nivel %{current_level}).
+          email_intro: '¡Gran trabajo! Has obtenido la insignia "<a href="%{resource_url}">%{badge_name}</a>" (nivel %{current_level}).'
           email_outro: Has recibido esta notificación porque has realizado actividad en nuestro sitio web.
-          email_subject: "¡Has ganado una nueva insignia: %{badge_name}!"
-          notification_title: ¡Enhorabuena! Has obtenido la insignia <a href="%{resource_path}">%{badge_name}</a> (nivel %{current_level}).
+          email_subject: '¡Has ganado una nueva insignia: %{badge_name}!'
+          notification_title: '¡Enhorabuena! Has obtenido la insignia <a href="%{resource_path}">%{badge_name}</a> (nivel %{current_level}).'
         level_up:
-          email_intro: ¡Gran trabajo! ¡Has alcanzado el nivel %{current_level} en la insignia "<a href="%{resource_url}">%{badge_name}</a>"!
+          email_intro: '¡Gran trabajo! ¡Has alcanzado el nivel %{current_level} en la insignia "<a href="%{resource_url}">%{badge_name}</a>"!'
           email_outro: Has recibido esta notificación porque has generado actividad en nuestro sitio web.
-          email_subject: "¡Has conseguido el nivel %{current_level} en la insignia %{badge_name}!"
-          notification_title: ¡Gran trabajo! ¡Has conseguido el nivel %{current_level} en la insignia <a href="%{resource_path}">%{badge_name}</a>!
+          email_subject: '¡Has conseguido el nivel %{current_level} en la insignia %{badge_name}!'
+          notification_title: '¡Gran trabajo! ¡Has conseguido el nivel %{current_level} en la insignia <a href="%{resource_path}">%{badge_name}</a>!'
       groups:
         demoted_membership:
           email_intro: Un administrador del grupo <a href="%{resource_url}">%{user_group_name}</a> ha eliminado tus permisos de administración para ese grupo.
@@ -469,7 +468,7 @@ es:
           email_subject: Te han invitado a unirte al grupo %{user_group_name}
           notification_title: Te han invitado a unirte al grupo <a href="%{resource_path}">%{user_group_name}</a> . Revisa la pestaña <a href="%{groups_profile_tab_path}">Grupos</a> en tu perfil para aceptar la invitación.
         join_request_accepted:
-          email_intro: ¡Felicidades! Un administrador del grupo <a href="%{resource_url}">%{user_group_name}</a> ha aceptado tu solicitud para unirte a él.
+          email_intro: '¡Felicidades! Un administrador del grupo <a href="%{resource_url}">%{user_group_name}</a> ha aceptado tu solicitud para unirte a él.'
           email_outro: Has recibido esta notificación porque tu solicitud de incorporación se ha actualizado.
           email_subject: Tu solicitud para unirte al grupo %{user_group_name} ha sido aceptada
           notification_title: Tu solicitud para unirte al grupo <a href="%{resource_path}">%{user_group_name}</a> ha sido aceptada.
@@ -486,12 +485,12 @@ es:
         promoted_to_admin:
           email_intro: Un administrador del grupo <a href="%{resource_url}">%{user_group_name}</a> te ha otorgado permisos de administración para ese grupo.
           email_outro: Has recibido esta notificación porque eres miembro de ese grupo.
-          email_subject: "¡Ahora eres administrador/a del grupo %{user_group_name}!"
+          email_subject: '¡Ahora eres administrador/a del grupo %{user_group_name}!'
           notification_title: Ahora eres administrador/a del grupo <a href="%{resource_path}">%{user_group_name}</a>.
         removed_from_group:
           email_intro: Un administrador del grupo <a href="%{resource_url}">%{user_group_name}</a> te ha eliminado del mismo.
           email_outro: Has recibido esta notificación porque eras miembro de ese grupo.
-          email_subject: "¡Has sido eliminado del grupo %{user_group_name}!"
+          email_subject: '¡Has sido eliminado del grupo %{user_group_name}!'
           notification_title: Has sido eliminado del grupo <a href="%{resource_path}">%{user_group_name}</a>.
       notification_event:
         notification_title: Un evento ha ocurrido en <a href="%{resource_path}">%{resource_title}</a>.
@@ -548,39 +547,39 @@ es:
       badges:
         continuity:
           conditions:
-          - Viene aquí a menudo
+            - Viene aquí a menudo
           description: Este distintivo se otorga cuando visitas la plataforma de forma regular. ¡Nos gusta tenerte por aquí!
           description_another: Este usuario se ha conectado durante %{score} días consecutivos en algún momento.
           description_own: Te has conectado durante %{score} días consecutivos en algún momento.
           name: Continuidad
-          next_level_in: "¡Conéctate durante %{score} días consecutivos para alcanzar el siguiente nivel!"
+          next_level_in: '¡Conéctate durante %{score} días consecutivos para alcanzar el siguiente nivel!'
           unearned_another: Este usuario no ha entrado durante más de un día consecutivo.
           unearned_own: No te has conectado por más de un día consecutivo.
         followers:
           conditions:
-          - Estar activo y seguir a otras personas seguramente hará que otras personas te sigan.
+            - Estar activo y seguir a otras personas seguramente hará que otras personas te sigan.
           description: Este distintivo se otorga cuando alcanzas un cierto número de seguidores. %{organization_name} es una red social y política, teje tu web para comunicarte con otras personas en la plataforma.
           description_another: Este usuario tiene %{score} seguidores.
           description_own: "%{score} usuarios te están siguiendo."
           name: Seguidores
-          next_level_in: "¡Consigue %{score} usuarios más para seguirte y alcanzar el siguiente nivel!"
+          next_level_in: '¡Consigue %{score} usuarios más para seguirte y alcanzar el siguiente nivel!'
           unearned_another: Este usuario no tiene seguidores todavía.
           unearned_own: Aún no tienes seguidores.
         index:
-          badge_title: Distintivo %{name}
+          badge_title: "Distintivo %{name}"
           how: Como puedes conseguirlo
           page_description: Los distintivos son reconocimientos a las acciones de los participantes y al progreso en la plataforma. A medida que comiences a descubrir, participar e interactuar en la plataforma, conseguirlo diferentes distintivo. Aquí está la lista de distintivos y algunas formas en que puedes conseguirlas.
           title: Distintivos
         invitations:
           conditions:
-          - Usa el enlace "invitar amigos" en tu página de usuario para invitar a tus amistades
-          - Personaliza, si quieres, el mensaje que estás enviando.
-          - Supera este nivel enviando invitaciones y registrándolas.
+            - Usa el enlace "invitar amigos" en tu página de usuario para invitar a tus amistades
+            - Personaliza, si quieres, el mensaje que estás enviando.
+            - Supera este nivel enviando invitaciones y registrándolas.
           description: Este distintivo se consigue cuando has invitado a algunas personas y han pasado un poco de tiempo para registrarse en %{organization_name} y se converten en participantes. ¡Gracias por dar a conocer %{organization_name} a otros y ayudar a ampliar la comunidad!
           description_another: Este usuario ha invitado a %{score} usuarios.
           description_own: Has invitado a %{score} usuarios.
           name: Invitaciones
-          next_level_in: "¡Invita %{score} usuarios más a alcanzar el siguiente nivel!"
+          next_level_in: '¡Invita %{score} usuarios más a alcanzar el siguiente nivel!'
           unearned_another: Este usuario aún no ha invitado a ningún usuario.
           unearned_own: No has invitado aún a ningún usuario.
       description: Las insignias son reconocimientos de las acciones de los participantes y el progreso en la plataforma. A medida que comienzas a descubrir, participar e interactuar en la plataforma, ganarás diferentes insignias.
@@ -588,7 +587,7 @@ es:
       reached_top: Has alcanzado el nivel superior para esta insignia.
     group_admins:
       actions:
-        are_you_sure: "¿Estás seguro? Esto no eliminará al usuario del grupo."
+        are_you_sure: '¿Estás seguro? Esto no eliminará al usuario del grupo.'
         demote_admin: Eliminar permisos de administración
       demote:
         error: Se ha producido un error al eliminar este usuario de la lista de administradores.
@@ -617,7 +616,7 @@ es:
         error: Se ha producido un error al aceptar esta solicitud de incorporación al grupo
         success: Solicitud aceptada con éxito
       actions:
-        are_you_sure: "¿Estás seguro?"
+        are_you_sure: '¿Estás seguro?'
         promote_to_admin: Hacer administrador
         remove_from_group: Eliminar usuario
       index:
@@ -634,7 +633,7 @@ es:
         success: Usuario eliminado del grupo correctamente
     groups:
       actions:
-        are_you_sure: "¿Estás seguro?"
+        are_you_sure: '¿Estás seguro?'
       create:
         error: Ha habido un problema al crear el grupo
         success: Grupo creado correctamente
@@ -674,7 +673,7 @@ es:
       main_topic:
         default_page:
           content: "<p>En %{organization} puedes participar y decidir sobre diferentes temas, a través de los espacios que ves en el menú superior: Procesos, Asambleas, Iniciativas, Consultas.</p> <p>Dentro de cada uno encontrarás diferentes opciones para participar: hacer propuestas - a nivel individual o con otras personas -, tomar parte en debates, priorizar proyectos a ejecutar, asistir a encuentros presenciales y otras acciones.</p>\n"
-          title: "¿Qué puedo hacer en %{organization}?"
+          title: '¿Qué puedo hacer en %{organization}?'
         description: Leer más sobre %{organization}
         title: Ayuda general
     last_activities:
@@ -715,12 +714,12 @@ es:
         new_conversation:
           greeting: Hola, %{recipient}!
           intro: "%{sender} ha iniciado una nueva conversación contigo. Haz click aquí para verla:"
-          outro: "¡Disfruta de decidim!"
+          outro: '¡Disfruta de decidim!'
           subject: "%{sender} ha iniciado una conversación contigo"
         new_message:
-          greeting: "¡Hola, %{recipient}!"
+          greeting: '¡Hola, %{recipient}!'
           intro: "%{sender} ha publicado nuevos mensajes en tu conversación. Haz clic aquí para verlos:"
-          outro: "¡Disfruta de decidim!"
+          outro: '¡Disfruta de decidim!'
           subject: Tienes nuevos mensajes de %{sender}
       conversations:
         create:
@@ -756,7 +755,7 @@ es:
     newsletter_mailer:
       newsletter:
         note: Has recibido este mensaje porque estás suscrito a boletines de noticias en %{organization_name}. Puedes cambiar la configuración en tu <a href="%{link}">página de notificaciones</a>.
-        see_on_website: ¿No puedes ver este correo electrónico correctamente? Accede a su <a href="%{link}" target="_blank">versión web</a>.
+        see_on_website: '¿No puedes ver este correo electrónico correctamente? Accede a su <a href="%{link}" target="_blank">versión web</a>.'
         unsubscribe: Si no quieres recibir este tipo de correo electrónico, <a href="%{link}" target="_blank" class="unsubscribe">unsubscríbete</a>.
     newsletters:
       unsubscribe:
@@ -773,20 +772,20 @@ es:
     newsletters_opt_in_mailer:
       notify:
         body_1: El procesamiento de datos personales y su protección es cada vez más importante para todos nosotros. Con el nuevo Reglamento General de Protección de Datos (RGPD) del 25 de mayo de 2018, las personas tienen un mejor control sobre sus datos personales. Por este motivo, necesitamos tu "OK" para seguir enviando información relevante sobre las actividades del %{organization_name}.
-        body_2: "¿Cómo puedes darnos tu consentimiento? Simplemente haz clic en el siguiente botón:"
+        body_2: '¿Cómo puedes darnos tu consentimiento? Simplemente haz clic en el siguiente botón:'
         body_3: Con este consentimiento, podrás continuar recibiendo información sobre los servicios de la plataforma. Si, por el contrario, no recibimos una confirmación positiva de tu parte, dejaremos de enviarte nuestros mensajes. Si confirmas que deseas mantenerte informado, siempre tendrás la opción de cancelar en cualquier momento.
         button: Sí, deseo continuar recibiendo información relevante
         greetings: Saludos,<br/>%{organization_name}<br/><a href="%{organization_url}">%{organization_url}</a>
         hello: Hola,
-        subject: "¿Deseas seguir recibiendo información relevante sobre %{organization_name}?"
+        subject: '¿Deseas seguir recibiendo información relevante sobre %{organization_name}?'
     notifications:
       no_notifications: No hay notificaciones aún.
     notifications_settings:
       show:
         email_on_notification: Quiero recibir un correo electrónico cada vez que recibo una notificación.
         everything_followed: Todo lo que sigo
-        newsletter_notifications: Quiero recibir boletines informativos
         newsletters: Boletines de noticias
+        newsletter_notifications: Quiero recibir boletines informativos
         own_activity: Mi propia actividad, como cuando alguien comenta en mi propuesta o me menciona.
         receive_notifications_about: Quiero recibir notificaciones sobre
         send_notifications_by_email: Enviar notificaciones por correo electrónico
@@ -810,7 +809,7 @@ es:
         extended:
           debates: Debates
           debates_explanation: Debate y discute, comparte tus opiniones y enriquece los temas relevantes.
-          how_to_participate: "¿Cómo tomo parte en un proceso?"
+          how_to_participate: '¿Cómo tomo parte en un proceso?'
           meetings: Encuentros
           meetings_explanation: Averigua dónde y cuándo puedes participar en encuentros públicos.
           more_info: Más información
@@ -859,7 +858,7 @@ es:
       terms_and_conditions:
         accept:
           error: Ha habido un error al aceptar los Términos y Condiciones.
-          success: "¡Estupendo! Has aceptado los Términos y Condiciones."
+          success: '¡Estupendo! Has aceptado los Términos y Condiciones.'
         form:
           agreement: Estoy de acuerdo con estos términos
           legend: Aceptar los Términos y Condiciones de uso
@@ -869,7 +868,7 @@ es:
           modal_btn_exit: Lo revisaré más tarde
           modal_button: Rechazar los términos
           modal_close: Cerrar modal
-          modal_title: "¿Confirmas que no aceptas los Términos y Condiciones actualizados?"
+          modal_title: '¿Confirmas que no aceptas los Términos y Condiciones actualizados?'
         required_review:
           alert: Hemos actualizado nuestros Términos de Servicio, por favor revísalos.
           body: Por favor dedica un momento a revisar la actualización de nuestras Términos de Servicio. De lo contrario, no podrás usar la plataforma.
@@ -991,8 +990,8 @@ es:
         no_activities_warning: Este usuario no ha tenido ninguna actividad todavía.
     user_interests:
       show:
+        no_scopes: '¡Esta organización aún no tiene ningún alcance!'
         my_interests: Mis intereses
-        no_scopes: "¡Esta organización aún no tiene ningún alcance!"
         select_your_interests: Seleccione los temas que le interesan para recibir eventos relacionados con ellos en la pestaña Línea de tiempo de su perfil.
         update_my_interests: Actualizar mis intereses
       update:
@@ -1011,11 +1010,11 @@ es:
     failure:
       already_authenticated: Ya has iniciado sesión.
       inactive: Tu cuenta aún no está activada.
-      invalid: "%{authentication_keys} o contraseña inválida."
+      invalid: '%{authentication_keys} o contraseña inválida.'
       invited: Tienes una invitación pendiente, acéptala para terminar de crear tu cuenta.
       last_attempt: Tienes un intento más antes de que tu cuenta se bloquee.
       locked: Tu cuenta está bloqueada.
-      not_found_in_database: "%{authentication_keys} o contraseña inválida."
+      not_found_in_database: '%{authentication_keys} o contraseña inválida.'
       timeout: Tu sesión expiró Por favor, inicia sesión de nuevo para continuar.
       unauthenticated: Debes iniciar sesión o registrarte antes de continuar.
     invitations:
@@ -1025,7 +1024,7 @@ es:
         submit_button: Guardar
         subtitle: Si aceptas la invitación, por favor establece tu nombre de usuario/a y contraseña.
       invitation_removed: Tu invitación fue eliminada.
-      invitation_token_invalid: "¡El token de invitación proporcionado no es válido!"
+      invitation_token_invalid: '¡El token de invitación proporcionado no es válido!'
       new:
         header: Enviar invitación
         submit_button: Enviar una invitación
@@ -1066,19 +1065,19 @@ es:
       organization_admin_invitation_instructions:
         subject: Has sido invitado para gestionar %{organization}
       password_change:
-        greeting: "¡Hola %{recipient}!"
+        greeting: '¡Hola %{recipient}!'
         message: Nos ponemos en contacto contigo para notificarte que tu contraseña ha sido cambiada correctamente.
         subject: Contraseña modificada
       reset_password_instructions:
         action: Cambiar mi contraseña
-        greeting: "¡Hola %{recipient}!"
+        greeting: '¡Hola %{recipient}!'
         instruction: Alguien ha solicitado un enlace para cambiar tu contraseña, y puede hacerlo a través del siguiente enlace.
         instruction_2: Si no lo solicitaste, ignora este correo electrónico.
         instruction_3: Tu contraseña no cambiará hasta que accedas al enlace de arriba y crees una nueva.
         subject: Restablecer instrucciones de contraseña
       unlock_instructions:
         action: Desbloquear mi cuenta
-        greeting: "¡Hola %{recipient}!"
+        greeting: '¡Hola %{recipient}!'
         instruction: 'Haz clic en el siguiente enlace para desbloquear tu cuenta:'
         message: Tu cuenta ha sido bloqueada debido a una cantidad excesiva de intentos de inicio de sesión fallidos.
         subject: Desbloquear instrucciones
@@ -1092,7 +1091,7 @@ es:
         confirm_new_password: Confirmar la nueva contraseña
         new_password: Contraseña
       new:
-        forgot_your_password: "¿Olvidaste tu contraseña?"
+        forgot_your_password: '¿Olvidaste tu contraseña?'
         send_me_reset_password_instructions: Enviarme instrucciones para restablecer la contraseña
       no_token: No puedes acceder a esta página sin venir de un correo electrónico de restablecimiento de contraseña. Si vienes de un correo electrónico de restablecimiento de contraseña, asegúrate de haber utilizado la URL provista completa.
       send_instructions: Recibirás un correo electrónico con instrucciones sobre cómo restablecer tu contraseña en unos minutos.
@@ -1100,19 +1099,19 @@ es:
       updated: Tu contraseña ha sido cambiada con éxito. Ya has iniciado sesión.
       updated_not_active: Tu contraseña ha sido cambiada con éxito.
     registrations:
-      destroyed: "¡Adiós! Tu cuenta ha sido cancelada exitosamente. Esperamos volverte a ver pronto."
+      destroyed: '¡Adiós! Tu cuenta ha sido cancelada exitosamente. Esperamos volverte a ver pronto.'
       edit:
-        are_you_sure: "¿Estás seguro?"
+        are_you_sure: '¿Estás seguro?'
         cancel_my_account: Cancelar mi cuenta
         currently_waiting_confirmation_for_email: 'Esperando de confirmación para: %{email}'
         leave_blank_if_you_don_t_want_to_change_it: Déjalo en blanco si no quieres cambiarlo
         title: Editar %{resource}
-        unhappy: "¿Infeliz?"
+        unhappy: '¿Infeliz?'
         update: Actualizar
         we_need_your_current_password_to_confirm_your_changes: Necesitamos tu contraseña actual para confirmar sus cambios
       new:
         sign_up: Regístrate
-      signed_up: "¡Bienvenido/a! Te has registrado con éxito."
+      signed_up: '¡Bienvenido/a! Te has registrado con éxito.'
       signed_up_but_inactive: Te has registrado con éxito. Sin embargo, no pudimos iniciar sesión porque tu cuenta aún no está activada.
       signed_up_but_locked: Te has registrado con éxito. Sin embargo, no pudimos iniciar sesión porque tu cuenta está bloqueada.
       signed_up_but_unconfirmed: Se ha enviado un mensaje con un enlace de confirmación a tu dirección de correo electrónico. Por favor, sigue el enlace para activar tu cuenta.
@@ -1127,9 +1126,9 @@ es:
     shared:
       links:
         back: Atrás
-        didn_t_receive_confirmation_instructions: "¿No has recibido las instrucciones de confirmación?"
-        didn_t_receive_unlock_instructions: "¿No has recibido instrucciones de desbloqueo?"
-        forgot_your_password: "¿Olvidaste tu contraseña?"
+        didn_t_receive_confirmation_instructions: '¿No has recibido las instrucciones de confirmación?'
+        didn_t_receive_unlock_instructions: '¿No has recibido instrucciones de desbloqueo?'
+        forgot_your_password: '¿Olvidaste tu contraseña?'
         sign_in: Iniciar sesión
         sign_in_with_provider: Inicia sesión con %{provider}
         sign_up: Regístrate

--- a/decidim-debates/config/locales/ca.yml
+++ b/decidim-debates/config/locales/ca.yml
@@ -1,4 +1,3 @@
----
 ca:
   activemodel:
     attributes:
@@ -65,8 +64,8 @@ ca:
             name: Debat
       admin_log:
         debate:
-          create: L'usuari %{user_name} ha creat el debat %{resource_name} a l'espai %{space_name}
-          update: L'usuari %{user_name} ha actualitzat el debat %{resource_name} a l'espai %{space_name}
+          create: "L'usuari %{user_name} ha creat el debat %{resource_name} a l'espai %{space_name}"
+          update: "L'usuari %{user_name} ha actualitzat el debat %{resource_name} a l'espai %{space_name}"
       debates:
         count:
           debates_count:
@@ -141,7 +140,7 @@ ca:
       badges:
         commented_debates:
           conditions:
-          - Tria un debat obert per participar
+            - Tria un debat obert per participar
           description: Aquest distintiu es desbloqueja quan participes activament en els diferents debats deixant els teus comentaris.
           description_another: Aquesta participant ha pres part en %{score} debats.
           description_own: Has participat en %{score} debats.

--- a/decidim-debates/config/locales/es.yml
+++ b/decidim-debates/config/locales/es.yml
@@ -1,4 +1,3 @@
----
 es:
   activemodel:
     attributes:
@@ -37,7 +36,7 @@ es:
             creation_enabled: Habilitar la creación de debates por los usuarios
     debates:
       actions:
-        confirm_destroy: "¿Seguro que quieres borrar el debate?"
+        confirm_destroy: '¿Seguro que quieres borrar el debate?'
         destroy: Borrar
         edit: Editar
         new: Nuevo %{name}
@@ -133,7 +132,7 @@ es:
           email_subject: Ya no se pueden crear debates en %{participatory_space_title}
           notification_title: La creación de debates ahora está deshabilitada en <a href="%{participatory_space_url}">%{participatory_space_title}</a>
         creation_enabled:
-          email_intro: "¡Ahora puedes crear nuevos debates en %{participatory_space_title}! Comienza a participar en esta página:"
+          email_intro: '¡Ahora puedes crear nuevos debates en %{participatory_space_title}! Comienza a participar en esta página:'
           email_outro: Has recibido esta notificación porque estás siguiendo %{participatory_space_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
           email_subject: Debates ahora disponibles en %{participatory_space_title}
           notification_title: Ahora puedes crear <a href="%{resource_path}">nuevos debates</a> en <a href="%{participatory_space_url}">%{participatory_space_title}</a>
@@ -141,12 +140,12 @@ es:
       badges:
         commented_debates:
           conditions:
-          - Elige un debate abierto para participar
+            - Elige un debate abierto para participar
           description: Este distintivo se otorga cuando participes activamente en los diferentes debates dejando tus comentarios.
           description_another: Este usuario ha participado en %{score} debates.
           description_own: Has participado en %{score} debates.
           name: Debates
-          next_level_in: "¡Participa en %{score} debates más para alcanzar el siguiente nivel!"
+          next_level_in: '¡Participa en %{score} debates más para alcanzar el siguiente nivel!'
           unearned_another: Este usuario aún no ha participado en ningún debate.
           unearned_own: Aún no has participado en ningún debate.
     metrics:

--- a/decidim-dev/config/locales/ca.yml
+++ b/decidim-dev/config/locales/ca.yml
@@ -1,4 +1,3 @@
----
 ca:
   activemodel:
     attributes:
@@ -17,7 +16,7 @@ ca:
       badges:
         test:
           conditions:
-          - Utilitza un entorn de prova per decidim.
+            - Utilitza un entorn de prova per decidim.
           description: Les participants obtenen aquesta insígnia creant proves.
           description_another: Aquesta participant ha creat %{score} proves.
           description_own: Heu creat %{score} proves.

--- a/decidim-dev/config/locales/es.yml
+++ b/decidim-dev/config/locales/es.yml
@@ -1,4 +1,3 @@
----
 es:
   activemodel:
     attributes:
@@ -17,12 +16,12 @@ es:
       badges:
         test:
           conditions:
-          - Utilice un entorno de prueba para decidim.
+            - Utilice un entorno de prueba para decidim.
           description: Los usuarios obtienen esta insignia al crear pruebas.
           description_another: Este usuario ha creado %{score} pruebas.
           description_own: Has creado %{score} pruebas.
           name: Pruebas
-          next_level_in: "¡Crea %{score} pruebas más para alcanzar el siguiente nivel!"
+          next_level_in: '¡Crea %{score} pruebas más para alcanzar el siguiente nivel!'
           unearned_another: Este usuario aún no ha creado ninguna prueba.
           unearned_own: No has creado ninguna prueba todavía.
     pages:

--- a/decidim-forms/config/locales/ca.yml
+++ b/decidim-forms/config/locales/ca.yml
@@ -1,4 +1,3 @@
----
 ca:
   activemodel:
     attributes:

--- a/decidim-forms/config/locales/es.yml
+++ b/decidim-forms/config/locales/es.yml
@@ -1,4 +1,3 @@
----
 es:
   activemodel:
     attributes:

--- a/decidim-initiatives/config/locales/ca.yml
+++ b/decidim-initiatives/config/locales/ca.yml
@@ -1,4 +1,3 @@
----
 ca:
   activemodel:
     attributes:
@@ -38,9 +37,9 @@ ca:
         undo_online_signatures_enabled: Permetre a les participants desfer les seves signatures digitals
         validate_sms_code_on_votes: Afegeix el pas de la validació mitjançant SMS al procés de signatura
       initiatives_vote:
-        date_of_birth: Data de naixement
-        document_number: Número de document
         name_and_surname: Nom i cognom
+        document_number: Número de document
+        date_of_birth: Data de naixement
         postal_code: Codi postal
       organization_data:
         address: Adreça
@@ -121,8 +120,8 @@ ca:
       badges:
         initiatives:
           conditions:
-          - Anar a Inciatives
-          - Segueix els passos per crear una nova iniciativa
+            - Anar a Inciatives
+            - Segueix els passos per crear una nova iniciativa
           description: Aquest distintiu es concedeix quan es llancen noves iniciatives, unint-te amb altres per dur-les a terme.
           description_another: Aquesta participant ha publicat %{score} iniciatives.
           description_own: Tens %{score} iniciatives publicades.
@@ -134,9 +133,7 @@ ca:
       participatory_spaces:
         initiatives:
           contextual: "<p>Una <strong>iniciativa</strong> és una proposta que pot ser promoguda per qualsevol persona per iniciativa pròpia (independentment d'altres canals o espais de participació) a través de la recollida de signatures (digitals) per a l'organització per dur a terme una acció específica (modificar una regulació, iniciar un projecte, canvieu el nom d'un departament o un carrer, etc.).</p> <p>Els promotors d'una iniciativa poden definir els seus objectius, recollir suport, debatre, divulgar-la i definir punts de trobada on es puguin recollir signatures dels assistents o debats oberts a altres participants.</p> <p>Exemples: una iniciativa pot recollir signatures per convocar una consulta entre totes les persones d'una organització, crear o convocar una assemblea o iniciar un procés d'augment del pressupost per a un territori o àrea de l'organització. Durant el procés de recollida de signatures, més persones poden afegir a aquesta demanda i portar-lo endavant a l'organització.</p>\n"
-          page: |
-            <p>Una <strong>iniciativa</strong> és una proposta que pot impulsar qualsevol persona per iniciativa pròpia (independentment de la resta de canals o espais de participació) mitjançant la recollida de signatures (digitals) perquè l'organització dugui a terme una acció específica (modificar un reglament, iniciar un projecte, canviar el nom d'un departament o un carrer, etc.).</p> <p>Les persones promotores d'una iniciativa poden definir els objectius de la mateixa, recollir suports, debatre, difondre-la i definir punts de trobada on es puguin recollir firmes dels assistents o debats oberts a altres participants.</p>
-            <p>Exemples: Una iniciativa pot recollir firmes per convocar una consulta entre totes les persones d'una organització, o per crear o convocar una assemblea, o per iniciar un procés d'augment de pressupost per a un territori o àmbit de l'organització. Durant el procés de recollida de signatures es poden sumar més persones a aquesta demanda i aconseguir tirar-la endavant en l'organització.</p>
+          page: "<p>Una <strong>iniciativa</strong> és una proposta que pot impulsar qualsevol persona per iniciativa pròpia (independentment de la resta de canals o espais de participació) mitjançant la recollida de signatures (digitals) perquè l'organització dugui a terme una acció específica (modificar un reglament, iniciar un projecte, canviar el nom d'un departament o un carrer, etc.).</p> <p>Les persones promotores d'una iniciativa poden definir els objectius de la mateixa, recollir suports, debatre, difondre-la i definir punts de trobada on es puguin recollir firmes dels assistents o debats oberts a altres participants.</p>\n<p>Exemples: Una iniciativa pot recollir firmes per convocar una consulta entre totes les persones d'una organització, o per crear o convocar una assemblea, o per iniciar un procés d'augment de pressupost per a un territori o àmbit de l'organització. Durant el procés de recollida de signatures es poden sumar més persones a aquesta demanda i aconseguir tirar-la endavant en l'organització.</p>\n"
           title: Què són les iniciatives?
     initiatives:
       actions:
@@ -144,8 +141,8 @@ ca:
       admin:
         answers:
           edit:
-            answer: Resposta
             title: Resposta per %{title}
+            answer: Resposta
           info_initiative:
             created_at: Creat a
             description: Descripció
@@ -323,12 +320,12 @@ ca:
           help: Si us plau, omple els següents camps amb les teves dades personals per signar la iniciativa
         finish:
           back_to_initiative: Torna a la iniciativa
-        sms_code:
-          continue: Comprova el codi i continua
-          help: Consulteu els SMS rebuts del vostre telèfon mòbil
         sms_phone_number:
           continue: Envia'm un SMS
           help: Ompliu el formulari amb el vostre número de telèfon mòbil verificat per sol·licitar el vostre codi de verificació
+        sms_code:
+          continue: Comprova el codi i continua
+          help: Consulteu els SMS rebuts del vostre telèfon mòbil
       initiative_votes:
         create:
           error: S'ha produït un error en signar la iniciativa.
@@ -440,8 +437,8 @@ ca:
     resources:
       initiatives_type:
         actions:
-          title: Accions
           vote: Signar
+          title: Accions
   layouts:
     decidim:
       admin:
@@ -467,8 +464,8 @@ ca:
         fill_personal_data: Completa les teves dades
         finish: Finalitzar
         finished: La iniciativa s'ha signat correctament
-        see_steps: vegeu els passos
         select_identity: Selecciona identitat
+        see_steps: vegeu els passos
         sms_code: Verificació per codi SMS
         sms_phone_number: Número de telèfon mòbil
         step: Pas %{current} de %{total}

--- a/decidim-initiatives/config/locales/es.yml
+++ b/decidim-initiatives/config/locales/es.yml
@@ -1,4 +1,3 @@
----
 es:
   activemodel:
     attributes:
@@ -38,9 +37,9 @@ es:
         undo_online_signatures_enabled: Permitir a los usuarios deshacer sus firmas en línea
         validate_sms_code_on_votes: Añadir paso de validación de código SMS al proceso de firma
       initiatives_vote:
-        date_of_birth: Fecha de nacimiento
-        document_number: Número del Documento
         name_and_surname: Nombre y apellido
+        document_number: Número del Documento
+        date_of_birth: Fecha de nacimiento
         postal_code: código postal
       organization_data:
         address: Dirección
@@ -102,32 +101,32 @@ es:
     events:
       initiatives:
         initiative_extended:
-          email_intro: "¡La fecha de finalización de las firmas para la iniciativa %{resource_title} se ha ampliado!"
+          email_intro: '¡La fecha de finalización de las firmas para la iniciativa %{resource_title} se ha ampliado!'
           email_outro: Has recibido esta notificación porque está siguiendo %{resource_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
-          email_subject: "¡Ampliado el términio de recogida de firmas para esta iniciativa!"
+          email_subject: '¡Ampliado el términio de recogida de firmas para esta iniciativa!'
           notification_title: La fecha de recogida de firmas para la iniciativa <a href="%{resource_path}">%{resource_title}</a> se ha ampliado.
         milestone_completed:
           affected_user:
-            email_intro: "¡Tu iniciativa %{resource_title} ha conseguido el %{percentage}% de firmas!"
+            email_intro: '¡Tu iniciativa %{resource_title} ha conseguido el %{percentage}% de firmas!'
             email_outro: Has recibido esta notificación porque eres el autor de la iniciativa %{resource_title}.
-            email_subject: "¡Nuevo hito completado!"
+            email_subject: '¡Nuevo hito completado!'
             notification_title: Tu iniciativa <a href="%{resource_path}">%{resource_title}</a> ha conseguido el %{percentage}% de firmas.
           follower:
-            email_intro: "¡La iniciativa %{resource_title} ha logrado el %{percentage}% de firmas!"
+            email_intro: '¡La iniciativa %{resource_title} ha logrado el %{percentage}% de firmas!'
             email_outro: Has recibido esta notificación porque estás siguiendo a %{resource_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
-            email_subject: "¡Nuevo hito completado!"
+            email_subject: '¡Nuevo hito completado!'
             notification_title: La iniciativa <a href="%{resource_path}">%{resource_title}</a> ha logrado el %{percentage}% de las firmas.
     gamification:
       badges:
         initiatives:
           conditions:
-          - Ir al espacio de participación de Iniciativas
-          - Sigue los pasos para crear una nueva iniciativa.
+            - Ir al espacio de participación de Iniciativas
+            - Sigue los pasos para crear una nueva iniciativa.
           description: Este distintivo se otorga cuando lanzas nuevas iniciativas, asociándote con otros para llevarlas a cabo.
           description_another: Este usuario ha publicado %{score} iniciativas.
           description_own: Tienes %{score} iniciativas publicadas.
           name: Iniciativas publicadas
-          next_level_in: "¡Publica %{score} iniciativas más para llegar al siguiente nivel!"
+          next_level_in: '¡Publica %{score} iniciativas más para llegar al siguiente nivel!'
           unearned_another: Este usuario aún no ha publicado ninguna iniciativa.
           unearned_own: Aún no tienes ninguna iniciativa publicada.
     help:
@@ -135,15 +134,15 @@ es:
         initiatives:
           contextual: "<p>Una iniciativa es una propuesta que puede impulsar cualquier persona por iniciativa propia (independientemente del resto de canales o espacios de participación) mediante la recogida de firmas (digitales) para que la organización lleve a cabo una acción específica (modificar un reglamento, iniciar un proyecto, cambiar el nombre de un departamento o una calle, etc.).</p> <p>Las personas promotoras de una iniciativa pueden definir los objetivos de la misma, recoger apoyos, debatir, difundirla y definir puntos de encuentro donde se puedan recoger firmas de los asistentes o debates abiertos a otras participantes.</p> <p>Ejemplos: Una iniciativa puede recoger firmas para convocar una consulta entre todas las personas de una organización, o para crear o convocar una asamblea, o para iniciar un proceso de aumento de presupuesto para un territorio o ámbito de la organización. Durante el proceso de recogida de firmas se pueden sumar más personas a esta demanda y lograr llevarla adelante en la organización.</p>\n"
           page: "<p>Una iniciativa es una propuesta que puede impulsar cualquier persona por iniciativa propia (independientemente del resto de canales o espacios de participación) mediante la recogida de firmas (digitales) para que la organización lleve a cabo una acción específica (modificar un reglamento, iniciar un proyecto, cambiar el nombre de un departamento o una calle, etc.).</p> <p>Las personas promotoras de una iniciativa pueden definir los objetivos de la misma, recoger apoyos, debatir, difundirla y definir puntos de encuentro donde se puedan recoger firmas de los asistentes o debates abiertos a otras participantes.</p> <p>Ejemplos: Una iniciativa puede recoger firmas para convocar una consulta entre todas las personas de una organización, o para crear o convocar una asamblea, o para iniciar un proceso de aumento de presupuesto para un territorio o ámbito de la organización. Durante el proceso de recogida de firmas se pueden sumar más personas a esta demanda y lograr llevarla adelante en la organización.</p>\n"
-          title: "¿Qué son las iniciativas?"
+          title: '¿Qué son las iniciativas?'
     initiatives:
       actions:
         answer: Responder
       admin:
         answers:
           edit:
-            answer: Responder
             title: Respuesta para %{title}
+            answer: Responder
           info_initiative:
             created_at: Creado en
             description: Descripción
@@ -153,7 +152,7 @@ es:
         committee_requests:
           index:
             approve: Aprobar
-            confirm_revoke: "¿Estás seguro?"
+            confirm_revoke: '¿Estás seguro?'
             invite_to_committee_help: Comparte este enlace para invitar a otros usuarios al comité de promoción
             no_members_yet: No hay miembros en el comité promotor
             revoke: Revocar
@@ -164,7 +163,7 @@ es:
         initiatives:
           edit:
             accept: Aceptar iniciativa
-            confirm: "¿Estás seguro?"
+            confirm: '¿Estás seguro?'
             discard: Descartar la iniciativa
             export_pdf_signatures: Exportar PDF de Firmas.
             export_votes: Soportes de exportación
@@ -201,7 +200,7 @@ es:
             success: El alcance ha sido eliminado con éxito
           edit:
             back: Volver
-            confirm_destroy: "¿Estás seguro?"
+            confirm_destroy: '¿Estás seguro?'
             destroy: Borrar
             title: Editar alcance del tipo de iniciativa
             update: Actualizar
@@ -219,7 +218,7 @@ es:
           destroy:
             success: El tipo de iniciativa se ha eliminado correctamente
           edit:
-            confirm_destroy: "¿Estás seguro?"
+            confirm_destroy: '¿Estás seguro?'
             destroy: Borrar
             update: Actualizar
           form:
@@ -265,7 +264,7 @@ es:
         finish:
           back: Volver
           back_to_initiatives: Volver a iniciativas
-          callout_text: "¡Felicidades! Tu iniciativa ciudadana ha sido creada con éxito."
+          callout_text: '¡Felicidades! Tu iniciativa ciudadana ha sido creada con éxito.'
           go_to_my_initiatives: Ir a mis iniciativas
           more_information: "(Más información)"
         finish_help:
@@ -278,7 +277,7 @@ es:
         previous_form:
           back: Volver
           continue: Continuar
-          help: "¿En qué consiste la iniciativa? Escribe el título y la descripción. Te rcomendamos un título corto y conciso, y una descripción centrada en la solución propuesta."
+          help: '¿En qué consiste la iniciativa? Escribe el título y la descripción. Te rcomendamos un título corto y conciso, y una descripción centrada en la solución propuesta.'
           more_information: "(Más información)"
         promotal_committee:
           back: Volver
@@ -321,17 +320,17 @@ es:
           help: Por favor, rellene los siguientes campos con sus datos personales para firmar la iniciativa.
         finish:
           back_to_initiative: Volver a la iniciativa
-        sms_code:
-          continue: Revisa el código y continúa
-          help: Consulta los SMS recibidos en tu teléfono.
         sms_phone_number:
           continue: Mandame un SMS
           help: Rellene el formulario con su número de teléfono verificado para solicitar su código de verificación
+        sms_code:
+          continue: Revisa el código y continúa
+          help: Consulta los SMS recibidos en tu teléfono.
       initiative_votes:
         create:
           error: Ha habido errores al firmar la iniciativa.
           invalid: Los datos proporcionados para firmar la iniciativa no son válidos.
-          success_html: "¡Felicidades! La iniciativa <strong> %{title}</strong> ha sido firmada correctamente."
+          success_html: '¡Felicidades! La iniciativa <strong> %{title}</strong> ha sido firmada correctamente.'
         personal_data:
           invalid: Los datos personales no son consistentes con los datos proporcionados para la autorización.
         sms_code:
@@ -399,7 +398,7 @@ es:
           title: Listado de firmas
         vote_cabin:
           already_voted: Ha sido firmado
-          supports_required: Se requieren %{total_supports} firmas
+          supports_required: "Se requieren %{total_supports} firmas"
           verification_required: Verifica tu cuenta para firmar la iniciativa.
           vote: Firmar
           votes_blocked: Firma desactivada
@@ -438,8 +437,8 @@ es:
     resources:
       initiatives_type:
         actions:
-          title: Comportamiento
           vote: Votar
+          title: Comportamiento
   layouts:
     decidim:
       admin:
@@ -465,8 +464,8 @@ es:
         fill_personal_data: Completa tus datos
         finish: Terminar
         finished: Firma de iniciativa creada
-        see_steps: ver los pasos
         select_identity: Seleccionar identidad
+        see_steps: ver los pasos
         sms_code: Verificación de código SMS
         sms_phone_number: Número de teléfono móvil
         step: Paso %{current} de %{total}
@@ -476,4 +475,4 @@ es:
           check: Échale un vistazo
           check_and_support: Compruébalo y firma
         no_initiatives_yet:
-          no_initiatives_yet: "¡No hay iniciativas todavía!"
+          no_initiatives_yet: '¡No hay iniciativas todavía!'

--- a/decidim-meetings/config/locales/ca.yml
+++ b/decidim-meetings/config/locales/ca.yml
@@ -1,4 +1,3 @@
----
 ca:
   activemodel:
     attributes:
@@ -137,7 +136,7 @@ ca:
       badges:
         attended_meetings:
           conditions:
-          - Inscriu-te a les reunions que vulguis assistir
+            - Inscriu-te a les reunions que vulguis assistir
           description: Aquest distintiu s'aconsegueix assistint a diverses reunions presencials.
           description_another: Aquest usuari ha assistit a %{score} trobades.
           description_own: Has assistit a %{score} trobades.

--- a/decidim-meetings/config/locales/es.yml
+++ b/decidim-meetings/config/locales/es.yml
@@ -1,4 +1,3 @@
----
 es:
   activemodel:
     attributes:
@@ -137,12 +136,12 @@ es:
       badges:
         attended_meetings:
           conditions:
-          - Regístrate en los encuentros a los que quieres asistir
+            - Regístrate en los encuentros a los que quieres asistir
           description: Este distintivo se otorga cuando asistas a varias reuniones presenciales.
           description_another: Este usuario asistió a %{score} encuentros.
           description_own: Has asistido a %{score} encuentros.
           name: Encuentros a los que has asistido
-          next_level_in: "¡Asiste a %{score} encuentros más para alcanzar el siguiente nivel!"
+          next_level_in: '¡Asiste a %{score} encuentros más para alcanzar el siguiente nivel!'
           unearned_another: Este usuario aún no ha asistido a ningún encunetro.
           unearned_own: No has asistido a ningún encuentro todavía.
     meetings:
@@ -151,7 +150,7 @@ es:
         attachment_collections: Carpetas
         attachments: Archivos adjuntos
         close: Cerrar
-        confirm_destroy: "¿Está seguro de que quiere eliminar este encuentro?"
+        confirm_destroy: '¿Está seguro de que quiere eliminar este encuentro?'
         destroy: Borrar
         edit: Editar
         minutes: Acta
@@ -376,7 +375,7 @@ es:
             validated: Validado
             validation_pending: VALIDACIÓN PENDIENTE
           remaining_slots:
-            one: Queda %{count} plaza
+            one: "Queda %{count} plaza"
             other: "%{count} plazas restantes"
           view: Ver
       meetings_map:

--- a/decidim-pages/config/locales/ca.yml
+++ b/decidim-pages/config/locales/ca.yml
@@ -1,4 +1,3 @@
----
 ca:
   activerecord:
     models:

--- a/decidim-pages/config/locales/es.yml
+++ b/decidim-pages/config/locales/es.yml
@@ -1,4 +1,3 @@
----
 es:
   activerecord:
     models:

--- a/decidim-participatory_processes/config/locales/ca.yml
+++ b/decidim-participatory_processes/config/locales/ca.yml
@@ -1,4 +1,3 @@
----
 ca:
   activemodel:
     attributes:

--- a/decidim-participatory_processes/config/locales/es.yml
+++ b/decidim-participatory_processes/config/locales/es.yml
@@ -1,4 +1,3 @@
----
 es:
   activemodel:
     attributes:
@@ -259,7 +258,7 @@ es:
         participatory_processes:
           contextual: "<p>Un <strong>proceso participativo</strong> es una secuencia de actividades participativas (p.e. primero rellenar una encuesta, luego realizar propuestas, debatirlas en encuentros presenciales o virtuales, y finalmente priorizarlas) con el objetivo de definir y tomar una decisión sobre un tema específico.</p> <p>Ejemplos de procesos participativos son: un proceso de elección de los miembros de un comité (donde primero se presentan unas candidaturas, luego se debate y finalmente se elige una candidatura), presupuestos participativos (donde se realizan propuestas, se valoran económicamente y se vota con el dinero disponible), un proceso de planificación estratégica, la redacción colaborativa de un reglamento o norma, el diseño de un espacio urbano o la producción de un plan de políticas públicas.</p>\n"
           page: "<p>Un <strong>proceso participativo</strong> es una secuencia de actividades participativas (p.e. primero rellenar una encuesta, luego realizar propuestas, debatirlas en encuentros presenciales o virtuales, y finalmente priorizarlas) con el objetivo de definir y tomar una decisión sobre un tema específico.</p> <p>Ejemplos de procesos participativos son: un proceso de elección de los miembros de un comité (donde primero se presentan unas candidaturas, luego se debate y finalmente se elige una candidatura), presupuestos participativos (donde se realizan propuestas, se valoran económicamente y se vota con el dinero disponible), un proceso de planificación estratégica, la redacción colaborativa de un reglamento o norma, el diseño de un espacio urbano o la producción de un plan de políticas públicas.</p>\n"
-          title: "¿Qué es un proceso participativo?"
+          title: '¿Qué es un proceso participativo?'
     menu:
       processes: Procesos
     metrics:

--- a/decidim-proposals/config/locales/ca.yml
+++ b/decidim-proposals/config/locales/ca.yml
@@ -1,4 +1,3 @@
----
 ca:
   activemodel:
     attributes:
@@ -37,7 +36,7 @@ ca:
         participatory_text:
           attributes:
             document:
-              invalid_document_type: 'Tipus de document no vàlid. Els formats acceptats són: %{valid_mime_types}'
+              invalid_document_type: "Tipus de document no vàlid. Els formats acceptats són: %{valid_mime_types}"
         proposal:
           attributes:
             attachment:
@@ -118,14 +117,14 @@ ca:
     events:
       proposals:
         collaborative_draft_access_accepted:
-          email_intro: S'ha acceptat %{requester_name} per accedir com a contribuidor de l'esborrany col·laboratiu <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: 'S''ha acceptat %{requester_name} per accedir com a contribuidor de l''esborrany col·laboratiu <a href="%{resource_path}">%{resource_title}</a>.'
           email_outro: Has rebut aquesta notificació perquè ets un contribuidor de <a href="%{resource_path}">%{resource_title}</a>.
-          email_subject: S'ha acceptat %{requester_name} per accedir com a contribuidor del %{resource_title}.
+          email_subject: "S'ha acceptat %{requester_name} per accedir com a contribuidor del %{resource_title}."
           notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> ha estat <strong>acceptat per accedir com a contribuidor</strong> de l'esborrany col·laboratiu <a href="%{resource_path}">%{resource_title}</a>.
         collaborative_draft_access_rejected:
-          email_intro: S'ha rebutjat %{requester_name} per accedir com a contribuidor de l'esborrany col·laboratiu <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: 'S''ha rebutjat %{requester_name} per accedir com a contribuidor de l''esborrany col·laboratiu <a href="%{resource_path}">%{resource_title}</a>.'
           email_outro: Has rebut aquesta notificació perquè ets un contribuidor de <a href="%{resource_path}">%{resource_title}</a>.
-          email_subject: S'ha rebutjat %{requester_name} per accedir com a col·laborador de l'esborrany col·lanoratiu %{resource_title}.
+          email_subject: "S'ha rebutjat %{requester_name} per accedir com a col·laborador de l'esborrany col·lanoratiu %{resource_title}."
           notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a><strong> ha estat rebutjat per accedir com a contribuïdor</strong> de l'esborrany col·laboratiu <a href="%{resource_path}">%{resource_title}</a>.
         collaborative_draft_access_requested:
           email_intro: '%{requester_name} ha sol·licitat accés com a contribuïdor. Pots <strong>acceptar o rebutjar la sol·licitud</strong> de l''esborrany col·laboratiu <a href="%{resource_path}">%{resource_title}</a>.'
@@ -224,8 +223,8 @@ ca:
       badges:
         accepted_proposals:
           conditions:
-          - Tria l'espai de participació del teu interès amb la creació de propostes activada
-          - Intenta fer propostes que es puguin dur a terme. D'aquesta manera és més probable que s'acceptin.
+            - Tria l'espai de participació del teu interès amb la creació de propostes activada
+            - Intenta fer propostes que es puguin dur a terme. D'aquesta manera és més probable que s'acceptin.
           description: Aquest distintiu es concedeix quan participes activament amb noves propostes i s'accepten.
           description_another: Aquesta participant ha aconseguit %{score} propostes acceptades.
           description_own: Has aconseguit que s'acceptin %{score} de les teves propostes.
@@ -235,8 +234,8 @@ ca:
           unearned_own: Cap de les teves propostes encara no ha estat acceptada.
         proposal_votes:
           conditions:
-          - Navega i passa un temps llegint les propostes d'altres persones
-          - Dóna suport a les propostes que desitgis o troba'n d'interessants
+            - Navega i passa un temps llegint les propostes d'altres persones
+            - Dóna suport a les propostes que desitgis o troba'n d'interessants
           description: Aquest distintiu es concedeix quan dones suport a propostes d'altres persones.
           description_another: Aquesta participant ha donat suport a %{score} propostes.
           description_own: Has donat suport a %{score} propostes.
@@ -246,8 +245,8 @@ ca:
           unearned_own: Encara no has donat suport a cap proposta.
         proposals:
           conditions:
-          - Tria un espai de participació del teu interès amb la creació de propostes activada
-          - Crea una proposta nova
+            - Tria un espai de participació del teu interès amb la creació de propostes activada
+            - Crea una proposta nova
           description: Aquest distintiu es concedeix quan participes activament amb noves propostes.
           description_another: Aquesta participant ha creat %{score} propostes.
           description_own: Has creat %{score} propostes.
@@ -300,10 +299,8 @@ ca:
         participatory_texts:
           bulk-actions:
             are_you_sure: Segur que vols descartar l'esborrany sencer de text participatiu?
-            discard_all: Descarta'l sencer
             import_doc: Importar document
-          discard:
-            success: S'han descartat tots els esborranys de textos participatius.
+            discard_all: Descarta'l sencer
           import:
             invalid: El formulari no és vàlid!
             success: Enhorabona, les seccions següents s'han convertit a propostes. Ara pots revisar-les i ajustar el que necessitis abans de publicar.
@@ -323,6 +320,8 @@ ca:
           publish:
             invalid: No s'han pogut publicar propostes
             success: S'han publicat totes les propostes
+          discard:
+            success: S'han descartat tots els esborranys de textos participatius.
           sections:
             article: "<em>Article</em>"
             section: "<em>Secció:</em> <strong>%{title}</strong>"
@@ -501,7 +500,7 @@ ca:
         requests:
           accepted_request:
             error: No has pogut ser acceptada com a contribuïdora, si us plau torna-ho a provar més tard.
-            success: S'ha acceptat amb èxit @%{user} com a contribuïdor
+            success: "S'ha acceptat amb èxit @%{user} com a contribuïdor"
           access_requested:
             error: No s'ha pogut completar la teva sol·licitud, si us plau torna-ho a provar més tard.
             success: La teva sol·licitud de contribució s'ha enviat correctament
@@ -627,7 +626,6 @@ ca:
           comments: Comentaris
         filters:
           activity: Activitat
-          amendment_type: Escriu
           category: Categoria
           category_prompt: Selecciona una categoria
           origin: Origen
@@ -635,6 +633,7 @@ ca:
           search: Cerca
           state: Estat
           voted: Has donat suport
+          amendment_type: Escriu
         filters_small_view:
           close_modal: Tancar finestra
           filter: Filtra

--- a/decidim-proposals/config/locales/es.yml
+++ b/decidim-proposals/config/locales/es.yml
@@ -1,4 +1,3 @@
----
 es:
   activemodel:
     attributes:
@@ -37,7 +36,7 @@ es:
         participatory_text:
           attributes:
             document:
-              invalid_document_type: 'Tipo de documento no válido. Los formatos aceptados son: %{valid_mime_types}'
+              invalid_document_type: "Tipo de documento no válido. Los formatos aceptados son: %{valid_mime_types}"
         proposal:
           attributes:
             attachment:
@@ -82,9 +81,7 @@ es:
         settings:
           global:
             amendments_enabled: Enmiendas habilitadas
-            announcement: 'Aviso
-
-'
+            announcement: "Aviso\n"
             attachments_allowed: Permitir archivos adjuntos
             can_accumulate_supports_beyond_threshold: Puede acumular apoyos más allá del umbral
             collaborative_drafts_enabled: Habilitar borradores colaborativos
@@ -150,12 +147,12 @@ es:
           email_subject: "%{author_name} %{author_nickname} ha retirado el borrador colaborativo %{resource_title}."
           notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> <strong>ha retirado</strong> el borrador colaborativo <a href="%{resource_path}">%{resource_title}</a>.
         creation_enabled:
-          email_intro: "¡Ahora puedes crear nuevas propuestas en %{participatory_space_title}! Empieza a participar en esta página:"
+          email_intro: '¡Ahora puedes crear nuevas propuestas en %{participatory_space_title}! Empieza a participar en esta página:'
           email_outro: Recibiste esta notificación porque estás siguiendo %{participatory_space_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
           email_subject: Propuestas ahora disponibles en %{participatory_space_title}
           notification_title: Ahora puedes presentar <a href="%{resource_path}">nuevas propuestas</a> en <a href="%{participatory_space_url}">%{participatory_space_title}</a>
         endorsing_enabled:
-          email_intro: "¡Puedes adherirte a propuestas en %{participatory_space_title}! Empieza a participar en esta página:"
+          email_intro: '¡Puedes adherirte a propuestas en %{participatory_space_title}! Empieza a participar en esta página:'
           email_outro: Recibiste esta notificación porque estás siguiendo %{participatory_space_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
           email_subject: La adhesión de propuestas ha comenzado para %{participatory_space_title}
           notification_title: Ahora puedes empezar a <a href="%{resource_path}">adherirte propuestas</a> en <a href="%{participatory_space_url}">%{participatory_space_title}</a>
@@ -218,7 +215,7 @@ es:
           email_subject: La categoría de la propuesta %{resource_title} ha sido actualizada
           notification_title: La categoría de la propuesta <a href="%{resource_path}">%{resource_title}</a> ha sido actualizada por un/a administrador/a.
         voting_enabled:
-          email_intro: "¡Puedes votar propuestas en %{participatory_space_title}! Empieza a participar en esta página:"
+          email_intro: '¡Puedes votar propuestas en %{participatory_space_title}! Empieza a participar en esta página:'
           email_outro: Recibiste esta notificación porque estás siguiendo %{participatory_space_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
           email_subject: La posibilidad de dar apoyo a las propuestas ha comenzado para %{participatory_space_title}
           notification_title: Ya puedes empezar a <a href="%{resource_path}">apoyar propuestas</a> en <a href="%{participatory_space_url}">%{participatory_space_title}</a>
@@ -226,35 +223,35 @@ es:
       badges:
         accepted_proposals:
           conditions:
-          - Elige el espacio de participación con la creación de propuestas habilitada de tu interés
-          - Intenta hacer propuestas que se puedan realizar. De esta manera es más probable que sean aceptadas.
+            - Elige el espacio de participación con la creación de propuestas habilitada de tu interés
+            - Intenta hacer propuestas que se puedan realizar. De esta manera es más probable que sean aceptadas.
           description: Este distintivo se otorga cuando participes activamente con nuevas propuestas y estas sean aceptadas.
-          description_another: "%{score} propuestas de este usuario han sido aceptadas."
-          description_own: "%{score} de tus propuestas han sido aceptadas."
+          description_another: '%{score} propuestas de este usuario han sido aceptadas.'
+          description_own: '%{score} de tus propuestas han sido aceptadas.'
           name: Propuestas aceptadas
-          next_level_in: "¡Consigue que se aprueben %{score} propuestas más para alcanzar el siguiente nivel!"
+          next_level_in: '¡Consigue que se aprueben %{score} propuestas más para alcanzar el siguiente nivel!'
           unearned_another: Este usuario aún no ha conseguido ninguna propuesta aceptada.
           unearned_own: Aún no tienes ninguna propuesta aceptada.
         proposal_votes:
           conditions:
-          - Navega y dedica un tiempo leyendo las propuestas de otras personas
-          - Da apoyo a las propuestas con las que estés de acuerdo o encuentres interesantes
+            - Navega y dedica un tiempo leyendo las propuestas de otras personas
+            - Da apoyo a las propuestas con las que estés de acuerdo o encuentres interesantes
           description: Este distintivo se otorga cuando apoyas propuestas de otras personas.
           description_another: Este usuario ha dado soporte a %{score} propuestas.
           description_own: Has dado soporte a %{score} propuestas.
           name: Apoyos a propuestas
-          next_level_in: "¡Apoya %{score} propuestas más para alcanzar el siguiente nivel!"
+          next_level_in: '¡Apoya %{score} propuestas más para alcanzar el siguiente nivel!'
           unearned_another: Este usuario aún no ha dado apoyo a ninguna propuesta.
           unearned_own: Todavía no has dado apoyo a ninguna propuesta.
         proposals:
           conditions:
-          - Elige el espacio de participación con la creación de propuestas habilitada que sea de tu interés
-          - Crear una nueva propuesta
+            - Elige el espacio de participación con la creación de propuestas habilitada que sea de tu interés
+            - Crear una nueva propuesta
           description: Este distintivo se otorga cuando participas activamente con nuevas propuestas.
           description_another: Este usuario ha creado %{score} propuestas.
           description_own: Has creado %{score} propuestas.
           name: Propuestas
-          next_level_in: "¡Crea %{score} propuestas más para alcanzar el siguiente nivel!"
+          next_level_in: '¡Crea %{score} propuestas más para alcanzar el siguiente nivel!'
           unearned_another: Este usuario no ha creado ninguna propuesta todavía.
           unearned_own: Aún no has creado propuestas.
     metrics:
@@ -301,13 +298,11 @@ es:
             name: Propuesta
         participatory_texts:
           bulk-actions:
-            are_you_sure: "¿Estás seguro de descartar todo el borrador del texto participativo?"
-            discard_all: Descartar todo
+            are_you_sure: '¿Estás seguro de descartar todo el borrador del texto participativo?'
             import_doc: Importar documento
-          discard:
-            success: Todos los borradores de textos participativos han sido descartados.
+            discard_all: Descartar todo
           import:
-            invalid: "¡El formulario no es válido!"
+            invalid: '¡El formulario no es válido!'
             success: Enhorabuena, los párrafos y secciones del documento importado se han convertido correctamente en propuestas. Ahora puedes revisarlas y ajustar las que necesites antes de publicar.
           index:
             info_1: Los párrafos y secciones del documento importado se han convertido correctamente en propuestas. Ahora puedes revisarlas y ajustar las que necesites antes de publicar.
@@ -325,6 +320,8 @@ es:
           publish:
             invalid: No se pudieron publicar las propuestas
             success: Todas las propuestas han sido publicadas
+          discard:
+            success: Todos los borradores de textos participativos han sido descartados.
           sections:
             article: "<em>Artículo</em>"
             section: "<em>Sección:</em> <strong>%{title}</strong>"
@@ -456,7 +453,7 @@ es:
             success: Borrador colaborativo retirado con éxito.
         compare:
           mine_is_different: Mi borrador colaborativo es diferente
-          no_similars_found: "¡Enhorabuena! No se encontraron borradores colaborativos similares"
+          no_similars_found: '¡Enhorabuena! No se encontraron borradores colaborativos similares'
           title: Borradores colaborativos similares
         complete:
           send: Enviar
@@ -603,7 +600,7 @@ es:
       proposals:
         compare:
           mine_is_different: Mi propuesta es diferente
-          no_similars_found: "¡Bien hecho! No se encontraron propuestas similares"
+          no_similars_found: '¡Bien hecho! No se encontraron propuestas similares'
           title: Propuestas similares
         complete:
           send: Enviar
@@ -620,7 +617,7 @@ es:
           title: Editar propuesta
         edit_draft:
           discard: Descartar este borrador
-          discard_confirmation: "¿Estás seguro que quieres descartar este borrador de propuesta?"
+          discard_confirmation: '¿Estás seguro que quieres descartar este borrador de propuesta?'
           send: Previsualizar
           title: Editar el borrador de la propuesta
         endorsement_identities_cabin:
@@ -629,7 +626,6 @@ es:
           comments: Comentarios
         filters:
           activity: Actividad
-          amendment_type: Tipo
           category: Categoría
           category_prompt: Selecciona una categoría
           origin: Origen
@@ -637,6 +633,7 @@ es:
           search: Buscar
           state: Estado
           voted: Apoyadas
+          amendment_type: Tipo
         filters_small_view:
           close_modal: Cerrar ventana
           filter: Filtrar
@@ -688,7 +685,7 @@ es:
           proposal_rejected_reason: 'Esta propuesta ha sido rechazada porque:'
           report: Denunciar
           withdraw_btn_hint: Puedes retirar tu propuesta si cambias de opinión, siempre que no haya recibido ningún soporte. La propuesta no se eliminará, aparecerá en la lista de propuestas retiradas.
-          withdraw_confirmation: "¿Estás seguro de retirar esta propuesta?"
+          withdraw_confirmation: '¿Estás seguro de retirar esta propuesta?'
           withdraw_proposal: Retirar propuesta
         tags:
           changed_from: "(cambiado desde <u>%{previous_category}</u> por un administrador)"

--- a/decidim-sortitions/config/locales/ca.yml
+++ b/decidim-sortitions/config/locales/ca.yml
@@ -1,4 +1,3 @@
----
 ca:
   activemodel:
     attributes:
@@ -140,7 +139,7 @@ ca:
           random_seed: Llavor aleatòria
           selected_proposals:
             one: 1 proposta seleccionada
-            other: "%{count} propostes seleccionades"
+            other: '%{count} propostes seleccionades'
           view: Veure
         sortition_author:
           deleted: Participant eliminada

--- a/decidim-sortitions/config/locales/es.yml
+++ b/decidim-sortitions/config/locales/es.yml
@@ -1,4 +1,3 @@
----
 es:
   activemodel:
     attributes:
@@ -62,7 +61,7 @@ es:
               other: Sorteos
         sortitions:
           confirm_destroy:
-            confirm_destroy: "¿Seguro que quieres cancelar este sorteo?"
+            confirm_destroy: '¿Seguro que quieres cancelar este sorteo?'
             destroy: Cancelar el sorteo
             title: Cancelar el sorteo
           create:
@@ -140,7 +139,7 @@ es:
           random_seed: Semilla aleatoria
           selected_proposals:
             one: 1 propuesta seleccionada
-            other: "%{count} propuestas seleccionadas"
+            other: '%{count} propuestas seleccionadas'
           view: Ver
         sortition_author:
           deleted: Usuario eliminado

--- a/decidim-surveys/config/locales/ca.yml
+++ b/decidim-surveys/config/locales/ca.yml
@@ -1,4 +1,3 @@
----
 ca:
   activemodel:
     models:

--- a/decidim-surveys/config/locales/es.yml
+++ b/decidim-surveys/config/locales/es.yml
@@ -1,4 +1,3 @@
----
 es:
   activemodel:
     models:

--- a/decidim-system/config/locales/ca.yml
+++ b/decidim-system/config/locales/ca.yml
@@ -1,4 +1,3 @@
----
 ca:
   decidim:
     system:

--- a/decidim-system/config/locales/es.yml
+++ b/decidim-system/config/locales/es.yml
@@ -1,9 +1,8 @@
----
 es:
   decidim:
     system:
       actions:
-        confirm_destroy: "¿Seguro que lo quieres eliminar?"
+        confirm_destroy: '¿Seguro que lo quieres eliminar?'
         destroy: Borrar
         edit: Editar
         new: Nuevo

--- a/decidim-verifications/config/locales/ca.yml
+++ b/decidim-verifications/config/locales/ca.yml
@@ -1,4 +1,3 @@
----
 ca:
   activemodel:
     attributes:
@@ -37,16 +36,16 @@ ca:
       admin:
         id_documents:
           help:
-          - Els usuaris omplen la informació de la seva identitat i carreguen una còpia del seu document.
-          - Emplenes la informació que es mostra a la imatge penjada.
-          - La informació ha de coincidir amb el que hagi omplert l'usuari.
-          - Si no pots veure la informació amb claredat o no la pots verificar, pots rebutjar la sol·licitud i l'usuari la podrà solucionar.
+            - Els usuaris omplen la informació de la seva identitat i carreguen una còpia del seu document.
+            - Emplenes la informació que es mostra a la imatge penjada.
+            - La informació ha de coincidir amb el que hagi omplert l'usuari.
+            - Si no pots veure la informació amb claredat o no la pots verificar, pots rebutjar la sol·licitud i l'usuari la podrà solucionar.
         postal_letter:
           help:
-          - Les participants sol·liciten un codi de verificació que s'enviarà a la seva adreça.
-          - Envies la carta a la seva adreça amb el codi de verificació.
-          - Marques la carta com a enviada.
-          - Una vegada la carta estigui marcada com a enviada, la participant podrà introduir el codi i verificar-se.
+            - Les participants sol·liciten un codi de verificació que s'enviarà a la seva adreça.
+            - Envies la carta a la seva adreça amb el codi de verificació.
+            - Marques la carta com a enviada.
+            - Una vegada la carta estigui marcada com a enviada, la participant podrà introduir el codi i verificar-se.
       csv_census:
         explanation: Verifica't mitjançant el cens de l'organització
         name: Cens de l'organització
@@ -100,8 +99,8 @@ ca:
             body: Per fer-ho, has d'entrar al panell d'administració i afegir les autoritzacions de csv_census a l'organització
             title: Has d'activar el cens csv d'aquesta organització
           new:
-            file: Fitxer .csv amb dades de correus electrònics
             info: 'Ha de ser un fitxer amb format CSV amb una columna: correu electrònic'
+            file: Fitxer .csv amb dades de correus electrònics
             submit: Penja el document
             title: Penja un nou cens
         authorizations:
@@ -148,7 +147,7 @@ ca:
               success: S'ha rebutjat la verificació. Es demanarà a la participant que modifiqui els seus documents
         authorizations:
           choose:
-            choose_a_type: 'Si us plau selecciona com et vols verificar:'
+            choose_a_type: "Si us plau selecciona com et vols verificar:"
             offline: Presencial
             online: Online
             title: Verifica't utilitzant el teu document d'identitat
@@ -206,14 +205,14 @@ ca:
           create:
             error: S'ha produït un problema amb la teva sol·licitud
             success: Gràcies! Hem enviat un SMS al teu telèfon.
-          destroy:
-            success: S'ha restablert el codi de verificació amb èxit. Torna a introduir el teu número de telèfon.
           edit:
             confirm_destroy: Segur que vols reiniciar el codi de verificació?
             destroy: Restableix el codi de verificació
-            resend: No has rebut el codi de verificació?
             send: Confirmar
+            resend: No has rebut el codi de verificació?
             title: Introdueix el codi de verificació que has rebut
+          destroy:
+            success: S'ha restablert el codi de verificació amb èxit. Torna a introduir el teu número de telèfon.
           new:
             send: Envia'm un SMS
             title: Sol·licita el teu codi de verificació

--- a/decidim-verifications/config/locales/es.yml
+++ b/decidim-verifications/config/locales/es.yml
@@ -1,4 +1,3 @@
----
 es:
   activemodel:
     attributes:
@@ -37,16 +36,16 @@ es:
       admin:
         id_documents:
           help:
-          - Los usuarios rellenan la información de su identidad y suben una copia de su documento.
-          - Rellenas la información presente en la imagen subida.
-          - La información debe coincidir con lo que el usuario envió.
-          - Si no puedes ver claramente la información o no puedes verificarla, puedes rechazar la solicitud y el usuario podrá corregirla.
+            - Los usuarios rellenan la información de su identidad y suben una copia de su documento.
+            - Rellenas la información presente en la imagen subida.
+            - La información debe coincidir con lo que el usuario envió.
+            - Si no puedes ver claramente la información o no puedes verificarla, puedes rechazar la solicitud y el usuario podrá corregirla.
         postal_letter:
           help:
-          - Los usuarios solicitan que se envíe un código de verificación a su dirección.
-          - Envías la carta a su dirección con el código de verificación.
-          - Marcas la carta como enviada.
-          - Una vez hayas marcado la carta como enviada, el usuario podrá introducir el código y ser verificado.
+            - Los usuarios solicitan que se envíe un código de verificación a su dirección.
+            - Envías la carta a su dirección con el código de verificación.
+            - Marcas la carta como enviada.
+            - Una vez hayas marcado la carta como enviada, el usuario podrá introducir el código y ser verificado.
       csv_census:
         explanation: Verifíquese utilizando el censo de la organización.
         name: Censo de la organización
@@ -86,7 +85,7 @@ es:
           census:
             create:
               error: Hubo un error al importar el censo.
-              success: "%{count} artículos importados exitosamente (%{errors} errores)"
+              success: '%{count} artículos importados exitosamente (%{errors} errores)'
             destroy_all:
               success: Todos los datos del censo han sido eliminados
           destroy:
@@ -100,8 +99,8 @@ es:
             body: Para ello, debe ingresar a la administración del sistema y agregar las autorizaciones csv_census a la organización
             title: Necesitas activar el censo csv para esta organización.
           new:
-            file: archivo .csv con datos de correos electrónicos
             info: 'Debe ser un archivo con formato CSV con una columna: correo electrónico'
+            file: archivo .csv con datos de correos electrónicos
             submit: Subir archivo
             title: Subir un nuevo censo
         authorizations:
@@ -148,7 +147,7 @@ es:
               success: Verificación rechazada. Se le pedirá al usuario que modifique sus documentos
         authorizations:
           choose:
-            choose_a_type: 'Por favor selecciona como quieres ser verificado:'
+            choose_a_type: "Por favor selecciona como quieres ser verificado:"
             offline: Presencial
             online: Online
             title: Verifícate utilizando tu documento de identidad
@@ -190,7 +189,7 @@ es:
         authorizations:
           create:
             error: Hubo un problema con su petición
-            success: "¡Gracias! Te enviaremos un código de verificación a tu dirección"
+            success: '¡Gracias! Te enviaremos un código de verificación a tu dirección'
           edit:
             send: Confirmar
             title: Introduce el código de verificación que recibiste
@@ -205,15 +204,15 @@ es:
         authorizations:
           create:
             error: Hubo un problema con tu solicitud
-            success: "¡Gracias! Hemos enviado un SMS a tu teléfono."
+            success: '¡Gracias! Hemos enviado un SMS a tu teléfono.'
+          edit:
+            confirm_destroy: '¿Estás seguro de que quieres restablecer el código de verificación?'
+            destroy: Restablecer código de verificación
+            send: Confirmar
+            resend: '¿No recibió el código de verificación?'
+            title: Introduce el código de verificación que has recibido
           destroy:
             success: Código de verificación restablecido con éxito. Por favor vuelva a ingresar su número de teléfono.
-          edit:
-            confirm_destroy: "¿Estás seguro de que quieres restablecer el código de verificación?"
-            destroy: Restablecer código de verificación
-            resend: "¿No recibió el código de verificación?"
-            send: Confirmar
-            title: Introduce el código de verificación que has recibido
           new:
             send: Mándame un SMS
             title: Solicita tu código de verificación


### PR DESCRIPTION
#### :tophat: What? Why?
This reverts commit 88f57c93c2e52285a2b6235692c523630b83052d from PR #4975, which is causing problems in the Crowdin PRs.

I thought we were checking for locale normalization when releasing new version, but we're actually skipping that check.

#### :pushpin: Related Issues
- Related to #4975


#### :clipboard: Subtasks
None