### PR TITLE
Fix linking to items in other modules than proposals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,7 @@ end
 - **decidim-admin**: Let admins visit the autrhorization workflows index page [\#4964](https://github.com/decidim/decidim/pull/4964/)
 - **decidim-admin**: Do not generate profile URL in officializations view if nickname is missing [\#4964](https://github.com/decidim/decidim/pull/4964/)
 - **decidim-core**: Fix user presenter for user groups breaking notifications views [\#4973](https://github.com/decidim/decidim/pull/4973/)
+- **decidim-proposals**: Fix linking to items in other modules than proposals [\#4978](https://github.com/decidim/decidim/pull/4978)
 
 **Removed**:
 

--- a/decidim-proposals/lib/decidim/content_parsers/proposal_parser.rb
+++ b/decidim-proposals/lib/decidim/content_parsers/proposal_parser.rb
@@ -22,8 +22,8 @@ module Decidim
       # Matches a URL
       URL_REGEX_SCHEME = '(?:http(s)?:\/\/)'
       URL_REGEX_CONTENT = '[\w.-]+[\w\-\._~:\/?#\[\]@!\$&\'\(\)\*\+,;=.]+'
-      URL_REGEX_END_CHAR = '[\w]'
-      URL_REGEX = /#{URL_REGEX_SCHEME}#{URL_REGEX_CONTENT}#{URL_REGEX_END_CHAR}/i
+      URL_REGEX_END_CHAR = '[\d]'
+      URL_REGEX = /#{URL_REGEX_SCHEME}#{URL_REGEX_CONTENT}\/proposals\/#{URL_REGEX_END_CHAR}+/i
       # Matches a mentioned Proposal ID (~(d)+ expression)
       ID_REGEX = /~(\d+)/
 

--- a/decidim-proposals/lib/decidim/content_parsers/proposal_parser.rb
+++ b/decidim-proposals/lib/decidim/content_parsers/proposal_parser.rb
@@ -23,7 +23,7 @@ module Decidim
       URL_REGEX_SCHEME = '(?:http(s)?:\/\/)'
       URL_REGEX_CONTENT = '[\w.-]+[\w\-\._~:\/?#\[\]@!\$&\'\(\)\*\+,;=.]+'
       URL_REGEX_END_CHAR = '[\d]'
-      URL_REGEX = /#{URL_REGEX_SCHEME}#{URL_REGEX_CONTENT}\/proposals\/#{URL_REGEX_END_CHAR}+/i
+      URL_REGEX = %r{#{URL_REGEX_SCHEME}#{URL_REGEX_CONTENT}/proposals/#{URL_REGEX_END_CHAR}+}i
       # Matches a mentioned Proposal ID (~(d)+ expression)
       ID_REGEX = /~(\d+)/
 

--- a/decidim-proposals/spec/lib/decidim/content_parsers/proposal_parser_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/content_parsers/proposal_parser_spec.rb
@@ -121,6 +121,21 @@ module Decidim
           end
         end
 
+        context "when content has a link that is not in a proposals component" do
+          let(:proposal) { create(:proposal, component: component) }
+          let(:content) do
+            url = proposal_url(proposal).sub(/\/proposals\//, "/something-else/")
+            "This content references a non-proposal with same ID as a proposal #{url}."
+          end
+
+          it { is_expected.to eq(content) }
+          it "has metadata with no reference to the proposal" do
+            subject
+            expect(parser.metadata).to be_a(Decidim::ContentParsers::ProposalParser::Metadata)
+            expect(parser.metadata.linked_proposals).to be_empty
+          end
+        end
+
         context "when content has words similar to links but not links" do
           let(:similars) do
             %w(AA:aaa AA:sss aa:aaa aa:sss aaa:sss aaaa:sss aa:ssss aaa:ssss)

--- a/decidim-proposals/spec/lib/decidim/content_parsers/proposal_parser_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/content_parsers/proposal_parser_spec.rb
@@ -124,7 +124,7 @@ module Decidim
         context "when content has a link that is not in a proposals component" do
           let(:proposal) { create(:proposal, component: component) }
           let(:content) do
-            url = proposal_url(proposal).sub(/\/proposals\//, "/something-else/")
+            url = proposal_url(proposal).sub(%r{/proposals/}, "/something-else/")
             "This content references a non-proposal with same ID as a proposal #{url}."
           end
 


### PR DESCRIPTION
#### :tophat: What? Why?
When linking to items inside Decidim that have similar URL structure as proposals, the links are always referring to proposals in case the other item's ID matches with an existing proposal.

#### :pushpin: Related Issues
- Fixes https://meta.decidim.org/processes/bug-report/f/210/proposals/14311

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [X] Add tests