### PR TITLE
Space CTA button text changes when no components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/decidim/decidim/tree/HEAD)
 
 **Added**:
+- **decidim-assemblies**, **decidim-conferences**, **decidim-participatory_processes** Space CTA button text changes when no components [\#5006](https://github.com/decidim/decidim/pull/5006)
 
 - **decidim-participatory_processes**: Add a select field for assign an area to participatory processes [#5011](https://github.com/decidim/decidim/pull/5011)
 - **decidim-accountability**: Also display the main scope as a filter for accountability results [#5022](https://github.com/decidim/decidim/pull/5022)

--- a/decidim-assemblies/app/cells/decidim/assemblies/assembly_m/footer.erb
+++ b/decidim-assemblies/app/cells/decidim/assemblies/assembly_m/footer.erb
@@ -7,7 +7,7 @@
       </div>
     <% end %>
     <%= link_to(
-      t("layouts.decidim.assemblies.assembly.take_part"),
+      t(model.cta_button_text_key, scope: "layouts.decidim.assemblies.assembly"),
       resource_path,
       class: "card__button button button--sc secondary light small"
     ) %>

--- a/decidim-assemblies/app/views/decidim/assemblies/assemblies/_promoted_assembly.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/assemblies/_promoted_assembly.html.erb
@@ -17,7 +17,7 @@
         <div class="card__content row collapse">
           <div class="large-6 large-offset-6 columns">
             <%= link_to assembly_path(promoted_assembly), class: "button expanded button--sc" do %>
-              <%= t("assemblies.promoted_assembly.take_part", scope: "layouts.decidim") %>
+              <%= t(promoted_assembly.cta_button_text_key, scope: "layouts.decidim.assemblies.promoted_assembly") %>
             <% end %>
           </div>
         </div>

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -352,6 +352,7 @@ en:
     decidim:
       assemblies:
         assembly:
+          more_info: More info
           take_part: Take part
         index:
           organizational_chart: Organizational chart

--- a/decidim-assemblies/spec/cells/decidim/assemblies/assembly_cell_spec.rb
+++ b/decidim-assemblies/spec/cells/decidim/assemblies/assembly_cell_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Assemblies
+  describe AssemblyCell, type: :cell do
+    controller Decidim::ApplicationController
+
+    subject { cell("decidim/assemblies/assembly", model).call }
+
+    let(:model) { create(:assembly, :published) }
+
+    it "renders the cell" do
+      expect(subject).to have_css("article.card--assembly")
+    end
+  end
+end

--- a/decidim-assemblies/spec/cells/decidim/assemblies/assembly_m_cell_spec.rb
+++ b/decidim-assemblies/spec/cells/decidim/assemblies/assembly_m_cell_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/core/test/shared_examples/space_cell_changes_button_text_cta"
+
+module Decidim::Assemblies
+  describe AssemblyMCell, type: :cell do
+    controller Decidim::Assemblies::AssembliesController
+
+    let!(:assembly) { create(:assembly) }
+    let(:model) { assembly }
+    let(:cell_html) { cell("decidim/assemblies/assembly_m", assembly).call }
+
+    context "when rendering" do
+      let(:show_space) { false }
+
+      it "renders the card" do
+        expect(cell_html).to have_css(".card--assembly")
+      end
+
+      it_behaves_like "space cell changes button text CTA"
+    end
+  end
+end

--- a/decidim-assemblies/spec/cells/decidim/assemblies/assembly_m_cell_spec.rb
+++ b/decidim-assemblies/spec/cells/decidim/assemblies/assembly_m_cell_spec.rb
@@ -5,17 +5,17 @@ require "decidim/core/test/shared_examples/space_cell_changes_button_text_cta"
 
 module Decidim::Assemblies
   describe AssemblyMCell, type: :cell do
-    controller Decidim::Assemblies::AssembliesController
+    controller Decidim::ApplicationController
 
-    let!(:assembly) { create(:assembly) }
-    let(:model) { assembly }
-    let(:cell_html) { cell("decidim/assemblies/assembly_m", assembly).call }
+    subject { cell("decidim/assemblies/assembly_m", model).call }
+
+    let(:model) { create(:assembly, :published) }
 
     context "when rendering" do
       let(:show_space) { false }
 
       it "renders the card" do
-        expect(cell_html).to have_css(".card--assembly")
+        expect(subject).to have_css("article.card--assembly")
       end
 
       it_behaves_like "space cell changes button text CTA"

--- a/decidim-conferences/app/cells/decidim/conferences/conference_m/footer.erb
+++ b/decidim-conferences/app/cells/decidim/conferences/conference_m/footer.erb
@@ -1,7 +1,7 @@
 <div class="card__footer card__footer--spaces">
   <div class="card__support">
     <%= link_to(
-      t("layouts.decidim.conferences.conference.take_part"),
+      t(model.cta_button_text_key, scope: "layouts.decidim.conferences.conference"),
       resource_path,
       class: "card__button button button--sc secondary light small"
     ) %>

--- a/decidim-conferences/app/views/decidim/conferences/conferences/_promoted_conference.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conferences/_promoted_conference.html.erb
@@ -17,7 +17,7 @@
         <div class="card__content row collapse">
           <div class="large-6 large-offset-6 columns">
             <%= link_to conference_path(promoted_conference), class: "button expanded button--sc" do %>
-              <%= t("conferences.promoted_conference.take_part", scope: "layouts.decidim") %>
+              <%= t(promoted_conference.cta_button_text_key, scope: "layouts.decidim.conferences.promoted_conference") %>
             <% end %>
           </div>
         </div>

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -553,6 +553,7 @@ en:
           take_part: Take part
       conferences:
         conference:
+          more_info: More info
           take_part: Take part
         index:
           promoted_conferences: Highlighted conferences

--- a/decidim-conferences/spec/cells/decidim/conferences/conference_cell_spec.rb
+++ b/decidim-conferences/spec/cells/decidim/conferences/conference_cell_spec.rb
@@ -6,12 +6,13 @@ module Decidim::Conferences
   describe ConferenceCell, type: :cell do
     controller Decidim::Conferences::ConferencesController
 
-    let!(:conference) { create(:conference) }
+    subject { cell("decidim/conferences/conference_m", model).call }
+
+    let(:model) { create(:conference) }
 
     context "when rendering" do
       it "renders the card" do
-        html = cell("decidim/conferences/conference", conference).call
-        expect(html).to have_css(".card--conference")
+        expect(subject).to have_css("article.card--conference")
       end
     end
   end

--- a/decidim-conferences/spec/cells/decidim/conferences/conference_m_cell_spec.rb
+++ b/decidim-conferences/spec/cells/decidim/conferences/conference_m_cell_spec.rb
@@ -7,15 +7,15 @@ module Decidim::Conferences
   describe ConferenceMCell, type: :cell do
     controller Decidim::Conferences::ConferencesController
 
-    let!(:conference) { create(:conference) }
-    let(:model) { conference }
-    let(:cell_html) { cell("decidim/conferences/conference_m", conference).call }
+    subject { cell("decidim/conferences/conference_m", model).call }
+
+    let(:model) { create(:conference) }
 
     context "when rendering" do
       let(:show_space) { false }
 
       it "renders the card" do
-        expect(cell_html).to have_css(".card--conference")
+        expect(subject).to have_css("article.card--conference")
       end
 
       it_behaves_like "space cell changes button text CTA"

--- a/decidim-conferences/spec/cells/decidim/conferences/conference_m_cell_spec.rb
+++ b/decidim-conferences/spec/cells/decidim/conferences/conference_m_cell_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "decidim/core/test/shared_examples/space_cell_changes_button_text_cta"
 
 module Decidim::Conferences
-  describe ConferenceCell, type: :cell do
+  describe ConferenceMCell, type: :cell do
     controller Decidim::Conferences::ConferencesController
 
     let!(:conference) { create(:conference) }
@@ -16,6 +17,8 @@ module Decidim::Conferences
       it "renders the card" do
         expect(cell_html).to have_css(".card--conference")
       end
+
+      it_behaves_like "space cell changes button text CTA"
     end
   end
 end

--- a/decidim-core/lib/decidim/core/test/shared_examples/space_cell_changes_button_text_cta.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/space_cell_changes_button_text_cta.rb
@@ -5,32 +5,25 @@ require "spec_helper"
 shared_examples_for "space cell changes button text CTA" do
   describe "within the card footer" do
     context "when it has no components" do
-      it "renders 'More Info' in the CTA button text" do
-        within ".card--conference .card__footer--spaces .card_button" do
-          expect(cell_html).to have_content("More info")
-        end
+      it "renders 'More info' in the CTA button text" do
+        expect(subject).to have_selector(".card__footer--spaces .card__button", text: "More info")
       end
     end
 
     context "when it has a component" do
-      let(:published_at) { nil }
-      let(:component) { create(:component, participatory_space: model, published_at: published_at) }
-
       context "and it is not published" do
-        it "renders 'More Info' in the CTA button text" do
-          within ".card--conference .card__footer--spaces .card_button" do
-            expect(cell_html).to have_content("More info")
-          end
+        let!(:component) { create(:component, :unpublished, manifest_name: "dummy", participatory_space: model) }
+
+        it "renders 'More info' in the CTA button text" do
+          expect(subject).to have_selector(".card__footer--spaces .card__button", text: "More info")
         end
       end
 
       context "and it is published" do
-        let(:published_at) { Time.current }
+        let!(:component) { create(:component, :published, manifest_name: "dummy", participatory_space: model) }
 
-        it "renders 'Participate' in the CTA button text" do
-          within ".card--conference .card__footer--spaces .card_button" do
-            expect(cell_html).to have_content("Participate")
-          end
+        it "renders 'Take part' in the CTA button text" do
+          expect(subject).to have_selector(".card__footer--spaces .card__button", text: "Take part")
         end
       end
     end

--- a/decidim-core/lib/decidim/core/test/shared_examples/space_cell_changes_button_text_cta.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/space_cell_changes_button_text_cta.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+shared_examples_for "space cell changes button text CTA" do
+  describe "within the card footer" do
+    context "when it has no components" do
+      it "renders 'More Info' in the CTA button text" do
+        within ".card--conference .card__footer--spaces .card_button" do
+          expect(cell_html).to have_content("More info")
+        end
+      end
+    end
+
+    context "when it has a component" do
+      let(:published_at) { nil }
+      let(:component) { create(:component, participatory_space: model, published_at: published_at) }
+
+      context "and it is not published" do
+        it "renders 'More Info' in the CTA button text" do
+          within ".card--conference .card__footer--spaces .card_button" do
+            expect(cell_html).to have_content("More info")
+          end
+        end
+      end
+
+      context "and it is published" do
+        let(:published_at) { Time.current }
+
+        it "renders 'Participate' in the CTA button text" do
+          within ".card--conference .card__footer--spaces .card_button" do
+            expect(cell_html).to have_content("Participate")
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/participable.rb
+++ b/decidim-core/lib/decidim/participable.rb
@@ -75,6 +75,15 @@ module Decidim
       def can_participate?(_user)
         true
       end
+
+      def empty_published_component?
+        components.published.empty?
+      end
+
+      def cta_button_text_key
+        return :more_info if empty_published_component?
+        :take_part
+      end
     end
 
     class_methods do

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_m/footer.erb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_m/footer.erb
@@ -7,7 +7,7 @@
       </div>
     <% end %>
     <%= link_to(
-      t("layouts.decidim.participatory_processes.participatory_process.take_part"),
+      t(model.cta_button_text_key, scope: "layouts.decidim.participatory_processes.participatory_process"),
       resource_path,
       class: "card__button button button--sc secondary light small"
     ) %>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/_promoted_process.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/_promoted_process.html.erb
@@ -17,7 +17,7 @@
         <div class="card__content row collapse">
           <div class="large-6 large-offset-6 columns">
             <%= link_to participatory_process_path(promoted_process), class: "button expanded button--sc" do %>
-              <%= t("participatory_processes.promoted_process.take_part", scope: "layouts.decidim") %>
+              <%= t(promoted_process.cta_button_text_key, scope: "layouts.decidim.participatory_processes.promoted_process") %>
               <% if promoted_process.active_step %>
                 <span class="button__info">
                   <%= t("participatory_processes.promoted_process.active_step", scope: "layouts.decidim") %> <%= translated_attribute promoted_process.active_step.title %>

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -383,6 +383,7 @@ en:
           promoted_processes: Highlighted processes
         participatory_process:
           active_step: 'Current phase:'
+          more_info: More info
           take_part: Take part
         promoted_process:
           active_step: 'Current phase:'

--- a/decidim-participatory_processes/spec/cells/decidim/participatory_processes/participatory_process_cell_spec.rb
+++ b/decidim-participatory_processes/spec/cells/decidim/participatory_processes/participatory_process_cell_spec.rb
@@ -1,24 +1,19 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "decidim/core/test/shared_examples/space_cell_changes_button_text_cta"
 
 module Decidim::ParticipatoryProcesses
-  describe ProcessMCell, type: :cell do
+  describe ProcessCell, type: :cell do
     controller Decidim::ApplicationController
 
-    subject { cell("decidim/participatory_processes/process_m", model).call }
+    subject { cell("decidim/participatory_processes/process", model).call }
 
     let(:model) { create(:participatory_process) }
 
     context "when rendering" do
-      let(:show_space) { false }
-
       it "renders the card" do
         expect(subject).to have_css("article.card--process")
       end
-
-      it_behaves_like "space cell changes button text CTA"
     end
   end
 end

--- a/decidim-participatory_processes/spec/cells/decidim/participatory_processes/participatory_process_m_cell_spec.rb
+++ b/decidim-participatory_processes/spec/cells/decidim/participatory_processes/participatory_process_m_cell_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/core/test/shared_examples/space_cell_changes_button_text_cta"
+
+module Decidim::ParticipatoryProcesses
+  describe ProcessMCell, type: :cell do
+    controller Decidim::ParticipatoryProcesses::ParticipatoryProcessesController
+
+    let!(:participatory_process) { create(:participatory_process) }
+    let(:model) { participatory_process }
+    let(:cell_html) { cell("decidim/participatory_processes/process_m", participatory_process).call }
+
+    context "when rendering" do
+      let(:show_space) { false }
+
+      it "renders the card" do
+        expect(cell_html).to have_css(".card--process")
+      end
+
+      it_behaves_like "space cell changes button text CTA"
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

When a Space does not have any component (enabled or active), the Call to Action button will say "More Info" and not "Take Part".

This is applied to:

- Assemblies
- Participatory Processes
- Conferences

#### :pushpin: Related Issues
- Related to [**Metadecidim**: Change text button assemblies when there are no components](https://meta.decidim.org/processes/roadmap/f/122/proposals/14315)

- Fixes #5000 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)

- Assemblies:
  ![decidim-assemblies-cta](https://user-images.githubusercontent.com/210216/54918628-15bf5b00-4eff-11e9-9585-d5ab28c058f5.png)
- Processes:
  ![decidim-processes-cta](https://user-images.githubusercontent.com/210216/54918653-253ea400-4eff-11e9-907f-063e59959e03.png)
- Conferences:
  ![decidim-conferences-cta](https://user-images.githubusercontent.com/210216/54918698-3e475500-4eff-11e9-8ee4-67f44c93586d.png)




