### PR TITLE
add card-stack to assemblies card when have children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 **Fixed**:
 
+- **decidim-assemblies**: Add class `card--stack` to assemblies when have children assemblies. [#5093](https://github.com/decidim/decidim/pull/5093)
 - **decidim-proposals**: Fix proposal participants metrics. [#5048](https://github.com/decidim/decidim/pull/5048)
 - **decidim-comments**: Don't show a second reply button when comment is hidden. [#5045](https://github.com/decidim/decidim/pull/5045)
 - **decidim-core**: Fix CSS transparencies using customized colors. [\#5071](https://github.com/decidim/decidim/pull/5071)

--- a/decidim-assemblies/app/cells/decidim/assemblies/assembly_m_cell.rb
+++ b/decidim-assemblies/app/cells/decidim/assemblies/assembly_m_cell.rb
@@ -18,6 +18,10 @@ module Decidim
         true
       end
 
+      def has_children?
+        model.children.any?
+      end
+
       def resource_path
         Decidim::Assemblies::Engine.routes.url_helpers.assembly_path(model)
       end
@@ -27,7 +31,26 @@ module Decidim
       end
 
       def statuses
-        [:creation_date, :follow]
+        return super unless has_children?
+        [:creation_date, :follow, :children_count]
+      end
+
+      def children_count_status
+        content_tag(
+          :strong,
+          t("layouts.decidim.assemblies.index.children")
+        ) + " " + children_assemblies_visible_for_user
+      end
+
+      def children_assemblies_visible_for_user
+        assemblies = model.children.published
+
+        if current_user
+          return assemblies.count.to_s if current_user.admin
+          assemblies.visible_for(current_user).count.to_s
+        else
+          assemblies.public_spaces.count.to_s
+        end
       end
 
       def resource_icon

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -360,7 +360,7 @@ en:
           more_info: More info
           take_part: Take part
         index:
-          children: "Assemblies: "
+          children: 'Assemblies: '
           organizational_chart: Organizational chart
           promoted_assemblies: Highlighted assemblies
           reset_chart: Reset

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -360,6 +360,7 @@ en:
           more_info: More info
           take_part: Take part
         index:
+          children: "Assemblies: "
           organizational_chart: Organizational chart
           promoted_assemblies: Highlighted assemblies
           reset_chart: Reset

--- a/decidim-assemblies/spec/system/assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/assemblies_spec.rb
@@ -112,6 +112,7 @@ describe "Assemblies", type: :system do
         expect(page).to have_content(translated(assembly.title, locale: :en))
         expect(page).to have_content(translated(promoted_assembly.title, locale: :en))
         expect(page).to have_selector("article.card", count: 2)
+        expect(page).to have_selector("article.card.card--stack", count: 1)
 
         expect(page).not_to have_content(translated(child_assembly.title, locale: :en))
         expect(page).not_to have_content(translated(unpublished_assembly.title, locale: :en))

--- a/decidim-core/app/cells/decidim/card_m_cell.rb
+++ b/decidim-core/app/cells/decidim/card_m_cell.rb
@@ -30,6 +30,10 @@ module Decidim
       false
     end
 
+    def has_children?
+      false
+    end
+
     def has_link_to_resource?
       true
     end
@@ -84,6 +88,7 @@ module Decidim
 
     def card_classes
       classes = [base_card_class]
+      classes = classes.concat(["card--stack"]).join(" ") if has_children?
       return classes unless has_state?
       classes.concat(state_classes).join(" ")
     end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds "card--stack" class to assemblies that has children.

#### :pushpin: Related Issues
- Related to #4773 
- Fixes #4773

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] add card--stack to assemblies cell. 
- [x] Add tests

### :camera: Screenshots (optional)
![Description](URL)

![screenshot-localhost-3000-2019 04 23-14-22-01](https://user-images.githubusercontent.com/28536082/56581414-33064880-65d5-11e9-9dbd-e0b17d749d3d.png)

