### PR TITLE
Fix results metric manage

### DIFF
--- a/decidim-accountability/app/queries/decidim/accountability/metrics/results_metric_manage.rb
+++ b/decidim-accountability/app/queries/decidim/accountability/metrics/results_metric_manage.rb
@@ -40,6 +40,7 @@ module Decidim
                                                   .left_outer_joins(:category)
           @query = @query.where("decidim_accountability_results.created_at <= ?", end_time)
           @query = @query.group("decidim_categorizations.decidim_category_id",
+                                "decidim_accountability_results.id",
                                 :participatory_space_type,
                                 :participatory_space_id,
                                 "decidim_components.id")

--- a/decidim-accountability/app/queries/decidim/accountability/metrics/results_metric_manage.rb
+++ b/decidim-accountability/app/queries/decidim/accountability/metrics/results_metric_manage.rb
@@ -16,10 +16,14 @@ module Decidim
             next if cumulative_value.zero?
             quantity_value = quantity[key] || 0
             category_id, space_type, space_id, related_object_id = key
-            record = Decidim::Metric.find_or_initialize_by(day: @day.to_s, metric_type: @metric_name,
-                                                           organization: @organization, decidim_category_id: category_id,
-                                                           participatory_space_type: space_type, participatory_space_id: space_id,
-                                                           related_object_type: "Decidim::Component", related_object_id: related_object_id)
+            record = Decidim::Metric.find_or_initialize_by(day: @day.to_s,
+                                                           metric_type: @metric_name,
+                                                           organization: @organization,
+                                                           decidim_category_id: category_id,
+                                                           participatory_space_type: space_type,
+                                                           participatory_space_id: space_id,
+                                                           related_object_type: "Decidim::Component",
+                                                           related_object_id: related_object_id)
             record.assign_attributes(cumulative: cumulative_value, quantity: quantity_value)
             @registry << record
           end
@@ -36,15 +40,15 @@ module Decidim
             manifest.participatory_spaces.call(@organization).public_spaces
           end
           components = Decidim::Component.where(participatory_space: spaces).published
-          @query = Decidim::Accountability::Result.where(component: components).joins(:component)
+          @query = Decidim::Accountability::Result.select(:decidim_component_id)
+                                                  .where(component: components)
+                                                  .joins(:component)
                                                   .left_outer_joins(:category)
           @query = @query.where("decidim_accountability_results.created_at <= ?", end_time)
           @query = @query.group("decidim_categorizations.decidim_category_id",
-                                "decidim_accountability_results.id",
                                 :participatory_space_type,
                                 :participatory_space_id,
-                                "decidim_components.id")
-
+                                :decidim_component_id)
           @query
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?
>We have an application running Decidim 0.16.0, the task bundle exec rake decidim:metrics:one["results"] generates the following error:

>ActiveRecord::StatementInvalid: PG::GroupingError: ERROR: column "decidim_accountability_results.id" must appear in the GROUP BY clause or be used in an aggregate function

I think I've been able to reproduce the problem and found a fix, but I'm not 100% sure.

#### :pushpin: Related Issues
- Fixes #4871 