### PR TITLE
Redirect to root path if stored location is tos_path

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -774,7 +774,7 @@ DEPENDENCIES
   web-console (~> 3.5)
 
 RUBY VERSION
-   ruby 2.6.3p62
+   ruby 2.5.3p105
 
 BUNDLED WITH
    1.17.3

--- a/decidim-core/app/assets/javascripts/decidim/newsletter_tos.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/newsletter_tos.js.es6
@@ -1,0 +1,22 @@
+$(() => {
+  const $input = $("#newsletter_tos");
+  let val = 0;
+
+  $input.on("change", () => {
+    if (val % 2 === 0) {
+      $input.val("1");
+    } else {
+      $input.val("0");
+    }
+
+    $.ajax({
+      type: "POST",
+      beforeSend: function(xhr) {xhr.setRequestHeader("X-CSRF-Token", $('meta[name="csrf-token"]').attr("content"))},
+      url: $input.data("url"),
+      data: `newsletter_notification=${$input.val()}`
+    });
+
+
+    val += 1;
+  });
+});

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
@@ -48,6 +48,21 @@ $datetime-bg: var(--primary);
   box-shadow: none;
 }
 
+.card--inline-m {
+  display: inline-block;
+  width: auto;
+  padding: 1rem;
+  margin-bottom: 0;
+
+  .switch {
+    margin-bottom: .5rem;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+
 .card__content{
   padding: $card-padding-small;
 

--- a/decidim-core/app/cells/decidim/tos_page/newsletter.erb
+++ b/decidim-core/app/cells/decidim/tos_page/newsletter.erb
@@ -1,0 +1,11 @@
+<div class="flex-center">
+  <div class="switch tiny switch-with-label newsletter_notifications">
+    <label>
+      <input name="newsletter_notifications" type="checkbox" value="0" class="switch-input" id="newsletter_tos" data-url="<%= decidim.newsletter_tos_path %>" />
+      <span class="switch-paddle"></span>
+      <span class="switch-label"><%= t("decidim.notifications_settings.show.newsletter_notifications") %></span>
+    </label>
+  </div>
+</div>
+
+<%= javascript_include_tag "decidim/newsletter_tos.js" %>

--- a/decidim-core/app/cells/decidim/tos_page/sticky_form.erb
+++ b/decidim-core/app/cells/decidim/tos_page/sticky_form.erb
@@ -14,6 +14,14 @@
           </h5>
         </div>
 
+        <% unless current_user.newsletter_notifications_at %>
+          <div class="row column newsletter_tos text-center">
+            <div class="card card--secondary card--inline-m">
+              <%= cell "decidim/tos_page", :newsletter %>
+            </div>
+          </div>
+        <% end %>
+
         <div class="row column flex-center">
           <%= cell "decidim/tos_page", :refuse_btn_modal %>
 

--- a/decidim-core/app/cells/decidim/tos_page_cell.rb
+++ b/decidim-core/app/cells/decidim/tos_page_cell.rb
@@ -20,6 +20,15 @@ module Decidim
       render model
     end
 
+    def accept_tos_params
+      return if params[:redirect_url].blank?
+
+      redirect_path = URI.parse(params[:redirect_url]).path
+      return if redirect_path == decidim.root_path
+
+      { redirect_url: params[:redirect_url] }
+    end
+
     private
 
     def announcement_args

--- a/decidim-core/app/controllers/concerns/decidim/needs_tos_accepted.rb
+++ b/decidim-core/app/controllers/concerns/decidim/needs_tos_accepted.rb
@@ -39,10 +39,17 @@ module Decidim
       decidim.page_path terms_and_conditions_page
     end
 
+    def tos_path_redirected
+      return tos_path if request.path == decidim.root_path
+
+      value = params[:redirect_url] || request.url
+      decidim.page_path terms_and_conditions_page, redirect_url: value
+    end
+
     def redirect_to_tos
       flash[:notice] = flash[:notice] if flash[:notice]
       flash[:secondary] = t("required_review.alert", scope: "decidim.pages.terms_and_conditions")
-      redirect_to tos_path
+      redirect_to tos_path_redirected
     end
   end
 end

--- a/decidim-core/app/controllers/decidim/tos_controller.rb
+++ b/decidim-core/app/controllers/decidim/tos_controller.rb
@@ -16,5 +16,14 @@ module Decidim
         redirect_to decidim.page_path tos_page
       end
     end
+
+    private
+
+    def after_sign_in_path_for(user)
+      stored_location = stored_location_for(user)
+      return signed_in_root_path(user) if stored_location == tos_path
+
+      stored_location || signed_in_root_path(user)
+    end
   end
 end

--- a/decidim-core/app/views/decidim/pages/index.html.erb
+++ b/decidim-core/app/views/decidim/pages/index.html.erb
@@ -71,9 +71,9 @@ edit_link(
                     <%= link_to t(".read_more"), page_path(page), class: "card__button button secondary button--sc small light" %>
                   </div>
                 </div>
-              </div>
             </article>
-          <% end %>
+            </div>
+        <% end %>
         </div>
       </div>
     </div>

--- a/decidim-core/config/locales/fr.yml
+++ b/decidim-core/config/locales/fr.yml
@@ -866,7 +866,7 @@ fr:
           modal_close: Fermer la fenêtre
           modal_title: Refusez-vous vraiment les conditions d'utilisation mises à jour ?
         required_review:
-          alert: Nous avons mis à jour nos conditions d'utilisation, veuillez les consulter.
+          alert: Vous n'avez pas accepté les conditions d'utilisation actuelles, veuillez les consulter.
           body: Veuillez prendre un moment pour examiner nos conditions d'utilisation mises à jour. Sinon, vous ne pourrez pas utiliser la plate-forme.
           title: 'Obligatoire : consultez les conditions d''utilisation mises à jour'
     participatory_space_private_users:

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -111,6 +111,7 @@ Decidim::Core::Engine.routes.draw do
   get "/static_map", to: "static_map#show", as: :static_map
   get "/cookies/accept", to: "cookie_policy#accept", as: :accept_cookies
   put "/pages/terms-and-conditions/accept", to: "tos#accept_tos", as: :accept_tos
+  match "/pages/terms-and-conditions/newsletter_tos", to: "tos#newsletter_tos", as: :newsletter_tos, via: :post
 
   match "/404", to: "errors#not_found", via: :all
   match "/500", to: "errors#internal_server_error", via: :all

--- a/decidim-core/spec/system/user_tos_acceptance_spec.rb
+++ b/decidim-core/spec/system/user_tos_acceptance_spec.rb
@@ -14,83 +14,132 @@ describe "UserTosAcceptance", type: :system do
   end
 
   describe "When the Organization TOS version is updated" do
-    before do
-      organization.update!(tos_version: Faker::Date.forward(15))
-      login_as user, scope: :user
-      visit decidim.root_path
-    end
-
-    context "when a user starts a session, has to accept and review them" do
-      it "redirects to the TOS page" do
-        expect(page).to have_current_path(decidim.page_path(tos_page))
-        expect(page).to have_content translated(tos_page.title)
-        expect(page).to have_content strip_tags(translated(tos_page.content))
-      end
-
-      it "renders an announcement requiring to review the TOS" do
-        expect(page).to have_content("Required: Review updates to our terms of service")
-      end
-
-      it "renders an announcement advising that TOS has been updated" do
-        expect(page).to have_content("We've updated our Terms of Service, please review them.")
-      end
-
-      it "shows a button to Agree the updated Terms" do
-        expect(page).to have_button btn_accept
-      end
-
-      it "shows a button to Refuse Terms" do
-        expect(page).to have_button btn_refuse
-      end
-    end
-
-    context "and the user accepts the updated TOS" do
+    context "when user comes from root path" do
       before do
+        organization.update!(tos_version: user.accepted_tos_version + 1.second)
+        login_as user, scope: :user
+        visit decidim.root_path
+      end
+
+      context "when a user starts a session, has to accept and review them" do
+        it "redirects to the TOS page" do
+          expect(page).to have_current_path(decidim.page_path(tos_page))
+          expect(page).to have_content translated(tos_page.title)
+          expect(page).to have_content strip_tags(translated(tos_page.content))
+        end
+
+        it "renders an announcement requiring to review the TOS" do
+          expect(page).to have_content("Required: Review updates to our terms of service")
+        end
+
+        it "renders an announcement advising that TOS has been updated" do
+          expect(page).to have_content("We've updated our Terms of Service, please review them.")
+        end
+
+        it "shows a button to Agree the updated Terms" do
+          expect(page).to have_button btn_accept
+        end
+
+        it "shows a button to Refuse Terms" do
+          expect(page).to have_button btn_refuse
+        end
+      end
+
+      context "when the user has not subscribed to newsletter notifications" do
+        it "display newsletter switch" do
+          expect(page).to have_selector(".newsletter_tos")
+        end
+
+        context "when user has subscribed to newsletter notifications" do
+          let!(:user) { create(:user, :confirmed, :newsletter_notifications, organization: organization) }
+
+          it "doesn't display newsletter switch" do
+            expect(page).not_to have_selector(".newsletter_tos")
+          end
+        end
+
+        context "when user switch on newsletter notifications" do
+          it "updates user preference" do
+            within ".switch.newsletter_notifications" do
+              page.find(".switch-paddle").click
+            end
+
+            visit current_path
+            # We are using a post request to update user preferences, in order to test if it's working, we need to let some time for the request to pass.
+            # we could have done "expect(user.newsletter_notifications_at).not_to be_nil" but the request would not have been executed yet.
+            # We do a little trick as we know this selector should not be present if user.newsletter_notifications_at is not nil.
+
+            expect(page).not_to have_selector(".newsletter_tos")
+          end
+        end
+      end
+
+      context "and the user accepts the updated TOS" do
+        before do
+          click_button btn_accept
+        end
+
+        it "renders a success announcement" do
+          expect(page).to have_content("Great! You have accepted the terms and conditions.")
+          expect(page).to have_css(".flash.success")
+        end
+
+        it "redirect to root path" do
+          expect(page).to have_current_path(decidim.root_path)
+        end
+      end
+
+      context "and the user refuses the updated TOS" do
+        before do
+          click_button btn_refuse
+        end
+
+        it "renders a modal" do
+          expect(page).to have_css("#tos-refuse-modal")
+          expect(page).to have_content("Do you really refuse the updated Terms and Conditions?")
+        end
+
+        context "with the refuse modal has different options" do
+          it "shows an option to accept the TOS" do
+            within "#tos-refuse-modal" do
+              expect(page).to have_button("Accept terms and continue")
+              expect(page).to have_tag("form", action: decidim.accept_tos_path)
+            end
+          end
+
+          it "shows an option to download the users data" do
+            within "#tos-refuse-modal" do
+              expect(page).to have_link("download your data", href: decidim.data_portability_path)
+            end
+          end
+
+          it "shows an option to logout" do
+            within "#tos-refuse-modal" do
+              expect(page).to have_button("I'll review it later")
+              expect(page).to have_tag("form", action: decidim.destroy_user_session_path)
+            end
+          end
+
+          it "shows an option delete the account" do
+            within "#tos-refuse-modal" do
+              expect(page).to have_link("delete your account", href: decidim.delete_account_path)
+            end
+          end
+        end
+      end
+    end
+
+    context "when user comes from another page" do
+      before do
+        organization.update!(tos_version: user.accepted_tos_version + 1.second)
+        login_as user, scope: :user
+        visit decidim.account_path
+      end
+
+      it "redirect to this page" do
         click_button btn_accept
-      end
 
-      it "renders a success announcement" do
-        expect(page).to have_content("Great! You have accepted the terms and conditions.")
-        expect(page).to have_css(".flash.success")
-      end
-    end
-
-    context "and the user refuses the updated TOS" do
-      before do
-        click_button btn_refuse
-      end
-
-      it "renders a modal" do
-        expect(page).to have_css("#tos-refuse-modal")
-        expect(page).to have_content("Do you really refuse the updated Terms and Conditions?")
-      end
-
-      context "with the refuse modal has different options" do
-        it "shows an option to accept the TOS" do
-          within "#tos-refuse-modal" do
-            expect(page).to have_button("Accept terms and continue")
-            expect(page).to have_tag("form", action: decidim.accept_tos_path)
-          end
-        end
-
-        it "shows an option to download the users data" do
-          within "#tos-refuse-modal" do
-            expect(page).to have_link("download your data", href: decidim.data_portability_path)
-          end
-        end
-
-        it "shows an option to logout" do
-          within "#tos-refuse-modal" do
-            expect(page).to have_button("I'll review it later")
-            expect(page).to have_tag("form", action: decidim.destroy_user_session_path)
-          end
-        end
-
-        it "shows an option delete the account" do
-          within "#tos-refuse-modal" do
-            expect(page).to have_link("delete your account", href: decidim.delete_account_path)
-          end
-        end
+        expect(page).to have_current_path(decidim.account_path)
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
When user uses SSO or is invited as admin she is redirected to a page where they need to accept the terms and conditions of the platform.
When clicking accept, they stay on the page and are confused about what to do next, also they cannot subscribe directly to newsletter.

When clicking "I agree", we send them to home page or on the page they were looking at when they clicked

#### :pushpin: Related Issues
- Fixes https://github.com/OpenSourcePolitics/decidim/issues/692

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/20232956/61059899-17ebed80-a3fa-11e9-826f-e7afab8704d2.png)

