### PR TITLE
Fix empty sender on tenant smtp_settings

### DIFF
--- a/decidim-core/app/mailers/decidim/application_mailer.rb
+++ b/decidim-core/app/mailers/decidim/application_mailer.rb
@@ -15,7 +15,7 @@ module Decidim
     def set_smtp
       return if @organization.nil? || @organization.smtp_settings.blank?
 
-      mail.from = @organization.smtp_settings["from"] if @organization
+      mail.from = @organization.smtp_settings["from"].presence || mail.from
       mail.delivery_method.settings.merge!(
         address: @organization.smtp_settings["address"],
         port: @organization.smtp_settings["port"],


### PR DESCRIPTION
Verify if the sender field is not blank otherwise use default sender.

#### :tophat: What? Why?
If a organization left the sender email in blank the application mailer use a empty sender for that organization, so any email sended are not delivered.

This fix that.
#### :pushpin: Related Issues
- Related to #4698 
