### PR TITLE
fix consultation admin menu hierarchy

### DIFF
--- a/decidim-consultations/app/views/layouts/decidim/admin/question.html.erb
+++ b/decidim-consultations/app/views/layouts/decidim/admin/question.html.erb
@@ -9,56 +9,69 @@
         </li>
       <% end %>
 
-      <% if allowed_to?(:update, :question, question: current_participatory_space) %>
-        <li <% if is_active_link?(decidim_admin_consultations.edit_question_path(current_participatory_space)) %> class="is-active" <% end %>>
-          <%= aria_selected_link_to t("info", scope: "decidim.admin.menu.questions_submenu"),
-                                    decidim_admin_consultations.edit_question_path(current_participatory_space) %>
-        </li>
-      <% end %>
+        <li <% if is_active_link?(decidim_admin_consultations.consultation_questions_path(current_participatory_space.consultation)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("questions", scope: "decidim.admin.menu.consultations_submenu"),
+                                    decidim_admin_consultations.consultation_questions_path(current_participatory_space.consultation) %>
 
-      <% if allowed_to? :read, :response %>
-        <li <% if is_active_link?(decidim_admin_consultations.responses_path(current_participatory_space)) %> class="is-active" <% end %>>
-          <%= aria_selected_link_to t("responses", scope: "decidim.admin.menu.questions_submenu"),
-                                    decidim_admin_consultations.responses_path(current_participatory_space) %>
-        </li>
-      <% end %>
+        <ul>
+        <% if allowed_to?(:update, :question, question: current_participatory_space) %>
+          <li <% if is_active_link?(decidim_admin_consultations.edit_question_path(current_participatory_space)) %> class="is-active" <% end %>>
+            <%= aria_selected_link_to t("info", scope: "decidim.admin.menu.questions_submenu"),
+                                      decidim_admin_consultations.edit_question_path(current_participatory_space) %>
+          </li>
+        <% end %>
 
-      <% if allowed_to? :read, :component %>
-        <li <% if is_active_link?(decidim_admin_consultations.components_path(current_participatory_space)) %> class="is-active" <% end %>>
-          <%= aria_selected_link_to t("components", scope: "decidim.admin.menu.questions_submenu"),
-                                    decidim_admin_consultations.components_path(current_participatory_space) %>
-          <ul>
-            <% current_participatory_space.components.each do |component| %>
-              <% if component.manifest.admin_engine %>
-                <li <% if is_active_link?(manage_component_path(component)) || is_active_link?(decidim_admin_consultations.edit_component_path(current_participatory_space, component)) || is_active_link?(decidim_admin_consultations.edit_component_permissions_path(current_participatory_space, component)) %> class="is-active" <% end %>>
-                  <%= link_to manage_component_path(component) do %>
-                    <%= translated_attribute component.name %>
-                    <% if component.primary_stat.present? %>
-                      <span class="component-counter <%= "component-counter--off" if component.primary_stat.zero? %>">
-                        <%= component.primary_stat %>
-                      </span>
+        <% if allowed_to? :read, :response %>
+          <li <% if is_active_link?(decidim_admin_consultations.responses_path(current_participatory_space)) %> class="is-active" <% end %>>
+            <%= aria_selected_link_to t("responses", scope: "decidim.admin.menu.questions_submenu"),
+                                      decidim_admin_consultations.responses_path(current_participatory_space) %>
+          </li>
+        <% end %>
+
+        <% if allowed_to? :read, :component %>
+          <li <% if is_active_link?(decidim_admin_consultations.components_path(current_participatory_space)) %> class="is-active" <% end %>>
+            <%= aria_selected_link_to t("components", scope: "decidim.admin.menu.questions_submenu"),
+                                      decidim_admin_consultations.components_path(current_participatory_space) %>
+            <ul>
+              <% current_participatory_space.components.each do |component| %>
+                <% if component.manifest.admin_engine %>
+                  <li <% if is_active_link?(manage_component_path(component)) || is_active_link?(decidim_admin_consultations.edit_component_path(current_participatory_space, component)) || is_active_link?(decidim_admin_consultations.edit_component_permissions_path(current_participatory_space, component)) %> class="is-active" <% end %>>
+                    <%= link_to manage_component_path(component) do %>
+                      <%= translated_attribute component.name %>
+                      <% if component.primary_stat.present? %>
+                        <span class="component-counter <%= "component-counter--off" if component.primary_stat.zero? %>">
+                          <%= component.primary_stat %>
+                        </span>
+                      <% end %>
                     <% end %>
-                  <% end %>
-                </li>
+                  </li>
+                <% end %>
               <% end %>
-            <% end %>
-          </ul>
-        </li>
-      <% end %>
+            </ul>
+          </li>
+        <% end %>
 
-      <% if allowed_to? :read, :category %>
-        <li <% if is_active_link?(decidim_admin_consultations.categories_path(current_participatory_space)) %> class="is-active" <% end %>>
-          <%= aria_selected_link_to t(".categories"),
-                                    decidim_admin_consultations.categories_path(current_participatory_space) %>
-        </li>
-      <% end %>
+        <% if allowed_to? :read, :category %>
+          <li <% if is_active_link?(decidim_admin_consultations.categories_path(current_participatory_space)) %> class="is-active" <% end %>>
+            <%= aria_selected_link_to t(".categories"),
+                                      decidim_admin_consultations.categories_path(current_participatory_space) %>
+          </li>
+        <% end %>
 
-      <% if allowed_to? :read, :attachment %>
-        <li <% if is_active_link?(decidim_admin_consultations.question_attachments_path(current_participatory_space)) %> class="is-active" <% end %>>
-          <%= aria_selected_link_to t(".attachments"),
-                                    decidim_admin_consultations.question_attachments_path(current_participatory_space) %>
-        </li>
-      <% end %>
+        <% if allowed_to? :read, :attachment %>
+          <li <% if is_active_link?(decidim_admin_consultations.question_attachments_path(current_participatory_space)) %> class="is-active" <% end %>>
+            <%= aria_selected_link_to t(".attachments"),
+                                      decidim_admin_consultations.question_attachments_path(current_participatory_space) %>
+          </li>
+        <% end %>
+        </ul>
+      </li>
+
+      <li <% if is_active_link?(decidim_admin_consultations.results_consultation_path(current_participatory_space.consultation)) %> class="is-active" <% end %>>
+          <%= aria_selected_link_to t("results", scope: "decidim.admin.menu.consultations_submenu"),
+                                    decidim_admin_consultations.results_consultation_path(current_participatory_space.consultation) %>
+      </li>
+
     </ul>
   </div>
 <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
When editing a question in a consultation the hierarchy position in the admin menu is lost, it seems you are editing some option of the consultation, which is weird. 
This is just a view change to maintain the parent "question" item. It adds a 3rd level for the menu if the question has components but I think it works just fine.

Before:
![image](https://user-images.githubusercontent.com/1401520/60513300-3275e680-9cd7-11e9-9331-6ab04822cd31.png)

After:
![image](https://user-images.githubusercontent.com/1401520/60513347-4d485b00-9cd7-11e9-9bfa-384b9b7a96af.png)


#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
