### PR TITLE
Do not show registration link if disabled

### DIFF
--- a/decidim-core/app/cells/decidim/content_blocks/footer_sub_hero/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/footer_sub_hero/show.erb
@@ -3,7 +3,7 @@
     <div class="columns small-centered large-10">
       <h2 class="heading3"><%= t("decidim.pages.home.footer_sub_hero.footer_sub_hero_headline", organization: current_organization.name) %></h2>
       <h5 class="heading4"><%== t("decidim.pages.home.footer_sub_hero.footer_sub_hero_body") %></h5>
-      <% unless current_user %>
+      <% if current_organization.sign_up_enabled? && !current_user %>
         <%= link_to decidim.new_user_registration_path, class: "button--sc link subhero-cta" do %>
           <%= t("decidim.pages.home.footer_sub_hero.register") %>
           <%= icon "chevron-right", aria_hidden: true %>


### PR DESCRIPTION

#### :tophat: What? Why?

When organization has sign up disabled, do not show register link.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
