### PR TITLE
fix Notification of registrations enabled when creating a Conference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - **decidim-core**: Filter forbidden characters in users invitations. [\#5245](https://github.com/decidim/decidim/pull/5245)
 - **decidim-assemblies**: Don't show private assemblies when becoming childs from another assembly. [#5235](https://github.com/decidim/decidim/pull/5235)
 - **decidim-conferences**: Fix: can't remove area, when conferences are enabled [#5234](https://github.com/decidim/decidim/pull/5234)
+- **decidim-conferences**: Don't send registrations enabled notification when creating a Conference[#5240](https://github.com/decidim/decidim/pull/5240)
 - **decidim-admin**: Fix: Proposals component form introduced regression [#5179](https://github.com/decidim/decidim/pull/5179)
 - **decidim-core**: Fix seeds and typo in ActionAuthorizer [#5168](https://github.com/decidim/decidim/pull/5168)
 - **decidim-proposals**: Fix seeds [#5168](https://github.com/decidim/decidim/pull/5168)

--- a/decidim-conferences/app/commands/decidim/conferences/admin/create_conference.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/create_conference.rb
@@ -29,7 +29,6 @@ module Decidim
             link_consultations
 
             broadcast(:ok, conference)
-            send_notification
           else
             form.errors.add(:hero_image, conference.errors[:hero_image]) if conference.errors.include? :hero_image
             form.errors.add(:banner_image, conference.errors[:banner_image]) if conference.errors.include? :banner_image
@@ -79,15 +78,6 @@ module Decidim
 
             Decidim::CreateFollow.new(form, admin).call
           end
-        end
-
-        def send_notification
-          Decidim::EventsManager.publish(
-            event: "decidim.events.conferences.registrations_enabled",
-            event_class: Decidim::Conferences::ConferenceRegistrationsEnabledEvent,
-            resource: conference,
-            followers: conference.followers
-          )
         end
 
         def participatory_processes

--- a/decidim-conferences/app/commands/decidim/conferences/admin/publish_conference.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/publish_conference.rb
@@ -28,11 +28,23 @@ module Decidim
           end
 
           broadcast(:ok)
+          send_notification
         end
 
         private
 
         attr_reader :conference, :current_user
+
+        def send_notification
+          return unless conference.registrations_enabled?
+          
+          Decidim::EventsManager.publish(
+            event: "decidim.events.conferences.registrations_enabled",
+            event_class: Decidim::Conferences::ConferenceRegistrationsEnabledEvent,
+            resource: conference,
+            followers: conference.followers
+          )
+        end
       end
     end
   end

--- a/decidim-conferences/app/commands/decidim/conferences/admin/publish_conference.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/publish_conference.rb
@@ -37,7 +37,7 @@ module Decidim
 
         def send_notification
           return unless conference.registrations_enabled?
-          
+
           Decidim::EventsManager.publish(
             event: "decidim.events.conferences.registrations_enabled",
             event_class: Decidim::Conferences::ConferenceRegistrationsEnabledEvent,

--- a/decidim-conferences/app/commands/decidim/conferences/admin/update_conference.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/update_conference.rb
@@ -100,7 +100,9 @@ module Decidim
         end
 
         def should_notify_followers_registrations_enabled?
-          @conference.previous_changes["registrations_enabled"].present? && @conference.registrations_enabled?
+          @conference.previous_changes["registrations_enabled"].present? && 
+          @conference.registrations_enabled? &&
+          @conference.published?
         end
 
         def send_notification_update_conference
@@ -113,7 +115,8 @@ module Decidim
         end
 
         def should_notify_followers_update_conference?
-          important_attributes.any? { |attr| @conference.previous_changes[attr].present? }
+          important_attributes.any? { |attr| @conference.previous_changes[attr].present? } &&
+          @conference.published?
         end
 
         def important_attributes

--- a/decidim-conferences/app/commands/decidim/conferences/admin/update_conference.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/update_conference.rb
@@ -100,9 +100,9 @@ module Decidim
         end
 
         def should_notify_followers_registrations_enabled?
-          @conference.previous_changes["registrations_enabled"].present? && 
-          @conference.registrations_enabled? &&
-          @conference.published?
+          @conference.previous_changes["registrations_enabled"].present? &&
+            @conference.registrations_enabled? &&
+            @conference.published?
         end
 
         def send_notification_update_conference
@@ -116,7 +116,7 @@ module Decidim
 
         def should_notify_followers_update_conference?
           important_attributes.any? { |attr| @conference.previous_changes[attr].present? } &&
-          @conference.published?
+            @conference.published?
         end
 
         def important_attributes

--- a/decidim-conferences/spec/commands/create_conference_spec.rb
+++ b/decidim-conferences/spec/commands/create_conference_spec.rb
@@ -146,19 +146,6 @@ module Decidim::Conferences
         linked_consultations = conference.linked_participatory_space_resources("Consultations", "included_consultations")
         expect(linked_consultations).to match_array(questions.collect(&:consultation).uniq)
       end
-
-      it "notifies the change" do
-        expect(Decidim::EventsManager)
-          .to receive(:publish)
-          .with(
-            event: "decidim.events.conferences.registrations_enabled",
-            event_class: ConferenceRegistrationsEnabledEvent,
-            resource: kind_of(Decidim::Conference),
-            followers: [current_user]
-          )
-
-        subject.call
-      end
     end
   end
 end

--- a/decidim-conferences/spec/commands/publish_conference_spec.rb
+++ b/decidim-conferences/spec/commands/publish_conference_spec.rb
@@ -6,7 +6,7 @@ module Decidim::Conferences
   describe Admin::PublishConference do
     subject { described_class.new(my_conference, user) }
 
-    let(:my_conference) { create :conference, :unpublished, organization: user.organization }
+    let!(:my_conference) { create :conference, :unpublished, organization: user.organization, registrations_enabled: true }
     let(:user) { create :user }
 
     context "when the conference is nil" do
@@ -26,6 +26,8 @@ module Decidim::Conferences
     end
 
     context "when the conference is not published" do
+      let(:follow) { create :follow, followable: my_conference, user: user }
+
       it "is valid" do
         expect { subject.call }.to broadcast(:ok)
       end
@@ -56,7 +58,7 @@ module Decidim::Conferences
             event: "decidim.events.conferences.registrations_enabled",
             event_class: ConferenceRegistrationsEnabledEvent,
             resource: kind_of(Decidim::Conference),
-            followers: [current_user]
+            followers: [follow.user]
           )
 
         subject.call

--- a/decidim-conferences/spec/commands/publish_conference_spec.rb
+++ b/decidim-conferences/spec/commands/publish_conference_spec.rb
@@ -48,6 +48,19 @@ module Decidim::Conferences
         expect(action_log.version).to be_present
         expect(action_log.version.event).to eq "update"
       end
+
+      it "notifies the change" do
+        expect(Decidim::EventsManager)
+          .to receive(:publish)
+          .with(
+            event: "decidim.events.conferences.registrations_enabled",
+            event_class: ConferenceRegistrationsEnabledEvent,
+            resource: kind_of(Decidim::Conference),
+            followers: [current_user]
+          )
+
+        subject.call
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
when create a conference and registrations are disabled, followers are reciving a notification/email  notifying them, that registrations are enabled.

As a follower, I expected to recieve this notification when conference is published and registrations enabled.

#### :pushpin: Related Issues
- Related to #3709 
- Fixes #5237 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Change event notification when conference is published
- [x] Refactor tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
