### PR TITLE
don't send email if user can not participate in space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ end
 
 **Fixed**:
 
+- **decidim-core**: Don't send email if user can not participate in space [/#4988](https://github.com/decidim/decidim/pull/4988)
 - **decidim-proposals**: Fix proposal wizard back button [\#4976](https://github.com/decidim/decidim/pull/4976)
 - **decidim-participatory_processes**: Fix visibility of private processes on process groups. [#4965](https://github.com/decidim/decidim/pull/4965)
 - **decidim-proposals**: Update error message when a Proposal can not be withdrawn due to already existing supports.  [#4961](https://github.com/decidim/decidim/pull/4961)

--- a/decidim-core/app/services/decidim/email_notification_generator.rb
+++ b/decidim-core/app/services/decidim/email_notification_generator.rb
@@ -38,13 +38,12 @@ module Decidim
 
       followers.each do |recipient|
         next unless ["all", "followed-only"].include?(recipient.notification_types)
-        next unless participatory_space.is_a?(Decidim::Participable) && participatory_space.can_participate?(recipient)
+        next unless participatory_space.present? && participatory_space.is_a?(Decidim::Participable) && participatory_space.can_participate?(recipient)
         send_email_to(recipient, user_role: :follower)
       end
 
       affected_users.each do |recipient|
         next unless ["all", "own-only"].include?(recipient.notification_types)
-        next unless participatory_space.is_a?(Decidim::Participable) && participatory_space.can_participate?(recipient)
         send_email_to(recipient, user_role: :affected_user)
       end
     end

--- a/decidim-core/app/services/decidim/email_notification_generator.rb
+++ b/decidim-core/app/services/decidim/email_notification_generator.rb
@@ -81,7 +81,7 @@ module Decidim
       return resource.component if resource.is_a?(Decidim::HasComponent)
       return resource if resource.is_a?(Decidim::Component)
     end
-    
+
     def participatory_space
       return resource if resource.is_a?(Decidim::ParticipatorySpaceResourceable)
       component&.participatory_space

--- a/decidim-core/app/services/decidim/email_notification_generator.rb
+++ b/decidim-core/app/services/decidim/email_notification_generator.rb
@@ -38,11 +38,13 @@ module Decidim
 
       followers.each do |recipient|
         next unless ["all", "followed-only"].include?(recipient.notification_types)
+        next unless participatory_space.is_a?(Decidim::Participable) && participatory_space.can_participate?(recipient)
         send_email_to(recipient, user_role: :follower)
       end
 
       affected_users.each do |recipient|
         next unless ["all", "own-only"].include?(recipient.notification_types)
+        next unless participatory_space.is_a?(Decidim::Participable) && participatory_space.can_participate?(recipient)
         send_email_to(recipient, user_role: :affected_user)
       end
     end
@@ -73,6 +75,16 @@ module Decidim
           extra
         )
         .deliver_later
+    end
+
+    def component
+      return resource.component if resource.is_a?(Decidim::HasComponent)
+      return resource if resource.is_a?(Decidim::Component)
+    end
+    
+    def participatory_space
+      return resource if resource.is_a?(Decidim::ParticipatorySpaceResourceable)
+      component&.participatory_space
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
A User following User2, that has made a publication in Private and NonTransparent Assembly, the first User are recieving emails with the post that User2 done inside the Private and NonTransparent Assembly.

This means that all the interactions that we make to the Private and Non-transparent Assemblies are received by the people who follow us!

Just emails, no notification.

#### :pushpin: Related Issues
- Fixes no issue created

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Check if recipient can_participate before send the email 

### :camera: Screenshots (optional)
![Description](URL)
