### PR TITLE
Adds security contact information on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,7 @@ Since Decidim is a ruby gem, you can check out the [dependent repositories](http
 * [Decidim Mataró](https://www.decidimmataro.cat) - [View code](https://github.com/AjuntamentDeMataro/decidim-mataro)
 * [Commission Nationale du Débat Public (France)](https://cndp.opensourcepolitics.eu/)
 * [MetaDecidim](https://meta.decidim.barcelona/) - [View Code](https://github.com/decidim/metadecidim)
+
+## Security 
+
+Security is very important to us. If you have any issue regarding security, please disclose the information responsibly by sending an email to security [at] decidim [dot] org and not by creating a github/metadecidim issue. We appreciate your effort to make Decidim more secure. 


### PR DESCRIPTION
#### :tophat: What? Why?

Adds security contact information on README, as it's not being found by people who wanted to know how to contact us for security issues. 
