### PR TITLE
[FIX] Filter emendations by rendering only proposals.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 **Fixed**:
 
+- **decidim-proposals**: Filter emendations by rendering only amendments. [#5025](https://github.com/decidim/decidim/pull/5025)
 - **decidim-proposals**: Add documents folder in proposals manifest for precompile assets. [#5015](https://github.com/decidim/decidim/pull/5015)
 
 **Removed**:

--- a/decidim-core/lib/decidim/amendable.rb
+++ b/decidim-core/lib/decidim/amendable.rb
@@ -17,6 +17,9 @@ module Decidim
       # resource.amended : the original resource that was amended
       has_one :amended, as: :amendable, foreign_key: "decidim_emendation_id", foreign_type: "decidim_emendation_type", class_name: "Decidim::Amendment"
       has_one :amendable, through: :amended, source: :amendable, source_type: name
+
+      scope :only_amendables, -> { where.not(id: joins(:amendable)) }
+      scope :only_emendations, -> { where(id: joins(:amendable)) }
     end
 
     class_methods do

--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -28,6 +28,7 @@ module Decidim
                        .where(component: current_component)
                        .published
                        .not_hidden
+                       .only_amendables
                        .includes(:category, :scope)
                        .order(position: :asc)
           render "decidim/proposals/proposals/participatory_texts/participatory_text"

--- a/decidim-proposals/app/services/decidim/proposals/proposal_search.rb
+++ b/decidim-proposals/app/services/decidim/proposals/proposal_search.rb
@@ -84,9 +84,9 @@ module Decidim
       def search_type
         case type
         when "proposals"
-          query.where.not(id: query.joins(:amendable).pluck(:id))
+          query.only_amendables
         when "amendments"
-          query.where(id: query.joins(:amendable).pluck(:id))
+          query.only_emendations
         else
           query
         end

--- a/decidim-proposals/spec/controllers/decidim/proposals_controller_spec.rb
+++ b/decidim-proposals/spec/controllers/decidim/proposals_controller_spec.rb
@@ -43,6 +43,19 @@ module Decidim
             expect(subject).to render_template(:participatory_text)
             expect(assigns(:proposals).order_values.first.expr.name).to eq(:position)
           end
+
+          context "when emendations exist" do
+            let!(:amendable) { create(:proposal, component: component) }
+            let!(:emendation) { create(:proposal, component: component) }
+            let!(:amendment) { create(:amendment, amendable: amendable, emendation: emendation, state: "accepted") }
+
+            it "does not include emendations" do
+              get :index
+              expect(response).to have_http_status(:ok)
+              emendations = assigns(:proposals).select(&:emendation?)
+              expect(emendations).to be_empty
+            end
+          end
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes the problem in the public participatory texts view that was rendering emendations.

#### :pushpin: Related Issues
- Fixes #5024

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [-] Add documentation regarding the feature 
- [-] Add/modify seeds
- [x] Add tests
- [x] Fix
