### PR TITLE
Fix admin assemblies form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 **Fixed**:
 
+- **decidim-assemblies**: Fix admin assemblies form. [\#5054](https://github.com/decidim/decidim/pull/5054)
 - **decidim-core**: Fix repeated amendments notifications. [\#5001](https://github.com/decidim/decidim/pull/5001)
 - **decidim-core**: Fix amendments forms: show error messages and render hashtags. [#4951](https://github.com/decidim/decidim/pull/4951)
 - **decidim-comments**: Fixes that as a normal user (no private user) I can comment on a private assembly where is available. [#4924](https://github.com/decidim/decidim/pull/4924)

--- a/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_form.rb
+++ b/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_form.rb
@@ -32,24 +32,20 @@ module Decidim
         translatable_attribute :target, String
         translatable_attribute :title, String
 
-        attribute :area_id, Integer
         attribute :assembly_type, String
-        attribute :banner_image
         attribute :created_by, String
         attribute :facebook_handler, String
         attribute :github_handler, String
         attribute :hashtag, String
-        attribute :hero_image
         attribute :instagram_handler, String
-        attribute :parent_id, Integer
-        attribute :remove_banner_image
-        attribute :remove_hero_image
-        attribute :scope_id, Integer
         attribute :slug, String
         attribute :twitter_handler, String
         attribute :youtube_handler, String
 
+        attribute :area_id, Integer
+        attribute :parent_id, Integer
         attribute :participatory_processes_ids, Array[Integer]
+        attribute :scope_id, Integer
 
         attribute :is_transparent, Boolean
         attribute :promoted, Boolean
@@ -57,21 +53,26 @@ module Decidim
         attribute :show_statistics, Boolean
         attribute :scopes_enabled, Boolean
 
-        attribute :creation_date, Decidim::Attributes::LocalizedDate
         attribute :closing_date, Decidim::Attributes::LocalizedDate
+        attribute :creation_date, Decidim::Attributes::LocalizedDate
         attribute :duration, Decidim::Attributes::LocalizedDate
         attribute :included_at, Decidim::Attributes::LocalizedDate
+
+        attribute :banner_image
+        attribute :hero_image
+        attribute :remove_banner_image
+        attribute :remove_hero_image
 
         validates :area, presence: true, if: proc { |object| object.area_id.present? }
         validates :parent, presence: true, if: ->(form) { form.parent_id.present? }
         validates :scope, presence: true, if: proc { |object| object.scope_id.present? }
         validates :slug, presence: true, format: { with: Decidim::Assembly.slug_format }
-        validates :title, :subtitle, :description, :short_description, translatable_presence: true
+
+        validate :slug_uniqueness
 
         validates :assembly_type_other, translatable_presence: true, if: ->(form) { form.assembly_type == "others" }
         validates :created_by_other, translatable_presence: true, if: ->(form) { form.created_by == "others" }
-
-        validate :slug_uniqueness
+        validates :title, :subtitle, :description, :short_description, translatable_presence: true
 
         validates :banner_image, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } }, file_content_type: { allow: ["image/jpeg", "image/png"] }
         validates :hero_image, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } }, file_content_type: { allow: ["image/jpeg", "image/png"] }

--- a/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_form.rb
+++ b/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_form.rb
@@ -47,11 +47,11 @@ module Decidim
         attribute :participatory_processes_ids, Array[Integer]
         attribute :private_space, Boolean
         attribute :assembly_type, String
-        attribute :creation_date, Decidim::Attributes::TimeWithZone
+        attribute :creation_date, Decidim::Attributes::LocalizedDate
         attribute :created_by, String
-        attribute :duration, Decidim::Attributes::TimeWithZone
-        attribute :included_at, Decidim::Attributes::TimeWithZone
-        attribute :closing_date, Decidim::Attributes::TimeWithZone
+        attribute :duration, Decidim::Attributes::LocalizedDate
+        attribute :included_at, Decidim::Attributes::LocalizedDate
+        attribute :closing_date, Decidim::Attributes::LocalizedDate
         attribute :is_transparent, Boolean
         attribute :twitter_handler, String
         attribute :facebook_handler, String

--- a/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_form.rb
+++ b/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_form.rb
@@ -12,66 +12,69 @@ module Decidim
         ASSEMBLY_TYPES = %w(government executive consultative_advisory participatory working_group commission others).freeze
         CREATED_BY = %w(city_council public others).freeze
 
-        translatable_attribute :title, String
-        translatable_attribute :subtitle, String
+        mimic :assembly
+
+        translatable_attribute :assembly_type_other, String
+        translatable_attribute :composition, String
+        translatable_attribute :closing_date_reason, String
+        translatable_attribute :created_by_other, String
         translatable_attribute :description, String
-        translatable_attribute :short_description, String
-        translatable_attribute :meta_scope, String
         translatable_attribute :developer_group, String
+        translatable_attribute :internal_organisation, String
         translatable_attribute :local_area, String
-        translatable_attribute :target, String
+        translatable_attribute :meta_scope, String
         translatable_attribute :participatory_scope, String
         translatable_attribute :participatory_structure, String
         translatable_attribute :purpose_of_action, String
-        translatable_attribute :composition, String
-        translatable_attribute :assembly_type_other, String
-        translatable_attribute :created_by_other, String
-        translatable_attribute :closing_date_reason, String
-        translatable_attribute :internal_organisation, String
+        translatable_attribute :short_description, String
         translatable_attribute :special_features, String
+        translatable_attribute :subtitle, String
+        translatable_attribute :target, String
+        translatable_attribute :title, String
 
-        mimic :assembly
-
-        attribute :slug, String
-        attribute :hashtag, String
-        attribute :promoted, Boolean
-        attribute :scopes_enabled, Boolean
-        attribute :scope_id, Integer
-        attribute :hero_image
-        attribute :remove_hero_image
-        attribute :banner_image
-        attribute :remove_banner_image
-        attribute :show_statistics, Boolean
         attribute :area_id, Integer
-        attribute :parent_id, Integer
-        attribute :participatory_processes_ids, Array[Integer]
-        attribute :private_space, Boolean
         attribute :assembly_type, String
-        attribute :creation_date, Decidim::Attributes::LocalizedDate
+        attribute :banner_image
         attribute :created_by, String
+        attribute :facebook_handler, String
+        attribute :github_handler, String
+        attribute :hashtag, String
+        attribute :hero_image
+        attribute :instagram_handler, String
+        attribute :parent_id, Integer
+        attribute :remove_banner_image
+        attribute :remove_hero_image
+        attribute :scope_id, Integer
+        attribute :slug, String
+        attribute :twitter_handler, String
+        attribute :youtube_handler, String
+
+        attribute :participatory_processes_ids, Array[Integer]
+
+        attribute :is_transparent, Boolean
+        attribute :promoted, Boolean
+        attribute :private_space, Boolean
+        attribute :show_statistics, Boolean
+        attribute :scopes_enabled, Boolean
+
+        attribute :creation_date, Decidim::Attributes::LocalizedDate
+        attribute :closing_date, Decidim::Attributes::LocalizedDate
         attribute :duration, Decidim::Attributes::LocalizedDate
         attribute :included_at, Decidim::Attributes::LocalizedDate
-        attribute :closing_date, Decidim::Attributes::LocalizedDate
-        attribute :is_transparent, Boolean
-        attribute :twitter_handler, String
-        attribute :facebook_handler, String
-        attribute :instagram_handler, String
-        attribute :youtube_handler, String
-        attribute :github_handler, String
 
-        validates :slug, presence: true, format: { with: Decidim::Assembly.slug_format }
-        validates :title, :subtitle, :description, :short_description, translatable_presence: true
-        validates :scope, presence: true, if: proc { |object| object.scope_id.present? }
         validates :area, presence: true, if: proc { |object| object.area_id.present? }
         validates :parent, presence: true, if: ->(form) { form.parent_id.present? }
+        validates :scope, presence: true, if: proc { |object| object.scope_id.present? }
+        validates :slug, presence: true, format: { with: Decidim::Assembly.slug_format }
+        validates :title, :subtitle, :description, :short_description, translatable_presence: true
 
         validates :assembly_type_other, translatable_presence: true, if: ->(form) { form.assembly_type == "others" }
         validates :created_by_other, translatable_presence: true, if: ->(form) { form.created_by == "others" }
 
         validate :slug_uniqueness
 
