### PR TITLE
Fix: Link `form.js` in `assets/config/decidim_admin_manifest.js`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ end
 
 **Fixed**:
 
+- **decidim-admin**: Fix: Link `form.js` in `assets/config/decidim_admin_manifest.js` [\#5165](https://github.com/decidim/decidim/pull/5165)
 - **decidim-core**: Fix: potential loop redirection when accepting TOS agreement on multi-languages sites [\#5162](https://github.com/decidim/decidim/pull/5162)
 - **decidim-assemblies**: Fix: Include asterisk in the required field `position` for `AssemblyMemberForm`. [\#5164](https://github.com/decidim/decidim/pull/5164)
 - **decidim-admin**: Fix: disallow enabling `ParticipatoryText` on component when there are proposals [\#5111](https://github.com/decidim/decidim/pull/5111)

--- a/decidim-admin/app/assets/config/decidim_admin_manifest.js
+++ b/decidim-admin/app/assets/config/decidim_admin_manifest.js
@@ -4,3 +4,4 @@
 //= link decidim/admin/welcome_notification.js
 //= link decidim/admin/newsletters.js
 //= link decidim/admin/application.css
+//= link decidim/admin/form.js

--- a/decidim-core/app/controllers/concerns/decidim/needs_tos_accepted.rb
+++ b/decidim-core/app/controllers/concerns/decidim/needs_tos_accepted.rb
@@ -32,7 +32,7 @@ module Decidim
                          decidim.export_data_portability_path,
                          decidim.download_file_data_portability_path]
       # ensure that path with or without query string pass
-      permitted_paths.find { |el| el.split('?').first == request.path }
+      permitted_paths.find { |el| el.split("?").first == request.path }
     end
 
     def tos_path


### PR DESCRIPTION
#### :tophat: What? Why?
Link `form.js` in `decidim-admin/app/assets/config/decidim_admin_manifest.js`

#### :pushpin: Related Issues
- Related to #5134

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
