### PR TITLE
Fix registration form in duplicated meeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ end
 
 **Fixed**:
 
+- **decidim-meetings**: Fix registration form in duplicated meeting [\#5136](https://github.com/decidim/decidim/pull/5136)
 - **decidim-meetings**: Fix `deliver_now` call on `send_email_confirmation` [\#5111](https://github.com/decidim/decidim/pull/5111)
 - **decidim-admin**: fix Decidim::Admin::NewsletterRecipient query [\#5109](https://github.com/decidim/decidim/pull/5109)
 - **decidim-proposals**: Fix participatory text form. [#5094](https://github.com/decidim/decidim/pull/5094)

--- a/decidim-meetings/app/commands/decidim/meetings/admin/copy_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/copy_meeting.rb
@@ -60,6 +60,7 @@ module Decidim
             private_meeting: @form.private_meeting,
             transparent: @form.transparent,
             organizer: @form.organizer,
+            questionnaire: @form.questionnaire,
             registrations_enabled: @meeting.registrations_enabled,
             available_slots: @meeting.available_slots,
             registration_terms: @meeting.registration_terms

--- a/decidim-meetings/app/forms/decidim/meetings/admin/meeting_copy_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/meeting_copy_form.rb
@@ -56,6 +56,10 @@ module Decidim
         def organizer
           @organizer ||= current_organization.users.find_by(id: organizer_id)
         end
+
+        def questionnaire
+          Decidim::Forms::Questionnaire.new
+        end
       end
     end
   end

--- a/decidim-meetings/app/views/decidim/meetings/admin/registrations/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/registrations/_form.html.erb
@@ -1,7 +1,7 @@
 <div class="card">
   <div class="card-divider">
     <h2 class="card-title">
-      <%= title %>
+      <%= t(".title") %>
       <%= link_to t(".invites"), meeting_registrations_invites_path(meeting), class: "button tiny button--title #{'disabled' unless allowed_to? :read_invites, :meeting, meeting: meeting}" %>
       <% if allowed_to? :export_registrations, :meeting, meeting: meeting %>
         <span class="exports dropdown tiny button button--simple button--title" data-toggle="export-dropdown"><%= t "actions.export", scope: "decidim.admin" %></span>

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -287,6 +287,7 @@ en:
               other: There has been %{count} registrations.
             reserved_slots_help: Leave it to 0 if you don't have reserved slots
             reserved_slots_less_than: Must be less than or equal to %{count}
+            title: Registrations
           update:
             invalid: There was a problem saving the registration settings.
             success: Meeting registrations settings successfully saved.

--- a/decidim-meetings/spec/commands/admin/copy_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/admin/copy_meeting_spec.rb
@@ -43,6 +43,7 @@ module Decidim::Meetings
         services_to_persist: services_to_persist,
         current_user: current_user,
         organizer: meeting.organizer,
+        questionnaire: Decidim::Forms::Questionnaire.new,
         private_meeting: meeting.private_meeting,
         transparent: meeting.transparent,
         current_component: meeting.component

--- a/decidim-meetings/spec/shared/duplicate_meetings_examples.rb
+++ b/decidim-meetings/spec/shared/duplicate_meetings_examples.rb
@@ -4,12 +4,14 @@ shared_examples "duplicate meetings" do
   let(:form) { Decidim::Meetings::Admin::MeetingCopyForm.from_model(meeting).with_context(context) }
   let(:context) { { current_organization: meeting.organization, current_component: meeting.component } }
   let(:copy_meeting) { Decidim::Meetings::Admin::CopyMeeting.new(form, meeting) }
-  let(:directory) { Decidim::EngineRouter.admin_proxy(meeting.component).meetings_path }
+
   let(:latitude) { meeting.latitude }
   let(:longitude) { meeting.longitude }
+  let(:meetings_path) { Decidim::EngineRouter.admin_proxy(meeting.component).meetings_path }
+
   let(:duplicated_meeting) { Decidim::Meetings::Meeting.find_by("title->>'en' = 'Duplicated meeting'") }
   let(:edit_duplicated_meeting_registrations_form_path) do
-    Decidim::EngineRouter.admin_proxy(component).edit_meeting_registrations_form_path(meeting_id: duplicated_meeting.id)
+    Decidim::EngineRouter.admin_proxy(component).edit_meeting_registrations_form_path(duplicated_meeting.id)
   end
 
   before do
@@ -18,7 +20,7 @@ shared_examples "duplicate meetings" do
   end
 
   it "duplicates a meeting" do
-    visit directory
+    visit meetings_path
     click_link "Duplicate"
     click_button "Copy"
 

--- a/decidim-meetings/spec/shared/duplicate_meetings_examples.rb
+++ b/decidim-meetings/spec/shared/duplicate_meetings_examples.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+shared_examples "duplicate meetings" do
+  let(:form) { Decidim::Meetings::Admin::MeetingCopyForm.from_model(meeting).with_context(context) }
+  let(:context) { { current_organization: meeting.organization, current_component: meeting.component } }
+  let(:copy_meeting) { Decidim::Meetings::Admin::CopyMeeting.new(form, meeting) }
+  let(:directory) { Decidim::EngineRouter.admin_proxy(meeting.component).meetings_path }
+  let(:latitude) { meeting.latitude }
+  let(:longitude) { meeting.longitude }
+  let(:duplicated_meeting) { Decidim::Meetings::Meeting.find_by("title->>'en' = 'Duplicated meeting'") }
+  let(:edit_duplicated_meeting_registrations_form_path) do
+    Decidim::EngineRouter.admin_proxy(component).edit_meeting_registrations_form_path(meeting_id: duplicated_meeting.id)
+  end
+
+  before do
+    stub_geocoding(meeting.address, [latitude, longitude])
+    form.title["en"] = "Duplicated meeting"
+  end
+
+  it "duplicates a meeting" do
+    visit directory
+    click_link "Duplicate"
+    click_button "Copy"
+
+    expect(page).to have_content("Meeting successfully duplicated.")
+  end
+
+  it "allows to edit the registration form of the duplicated meeting" do
+    copy_meeting.call
+    visit edit_duplicated_meeting_registrations_form_path
+    fill_in :questionnaire_title_en, with: "Title"
+    fill_in_i18n_editor(:questionnaire_tos, "#questionnaire-tos-tabs", en: "ToS", ca: "ToS", es: "ToS")
+    click_button "Save"
+
+    expect(page).to have_content("Forms successfully saved.")
+  end
+end

--- a/decidim-meetings/spec/system/admin_manages_meetings_spec.rb
+++ b/decidim-meetings/spec/system/admin_manages_meetings_spec.rb
@@ -8,12 +8,12 @@ describe "Admin manages meetings", type: :system, serves_map: true do
 
   include_context "when managing a component as an admin"
 
-  # it_behaves_like "manage meetings"
-  # it_behaves_like "manage registrations"
-  # it_behaves_like "manage announcements"
-  # it_behaves_like "manage agenda"
-  # it_behaves_like "manage minutes"
-  # it_behaves_like "manage invites"
-  # it_behaves_like "export meetings"
+  it_behaves_like "manage meetings"
+  it_behaves_like "manage registrations"
+  it_behaves_like "manage announcements"
+  it_behaves_like "manage agenda"
+  it_behaves_like "manage minutes"
+  it_behaves_like "manage invites"
+  it_behaves_like "export meetings"
   it_behaves_like "duplicate meetings"
 end

--- a/decidim-meetings/spec/system/admin_manages_meetings_spec.rb
+++ b/decidim-meetings/spec/system/admin_manages_meetings_spec.rb
@@ -8,11 +8,12 @@ describe "Admin manages meetings", type: :system, serves_map: true do
 
   include_context "when managing a component as an admin"
 
-  it_behaves_like "manage meetings"
-  it_behaves_like "manage registrations"
-  it_behaves_like "manage announcements"
-  it_behaves_like "manage agenda"
-  it_behaves_like "manage minutes"
-  it_behaves_like "manage invites"
-  it_behaves_like "export meetings"
+  # it_behaves_like "manage meetings"
+  # it_behaves_like "manage registrations"
+  # it_behaves_like "manage announcements"
+  # it_behaves_like "manage agenda"
+  # it_behaves_like "manage minutes"
+  # it_behaves_like "manage invites"
+  # it_behaves_like "export meetings"
+  it_behaves_like "duplicate meetings"
 end


### PR DESCRIPTION
#### :tophat: What? Why?
>Impossible to edit a form in a duplicate meeting

Also, changed a card title translation in the Registrations page as it rendered the `current_organization.name` 

#### :pushpin: Related Issues
- Fixes #5120

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)
![registrations_title](https://user-images.githubusercontent.com/40306853/57621869-c3103000-758c-11e9-8ab5-78dea1abf1a0.png)

