### PR TITLE
remove dead link in applications example

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,5 +164,4 @@ Since Decidim is a ruby gem, you can check out the [dependent repositories](http
 * [Vilanova Participa](http://participa.vilanova.cat) - [View code](https://github.com/vilanovailageltru/decidim-vilanova)
 * [Erabaki Pamplona](https://erabaki.pamplona.es) - [View code](https://github.com/ErabakiPamplona/erabaki)
 * [Decidim Mataró](https://www.decidimmataro.cat) - [View code](https://github.com/AjuntamentDeMataro/decidim-mataro)
-* [Commission Nationale du Débat Public (France)](https://cndp.opensourcepolitics.eu/)
 * [MetaDecidim](https://meta.decidim.barcelona/) - [View Code](https://github.com/decidim/metadecidim)


### PR DESCRIPTION
https://cndp.opensourcepolitics.eu/ dot not seem online anymore.
