### PR TITLE
Add styles on votes pdf inline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - **decidim-core**: Change attachment photo image alt texts to title instead of description. [#5043](https://github.com/decidim/decidim/pull/5043)
 - **decidim-comments**: Allow cancelling a vote on a comment. [#5042](https://github.com/decidim/decidim/pull/5042)
+- **decidim-initiatives**: Add styles inline in PDF document of signatures [#5103](https://github.com/decidim/decidim/pull/5103)
 
 **Fixed**:
 

--- a/decidim-initiatives/app/cells/decidim/initiatives_votes/vote/show.erb
+++ b/decidim-initiatives/app/cells/decidim/initiatives_votes/vote/show.erb
@@ -1,29 +1,30 @@
-<div class="initiatives-votes-table-row">
-  <div class="initiatives-votes-table-cell w11">
+<br />
+<div class="initiatives-votes-table-row" style="width: 100%; display: inline-block; min-height: 33pt; border-bottom: 1pt solid black;">
+  <div class="initiatives-votes-table-cell w11" style="width: 10.8%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
     <%= initiative_id %>
   </div>
-  <div class="initiatives-votes-table-cell w11">
+  <div class="initiatives-votes-table-cell w11" style="width: 10.8%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
     <%= initiative_title %>
   </div>
-  <div class="initiatives-votes-table-cell w11">
+  <div class="initiatives-votes-table-cell w11" style="width: 10.8%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
     <%= name_and_surname %>
   </div>
-  <div class="initiatives-votes-table-cell w11">
+  <div class="initiatives-votes-table-cell w11" style="width: 10.8%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
     <%= document_number %>
   </div>
-  <div class="initiatives-votes-table-cell w11">
+  <div class="initiatives-votes-table-cell w11" style="width: 10.8%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
     <%= date_of_birth %>
   </div>
-  <div class="initiatives-votes-table-cell w11">
+  <div class="initiatives-votes-table-cell w11" style="width: 10.8%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
     <%= postal_code %>
   </div>
-  <div class="initiatives-votes-table-cell w11">
+  <div class="initiatives-votes-table-cell w11" style="width: 10.8%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
     <%= time_and_date %>
   </div>
-  <div class="initiatives-votes-table-cell w11">
+  <div class="initiatives-votes-table-cell w11" style="width: 10.8%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
     <%= timestamp %>
   </div>
-  <div class="initiatives-votes-table-cell w11">
+  <div class="initiatives-votes-table-cell w11" style="width: 10.8%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
     <%= hash_id %>
   </div>
 </div>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/export_pdf_signatures.pdf.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/export_pdf_signatures.pdf.erb
@@ -1,33 +1,73 @@
-<div class="initiative-title"> <%= translated_attribute(current_initiative.title) %> </div>
-<div class="initiatives-votes-table">
-  <div class="initiatives-votes-table-header">
-    <div class="initiatives-votes-table-cell w20"><%= t("models.initiatives_votes.fields.initiative_id", scope: "decidim.admin") %></div>
-    <div class="initiatives-votes-table-cell w20"><%= t("models.initiatives_votes.fields.initiative_title", scope: "decidim.admin") %></div>
-    <div class="initiatives-votes-table-cell w20"><%= t("models.initiatives_votes.fields.initiative_start_date", scope: "decidim.admin") %></div>
-    <div class="initiatives-votes-table-cell w20"><%= t("models.initiatives_votes.fields.initiative_end_date", scope: "decidim.admin") %></div>
-    <div class="initiatives-votes-table-cell w20"><%= t("models.initiatives_votes.fields.initiative_signatures_count", scope: "decidim.admin") %></div>
+<div class="initiative-title" style="border: 1pt solid black; margin: 15pt 0; font-size: 12pt; font-weight: bold; text-transform: uppercase; text-align: center;">
+  <%= translated_attribute(current_initiative.title) %>
+</div>
+<div class="initiatives-votes-table" style="width: 100%; display: block; border: 1pt solid black;">
+  <div class="initiatives-votes-table-header" style="background-color: lightgray; display: inline-block; width: 100%; font-size: 12pt; font-weight: bold; border-bottom: 1pt solid black;">
+    <div class="initiatives-votes-table-cell w20" style="width: 19%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
+      <%= t("models.initiatives_votes.fields.initiative_id", scope: "decidim.admin") %>
+    </div>
+    <div class="initiatives-votes-table-cell w20" style="width: 19%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
+      <%= t("models.initiatives_votes.fields.initiative_title", scope: "decidim.admin") %>
+    </div>
+    <div class="initiatives-votes-table-cell w20" style="width: 19%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
+      <%= t("models.initiatives_votes.fields.initiative_start_date", scope: "decidim.admin") %>
+    </div>
+    <div class="initiatives-votes-table-cell w20" style="width: 19%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
+      <%= t("models.initiatives_votes.fields.initiative_end_date", scope: "decidim.admin") %>
+    </div>
+    <div class="initiatives-votes-table-cell w20" style="width: 19%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
+      <%= t("models.initiatives_votes.fields.initiative_signatures_count", scope: "decidim.admin") %>
+    </div>
   </div>
-  <div class="initiatives-votes-table-row">
-    <div class="initiatives-votes-table-cell w20"><%= current_initiative.reference %></div>
-    <div class="initiatives-votes-table-cell w20"><%= translated_attribute(current_initiative.title) %></div>
-    <div class="initiatives-votes-table-cell w20"><%= current_initiative.signature_start_date %></div>
-    <div class="initiatives-votes-table-cell w20"><%= current_initiative.signature_end_date %></div>
-    <div class="initiatives-votes-table-cell w20"><%= @votes.count %></div>
+  <div class="initiatives-votes-table-row" style="width: 100%; display: inline-block; min-height: 33pt;">
+    <div class="initiatives-votes-table-cell w20" style="width: 19%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
+      <%= current_initiative.reference %>
+    </div>
+    <div class="initiatives-votes-table-cell w20" style="width: 19%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
+      <%= translated_attribute(current_initiative.title) %>
+    </div>
+    <div class="initiatives-votes-table-cell w20" style="width: 19%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
+      <%= current_initiative.signature_start_date %>
+    </div>
+    <div class="initiatives-votes-table-cell w20" style="width: 19%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
+      <%= current_initiative.signature_end_date %>
+    </div>
+    <div class="initiatives-votes-table-cell w20" style="width: 19%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
+      <%= @votes.count %>
+    </div>
   </div>
 </div>
 <br />
 <br />
-<div class="initiatives-votes-table">
-  <div class="initiatives-votes-table-header">
-    <div class="initiatives-votes-table-cell w11"><%= t("models.initiatives_votes.fields.initiative_id", scope: "decidim.admin") %></div>
-    <div class="initiatives-votes-table-cell w11"><%= t("models.initiatives_votes.fields.initiative_title", scope: "decidim.admin") %></div>
-    <div class="initiatives-votes-table-cell w11"><%= t("models.initiatives_votes.fields.name_and_surname", scope: "decidim.admin") %></div>
-    <div class="initiatives-votes-table-cell w11"><%= t("models.initiatives_votes.fields.document_number", scope: "decidim.admin") %></div>
-    <div class="initiatives-votes-table-cell w11"><%= t("models.initiatives_votes.fields.date_of_birth", scope: "decidim.admin") %></div>
-    <div class="initiatives-votes-table-cell w11"><%= t("models.initiatives_votes.fields.postal_code", scope: "decidim.admin") %></div>
-    <div class="initiatives-votes-table-cell w11"><%= t("models.initiatives_votes.fields.time_and_date", scope: "decidim.admin") %></div>
-    <div class="initiatives-votes-table-cell w11"><%= t("models.initiatives_votes.fields.timestamp", scope: "decidim.admin") %></div>
-    <div class="initiatives-votes-table-cell w11"><%= t("models.initiatives_votes.fields.hash", scope: "decidim.admin") %></div>
+<div class="initiatives-votes-table" style="width: 100%; display: block; border: 1pt solid black;">
+  <div class="initiatives-votes-table-header" style="background-color: lightgray; display: inline-block; width: 100%; font-size: 12pt; font-weight: bold; border-bottom: 1pt solid black;">
+    <div class="initiatives-votes-table-cell w11" style="width: 10.8%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
+      <%= t("models.initiatives_votes.fields.initiative_id", scope: "decidim.admin") %>
+    </div>
+    <div class="initiatives-votes-table-cell w11" style="width: 10.8%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
+      <%= t("models.initiatives_votes.fields.initiative_title", scope: "decidim.admin") %>
+    </div>
+    <div class="initiatives-votes-table-cell w11" style="width: 10.8%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
+      <%= t("models.initiatives_votes.fields.name_and_surname", scope: "decidim.admin") %>
+    </div>
+    <div class="initiatives-votes-table-cell w11" style="width: 10.8%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
+      <%= t("models.initiatives_votes.fields.document_number", scope: "decidim.admin") %>
+    </div>
+    <div class="initiatives-votes-table-cell w11" style="width: 10.8%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
+      <%= t("models.initiatives_votes.fields.date_of_birth", scope: "decidim.admin") %>
+    </div>
+    <div class="initiatives-votes-table-cell w11" style="width: 10.8%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
+      <%= t("models.initiatives_votes.fields.postal_code", scope: "decidim.admin") %>
+    </div>
+    <div class="initiatives-votes-table-cell w11" style="width: 10.8%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
+      <%= t("models.initiatives_votes.fields.time_and_date", scope: "decidim.admin") %>
+    </div>
+    <div class="initiatives-votes-table-cell w11" style="width: 10.8%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
+      <%= t("models.initiatives_votes.fields.timestamp", scope: "decidim.admin") %>
+    </div>
+    <div class="initiatives-votes-table-cell w11" style="width: 10.8%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
+      <%= t("models.initiatives_votes.fields.hash", scope: "decidim.admin") %>
+    </div>
   </div>
   <% @votes.each do |vote| %>
     <%= cell "decidim/initiatives_votes/vote", vote %>


### PR DESCRIPTION
#### :tophat: What? Why?

The PDF generated with wicked_pdf gem uses a stylesheets file which is not being loaded in some environments. This PR adds the styles inline on each tag of the html which is going to be transformed in a PDF document.

#### :pushpin: Related Issues
- Related to #4655 
- Related to #4644

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