-        validates :hero_image, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } }, file_content_type: { allow: ["image/jpeg", "image/png"] }
         validates :banner_image, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } }, file_content_type: { allow: ["image/jpeg", "image/png"] }
+        validates :hero_image, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } }, file_content_type: { allow: ["image/jpeg", "image/png"] }
 
         def map_model(model)
           self.scope_id = model.decidim_scope_id

--- a/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_form.rb
+++ b/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_form.rb
@@ -74,8 +74,12 @@ module Decidim
         validates :created_by_other, translatable_presence: true, if: ->(form) { form.created_by == "others" }
         validates :title, :subtitle, :description, :short_description, translatable_presence: true
 
-        validates :banner_image, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } }, file_content_type: { allow: ["image/jpeg", "image/png"] }
-        validates :hero_image, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } }, file_content_type: { allow: ["image/jpeg", "image/png"] }
+        validates :banner_image,
+                  file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } },
+                  file_content_type: { allow: ["image/jpeg", "image/png"] }
+        validates :hero_image,
+                  file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } },
+                  file_content_type: { allow: ["image/jpeg", "image/png"] }
 
         def map_model(model)
           self.scope_id = model.decidim_scope_id
@@ -99,10 +103,10 @@ module Decidim
         end
 
         def created_by_for_select
-          CREATED_BY.map do |by|
+          CREATED_BY.map do |creator|
             [
-              I18n.t("created_by.#{by}", scope: "decidim.assemblies"),
-              by
+              I18n.t("created_by.#{creator}", scope: "decidim.assemblies"),
+              creator
             ]
           end
         end
@@ -112,8 +116,10 @@ module Decidim
         end
 
         def processes_for_select
-          @processes_for_select ||= Decidim.find_participatory_space_manifest(:participatory_processes)
-                                           .participatory_spaces.call(current_organization)&.order(title: :asc)&.map do |process|
+          processes = Decidim.find_participatory_space_manifest(:participatory_processes)
+                             .participatory_spaces.call(current_organization)
+
+          @processes_for_select ||= processes&.order(title: :asc)&.map do |process|
             [
               translated_attribute(process.title),
               process.id
@@ -124,7 +130,10 @@ module Decidim
         private
 
         def slug_uniqueness
-          return unless OrganizationAssemblies.new(current_organization).query.where(slug: slug).where.not(id: context[:assembly_id]).any?
+          return unless OrganizationAssemblies
+                        .new(current_organization).query
+                        .where(slug: slug)
+                        .where.not(id: context[:assembly_id]).any?
 
           errors.add(:slug, :taken)
         end

--- a/decidim-assemblies/spec/shared/manage_assemblies_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assemblies_examples.rb
@@ -17,9 +17,14 @@ shared_examples "manage assemblies" do
         es: "Mi nuevo título",
         ca: "El meu nou títol"
       )
+
       attach_file :assembly_banner_image, image3_path
 
       within ".edit_assembly" do
+        fill_in "assembly[creation_date]", with: Date.yesterday
+        fill_in "assembly[included_at]", with: Date.current
+        fill_in "assembly[duration]", with: Date.tomorrow
+        fill_in "assembly[closing_date]", with: Date.tomorrow
         find("*[type=submit]").click
       end
 
@@ -28,6 +33,9 @@ shared_examples "manage assemblies" do
       within ".container" do
         expect(page).to have_selector("input[value='My new title']")
         expect(page).to have_css("img[src*='#{image3_filename}']")
+        expect(page).to have_css("input[value='#{Date.yesterday}']")
+        expect(page).to have_css("input[value='#{Date.current}']")
+        expect(page).to have_css("input[value='#{Date.tomorrow}']", count: 2)
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
In `Decidim::Assemblies::Admin::AssemblyForm`, date related attributes where being casted to `Decidim::Attributes::TimeWithZone` and the form was ignoring the values introduced by the user on those fields (`date_fields`).

Changing type cast to `Decidim::Attributes::LocalizedDate` fixed the issue.

#### Also
- Reordered form attributes for better readability

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests