### PR TITLE
Add optional parameter :col_sep to CSV exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Added**:
 
+- **decidim-core** Add optional parameter :col_sep to CSV exporter [\#5089](https://github.com/decidim/decidim/pull/5089)
 - **decidim-meetings** Let user groups join meetings [\#5060](https://github.com/decidim/decidim/pull/5060)
 - **decidim-assemblies**, **decidim-participatory_processes** Reorganize admin form [\#5068](https://github.com/decidim/decidim/pull/5068)
 - **decidim-assemblies**, **decidim-participatory_processes** Table headers sortable links [\#5010](https://github.com/decidim/decidim/pull/5010)

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -261,6 +261,11 @@ module Decidim
   # signature to the document
   config_accessor :pdf_signature_service
 
+  # Exposes a configuration option: Decidim::Exporters::CSV's default column separator
+  config_accessor :default_csv_col_sep do
+    ";"
+  end
+
   # Public: Registers a global engine. This method is intended to be used
   # by component engines that also offer unscoped functionality
   #

--- a/decidim-core/lib/decidim/exporters/csv.rb
+++ b/decidim-core/lib/decidim/exporters/csv.rb
@@ -15,8 +15,8 @@ module Decidim
       # provided serializer and following the previously described strategy.
       #
       # Returns an ExportData instance.
-      def export
-        data = ::CSV.generate(headers: headers, write_headers: true, col_sep: ";") do |csv|
+      def export(col_sep = ";")
+        data = ::CSV.generate(headers: headers, write_headers: true, col_sep: col_sep) do |csv|
           processed_collection.each do |resource|
             csv << headers.map { |header| resource[header] }
           end

--- a/decidim-core/lib/decidim/exporters/csv.rb
+++ b/decidim-core/lib/decidim/exporters/csv.rb
@@ -15,7 +15,7 @@ module Decidim
       # provided serializer and following the previously described strategy.
       #
       # Returns an ExportData instance.
-      def export(col_sep = ";")
+      def export(col_sep = Decidim.default_csv_col_sep)
         data = ::CSV.generate(headers: headers, write_headers: true, col_sep: col_sep) do |csv|
           processed_collection.each do |resource|
             csv << headers.map { |header| resource[header] }


### PR DESCRIPTION
#### :tophat: What? Why?
>Currently, Decidim::Exporters::CSV exports all data separated by a semicolon.
>It would be nice to add an optional parameter so the String placed between each field can be changed.

#### :pushpin: Related Issues
- Related to #5089

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry