### PR TITLE
Helper scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ end
 
 **Added**:
 
+- **decidim-core**, Add rake task to recalculate all metrics since some specific date. [#5117](https://github.com/decidim/decidim/pull/5117)
 - **decidim-core**, Add instructions to recalculate participants metrics. [#5110](https://github.com/decidim/decidim/pull/5110)
 - **decidim-core**, **decidim-admin**, Add Selective Newsletter and allow Space admins to manage them. [#5039](https://github.com/decidim/decidim/pull/5039)
 - **decidim-core** Persistence related documentation for Metrics. [\#5108](https://github.com/decidim/decidim/pull/5108)

--- a/decidim-core/lib/tasks/decidim_metrics_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_metrics_tasks.rake
@@ -30,6 +30,41 @@ namespace :decidim do
       end
     end
 
+    desc "Rebuild calculations from specific day"
+    task :rebuild, [:metric, :day] => :environment do |_task, args|
+      metric = args.metric
+      day = args.day
+      if args.day.blank?
+        day = args.metric
+        metric = nil
+      end
+      begin
+        raise ArgumentError if day.blank?
+        (Date.parse(day)..Time.zone.today).each do |d|
+          Decidim::Organization.find_each do |organization|
+            if metric
+              m_manifest = Decidim.metrics_registry.for(metric)
+              puts "[#{organization.name}]: rebuilding metric [#{metric}] for day [#{d}]"
+              call_metric_job(m_manifest, organization, day)
+            else
+              puts "[#{organization.name}]: rebuilding all metrics for day [#{d}]"
+              Decidim.metrics_registry.all.each do |metric_manifest|
+                call_metric_job(metric_manifest, organization, day)
+              end
+            end
+          end
+        end
+      rescue ArgumentError
+        puts "ERROR: Please specify since which date should the metrics be rebuild"
+        puts "ie: rails decidim:metrics:rebuild[2019-01-01]"
+      end
+    end
+
+    desc "Show available metrics"
+    task list: :environment do
+      puts Decidim.metrics_registry.all.pluck :metric_name
+    end
+
     def call_metric_job(metric_manifest, organization, day = nil)
       Decidim::MetricJob.perform_later(
         metric_manifest.manager_class,

--- a/decidim-core/spec/tasks/decidim_tasks_metrics_spec.rb
+++ b/decidim-core/spec/tasks/decidim_tasks_metrics_spec.rb
@@ -48,4 +48,37 @@ describe "Executing Decidim Metrics tasks" do
       end
     end
   end
+
+  describe "rake decidim:metrics:rebuild", type: :task do
+    let!(:organizations) { create_list(:organization, 2) }
+
+    context "when executing task" do
+      after do
+        clear_enqueued_jobs
+      end
+
+      it "does nos create jobs if no date given" do
+        Rake::Task[:"decidim:metrics:rebuild"].reenable
+        expect { Rake::Task[:"decidim:metrics:rebuild"].invoke }.to have_enqueued_job(Decidim::MetricJob).exactly(0).times
+      end
+
+      it "have to be executed without failures" do
+        Rake::Task[:"decidim:metrics:rebuild"].reenable
+        expect { Rake::Task[:"decidim:metrics:rebuild"].invoke(Time.zone.yesterday.to_s) }.not_to raise_error
+        expect { Rake::Task[:"decidim:metrics:rebuild"].invoke(Decidim.metrics_registry.all.first.metric_name, Time.zone.yesterday.to_s) }.not_to raise_error
+      end
+
+      it "creates jobs for each organization and time range" do
+        Rake::Task[:"decidim:metrics:rebuild"].reenable
+        expect { Rake::Task[:"decidim:metrics:rebuild"].invoke(Decidim.metrics_registry.all.first.metric_name, Time.zone.yesterday.to_s) }.to have_enqueued_job(Decidim::MetricJob).at_least(Decidim::Organization.count * 2).times
+      end
+    end
+  end
+
+  describe "rake decidim:metrics:list", type: :task do
+    it "have to be executed without failures" do
+      Rake::Task[:"decidim:metrics:list"].reenable
+      expect { Rake::Task[:"decidim:metrics:rebuild"].invoke }.not_to raise_error
+    end
+  end
 end

--- a/docs/advanced/metrics.md
+++ b/docs/advanced/metrics.md
@@ -21,7 +21,23 @@ Metrics calculations must be executed everyday. Some `rake task` have been added
   bundle exec rake decidim:metrics:one["<metric name>","YYYY-MM-DD"]
   ```
 
+- It is possible to rebuild one or all metrics since some specific day. This is useful in case current metrics are no generated or corrupt. **Depending on the size of the database this can take a long time!**. The command will execute the same calculations as the commands above for **each** day between *today* and the date specified.
+
+- To rebuild metrics since a given date (all or an specific one)
+
+  ```ruby
+  bundle exec rake decidim:metrics:rebuild["YYYY-MM-DD"]
+  bundle exec rake decidim:metrics:rebuild["<metric name>","YYYY-MM-DD"]
+  ```
+
 ## Available metrics
+
+- Use the command `decidim:metrics:list` to list all available metrics using the console:
+
+```ruby
+bundle exec rake decidim:metrics:list
+```
+Currently, available metrics are:
 
 - **users**, created `Users`
 - **proposals**, published, not withdrawn and not *hidden* `Proposals`


### PR DESCRIPTION
#### :tophat: What? Why?

Sometimes you need to rebuild all the metrics of some site. This PR provides a handy rake command to do that since some specific day.

New rake task are:

rebuild all metrics since YYYY-MM-DD:

```ruby
rake decidim:metrics:rebuild[YYYY-MM-DD] 
```
rebuild one specific metric since YYYY-MM-DD:

```ruby
rake decidim:metrics:rebuild[metric_name,YYYY-MM-DD] 
```

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [x] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

All metrics:

```bash
$ bin/rails decidim:metrics:rebuild[2019-05-01] 
[Sauer Group]: rebuilding all metrics for day [2019-05-01]
[Sauer Group]: rebuilding all metrics for day [2019-05-02]
[Sauer Group]: rebuilding all metrics for day [2019-05-03]
[Sauer Group]: rebuilding all metrics for day [2019-05-04]
[Sauer Group]: rebuilding all metrics for day [2019-05-05]
[Sauer Group]: rebuilding all metrics for day [2019-05-06]
[Sauer Group]: rebuilding all metrics for day [2019-05-07]
[Sauer Group]: rebuilding all metrics for day [2019-05-08]
```

One metric:

```bash
$ bin/rails decidim:metrics:rebuild[proposals,2019-05-01]
[Sauer Group]: rebuilding metric [proposals] for day [2019-05-01]
[Sauer Group]: rebuilding metric [proposals] for day [2019-05-02]
[Sauer Group]: rebuilding metric [proposals] for day [2019-05-03]
[Sauer Group]: rebuilding metric [proposals] for day [2019-05-04]
[Sauer Group]: rebuilding metric [proposals] for day [2019-05-05]
[Sauer Group]: rebuilding metric [proposals] for day [2019-05-06]
[Sauer Group]: rebuilding metric [proposals] for day [2019-05-07]
[Sauer Group]: rebuilding metric [proposals] for day [2019-05-08]
```
