### PR TITLE
Add missing locales when creating a new user group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - **decidim-core**: Fix seeds and typo in ActionAuthorizer [#5168](https://github.com/decidim/decidim/pull/5168)
 - **decidim-proposals**: Fix seeds [#5168](https://github.com/decidim/decidim/pull/5168)
 - **decidim-core**: Fix user names migration [#5209](https://github.com/decidim/decidim/pull/5209)
+- **decidim-core**: Add missing locales when creating a new user group [#5262](https://github.com/decidim/decidim/pull/5262)
 
 
 **Removed**:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -4,6 +4,14 @@ en:
     attributes:
       account:
         delete_reason: Reason to delete your account
+      group:
+        about: About
+        avatar: Avatar
+        document_number: Document number
+        email: Email
+        name: Name
+        nickname: Nickname
+        phone: Phone
       report:
         details: Additional comments
       user:


### PR DESCRIPTION
#### :tophat: What? Why?

Adds missing locales so we can translate the fields in the new user group form.

#### :pushpin: Related Issues
- Related to #4256 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
