### PR TITLE
Feat: Improvements in amendments diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 **Added**:
 
+- **decidim-core**, **decidim-proposals**: Add: Improvements in amendments on `Proposals` control version [#5185](https://github.com/decidim/decidim/pull/5185)
 
 **Changed**:
 

--- a/decidim-core/app/commands/decidim/amendable/create.rb
+++ b/decidim-core/app/commands/decidim/amendable/create.rb
@@ -37,6 +37,9 @@ module Decidim
 
       attr_reader :form
 
+      # To be able to diff amendments we store the original attributes being amended
+      # in a PaperTrail::Version. We do that by first creating the emendation
+      # with the amendable_params; next updating it with the emendation_params.
       def create_emendation!
         @emendation = Decidim.traceability.perform_action!(
           "publish",
@@ -44,11 +47,12 @@ module Decidim
           @amender,
           visibility: "public-only"
         ) do
-          emendation = @amendable.amendable_type.constantize.new(form.emendation_params)
+          emendation = @amendable.amendable_type.constantize.new(form.amendable_params)
           emendation.component = @amendable.component
           emendation.published_at = Time.current if proposal?
           emendation.add_coauthor(@amender, user_group: @user_group)
           emendation.save!
+          emendation.update!(form.emendation_params)
           emendation
         end
       end

--- a/decidim-core/app/forms/decidim/amendable/create_form.rb
+++ b/decidim-core/app/forms/decidim/amendable/create_form.rb
@@ -11,6 +11,7 @@ module Decidim
       attribute :amendable_gid, String
       attribute :user_group_id, Integer
       attribute :emendation_params, Object
+      attribute :amendable_params, Object
 
       validates :amendable_gid, presence: true
       validates :emendation_params, presence: true
@@ -20,7 +21,7 @@ module Decidim
       def emendation_changes_amendable
         return unless amendable.amendable_fields == [:title, :body]
         return unless present(amendable).title == present(emendation).title
-        return unless present(amendable).body.delete("\r") == present(emendation).body.delete("\r")
+        return unless present(amendable).body.strip == present(emendation).body.strip
 
         amendable_form.errors.add(:title, :identical)
         amendable_form.errors.add(:body, :identical)
@@ -32,6 +33,10 @@ module Decidim
 
       def emendation
         amendable.amendable_type.constantize.new(@emendation_params)
+      end
+
+      def amendable_params
+        amendable.attributes.slice(*amendable.amendable_fields.map(&:to_s))
       end
     end
   end

--- a/decidim-core/app/views/decidim/amendments/review.html.erb
+++ b/decidim-core/app/views/decidim/amendments/review.html.erb
@@ -1,6 +1,6 @@
 <main class="wrapper">
   <div class="row">
-    <div class="columns large-3">
+    <div class="columns">
       <div class="m-bottom">
         <%= link_to :back do %>
           <%= icon "chevron-left", class: "icon--small" %>
@@ -16,7 +16,10 @@
         </p>
       </div>
     </div>
-    <div class="columns large-6">
+    <div class="columns mediumlarge-6">
+      <%= cell("decidim/diff", emendation.versions.last) %>
+    </div>
+    <div class="columns mediumlarge-6">
       <h2 class="section-heading">
         <%= t(".heading") %>
       </h2>
@@ -34,6 +37,5 @@
         </div>
       </div>
     </div>
-    <div class="columns large-3"></div>
   </div>
 </main>

--- a/decidim-proposals/app/commands/decidim/proposals/update_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/update_proposal.rb
@@ -67,7 +67,12 @@ module Decidim
       end
 
       def update_proposal
-        @proposal.update!(attributes)
+        @proposal = Decidim.traceability.update!(
+          @proposal,
+          current_user,
+          attributes,
+          visibility: "public-only"
+        )
         @proposal.coauthorships.clear
         @proposal.add_coauthor(current_user, user_group: user_group)
       end

--- a/decidim-proposals/app/services/decidim/proposals/diff_renderer.rb
+++ b/decidim-proposals/app/services/decidim/proposals/diff_renderer.rb
@@ -58,7 +58,7 @@ module Decidim
       # Returns the last version if the amendment is being evaluated; else,
       # returns the original version at the moment of creating the amendment.
       def emendation_value_for(attribute)
-        return unless proposal.emendation?
+        return unless proposal&.emendation?
         return last_version(attribute) if proposal.amendment.evaluating?
 
         original_version(attribute)
@@ -76,7 +76,7 @@ module Decidim
       end
 
       def proposal
-        @proposal ||= Proposal.find(version.item_id)
+        @proposal ||= Proposal.find_by(id: version.item_id)
       end
     end
   end

--- a/decidim-proposals/app/services/decidim/proposals/diff_renderer.rb
+++ b/decidim-proposals/app/services/decidim/proposals/diff_renderer.rb
@@ -48,10 +48,35 @@ module Decidim
           attribute => {
             type: type,
             label: I18n.t(attribute, scope: "activemodel.attributes.collaborative_draft"),
-            old_value: values[0],
+            old_value: emendation_value_for(attribute) || values[0],
             new_value: values[1]
           }
         )
