### PR TITLE
Fix meeting minutes related information in public view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ end
 
 **Fixed**:
 
+- **decidim-meetings**: Fix meeting minutes related information in public view [\#5137](https://github.com/decidim/decidim/pull/5137)
 - **decidim-meetings**: Fix `deliver_now` call on `send_email_confirmation` [\#5111](https://github.com/decidim/decidim/pull/5111)
 - **decidim-admin**: fix Decidim::Admin::NewsletterRecipient query [\#5109](https://github.com/decidim/decidim/pull/5109)
 - **decidim-proposals**: Fix participatory text form. [#5094](https://github.com/decidim/decidim/pull/5094)

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_minutes.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_minutes.html.erb
@@ -28,7 +28,7 @@
             </div>
           </div>
         <% end %>
-        <% if meeting.minutes.video_url.presence %>
+        <% if meeting.minutes.audio_url.presence %>
           <div class="card--list__item">
             <div class="card--list__text">
               <div>

--- a/decidim-meetings/spec/system/meeting_minutes_spec.rb
+++ b/decidim-meetings/spec/system/meeting_minutes_spec.rb
@@ -57,5 +57,25 @@ describe "Meeting minutes", type: :system do
         end
       end
     end
+
+    context "when video url is NOT present" do
+      it "does not show the video url" do
+        meeting.minutes.update(video_url: nil)
+        visit_meeting
+        within ".minutes-section" do
+          expect(page).not_to have_content(minutes.video_url)
+        end
+      end
+    end
+
+    context "when audio url is NOT present" do
+      it "does not show the audio url" do
+        meeting.minutes.update(audio_url: nil)
+        visit_meeting
+        within ".minutes-section" do
+          expect(page).not_to have_content(minutes.audio_url)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
>In the minutes, we can inesrt videos or audio urls. If you only put one of the two (in this case, video), a blank box appears below (since nothing has been indicated). The blank box should not appear if we have not indicated anything in the Dashboard.

#### :pushpin: Related Issues
- Fixes #5129

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
