### PR TITLE
Remove useless button on the admin page for accountability statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - **decidim-admin**, **decidim-forms**, **decidim-meetings**: Fix dynamic fields components on IE11. [#5052](https://github.com/decidim/decidim/pull/5052)
 - **decidim-core**: Fix possible NoMethodErrors in the notification jobs filling logs. [#5083](https://github.com/decidim/decidim/pull/5083)
 - **decidim-participatory_processes**: Fix step CTA URL when abse URL had params [#5082](https://github.com/decidim/decidim/pull/5082)
+- **decidim-accountability**: Remove useless button on the admin page for accountability statuses [#5099](https://github.com/decidim/decidim/pull/5099)
 
 **Removed**:
 

--- a/decidim-accountability/app/views/decidim/accountability/admin/statuses/index.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/statuses/index.html.erb
@@ -3,7 +3,6 @@
     <h2 class="card-title">
       <%= t(".title") %>
       <%= link_to t("actions.new", scope: "decidim.accountability", name: t("models.status.name", scope: "decidim.accountability.admin")), new_status_path, class: "button tiny button--title" if allowed_to? :create, :status %>
-      <%= render partial: "decidim/accountability/admin/shared/subnav" %>
     </h2>
   </div>
 


### PR DESCRIPTION
#### :tophat: What? Why?

Remove useless button on the admin page for accountability statuses

#### :pushpin: Related Issues
- Fixes #5098

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![Capture d’écran 2019-04-25 à 12 51 08](https://user-images.githubusercontent.com/7223028/56730719-e3e92080-6758-11e9-9d2f-57829070f637.png)
