### PR TITLE
Fix ParticipatoryProcesses admin dashboard process group link

### DIFF
--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/index.html.erb
@@ -6,7 +6,7 @@
       <% if @process_group %>
         <span>&lt;</span>
         <%= link_to translated_attribute(@process_group.name),
-            decidim_participatory_processes.participatory_process_group_path(@process_group) %>
+                    edit_participatory_process_group_path(@process_group) %>
       <% end %>
 
       <% if allowed_to? :create, :process %>

--- a/decidim-participatory_processes/spec/shared/manage_processes_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_processes_examples.rb
@@ -1,6 +1,37 @@
 # frozen_string_literal: true
 
 shared_examples "manage processes examples" do
+  context "when viewing the processes list" do
+    let!(:process_group) { create(:participatory_process_group, organization: organization) }
+    let!(:process_with_group) { create(:participatory_process, organization: organization, participatory_process_group: process_group) }
+    let!(:process_without_group) { create(:participatory_process, organization: organization) }
+
+    before do
+      visit decidim_admin_participatory_processes.participatory_processes_path
+    end
+
+    it "allows the user to filter processes by process_group" do
+      find("button", text: "PROCESS GROUPS").click
+      click_link translated(process_group.name)
+
+      expect(page).to have_content(translated(process_with_group.title))
+      expect(page).not_to have_content(translated(process_without_group.title))
+    end
+
+    context "when processes are filtered by process_group" do
+      before do
+        find("button", text: "PROCESS GROUPS").click
+        click_link translated(process_group.name)
+      end
+
+      it "allows the user to edit the process_group" do
+        click_link translated(process_group.name)
+
+        expect(page).to have_content("EDIT PROCESS GROUP")
+      end
+    end
+  end
+
   context "when previewing processes" do
     context "when the process is unpublished" do
       let!(:participatory_process) { create(:participatory_process, :unpublished, organization: organization) }
@@ -25,35 +56,6 @@ shared_examples "manage processes examples" do
 
         expect(page).to have_current_path decidim_participatory_processes.participatory_process_path(participatory_process)
         expect(page).to have_content(translated(participatory_process.title))
-      end
-    end
-  end
-
-  context "when viewing the processes list" do
-    context "when a process belongs to a process_group" do
-      let!(:process_group) { Decidim::ParticipatoryProcessGroup.last }
-      let!(:process_with_group) { create(:participatory_process, organization: organization, participatory_process_group: process_group) }
-      let!(:process_without_group) { create(:participatory_process, organization: organization) }
-
-      it "can be filtered by process_group" do
-        find("button", text: "PROCESS GROUPS").click
-        click_link translated(process_group.name)
-
-        expect(page).to have_content(translated(process_with_group.title))
-        expect(page).not_to have_content(translated(process_without_group.title))
-      end
-
-      context "when the process is filtered by its group" do
-        before do
-          find("button", text: "PROCESS GROUPS").click
-          click_link translated(process_group.name)
-        end
-
-        it "allows the user to edit the process_group by clicking its name" do
-          click_link translated(process_group.name)
-
-          expect(page).to have_content("EDIT PROCESS GROUP")
-        end
       end
     end
   end

--- a/decidim-participatory_processes/spec/shared/manage_processes_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_processes_examples.rb
@@ -18,13 +18,42 @@ shared_examples "manage processes examples" do
     context "when the process is published" do
       let!(:participatory_process) { create(:participatory_process, organization: organization) }
 
-      it "allows the user to preview the unpublished process" do
+      it "allows the user to preview the published process" do
         within find("tr", text: translated(participatory_process.title)) do
           click_link "Preview"
         end
 
         expect(page).to have_current_path decidim_participatory_processes.participatory_process_path(participatory_process)
         expect(page).to have_content(translated(participatory_process.title))
+      end
+    end
+  end
+
+  context "when viewing the processes list" do
+    context "when a process belongs to a process_group" do
+      let!(:process_group) { Decidim::ParticipatoryProcessGroup.last }
+      let!(:process_with_group) { create(:participatory_process, organization: organization, participatory_process_group: process_group) }
+      let!(:process_without_group) { create(:participatory_process, organization: organization) }
+
+      it "can be filtered by process_group" do
+        find("button", text: "PROCESS GROUPS").click
+        click_link translated(process_group.name)
+
+        expect(page).to have_content(translated(process_with_group.title))
+        expect(page).not_to have_content(translated(process_without_group.title))
+      end
+
+      context "when the process is filtered by its group" do
+        before do
+          find("button", text: "PROCESS GROUPS").click
+          click_link translated(process_group.name)
+        end
+
+        it "allows the user to edit the process_group by clicking its name" do
+          click_link translated(process_group.name)
+
+          expect(page).to have_content("EDIT PROCESS GROUP")
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
The `ParticipatoryProcessGroup` name link pointed to the public view instead of the bakcoffice.

#### :pushpin: Related Issues
- Related to #5009 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)
![processes_by_group](https://user-images.githubusercontent.com/40306853/56293001-8d605e80-6128-11e9-9bca-16632719d0ff.png)

