### PR TITLE
Render readonly questionnaire to non logged participant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ end
 - **decidim-admin**: Add css variables for multitenant custom colors. [\#4882](https://github.com/decidim/decidim/pull/4882)
 - **decidim-verifications**: Allow definition of attributes in settings manifest to be required always on authorizations. [\#4911](https://github.com/decidim/decidim/pull/4911)
 - **decidim-verifications**: Allow resending SMS code. [\#4928](https://github.com/decidim/decidim/pull/4928)
+- **decidim-forms** Render readonly questionnaire to non logged participants [\#4991](https://github.com/decidim/decidim/pull/4991)
 
 **Changed**:
 

--- a/decidim-forms/app/assets/config/decidim_forms_manifest.css
+++ b/decidim-forms/app/assets/config/decidim_forms_manifest.css
@@ -1,0 +1,3 @@
+/*
+ *= link decidim/forms/forms.scss
+ */

--- a/decidim-forms/app/assets/stylesheets/decidim/forms/forms.scss
+++ b/decidim-forms/app/assets/stylesheets/decidim/forms/forms.scss
@@ -1,0 +1,37 @@
+.questionnaire-question_readonly{
+  font-weight: bold;
+  font-size: .875rem;
+
+  p{
+    margin-bottom: .5rem;
+  }
+
+  em{
+    font-weight: normal;
+    font-size: 90%;
+  }
+
+  p + ul{
+    margin-top: -.5rem;
+  }
+}
+
+.questionnaire-question_readonly-answers{
+  margin-bottom: .5rem;
+
+  &.single_option{
+    list-style-type: disc;
+  }
+
+  &.multiple_option{
+    list-style-type: square;
+  }
+
+  &.sorting{
+    list-style-type: circle;
+  }
+}
+
+.questionnaire-question_readonly-answer{
+  font-weight: normal;
+}

--- a/decidim-forms/app/cells/decidim/forms/answer_readonly/show.erb
+++ b/decidim-forms/app/cells/decidim/forms/answer_readonly/show.erb
@@ -1,0 +1,3 @@
+<li class="questionnaire-question_readonly-answer">
+  <%= translated_attribute(model.body) %>
+</li>

--- a/decidim-forms/app/cells/decidim/forms/answer_readonly_cell.rb
+++ b/decidim-forms/app/cells/decidim/forms/answer_readonly_cell.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Forms
+    # This cell renders a possible answer of a question (readonly)
+    class AnswerReadonlyCell < Decidim::ViewModel
+    end
+  end
+end

--- a/decidim-forms/app/cells/decidim/forms/question_readonly/show.erb
+++ b/decidim-forms/app/cells/decidim/forms/question_readonly/show.erb
@@ -1,0 +1,15 @@
+<li class="questionnaire-question_readonly">
+  <p>
+    <%= translated_attribute(model.body) %>
+    <br />
+    <em>
+      (<%= t(model.question_type, scope: "decidim.forms.question_types") %>)
+    </em>
+  </p>
+
+  <% if model.multiple_choice? %>
+    <ul class="questionnaire-question_readonly-answers <%= model.question_type %>">
+      <%= cell("decidim/forms/answer_readonly", collection: model.answer_options) %>
+    </ul>
+  <% end %>
+</li>

--- a/decidim-forms/app/cells/decidim/forms/question_readonly_cell.rb
+++ b/decidim-forms/app/cells/decidim/forms/question_readonly_cell.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Forms
+    # This cell renders a question (readonly) of a questionnaire
+    class QuestionReadonlyCell < Decidim::ViewModel
+    end
+  end
+end

--- a/decidim-forms/app/views/decidim/forms/questionnaires/show.html.erb
+++ b/decidim-forms/app/views/decidim/forms/questionnaires/show.html.erb
@@ -66,6 +66,10 @@
               <p>
                 <%= t(".answer_questionnaire.anonymous_user_message", sign_in_link: decidim.new_user_session_path, sign_up_link: decidim.new_user_registration_path).html_safe %>
               </p>
+
+              <ol>
+                <%= cell("decidim/forms/question_readonly", collection: @questionnaire.questions) %>
+              </ol>
             </div>
           <% end %>
         <% else %>

--- a/decidim-forms/lib/decidim/forms/engine.rb
+++ b/decidim-forms/lib/decidim/forms/engine.rb
@@ -6,8 +6,12 @@ module Decidim
     class Engine < ::Rails::Engine
       isolate_namespace Decidim::Forms
 
+      initializer "decidim_forms.add_cells_view_paths" do
+        Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Forms::Engine.root}/app/cells")
+      end
+
       initializer "decidim_forms.assets" do |app|
-        app.config.assets.precompile += %w(decidim_forms_manifest.js)
+        app.config.assets.precompile += %w(decidim_forms_manifest.js decidim_forms_manifest.css)
       end
     end
   end

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
@@ -10,7 +10,11 @@ shared_examples_for "has questionnaire" do
       expect(page).to have_i18n_content(questionnaire.title, upcase: true)
       expect(page).to have_i18n_content(questionnaire.description)
 
-      expect(page).to have_no_i18n_content(question.body)
+      expect(page).not_to have_css(".form.answer-questionnaire")
+
+      within ".questionnaire-question_readonly" do
+        expect(page).to have_i18n_content(question.body)
+      end
 
       expect(page).to have_content("Sign in with your account or sign up to answer the form.")
     end

--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -125,7 +125,11 @@ describe "Meeting registrations", type: :system do
             expect(page).to have_i18n_content(questionnaire.title, upcase: true)
             expect(page).to have_i18n_content(questionnaire.description)
 
-            expect(page).to have_no_i18n_content(question.body)
+            expect(page).not_to have_css(".form.answer-questionnaire")
+
+            within ".questionnaire-question_readonly" do
+              expect(page).to have_i18n_content(question.body)
+            end
 
             expect(page).to have_content("Sign in with your account or sign up to answer the form")
           end

--- a/decidim-surveys/app/assets/stylesheets/decidim/surveys/surveys.scss
+++ b/decidim-surveys/app/assets/stylesheets/decidim/surveys/surveys.scss
@@ -1,3 +1,5 @@
+@import "decidim/forms/forms";
+
 form.answer-questionnaire{
   .radio-button-collection,
   .check-box-collection,

--- a/decidim-surveys/spec/system/private_space_survey_spec.rb
+++ b/decidim-surveys/spec/system/private_space_survey_spec.rb
@@ -55,7 +55,11 @@ describe "Private Space Answer a survey", type: :system do
           expect(page).to have_i18n_content(questionnaire.title, upcase: true)
           expect(page).to have_i18n_content(questionnaire.description)
 
-          expect(page).to have_no_i18n_content(question.body)
+          expect(page).not_to have_css(".form.answer-questionnaire")
+
+          within ".questionnaire-question_readonly" do
+            expect(page).to have_i18n_content(question.body)
+          end
 
           expect(page).to have_content("Sign in with your account or sign up to answer the form.")
         end


### PR DESCRIPTION
#### :tophat: What? Why?

Not logged in Participants will be able to see the questions, **readonly**, in the questionnaires.

#### :pushpin: Related Issues
- Related to [**Metadecidim**: Enhancement to surveys: Id + Visible without logging](https://meta.decidim.org/processes/roadmap/f/122/proposals/14314?locale=en)
- Fixes #4993

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Refactor tests

### :camera: Screenshots (optional)

Before this PR:
![before-4991-readonly-questionnaire](https://user-images.githubusercontent.com/210216/54740293-2f893700-4bbb-11e9-85d2-491e3ea15c3f.png)

After this PR:
![after-4991-readonly-questionnaire](https://user-images.githubusercontent.com/210216/54740305-3c0d8f80-4bbb-11e9-9ea2-bc3cf786edd8.png)


