### PR TITLE
Add instructions on how to run a single test file

### DIFF
--- a/docs/advanced/testing.md
+++ b/docs/advanced/testing.md
@@ -8,6 +8,18 @@ You need to create a dummy application to run your tests. Run the following comm
 bundle exec rake test_app
 ```
 
+## Running a specific test file or just a single spec
+
+If you are writing new specs, you can run the tests contained in a single file by opening a console window in the corresponding module and calling `rspec`on the file. For example:
+```bash
+cd decidim-participatory_processes
+bundle exec rspec spec/forms/participatory_process_form_spec.rb
+```
+You can also run a single test by appending its start line number to the command:
+```bash
+bundle exec rspec spec/forms/participatory_process_form_spec.rb:134
+```
+
 ## Running tests for a specific component
 
 A Decidim engine can be tested running the rake task named after it. For


### PR DESCRIPTION
#### :tophat: What? Why?

I had trouble to run specific tests the other day when writing new specs. The solution wasn't too hard, it was just to run the command from the specific module the spec file is in, but for me it wasn't obvious.

So I wrote a new paragraph in the docs. Tell me if it sounds useful to you too.