### PR TITLE
Fix scopes in results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Added**:
 
 - **decidim-participatory_processes**: Add a select field for assign an area to participatory processes [#5011](https://github.com/decidim/decidim/pull/5011)
+- **decidim-accountability**: Also display the main scope as a filter for accountability results [#5022](https://github.com/decidim/decidim/pull/5022)
 
 **Changed**:
 

--- a/decidim-accountability/app/views/decidim/accountability/results/_scope_filters.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_scope_filters.html.erb
@@ -5,6 +5,11 @@
     <ul class="tags tags--action">
       <li <%= active_class_if_current(nil) %>><%= link_to t("results.filters.all", scope: "decidim.accountability"), url_for(filter: { category_id: category.try(:id) }) %></li>
 
+      <% if current_participatory_space.scope %>
+        <li <%= active_class_if_current(current_participatory_space.scope.id) %>>
+          <%= link_to translated_attribute(current_participatory_space.scope.name), url_for(filter: { scope_id: current_participatory_space.scope.id, category_id: category.try(:id) }) %>
+        </li>
+      <% end %>
       <% current_participatory_space.subscopes.each do |scope| %>
         <li <%= active_class_if_current(scope.id) %>><%= link_to translated_attribute(scope.name), url_for(filter: { scope_id: scope.id, category_id: category.try(:id) }) %></li>
       <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

We should also show the scope from the participatory space, otherwise you can filter results by their children only.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

