### PR TITLE
Display pointer cursor icon for all elements with the "link" class

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_buttons.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_buttons.scss
@@ -211,6 +211,7 @@
 }
 
 .link{
+  cursor: pointer;
   color: $anchor-color;
   font-weight: 600;
 }


### PR DESCRIPTION
#### :tophat: What? Why?
Currently e.g. buttons that have the `.link` class assigned to them do not display the pointer icon when hovering the mouse over them. This has caused some confusion among the users.

Small but important change regarding UX.

### :camera: Screenshots (optional)
![ux-button-links](https://user-images.githubusercontent.com/864340/54679161-483c1300-4b0f-11e9-921e-deeb1b31e538.png)