### PR TITLE
Force users authenticate before access to organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 **Added**:
 
+- **decidim-core**, **decidim-system**: Add force users to authenticate before access to the organization [#5189](https://github.com/decidim/decidim/pull/5189)
 - **decidim-proposals**: Add :amend action to proposal's authorization workflow [#5184](https://github.com/decidim/decidim/pull/5184)
 - **decidim-core**, **decidim-proposals**: Add: Improvements in amendments on `Proposals` control version [#5185](https://github.com/decidim/decidim/pull/5185)
 

--- a/decidim-core/app/controllers/concerns/decidim/force_authentication.rb
+++ b/decidim-core/app/controllers/concerns/decidim/force_authentication.rb
@@ -30,11 +30,7 @@ module Decidim
     # authorized
     def allow_unauthorized_path?
       # Changing the locale
-      if request.path =~ /^\/locale/
-        return true
-      elsif request.path =~ /^\/cookies/
-        return true
-      end
+      return true if %r{^\/locale}.match?(request.path) || %r{^\/cookies}.match?(request.path)
       false
     end
   end

--- a/decidim-core/app/controllers/concerns/decidim/force_authentication.rb
+++ b/decidim-core/app/controllers/concerns/decidim/force_authentication.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Decidim
+  # Shared behaviour for force_users_to_authenticate_before_access_organization
+  module ForceAuthentication
+    extend ActiveSupport::Concern
+
+    included do
+      before_action :ensure_authenticated!, unless: :allow_unauthorized_path?
+    end
+
+    private
+
+    # For Devise helper functions, see:
+    # https://github.com/plataformatec/devise#getting-started
+    #
+    # Breaks the request lifecycle, if user is not authenticated.
+    # Otherwise returns.
+    def ensure_authenticated!
+      return true unless current_organization.force_users_to_authenticate_before_access_organization
+
+      # Next stop: Let's check whether auth is ok
+      unless user_signed_in?
+        flash[:warning] = t("actions.login_before_access", scope: "decidim.core")
+        return redirect_to decidim.new_user_session_path
+      end
+    end
+
+    # Check for all paths that should be allowed even if the user is not yet
+    # authorized
+    def allow_unauthorized_path?
+      # Changing the locale
+      if request.path =~ /^\/locale/
+        return true
+      elsif request.path =~ /^\/cookies/
+        return true
+      end
+      false
+    end
+  end
+end

--- a/decidim-core/app/controllers/decidim/application_controller.rb
+++ b/decidim-core/app/controllers/decidim/application_controller.rb
@@ -11,6 +11,7 @@ module Decidim
     include NeedsTosAccepted
     include HttpCachingDisabler
     include ActionAuthorization
+    include ForceAuthentication
 
     helper Decidim::MetaTagsHelper
     helper Decidim::DecidimFormHelper

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -300,6 +300,7 @@ en:
         name: Sub hero banner
     core:
       actions:
+        login_before_access: Please, login with your account before access
         unauthorized: You are not authorized to perform this action
     data_portability:
       export:

--- a/decidim-core/db/migrate/20190610093742_add_force_users_to_authenticate_before_access_organization.rb
+++ b/decidim-core/db/migrate/20190610093742_add_force_users_to_authenticate_before_access_organization.rb
@@ -5,25 +5,6 @@ class AddForceUsersToAuthenticateBeforeAccessOrganization < ActiveRecord::Migrat
     add_column :decidim_organizations,
                  :force_users_to_authenticate_before_access_organization,
                  :boolean,
-                 default: :false
+                 default: false
   end
-  
-  # def up
-  #   ActiveRecord::Base.transaction do
-  #     add_column :decidim_organizations,
-  #                :force_users_to_authenticate_before_access_organization,
-  #                :boolean,
-  #                default: :false
-  #   end
-
-  #   # Decidim::Organization.find_each do |organization|
-  #   #   organization.update(force_users_to_authenticate_before_access_organization: false)
-  #   # end
-  # end
-
-  # def down
-  #   ActiveRecord::Base.transaction do
-  #     remove_column :decidim_organizations, :force_users_to_authenticate_before_access_organization
-  #   end
-  # end
 end

--- a/decidim-core/db/migrate/20190610093742_add_force_users_to_authenticate_before_access_organization.rb
+++ b/decidim-core/db/migrate/20190610093742_add_force_users_to_authenticate_before_access_organization.rb
@@ -3,28 +3,27 @@
 class AddForceUsersToAuthenticateBeforeAccessOrganization < ActiveRecord::Migration[5.2]
   def up
     ActiveRecord::Base.transaction do
-      add_column :decidim_organizations, 
-      					 :force_users_to_authenticate_before_access_organization, 
-      					 :boolean, 
-      					 default: nil
- 
+      add_column :decidim_organizations,
+                 :force_users_to_authenticate_before_access_organization,
+                 :boolean,
+                 default: nil
+
       execute <<~SQL
         ALTER TABLE decidim_organizations ALTER COLUMN force_users_to_authenticate_before_access_organization SET DEFAULT false;
       SQL
     end
- 
+
     Decidim::Organization.find_each do |organization|
-      puts "Processing organization number ##{organization.id}"
-      organization.update_attributes(force_users_to_authenticate_before_access_organization: :false)
+      organization.update(force_users_to_authenticate_before_access_organization: false)
     end
- 
+
     ActiveRecord::Base.transaction do
       execute <<~SQL
         ALTER TABLE decidim_organizations ALTER COLUMN force_users_to_authenticate_before_access_organization SET NOT NULL;
       SQL
     end
   end
- 
+
   def down
     ActiveRecord::Base.transaction do
       remove_column :decidim_organizations, :force_users_to_authenticate_before_access_organization

--- a/decidim-core/db/migrate/20190610093742_add_force_users_to_authenticate_before_access_organization.rb
+++ b/decidim-core/db/migrate/20190610093742_add_force_users_to_authenticate_before_access_organization.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class AddForceUsersToAuthenticateBeforeAccessOrganization < ActiveRecord::Migration[5.2]
+  def up
+    ActiveRecord::Base.transaction do
+      add_column :decidim_organizations, 
+      					 :force_users_to_authenticate_before_access_organization, 
+      					 :boolean, 
+      					 default: nil
+ 
+      execute <<~SQL
+        ALTER TABLE decidim_organizations ALTER COLUMN force_users_to_authenticate_before_access_organization SET DEFAULT false;
+      SQL
+    end
+ 
+    Decidim::Organization.find_each do |organization|
+      puts "Processing organization number ##{organization.id}"
+      organization.update_attributes(force_users_to_authenticate_before_access_organization: :false)
+    end
+ 
+    ActiveRecord::Base.transaction do
+      execute <<~SQL
+        ALTER TABLE decidim_organizations ALTER COLUMN force_users_to_authenticate_before_access_organization SET NOT NULL;
+      SQL
+    end
+  end
+ 
+  def down
+    ActiveRecord::Base.transaction do
+      remove_column :decidim_organizations, :force_users_to_authenticate_before_access_organization
+    end
+  end
+end

--- a/decidim-core/db/migrate/20190610093742_add_force_users_to_authenticate_before_access_organization.rb
+++ b/decidim-core/db/migrate/20190610093742_add_force_users_to_authenticate_before_access_organization.rb
@@ -3,8 +3,8 @@
 class AddForceUsersToAuthenticateBeforeAccessOrganization < ActiveRecord::Migration[5.2]
   def change
     add_column :decidim_organizations,
-                 :force_users_to_authenticate_before_access_organization,
-                 :boolean,
-                 default: false
+               :force_users_to_authenticate_before_access_organization,
+               :boolean,
+               default: false
   end
 end

--- a/decidim-core/db/migrate/20190610093742_add_force_users_to_authenticate_before_access_organization.rb
+++ b/decidim-core/db/migrate/20190610093742_add_force_users_to_authenticate_before_access_organization.rb
@@ -1,32 +1,29 @@
 # frozen_string_literal: true
 
 class AddForceUsersToAuthenticateBeforeAccessOrganization < ActiveRecord::Migration[5.2]
-  def up
-    ActiveRecord::Base.transaction do
-      add_column :decidim_organizations,
+  def change
+    add_column :decidim_organizations,
                  :force_users_to_authenticate_before_access_organization,
                  :boolean,
-                 default: nil
-
-      execute <<~SQL
-        ALTER TABLE decidim_organizations ALTER COLUMN force_users_to_authenticate_before_access_organization SET DEFAULT false;
-      SQL
-    end
-
-    Decidim::Organization.find_each do |organization|
-      organization.update(force_users_to_authenticate_before_access_organization: false)
-    end
-
-    ActiveRecord::Base.transaction do
-      execute <<~SQL
-        ALTER TABLE decidim_organizations ALTER COLUMN force_users_to_authenticate_before_access_organization SET NOT NULL;
-      SQL
-    end
+                 default: :false
   end
+  
+  # def up
+  #   ActiveRecord::Base.transaction do
+  #     add_column :decidim_organizations,
+  #                :force_users_to_authenticate_before_access_organization,
+  #                :boolean,
+  #                default: :false
+  #   end
 
-  def down
-    ActiveRecord::Base.transaction do
-      remove_column :decidim_organizations, :force_users_to_authenticate_before_access_organization
-    end
-  end
+  #   # Decidim::Organization.find_each do |organization|
+  #   #   organization.update(force_users_to_authenticate_before_access_organization: false)
+  #   # end
+  # end
+
+  # def down
+  #   ActiveRecord::Base.transaction do
+  #     remove_column :decidim_organizations, :force_users_to_authenticate_before_access_organization
+  #   end
+  # end
 end

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -87,6 +87,7 @@ FactoryBot.define do
     badges_enabled { true }
     user_groups_enabled { true }
     send_welcome_notification { true }
+    force_users_to_authenticate_before_access_organization { false }
     smtp_settings do
       {
         "from" => "test@example.org",
@@ -96,7 +97,7 @@ FactoryBot.define do
         "address" => "smtp.example.org"
       }
     end
-
+    
     after(:create) do |organization|
       tos_page = Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization: organization)
       create(:static_page, :tos, organization: organization) if tos_page.nil?

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -97,7 +97,7 @@ FactoryBot.define do
         "address" => "smtp.example.org"
       }
     end
