### PR TITLE
fix can't remove area, when conferences are enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 **Fixed**:
 
+- **decidim-conferences**: Fix: can't remove area, when conferences are enabled [#5234](https://github.com/decidim/decidim/pull/5234)
 - **decidim-admin**: Fix: Proposals component form introduced regression [#5179](https://github.com/decidim/decidim/pull/5179)
 - **decidim-core**: Fix seeds and typo in ActionAuthorizer [#5168](https://github.com/decidim/decidim/pull/5168)
 - **decidim-proposals**: Fix seeds [#5168](https://github.com/decidim/decidim/pull/5168)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ PATH
       foundation-rails (~> 6.4, < 6.5)
       foundation_rails_helper (~> 3.0)
       geocoder (~> 1.5)
-      hashdiff (>= 1.0.0.beta1, < 2.0.0)
+      hashdiff (>= 0.4.0, < 2.0.0)
       invisible_captcha (~> 0.12)
       jquery-rails (~> 4.3)
       kaminari (~> 1.1)

--- a/decidim-conferences/app/models/decidim/conference.rb
+++ b/decidim-conferences/app/models/decidim/conference.rb
@@ -20,10 +20,7 @@ module Decidim
     belongs_to :organization,
                foreign_key: "decidim_organization_id",
                class_name: "Decidim::Organization"
-    belongs_to :area,
-               foreign_key: "decidim_area_id",
-               class_name: "Decidim::Area",
-               optional: true
+
     has_many :categories,
              foreign_key: "decidim_participatory_space_id",
              foreign_type: "decidim_participatory_space_type",


### PR DESCRIPTION
#### :tophat: What? Why?
The problem is that the association exists in the model, but there is no migration that creates the FK in the DB, Also the form, command, and view, not have the necessary fields to assign area to conference.

#### :pushpin: Related Issues
- Related to #5041 
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Remove unnecessary association

### :camera: Screenshots (optional)
![Description](URL)
