### PR TITLE
Add CODEOWNERS file for Pull Requests reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# https://help.github.com/en/articles/about-code-owners 
+
+* 	@decidim/lot-core 
+


### PR DESCRIPTION
Configures GitHub with our current workflow for Pull Requests
Review. Only the @decidim/lot-core developers should have permissions
to accept changes on branch master.