### PR TITLE
Fix decidim-verifications README.md broken links

### DIFF
--- a/decidim-verifications/README.md
+++ b/decidim-verifications/README.md
@@ -150,7 +150,7 @@ on the context where the authorization is being performed.
 
 For example, you can require authorization for supporting proposals in a participatory
 process, and also restrict it to users with postal codes 12345 and 12346. The
-[example authorization handler](https://github.com/decidim/decidim/blob/master/decidim-verifications/app/services/decidim/dummy_authorization_handler.rb)
+[example authorization handler](https://github.com/decidim/decidim/blob/master/decidim-generators/lib/decidim/generators/app_templates/dummy_authorization_handler.rb)
 included in this module allows to do that. As an admin user, you should visit
 the proposals componenent permissions screen, choose the `Example authorization`
 as the authorization handler name for the `vote` action and type something like
@@ -188,7 +188,7 @@ Decidim::Verifications.register_workflow(:my_verification) do |workflow|
 end
 ```
 
-Check the [example authorization handler](https://github.com/decidim/decidim/blob/master/decidim-verifications/app/services/decidim/dummy_authorization_handler.rb)
+Check the [example authorization handler](https://github.com/decidim/decidim/blob/master/decidim-generators/lib/decidim/generators/app_templates/dummy_authorization_handler.rb)
 and the [DefaultActionAuthorizer class](https://github.com/decidim/decidim/blob/master/decidim-verifications/lib/decidim/verifications/default_action_authorizer.rb)
 for additional technical details.
 
@@ -225,7 +225,7 @@ See [Decidim](https://github.com/decidim/decidim).
 
 See [Decidim](https://github.com/decidim/decidim).
 
-[authorization handler base class]: https://github.com/decidim/decidim/blob/master/decidim-core/app/services/decidim/authorization_handler.rb
+[authorization handler base class]: https://github.com/decidim/decidim/blob/master/decidim-verifications/app/services/decidim/authorization_handler.rb
 [example SMS gateway]: https://github.com/decidim/decidim/blob/master/decidim-verifications/lib/decidim/verifications/sms/example_gateway.rb
 
 [Decidim Barcelona]: https://github.com/AjuntamentdeBarcelona/decidim-barcelona/blob/master/app/services/census_authorization_handler.rb


### PR DESCRIPTION
#### :tophat: What? Why?

Some links in the verifications README.md documentation are broken, this PR fixes those broken links.

#### :pushpin: Related Issues


#### :clipboard: Subtasks


### :camera: Screenshots (optional)