-    
+
     after(:create) do |organization|
       tos_page = Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization: organization)
       create(:static_page, :tos, organization: organization) if tos_page.nil?

--- a/decidim-core/spec/controllers/application_controller_spec.rb
+++ b/decidim-core/spec/controllers/application_controller_spec.rb
@@ -42,6 +42,35 @@ module Decidim
           expect(response.headers["Expires"]).to be_nil
         end
       end
+
+      context "when organization force users to authenticate before access" do
+        before do
+          organization.force_users_to_authenticate_before_access_organization = true
+          organization.save
+        end
+
+        context "when authenticated" do
+          before do
+            sign_in user
+          end
+
+          it "sets the appropiate headers" do
+            get :show
+
+            expect(response.headers["Cache-Control"]).to eq("no-cache, no-store")
+            expect(response.headers["Pragma"]).to eq("no-cache")
+            expect(response.headers["Expires"]).to eq("Fri, 01 Jan 1990 00:00:00 GMT")
+          end
+        end
+
+        context "when not authenticated" do
+          it "redirects to sign in path" do
+            get :show
+            expect(response).to redirect_to("/users/sign_in")
+            expect(flash[:warning]).to include("Please, login with your account before access")
+          end
+        end
+      end
     end
   end
 end

--- a/decidim-system/app/commands/decidim/system/register_organization.rb
+++ b/decidim-system/app/commands/decidim/system/register_organization.rb
@@ -52,6 +52,7 @@ module Decidim
           available_locales: form.available_locales,
           available_authorizations: form.clean_available_authorizations,
           users_registration_mode: form.users_registration_mode,
