### PR TITLE
Fix possible NoMethodErrors in the notification jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - **decidim-proposals**: Add documents folder in proposals manifest for precompile assets. [#5015](https://github.com/decidim/decidim/pull/5015)
 - **decidim-core**: Fix user notification and interest settings on IE11. [#5044](https://github.com/decidim/decidim/pull/5044)
 - **decidim-admin**, **decidim-forms**, **decidim-meetings**: Fix dynamic fields components on IE11. [#5052](https://github.com/decidim/decidim/pull/5052)
+- **decidim-core**: Fix possible NoMethodErrors in the notification jobs filling logs. [#5083](https://github.com/decidim/decidim/pull/5083)
 
 **Removed**:
 

--- a/decidim-core/app/jobs/decidim/email_notification_generator_job.rb
+++ b/decidim-core/app/jobs/decidim/email_notification_generator_job.rb
@@ -6,6 +6,8 @@ module Decidim
 
     # rubocop:disable Metrics/ParameterLists
     def perform(event, event_class_name, resource, followers, affected_users, extra)
+      return if event_class_name.nil?
+
       event_class = event_class_name.constantize
       EmailNotificationGenerator.new(event, event_class, resource, followers, affected_users, extra).generate
     end

--- a/decidim-core/app/jobs/decidim/notification_generator_job.rb
+++ b/decidim-core/app/jobs/decidim/notification_generator_job.rb
@@ -6,6 +6,8 @@ module Decidim
 
     # rubocop:disable Metrics/ParameterLists
     def perform(event, event_class_name, resource, followers, affected_users, extra)
+      return if event_class_name.nil?
+
       event_class = event_class_name.constantize
       NotificationGenerator.new(event, event_class, resource, followers, affected_users, extra).generate
     end

--- a/decidim-core/spec/jobs/decidim/email_notification_generator_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/email_notification_generator_job_spec.rb
@@ -33,5 +33,15 @@ describe Decidim::EmailNotificationGeneratorJob do
 
       subject.perform_now(event, event_class_name, resource, followers, affected_users, extra)
     end
+
+    context "when event_class_name is nil" do
+      let(:event_class_name) { nil }
+
+      it "does not raise error" do
+        expect do
+          subject.perform_now(event, event_class_name, resource, followers, affected_users, extra)
+        end.not_to raise_error
+      end
+    end
   end
 end

--- a/decidim-core/spec/jobs/decidim/notification_generator_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/notification_generator_job_spec.rb
@@ -33,5 +33,15 @@ describe Decidim::NotificationGeneratorJob do
 
       subject.perform_now(event, event_class_name, resource, followers, affected_users, extra)
     end
+
+    context "when event_class_name is nil" do
+      let(:event_class_name) { nil }
+
+      it "does not raise error" do
+        expect do
+          subject.perform_now(event, event_class_name, resource, followers, affected_users, extra)
+        end.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
We are receiving a lot of the following types of errors from the notification jobs in live instances where we are using Resque to process the jobs:

```
E, [2019-03-15T20:31:58.642308 #32702] ERROR -- : [ActiveJob] [Decidim::NotificationGeneratorJob] [12ab1234-12a3-12a3-ab1c-12ab3c4de567] Error performing Decidim::NotificationGeneratorJob (Job ID: 12ab1234-12a3-12a3-ab1c-12ab3c4de567) from Resque(decidim-production_events) in 1.82ms: NoMethodError (undefined method `constantize' for nil:NilClass):
/path/to/shared/bundle/ruby/2.5.0/gems/decidim-core-0.16.1/app/jobs/decidim/notification_generator_job.rb:9:in `perform'
...
```

```
E, [2019-03-15T20:57:54.092382 #1697] ERROR -- : [ActiveJob] [Decidim::EmailNotificationGeneratorJob] [12ab1234-12a3-12a3-ab1c-12ab3c4de567] Error performing Decidim::EmailNotificationGeneratorJob (Job ID: 12ab1234-12a3-12a3-ab1c-12ab3c4de567) from Resque(decidim-production_events) in 2.62ms: NoMethodError (undefined method `constantize' for nil:NilClass):
/path/to/shared/bundle/ruby/2.5.0/gems/decidim-core-0.16.1/app/jobs/decidim/email_notification_generator_job.rb:9:in `perform'
```

I have no idea what is causing these types of events because the log entries do not contain this information. This fixes at least the jobs that are currently causing a lot of unnecessary load for Resque as it has to write these to the logs. These are logged for each an every instance of the notifications which causes lots of entries e.g. when a notification is triggered for the whole user base (1 log entry * number of users). These log entries are then written very fast by resque to the log as it happens at the same time for the user.

The underlying reason still remains a mystery and would require more investigation.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [X] Add tests