### PR TITLE
Fix step CTA button when base URL has params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - **decidim-proposals**: Add documents folder in proposals manifest for precompile assets. [#5015](https://github.com/decidim/decidim/pull/5015)
 - **decidim-core**: Fix user notification and interest settings on IE11. [#5044](https://github.com/decidim/decidim/pull/5044)
 - **decidim-admin**, **decidim-forms**, **decidim-meetings**: Fix dynamic fields components on IE11. [#5052](https://github.com/decidim/decidim/pull/5052)
+- **decidim-participatory_processes**: Fix step CTA URL when abse URL had params [#5082](https://github.com/decidim/decidim/pull/5082)
 
 **Removed**:
 

--- a/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
+++ b/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
@@ -21,6 +21,22 @@ module Decidim
         dates = [participatory_process_step.start_date, participatory_process_step.end_date]
         dates.map { |date| date ? localize(date.to_date, format: :default) : "?" }.join(" - ")
       end
+
+      # Public: Builds the URL for the step Call To Action. Takes URL params
+      # into account.
+      #
+      # process - a ParticipatoryProcess
+      #
+      # Returns a String that can be used as a URL.
+      def step_cta_url(process)
+        base_url, params = decidim_participatory_processes.participatory_process_path(process).split("?")
+
+        if params.present?
+          [base_url, "/", process.active_step.cta_path, "?", params].join("")
+        else
+          [base_url, "/", process.active_step.cta_path].join("")
+        end
+      end
     end
   end
 end

--- a/decidim-participatory_processes/app/views/layouts/decidim/_process_header_steps.html.erb
+++ b/decidim-participatory_processes/app/views/layouts/decidim/_process_header_steps.html.erb
@@ -26,7 +26,7 @@
         <%= link_to t(".view_steps"), decidim_participatory_processes.participatory_process_participatory_process_steps_path(current_participatory_space) %>
         <%= link_to(
           cta_text,
-          decidim_participatory_processes.participatory_process_path(participatory_process) + "/" + participatory_process.active_step.cta_path,
+          step_cta_url(participatory_process),
           class: "button small button--sc show-for-medium"
         ) %>
       <% else %>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes process steps CTA URL, which was broken when the base URL had params (ie using a non-default locale).

#### :pushpin: Related Issues
- Fixes #5051

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
