### PR TITLE
Add label "for" attributes for the switch paddle labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - **decidim-accountability**: Handle special case when all children weight are nil on accountability. [#5026](https://github.com/decidim/decidim/pull/5026)
 - **decidim-proposals**: Filter emendations by rendering only amendments. [#5025](https://github.com/decidim/decidim/pull/5025)
 - **decidim-proposals**: Add documents folder in proposals manifest for precompile assets. [#5015](https://github.com/decidim/decidim/pull/5015)
+- **decidim-core**: Fix user notification and interest settings on IE11. [#5044](https://github.com/decidim/decidim/pull/5044)
 
 **Removed**:
 

--- a/decidim-core/app/views/decidim/notifications_settings/show.html.erb
+++ b/decidim-core/app/views/decidim/notifications_settings/show.html.erb
@@ -2,27 +2,27 @@
   <%= form_for(@notifications_settings, url: notifications_settings_path, method: :put, class: "user-form") do |f| %>
     <p><strong><%= t(".receive_notifications_about") %></strong></p>
     <div class="switch tiny switch-with-label notifications_from_own_activity">
-      <label>
+      <%= f.label :notifications_from_own_activity do %>
         <%= f.check_box :notifications_from_own_activity, label: false, class: "switch-input" %>
         <span class="switch-paddle"></span>
         <span class="switch-label"><%= t(".own_activity") %></span>
-      </label>
+      <% end %>
     </div>
     <div class="switch tiny switch-with-label notifications_from_followed">
-      <label>
+      <%= f.label :notifications_from_followed do %>
         <%= f.check_box :notifications_from_followed, label: false, class: "switch-input" %>
         <span class="switch-paddle"></span>
         <span class="switch-label"><%= t(".everything_followed") %></span>
-      </label>
+      <% end %>
     </div>
 
     <p><strong><%= t(".send_notifications_by_email") %></strong></p>
     <div class="switch tiny switch-with-label email_on_notification">
-      <label>
+      <%= f.label :email_on_notification do %>
         <%= f.check_box :email_on_notification, label: false, class: "switch-input" %>
         <span class="switch-paddle"></span>
         <span class="switch-label"><%= t(".email_on_notification") %></span>
-      </label>
+      <% end %>
     </div>
 
     <p><strong><%= t(".newsletters") %></strong></p>

--- a/decidim-core/app/views/decidim/user_interests/_areas.html.erb
+++ b/decidim-core/app/views/decidim/user_interests/_areas.html.erb
@@ -2,11 +2,11 @@
   <% areas.each do |area| %>
     <li class="switch tiny switch-with-label">
       <%= f.fields_for "areas[]", area do |form| %>
-        <label>
+        <%= form.label "checked" do %>
           <%= form.check_box "checked", label: false, class: "switch-input" %>
           <span class="switch-paddle"></span>
           <span class="switch-label"><%= translated_attribute area.name %></span>
-        </label>
+        <% end %>
         <%= form.hidden_field "id", value: area.id %>
       <% end %>
     </li>

--- a/decidim-core/app/views/decidim/user_interests/_scopes.html.erb
+++ b/decidim-core/app/views/decidim/user_interests/_scopes.html.erb
@@ -2,11 +2,11 @@
   <% scopes.each do |scope| %>
     <li class="switch tiny switch-with-label">
       <%= f.fields_for "scopes[]", scope do |form| %>
-        <label>
+        <%= form.label "checked" do %>
           <%= form.check_box "checked", label: false, class: "switch-input" %>
           <span class="switch-paddle"></span>
           <span class="switch-label"><%= translated_attribute scope.name %></span>
-        </label>
+        <% end %>
         <%= form.hidden_field "id", value: scope.id %>
       <% end %>
     </li>

--- a/decidim-core/app/views/decidim/user_interests/show.html.erb
+++ b/decidim-core/app/views/decidim/user_interests/show.html.erb
@@ -3,7 +3,9 @@
   <%= form_for(@user_interests, url: user_interests_path, method: :put, class: "user-form") do |f| %>
     <p><strong><%= t(".my_interests") %></strong></p>
     <% if @user_interests.scopes.any? %>
-      <%= render partial: "scopes", locals: { scopes: @user_interests.scopes, f: f } %>
+      <div class="clearfix m-bottom">
+        <%= render partial: "scopes", locals: { scopes: @user_interests.scopes, f: f } %>
+      </div>
       <%= f.submit t(".update_my_interests"), disable_with: true %>
     <% else %>
       <p><%= t(".no_scopes") %></p>


### PR DESCRIPTION
#### :tophat: What? Why?
Adds "for" attributes for the switch paddle labels because the missing attributes caused the switch paddle functionality to break on IE11.

#### :pushpin: Related Issues
- Fixes #5031

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry