### PR TITLE
Fixed wrong string in en.yml

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -40,7 +40,7 @@ en:
         one: Amendment
         other: Amendments
       decidim/user:
-        one: No participants
+        one: Participant
         other: Participants
       decidim/user_group:
         one: Group


### PR DESCRIPTION
#### :tophat: What? Why?
Participants CardM are rendered with a wrong label: "No participants" ; It should be "Participant".

To reproduce: visit the followers or followings of a participant profile :
- https://meta.decidim.org/profiles/agustibr/following
- https://meta.decidim.org/profiles/agustibr/followers


#### :clipboard: Subtasks
Note: Not adding this to the changelog since this is a minimum change
