### PR TITLE
Fix user names migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - **decidim-admin**: Fix: Proposals component form introduced regression [#5179](https://github.com/decidim/decidim/pull/5179)
 - **decidim-core**: Fix seeds and typo in ActionAuthorizer [#5168](https://github.com/decidim/decidim/pull/5168)
 - **decidim-proposals**: Fix seeds [#5168](https://github.com/decidim/decidim/pull/5168)
+- **decidim-core**: Fix user names migration [#5209](https://github.com/decidim/decidim/pull/5209)
 
 
 **Removed**:

--- a/decidim-core/db/migrate/20190412131728_fix_user_names.rb
+++ b/decidim-core/db/migrate/20190412131728_fix_user_names.rb
@@ -8,14 +8,15 @@ class FixUserNames < ActiveRecord::Migration[5.2]
     characters_to_remove = "<>?%&^*\#@()[]=+:;\"{}\\|/"
 
     weird_characters.each do |character|
-      Decidim::UserBaseEntity.where("name like '%#{character}%' escape '\' OR nickname like '%#{character}%' escape '\'").find_each do |entity|
-        Rails.logger.log "detected character: #{character}"
-        Rails.logger.log "UserBaseEntity ID: #{entity.id}"
-        Rails.logger.log "#{entity.name} => #{entity.name.delete(characters_to_remove).strip}"
-        Rails.logger.log "#{entity.nickname} => #{entity.nickname.delete(characters_to_remove).strip}"
+      Decidim::UserBaseEntity.where(deleted_at: nil).where("name like '%#{character}%' escape '\' OR nickname like '%#{character}%' escape '\'").find_each do |entity|
+        Rails.logger.debug "detected character: #{character}"
+        Rails.logger.debug "UserBaseEntity ID: #{entity.id}"
+        Rails.logger.debug "#{entity.name} => #{entity.name.delete(characters_to_remove).strip}"
+        Rails.logger.debug "#{entity.nickname} => #{entity.nickname.delete(characters_to_remove).strip}"
 
         entity.name = entity.name.delete(characters_to_remove).strip
-        entity.nickname = entity.nickname.delete(characters_to_remove).strip
+        sanitized_nickname = entity.nickname.delete(characters_to_remove).strip
+        entity.nickname = Decidim::UserBaseEntity.nicknamize(sanitized_nickname, organization: entity.organization)
         entity.save!
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

Ignores deleted users and also takes into account that a nick could already exist.

#### :pushpin: Related Issues
- Related to #5087 
- Fixes #5191 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