+          force_users_to_authenticate_before_access_organization: form.force_users_to_authenticate_before_access_organization,
           badges_enabled: true,
           user_groups_enabled: true,
           default_locale: form.default_locale,

--- a/decidim-system/app/commands/decidim/system/update_organization.rb
+++ b/decidim-system/app/commands/decidim/system/update_organization.rb
@@ -44,6 +44,7 @@ module Decidim
         organization.name = form.name
         organization.host = form.host
         organization.secondary_hosts = form.clean_secondary_hosts
+        organization.force_users_to_authenticate_before_access_organization = form.force_users_to_authenticate_before_access_organization
         organization.available_authorizations = form.clean_available_authorizations
         organization.users_registration_mode = form.users_registration_mode
         organization.smtp_settings = form.encrypted_smtp_settings

--- a/decidim-system/app/forms/decidim/system/register_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/register_organization_form.rb
@@ -16,6 +16,7 @@ module Decidim
       attribute :default_locale, String
       attribute :reference_prefix
       attribute :users_registration_mode, String
+      attribute :force_users_to_authenticate_before_access_organization, Boolean
 
       validates :organization_admin_email, :organization_admin_name, :name, :host, :reference_prefix, :users_registration_mode, presence: true
       validates :available_locales, presence: true

--- a/decidim-system/app/forms/decidim/system/update_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/update_organization_form.rb
@@ -15,6 +15,7 @@ module Decidim
       attribute :name, String
       attribute :host, String
       attribute :secondary_hosts, String
