### PR TITLE
Move helper to decidim-core

### DIFF
--- a/decidim-core/app/helpers/decidim/application_helper.rb
+++ b/decidim-core/app/helpers/decidim/application_helper.rb
@@ -67,5 +67,23 @@ module Decidim
 
       super(name, model, options, &block)
     end
+
+    # Public: Builds the URL for the step Call To Action. Takes URL params
+    # into account.
+    #
+    # process - a ParticipatoryProcess
+    #
+    # Returns a String that can be used as a URL.
+    def step_cta_url(process)
+      return unless respond_to?(:decidim_participatory_processes)
+
+      base_url, params = decidim_participatory_processes.participatory_process_path(process).split("?")
+
+      if params.present?
+        [base_url, "/", process.active_step.cta_path, "?", params].join("")
+      else
+        [base_url, "/", process.active_step.cta_path].join("")
+      end
+    end
   end
 end

--- a/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
+++ b/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
@@ -21,22 +21,6 @@ module Decidim
         dates = [participatory_process_step.start_date, participatory_process_step.end_date]
         dates.map { |date| date ? localize(date.to_date, format: :default) : "?" }.join(" - ")
       end
-
-      # Public: Builds the URL for the step Call To Action. Takes URL params
-      # into account.
-      #
-      # process - a ParticipatoryProcess
-      #
-      # Returns a String that can be used as a URL.
-      def step_cta_url(process)
-        base_url, params = decidim_participatory_processes.participatory_process_path(process).split("?")
-
-        if params.present?
-          [base_url, "/", process.active_step.cta_path, "?", params].join("")
-        else
-          [base_url, "/", process.active_step.cta_path].join("")
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Moves helper method to `decidim-core` otherwise it's not available for other modules.

#### :pushpin: Related Issues
- Related to #5082
