### PR TITLE
Provide "good" password rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ end
 - **decidim-accountability**: Also display the main scope as a filter for accountability results [#5022](https://github.com/decidim/decidim/pull/5022)
 - **decidim-system**: Add custom SMTP settings for multitenant [#4698](https://github.com/decidim/decidim/pull/4698)
 - **decidim-proposals**: Add proposal answers to the proposal export [#5139](https://github.com/decidim/decidim/pull/5139)
+- **decidim-core**: Provide "good" password rules [#5106](https://github.com/decidim/decidim/pull/5106)
 
 **Changed**:
 

--- a/decidim-core/app/views/decidim/account/_password_fields.html.erb
+++ b/decidim-core/app/views/decidim/account/_password_fields.html.erb
@@ -1,2 +1,2 @@
-<%= form.password_field :password, value: form.object.password, autocomplete: "off" %>
+<%= form.password_field :password, value: form.object.password, autocomplete: "off", help_text: t("devise.passwords.edit.password_help", minimun_characters: NOBSPW.configuration.min_password_length) %>
 <%= form.password_field :password_confirmation, value: form.object.password_confirmation, autocomplete: "off" %>

--- a/decidim-core/app/views/decidim/devise/passwords/edit.html.erb
+++ b/decidim-core/app/views/decidim/devise/passwords/edit.html.erb
@@ -14,7 +14,7 @@
             <%= f.hidden_field :reset_password_token %>
 
             <div class="field">
-              <%= f.password_field :password, autocomplete: "off" %>
+              <%= f.password_field :password, autocomplete: "off", help_text: t("devise.passwords.edit.password_help", minimun_characters: NOBSPW.configuration.min_password_length) %>
             </div>
 
             <div class="field">

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -45,7 +45,7 @@
             </div>
 
             <div class="field">
-              <%= f.password_field :password, autocomplete: "off" %>
+              <%= f.password_field :password, help_text: t(".password_help", minimun_characters: NOBSPW.configuration.min_password_length), autocomplete: "off" %>
             </div>
 
             <div class="field">

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -326,6 +326,7 @@ en:
           newsletter: Receive an occasional newsletter with relevant information
           newsletter_title: Contact permission
           nickname_help: Your alias (@nickname) in %{organization}
+          password_help: '%{minimun_characters} characters minimum, must not be too common (e.g. 123456) and must be different from your nickname and your email.'
           sign_in: Log in
           sign_up: Sign up
           sign_up_as:
@@ -1099,6 +1100,7 @@ en:
         change_your_password: Change your password
         confirm_new_password: Confirm new password
         new_password: New password
+        password_help: '%{minimun_characters} characters minimum, must not be too common (e.g. 123456) and must be different from your nickname and your email.'
       new:
         forgot_your_password: Forgot your password?
         send_me_reset_password_instructions: Send me reset password instructions

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -326,7 +326,7 @@ en:
           newsletter: Receive an occasional newsletter with relevant information
           newsletter_title: Contact permission
           nickname_help: Your alias (@nickname) in %{organization}
-          password_help: '%{minimun_characters} characters minimum, must not be too common (e.g. 123456) and must be different from your nickname and your email.'
+          password_help: "%{minimun_characters} characters minimum, must not be too common (e.g. 123456) and must be different from your nickname and your email."
           sign_in: Log in
           sign_up: Sign up
           sign_up_as:
@@ -1100,7 +1100,7 @@ en:
         change_your_password: Change your password
         confirm_new_password: Confirm new password
         new_password: New password
-        password_help: '%{minimun_characters} characters minimum, must not be too common (e.g. 123456) and must be different from your nickname and your email.'
+        password_help: "%{minimun_characters} characters minimum, must not be too common (e.g. 123456) and must be different from your nickname and your email."
       new:
         forgot_your_password: Forgot your password?
         send_me_reset_password_instructions: Send me reset password instructions


### PR DESCRIPTION
#### :tophat: What? Why?
As a user, I expect to have all the information I need to fill the registration form. Unfortunately, it happens that there are constraints on the password that aren't explicitly given.

Since the main rule is "minimum 10 characters" (unless configured differently), I expect this rule at least to be shown in the form.

#### :pushpin: Related Issues
- Fixes #5104

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)

![imatge](https://user-images.githubusercontent.com/717367/56950171-2170f380-6b35-11e9-824b-d52a3d63e5bb.png)
