### PR TITLE
Fix: Proposals component form introduced regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 **Fixed**:
 
+- **decidim-admin**: Fix: Proposals component form introduced regression [#5179](https://github.com/decidim/decidim/pull/5179)
 - **decidim-core**: Fix seeds and typo in ActionAuthorizer [#5168](https://github.com/decidim/decidim/pull/5168)
 - **decidim-proposals**: Fix seeds [#5168](https://github.com/decidim/decidim/pull/5168)
 

--- a/decidim-admin/app/assets/javascripts/decidim/admin/form.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/form.js.es6
@@ -1,8 +1,13 @@
-// Checks if the form contains a field with a special CSS class added
-// in Decidim::Admin::SettingsHelper. If so, extracts the stored text and
-// adds a new paragraph after the field.
+// Checks if the form contains a field with a special CSS class added in
+// Decidim::Admin::SettingsHelper. If so, prevents the checkbox from being clicked,
+// extracts the stored text and adds a new paragraph after the field.
 $(() => {
   const $checkbox = $(".participatory_texts_disabled");
+
+  $checkbox.click((event) => {
+    event.preventDefault();
+    return false;
+  });
 
   if ($checkbox.length > 0) {
     const $text = $checkbox[0].dataset.text

--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_forms.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_forms.scss
@@ -132,5 +132,5 @@ textarea{
 
 .participatory_texts_disabled{
   cursor: not-allowed;
-  opacity:0.5;
+  opacity: .5;
 }

--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_forms.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_forms.scss
@@ -129,3 +129,8 @@ textarea{
     }
   }
 }
+
+.participatory_texts_disabled{
+  cursor: not-allowed;
+  opacity:0.5;
+}

--- a/decidim-admin/app/forms/decidim/admin/component_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/component_form.rb
@@ -44,7 +44,8 @@ module Decidim
       # Does not add a custom error message as it would be unused, because
       # the setting's checkbox is automatically being disabled on the frontend.
       def must_be_able_to_change_participatory_texts_setting
-        return unless settings[:participatory_texts_enabled] &.!= component.settings.participatory_texts_enabled
+        form_setting_value = settings[:participatory_texts_enabled].to_i == 1 # Convert "1"/"0" to true/false
+        return if form_setting_value == component.settings.participatory_texts_enabled
 
         errors.add(:settings) if Decidim::Proposals::Proposal.where(component: component).any?
       end

--- a/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
@@ -37,9 +37,9 @@ module Decidim
         TYPES[attribute.type.to_sym]
       end
 
-      # Disables :participatory_texts_enabled checkbox if the Proposals component
-      # has existing proposals, and stores the help text that will be added in a
-      # new div via JavaScript in "decidim/admin/form".
+      # Marks :participatory_texts_enabled checkbox with a unique class if
+      # the Proposals component has existing proposals, and stores the help text
+      # that will be added in a new div via JavaScript in "decidim/admin/form".
       #
       # field_name - The name of the field to disable.
       #
@@ -50,7 +50,6 @@ module Decidim
 
         {
           class: "participatory_texts_disabled",
-          disabled: true,
           data: { text: t("decidim.admin.components.form.participatory_texts_enabled_help") }
         }
       end


### PR DESCRIPTION
#### :tophat: What? Why?
The reason [`settings[:participatory_texts_enabled]` was returning `nil`](https://github.com/decidim/decidim/pull/5134#issuecomment-496150966) in the component form validation was that the checkbox was being disabled via **HTML** and that caused the form to **ignore** the value from that field, essentially updating the value to `nil` every time.  I did not catch it via tests because I did not succeed in using anything other than a [stub for the form](https://github.com/CodiTramuntana/decidim/blob/ed2f8d4b5bdfa7a06e6ed21356628e4bf198ad6b/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb#L37) in the spec.

I've changed the code to emulate the appearance of a disabled element and prevented clicking via javascript.

I'm sorry for the inconveniences.

#### :pushpin: Related Issues
- Related to #5134 
- Related to #5165 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry