### PR TITLE
Escape fingerprint content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ end
 - **decidim-admin**: Ensure static pages slugs are relative paths [#5085](https://github.com/decidim/decidim/pull/5085)
 - **decidim-accountability**: Remove useless button on the admin page for accountability statuses [#5099](https://github.com/decidim/decidim/pull/5099)
 - **decidim-budgets**: Fix import of proposals to budget projects [#5097](https://github.com/decidim/decidim/pull/5097)
+- **decidim-core**: Escape fingerprint content [#5146](https://github.com/decidim/decidim/pull/5146)
 
 **Removed**:
 

--- a/decidim-accountability/spec/shared/manage_results_examples.rb
+++ b/decidim-accountability/spec/shared/manage_results_examples.rb
@@ -5,7 +5,7 @@ shared_examples "manage results" do
 
   context "when having existing proposals" do
     let!(:proposal_component) { create(:proposal_component, participatory_space: participatory_space) }
-    let!(:proposals) { create_list :proposal, 5, component: proposal_component }
+    let!(:proposals) { create_list :proposal, 5, component: proposal_component, skip_injection: true }
 
     it "updates a result" do
       within find("tr", text: translated(result.title)) do

--- a/decidim-core/app/cells/decidim/fingerprint/show.erb
+++ b/decidim-core/app/cells/decidim/fingerprint/show.erb
@@ -7,11 +7,11 @@
   <p><%= t "decidim.fingerprint.explanation" %></p>
   <p>
     <strong><%= t "decidim.fingerprint.value" %>:</strong>
-    <code class="fingerprint-value"><%= model.fingerprint.value %></code>
+    <code class="fingerprint-value"><%= decidim_html_escape model.fingerprint.value %></code>
   </p>
   <p>
     <strong><%= t "decidim.fingerprint.source" %>:</strong>
-    <code class="fingerprint-source"><%= model.fingerprint.source %></code>
+    <code class="fingerprint-source"><%= decidim_html_escape model.fingerprint.source %></code>
   </p>
 
   <p><%= t "decidim.fingerprint.replicate_help", online_calculator_link: link_to(t("decidim.fingerprint.online_calculator_name"), "http://www.md5calc.com/sha256", target: "_blank") %>

--- a/decidim-core/app/cells/decidim/fingerprint_cell.rb
+++ b/decidim-core/app/cells/decidim/fingerprint_cell.rb
@@ -3,6 +3,7 @@
 module Decidim
   class FingerprintCell < Decidim::ViewModel
     include ActionView::RecordIdentifier
+    include Decidim::SanitizeHelper
 
     def show
       render

--- a/decidim-initiatives/app/cells/decidim/initiatives/initiative_m_cell.rb
+++ b/decidim-initiatives/app/cells/decidim/initiatives/initiative_m_cell.rb
@@ -11,6 +11,10 @@ module Decidim
 
       private
 
+      def title
+        decidim_html_escape(translated_attribute(model.title))
+      end
+
       def has_state?
         true
       end

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_proposal_preview.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_proposal_preview.html.erb
@@ -1,11 +1,11 @@
 <div class="row column view-header">
-  <h2 class="heading2"><%= present(@proposal).title(links: true) %></h2>
+  <h2 class="heading2"><%= present(@proposal).title(links: true, html_escape: true) %></h2>
   <% unless component_settings.participatory_texts_enabled? %>
     <%= cell("decidim/coauthorships", @proposal) %>
   <% end %>
 </div>
 <div class="row column">
-  <%= simple_format present(@proposal).body(links: true) %>
+  <%= simple_format present(@proposal).body(links: true, strip_tags: true) %>
 </div>
 <br />
 <%= attachments_for(@proposal) %>

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -248,7 +248,7 @@ FactoryBot.define do
       user_groups { [] }
     end
 
-    title { "<script>alert(\"TITLE\");</script> " + generate(:title) }
+    title { "<script>alert('TITLE');</script> " + generate(:title) }
     body { "<script>alert(\"BODY\");</script>\n" + Faker::Lorem.sentences(3).join("\n") }
     component { create(:proposal_component) }
     published_at { Time.current }

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -246,10 +246,19 @@ FactoryBot.define do
       users { nil }
       # user_groups correspondence to users is by sorting order
       user_groups { [] }
+      skip_injection { false }
     end
 
-    title { "<script>alert('TITLE');</script> " + generate(:title) }
-    body { "<script>alert(\"BODY\");</script>\n" + Faker::Lorem.sentences(3).join("\n") }
+    title do
+      content = generate(:title).dup
+      content.prepend("<script>alert('TITLE');</script> ") unless skip_injection
+      content
+    end
+    body do
+      content = Faker::Lorem.sentences(3).join("\n")
+      content.prepend("<script>alert('BODY');</script> ") unless skip_injection
+      content
+    end
     component { create(:proposal_component) }
     published_at { Time.current }
     address { "#{Faker::Address.street_name}, #{Faker::Address.city}" }

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -47,7 +47,7 @@ describe "Proposals", type: :system do
       click_link proposal.title
 
       expect(page).to have_content(proposal.title)
-      expect(page).to have_content(strip_tags(proposal.body))
+      expect(page).to have_content(strip_tags(proposal.body).strip)
       expect(page).to have_author(proposal.creator_author.name)
       expect(page).to have_content(proposal.reference)
       expect(page).to have_creation_date(I18n.l(proposal.published_at, format: :decidim_short))

--- a/decidim-proposals/spec/system/search_proposals_spec.rb
+++ b/decidim-proposals/spec/system/search_proposals_spec.rb
@@ -6,7 +6,7 @@ describe "Search proposals", type: :system do
   include_context "with a component"
   let(:manifest_name) { "proposals" }
   let!(:searchables) { create_list(:proposal, 3, component: component) }
-  let!(:term) { searchables.first.title.split(" ").sample }
+  let!(:term) { searchables.first.title.split(" ").last }
 
   before do
     searchables.each { |s| s.update(published_at: Time.current) }


### PR DESCRIPTION
#### :tophat: What? Why?

We also need to escape the content the fingerprint signature prints and during the proposal preview.

#### :pushpin: Related Issues
- Related to #5037

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

