### PR TITLE
Feat: `amendments_visibility` component step setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 **Added**:
 
+- **decidim-core**, **decidim-admin**, **decidim-proposals**: Add: `amendments_visibility` component step setting [#5223](https://github.com/decidim/decidim/pull/5223)
+- **decidim-core**, **decidim-admin**, **decidim-proposals**: Add: admin configuration of amendments by step [#5178](https://github.com/decidim/decidim/pull/5178)
 - **decidim-consultations**: Add admin results page to consultations [#5188](https://github.com/decidim/decidim/pull/5188)
 - **decidim-core**: Adds SECURITY.md per Github recommendations [#5181](https://github.com/decidim/decidim/pull/5181)
 - **decidim-core**, **decidim-system**: Add force users to authenticate before access to the organization [#5189](https://github.com/decidim/decidim/pull/5189)

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -191,6 +191,7 @@ ignore_unused:
   - decidim.assemblies.filter.*
   - decidim.initiatives.initiatives.votes_count.count.*
   - decidim.proposals.admin.participatory_texts.new_import.accepted_mime_types.*
+  - decidim.amendments.visibility_options.*
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/decidim-admin/app/forms/decidim/admin/component_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/component_form.rb
@@ -22,6 +22,7 @@ module Decidim
       attribute :participatory_space
 
       validate :must_be_able_to_change_participatory_texts_setting, if: :proposal_component?
+      validate :amendments_visibility_options_must_be_valid, if: :proposal_component?
 
       def settings?
         settings.manifest.attributes.any?
@@ -48,6 +49,15 @@ module Decidim
         return if form_setting_value == component.settings.participatory_texts_enabled
 
         errors.add(:settings) if Decidim::Proposals::Proposal.where(component: component).any?
+      end
+
+      def amendments_visibility_options_must_be_valid
+        return unless component.settings.amendments_enabled
+        return unless step_settings.any? do |_step, settings|
+          Decidim::Amendment::VisibilityStepSetting.options.map(&:last).exclude? settings[:amendments_visibility]
+        end
+
+        errors.add(:settings)
       end
     end
   end

--- a/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
@@ -23,7 +23,9 @@ module Decidim
       #
       # Returns a rendered form field.
       def settings_attribute_input(form, attribute, name, options = {})
-        if attribute.translated?
+        if name == :amendments_visibility
+          amendments_visibility_form_field(form, options)
+        elsif attribute.translated?
           form.send(:translated, form_method_for_attribute(attribute), name, options.merge(tabs_id: "#{options[:tabs_prefix]}-#{name}-tabs"))
         else
           form.send(form_method_for_attribute(attribute), name, options.merge(extra_options_for(name)))
@@ -37,6 +39,30 @@ module Decidim
       end
 
       private
+
+      # Returns a radio buttons collection input for the component's step setting
+      # :amendments_visibility; all wrap in a label tag and with help text.
+      def amendments_visibility_form_field(form, options)
+        collection = Decidim::Amendment::VisibilityStepSetting.options
+        step_number = options[:tabs_prefix].split("-")[1] # Gets the number in a String like "step-N-settings"
+        checked = @component.step_settings[step_number].amendments_visibility
+
+        html = label_tag(:amendments_visibility) do
+          concat options[:label]
+          concat tag(:br)
+          concat form.collection_radio_buttons(:amendments_visibility,
+                                               collection,
+                                               :last,
+                                               :first,
+                                               { checked: checked },
+                                               amendments_extra_options)
+        end
+        html << content_tag(:p,
+                            help_text_for_component_setting(:amendments_visibility, :step, :proposals),
+                            class: "help-text")
+
+        html.html_safe
+      end
 
       def form_method_for_attribute(attribute)
         return :editor if attribute.type.to_sym == :text && attribute.editor?

--- a/decidim-core/app/cells/decidim/amendable/amenders_list_cell.rb
+++ b/decidim-core/app/cells/decidim/amendable/amenders_list_cell.rb
@@ -17,9 +17,13 @@ module Decidim::Amendable
       model
     end
 
+    def visible_amendments
+      amendable.visible_amendments_for(current_user)
+    end
+
     # Returns a UserPresenter array
     def amenders
-      @amenders ||= amendable.amendments.map { |amendment| present(amendment.amender) }.uniq
+      @amenders ||= visible_amendments.map { |amendment| present(amendment.amender) }.uniq
     end
 
     def options

--- a/decidim-core/app/cells/decidim/amendable/announcement_cell.rb
+++ b/decidim-core/app/cells/decidim/amendable/announcement_cell.rb
@@ -24,6 +24,7 @@ module Decidim::Amendable
 
     def promoted_message
       return "" unless model.amendment.promoted?
+
       proposal = model.linked_promoted_resource
       text = message(:promoted, amendable_type)
       %(<br><strong>#{proposal_link(proposal, text)}</strong>)

--- a/decidim-core/app/helpers/decidim/amendments_helper.rb
+++ b/decidim-core/app/helpers/decidim/amendments_helper.rb
@@ -7,14 +7,15 @@ module Decidim
     #
     # Returns Html grid of CardM.
     def amendments_for(amendable)
-      return unless amendable.amendable? && amendable.emendations.count.positive?
+      return unless amendable.amendable?
+      return unless (emendations = amendable.visible_emendations_for(current_user)).any?
 
       content = content_tag(:h2, class: "section-heading", id: "amendments") do
-        t("section_heading", scope: "decidim.amendments.amendable", count: amendable.emendations.count)
+        t("section_heading", scope: "decidim.amendments.amendable", count: emendations.count)
       end
 
       content << cell("decidim/collapsible_list",
-                      amendable.emendations,
+                      emendations,
                       cell_options: { context: { current_user: current_user } },
                       list_class: "row small-up-1 medium-up-2 card-grid amendment-list",
                       size: 4).to_s

--- a/decidim-core/app/models/decidim/amendment.rb
+++ b/decidim-core/app/models/decidim/amendment.rb
@@ -23,5 +23,23 @@ module Decidim
 
       emendation.linked_promoted_resource.present?
     end
+
+    # VisibilityStepSetting::options can be expanded via config setting.
+    #
+    # For new options, add the missing locales in `decidim-core/config/locales/en.yml` and
+    # change the logic of the filtering methods in the Amendable concern to fit your needs:
+    # - Decidim::Amendable::only_visible_emendations_for(user, component)
+    # - Decidim::Amendable::amendables_and_visible_emendations_for(user, component)
+    # - Decidim::Amendable#visible_emendations_for(user)
+    #
+    # Returns an Array of Arrays of translation, value:
+    # i.e. [["All amendments are visible", "all"], ...]
+    class VisibilityStepSetting
+      def self.options
+        Decidim.config.amendments_visibility_options.map do |option|
+          [I18n.t(option, scope: "decidim.amendments.visibility_options"), option]
+        end
+      end
+    end
   end
 end

--- a/decidim-core/app/services/decidim/resource_search.rb
+++ b/decidim-core/app/services/decidim/resource_search.rb
@@ -45,7 +45,7 @@ module Decidim
                         end
 
       conditions = []
-      conditions << "decidim_scope_id IS NULL" if clean_scope_ids.delete("global")
+      conditions << "#{query.model_name.plural}.decidim_scope_id IS NULL" if clean_scope_ids.delete("global")
       conditions.concat(["? = ANY(decidim_scopes.part_of)"] * clean_scope_ids.count) if clean_scope_ids.any?
 
       query.includes(:scope).references(:decidim_scopes).where(conditions.join(" OR "), *clean_scope_ids.map(&:to_i))

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -180,6 +180,9 @@ en:
         heading: Review the amendment
         help_text: You are reviewing an amendment to the %{model_name}
         send: Accept amendment
+      visibility_options:
+        all: All amendments are visible
+        participants: Participants can only see their own amendments
     anonymous_user: Anonymous
     application:
       collection:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -181,8 +181,8 @@ en:
         help_text: You are reviewing an amendment to the %{model_name}
         send: Accept amendment
       visibility_options:
-        all: All amendments are visible
-        participants: Participants can only see their own amendments
+        all: Amendments are visible to all
+        participants: Amendments are visible only to their authors
     anonymous_user: Anonymous
     application:
       collection:

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -275,6 +275,16 @@ module Decidim
     %w(admin user_manager)
   end
 
+  # Exposes a configuration option: An Array of Strings that serve both as
+  # locale keys and values to construct the input collection in
+  # Decidim::Amendment::VisibilityStepSetting::options.
+  # This collection is used in Decidim::Admin::SettingsHelper to generate a
+  # radio buttons collection input field form for a Decidim::Component
+  # step setting :amendments_visibility.
+  config_accessor :amendments_visibility_options do
+    %w(all participants)
+  end
+
   # Public: Registers a global engine. This method is intended to be used
   # by component engines that also offer unscoped functionality
   #

--- a/decidim-proposals/app/services/decidim/proposals/proposal_search.rb
+++ b/decidim-proposals/app/services/decidim/proposals/proposal_search.rb
@@ -10,6 +10,8 @@ module Decidim
       # page        - The page number to paginate the results.
       # per_page    - The number of proposals to return per page.
       def initialize(options = {})
+        @component = options[:component]
+        @current_user = options[:current_user]
         super(Proposal.all, options)
       end
 
@@ -86,9 +88,9 @@ module Decidim
         when "proposals"
           query.only_amendables
         when "amendments"
-          query.only_emendations
-        else
-          query
+          query.only_visible_emendations_for(@current_user, @component)
+        else # Assume 'all'
+          query.amendables_and_visible_emendations_for(@current_user, @component)
         end
       end
 

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
@@ -12,7 +12,7 @@
     </div>
   </div>
 
-  <% if Decidim::Proposals::Proposal.only_emendations.any? %>
+  <% if Decidim::Proposals::Proposal.only_visible_emendations_for(current_user, current_component).any? %>
     <%= form.collection_radio_buttons :type, filter_type_values, :first, :last, legend_title: t(".amendment_type") %>
   <% end %>
   <% if component_settings.official_proposals_enabled %>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -118,7 +118,7 @@ en:
             amendment_reaction_enabled: Amendment reaction enabled
             amendment_reaction_enabled_help: Proposal's authors will be able to accept or reject Participant's emendations.
             amendments_visibility: Amendment visibility
-            amendments_visibility_help: If the option "Participants can only see their own amendments" is selected, participant must be logged in to see the amendments made.
+            amendments_visibility_help: If the option "Amendments are visible only to their authors" is selected, participant must be logged in to see the amendments made.
             announcement: Announcement
             automatic_hashtags: Hashtags added to all proposals
             comments_blocked: Comments blocked

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -117,6 +117,8 @@ en:
             amendment_promotion_enabled_help: Emandation authors will be able to promote to Proposal the rejected emendation.
             amendment_reaction_enabled: Amendment reaction enabled
             amendment_reaction_enabled_help: Proposal's authors will be able to accept or reject Participant's emendations.
+            amendments_visibility: Amendment visibility
+            amendments_visibility_help: If the option "Participants can only see their own amendments" is selected, participant must be logged in to see the amendments made.
             announcement: Announcement
             automatic_hashtags: Hashtags added to all proposals
             comments_blocked: Comments blocked

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -58,6 +58,7 @@ Decidim.register_component(:proposals) do |component|
     settings.attribute :amendment_creation_enabled, type: :boolean, default: true
     settings.attribute :amendment_reaction_enabled, type: :boolean, default: true
     settings.attribute :amendment_promotion_enabled, type: :boolean, default: true
+    settings.attribute :amendments_visibility, type: :string, default: "all"
     settings.attribute :announcement, type: :text, translated: true, editor: true
     settings.attribute :automatic_hashtags, type: :text, editor: false, required: false
     settings.attribute :suggested_hashtags, type: :text, editor: false, required: false

--- a/decidim-proposals/spec/system/amend_proposal_spec.rb
+++ b/decidim-proposals/spec/system/amend_proposal_spec.rb
@@ -141,6 +141,71 @@ describe "Amend Proposal", versioning: true, type: :system do
         end
       end
     end
+
+    context "when amendments VISIBILITY is set to 'participants'" do
+      before do
+        update_component_step_setting(component, :amendments_visibility, "participants")
+      end
+
+      context "when the user is logged in" do
+        before do
+          login_as user, scope: :user
+          visit proposal_path
+        end
+
+        context "and visit an amendable proposal that they have amended" do
+          let(:user) { emendation.creator_author }
+
+          it "is shown the emendation from other user in the amendments list" do
+            within ".amendment-list" do
+              expect(page).to have_content(emendation.title)
+            end
+          end
+
+          it "is shown the other user in the amenders list" do
+            within ".amender-list" do
+              expect(page).to have_content(emendation.creator_author.name)
+            end
+          end
+        end
+
+        context "and visit an amendable proposal that they have NOT amended" do
+          let!(:user) { create :user, :confirmed, organization: component.organization }
+
+          it "is shown the emendation from other users in the amendments list" do
+            within ".amendment-list" do
+              expect(page).to have_content(emendation.title)
+            end
+          end
+
+          it "is shown other users in the amenders list" do
+            within ".amender-list" do
+              expect(page).to have_content(emendation.creator_author.name)
+            end
+          end
+        end
+      end
+
+      context "when the user is NOT logged in" do
+        before do
+          visit proposal_path
+        end
+
+        context "and visit an amendable proposal" do
+          it "is shown the emendation from other users in the amendments list" do
+            within ".amendment-list" do
+              expect(page).to have_content(emendation.title)
+            end
+          end
+
+          it "is shown other users in the amenders list" do
+            within ".amender-list" do
+              expect(page).to have_content(emendation.creator_author.name)
+            end
+          end
+        end
+      end
+    end
   end
 
   context "with amendments enabled" do
@@ -163,11 +228,11 @@ describe "Amend Proposal", versioning: true, type: :system do
         end
 
         context "when the user is not logged in and clicks" do
-          it "is shown the login modal" do
-            within ".card__amend-button", match: :first do
-              click_link "Amend Proposal"
-            end
+          before do
+            click_link "Amend Proposal"
+          end
 
+          it "is shown the login modal" do
             expect(page).to have_css("#loginModal", visible: true)
           end
         end
@@ -417,6 +482,128 @@ describe "Amend Proposal", versioning: true, type: :system do
         it "is NOT shown the promote button" do
           expect(page).not_to have_content("PROMOTE TO PROPOSAL")
           expect(page).not_to have_content("You can promote this emendation and publish it as an independent proposal")
+        end
+      end
+    end
+
+    context "when amendments VISIBILITY is set to 'participants'" do
+      before do
+        update_component_step_setting(component, :amendments_visibility, "participants")
+      end
+
+      context "when the user is logged in" do
+        before do
+          login_as user, scope: :user
+          visit proposal_path
+        end
+
+        context "and visit an amendable proposal that they have amended" do
+          let(:user) { emendation.creator_author }
+
+          it "is shown the emendation in the amendments list" do
+            within ".amendment-list" do
+              expect(page).to have_content(emendation.title)
+            end
+          end
+
+          it "is shown the user in the amenders list" do
+            within ".amender-list" do
+              expect(page).to have_content(user.name)
+            end
+          end
+        end
+
+        context "and visit an amendable proposal that they have NOT amended" do
+          let!(:user) { create :user, :confirmed, organization: component.organization }
+
+          it "is NOT shown the amendments list" do
+            expect(page).not_to have_css(".amendment-list")
+          end
+
+          it "is NOT shown the amenders list" do
+            expect(page).not_to have_css(".amender-list")
+          end
+        end
+      end
+
+      context "when the user is NOT logged in" do
+        before do
+          visit proposal_path
+        end
+
+        context "and visit an amendable proposal" do
+          it "is NOT shown the amendments list" do
+            expect(page).not_to have_css(".amendment-list")
+          end
+
+          it "is NOT shown the amenders list" do
+            expect(page).not_to have_css(".amender-list")
+          end
+        end
+      end
+    end
+
+    context "when amendments VISIBILITY is set to 'all'" do
+      before do
+        update_component_step_setting(component, :amendments_visibility, "all")
+      end
+
+      context "when the user is logged in" do
+        before do
+          login_as user, scope: :user
+          visit proposal_path
+        end
+
+        context "and visit an amendable proposal that they have amended" do
+          let(:user) { emendation.creator_author }
+
+          it "is shown the emendation from other user in the amendments list" do
+            within ".amendment-list" do
+              expect(page).to have_content(emendation.title)
+            end
+          end
+
+          it "is shown the other user in the amenders list" do
+            within ".amender-list" do
+              expect(page).to have_content(emendation.creator_author.name)
+            end
+          end
+        end
+
+        context "and visit an amendable proposal that they have NOT amended" do
+          let!(:user) { create :user, :confirmed, organization: component.organization }
+
+          it "is shown the emendation from other users in the amendments list" do
+            within ".amendment-list" do
+              expect(page).to have_content(emendation.title)
+            end
+          end
+
+          it "is shown other users in the amenders list" do
+            within ".amender-list" do
+              expect(page).to have_content(emendation.creator_author.name)
+            end
+          end
+        end
+      end
+
+      context "when the user is NOT logged in" do
+        before do
+          visit proposal_path
+        end
+
+        context "and visit an amendable proposal" do
+          it "is shown the emendation from other users in the amendments list" do
+            within ".amendment-list" do
+              expect(page).to have_content(emendation.title)
+            end
+          end
+
+          it "is shown other users in the amenders list" do
+            within ".amender-list" do
+              expect(page).to have_content(emendation.creator_author.name)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

> The administrator can configure whether amendments are visible to everyone or participants only view the amendments that they have created -> Only when amendment is enabled

#### :pushpin: Related Issues
- Related to #5178
- Related to [Improvements to amendments](https://meta.decidim.org/processes/roadmap/f/122/proposals/14601)

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)
![amendments_visibility_updated](https://user-images.githubusercontent.com/40306853/59915658-733f4700-941d-11e9-86a7-8cbd05dac8f3.png)
