### PR TITLE
Fix: Include asterisk in the required field `position` for `AssemblyMemberForm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ end
 
 **Fixed**:
 
+- **decidim-assemblies**: Fix: Include asterisk in the required field `position` for `AssemblyMemberForm`. [\#5164](https://github.com/decidim/decidim/pull/5164)
 - **decidim-admin**: Fix: disallow enabling `ParticipatoryText` on component when there are proposals [\#5111](https://github.com/decidim/decidim/pull/5111)
 - **decidim-meetings**: Fix registration form in duplicated meeting [\#5136](https://github.com/decidim/decidim/pull/5136)
 - **decidim-meetings**: Fix meeting minutes related information in public view [\#5137](https://github.com/decidim/decidim/pull/5137)

--- a/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_member_form.rb
+++ b/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_member_form.rb
@@ -23,7 +23,7 @@ module Decidim
 
         validates :designation_date, presence: true
         validates :full_name, presence: true, unless: proc { |object| object.existing_user }
-        validates :position, inclusion: { in: Decidim::AssemblyMember::POSITIONS }
+        validates :position, presence: true, inclusion: { in: Decidim::AssemblyMember::POSITIONS }
         validates :position_other, presence: true, if: ->(form) { form.position == "other" }
         validates :ceased_date, date: { after: :designation_date, allow_blank: true }
         validates :user, presence: true, if: proc { |object| object.existing_user }


### PR DESCRIPTION
#### :tophat: What? Why?

> The "Select position" field is not marked as mandatory but can't be created without indicating it.

Specs already [test for it](https://github.com/decidim/decidim/blob/27880060af446d807ea9a4d41d56f0cc75c7566c/decidim-assemblies/spec/forms/assembly_member_form_spec.rb#L55).

#### :pushpin: Related Issues
- Fixes #5156 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![assembly_member_required_fields](https://user-images.githubusercontent.com/40306853/58751304-2fe85d00-849d-11e9-8abb-461deb80f74b.png)

