### PR TITLE
 Fix deliver_now call on #send_email_confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ end
 
 **Fixed**:
 
+- **decidim-meetings**: Fix `deliver_now` call on `send_email_confirmation` [\#5111](https://github.com/decidim/decidim/pull/5111)
 - **decidim-admin**: fix Decidim::Admin::NewsletterRecipient query [\#5109](https://github.com/decidim/decidim/pull/5109)
 - **decidim-proposals**: Fix participatory text form. [#5094](https://github.com/decidim/decidim/pull/5094)
 - **decidim-assemblies**: Add class `card--stack` to assemblies when have children assemblies. [#5093](https://github.com/decidim/decidim/pull/5093)

--- a/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
@@ -64,11 +64,7 @@ module Decidim
       end
 
       def send_email_confirmation
-        Decidim::Meetings::RegistrationMailer.confirmation(
-          @user,
-          @meeting,
-          @registration
-        ).deliver_now
+        Decidim::Meetings::RegistrationMailer.confirmation(user, meeting, registration).deliver_later
       end
 
       def send_notification_confirmation

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -8,7 +8,7 @@ module Decidim
       include Paginable
       helper Decidim::WidgetUrlsHelper
 
-      helper_method :meetings, :meeting, :search
+      helper_method :meetings, :meeting, :registration, :search
 
       def index
         return unless search.results.empty? && params.dig("filter", "date") != "past"
@@ -36,6 +36,10 @@ module Decidim
 
       def meetings
         @meetings ||= paginate(search.results)
+      end
+
+      def registration
+        @registration ||= meeting.registrations.find_by(user: current_user)
       end
 
       def search_klass

--- a/decidim-meetings/app/helpers/decidim/meetings/meetings_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/meetings_helper.rb
@@ -88,18 +88,20 @@ module Decidim
         html.html_safe
       end
 
-      def registration
-        @registration ||= Decidim::Meetings::Registration
-                          .where(decidim_user_id: current_user)
-                          .find_by(decidim_meeting_id: @meeting.id)
-      end
-
+      # Public: Registration code generic help text.
+      #
+      # Returns a String.
       def registration_code_help_text
         t("registration_code_help_text", scope: "decidim.meetings.meetings.show")
       end
 
-      def registration_validation_state
-        if @registration.validated_at
+      # Public: Registration validation state as text.
+      #
+      # registration - The registration that holds the validation code.
+      #
+      # Returns a String.
+      def validation_state_for(registration)
+        if registration.validated?
           t("validated", scope: "decidim.meetings.meetings.show.registration_state")
         else
           t("validation_pending", scope: "decidim.meetings.meetings.show.registration_state")

--- a/decidim-meetings/app/models/decidim/meetings/registration.rb
+++ b/decidim-meetings/app/models/decidim/meetings/registration.rb
@@ -29,6 +29,13 @@ module Decidim
         pluck(:decidim_user_group_id)
       end
 
+      # Public: Checks if the registration has been validated.
+      #
+      # Returns Boolean.
+      def validated?
+        validated_at?
+      end
+
       private
 
       def generate_code

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -60,7 +60,7 @@ edit_link(
       <% end %>
     </div>
 
-    <% if registration %>
+    <% if registration.present? %>
       <div class="card extra">
         <div class="card__content">
             <div class="registration_code">

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -66,7 +66,7 @@ edit_link(
             <div class="registration_code">
               <span><%= registration_code_help_text %></span>
               <span><strong><%= registration.code %></strong></span>
-              <div class="text-small"><%= registration_validation_state %></div>
+              <div class="text-small"><%= validation_state_for(registration) %></div>
             </div>
         </div>
       </div>


### PR DESCRIPTION
#### :tophat: What? Why?
A few months ago, when I didn't know much, I changed the method `send_email_confirmation` to use `deliver_now` insread of `deliver_later` in the `join_meeting` command. This PR fixes it.

#### :pushpin: Related Issues
- Related to #4636

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry