### PR TITLE
Organize ParticipatoryProcesses and Assemblies admin forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Added**:
 
+- **decidim-assemblies**, **decidim-participatory_processes** Reorganize admin form [\#5068](https://github.com/decidim/decidim/pull/5068)
 - **decidim-assemblies**, **decidim-participatory_processes** Table headers sortable links [\#5010](https://github.com/decidim/decidim/pull/5010)
 - **decidim-assemblies**, **decidim-participatory_processes** Filter spaces by scope and area [\#5047](https://github.com/decidim/decidim/pull/5047)
 - **decidim-admin**: Do not allow to delete areas when they have dependent spaces. [#5041](https://github.com/decidim/decidim/pull/5041)

--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_process-header.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_process-header.scss
@@ -1,3 +1,4 @@
+.assembly-header__title,
 .process-header__title{
   text-transform: uppercase;
   font-size: .8rem;
@@ -5,6 +6,7 @@
   color: $muted;
 }
 
+.assembly-title-summary,
 .process-title-summary{
   @extend .card-title;
 

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
@@ -2,7 +2,7 @@
 
 <div class="card">
   <div class="card-divider">
-    <h2 class="card-title"><%= t "assemblies.form.title", scope: "decidim.admin" %></h2>
+    <h2 class="card-title"><%= t(".title") %></h2>
   </div>
 
   <div class="card-section">
@@ -14,27 +14,17 @@
       <%= form.translated :text_field, :subtitle %>
     </div>
 
-    <% if params[:parent_id].present? %>
-      <%= form.hidden_field :parent_id, value: @form.parent_id %>
-    <% else %>
-      <div class="row column">
-        <%= form.select :parent_id, options_from_collection_for_select(@all_assemblies, :id, :translated_title, selected: current_assembly.try(:parent_id)), include_blank: t(".select_parent_assembly") %>
-      </div>
-    <% end %>
-
     <div class="row">
       <div class="columns xlarge-6 slug">
         <%= form.text_field :slug %>
-        <p class="help-text"><%== t(".slug_help", url: decidim_form_slug_url(:assemblies, form.object.slug)) %></p>
+        <p class="help-text">
+          <%= t(".slug_help", url: decidim_form_slug_url(:assemblies, form.object.slug)) %>
+        </p>
       </div>
 
       <div class="columns xlarge-6">
         <%= form.text_field :hashtag %>
       </div>
-    </div>
-
-    <div class="row column">
-      <%= form.check_box :promoted %>
     </div>
 
     <div class="row column">
@@ -45,6 +35,52 @@
       <%= form.translated :editor, :description, toolbar: :full, lines: 25 %>
     </div>
 
+    <div class="row column">
+      <%= form.translated :editor, :purpose_of_action %>
+    </div>
+
+    <div class="row column">
+      <%= form.translated :editor, :composition %>
+    </div>
+
+    <div class="row column">
+      <%= form.translated :editor, :internal_organisation %>
+    </div>
+  </div>
+
+  <div class="card-divider">
+    <h2 class="card-title"><%= t(".duration") %></h2>
+  </div>
+
+  <div class="card-section">
+    <div class="row column">
+      <%= form.date_field :creation_date %>
+    </div>
+
+    <div class="row column">
+      <%= form.date_field :included_at %>
+      <p class="help-text"><%= t(".included_at_help") %></p>
+    </div>
+
+    <div class="row column">
+      <%= form.date_field :duration %>
+      <p class="help-text"><%= t(".duration_help") %></p>
+    </div>
+
+    <div class="row column" id="closing_date_div">
+      <%= form.date_field :closing_date %>
+    </div>
+
+    <div class="row column" id="closing_date_reason_div">
+      <%= form.translated :editor, :closing_date_reason %>
+    </div>
+  </div>
+
+  <div class="card-divider">
+    <h2 class="card-title"><%= t(".images") %></h2>
+  </div>
+
+  <div class="card-section">
     <div class="row">
       <div class="columns xlarge-6">
         <%= form.upload :hero_image %>
@@ -54,7 +90,41 @@
         <%= form.upload :banner_image %>
       </div>
     </div>
+    </div>
 
+  <div class="card-divider">
+    <h2 class="card-title"><%= t(".filters") %></h2>
+  </div>
+
+  <div class="card-section">
+    <div class="row column">
+      <%= form.check_box :scopes_enabled %>
+    </div>
+
+    <div class="row column">
+      <%= scopes_picker_field form, :scope_id, root: nil %>
+    </div>
+
+    <div class="row column">
+      <%= form.areas_select :area_id,
+                            areas_for_select(current_organization),
+                            selected: current_assembly.try(:decidim_area_id),
+                            include_blank: t(".select_an_area") %>
+    </div>
+  </div>
+
+  <div class="card-divider">
+    <h2 class="card-title"><%= t(".metadata") %></h2>
+  </div>
+
+  <div class="card-section">
+    <div class="row column">
+      <%= form.translated :text_field, :participatory_scope %>
+    </div>
+
+    <div class="row column">
+      <%= form.translated :text_field, :participatory_structure %>
+    </div>
     <div class="row">
       <div class="columns xlarge-6">
         <%= form.translated :text_field, :meta_scope %>
@@ -74,91 +144,30 @@
     <div class="row column">
       <%= form.translated :text_field, :target %>
     </div>
+      </div>
+
+  <div class="card-divider">
+    <h2 class="card-title"><%= t(".visbility") %></h2>
+  </div>
+
+  <div class="card-section">
+    <% if params[:parent_id].present? %>
+      <%= form.hidden_field :parent_id, value: @form.parent_id %>
+    <% else %>
+      <div class="row column">
+        <%= form.select :parent_id,
+                        options_from_collection_for_select(
+                          @all_assemblies,
+                          :id,
+                          :translated_title,
+                          selected: current_assembly.try(:parent_id)
+                        ),
+                        include_blank: t(".select_parent_assembly") %>
+      </div>
+    <% end %>
 
     <div class="row column">
-      <%= form.check_box :scopes_enabled %>
-    </div>
-
-    <div class="row column">
-      <%= scopes_picker_field form, :scope_id, root: nil %>
-    </div>
-
-    <div class="row column">
-      <%= form.areas_select :area_id,
-                            areas_for_select(current_organization),
-                            selected: current_assembly.try(:decidim_area_id),
-                            include_blank: t(".select_an_area") %>
-    </div>
-
-    <div class="row column">
-      <%= form.translated :text_field, :participatory_scope %>
-    </div>
-
-    <div class="row column">
-      <%= form.translated :text_field, :participatory_structure %>
-    </div>
-
-    <div class="row column">
-      <%= form.check_box :show_statistics %>
-    </div>
-
-    <div class="row column">
-      <% if @form.processes_for_select %>
-        <%= form.select :participatory_processes_ids,
-                        options_for_select(@form.processes_for_select, selected: processes_selected ),
-                        { include_blank: false },
-                        { multiple: true, class: "chosen-select" } %>
-      <% end %>
-    </div>
-
-    <div class="row column">
-      <%= form.translated :editor, :purpose_of_action %>
-    </div>
-
-    <div class="row column">
-      <%= form.translated :editor, :composition %>
-    </div>
-
-    <div class="row column">
-      <%= form.select :assembly_type, @form.assembly_types_for_select, { include_blank: t(".select_an_assembly_type") }, { multiple: false } %>
-    </div>
-
-    <div class="row column" id="assembly_type_other">
-      <%= form.translated :text_field, :assembly_type_other %>
-    </div>
-
-    <div class="row column">
-      <%= form.date_field :creation_date %>
-    </div>
-
-    <div class="row column">
-      <%= form.select :created_by, @form.created_by_for_select, { include_blank: t(".select_a_created_by") }, { multiple: false } %>
-    </div>
-
-    <div class="row column" id="created_by_other">
-      <%= form.translated :text_field, :created_by_other %>
-    </div>
-
-    <div class="row column">
-      <%= form.date_field :duration %>
-      <p class="help-text"><%== t(".duration_help") %></p>
-    </div>
-
-    <div class="row column">
-      <%= form.date_field :included_at %>
-      <p class="help-text"><%== t(".included_at_help") %></p>
-    </div>
-
-    <div class="row column" id="closing_date_div">
-      <%= form.date_field :closing_date %>
-    </div>
-
-    <div class="row column" id="closing_date_reason_div">
-      <%= form.translated :editor, :closing_date_reason %>
-    </div>
-
-    <div class="row column">
-      <%= form.translated :editor, :internal_organisation %>
+      <%= form.check_box :promoted %>
     </div>
 
     <div class="row column" id="private_space">
@@ -168,13 +177,61 @@
     <div class="row column" id="is_transparent">
       <%= form.check_box :is_transparent %>
     </div>
+  </div>
+
+  <div class="card-divider">
+    <h2 class="card-title"><%= t(".other") %></h2>
+  </div>
+
+  <div class="card-section">
+    <div class="row column">
+      <%= form.select :created_by,
+                      @form.created_by_for_select,
+                      { include_blank: t(".select_a_created_by") },
+                      { multiple: false } %>
+    </div>
+
+    <div class="row column" id="created_by_other">
+      <%= form.translated :text_field, :created_by_other %>
+    </div>
+
+    <div class="row column">
+      <%= form.select :assembly_type,
+                      @form.assembly_types_for_select,
+                      { include_blank: t(".select_an_assembly_type") },
+                      { multiple: false } %>
+    </div>
+
+    <div class="row column" id="assembly_type_other">
+      <%= form.translated :text_field, :assembly_type_other %>
+    </div>
+
+    <div class="row column">
+      <% if @form.processes_for_select %>
+        <%= form.select :participatory_processes_ids,
+                        options_for_select(
+                            @form.processes_for_select,
+                            selected: processes_selected
+                          ),
+                        { include_blank: false },
+                        { multiple: true, class: "chosen-select" } %>
+      <% end %>
+    </div>
 
     <div class="row column" id="special_features">
       <%= form.translated :editor, :special_features %>
     </div>
 
     <div class="columns xlarge-6">
-      <%= form.social_field :text_field, :social_handlers, Decidim::Assembly::SOCIAL_HANDLERS, label: t("social_handlers", scope: "decidim.assemblies.admin.assemblies.form") %>
+      <%= form.social_field :text_field,
+                            :social_handlers,
+                            Decidim::Assembly::SOCIAL_HANDLERS,
+                            label: t("social_handlers",
+                            scope: "decidim.assemblies.admin.assemblies.form") %>
+    </div>
+
+    <div class="row column">
+      <%= form.check_box :show_statistics %>
     </div>
   </div>
 </div>

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
@@ -18,7 +18,7 @@
       <div class="columns xlarge-6 slug">
         <%= form.text_field :slug %>
         <p class="help-text">
-          <%= t(".slug_help", url: decidim_form_slug_url(:assemblies, form.object.slug)) %>
+          <%== t(".slug_help", url: decidim_form_slug_url(:assemblies, form.object.slug)) %>
         </p>
       </div>
 
@@ -59,12 +59,12 @@
 
     <div class="row column">
       <%= form.date_field :included_at %>
-      <p class="help-text"><%= t(".included_at_help") %></p>
+      <p class="help-text"><%== t(".included_at_help") %></p>
     </div>
 
     <div class="row column">
       <%= form.date_field :duration %>
-      <p class="help-text"><%= t(".duration_help") %></p>
+      <p class="help-text"><%== t(".duration_help") %></p>
     </div>
 
     <div class="row column" id="closing_date_div">

--- a/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
@@ -17,14 +17,16 @@ edit_link(
 <%= participatory_space_floating_help %>
 
 <% if current_participatory_space.private_space? %>
-  <%= render partial: "decidim/shared/private_participatory_space", locals: { text: t("assemblies.show.private_space", scope: "decidim") } %>
+  <%= render partial: "decidim/shared/private_participatory_space",
+             locals: { text: t("private_space", scope: "decidim.assemblies.show") } %>
 <% end %>
 
 <div class="row column">
   <% if current_participatory_space.parent.present? %>
     <div class="row">
       <div class="small-12 columns">
-        <%= render partial: "decidim/assemblies/assemblies/nav_breadcumb", locals: { assemblies: current_participatory_space.ancestors.to_a } %>
+        <%= render partial: "decidim/assemblies/assemblies/nav_breadcumb",
+                   locals: { assemblies: current_participatory_space.ancestors.to_a } %>
       </div>
     </div>
   <% end %>
@@ -45,33 +47,33 @@ edit_link(
           translated_attribute(current_participatory_space.internal_organisation).present? ||
           translated_attribute(current_participatory_space.composition).present? %>
         <div class="show-more">
-          <button class="button button--muted small"><%= t("assemblies.show.read_more", scope: "decidim") %></button>
+          <button class="button button--muted small"><%= t("read_more", scope: "decidim.assemblies.show") %></button>
         </div>
 
         <div class="hide show-more-panel">
           <% if translated_attribute(current_participatory_space.purpose_of_action).present? %>
             <div class="section">
-              <h4 class="section-heading"><%= t("assemblies.show.purpose_of_action", scope: "decidim") %></h4>
+              <h4 class="section-heading"><%= t("purpose_of_action", scope: "decidim.assemblies.show") %></h4>
               <%= decidim_sanitize translated_attribute(current_participatory_space.purpose_of_action) %>
             </div>
           <% end %>
 
           <% if translated_attribute(current_participatory_space.internal_organisation).present? %>
             <div class="section">
-              <h4 class="section-heading"><%= t("assemblies.show.internal_organisation", scope: "decidim") %></h4>
+              <h4 class="section-heading"><%= t("internal_organisation", scope: "decidim.assemblies.show") %></h4>
               <%= decidim_sanitize translated_attribute(current_participatory_space.internal_organisation) %>
             </div>
           <% end %>
 
           <% if translated_attribute(current_participatory_space.composition).present? %>
             <div class="section">
-              <h4 class="section-heading"><%= t("assemblies.show.composition", scope: "decidim") %></h4>
+              <h4 class="section-heading"><%= t("composition", scope: "decidim.assemblies.show") %></h4>
               <%= decidim_sanitize translated_attribute(current_participatory_space.composition) %>
             </div>
           <% end %>
           <div class="section text-center">
             <div class="hide-more">
-              <button class="button button--muted small"><%= t("assemblies.show.read_less", scope: "decidim") %></button>
+              <button class="button button--muted small"><%= t("read_less", scope: "decidim.assemblies.show") %></button>
             </div>
           </div>
         </div>
@@ -82,7 +84,7 @@ edit_link(
       <%= attachments_for current_participatory_space %>
       <% if current_participatory_space.children.count.positive? %>
         <section id="assemblies-grid" class="section row collapse">
-          <h4 class="section-heading"><%= t("assemblies.show.children", scope: "decidim") %></h4>
+          <h4 class="section-heading"><%= t("children", scope: "decidim.assemblies.show") %></h4>
           <div class="row small-up-1 medium-up-2 large-up-2 card-grid">
             <%= render partial: "decidim/assemblies/assembly", collection: current_participatory_space.children.published %>
           </div>
@@ -101,56 +103,60 @@ edit_link(
       <div class="card extra definition-data">
         <% if translated_attribute(current_participatory_space.meta_scope).present? %>
           <div class="definition-data__item scope">
-            <span class="definition-data__title"><%= t("assemblies.show.scope", scope: "decidim") %></span>
+            <span class="definition-data__title"><%= t("scope", scope: "decidim.assemblies.show") %></span>
             <%= translated_attribute(current_participatory_space.meta_scope) %>
           </div>
         <% end %>
 
         <% if translated_attribute(current_participatory_space.developer_group).present? %>
           <div class="definition-data__item developer-group">
-            <span class="definition-data__title"><%= t("assemblies.show.developer_group", scope: "decidim") %></span>
+            <span class="definition-data__title"><%= t("developer_group", scope: "decidim.assemblies.show") %></span>
             <%= translated_attribute(current_participatory_space.developer_group) %>
           </div>
         <% end %>
 
         <% if translated_attribute(current_participatory_space.local_area).present? %>
           <div class="definition-data__item local_area">
-            <span class="definition-data__title"><%= t("assemblies.show.local_area", scope: "decidim") %></span>
+            <span class="definition-data__title"><%= t("local_area", scope: "decidim.assemblies.show") %></span>
             <%= translated_attribute(current_participatory_space.local_area) %>
           </div>
         <% end %>
 
          <% if translated_attribute(current_participatory_space.target).present? %>
           <div class="definition-data__item target">
-            <span class="definition-data__title"><%= t("assemblies.show.target", scope: "decidim") %></span>
+            <span class="definition-data__title"><%= t("target", scope: "decidim.assemblies.show") %></span>
             <%= translated_attribute(current_participatory_space.target) %>
           </div>
         <% end %>
 
          <% if translated_attribute(current_participatory_space.participatory_scope).present? %>
           <div class="definition-data__item participatory_scope">
-            <span class="definition-data__title"><%= t("assemblies.show.participatory_scope", scope: "decidim") %></span>
+            <span class="definition-data__title"><%= t("participatory_scope", scope: "decidim.assemblies.show") %></span>
               <%= translated_attribute(current_participatory_space.participatory_scope) %>
           </div>
         <% end %>
 
         <% if translated_attribute(current_participatory_space.participatory_structure).present? %>
           <div class="definition-data__item participatory_structure">
-            <span class="definition-data__title"><%= t("assemblies.show.participatory_structure", scope: "decidim") %></span>
+            <span class="definition-data__title"><%= t("participatory_structure", scope: "decidim.assemblies.show") %></span>
             <%= translated_attribute(current_participatory_space.participatory_structure) %>
           </div>
         <% end %>
 
-        <% if translated_attribute(current_participatory_space.try(:area).try(:name)).present? %>
+        <% area = current_participatory_space.area %>
+        <% if translated_attribute(area&.name).present? %>
           <div class="definition-data__item area">
-            <span class="definition-data__title"><%= t("assemblies.show.area", scope: "decidim") %></span>
-            <%= translated_attribute(current_participatory_space.area.area_type&.name) %> - <%= translated_attribute(current_participatory_space.area.name) %>
+            <span class="definition-data__title"><%= t("area", scope: "decidim.assemblies.show") %></span>
+            <% if translated_attribute(area.area_type&.name).present? %>
+              <%= translated_attribute(area.area_type.name) %><span>&#45;</span>
+            <% end %>
+            <%= translated_attribute(area.name) %>
           </div>
         <% end %>
 
-        <% if current_participatory_space.assembly_type.presence %>
+        <% if current_participatory_space.assembly_type.present? %>
           <div class="definition-data__item assembly_type">
-            <span class="definition-data__title"><%= t("assemblies.show.assembly_type", scope: "decidim") %></span>
+            <span class="definition-data__title"><%= t("assembly_type", scope: "decidim.assemblies.show") %></span>
             <% if current_participatory_space.assembly_type == "others" %>
               <%= translated_attribute(current_participatory_space.assembly_type_other) %>
             <% else %>
@@ -159,16 +165,16 @@ edit_link(
           </div>
         <% end %>
 
-        <% if current_participatory_space.creation_date.presence %>
+        <% if current_participatory_space.creation_date.present? %>
           <div class="definition-data__item creation_date">
-            <span class="definition-data__title"><%= t("assemblies.show.creation_date", scope: "decidim") %></span>
+            <span class="definition-data__title"><%= t("creation_date", scope: "decidim.assemblies.show") %></span>
             <%= l current_participatory_space.creation_date, format: :decidim_short %>
           </div>
         <% end %>
 
-        <% if current_participatory_space.created_by.presence %>
+        <% if current_participatory_space.created_by.present? %>
           <div class="definition-data__item created_by">
-            <span class="definition-data__title"><%= t("assemblies.show.created_by", scope: "decidim") %></span>
+            <span class="definition-data__title"><%= t("created_by", scope: "decidim.assemblies.show") %></span>
             <% if current_participatory_space.created_by == "others" %>
               <%= translated_attribute(current_participatory_space.created_by_other) %>
             <% else %>
@@ -177,26 +183,26 @@ edit_link(
           </div>
         <% end %>
 
-        <div class="definition-data__item duration">
-          <span class="definition-data__title"><%= t("assemblies.show.duration", scope: "decidim") %></span>
-          <% if current_participatory_space.duration.presence %>
-            <%= l current_participatory_space.duration, format: :decidim_short %>
-          <% else %>
-            <%= t("assemblies.show.indefinite_duration", scope: "decidim") %>
-          <% end %>
-        </div>
-
-        <% if current_participatory_space.included_at.presence %>
+        <% if current_participatory_space.included_at.present? %>
           <div class="definition-data__item included_at">
-            <span class="definition-data__title"><%= t("assemblies.show.included_at", scope: "decidim") %></span>
+            <span class="definition-data__title"><%= t("included_at", scope: "decidim.assemblies.show") %></span>
             <%= l current_participatory_space.included_at, format: :decidim_short %>
           </div>
         <% end %>
 
-        <% if current_participatory_space.closing_date.presence %>
+        <div class="definition-data__item duration">
+          <span class="definition-data__title"><%= t("duration", scope: "decidim.assemblies.show") %></span>
+          <% if current_participatory_space.duration.present? %>
+            <%= l current_participatory_space.duration, format: :decidim_short %>
+          <% else %>
+            <%= t("indefinite_duration", scope: "decidim.assemblies.show") %>
+          <% end %>
+        </div>
+
+        <% if current_participatory_space.closing_date.present? %>
           <div class="definition-data__item closing_date">
-            <span class="definition-data__title"><%= t("assemblies.show.closing_date", scope: "decidim") %></span>
-            <%= l current_participatory_space.closing_date, format: :decidim_short %>
+            <span class="definition-data__title"><%= t("closing_date", scope: "decidim.assemblies.show") %></span>
+            <%= l(current_participatory_space.closing_date, format: :decidim_short) %>
             <br />
             <%= decidim_sanitize translated_attribute(current_participatory_space.closing_date_reason) %>
           </div>

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -85,8 +85,6 @@ en:
           success: Assembly created successfully.
         edit:
           update: Update
-        form:
-          title: General Information
         index:
           not_published: Not published
           private: Private
@@ -212,14 +210,21 @@ en:
       admin:
         assemblies:
           form:
+            duration: Duration
             duration_help: If the duration of this assembly is limited, select the end date. Otherwise, it will appear as indefinite.
+            filters: Filters
+            images: Images
             included_at_help: Select the date when this assembly was added to Decidim. It does not necessarily have to be the same as the creation date.
+            metadata: Metadata
+            other: Other
             select_a_created_by: Select a created by
             select_an_area: Select an Area
             select_an_assembly_type: Select an assembly type
             select_parent_assembly: Select parent assembly
             slug_help: 'URL slugs are used to generate the URLs that point to this assembly. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
             social_handlers: Social
+            title: General Information
+            visbility: Visibility
         assembly_copies:
           form:
             slug_help: 'URL slugs are used to generate the URLs that point to this assembly. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'

--- a/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_form.rb
+++ b/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_form.rb
@@ -9,45 +9,54 @@ module Decidim
       class ParticipatoryProcessForm < Form
         include TranslatableAttributes
 
-        translatable_attribute :title, String
-        translatable_attribute :subtitle, String
-        translatable_attribute :description, String
-        translatable_attribute :short_description, String
-        translatable_attribute :meta_scope, String
-        translatable_attribute :developer_group, String
-        translatable_attribute :local_area, String
-        translatable_attribute :target, String
-        translatable_attribute :participatory_scope, String
-        translatable_attribute :participatory_structure, String
-        translatable_attribute :announcement, String
-
         mimic :participatory_process
 
-        attribute :start_date, Decidim::Attributes::LocalizedDate
-        attribute :end_date, Decidim::Attributes::LocalizedDate
-        attribute :slug, String
+        translatable_attribute :announcement, String
+        translatable_attribute :description, String
+        translatable_attribute :developer_group, String
+        translatable_attribute :local_area, String
+        translatable_attribute :meta_scope, String
+        translatable_attribute :participatory_scope, String
+        translatable_attribute :participatory_structure, String
+        translatable_attribute :subtitle, String
+        translatable_attribute :short_description, String
+        translatable_attribute :title, String
+        translatable_attribute :target, String
+
         attribute :hashtag, String
+        attribute :slug, String
+
+        attribute :area_id, Integer
+        attribute :participatory_process_group_id, Integer
+        attribute :scope_id, Integer
+
+        attribute :private_space, Boolean
         attribute :promoted, Boolean
         attribute :scopes_enabled, Boolean
-        attribute :scope_id, Integer
-        attribute :area_id, Integer
-        attribute :hero_image
-        attribute :remove_hero_image
-        attribute :banner_image
-        attribute :remove_banner_image
-        attribute :participatory_process_group_id, Integer
         attribute :show_statistics, Boolean
-        attribute :private_space, Boolean
 
-        validates :slug, presence: true, format: { with: Decidim::ParticipatoryProcess.slug_format }
-        validates :title, :subtitle, :description, :short_description, translatable_presence: true
-        validates :scope, presence: true, if: proc { |object| object.scope_id.present? }
+        attribute :end_date, Decidim::Attributes::LocalizedDate
+        attribute :start_date, Decidim::Attributes::LocalizedDate
+
+        attribute :banner_image
+        attribute :hero_image
+        attribute :remove_banner_image
+        attribute :remove_hero_image
+
         validates :area, presence: true, if: proc { |object| object.area_id.present? }
+        validates :scope, presence: true, if: proc { |object| object.scope_id.present? }
+        validates :slug, presence: true, format: { with: Decidim::ParticipatoryProcess.slug_format }
 
         validate :slug_uniqueness
 
-        validates :hero_image, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } }, file_content_type: { allow: ["image/jpeg", "image/png"] }
-        validates :banner_image, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } }, file_content_type: { allow: ["image/jpeg", "image/png"] }
+        validates :title, :subtitle, :description, :short_description, translatable_presence: true
+
+        validates :banner_image,
+                  file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } },
+                  file_content_type: { allow: ["image/jpeg", "image/png"] }
+        validates :hero_image,
+                  file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } },
+                  file_content_type: { allow: ["image/jpeg", "image/png"] }
 
         def map_model(model)
           self.scope_id = model.decidim_scope_id
@@ -68,8 +77,15 @@ module Decidim
 
         private
 
+        def organization_participatory_processes
+          OrganizationParticipatoryProcesses.new(current_organization).query
+        end
+
         def slug_uniqueness
-          return unless OrganizationParticipatoryProcesses.new(current_organization).query.where(slug: slug).where.not(id: context[:process_id]).any?
+          return unless organization_participatory_processes
+                        .where(slug: slug)
+                        .where.not(id: context[:process_id])
+                        .any?
 
           errors.add(:slug, :taken)
         end

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
@@ -18,7 +18,7 @@
       <div class="columns xlarge-6 slug">
         <%= form.text_field :slug %>
         <p class="help-text">
-          <%= t(".slug_help", url: decidim_form_slug_url(:processes, form.object.slug)) %>
+          <%== t(".slug_help", url: decidim_form_slug_url(:processes, form.object.slug)) %>
         </p>
       </div>
 
@@ -37,7 +37,7 @@
 
     <div class="row column">
       <%= form.translated :editor, :announcement %>
-      <p class="help-text"><%= t(".announcement_help") %></p>
+      <p class="help-text"><%== t(".announcement_help") %></p>
     </div>
   </div>
 

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
@@ -2,7 +2,7 @@
 
 <div class="card">
   <div class="card-divider">
-    <h2 class="card-title"><%= t "participatory_processes.form.title", scope: "decidim.admin" %></h2>
+    <h2 class="card-title"><%= t(".title") %></h2>
   </div>
 
   <div class="card-section">
@@ -17,26 +17,14 @@
     <div class="row">
       <div class="columns xlarge-6 slug">
         <%= form.text_field :slug %>
-        <p class="help-text"><%== t(".slug_help", url: decidim_form_slug_url(:processes, form.object.slug)) %></p>
+        <p class="help-text">
+          <%= t(".slug_help", url: decidim_form_slug_url(:processes, form.object.slug)) %>
+        </p>
       </div>
 
       <div class="columns xlarge-6">
         <%= form.text_field :hashtag %>
       </div>
-    </div>
-
-    <div class="row">
-      <div class="columns xlarge-6">
-        <%= form.date_field :start_date %>
-      </div>
-
-      <div class="columns xlarge-6">
-        <%= form.date_field :end_date %>
-      </div>
-    </div>
-
-    <div class="row column">
-      <%= form.check_box :promoted %>
     </div>
 
     <div class="row column">
@@ -47,6 +35,33 @@
       <%= form.translated :editor, :description, toolbar: :full, lines: 25 %>
     </div>
 
+    <div class="row column">
+      <%= form.translated :editor, :announcement %>
+      <p class="help-text"><%= t(".announcement_help") %></p>
+    </div>
+  </div>
+
+  <div class="card-divider">
+    <h2 class="card-title"><%= t(".duration") %></h2>
+  </div>
+
+  <div class="card-section">
+    <div class="row">
+      <div class="columns xlarge-6">
+        <%= form.date_field :start_date %>
+      </div>
+
+      <div class="columns xlarge-6">
+        <%= form.date_field :end_date %>
+      </div>
+    </div>
+  </div>
+
+  <div class="card-divider">
+    <h2 class="card-title"><%= t(".images") %></h2>
+  </div>
+
+  <div class="card-section">
     <div class="row">
       <div class="columns xlarge-6">
         <%= form.upload :hero_image %>
@@ -56,7 +71,13 @@
         <%= form.upload :banner_image %>
       </div>
     </div>
+  </div>
 
+  <div class="card-divider">
+    <h2 class="card-title"><%= t(".metadata") %></h2>
+  </div>
+
+  <div class="card-section">
     <div class="row">
       <div class="columns xlarge-6">
         <%= form.translated :text_field, :developer_group %>
@@ -76,6 +97,20 @@
     </div>
 
     <div class="row column">
+      <%= form.translated :text_field, :participatory_scope %>
+    </div>
+
+    <div class="row column">
+      <%= form.translated :text_field, :participatory_structure %>
+    </div>
+  </div>
+
+  <div class="card-divider">
+    <h2 class="card-title"><%= t(".filters") %></h2>
+  </div>
+
+  <div class="card-section">
+    <div class="row column">
       <%= form.check_box :scopes_enabled %>
     </div>
 
@@ -89,32 +124,36 @@
                             selected: current_participatory_process.try(:decidim_area_id),
                             include_blank: t(".select_an_area") %>
     </div>
+  </div>
 
-    <div class="row column">
-      <%= form.translated :text_field, :participatory_scope %>
-    </div>
+  <div class="card-divider">
+    <h2 class="card-title"><%= t(".visbility") %></h2>
+  </div>
 
-    <div class="row column">
-      <%= form.translated :text_field, :participatory_structure %>
-    </div>
-
+  <div class="card-section">
     <div class="row column">
       <% if process_groups_for_select %>
-        <%= form.select :participatory_process_group_id, process_groups_for_select, prompt: I18n.t("decidim.participatory_processes.participatory_process_groups.none") %>
+        <%= form.select :participatory_process_group_id,
+                        process_groups_for_select,
+                        include_blank: t(".select_process_group") %>
       <% end %>
     </div>
 
     <div class="row column">
       <%= form.check_box :private_space %>
     </div>
+        <div class="row column">
+      <%= form.check_box :promoted %>
+    </div>
+  </div>
 
+  <div class="card-divider">
+    <h2 class="card-title"><%= t(".other") %></h2>
+  </div>
+
+  <div class="card-section">
     <div class="row column">
       <%= form.check_box :show_statistics %>
-    </div>
-
-    <div class="row column">
-      <%= form.translated :editor, :announcement %>
-      <p class="help-text"><%== t(".announcement_help") %></p>
     </div>
   </div>
 </div>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
@@ -102,14 +102,14 @@ edit_link(
         <% if current_participatory_space.start_date.present? %>
           <div class="definition-data__item start-date">
             <span class="definition-data__title"><%= t("start_date", scope: "decidim.participatory_processes.show") %></span>
-            <%= l(current_participatory_space.start_date, format: :long) %>
+            <%== l(current_participatory_space.start_date, format: :long) %>
           </div>
         <% end %>
 
         <% if current_participatory_space.end_date.present? %>
           <div class="definition-data__item end-date">
             <span class="definition-data__title"><%= t("end_date", scope: "decidim.participatory_processes.show") %></span>
-            <%= l(current_participatory_space.end_date, format: :long) %>
+            <%== l(current_participatory_space.end_date, format: :long) %>
           </div>
         <% end %>
       </div>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
@@ -17,11 +17,13 @@ edit_link(
 <%= participatory_space_floating_help %>
 
 <% if current_participatory_space.private_space? %>
-  <%= render partial: "decidim/shared/private_participatory_space", locals: { text: t("participatory_processes.show.private_space", scope: "decidim") } %>
+  <%= render partial: "decidim/shared/private_participatory_space",
+             locals: { text: t("private_space", scope: "decidim.participatory_processes.show") } %>
 <% end %>
 
 <% if translated_attribute(current_participatory_space.announcement).present? %>
-  <%= render partial: "decidim/shared/announcement", locals: { announcement: current_participatory_space.announcement } %>
+  <%= render partial: "decidim/shared/announcement",
+             locals: { announcement: current_participatory_space.announcement } %>
 <% end %>
 
 <div class="row column">
@@ -39,70 +41,75 @@ edit_link(
     <div class="section columns medium-5 mediumlarge-4 large-3">
       <div class="card extra">
         <div class="card__content">
-          <%= render partial: "decidim/shared/follow_button", locals: { followable: current_participatory_space, large: false } %>
+          <%= render partial: "decidim/shared/follow_button",
+                     locals: { followable: current_participatory_space, large: false } %>
         </div>
       </div>
       <div class="card extra definition-data">
         <% if translated_attribute(current_participatory_space.participatory_scope).present? %>
           <div class="definition-data__item participatory_scope">
-            <span class="definition-data__title"><%= t("participatory_processes.show.participatory_scope", scope: "decidim") %></span>
+            <span class="definition-data__title"><%= t("participatory_scope", scope: "decidim.participatory_processes.show") %></span>
             <%= translated_attribute(current_participatory_space.participatory_scope) %>
           </div>
         <% end %>
 
         <% if translated_attribute(current_participatory_space.target).present? %>
           <div class="definition-data__item target">
-            <span class="definition-data__title"><%= t("participatory_processes.show.target", scope: "decidim") %></span>
+            <span class="definition-data__title"><%= t("target", scope: "decidim.participatory_processes.show") %></span>
             <%= translated_attribute(current_participatory_space.target) %>
           </div>
         <% end %>
 
         <% if translated_attribute(current_participatory_space.participatory_structure).present? %>
           <div class="definition-data__item participatory_structure">
-            <span class="definition-data__title"><%= t("participatory_processes.show.participatory_structure", scope: "decidim") %></span>
+            <span class="definition-data__title"><%= t("participatory_structure", scope: "decidim.participatory_processes.show") %></span>
             <%= translated_attribute(current_participatory_space.participatory_structure) %>
           </div>
         <% end %>
 
-        <% if translated_attribute(current_participatory_space.try(:area).try(:name)).present? %>
+        <% area = current_participatory_space.area %>
+        <% if translated_attribute(area&.name).present? %>
           <div class="definition-data__item area">
-            <span class="definition-data__title"><%= t("participatory_processes.show.area", scope: "decidim") %></span>
-            <%= translated_attribute(current_participatory_space.area.area_type&.name) %> - <%= translated_attribute(current_participatory_space.area.name) %>
+            <span class="definition-data__title"><%= t("area", scope: "decidim.participatory_processes.show") %></span>
+            <% if translated_attribute(area.area_type&.name).present? %>
+              <%= translated_attribute(area.area_type.name) %><span>&#45;</span>
+            <% end %>
+            <%= translated_attribute(area.name) %>
           </div>
         <% end %>
 
         <% if translated_attribute(current_participatory_space.meta_scope).present? %>
           <div class="definition-data__item scope">
-            <span class="definition-data__title"><%= t("participatory_processes.show.scope", scope: "decidim") %></span>
-              <%= translated_attribute(current_participatory_space.meta_scope) %>
+            <span class="definition-data__title"><%= t("scope", scope: "decidim.participatory_processes.show") %></span>
+            <%= translated_attribute(current_participatory_space.meta_scope) %>
           </div>
         <% end %>
 
         <% if translated_attribute(current_participatory_space.local_area).present? %>
           <div class="definition-data__item local_area">
-            <span class="definition-data__title"><%= t("participatory_processes.show.local_area", scope: "decidim") %></span>
+            <span class="definition-data__title"><%= t("local_area", scope: "decidim.participatory_processes.show") %></span>
             <%= translated_attribute(current_participatory_space.local_area) %>
           </div>
         <% end %>
 
         <% if translated_attribute(current_participatory_space.developer_group).present? %>
           <div class="definition-data__item developer-group">
-            <span class="definition-data__title"><%= t("participatory_processes.show.developer_group", scope: "decidim") %></span>
+            <span class="definition-data__title"><%= t("developer_group", scope: "decidim.participatory_processes.show") %></span>
             <%= translated_attribute(current_participatory_space.developer_group) %>
           </div>
         <% end %>
 
         <% if current_participatory_space.start_date.present? %>
           <div class="definition-data__item start-date">
-            <span class="definition-data__title"><%= t("participatory_processes.show.start_date", scope: "decidim") %></span>
-              <%== l(current_participatory_space.start_date, format: :long) %>
+            <span class="definition-data__title"><%= t("start_date", scope: "decidim.participatory_processes.show") %></span>
+            <%= l(current_participatory_space.start_date, format: :long) %>
           </div>
         <% end %>
 
         <% if current_participatory_space.end_date.present? %>
           <div class="definition-data__item end-date">
-            <span class="definition-data__title"><%= t("participatory_processes.show.end_date", scope: "decidim") %></span>
-              <%== l(current_participatory_space.end_date, format: :long) %>
+            <span class="definition-data__title"><%= t("end_date", scope: "decidim.participatory_processes.show") %></span>
+            <%= l(current_participatory_space.end_date, format: :long) %>
           </div>
         <% end %>
       </div>
@@ -111,6 +118,7 @@ edit_link(
       <%= embed_modal_for participatory_process_participatory_process_widget_url(current_participatory_space, format: :js) %>
     </div>
   </div>
+
   <% if current_participatory_space.show_statistics? %>
     <%= render partial: "statistics" %>
     <%= render partial: "metrics" %>

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -204,8 +204,6 @@ en:
           success: Participatory process successfully created. Configure now its phases.
         edit:
           update: Update
-        form:
-          title: General Information
         index:
           not_published: Not published
           private: Private
@@ -297,8 +295,16 @@ en:
         participatory_processes:
           form:
             announcement_help: The text you enter here will be shown to the user right below the process information.
+            duration: Duration
+            filters: Filters
+            images: Images
+            metadata: Metadata
+            other: Other
             select_an_area: Select an Area
+            select_process_group: Select a process group
             slug_help: 'URL slugs are used to generate the URLs that point to this process. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
+            title: General Information
+            visbility: Visibility
       content_blocks:
         highlighted_processes:
           name: Highlighted processes
@@ -314,8 +320,6 @@ en:
             more_information: More information
             participate: Participate
             see_all_processes: See all processes
-      participatory_process_groups:
-        none: None
       participatory_processes:
         filters:
           counters:


### PR DESCRIPTION
#### :tophat: What? Why?
`ParticipatoryProcesses` and `Assemblies` admin forms:
- Group common fields and add card dividers for better user experience

#### Also
- Add logic to show/hide `area_type.name` and dash in metadata column
- Reordered `ParticipatoryProcessForm` attributes for better readability

#### :pushpin: Related Issues

- Related to #5062

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)

#### Admin assemblies form (large image)
https://drive.google.com/file/d/156sZkkx4sPT5cF-nSP93znUN9NMrrJbf/view?usp=sharing

#### Admin processes form  (large image)
https://drive.google.com/file/d/1-4sW6xDnbxIfmVrhf8Jkhp-0m92Yp2TA/view?usp=sharing

