### PR TITLE
Add proposal answers to the proposal export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ end
 - **decidim-participatory_processes**: Add a select field for assign an area to participatory processes [#5011](https://github.com/decidim/decidim/pull/5011)
 - **decidim-accountability**: Also display the main scope as a filter for accountability results [#5022](https://github.com/decidim/decidim/pull/5022)
 - **decidim-system**: Add custom SMTP settings for multitenant [#4698](https://github.com/decidim/decidim/pull/4698)
+- **decidim-proposals**: Add proposal answers to the proposal export [#5139](https://github.com/decidim/decidim/pull/5139)
 
 **Changed**:
 

--- a/decidim-core/app/helpers/decidim/translations_helper.rb
+++ b/decidim-core/app/helpers/decidim/translations_helper.rb
@@ -35,6 +35,25 @@ module Decidim
       end
     end
 
-    module_function :multi_translation, :empty_translatable
+    # Public: Creates a translation for each available language in the list with
+    # the given value so empty fields still have the correct format. If the
+    # value is not a hash, an `empty_translatable` will be returned.
+    #
+    # value   - A hash value containing the values for each locale. Those
+    #           locales that do not have a corresponding value in the hash will
+    #           be replaced by an empty string.
+    # locales - A list of locales to scope the translations to. Picks up all the
+    #           available locales by default.
+    #
+    # Returns a Hash with the locales as keys and value strings as values.
+    def ensure_translatable(value, locales = Decidim.available_locales)
+      return empty_translatable(locales) unless value.is_a?(Hash)
+
+      locales.each_with_object({}) do |locale, result|
+        result[locale.to_s] = value[locale.to_s] || value[locale] || ""
+      end
+    end
+
+    module_function :multi_translation, :empty_translatable, :ensure_translatable
   end
 end

--- a/decidim-core/spec/helpers/decidim/translations_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/translations_helper_spec.rb
@@ -72,5 +72,39 @@ module Decidim
         end
       end
     end
+
+    describe "#ensure_translatable" do
+      let(:locales) { [:en, :ca] }
+
+      context "when given a non-hash and a list of locales" do
+        let(:value) { nil }
+
+        it "returns a hash with each locale as the key and empty string values" do
+          result = TranslationsHelper.ensure_translatable(value, locales)
+          expect(result.keys.length).to eq(locales.length)
+          expect(result).to include("en" => "", "ca" => "")
+        end
+      end
+
+      context "when given a hash with value only for one of the locales" do
+        let(:value) { { en: "Value" } }
+
+        it "returns a hash with each locale as the key and empty string values" do
+          result = TranslationsHelper.ensure_translatable(value, [:en, :ca])
+          expect(result.keys.length).to eq(locales.length)
+          expect(result).to include("en" => "Value", "ca" => "")
+        end
+      end
+
+      context "when given a hash with each locale having a value" do
+        let(:value) { { en: "Value", ca: "Valor" } }
+
+        it "returns a hash with each locale as the key and empty string values" do
+          result = TranslationsHelper.ensure_translatable(value, [:en, :ca])
+          expect(result.keys.length).to eq(locales.length)
+          expect(result).to include("en" => "Value", "ca" => "Valor")
+        end
+      end
+    end
   end
 end

--- a/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
+++ b/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
@@ -35,6 +35,7 @@ module Decidim
           body: present(proposal).body,
           state: proposal.state.to_s,
           reference: proposal.reference,
+          answer: ensure_translatable(proposal.answer),
           supports: proposal.proposal_votes_count,
           endorsements: proposal.endorsements.count,
           comments: proposal.comments.count,


### PR DESCRIPTION
#### :tophat: What? Why?
This adds the proposal answers to the proposal serializer which is used when exporting the proposals. The answers are important to have in the export data as they are sometimes needed.

Alongside, this adds a new method to the `Decidim::TranslationsHelper` module to help creating these exported translated values. This method will ensure that all the expected locale keys exists in the export data in order to have all the columns for each language in the export data in case some exported items do not have a corresponding translated value.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [X] Add tests