### PR TITLE
Fix/action log rendering of deleted proposals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 **Fixed**:
 
+- **decidim-core**, **decidim-proposals**: When rendering the admin log for a Proposal, use the title from extras instead of crashing, when proposal has been deleted. [#5267](https://github.com/decidim/decidim/pull/5267)
 - **decidim-core**, **decidim-proposals**: Fix: diffing withdrawn amendments and new lines in body [#5242](https://github.com/decidim/decidim/pull/5242)
 - **decidim-core**: Filter forbidden characters in users invitations. [\#5245](https://github.com/decidim/decidim/pull/5245)
 - **decidim-assemblies**: Don't show private assemblies when becoming childs from another assembly. [#5235](https://github.com/decidim/decidim/pull/5235)

--- a/decidim-core/app/presenters/decidim/log/resource_presenter.rb
+++ b/decidim-core/app/presenters/decidim/log/resource_presenter.rb
@@ -42,10 +42,11 @@ module Decidim
       #
       # Returns an HTML-safe String.
       def present_resource
-        span = h.content_tag(:span, present_resource_name, class: "logs__log__resource")
-        return span if resource.blank? || resource_path.blank?
-
-        h.link_to(present_resource_name, resource_path, class: "logs__log__resource")
+        if resource.blank? || resource_path.blank?
+          span = h.content_tag(:span, present_resource_name, class: "logs__log__resource")
+        else
+          h.link_to(present_resource_name, resource_path, class: "logs__log__resource")
+        end
       end
 
       # Private: Finds the public link for the given resource.

--- a/decidim-core/app/presenters/decidim/log/resource_presenter.rb
+++ b/decidim-core/app/presenters/decidim/log/resource_presenter.rb
@@ -43,7 +43,7 @@ module Decidim
       # Returns an HTML-safe String.
       def present_resource
         if resource.blank? || resource_path.blank?
-          span = h.content_tag(:span, present_resource_name, class: "logs__log__resource")
+          h.content_tag(:span, present_resource_name, class: "logs__log__resource")
         else
           h.link_to(present_resource_name, resource_path, class: "logs__log__resource")
         end

--- a/decidim-proposals/app/presenters/decidim/proposals/log/resource_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/log/resource_presenter.rb
@@ -10,7 +10,11 @@ module Decidim
         #
         # Returns an HTML-safe String.
         def present_resource_name
-          Decidim::Proposals::ProposalPresenter.new(resource).title
+          if resource.present?
+            Decidim::Proposals::ProposalPresenter.new(resource).title
+          else
+            super
+          end
         end
       end
     end

--- a/decidim-proposals/spec/presenters/decidim/proposals/log/resource_presenter_spec.rb
+++ b/decidim-proposals/spec/presenters/decidim/proposals/log/resource_presenter_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Proposals::Log::ResourcePresenter, type: :helper do
+  let(:presenter) { described_class.new(resource, helper, extra) }
+  let(:resource) { create(:proposal, title: Faker::Book.unique.title) }
+  let(:extra) do
+    {
+      "title" => Faker::Book.unique.title
+    }
+  end
+  let(:resource_path) { Decidim::ResourceLocatorPresenter.new(resource).path }
+
+  before do
+    helper.extend(Decidim::ApplicationHelper)
+    helper.extend(Decidim::TranslationsHelper)
+  end
+
+  context "when the resource exists" do
+    it "links to its public page with the name of the proposal" do
+      html = presenter.present
+      expect(html).to have_link(resource.title, href: resource_path)
+    end
+  end
+
+  context "when the resource doesn't exist" do
+    let(:resource) { nil }
+    let(:extra) do
+      {
+        "title" => "My title"
+      }
+    end
+
+    it "doesn't link to its public page but renders its name" do
+      expect(presenter.present).not_to have_link("My title")
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
When rendering the admin log for a Proposal, use the _title_ from extras instead of crashing, when proposal has been deleted.

#### :pushpin: Related Issues 
- Fixes #5265

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [x] Add tests
- [x] Apply fix

### :camera: Screenshots (optional)
![Description](URL)
