### PR TITLE
Add area to participatory processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 **Added**:
 
+- **decidim-participatory_processes**: Add a select field for assign an area to participatory processes [#5011](https://github.com/decidim/decidim/pull/5011)
+
 **Changed**:
 
 **Fixed**:

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/copy_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/copy_assembly.rb
@@ -53,6 +53,7 @@ module Decidim
             parent: @assembly.parent,
             developer_group: @assembly.developer_group,
             local_area: @assembly.local_area,
+            area: @assembly.area,
             target: @assembly.target,
             participatory_scope: @assembly.participatory_scope,
             participatory_structure: @assembly.participatory_structure,

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/copy_participatory_process.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/copy_participatory_process.rb
@@ -53,6 +53,7 @@ module Decidim
             scope: @participatory_process.scope,
             developer_group: @participatory_process.developer_group,
             local_area: @participatory_process.local_area,
+            area: @participatory_process.area,
             target: @participatory_process.target,
             participatory_scope: @participatory_process.participatory_scope,
             participatory_structure: @participatory_process.participatory_structure,

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process.rb
@@ -54,6 +54,7 @@ module Decidim
             private_space: form.private_space,
             developer_group: form.developer_group,
             local_area: form.local_area,
+            area: form.area,
             target: form.target,
             participatory_scope: form.participatory_scope,
             participatory_structure: form.participatory_structure,

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/update_participatory_process.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/update_participatory_process.rb
@@ -67,6 +67,7 @@ module Decidim
             private_space: form.private_space,
             developer_group: form.developer_group,
             local_area: form.local_area,
+            area: form.area,
             target: form.target,
             participatory_scope: form.participatory_scope,
             participatory_structure: form.participatory_structure,

--- a/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_form.rb
+++ b/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_form.rb
@@ -30,6 +30,7 @@ module Decidim
         attribute :promoted, Boolean
         attribute :scopes_enabled, Boolean
         attribute :scope_id, Integer
+        attribute :area_id, Integer
         attribute :hero_image
         attribute :remove_hero_image
         attribute :banner_image
@@ -41,6 +42,7 @@ module Decidim
         validates :slug, presence: true, format: { with: Decidim::ParticipatoryProcess.slug_format }
         validates :title, :subtitle, :description, :short_description, translatable_presence: true
         validates :scope, presence: true, if: proc { |object| object.scope_id.present? }
+        validates :area, presence: true, if: proc { |object| object.area_id.present? }
 
         validate :slug_uniqueness
 
@@ -54,6 +56,10 @@ module Decidim
 
         def scope
           @scope ||= current_organization.scopes.find_by(id: scope_id)
+        end
+
+        def area
+          @area ||= current_organization.areas.find_by(id: area_id)
         end
 
         def participatory_process_group

--- a/decidim-participatory_processes/app/models/decidim/participatory_process.rb
+++ b/decidim-participatory_processes/app/models/decidim/participatory_process.rb
@@ -22,6 +22,10 @@ module Decidim
     belongs_to :organization,
                foreign_key: "decidim_organization_id",
                class_name: "Decidim::Organization"
+    belongs_to :area,
+               foreign_key: "decidim_area_id",
+               class_name: "Decidim::Area",
+               optional: true
     belongs_to :participatory_process_group,
                foreign_key: "decidim_participatory_process_group_id",
                class_name: "Decidim::ParticipatoryProcessGroup",

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/admin_log/participatory_process_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/admin_log/participatory_process_presenter.rb
@@ -20,6 +20,7 @@ module Decidim
             description: :i18n,
             developer_group: :i18n,
             hashtag: :string,
+            decidim_area_id: :area,
             local_area: :i18n,
             meta_scope: :i18n,
             participatory_scope: :i18n,

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
@@ -84,6 +84,10 @@
     </div>
 
     <div class="row column">
+      <%= form.select :area_id, option_groups_from_collection_for_select(current_organization.area_types, :areas, :translated_name, :id, :translated_name, current_participatory_process.try(:decidim_area_id)), include_blank: t(".select_an_area") %>
+    </div>
+
+    <div class="row column">
       <%= form.translated :text_field, :participatory_scope %>
     </div>
 

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
@@ -64,6 +64,13 @@ edit_link(
           </div>
         <% end %>
 
+        <% if translated_attribute(current_participatory_space.try(:area).try(:name)).present? %>
+          <div class="definition-data__item area">
+            <span class="definition-data__title"><%= t("participatory_processes.show.area", scope: "decidim") %></span>
+            <%= translated_attribute(current_participatory_space.area.area_type.name) %> - <%= translated_attribute(current_participatory_space.area.name) %>
+          </div>
+        <% end %>
+
         <% if translated_attribute(current_participatory_space.meta_scope).present? %>
           <div class="definition-data__item scope">
             <span class="definition-data__title"><%= t("participatory_processes.show.scope", scope: "decidim") %></span>

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -341,6 +341,7 @@ en:
         index:
           loading: Loading results...
       show:
+        area: Area
         developer_group: Promoter group
         end_date: End date
         local_area: Organization Area

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -4,10 +4,12 @@ en:
     attributes:
       participatory_process:
         announcement: Announcement
+        area_id: Area
         banner_image: Banner image
         copy_categories: Copy categories
         copy_components: Copy components
         copy_steps: Copy steps
+        decidim_area_id: Area
         description: Description
         developer_group: Promoter group
         domain: Domain
@@ -292,6 +294,7 @@ en:
         participatory_processes:
           form:
             announcement_help: The text you enter here will be shown to the user right below the process information.
+            select_an_area: Select an Area
             slug_help: 'URL slugs are used to generate the URLs that point to this process. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
       content_blocks:
         highlighted_processes:

--- a/decidim-participatory_processes/db/migrate/20190322125517_add_area_to_participatory_processes.rb
+++ b/decidim-participatory_processes/db/migrate/20190322125517_add_area_to_participatory_processes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAreaToParticipatoryProcesses < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :decidim_participatory_processes, :decidim_area, index: true
+  end
+end

--- a/decidim-participatory_processes/spec/commands/create_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/commands/create_participatory_process_spec.rb
@@ -9,6 +9,7 @@ module Decidim::ParticipatoryProcesses
     let(:organization) { create :organization }
     let(:participatory_process_group) { create :participatory_process_group, organization: organization }
     let(:scope) { create :scope, organization: organization }
+    let(:area) { create :area, organization: organization }
     let(:current_user) { create :user, :admin, organization: organization }
     let(:errors) { double.as_null_object }
     let(:form) do
@@ -37,6 +38,7 @@ module Decidim::ParticipatoryProcesses
         scopes_enabled: true,
         private_space: false,
         scope: scope,
+        area: area,
         errors: errors,
         participatory_process_group: participatory_process_group
       )

--- a/decidim-participatory_processes/spec/commands/update_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/commands/update_participatory_process_spec.rb
@@ -31,6 +31,7 @@ module Decidim::ParticipatoryProcesses
             current_organization: my_process.organization,
             scopes_enabled: my_process.scopes_enabled,
             scope: my_process.scope,
+            area: my_process.area,
             errors: my_process.errors,
             participatory_process_group: my_process.participatory_process_group,
             show_statistics: my_process.show_statistics,


### PR DESCRIPTION
#### :tophat: What? Why?
This Pr adds Area to ParticipatoryProcces

#### :pushpin: Related Issues
- Related to https://meta.decidim.org/processes/roadmap/f/122/proposals/14328?locale=ca

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add Area when copying Assembly
- [x] Add Area when copying Process
- [x] Add Area when creating Process
- [x] Add Area when updating Process
- [x] Add area_id on participatory process form
- [x] Add Area on ParticipatoryProcess Show
- [x] Add relationship between area and process
- [x] Add area on participatory process presenter
- [x] Add locales
- [x] Create migration
- [x] Improve Specs

### :camera: Screenshots (optional)
![Description](URL)
