### PR TITLE
Add a migration to fix user names and nicknames

### DIFF
--- a/decidim-core/db/migrate/20190412131728_fix_user_names.rb
+++ b/decidim-core/db/migrate/20190412131728_fix_user_names.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class FixUserNames < ActiveRecord::Migration[5.2]
+  def change
+    # Comes from Decidim::User specs
+    weird_characters =
+      ["<", ">", "?", "\\%", "&", "^", "*", "#", "@", "(", ")", "[", "]", "=", "+", ":", ";", "\"", "{", "}", "\\", "|"]
+    characters_to_remove = "<>?%&^*\#@()[]=+:;\"{}\\|"
+
+    weird_characters.each do |character|
+      Decidim::UserBaseEntity.where("name like '%#{character}%' escape '\'").find_each do |entity|
+        p "detected character: #{character}"
+        p "UserBaseEntity ID: #{entity.id}"
+        p "#{entity.name} => #{entity.name.delete(characters_to_remove).strip}"
+        p "#{entity.nickname} => #{entity.nickname.delete(characters_to_remove).strip}"
+
+        entity.name = entity.name.delete(characters_to_remove).strip
+        entity.nickname = entity.nickname.delete(characters_to_remove).strip
+        entity.save!
+      end
+    end
+  end
+end

--- a/decidim-core/db/migrate/20190412131728_fix_user_names.rb
+++ b/decidim-core/db/migrate/20190412131728_fix_user_names.rb
@@ -8,7 +8,7 @@ class FixUserNames < ActiveRecord::Migration[5.2]
     characters_to_remove = "<>?%&^*\#@()[]=+:;\"{}\\|"
 
     weird_characters.each do |character|
-      Decidim::UserBaseEntity.where("name like '%#{character}%' escape '\'").find_each do |entity|
+      Decidim::UserBaseEntity.where("name like '%#{character}%' escape '\' OR nickname like '%#{character}%' escape '\'").find_each do |entity|
         p "detected character: #{character}"
         p "UserBaseEntity ID: #{entity.id}"
         p "#{entity.name} => #{entity.name.delete(characters_to_remove).strip}"

--- a/decidim-core/db/migrate/20190412131728_fix_user_names.rb
+++ b/decidim-core/db/migrate/20190412131728_fix_user_names.rb
@@ -4,7 +4,7 @@ class FixUserNames < ActiveRecord::Migration[5.2]
   def change
     # Comes from Decidim::User specs
     weird_characters =
-      ["<", ">", "?", "\\%", "&", "^", "*", "#", "@", "(", ")", "[", "]", "=", "+", ":", ";", "\"", "{", "}", "\\", "|"]
+      ["<", ">", "?", "\\%", "&", "^", "*", "#", "@", "(", ")", "[", "]", "=", "+", ":", ";", "\"", "{", "}", "\\", "|", "/"]
     characters_to_remove = "<>?%&^*\#@()[]=+:;\"{}\\|"
 
     weird_characters.each do |character|

--- a/decidim-core/db/migrate/20190412131728_fix_user_names.rb
+++ b/decidim-core/db/migrate/20190412131728_fix_user_names.rb
@@ -5,7 +5,7 @@ class FixUserNames < ActiveRecord::Migration[5.2]
     # Comes from Decidim::User specs
     weird_characters =
       ["<", ">", "?", "\\%", "&", "^", "*", "#", "@", "(", ")", "[", "]", "=", "+", ":", ";", "\"", "{", "}", "\\", "|", "/"]
-    characters_to_remove = "<>?%&^*\#@()[]=+:;\"{}\\|"
+    characters_to_remove = "<>?%&^*\#@()[]=+:;\"{}\\|/"
 
     weird_characters.each do |character|
       Decidim::UserBaseEntity.where("name like '%#{character}%' escape '\' OR nickname like '%#{character}%' escape '\'").find_each do |entity|

--- a/decidim-core/db/migrate/20190412131728_fix_user_names.rb
+++ b/decidim-core/db/migrate/20190412131728_fix_user_names.rb
@@ -9,10 +9,10 @@ class FixUserNames < ActiveRecord::Migration[5.2]
 
     weird_characters.each do |character|
       Decidim::UserBaseEntity.where("name like '%#{character}%' escape '\' OR nickname like '%#{character}%' escape '\'").find_each do |entity|
-        p "detected character: #{character}"
-        p "UserBaseEntity ID: #{entity.id}"
-        p "#{entity.name} => #{entity.name.delete(characters_to_remove).strip}"
-        p "#{entity.nickname} => #{entity.nickname.delete(characters_to_remove).strip}"
+        Rails.logger.log "detected character: #{character}"
+        Rails.logger.log "UserBaseEntity ID: #{entity.id}"
+        Rails.logger.log "#{entity.name} => #{entity.name.delete(characters_to_remove).strip}"
+        Rails.logger.log "#{entity.nickname} => #{entity.nickname.delete(characters_to_remove).strip}"
 
         entity.name = entity.name.delete(characters_to_remove).strip
         entity.nickname = entity.nickname.delete(characters_to_remove).strip


### PR DESCRIPTION
#### :tophat: What? Why?
Since #4317, user names/nicknames are not allowed to have some special characters. Some of them seem to still have them, since we have reports about them.

This PR adds a migration that removes these special characters from the user names and nicknames. Also applies to user groups.

#### :pushpin: Related Issues
- Fixes #5018

#### :clipboard: Subtasks
None