### PR TITLE
Fix participatory text form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 **Fixed**:
 
+- **decidim-proposals**: Fix participatory text form. [#5094](https://github.com/decidim/decidim/pull/5094)
 - **decidim-proposals**: Fix proposal participants metrics. [#5048](https://github.com/decidim/decidim/pull/5048)
 - **decidim-comments**: Don't show a second reply button when comment is hidden. [#5045](https://github.com/decidim/decidim/pull/5045)
 - **decidim-core**: Fix CSS transparencies using customized colors. [\#5071](https://github.com/decidim/decidim/pull/5071)

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -190,6 +190,7 @@ ignore_unused:
   - decidim.searches.filters.state.*
   - decidim.assemblies.filter.*
   - decidim.initiatives.initiatives.votes_count.count.*
+  - decidim.proposals.admin.participatory_texts.new_import.accepted_mime_types.*
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/decidim-proposals/app/forms/decidim/proposals/admin/import_participatory_text_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/import_participatory_text_form.rb
@@ -14,8 +14,43 @@ module Decidim
         translatable_attribute :description, String
         attribute :document
 
+        validates :document, presence: true, if: :new_participatory_text?
         validates :title, translatable_presence: true
-        validate :accepted_mime_type
+        validate :document_type_must_be_valid, if: :document
+
+        # Assume it's a NEW participatory_text if there are no proposals
+        # Validate document presence while CREATING proposals from document
+        # Allow skipping document validation while UPDATING title/description
+        def new_participatory_text?
+          Decidim::Proposals::Proposal.where(component: current_component).blank?
+        end
+
+        def document_type_must_be_valid
+          return if valid_mime_types.include?(document_type)
+
+          errors.add(:document, i18n_invalid_document_type_text)
+        end
+
+        # Return ACCEPTED_MIME_TYPES plus `text/plain` for better markdown support
+        def valid_mime_types
+          ACCEPTED_MIME_TYPES.values + [Decidim::Proposals::DocToMarkdown::TEXT_PLAIN_MIME_TYPE]
+        end
+
+        def document_type
+          document.content_type
+        end
+
+        def i18n_invalid_document_type_text
+          I18n.t("invalid_document_type",
+                 scope: "activemodel.errors.models.participatory_text.attributes.document.invalid_document_type",
+                 valid_mime_types: i18n_valid_mime_types_text)
+        end
+
+        def i18n_valid_mime_types_text
+          ACCEPTED_MIME_TYPES.keys.map do |type|
+            I18n.t("decidim.proposals.admin.participatory_texts.new_import.accepted_mime_types.#{type}")
+          end.join(", ")
+        end
 
         def default_locale
           current_participatory_space.organization.default_locale
@@ -23,21 +58,6 @@ module Decidim
 
         def document_text
           @document_text ||= document&.read
-        end
-
-        def document_type
-          document.content_type
-        end
-
-        def accepted_mime_type
-          accepted_mime_types = ACCEPTED_MIME_TYPES.values + [Decidim::Proposals::DocToMarkdown::TEXT_PLAIN_MIME_TYPE]
-          return if accepted_mime_types.include?(document_type)
-
-          errors.add(:document,
-                     I18n.t("activemodel.errors.models.participatory_text.attributes.document.invalid_document_type",
-                            valid_mime_types: ACCEPTED_MIME_TYPES.keys.map do |m|
-                              I18n.t("decidim.proposals.admin.participatory_texts.new_import.accepted_mime_types.#{m}")
-                            end.join(", ")))
         end
       end
     end

--- a/decidim-proposals/app/forms/decidim/proposals/admin/import_participatory_text_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/import_participatory_text_form.rb
@@ -14,8 +14,8 @@ module Decidim
         translatable_attribute :description, String
         attribute :document
 
-        validates :document, presence: true, if: :new_participatory_text?
         validates :title, translatable_presence: true
+        validates :document, presence: true, if: :new_participatory_text?
         validate :document_type_must_be_valid, if: :document
 
         # Assume it's a NEW participatory_text if there are no proposals
@@ -42,7 +42,7 @@ module Decidim
 
         def i18n_invalid_document_type_text
           I18n.t("invalid_document_type",
-                 scope: "activemodel.errors.models.participatory_text.attributes.document.invalid_document_type",
+                 scope: "activemodel.errors.models.participatory_text.attributes.document",
                  valid_mime_types: i18n_valid_mime_types_text)
         end
 

--- a/decidim-proposals/app/forms/decidim/proposals/admin/import_participatory_text_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/import_participatory_text_form.rb
@@ -47,8 +47,8 @@ module Decidim
         end
 
         def i18n_valid_mime_types_text
-          ACCEPTED_MIME_TYPES.keys.map do |type|
-            I18n.t("decidim.proposals.admin.participatory_texts.new_import.accepted_mime_types.#{type}")
+          ACCEPTED_MIME_TYPES.keys.map do |mime_type|
+            I18n.t(mime_type, scope: "decidim.proposals.admin.participatory_texts.new_import.accepted_mime_types")
           end.join(", ")
         end
 

--- a/decidim-proposals/spec/forms/decidim/proposals/admin/import_participatory_text_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/admin/import_participatory_text_form_spec.rb
@@ -8,7 +8,7 @@ module Decidim
       describe ImportParticipatoryTextForm do
         subject { form }
 
-        let(:component) { create :component }
+        let(:component) { create :component, manifest_name: "proposals" }
         let(:title) do
           {
             ca: "Yes very good, patates amb suc",
@@ -44,10 +44,22 @@ module Decidim
           it { is_expected.to be_invalid }
         end
 
-        context "when the document is not valid" do
-          let(:document_file) { nil }
+        context "when creating a participatory_text" do
+          context "when the document is not valid" do
+            let(:document) { nil }
 
-          it { is_expected.to be_valid }
+            it { is_expected.to be_invalid }
+          end
+        end
+
+        context "when updating a participatory_text which has existing proposals" do
+          let!(:proposal) { create :proposal, component: component }
+
+          context "when the document is not valid" do
+            let(:document) { nil }
+
+            it { is_expected.to be_valid }
+          end
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
>**Describe the bug**
If I have a proposal component with the "participatory texts" flag active, and I try to create a participatory text without uploading any file, the platform generates a server error (undefined method "content_type" for nil).

>**Expected behavior**
The form should validate there's an uploaded document.

As @tramuntanal said in https://github.com/decidim/decidim/issues/5074#issuecomment-485741119:
>The form should validate there's an uploaded document only on create.

#### Also
- Added an exception to ignore `I18n sanity does not have unused keys`. An image is attached as proof that the keys are being used.

#### :pushpin: Related Issues
- Fixes #5074 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)
![i18n_invalid_document_type_text_translation](https://user-images.githubusercontent.com/40306853/56590427-6225b580-65e7-11e9-80f5-c2d66408ca3f.png)
