### PR TITLE
Import proposals to budgets includes scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - **decidim-admin**, **decidim-forms**, **decidim-meetings**: Fix dynamic fields components on IE11. [#5052](https://github.com/decidim/decidim/pull/5052)
 - **decidim-core**: Fix possible NoMethodErrors in the notification jobs filling logs. [#5083](https://github.com/decidim/decidim/pull/5083)
 - **decidim-participatory_processes**: Fix step CTA URL when abse URL had params [#5082](https://github.com/decidim/decidim/pull/5082)
+- **decidim-budgets**: Fix import of proposals to budget projects [#5097](https://github.com/decidim/decidim/pull/5097)
 
 **Removed**:
 

--- a/decidim-budgets/app/commands/decidim/budgets/admin/import_proposals_to_budgets.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/admin/import_proposals_to_budgets.rb
@@ -39,6 +39,7 @@ module Decidim
               project.description = project_localized(original_proposal.body)
               project.budget = form.default_budget
               project.category = original_proposal.category
+              project.scope = original_proposal.scope
               project.component = target_component
               project.save!
 

--- a/decidim-budgets/spec/commands/admin/import_proposals_to_budgets_spec.rb
+++ b/decidim-budgets/spec/commands/admin/import_proposals_to_budgets_spec.rb
@@ -98,6 +98,7 @@ module Decidim
               expect(translated(new_project.title)).to eq(proposal.title)
               expect(translated(new_project.description)).to eq(proposal.body)
               expect(new_project.category).to eq(proposal.category)
+              expect(new_project.scope).to eq(proposal.scope)
             end
           end
         end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes the import from proposals to budget projects which now includes the scope.

#### :pushpin: Related Issues
- Fixes #5096

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
