### PR TITLE
Add new fields to proposal serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 **Added**:
 
+- **decidim-proposals**: Add new fields to proposal_serializer [#5186](https://github.com/decidim/decidim/pull/5186)
 - **decidim-proposals**: Add :amend action to proposal's authorization workflow [#5184](https://github.com/decidim/decidim/pull/5184)
 - **decidim-core**, **decidim-proposals**: Add: Improvements in amendments on `Proposals` control version [#5185](https://github.com/decidim/decidim/pull/5185)
 

--- a/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
+++ b/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
@@ -85,7 +85,7 @@ module Decidim
       end
 
       def original_proposal_url
-        return unless proposal.emendation?
+        return unless proposal.emendation? && proposal.amendable.present?
         Decidim::ResourceLocatorPresenter.new(proposal.amendable).url
       end
     end

--- a/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
+++ b/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
@@ -37,14 +37,22 @@ module Decidim
           reference: proposal.reference,
           answer: ensure_translatable(proposal.answer),
           supports: proposal.proposal_votes_count,
-          endorsements: proposal.endorsements.count,
+          endorsements: {
+            total_count: proposal.endorsements.count,
+            user_endorsements: user_endorsements,
+          },
           comments: proposal.comments.count,
           attachments: proposal.attachments.count,
           followers: proposal.followers.count,
           published_at: proposal.published_at,
           url: url,
           meeting_urls: meetings,
-          related_proposals: related_proposals
+          related_proposals: related_proposals,
+          is_amend: proposal.emendation?,
+          original_proposal: {
+            title: proposal&.amendable&.title,
+            url: original_proposal_url
+          }
         }
       end
 
@@ -70,6 +78,15 @@ module Decidim
 
       def url
         Decidim::ResourceLocatorPresenter.new(proposal).url
+      end
+
+      def user_endorsements
+        proposal.endorsements.for_listing.map { |identity| identity.normalized_author&.name }
+      end
+
+      def original_proposal_url
+        return unless proposal.emendation?
+        Decidim::ResourceLocatorPresenter.new(proposal.amendable).url
       end
     end
   end

--- a/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
+++ b/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
@@ -39,7 +39,7 @@ module Decidim
           supports: proposal.proposal_votes_count,
           endorsements: {
             total_count: proposal.endorsements.count,
-            user_endorsements: user_endorsements,
+            user_endorsements: user_endorsements
           },
           comments: proposal.comments.count,
           attachments: proposal.attachments.count,

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
@@ -110,14 +110,24 @@ module Decidim
           expect(serialized).to include(attachments: proposal.attachments.count)
         end
 
-        it "serializes the amount of endorsements" do
-          expect(serialized).to include(endorsements: proposal.endorsements.count)
+        it "serializes the endorsements" do
+          expect(serialized[:endorsements]).to include(total_count: proposal.endorsements.count)
+          expect(serialized[:endorsements]).to include(user_endorsements: proposal.endorsements.for_listing.map { |identity| identity.normalized_author&.name })
         end
 
         it "serializes related proposals" do
           expect(serialized[:related_proposals].length).to eq(2)
           expect(serialized[:related_proposals].first).to match(%r{http.*/proposals})
         end
+
+        it "serializes if proposal is_amend" do
+          expect(serialized).to include(is_amend: proposal.emendation?)
+        end
+
+        it "serializes the original proposal" do
+          expect(serialized[:original_proposal]).to include(title: proposal&.amendable&.title)
+          expect(serialized[:original_proposal][:url]).to be_nil || include("http", proposal.id.to_s)
+        end   
 
         context "with proposal having an answer" do
           let!(:proposal) { create(:proposal, :with_answer) }

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
@@ -127,7 +127,7 @@ module Decidim
         it "serializes the original proposal" do
           expect(serialized[:original_proposal]).to include(title: proposal&.amendable&.title)
           expect(serialized[:original_proposal][:url]).to be_nil || include("http", proposal.id.to_s)
-        end   
+        end
 
         context "with proposal having an answer" do
           let!(:proposal) { create(:proposal, :with_answer) }


### PR DESCRIPTION
#### :tophat: What? Why?
Add new fields to proposals serializer for export emmendations info.
This PR is part of https://meta.decidim.org/processes/roadmap/f/122/proposals/14601

File export: Add the following fields 
1- Field that indicates if it is an amendment (is_amend?)
2- Field that indicates statuts of amendment (already_exists)
3- Field that indicates participants and participants group have endorsed (endorsements) 
4- Field that indicates which proposal is being amended (original_proposal)
5- Field that indicates the url of the change in the proposal (is the proposal show path, already exists)

#### :pushpin: Related Issues
- Related to # https://meta.decidim.org/processes/roadmap/f/122/proposals/14601
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add new fields
- [x] Fix tests

### :camera: Screenshots (optional)
![Description](URL)
