### PR TITLE
Chronologically order participatory processes

### DIFF
--- a/decidim-participatory_processes/app/queries/decidim/participatory_processes/filtered_participatory_process_groups.rb
+++ b/decidim-participatory_processes/app/queries/decidim/participatory_processes/filtered_participatory_process_groups.rb
@@ -11,7 +11,7 @@ module Decidim
       end
 
       def query
-        processes = Decidim::ParticipatoryProcess.all
+        processes = Decidim::ParticipatoryProcess
 
         processes = case @filter
                     when "past"

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/_order_by_processes.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/_order_by_processes.html.erb
@@ -1,1 +1,1 @@
-<%= cell "decidim/participatory_processes/process_filters", process_count_by_filter, current_filter: filter %>
+<%= cell "decidim/participatory_processes/process_filters", process_count_by_filter, current_filter: current_filter %>

--- a/decidim-participatory_processes/spec/controllers/participatory_processes_controller_spec.rb
+++ b/decidim-participatory_processes/spec/controllers/participatory_processes_controller_spec.rb
@@ -22,7 +22,7 @@ module Decidim
           request.env["decidim.current_organization"] = organization
         end
 
-        it "orders them by end_date" do
+        it "orders them by start_date (descendingly)" do
           unpublished = create(
             :participatory_process,
             :with_steps,
@@ -35,7 +35,7 @@ module Decidim
             :with_steps,
             :published,
             organization: organization,
-            end_date: nil
+            start_date: 1.month.ago
           )
           last.active_step.update!(end_date: nil)
 
@@ -44,7 +44,7 @@ module Decidim
             :with_steps,
             :published,
             organization: organization,
-            end_date: Date.current.advance(days: 10)
+            start_date: 1.day.ago
           )
           first.active_step.update!(end_date: Date.current.advance(days: 2))
 
@@ -53,7 +53,7 @@ module Decidim
             :with_steps,
             :published,
             organization: organization,
-            end_date: Date.current.advance(days: 20)
+            start_date: 1.week.ago
           )
           second.active_step.update!(end_date: Date.current.advance(days: 4))
 
@@ -111,13 +111,13 @@ module Decidim
           it "ignores invalid filters" do
             controller.params = { filter: "foo-filter" }
 
-            expect(controller.helpers.filter).to eq("active")
+            expect(controller.helpers.current_filter).to eq("active")
           end
 
           it "allows known filters" do
             controller.params = { filter: "past" }
 
-            expect(controller.helpers.filter).to eq("past")
+            expect(controller.helpers.current_filter).to eq("past")
           end
         end
       end

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -131,65 +131,106 @@ describe "Participatory Processes", type: :system do
     end
 
     context "and filtering processes" do
+      before do
+        grouped_process.update(private_space: true)
+      end
+
       context "and choosing 'active' processes" do
-        it "lists the active processes" do
+        before do
+          participatory_process.update(title: "Started 1 day ago", start_date: 1.day.ago)
+          promoted_process.update(title: "Started 1 year ago", start_date: 1.year.ago)
+          visit decidim_participatory_processes.participatory_processes_path
+        end
+
+        it "lists the active processes ordered by start_date (descendingly)" do
           within "#processes-grid h2" do
-            expect(page).to have_content("3 ACTIVE PROCESSES")
+            expect(page).to have_content("2 ACTIVE PROCESSES")
           end
 
-          expect(page).to have_content(translated(participatory_process.title, locale: :en))
-          expect(page).to have_content(translated(promoted_process.title, locale: :en))
+          within "#processes-grid" do
+            titles = page.all(".card__title")
+            expect(titles.first.text).to eq("Started 1 day ago")
+            expect(titles.last.text).to eq("Started 1 year ago")
+          end
         end
       end
 
       context "and choosing 'past' processes" do
+        let!(:past_process_2) { create :participatory_process, :past, organization: organization }
+
         before do
+          past_process.update(title: "Ended 1 week ago")
+          past_process_2.update(title: "Ended 1 year ago", end_date: 1.year.ago)
           within ".order-by__tabs" do
             click_link "Past"
           end
         end
 
-        it "lists the past processes" do
+        it "lists the past processes ordered by end_date (descendingly)" do
           within "#processes-grid h2" do
-            expect(page).to have_content("1")
+            expect(page).to have_content("2 PAST PROCESSES")
           end
 
-          expect(page).to have_content(translated(past_process.title, locale: :en))
+          within "#processes-grid" do
+            titles = page.all(".card__title")
+            expect(titles.first.text).to eq("Ended 1 week ago")
+            expect(titles.last.text).to eq("Ended 1 year ago")
+          end
         end
       end
 
       context "and choosing 'upcoming' processes" do
+        let!(:upcoming_process_2) { create :participatory_process, :upcoming, organization: organization }
+
         before do
+          upcoming_process.update(title: "Starts 1 week from now")
+          upcoming_process_2.update(title: "Starts 1 year from now", start_date: 1.year.from_now)
           within ".order-by__tabs" do
             click_link "Upcoming"
           end
         end
 
-        it "lists the upcoming processes" do
+        it "lists the upcoming processes ordered by start_date (ascendingly)" do
           within "#processes-grid h2" do
             expect(page).to have_content("1")
           end
 
-          expect(page).to have_content(translated(upcoming_process.title, locale: :en))
+          within "#processes-grid" do
+            titles = page.all(".card__title")
+            expect(titles.first.text).to eq("Starts 1 week from now")
+            expect(titles.last.text).to eq("Starts 1 year from now")
+          end
         end
       end
 
       context "and choosing 'all' processes" do
         before do
+          promoted_process.update(title: "Started just NOW")
+          participatory_process.update(title: "Started 1 day ago", start_date: 1.day.ago)
+          past_process.update(title: "Sarted 2 weeks ago")
+          upcoming_process.update(title: "Starts 1 year from now", start_date: 1.year.from_now)
           within ".order-by__tabs" do
             click_link "All"
           end
         end
 
-        it "lists all processes" do
+        it "lists all processes ordered by start_date (closest to current_date)" do
           within "#processes-grid h2" do
-            expect(page).to have_content("5 PROCESSES")
+            expect(page).to have_content("4 PROCESSES")
           end
 
           expect(page).to have_content(translated(participatory_process.title, locale: :en))
           expect(page).to have_content(translated(promoted_process.title, locale: :en))
           expect(page).to have_content(translated(past_process.title, locale: :en))
           expect(page).to have_content(translated(upcoming_process.title, locale: :en))
+
+          within "#processes-grid" do
+            titles = page.all(".card__title")
+            expect(titles[0].text).to eq("Started just NOW")
+            expect(titles[1].text).to eq("Started 1 day ago")
+            expect(titles[2].text).to eq("Sarted 2 weeks ago")
+            expect(titles[3].text).to eq("Starts 1 year from now")
+          end
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
The following changes are made to participatory processes index **filters**:
- **Past:** order by closest `end_date`
- **Active**, **All**, **Upcoming**: order by closest `start_date`

#### :pushpin: Related Issues
- Related to #4994 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [x] Add tests