+      end
+
+      # Retrieves the attribute value of the amended proposal.
+      # Returns the last version if the amendment is being evaluated; else,
+      # returns the original version at the moment of creating the amendment.
+      def emendation_value_for(attribute)
+        return unless proposal.emendation?
+        return last_version(attribute) if proposal.amendment.evaluating?
+
+        original_version(attribute)
+      end
+
+      # Retrieves the CURRENT attribute value of the amended proposal.
+      def last_version(attribute)
+        proposal.amendable.attributes[attribute.to_s]
+      end
+
+      # Retrieves the attribute value of the amended proposal STORED in the first
+      # version created in Decidim::Amendable::Create.create_emendation!
+      def original_version(attribute)
+        proposal.versions.first.changeset[attribute.to_s].last
+      end
+
+      def proposal
+        @proposal ||= Proposal.find(version.item_id)
       end
     end
   end

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -23,7 +23,11 @@ edit_link(
 <% end %>
 <%= emendation_announcement_for @proposal %>
 <div class="row column view-header">
-  <h2 class="heading2"><%= present(@proposal).title(links: true, html_escape: true) %></h2>
+  <% if @proposal.emendation? %>
+    <h2 class="heading2"><%= t(".changes_at_title", title: present(@proposal.amendable).title(links: true, html_escape: true)) %></h2>
+  <% else %>
+    <h2 class="heading2"><%= present(@proposal).title(links: true, html_escape: true) %></h2>
+  <% end %>
   <% unless component_settings.participatory_texts_enabled? %>
     <%= cell("decidim/coauthorships", @proposal, has_actions: true, size: 3, context: { current_user: current_user }) %>
   <% end %>
@@ -92,8 +96,10 @@ edit_link(
   </div>
   <div class="columns mediumlarge-8 mediumlarge-pull-4">
     <div class="section">
-      <%== cell("decidim/proposals/proposal_m", @proposal, full_badge: true).badge %>
-      <% unless @proposal.participatory_text_level == "section" || @proposal.participatory_text_level == "subsection" %>
+      <% if @proposal.emendation? %>
+        <%= cell("decidim/diff", @proposal.versions.last) %>
+      <% elsif not ["section","subsection"].include? @proposal.participatory_text_level %>
+        <%== cell("decidim/proposals/proposal_m", @proposal, full_badge: true).badge %>
         <%= simple_format present(@proposal).body(links: true, strip_tags: true) %>
       <% end %>
       <% if component_settings.geocoding_enabled? %>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -678,6 +678,7 @@ en:
           view_proposal: View proposal
         show:
           back_to: Back to
+          changes_at_title: Amendment to "%{title}"
           edit_proposal: Edit proposal
           endorsements_list: List of Endorsements
           hidden_endorsers_count:

--- a/decidim-proposals/spec/system/amend_proposal_spec.rb
+++ b/decidim-proposals/spec/system/amend_proposal_spec.rb
@@ -6,7 +6,7 @@ describe "Amend Proposal", versioning: true, type: :system do
   include_context "with a component"
   let(:manifest_name) { "proposals" }
 
-  let!(:proposal) { create(:proposal, title: "Title", body: "One liner body",component: component) }
+  let!(:proposal) { create(:proposal, title: "Title", body: "One liner body", component: component) }
   let!(:emendation) { create(:proposal, body: "Amended One liner body", component: component) }
   let!(:amendment) { create :amendment, amendable: proposal, emendation: emendation }
   let!(:user) { create :user, :confirmed, organization: organization }


### PR DESCRIPTION
#### :tophat: What? Why?

- Changed the amendment show page to display changes made using version control (as was originally  intended in #2292).
- Added a diff renderer when accepting an amendment (review page) to help with the reviewing process.

#### :pushpin: Related Issues
- Related to [Improvements to amendments](https://meta.decidim.org/processes/roadmap/f/122/proposals/14601#comment_21740)

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)
#### Amendment show page
![amendment_show_changed_title](https://user-images.githubusercontent.com/40306853/59163337-087a3b80-8b00-11e9-9ba6-b9dcbe47d1af.png)

#### Amendment review page (unified mode)
![review_block](https://user-images.githubusercontent.com/40306853/59163358-74f53a80-8b00-11e9-9d2b-f1ca94bab15d.png)

#### Amendment review page (unified mode)
![review_split](https://user-images.githubusercontent.com/40306853/59163359-76befe00-8b00-11e9-8570-0f8136098ea2.png)

#### Amendment review page (mobile version)
![preview-review_mobile](https://user-images.githubusercontent.com/40306853/59163356-73c40d80-8b00-11e9-803f-6db8c13c861f.png)
