### PR TITLE
[FEATURE] Do not allow to delete areas when they have dependent spaces.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## [Unreleased](https://github.com/decidim/decidim/tree/HEAD)
 
 **Added**:
-- **decidim-assemblies**, **decidim-conferences**, **decidim-participatory_processes** Space CTA button text changes when no components [\#5006](https://github.com/decidim/decidim/pull/5006)
 
+- **decidim-admin**: Do not allow to delete areas when they have dependent spaces. [#5041](https://github.com/decidim/decidim/pull/5041)
+- **decidim-assemblies**, **decidim-conferences**, **decidim-participatory_processes** Space CTA button text changes when no components [\#5006](https://github.com/decidim/decidim/pull/5006)
 - **decidim-participatory_processes**: Add a select field for assign an area to participatory processes [#5011](https://github.com/decidim/decidim/pull/5011)
 - **decidim-accountability**: Also display the main scope as a filter for accountability results [#5022](https://github.com/decidim/decidim/pull/5022)
 

--- a/decidim-admin/app/commands/decidim/admin/destroy_area.rb
+++ b/decidim-admin/app/commands/decidim/admin/destroy_area.rb
@@ -20,7 +20,7 @@ module Decidim
       #
       # Returns nothing.
       def call
-        if area_has_dependencies?
+        if @area.has_dependencies?
           broadcast(:has_spaces)
         else
           destroy_area
@@ -31,17 +31,6 @@ module Decidim
       private
 
       attr_reader :current_user
-
-      def area_has_dependencies?
-        Decidim.participatory_space_registry.manifests.any? do |manifest|
-          manifest
-            .participatory_spaces
-            .call(@area.organization)
-            .any? do |space|
-            space.respond_to?(:area) && space.decidim_area_id == @area.id
-          end
-        end
-      end
 
       def destroy_area
         Decidim.traceability.perform_action!(

--- a/decidim-admin/app/commands/decidim/admin/destroy_area.rb
+++ b/decidim-admin/app/commands/decidim/admin/destroy_area.rb
@@ -33,7 +33,14 @@ module Decidim
       attr_reader :current_user
 
       def area_has_dependencies?
-        ::Decidim::ParticipatoryProcess.where(area: @area).exists? || ::Decidim::Assembly.where(area: @area).exists?
+        Decidim.participatory_space_registry.manifests.any? do |manifest|
+          manifest
+            .participatory_spaces
+            .call(@area.organization)
+            .any? do |space|
+            space.respond_to?(:area) && space.decidim_area_id == @area.id
+          end
+        end
       end
 
       def destroy_area

--- a/decidim-admin/app/commands/decidim/admin/destroy_area.rb
+++ b/decidim-admin/app/commands/decidim/admin/destroy_area.rb
@@ -20,11 +20,11 @@ module Decidim
       #
       # Returns nothing.
       def call
-        if @area.has_dependencies?
-          broadcast(:has_spaces)
-        else
+        begin
           destroy_area
           broadcast(:ok)
+        rescue ActiveRecord::RecordNotDestroyed
+          broadcast(:has_spaces)
         end
       end
 

--- a/decidim-admin/app/commands/decidim/admin/destroy_area.rb
+++ b/decidim-admin/app/commands/decidim/admin/destroy_area.rb
@@ -20,12 +20,10 @@ module Decidim
       #
       # Returns nothing.
       def call
-        begin
-          destroy_area
-          broadcast(:ok)
-        rescue ActiveRecord::RecordNotDestroyed
-          broadcast(:has_spaces)
-        end
+        destroy_area
+        broadcast(:ok)
+      rescue ActiveRecord::RecordNotDestroyed
+        broadcast(:has_spaces)
       end
 
       private

--- a/decidim-admin/app/commands/decidim/admin/destroy_area.rb
+++ b/decidim-admin/app/commands/decidim/admin/destroy_area.rb
@@ -20,13 +20,21 @@ module Decidim
       #
       # Returns nothing.
       def call
-        destroy_area
-        broadcast(:ok)
+        if area_has_dependencies?
+          broadcast(:has_spaces)
+        else
+          destroy_area
+          broadcast(:ok)
+        end
       end
 
       private
 
       attr_reader :current_user
+
+      def area_has_dependencies?
+        ::Decidim::ParticipatoryProcess.where(area: @area).exists? || ::Decidim::Assembly.where(area: @area).exists?
+      end
 
       def destroy_area
         Decidim.traceability.perform_action!(

--- a/decidim-admin/app/controllers/decidim/admin/areas_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/areas_controller.rb
@@ -64,6 +64,10 @@ module Decidim
             flash[:notice] = I18n.t("areas.destroy.success", scope: "decidim.admin")
             redirect_to areas_path
           end
+          on(:has_spaces) do
+            flash[:alert] = I18n.t("areas.destroy.has_spaces", scope: "decidim.admin")
+            redirect_to areas_path
+          end
         end
       end
 

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -157,6 +157,7 @@ en:
           error: There was a problem creating a new area.
           success: Area created successfully.
         destroy:
+          has_spaces: Area has depedent spaces, it must not have dependencies in order to be deleted.
           success: Area successfully destroyed
         edit:
           title: Edit area

--- a/decidim-admin/spec/commands/decidim/admin/destroy_area_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/destroy_area_spec.rb
@@ -35,5 +35,25 @@ module Decidim::Admin
       action_log = Decidim::ActionLog.last
       expect(action_log.version).to be_present
     end
+
+    context "when a participatory process associated to a given area exist" do
+      let!(:process) { create(:participatory_process, organization: area.organization, area: area) }
+
+      it "can not be deleted" do
+        expect { subject.call }.to broadcast(:has_spaces)
+        area.reload
+        expect(area.destroyed?).to be false
+      end
+    end
+
+    context "when an assembly associated to a given area exist" do
+      let!(:process) { create(:assembly, organization: area.organization, area: area) }
+
+      it "can not be deleted" do
+        expect { subject.call }.to broadcast(:has_spaces)
+        area.reload
+        expect(area.destroyed?).to be false
+      end
+    end
   end
 end

--- a/decidim-admin/spec/system/admin_manages_organization_areas_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_areas_spec.rb
@@ -75,9 +75,7 @@ describe "Organization Areas", type: :system do
       end
 
       it "can delete them" do
-        within find("tr", text: translated(area.name)) do
-          accept_confirm { click_link "Delete" }
-        end
+        click_delete_area
 
         expect(page).to have_admin_callout("successfully")
 
@@ -85,6 +83,28 @@ describe "Organization Areas", type: :system do
           expect(page).to have_no_content(translated(area.name))
         end
       end
+
+      context "when a participatory space associated to a given area exist" do
+        let!(:process) { create(:participatory_process, organization: area.organization, area: area) }
+
+        it "can not be deleted" do
+          click_delete_area
+          expect(area.reload.destroyed?).to be false
+          expect(page).to have_admin_callout("Area has depedent spaces")
+        end
+      end
+    end
+  end
+
+  #---------------------------------------------------
+
+  private
+
+  #---------------------------------------------------
+
+  def click_delete_area
+    within find("tr", text: translated(area.name)) do
+      accept_confirm { click_link "Delete" }
     end
   end
 end

--- a/decidim-assemblies/spec/commands/admin/destroy_area_with_assemblies_spec.rb
+++ b/decidim-assemblies/spec/commands/admin/destroy_area_with_assemblies_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Admin
+  describe DestroyArea do
+    subject { described_class.new(area, user) }
+
+    let(:organization) { create :organization }
+    let(:user) { create :user, :admin, :confirmed, organization: organization }
+    let(:area) { create :area, organization: organization }
+
+    context "when an assembly associated to a given area exist" do
+      let!(:assembly) { create(:assembly, organization: organization, area: area) }
+
+      it "can not be deleted" do
+        expect { subject.call }.to broadcast(:has_spaces)
+        expect(area.reload.destroyed?).to be false
+      end
+    end
+  end
+end

--- a/decidim-core/app/models/decidim/area.rb
+++ b/decidim-core/app/models/decidim/area.rb
@@ -21,6 +21,8 @@ module Decidim
     validates :name, :organization, presence: true
     validates :name, uniqueness: { scope: [:organization, :area_type] }
 
+    before_destroy :abort_if_dependencies
+
     def self.log_presenter_class_for(_log)
       Decidim::AdminLog::AreaPresenter
     end
@@ -38,6 +40,11 @@ module Decidim
           space.respond_to?(:area) && space.decidim_area_id == id
         end
       end
+    end
+
+    # used on before_destroy
+    def abort_if_dependencies
+      throw(:abort) if has_dependencies?
     end
   end
 end

--- a/decidim-core/app/models/decidim/area.rb
+++ b/decidim-core/app/models/decidim/area.rb
@@ -28,5 +28,16 @@ module Decidim
     def translated_name
       Decidim::AreaPresenter.new(self).translated_name
     end
+
+    def has_dependencies?
+      Decidim.participatory_space_registry.manifests.any? do |manifest|
+        manifest
+          .participatory_spaces
+          .call(organization)
+          .any? do |space|
+          space.respond_to?(:area) && space.decidim_area_id == id
+        end
+      end
+    end
   end
 end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
@@ -31,7 +31,7 @@ FactoryBot.define do
     private_space { false }
     start_date { Date.current }
     end_date { 2.months.from_now }
-    area
+    area { nil }
 
     trait :promoted do
       promoted { true }

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
@@ -31,6 +31,7 @@ FactoryBot.define do
     private_space { false }
     start_date { Date.current }
     end_date { 2.months.from_now }
+    area
 
     trait :promoted do
       promoted { true }

--- a/decidim-participatory_processes/spec/commands/admin/destroy_area_with_processes_spec.rb
+++ b/decidim-participatory_processes/spec/commands/admin/destroy_area_with_processes_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Admin
+  describe DestroyArea do
+    subject { described_class.new(area, user) }
+
+    let(:organization) { create :organization }
+    let(:user) { create :user, :admin, :confirmed, organization: organization }
+    let(:area) { create :area, organization: organization }
+
+    context "when a participatory process associated to a given area exist" do
+      let!(:process) { create(:participatory_process, organization: organization, area: area) }
+
+      it "can not be deleted" do
+        expect { subject.call }.to broadcast(:has_spaces)
+        expect(area.reload.destroyed?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
When an area has dependent models, i.e. processes or assemblies, it is still possible to delete it.
It should not be possible to delete an Area if it has dependent spaces.

#### :pushpin: Related Issues
- Related to #5040 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [-] Add documentation regarding the feature 
- [-] Add/modify seeds
- [x] Add tests
- [x] Feature

### :camera: Screenshots (optional)
![ezgif-1-25c37edec6d6](https://user-images.githubusercontent.com/199462/55420321-04b5c000-5577-11e9-829e-ef3d09a8531d.gif)
