### PR TITLE
Fix disallow enabling ParticipatoryText with existing proposals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ end
 
 **Fixed**:
 
+- **decidim-admin**: Fix: disallow enabling `ParticipatoryText` on component when there are proposals [\#5111](https://github.com/decidim/decidim/pull/5111)
 - **decidim-meetings**: Fix `deliver_now` call on `send_email_confirmation` [\#5111](https://github.com/decidim/decidim/pull/5111)
 - **decidim-admin**: fix Decidim::Admin::NewsletterRecipient query [\#5109](https://github.com/decidim/decidim/pull/5109)
 - **decidim-proposals**: Fix participatory text form. [#5094](https://github.com/decidim/decidim/pull/5094)

--- a/decidim-admin/app/assets/javascripts/decidim/admin/form.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/form.js.es6
@@ -1,13 +1,9 @@
 $(() => {
-  const $form = $(".form.edit_component");
+  const $checkbox = $(".participatory_texts_disabled");
 
-  if ($form.length > 0) {
-    const $checkbox = $(".participatory_texts_disabled");
+  if ($checkbox.length > 0) {
+    const $text = $checkbox[0].dataset.text
 
-    if ($checkbox.length > 0) {
-      const $text = $checkbox[0].dataset.text
-
-      $checkbox.parent().after(`<p class="help-text">${$text}</p`)
-    }
+    $checkbox.parent().after(`<p class="help-text">${$text}</p>`)
   }
 });

--- a/decidim-admin/app/assets/javascripts/decidim/admin/form.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/form.js.es6
@@ -1,3 +1,6 @@
+// Checks if the form contains a field with a special CSS class added
+// in Decidim::Admin::SettingsHelper. If so, extracts the stored text and
+// adds a new paragraph after the field.
 $(() => {
   const $checkbox = $(".participatory_texts_disabled");
 

--- a/decidim-admin/app/assets/javascripts/decidim/admin/form.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/form.js.es6
@@ -1,0 +1,13 @@
+$(() => {
+  const $form = $(".form.edit_component");
+
+  if ($form.length > 0) {
+    const $checkbox = $('.participatory_texts_disabled');
+
+    if ($checkbox.length > 0) {
+      const $text = $checkbox[0].dataset.text
+
+      $checkbox.parent().after("<p class='help-text'>"+$text+"</p")
+    }
+  }
+});

--- a/decidim-admin/app/assets/javascripts/decidim/admin/form.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/form.js.es6
@@ -2,12 +2,12 @@ $(() => {
   const $form = $(".form.edit_component");
 
   if ($form.length > 0) {
-    const $checkbox = $('.participatory_texts_disabled');
+    const $checkbox = $(".participatory_texts_disabled");
 
     if ($checkbox.length > 0) {
       const $text = $checkbox[0].dataset.text
 
-      $checkbox.parent().after("<p class='help-text'>"+$text+"</p")
+      $checkbox.parent().after(`<p class="help-text">${$text}</p`)
     }
   }
 });

--- a/decidim-admin/app/controllers/decidim/admin/components_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/components_controller.rb
@@ -64,8 +64,8 @@ module Decidim
           end
 
           on(:invalid) do
-            flash.now[:alert] = I18n.t("components.update.error", scope: "decidim.admin")
-            render action: "new"
+            flash[:alert] = I18n.t("components.update.error", scope: "decidim.admin")
+            redirect_to action: :edit
           end
         end
       end

--- a/decidim-admin/app/forms/decidim/admin/component_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/component_form.rb
@@ -21,7 +21,7 @@ module Decidim
       attribute :step_settings, Hash[String => Object]
       attribute :participatory_space
 
-      validate :must_be_able_to_update_participatory_texts_setting, if: :proposal_component?
+      validate :must_be_able_to_change_participatory_texts_setting, if: :proposal_component?
 
       def settings?
         settings.manifest.attributes.any?
@@ -31,21 +31,23 @@ module Decidim
         default_step_settings.manifest.attributes.any?
       end
 
-      def proposal_component?
-        component.manifest_name == "proposals"
-      end
-
-      # Custom `Proposals` component validation for the global setting
-      # :participatory_texts_enabled. Checkbox's automatically disabled on frontend.
-      # Prevents updating ParticipatoryTexts setting when there are proposals.
-      def must_be_able_to_update_participatory_texts_setting
-        errors.add(:settings) if
-        Decidim::Proposals::Proposal.where(component: component).any? &&
-        component.settings.participatory_texts_enabled != settings[:participatory_texts_enabled]
-      end
-
       def component
-        @component ||= Component.find(id)
+        @component ||= Component.find_by(id: id)
+      end
+
+      def proposal_component?
+        component&.manifest_name == "proposals"
+      end
+
+      # Validation for `Proposals` components. Prevents changing the global
+      # setting `participatory_texts_enabled` when there are proposals.
+      # Does not add a custom error message as it would be unused, because
+      # the setting's checkbox is automatically being disabled on the frontend.
+      def must_be_able_to_change_participatory_texts_setting
+        errors.add(:settings) if
+        settings.dig(:participatory_texts_enabled) &&
+        settings[:participatory_texts_enabled] != component.settings.participatory_texts_enabled &&
+        Decidim::Proposals::Proposal.where(component: component).any?
       end
     end
   end

--- a/decidim-admin/app/forms/decidim/admin/component_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/component_form.rb
@@ -21,12 +21,31 @@ module Decidim
       attribute :step_settings, Hash[String => Object]
       attribute :participatory_space
 
+      validate :must_be_able_to_update_participatory_texts_setting, if: :proposal_component?
+
       def settings?
         settings.manifest.attributes.any?
       end
 
       def default_step_settings?
         default_step_settings.manifest.attributes.any?
+      end
+
+      def proposal_component?
+        component.manifest_name == "proposals"
+      end
+
+      # Custom `Proposals` component validation for the global setting
+      # :participatory_texts_enabled. Checkbox's automatically disabled on frontend.
+      # Prevents updating ParticipatoryTexts setting when there are proposals.
+      def must_be_able_to_update_participatory_texts_setting
+        errors.add(:settings) if
+        Decidim::Proposals::Proposal.where(component: component).any? &&
+        component.settings.participatory_texts_enabled != settings[:participatory_texts_enabled]
+      end
+
+      def component
+        @component ||= Component.find(id)
       end
     end
   end

--- a/decidim-admin/app/forms/decidim/admin/component_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/component_form.rb
@@ -44,10 +44,9 @@ module Decidim
       # Does not add a custom error message as it would be unused, because
       # the setting's checkbox is automatically being disabled on the frontend.
       def must_be_able_to_change_participatory_texts_setting
-        errors.add(:settings) if
-        settings.dig(:participatory_texts_enabled) &&
-        settings[:participatory_texts_enabled] != component.settings.participatory_texts_enabled &&
-        Decidim::Proposals::Proposal.where(component: component).any?
+        return unless settings[:participatory_texts_enabled] &.!= component.settings.participatory_texts_enabled
+
+        errors.add(:settings) if Decidim::Proposals::Proposal.where(component: component).any?
       end
     end
   end

--- a/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
@@ -26,7 +26,7 @@ module Decidim
         if attribute.translated?
           form.send(:translated, form_method_for_attribute(attribute), name, options.merge(tabs_id: "#{options[:tabs_prefix]}-#{name}-tabs"))
         else
-          form.send(form_method_for_attribute(attribute), name, options)
+          form.send(form_method_for_attribute(attribute), name, options.merge(extra_options_for(name)))
         end
       end
 
@@ -35,6 +35,17 @@ module Decidim
       def form_method_for_attribute(attribute)
         return :editor if attribute.type.to_sym == :text && attribute.editor?
         TYPES[attribute.type.to_sym]
+      end
+
+      def extra_options_for(attribute_name)
+        return {} unless attribute_name == :participatory_texts_enabled
+        return {} unless Decidim::Proposals::Proposal.where(decidim_component_id: params[:id]).any?
+
+        {
+          disabled: true,
+          data: { text: t(".participatory_texts_enabled_help") },
+          class: "participatory_texts_disabled"
+        }
       end
     end
   end

--- a/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
@@ -38,15 +38,15 @@ module Decidim
       end
 
       # Disables :participatory_texts_enabled checkbox if the Proposals component
-      # has existing proposals and stores the help text that will be added in a
+      # has existing proposals, and stores the help text that will be added in a
       # new div via JavaScript in "decidim/admin/form".
       #
       # field_name - The name of the field to disable.
       #
       # Returns an empty Hash or a Hash with extra HTML options.
       def extra_options_for(field_name)
-        return {} unless field_name == :participatory_texts_enabled
-        return {} unless Decidim::Proposals::Proposal.where(decidim_component_id: params[:id]).any?
+        return {} unless field_name == :participatory_texts_enabled &&
+                         Decidim::Proposals::Proposal.where(component: @component).any?
 
         {
           class: "participatory_texts_disabled",

--- a/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
@@ -43,7 +43,7 @@ module Decidim
       #
       # field_name - The name of the field to disable.
       #
-      # Returns Nil or a Hash with extra HTML options.
+      # Returns an empty Hash or a Hash with extra HTML options.
       def extra_options_for(field_name)
         return {} unless field_name == :participatory_texts_enabled
         return {} unless Decidim::Proposals::Proposal.where(decidim_component_id: params[:id]).any?

--- a/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
@@ -37,8 +37,15 @@ module Decidim
         TYPES[attribute.type.to_sym]
       end
 
-      def extra_options_for(attribute_name)
-        return {} unless attribute_name == :participatory_texts_enabled
+      # Disables :participatory_texts_enabled checkbox if the Proposals component
+      # has existing proposals and stores the help text that will be added in a
+      # new div via JavaScript in "decidim/admin/form".
+      #
+      # field_name - The name of the field to disable.
+      #
+      # Returns Nil or a Hash with extra HTML options.
+      def extra_options_for(field_name)
+        return {} unless field_name == :participatory_texts_enabled
         return {} unless Decidim::Proposals::Proposal.where(decidim_component_id: params[:id]).any?
 
         {

--- a/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
@@ -49,9 +49,9 @@ module Decidim
         return {} unless Decidim::Proposals::Proposal.where(decidim_component_id: params[:id]).any?
 
         {
+          class: "participatory_texts_disabled",
           disabled: true,
-          data: { text: t(".participatory_texts_enabled_help") },
-          class: "participatory_texts_disabled"
+          data: { text: t("decidim.admin.components.form.participatory_texts_enabled_help") }
         }
       end
     end

--- a/decidim-admin/app/views/decidim/admin/components/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/components/_form.html.erb
@@ -80,3 +80,5 @@
     </div>
   </div>
 </div>
+
+<%= javascript_include_tag "decidim/admin/form" %>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -259,14 +259,14 @@ en:
           title: 'Add component: %{name}'
         publish:
           success: The component has been successfully published.
+        settings_fields:
+          participatory_texts_enabled_help: Cannot do this if there are proposals. Please, create a new `Proposals component` if you want to enable this feature or discard all proposals  in the `Participatory Texts` menu if you want to disable it.
         title: Components
         unpublish:
           success: The component has been successfully unpublished.
         update:
           error: There was a problem updating this component.
           success: The component was updated successfully.
-        settings_fields:
-          participatory_texts_enabled_help: "Cannot do this if there are proposals.\nPlease, create a new `Proposals component` if you want to enable this feature or discard all proposals  in the `Participatory Texts` menu if you want to disable it."
       dashboard:
         show:
           view_more_logs: View more logs

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -247,6 +247,7 @@ en:
         form:
           default_step_settings: Default step settings
           global_settings: Global settings
+          participatory_texts_enabled_help: Cannot interact with this settings if there are existing proposals. Please, create a new `Proposals component` if you want to enable this feature or discard all imported proposals in the `Participatory Texts` menu if you want to disable it.
           step_settings: Step settings
         index:
           add: Add component
@@ -259,8 +260,6 @@ en:
           title: 'Add component: %{name}'
         publish:
           success: The component has been successfully published.
-        settings_fields:
-          participatory_texts_enabled_help: Cannot interact with this settings if there are existing proposals. Please, create a new `Proposals component` if you want to enable this feature or discard all imported proposals in the `Participatory Texts` menu if you want to disable it.
         title: Components
         unpublish:
           success: The component has been successfully unpublished.

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -247,7 +247,7 @@ en:
         form:
           default_step_settings: Default step settings
           global_settings: Global settings
-          participatory_texts_enabled_help: Cannot interact with this settings if there are existing proposals. Please, create a new `Proposals component` if you want to enable this feature or discard all imported proposals in the `Participatory Texts` menu if you want to disable it.
+          participatory_texts_enabled_help: Cannot interact with this setting if there are existing proposals. Please, create a new `Proposals component` if you want to enable this feature or discard all imported proposals in the `Participatory Texts` menu if you want to disable it.
           step_settings: Step settings
         index:
           add: Add component

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -265,6 +265,8 @@ en:
         update:
           error: There was a problem updating this component.
           success: The component was updated successfully.
+        settings_fields:
+          participatory_texts_enabled_help: "Cannot do this if there are proposals.\nPlease, create a new `Proposals component` if you want to enable this feature or discard all proposals  in the `Participatory Texts` menu if you want to disable it."
       dashboard:
         show:
           view_more_logs: View more logs

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -260,7 +260,7 @@ en:
         publish:
           success: The component has been successfully published.
         settings_fields:
-          participatory_texts_enabled_help: Cannot do this if there are proposals. Please, create a new `Proposals component` if you want to enable this feature or discard all proposals  in the `Participatory Texts` menu if you want to disable it.
+          participatory_texts_enabled_help: Cannot interact with this settings if there are existing proposals. Please, create a new `Proposals component` if you want to enable this feature or discard all imported proposals in the `Participatory Texts` menu if you want to disable it.
         title: Components
         unpublish:
           success: The component has been successfully unpublished.

--- a/decidim-admin/spec/helpers/settings_helper_spec.rb
+++ b/decidim-admin/spec/helpers/settings_helper_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 module Decidim
   module Admin
     describe SettingsHelper do
-      let(:options) { double }
+      let(:options) { {} }
       let(:attribute) { double(type: type, translated?: false, editor?: false) }
       let(:type) { :boolean }
       let(:name) { :test }

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -11,11 +11,6 @@ Decidim.register_component(:proposals) do |component|
     raise "Can't destroy this component when there are proposals" if Decidim::Proposals::Proposal.where(component: instance).any?
   end
 
-  component.on(:update) do |instance|
-    next unless instance.settings.participatory_texts_enabled == instance.reload.settings.participatory_texts_enabled
-    raise "Can't update ParticipatoryText setting when there are proposals" if Decidim::Proposals::Proposal.where(component: instance).any?
-  end
-
   component.data_portable_entities = ["Decidim::Proposals::Proposal"]
 
   component.newsletter_participant_entities = ["Decidim::Proposals::Proposal"]

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -12,8 +12,7 @@ Decidim.register_component(:proposals) do |component|
   end
 
   component.on(:update) do |instance|
-    update_setting_value = instance.settings.participatory_texts_enabled
-    return unless update_setting_value == instance.reload.settings.participatory_texts_enabled
+    next unless instance.settings.participatory_texts_enabled == instance.reload.settings.participatory_texts_enabled
     raise "Can't update ParticipatoryText setting when there are proposals" if Decidim::Proposals::Proposal.where(component: instance).any?
   end
 

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -11,6 +11,12 @@ Decidim.register_component(:proposals) do |component|
     raise "Can't destroy this component when there are proposals" if Decidim::Proposals::Proposal.where(component: instance).any?
   end
 
+  component.on(:update) do |instance|
+    update_setting_value = instance.settings.participatory_texts_enabled
+    return unless update_setting_value == instance.reload.settings.participatory_texts_enabled
+    raise "Can't update ParticipatoryText setting when there are proposals" if Decidim::Proposals::Proposal.where(component: instance).any?
+  end
+
   component.data_portable_entities = ["Decidim::Proposals::Proposal"]
 
   component.newsletter_participant_entities = ["Decidim::Proposals::Proposal"]

--- a/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
@@ -32,6 +32,44 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
     end
   end
 
+  describe "on update" do
+    context "when trying to change the `participatory_texts_enabled` setting" do
+      let(:form) do
+        instance_double(
+          Decidim::Admin::ComponentForm,
+          invalid?: false,
+          weight: 0,
+          name: {},
+          default_step_settings: {},
+          step_settings: {},
+          settings: {
+            participatory_texts_enabled: true
+          },
+        )
+      end
+
+      context "when there are no proposals for the component" do
+        it "updates the component" do
+          expect do
+            Decidim::Admin::UpdateComponent.call(form, component)
+          end.to change { component.settings.participatory_texts_enabled }
+        end
+      end
+
+      context "when there are proposals for the component" do
+        before do
+          create(:proposal, component: component)
+        end
+
+        it "raises an error" do
+          expect do
+            Decidim::Admin::UpdateComponent.call(form, component)
+          end.to raise_error("Can't update ParticipatoryText setting when there are proposals")
+        end
+      end
+    end
+  end
+
   describe "stats" do
     subject { current_stat[2] }
 

--- a/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
@@ -105,4 +105,44 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
       end
     end
   end
+
+  describe "on edit", type: :system do
+    let(:edit_proposal_component_path) do
+      "/admin/participatory_processes/#{component.participatory_space.slug}/components/#{component.id}/edit"
+    end
+    let(:participatory_texts_enabled_checkbox) do
+      page.find("input[name='component[settings][participatory_texts_enabled]']")
+    end
+
+    before do
+      current_user.update(admin: true)
+      switch_to_host(component.organization.host)
+      login_as current_user, scope: :user
+    end
+
+    context "when there are no proposals for the component" do
+      before do
+        visit edit_proposal_component_path
+      end
+
+      it "ALLOWS the admin the enable the Participatory texts feature" do
+        expect(participatory_texts_enabled_checkbox[:class]).not_to include("disabled")
+      end
+    end
+
+    context "when there are proposals for the component" do
+      before do
+        create(:proposal, component: component)
+        visit edit_proposal_component_path
+      end
+
+      it "DOES NOT ALLOW the admin the enable the Participatory texts feature" do
+        expect(participatory_texts_enabled_checkbox[:class]).to include("disabled")
+
+        within ".help-text" do
+          expect(page).to have_content("Cannot interact with this settings if there are existing proposals. Please, create a new `Proposals component` if you want to enable this feature or discard all imported proposals in the `Participatory Texts` menu if you want to disable it.")
+        end
+      end
+    end
+  end
 end

--- a/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
@@ -52,7 +52,9 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
         it "updates the component" do
           expect do
             Decidim::Admin::UpdateComponent.call(form, component)
-          end.to change(component.settings.participatory_texts_enabled)
+          end.to change {
+            component.settings.participatory_texts_enabled
+          }.from(false).to(true)
         end
       end
 

--- a/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
@@ -44,7 +44,7 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
           step_settings: {},
           settings: {
             participatory_texts_enabled: true
-          },
+          }
         )
       end
 
@@ -52,7 +52,7 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
         it "updates the component" do
           expect do
             Decidim::Admin::UpdateComponent.call(form, component)
-          end.to change { component.settings.participatory_texts_enabled }
+          end.to change(component.settings.participatory_texts_enabled)
         end
       end
 

--- a/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
@@ -37,7 +37,7 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
       let(:form) do
         instance_double(
           Decidim::Admin::ComponentForm,
-          invalid?: false,
+          invalid?: !valid,
           weight: 0,
           name: {},
           default_step_settings: {},
@@ -49,6 +49,8 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
       end
 
       context "when there are no proposals for the component" do
+        let(:valid) { true }
+
         it "updates the component" do
           expect do
             Decidim::Admin::UpdateComponent.call(form, component)
@@ -59,14 +61,13 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
       end
 
       context "when there are proposals for the component" do
-        before do
-          create(:proposal, component: component)
-        end
+        let(:proposal) { create(:proposal, component: component) }
+        let(:valid) { false }
 
-        it "raises an error" do
+        it "does not update the component" do
           expect do
             Decidim::Admin::UpdateComponent.call(form, component)
-          end.to raise_error("Can't update ParticipatoryText setting when there are proposals")
+          end.to broadcast(:invalid)
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
> It shouldn't be possible to enable participatory_texts when there are existing proposals.

#### :pushpin: Related Issues
- Fixes #5072

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)

![participatory_texts_enabled](https://user-images.githubusercontent.com/40306853/57573827-c8efff00-742e-11e9-83f1-30852aa021ab.png)