+      attribute :force_users_to_authenticate_before_access_organization, Boolean
       attribute :available_authorizations, Array[String]
       attribute :users_registration_mode, String
       jsonb_attribute :smtp_settings, [

--- a/decidim-system/app/views/decidim/system/organizations/edit.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/edit.html.erb
@@ -13,6 +13,11 @@
   </div>
 
   <div class="field">
+    <%= f.label :force_authentication %>
+    <%= f.check_box :force_users_to_authenticate_before_access_organization %>
+  </div>
+
+  <div class="field">
     <%= f.label :users_registration_mode %>
     <%= f.collection_radio_buttons :users_registration_mode,
                                    Decidim::Organization.users_registration_modes,

--- a/decidim-system/app/views/decidim/system/organizations/new.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/new.html.erb
@@ -54,6 +54,11 @@
   <% end %>
 
   <div class="field">
+    <%= f.label :force_authentication %>
+    <%= f.check_box :force_users_to_authenticate_before_access_organization %>
+  </div>
+
+  <div class="field">
     <%= f.label :users_registration_mode %>
     <%= f.collection_radio_buttons :users_registration_mode,
                                    Decidim::Organization.users_registration_modes,

--- a/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
@@ -24,6 +24,7 @@ module Decidim
               available_locales: ["en"],
               default_locale: "en",
               users_registration_mode: "enabled",
+              force_users_to_authenticate_before_access_organization: "false",
               smtp_settings: {
                 "address" => "mail.gotham.gov",
                 "port" => "25",

--- a/decidim-system/spec/commands/decidim/system/update_organization_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/update_organization_spec.rb
@@ -19,6 +19,7 @@ module Decidim
               name: "Gotham City",
               host: "decide.gotham.gov",
               secondary_hosts: "foo.gotham.gov\r\n\r\nbar.gotham.gov",
+              force_users_to_authenticate_before_access_organization: false,
               users_registration_mode: "existing"
             }
           end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds the Possibility to force login before accessing the platform.

#### :pushpin: Related Issues
- Related to # https://meta.decidim.org/processes/roadmap/f/122/proposals/13132
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add documentation regarding the feature 
- [x] Add/modify seeds
- [x] Add tests
- [x] Add checkbox on System to force users to login before access to the organization.

- [ ] Another subtask

### :camera: Screenshots (optional)
System

![screenshot-localhost-3000-2019 06 11-15-34-30](https://user-images.githubusercontent.com/28536082/59276350-6cb31180-8c5e-11e9-9e0b-ae74e94369d5.png)

Organization
![screenshot-localhost-3000-2019 06 11-15-36-26](https://user-images.githubusercontent.com/28536082/59276525-c1568c80-8c5e-11e9-9eb8-bcef69e8abdb.png)
