### PR TITLE
BACKPORT 0.17 add documents folder to decidim_proposals_manifest.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 **Fixed**:
 
+- **decidim-proposals**: Add documents folder in proposals manifest for precompile assets. [#5016](https://github.com/decidim/decidim/pull/5016)
+
 **Removed**:
 
 ## [0.17.0](https://github.com/decidim/decidim/tree/v0.17.0)

--- a/decidim-proposals/app/assets/config/decidim_proposals_manifest.js
+++ b/decidim-proposals/app/assets/config/decidim_proposals_manifest.js
@@ -2,3 +2,4 @@
 //= link decidim/proposals/add_proposal.js
 //= link decidim/proposals/admin/proposals_form.js
 //= link_tree ../images/decidim
+//= link_tree ../documents/decidim


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes a broken links in participatory text page with the expected format for the import file.

#### :pushpin: Related Issues
- Related to #4764

#### :clipboard: Subtasks
- [x] Add CHANGELOG entry
- [x] Add folder in config manifest for precompile

### :camera: Screenshots (optional)
![Description](URL)
