### PR TITLE
Update project maintainer email to hola [at] decidim

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -35,7 +35,7 @@ This code of conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting a project maintainer at josepjaume@gmail.com. All
+reported by contacting a project maintainer at hola@decidim.org. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. Maintainers are
 obligated to maintain confidentiality with regard to the reporter of an


### PR DESCRIPTION
#### :tophat: What? Why?

Updates the project maintainer email on Code of Conduct to a generic decidim.org email.  
