### PR TITLE
Backport/fix/5040 do not allow to delete areas when they have dependent models

### DIFF
--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -162,7 +162,7 @@ en:
           error: There was a problem creating a new area.
           success: Area created successfully.
         destroy:
-          has_spaces: Area has depedent spaces, it must not have dependencies in order to be deleted.
+          has_spaces: Area has dependent spaces, it must not have dependencies in order to be deleted.
           success: Area successfully destroyed
         edit:
           title: Edit area

--- a/decidim-admin/spec/commands/decidim/admin/destroy_area_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/destroy_area_spec.rb
@@ -35,25 +35,5 @@ module Decidim::Admin
       action_log = Decidim::ActionLog.last
       expect(action_log.version).to be_present
     end
-
-    context "when a participatory process associated to a given area exist" do
-      let!(:process) { create(:participatory_process, organization: area.organization, area: area) }
-
-      it "can not be deleted" do
-        expect { subject.call }.to broadcast(:has_spaces)
-        area.reload
-        expect(area.destroyed?).to be false
-      end
-    end
-
-    context "when an assembly associated to a given area exist" do
-      let!(:process) { create(:assembly, organization: area.organization, area: area) }
-
-      it "can not be deleted" do
-        expect { subject.call }.to broadcast(:has_spaces)
-        area.reload
-        expect(area.destroyed?).to be false
-      end
-    end
   end
 end

--- a/decidim-admin/spec/system/admin_manages_organization_areas_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_areas_spec.rb
@@ -90,17 +90,13 @@ describe "Organization Areas", type: :system do
         it "can not be deleted" do
           click_delete_area
           expect(area.reload.destroyed?).to be false
-          expect(page).to have_admin_callout("Area has depedent spaces")
+          expect(page).to have_admin_callout("Area has dependent spaces")
         end
       end
     end
   end
 
-  #---------------------------------------------------
-
   private
-
-  #---------------------------------------------------
 
   def click_delete_area
     within find("tr", text: translated(area.name)) do


### PR DESCRIPTION
#### :tophat: What? Why?
Backport https://github.com/decidim/decidim/pull/5050

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/pull/5050

#### :clipboard: Subtasks
- [] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
