### PR TITLE
fix Decidim::Admin::NewsletterRecipient query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 **Fixed**:
 
+- **decidim-admin**: fix Decidim::Admin::NewsletterRecipient query [\#5109](https://github.com/decidim/decidim/pull/5109)
 - **decidim-proposals**: Fix participatory text form. [#5094](https://github.com/decidim/decidim/pull/5094)
 - **decidim-assemblies**: Add class `card--stack` to assemblies when have children assemblies. [#5093](https://github.com/decidim/decidim/pull/5093)
 - **decidim-proposals**: Fix proposal participants metrics. [#5048](https://github.com/decidim/decidim/pull/5048)

--- a/decidim-admin/app/queries/decidim/admin/newsletter_recipients.rb
+++ b/decidim-admin/app/queries/decidim/admin/newsletter_recipients.rb
@@ -23,6 +23,8 @@ module Decidim
 
         participants = recipients.where(id: participant_ids) if @form.send_to_participants
 
+        recipients = participants if @form.send_to_participants
+        recipients = followers if @form.send_to_followers
         recipients = (followers + participants).uniq if @form.send_to_followers && @form.send_to_participants
 
         recipients


### PR DESCRIPTION
#### :tophat: What? Why?

When sending a Selective Newsletter, in some cases were only followers where selected, the query returns wrong recipients.

This PR fixes this and adds spec examples to assure the query is working as expected.
 
#### :pushpin: Related Issues
- Related to #5039

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
- [x] fix Decidim::Admin::NewsletterRecipient
