### PR TITLE
fix patch method lost when re-submitin consultation form

### DIFF
--- a/decidim-consultations/app/views/decidim/consultations/admin/consultations/edit.html.erb
+++ b/decidim-consultations/app/views/decidim/consultations/admin/consultations/edit.html.erb
@@ -1,4 +1,7 @@
-<%= decidim_form_for(@form, html: { class: "form edit_consultation" }) do |f| %>
+<%= decidim_form_for @form,
+                     method: :patch,
+                     url: consultation_path(current_consultation),
+                     html: { class: "form edit_consultation" } do |f| %>
   <%= render partial: "form", object: f %>
   <div class="button--double form-general-submit">
     <%= f.submit t("consultations.edit.update", scope: "decidim.admin"), class: "button" %>


### PR DESCRIPTION
#### :tophat: What? Why?
If you make a mistake saving the consultation form, rails somehow send further submissions to create a new consultation instead of updating the old one.
This is the same as the issue https://github.com/decidim/decidim/pull/5250, I didn't realize that the same happens for the consultation forms.

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/pull/5250

