### PR TITLE
Fix: Decidim::Admin::ComponentForm validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 **Added**:
 
+- **decidim-admin**, **decidim-assemblies**, **decidim-conferences**, **decidim-consultations**, **decidim-core**, **decidim-dev**, **decidim-initiatives**, **decidim-participatory_processes**: Fix: `Decidim::Admin::ComponentForm` validations [#5269](https://github.com/decidim/decidim/pull/5269)
 - **decidim-core**, **decidim-proposals**: Add: amendments Wizard Step Form [#5244](https://github.com/decidim/decidim/pull/5244)
 - **decidim-core**, **decidim-admin**, **decidim-proposals**: Add: `amendments_visibility` component step setting [#5223](https://github.com/decidim/decidim/pull/5223)
 - **decidim-core**, **decidim-admin**, **decidim-proposals**: Add: admin configuration of amendments by step [#5178](https://github.com/decidim/decidim/pull/5178)

--- a/decidim-admin/app/commands/decidim/admin/create_component.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_component.rb
@@ -8,13 +8,10 @@ module Decidim
 
       # Public: Initializes the command.
       #
-      # manifest            - The component's manifest to create a component from.
-      # form                - The form from which the data in this component comes from.
-      # participatory_space - The participatory space that will hold this component.
-      def initialize(manifest, form, participatory_space)
-        @manifest = manifest
+      # form - The form from which the data in this component comes from.
+      def initialize(form)
         @form = form
-        @participatory_space = participatory_space
+        @manifest = form.manifest
       end
 
       # Public: Creates the Component.
@@ -39,7 +36,7 @@ module Decidim
           form.current_user,
           manifest_name: manifest.name,
           name: form.name,
-          participatory_space: participatory_space,
+          participatory_space: form.participatory_space,
           weight: form.weight,
           settings: form.settings,
           default_step_settings: form.default_step_settings,

--- a/decidim-admin/app/controllers/decidim/admin/components_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/components_controller.rb
@@ -27,10 +27,10 @@ module Decidim
       end
 
       def create
-        @form = form(ComponentForm).from_params(params)
+        @form = form(ComponentForm).from_params(form_params)
         enforce_permission_to :create, :component
 
-        CreateComponent.call(manifest, @form, current_participatory_space) do
+        CreateComponent.call(@form) do
           on(:ok) do
             flash[:notice] = I18n.t("components.create.success", scope: "decidim.admin")
             redirect_to action: :index
@@ -52,7 +52,7 @@ module Decidim
 
       def update
         @component = query_scope.find(params[:id])
-        @form = form(ComponentForm).from_params(params)
+        @form = form(ComponentForm).from_params(form_params)
         enforce_permission_to :update, :component, component: @component
 
         UpdateComponent.call(@form, @component) do
@@ -65,7 +65,7 @@ module Decidim
 
           on(:invalid) do
             flash[:alert] = I18n.t("components.update.error", scope: "decidim.admin")
-            redirect_to action: :edit
+            render action: :edit
           end
         end
       end
@@ -113,12 +113,36 @@ module Decidim
 
       private
 
+      # Returns a Class with the attributes sanitized, coerced  and filtered
+      # to the right type. See Decidim::SettingsManifest#schema.
+      def new_settings_schema(name, data)
+        manifest.settings(name).schema.new(data, current_organization.default_locale)
+      end
+
+      # Processes the component params so Decidim::Admin::ComponentForm
+      # can assign and validate the attributes when using #from_params.
+      def form_params
+        form_params = params[:component].permit!
+        form_params[:id] = params[:id]
+        form_params[:manifest] = manifest
+        form_params[:participatory_space] = current_participatory_space
+        form_params[:settings] = new_settings_schema(:global, form_params[:settings])
+        if form_params[:default_step_settings]
+          form_params[:default_step_settings] = new_settings_schema(:step, form_params[:default_step_settings])
+        else
+          form_params[:step_settings].each do |key, value|
+            form_params[:step_settings][key] = new_settings_schema(:step, value)
+          end
+        end
+        form_params
+      end
+
       def query_scope
         current_participatory_space.components
       end
 
       def manifest
-        Decidim.find_component_manifest(params[:type])
+        @component&.manifest || Decidim.find_component_manifest(params[:type])
       end
 
       def default_name(manifest)

--- a/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
@@ -44,8 +44,7 @@ module Decidim
       # :amendments_visibility; all wrap in a label tag and with help text.
       def amendments_visibility_form_field(form, options)
         collection = Decidim::Amendment::VisibilityStepSetting.options
-        step_number = options[:tabs_prefix].split("-")[1] # Gets the number in a String like "step-N-settings"
-        checked = @component.step_settings[step_number].amendments_visibility
+        checked = form.object.amendments_visibility
 
         html = label_tag(:amendments_visibility) do
           concat options[:label]

--- a/decidim-admin/app/views/decidim/admin/components/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/components/_form.html.erb
@@ -19,8 +19,8 @@
                 <%= render partial: "decidim/admin/components/settings_fields",
                            locals: {
                              form: settings_fields,
-                             component: @component,
-                             settings_name: "global",
+                             manifest: form.object.manifest,
+                             settings_name: :global,
                              tabs_prefix: "global-settings"
                            } %>
               <% end %>
@@ -46,8 +46,8 @@
                       <%= render partial: "decidim/admin/components/settings_fields",
                                  locals: {
                                    form: settings_fields,
-                                   component: component,
-                                   settings_name: "step",
+                                   manifest: form.object.manifest,
+                                   settings_name: :step,
                                    tabs_prefix: "step-#{step.id}-settings"
                                  } %>
                     <% end %>
@@ -68,8 +68,8 @@
                 <%= render partial: "decidim/admin/components/settings_fields",
                            locals: {
                              form: settings_fields,
-                             component: @component,
-                             settings_name: "step",
+                             manifest: form.object.manifest,
+                             settings_name: :step,
                              tabs_prefix: "default-step-settings"
                            } %>
               <% end %>

--- a/decidim-admin/app/views/decidim/admin/components/_settings_fields.html.erb
+++ b/decidim-admin/app/views/decidim/admin/components/_settings_fields.html.erb
@@ -1,10 +1,10 @@
-<% form.object.manifest.attributes.each do |name, attribute| %>
+<% manifest.settings(settings_name).attributes.each do |field_name, settings_attribute| %>
   <%= settings_attribute_input(
     form,
-    attribute,
-    name,
-    label: t("decidim.components.#{component.manifest.name}.settings.#{settings_name}.#{name}"),
+    settings_attribute,
+    field_name,
+    label: t("decidim.components.#{manifest.name}.settings.#{settings_name}.#{field_name}"),
     tabs_prefix: tabs_prefix,
-    help_text: help_text_for_component_setting(name, settings_name, component.manifest.name)
+    help_text: help_text_for_component_setting(field_name, settings_name, manifest.name)
   ) %>
 <% end %>

--- a/decidim-admin/spec/commands/decidim/admin/create_component_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/create_component_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 module Decidim::Admin
   describe CreateComponent do
-    subject { described_class.new(manifest, form, participatory_process) }
+    subject { described_class.new(form) }
 
     let(:manifest) { Decidim.find_component_manifest(:dummy) }
     let(:form) do
@@ -19,6 +19,8 @@ module Decidim::Admin
         valid?: valid,
         current_user: current_user,
         weight: 2,
+        manifest: manifest,
+        participatory_space: participatory_process,
         settings: {
           dummy_global_attribute_1: true,
           dummy_global_attribute_2: false

--- a/decidim-admin/spec/commands/decidim/admin/update_component_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/update_component_spec.rb
@@ -74,7 +74,19 @@ module Decidim::Admin
       it "broadcasts the previous and current settings" do
         expect do
           described_class.call(form, component)
-        end.to broadcast(:ok, true, {}, hash_including("global" => kind_of(Hash), "default_step" => kind_of(Hash), "steps" => kind_of(Hash)))
+        end.to broadcast(
+          :ok,
+          true,
+          hash_including(
+            "global" => kind_of(Hash),
+            "default_step" => kind_of(Hash)
+          ),
+          hash_including(
+            "global" => kind_of(Hash),
+            "default_step" => kind_of(Hash),
+            "steps" => kind_of(Hash)
+          )
+        )
       end
     end
 

--- a/decidim-admin/spec/forms/decidim/admin/component_form_spec.rb
+++ b/decidim-admin/spec/forms/decidim/admin/component_form_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Admin
+    describe ComponentForm do
+      subject { form }
+
+      let(:organization) { create(:organization) }
+      let(:participatory_space) { create(:participatory_process, organization: organization) }
+      let(:manifest) { Decidim.find_component_manifest("dummy") }
+      let(:name) { generate_localized_title }
+
+      let(:default_registration_terms) do
+        {
+          "default_registration_terms_ca" => "",
+          "default_registration_terms_en" => "Default terms en",
+          "default_registration_terms_es" => ""
+
+        }
+      end
+
+      let(:announcement) do
+        {
+          "announcement_ca" => "",
+          "announcement_en" => "Default terms en",
+          "announcement_es" => ""
+
+        }
+      end
+
+      let(:settings) do
+        return {} unless manifest
+
+        manifest.settings(:global).schema.new(default_registration_terms, "en")
+      end
+
+      let(:default_step_settings) do
+        return {} unless manifest
+
+        manifest.settings(:step).schema.new(announcement, "en")
+      end
+
+      let(:params) do
+        {
+          "name" => name,
+          "manifest" => manifest,
+          "participatory_space" => participatory_space,
+          "settings" => settings,
+          "default_step_settings" => default_step_settings
+        }
+      end
+
+      let(:form) do
+        described_class.from_params(params).with_context(current_organization: organization)
+      end
+
+      context "when everything is ok" do
+        it { is_expected.to be_valid }
+      end
+
+      context "when the name is missing" do
+        let(:name) { nil }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when the manifest is missing" do
+        let(:manifest) { nil }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when the participatory_space is missing" do
+        let(:participatory_space) { nil }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when a settings required attribute is missing" do
+        let(:default_registration_terms) do
+          {
+            "default_registration_terms_ca" => "Default terms ca",
+            "default_registration_terms_en" => "",
+            "default_registration_terms_es" => "Default terms es"
+
+          }
+        end
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when a default_step_settings required attribute is missing" do
+        let(:announcement) do
+          {
+            "announcement_ca" => "Default terms ca",
+            "announcement_en" => "",
+            "announcement_es" => "Default terms es"
+
+          }
+        end
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when the form has step_settings" do
+        before do
+          params.except("default_step_settings").merge(
+            "step_settings" => { "1" => default_step_settings }
+          )
+        end
+
+        context "and a step_settings required attribute is missing" do
+          let(:announcement) do
+            {
+              "announcement_ca" => "Default terms ca",
+              "announcement_en" => "",
+              "announcement_es" => "Default terms es"
+
+            }
+          end
+
+          it { is_expected.not_to be_valid }
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/forms/decidim/admin/component_form_spec.rb
+++ b/decidim-admin/spec/forms/decidim/admin/component_form_spec.rb
@@ -12,34 +12,32 @@ module Decidim
       let(:manifest) { Decidim.find_component_manifest("dummy") }
       let(:name) { generate_localized_title }
 
-      let(:default_registration_terms) do
+      let(:dummy_global_translatable_text) do
         {
-          "default_registration_terms_ca" => "",
-          "default_registration_terms_en" => "Default terms en",
-          "default_registration_terms_es" => ""
-
+          "dummy_global_translatable_text_ca" => "",
+          "dummy_global_translatable_text_en" => "Dummy text en",
+          "dummy_global_translatable_text_es" => ""
         }
       end
 
-      let(:announcement) do
+      let(:dummy_step_translatable_text) do
         {
-          "announcement_ca" => "",
-          "announcement_en" => "Default terms en",
-          "announcement_es" => ""
-
+          "dummy_step_translatable_text_ca" => "",
+          "dummy_step_translatable_text_en" => "Dummy text en",
+          "dummy_step_translatable_text_es" => ""
         }
       end
 
       let(:settings) do
         return {} unless manifest
 
-        manifest.settings(:global).schema.new(default_registration_terms, "en")
+        manifest.settings(:global).schema.new(dummy_global_translatable_text, "en")
       end
 
       let(:default_step_settings) do
         return {} unless manifest
 
-        manifest.settings(:step).schema.new(announcement, "en")
+        manifest.settings(:step).schema.new(dummy_step_translatable_text, "en")
       end
 
       let(:params) do
@@ -79,12 +77,11 @@ module Decidim
       end
 
       context "when a settings required attribute is missing" do
-        let(:default_registration_terms) do
+        let(:dummy_global_translatable_text) do
           {
-            "default_registration_terms_ca" => "Default terms ca",
-            "default_registration_terms_en" => "",
-            "default_registration_terms_es" => "Default terms es"
-
+            "dummy_global_translatable_text_ca" => "Dummy text ca",
+            "dummy_global_translatable_text_en" => "",
+            "dummy_global_translatable_text_es" => "Dummy text es"
           }
         end
 
@@ -92,12 +89,11 @@ module Decidim
       end
 
       context "when a default_step_settings required attribute is missing" do
-        let(:announcement) do
+        let(:dummy_step_translatable_text) do
           {
-            "announcement_ca" => "Default terms ca",
-            "announcement_en" => "",
-            "announcement_es" => "Default terms es"
-
+            "dummy_step_translatable_text_ca" => "Dummy text ca",
+            "dummy_step_translatable_text_en" => "",
+            "dummy_step_translatable_text_es" => "Dummy text es"
           }
         end
 
@@ -112,12 +108,11 @@ module Decidim
         end
 
         context "and a step_settings required attribute is missing" do
-          let(:announcement) do
+          let(:dummy_step_translatable_text) do
             {
-              "announcement_ca" => "Default terms ca",
-              "announcement_en" => "",
-              "announcement_es" => "Default terms es"
-
+              "dummy_step_translatable_text_ca" => "Dummy text ca",
+              "dummy_step_translatable_text_en" => "",
+              "dummy_step_translatable_text_es" => "Dummy text es"
             }
           end
 

--- a/decidim-assemblies/spec/controllers/admin/components_controller_spec.rb
+++ b/decidim-assemblies/spec/controllers/admin/components_controller_spec.rb
@@ -36,10 +36,12 @@ module Decidim
             {
               name_en: "Dummy component",
               settings: {
-                comments_enabled: true
+                comments_enabled: true,
+                dummy_global_translatable_text_en: "Dummy text"
               },
               default_step_settings: {
-                comments_blocked: true
+                comments_blocked: true,
+                dummy_step_translatable_text_en: "Dummy text"
               }
             }
           end
@@ -47,7 +49,7 @@ module Decidim
           it "publishes the default step settings change" do
             expect(Decidim::SettingsChange).to receive(:publish).with(
               component,
-              {},
+              hash_including("comments_blocked" => false),
               hash_including("comments_blocked" => true)
             )
 

--- a/decidim-assemblies/spec/shared/manage_assembly_components_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assembly_components_examples.rb
@@ -26,10 +26,20 @@ shared_examples "manage assembly components" do
         )
 
         within ".global-settings" do
+          fill_in_i18n_editor(
+            :component_settings_dummy_global_translatable_text,
+            "#global-settings-dummy_global_translatable_text-tabs",
+            en: "Dummy Text"
+          )
           all("input[type=checkbox]").last.click
         end
 
         within ".default-step-settings" do
+          fill_in_i18n_editor(
+            :component_default_step_settings_dummy_step_translatable_text,
+            "#default-step-settings-dummy_step_translatable_text-tabs",
+            en: "Dummy Text for Step"
+          )
           all("input[type=checkbox]").first.click
         end
 

--- a/decidim-conferences/spec/controllers/admin/components_controller_spec.rb
+++ b/decidim-conferences/spec/controllers/admin/components_controller_spec.rb
@@ -36,10 +36,12 @@ module Decidim
             {
               name_en: "Dummy component",
               settings: {
-                comments_enabled: true
+                comments_enabled: true,
+                dummy_global_translatable_text_en: "Dummy text"
               },
               default_step_settings: {
-                comments_blocked: true
+                comments_blocked: true,
+                dummy_step_translatable_text_en: "Dummy text"
               }
             }
           end
@@ -47,7 +49,7 @@ module Decidim
           it "publishes the default step settings change" do
             expect(Decidim::SettingsChange).to receive(:publish).with(
               component,
-              {},
+              hash_including("comments_blocked" => false),
               hash_including("comments_blocked" => true)
             )
 

--- a/decidim-conferences/spec/shared/manage_conference_components_examples.rb
+++ b/decidim-conferences/spec/shared/manage_conference_components_examples.rb
@@ -26,10 +26,20 @@ shared_examples "manage conference components" do
         )
 
         within ".global-settings" do
+          fill_in_i18n_editor(
+            :component_settings_dummy_global_translatable_text,
+            "#global-settings-dummy_global_translatable_text-tabs",
+            en: "Dummy Text"
+          )
           all("input[type=checkbox]").last.click
         end
 
         within ".default-step-settings" do
+          fill_in_i18n_editor(
+            :component_default_step_settings_dummy_step_translatable_text,
+            "#default-step-settings-dummy_step_translatable_text-tabs",
+            en: "Dummy Text for Step"
+          )
           all("input[type=checkbox]").first.click
         end
 

--- a/decidim-consultations/spec/system/admin/admin_manages_question_component_spec.rb
+++ b/decidim-consultations/spec/system/admin/admin_manages_question_component_spec.rb
@@ -33,10 +33,20 @@ describe "Admin manages consultation components", type: :system do
         )
 
         within ".global-settings" do
+          fill_in_i18n_editor(
+            :component_settings_dummy_global_translatable_text,
+            "#global-settings-dummy_global_translatable_text-tabs",
+            en: "Dummy Text"
+          )
           all("input[type=checkbox]").last.click
         end
 
         within ".default-step-settings" do
+          fill_in_i18n_editor(
+            :component_default_step_settings_dummy_step_translatable_text,
+            "#default-step-settings-dummy_step_translatable_text-tabs",
+            en: "Dummy Text for Step"
+          )
           all("input[type=checkbox]").first.click
         end
 

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -300,12 +300,14 @@ en:
           global:
             amendments_enabled: Amendments enabled
             comments_enabled: Comments enabled
+            dummy_global_translatable_text: Dummy Translatable Text
             dummy_global_attribute_1: Dummy Attribute 1
             dummy_global_attribute_2: Dummy Attribute 2
             enable_pads_creation: Enable pads creation
             resources_permissions_enabled: Resources permissions enabled
           step:
             comments_blocked: Comments blocked
+            dummy_step_translatable_text: Dummy Step Translatable Text
             dummy_step_attribute_1: Dummy Step Attribute 1
             dummy_step_attribute_2: Dummy Step Attribute 2
     contact: Contact

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -300,16 +300,16 @@ en:
           global:
             amendments_enabled: Amendments enabled
             comments_enabled: Comments enabled
-            dummy_global_translatable_text: Dummy Translatable Text
             dummy_global_attribute_1: Dummy Attribute 1
             dummy_global_attribute_2: Dummy Attribute 2
+            dummy_global_translatable_text: Dummy Translatable Text
             enable_pads_creation: Enable pads creation
             resources_permissions_enabled: Resources permissions enabled
           step:
             comments_blocked: Comments blocked
-            dummy_step_translatable_text: Dummy Step Translatable Text
             dummy_step_attribute_1: Dummy Step Attribute 1
             dummy_step_attribute_2: Dummy Step Attribute 2
+            dummy_step_translatable_text: Dummy Step Translatable Text
     contact: Contact
     content_blocks:
       footer_sub_hero:

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -312,6 +312,17 @@ FactoryBot.define do
     participatory_space { create(:participatory_process, organization: organization) }
     manifest_name { "dummy" }
     published_at { Time.current }
+    settings do
+      {
+        dummy_global_translatable_text: generate_localized_title
+      }
+    end
+
+    default_step_settings do
+      {
+        dummy_step_translatable_text: generate_localized_title
+      }
+    end
 
     trait :unpublished do
       published_at { nil }

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -28,6 +28,23 @@ module Decidim
     end
     # rubocop:enable Metrics/ParameterLists
 
+    # Public: generates a radio buttons input from a collection and adds help
+    # text and errors.
+    #
+    # attribute       - the name of the field
+    # collection      - the collection from which we will render the check boxes
+    # value_attribute - a Symbol or a Proc defining how to find the value attribute
+    # text_attribute  - a Symbol or a Proc defining how to find the text attribute
+    # options         - a Hash with options
+    # html_options    - a Hash with options
+    #
+    # Renders a collection of radio buttons.
+    # rubocop:disable Metrics/ParameterLists
+    def collection_radio_buttons(attribute, collection, value_attribute, text_attribute, options = {}, html_options = {})
+      super + error_and_help_text(attribute, options)
+    end
+    # rubocop:enable Metrics/ParameterLists
+
     # Public: Generates an form field for each locale.
     #
     # type - The form field's type, like `text_area` or `text_input`
@@ -300,7 +317,7 @@ module Decidim
 
     # Public: Override so checkboxes are rendered before the label.
     def check_box(attribute, options = {}, checked_value = "1", unchecked_value = "0")
-      custom_label(attribute, options[:label], options[:label_options], true, false) do
+      custom_label(attribute, options[:label], options[:label_options], true) do
         options.delete(:label)
         options.delete(:label_options)
         @template.check_box(@object_name, attribute, objectify_options(options), checked_value, unchecked_value)

--- a/decidim-core/lib/decidim/has_settings.rb
+++ b/decidim-core/lib/decidim/has_settings.rb
@@ -62,6 +62,8 @@ module Decidim
     # Returns a Class with the attributes sanitized, coerced  and filtered
     # to the right type. See Decidim::SettingsManifest#schema.
     def new_settings_schema(name, data)
+      return {} unless manifest && participatory_space
+
       manifest.settings(name).schema.new(data, participatory_space.organization.default_locale)
     end
 

--- a/decidim-core/lib/decidim/has_settings.rb
+++ b/decidim-core/lib/decidim/has_settings.rb
@@ -11,11 +11,11 @@ module Decidim
     end
 
     def settings
-      settings_schema(:global).new(self[:settings]["global"])
+      new_settings_schema(:global, self[:settings]["global"])
     end
 
     def settings=(data)
-      self[:settings]["global"] = settings_schema(:global).new(data)
+      self[:settings]["global"] = new_settings_schema(:global, data)
     end
 
     def current_settings
@@ -27,24 +27,24 @@ module Decidim
     end
 
     def default_step_settings
-      settings_schema(:step).new(self[:settings]["default_step"])
+      new_settings_schema(:step, self[:settings]["default_step"])
     end
 
     def default_step_settings=(data)
-      self[:settings]["default_step"] = settings_schema(:step).new(data)
+      self[:settings]["default_step"] = new_settings_schema(:step, data)
     end
 
     def step_settings
       return {} unless participatory_space.allows_steps?
 
       participatory_space.steps.each_with_object({}) do |step, result|
-        result[step.id.to_s] = settings_schema(:step).new(self[:settings].dig("steps", step.id.to_s))
+        result[step.id.to_s] = new_settings_schema(:step, self[:settings].dig("steps", step.id.to_s))
       end
     end
 
     def step_settings=(data)
       self[:settings]["steps"] = data.each_with_object({}) do |(key, value), result|
-        result[key.to_s] = settings_schema(:step).new(value)
+        result[key.to_s] = new_settings_schema(:step, value)
       end
     end
 
@@ -59,8 +59,10 @@ module Decidim
       step_settings.fetch(active_step.id.to_s)
     end
 
-    def settings_schema(name)
-      manifest.settings(name.to_sym).schema
+    # Returns a Class with the attributes sanitized, coerced  and filtered
+    # to the right type. See Decidim::SettingsManifest#schema.
+    def new_settings_schema(name, data)
+      manifest.settings(name).schema.new(data, participatory_space.organization.default_locale)
     end
 
     def default_values

--- a/decidim-core/lib/decidim/settings_manifest.rb
+++ b/decidim-core/lib/decidim/settings_manifest.rb
@@ -99,7 +99,7 @@ module Decidim
       attribute :default
       attribute :translated, Boolean, default: false
       attribute :editor, Boolean, default: false
-      attribute :required, Boolean, default: true
+      attribute :required, Boolean, default: false
       attribute :required_for_authorization, Boolean, default: false
 
       validates :type, inclusion: { in: TYPES.keys }

--- a/decidim-core/lib/decidim/settings_manifest.rb
+++ b/decidim-core/lib/decidim/settings_manifest.rb
@@ -45,7 +45,8 @@ module Decidim
         cattr_accessor :manifest
         attr_reader :default_locale
 
-        # Allows to set a :default_locale to validate translatable attributes.
+        # Overwrites Virtus::InstanceMethods::Constructor#initialize to allow
+        # passing a default_locale needed to validate translatable attributes.
         # See TranslatablePresenceValidator#default_locale_for(record).
         def initialize(attributes = nil, default_locale = nil)
           @default_locale = default_locale

--- a/decidim-core/lib/decidim/settings_manifest.rb
+++ b/decidim-core/lib/decidim/settings_manifest.rb
@@ -43,6 +43,14 @@ module Decidim
         include TranslatableAttributes
 
         cattr_accessor :manifest
+        attr_reader :default_locale
+
+        # Allows to set a :default_locale to validate translatable attributes.
+        # See TranslatablePresenceValidator#default_locale_for(record).
+        def initialize(attributes = nil, default_locale = nil)
+          @default_locale = default_locale
+          super(attributes)
+        end
 
         def self.model_name
           ActiveModel::Name.new(self, nil, "Settings")

--- a/decidim-core/spec/lib/settings_manifest_spec.rb
+++ b/decidim-core/spec/lib/settings_manifest_spec.rb
@@ -150,18 +150,22 @@ module Decidim
         end
 
         context "and `default_locale` is present" do
+          let(:default_locale) { "en" }
+
           it "allows to validate the translatable presence of the setting" do
-            settings = subject.schema.new({ translatable_setting_en: "Some text" }, "en")
+            settings = subject.schema.new({ translatable_setting_en: "Some text" }, default_locale)
             expect(settings).to be_valid
 
-            settings = subject.schema.new({ translatable_setting_en: "" }, "en")
+            settings = subject.schema.new({ translatable_setting_en: "" }, default_locale)
             expect(settings).not_to be_valid
           end
         end
 
         context "and `default_locale` is nil" do
-          it "raises an error when trying to validate translatable presence of the setting" do
-            settings = subject.schema.new(translatable_setting_en: "Some text")
+          let(:default_locale) { nil }
+
+          it "raises an error when trying to validate the translatable presence of the setting" do
+            settings = subject.schema.new({ translatable_setting_en: "Some text" }, default_locale)
             expect { settings.validate }.to raise_error(NoMethodError)
           end
         end

--- a/decidim-core/spec/lib/settings_manifest_spec.rb
+++ b/decidim-core/spec/lib/settings_manifest_spec.rb
@@ -8,7 +8,7 @@ module Decidim
 
     describe "attribute" do
       it "adds an attribute to the attribute hash with defaults" do
-        subject.attribute :something
+        subject.attribute :something # default: boolean
         expect(subject.attributes[:something].type).to eq(:boolean)
       end
 
@@ -24,14 +24,47 @@ module Decidim
       end
 
       it "stores presenceness" do
-        subject.attribute :something
-        expect(subject.attributes[:something].required).to eq(true)
+        subject.attribute :something # default: false
+        expect(subject.attributes[:something].required).to eq(false)
 
         subject.attribute :something, required: true
         expect(subject.attributes[:something].required).to eq(true)
 
         subject.attribute :something, required: false
         expect(subject.attributes[:something].required).to eq(false)
+      end
+
+      it "stores `translated`" do
+        subject.attribute :something # default: false
+        expect(subject.attributes[:something].translated).to eq(false)
+
+        subject.attribute :something, translated: true
+        expect(subject.attributes[:something].translated).to eq(true)
+
+        subject.attribute :something, translated: false
+        expect(subject.attributes[:something].translated).to eq(false)
+      end
+
+      it "stores `editor`" do
+        subject.attribute :something # default: false
+        expect(subject.attributes[:something].editor).to eq(false)
+
+        subject.attribute :something, editor: true
+        expect(subject.attributes[:something].editor).to eq(true)
+
+        subject.attribute :something, editor: false
+        expect(subject.attributes[:something].editor).to eq(false)
+      end
+
+      it "stores `required_for_authorization`" do
+        subject.attribute :something # default: false
+        expect(subject.attributes[:something].required_for_authorization).to eq(false)
+
+        subject.attribute :something, required_for_authorization: true
+        expect(subject.attributes[:something].required_for_authorization).to eq(true)
+
+        subject.attribute :something, required_for_authorization: false
+        expect(subject.attributes[:something].required_for_authorization).to eq(false)
       end
 
       describe "supported types" do
@@ -57,6 +90,12 @@ module Decidim
           attribute = SettingsManifest::Attribute.new(type: :text)
           expect(attribute.type_class).to eq(String)
           expect(attribute.default_value).to eq(nil)
+        end
+
+        it "supports arrays" do
+          attribute = SettingsManifest::Attribute.new(type: :array)
+          expect(attribute.type_class).to eq(Array)
+          expect(attribute.default_value).to eq([])
         end
       end
 
@@ -86,15 +125,46 @@ module Decidim
         expect(settings.attributes).not_to include(invalid_option: true)
       end
 
-      it "adds presence validation to the model according the the presenceness of the setting" do
-        subject.attribute :something_enabled, required: false
-        subject.attribute :comments_enabled
+      it "adds presence validation to the model according the presenceness of the setting" do
+        subject.attribute :something_enabled
+        subject.attribute :comments_enabled, required: true
 
         settings = subject.schema.new(something_enabled: true)
         expect(settings).not_to be_valid
 
         settings = subject.schema.new(comments_enabled: true)
         expect(settings).to be_valid
+      end
+
+      it "allows passing an optional argument `default_locale` that defaults to nil" do
+        settings = subject.schema.new({}, "en")
+        expect(settings.default_locale).to eq("en")
+
+        settings = subject.schema.new({})
+        expect(settings.default_locale).to eq(nil)
+      end
+
+      context "when adding presence validation to the model from a translated setting" do
+        before do
+          subject.attribute :translatable_setting, type: :text, translated: true, required: true
+        end
+
+        context "and `default_locale` is present" do
+          it "allows to validate the translatable presence of the setting" do
+            settings = subject.schema.new({ translatable_setting_en: "Some text" }, "en")
+            expect(settings).to be_valid
+
+            settings = subject.schema.new({ translatable_setting_en: "" }, "en")
+            expect(settings).not_to be_valid
+          end
+        end
+
+        context "and `default_locale` is nil" do
+          it "raises an error when trying to validate translatable presence of the setting" do
+            settings = subject.schema.new(translatable_setting_en: "Some text")
+            expect { settings.validate }.to raise_error(NoMethodError)
+          end
+        end
       end
     end
   end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
@@ -123,14 +123,14 @@ Decidim.register_component(:dummy) do |component|
     settings.attribute :dummy_global_attribute_2, type: :boolean, required: false
     settings.attribute :enable_pads_creation, type: :boolean, default: false, required: false
     settings.attribute :amendments_enabled, type: :boolean, default: false, required: false
-    settings.attribute :default_registration_terms, type: :text, translated: true, editor: true
+    settings.attribute :dummy_global_translatable_text, type: :text, translated: true, editor: true
   end
 
   component.settings(:step) do |settings|
-    settings.attribute :announcement, type: :text, translated: true, editor: true
     settings.attribute :comments_blocked, type: :boolean, default: false, required: false
     settings.attribute :dummy_step_attribute_1, type: :boolean, required: false
     settings.attribute :dummy_step_attribute_2, type: :boolean, required: false
+    settings.attribute :dummy_step_translatable_text, type: :text, translated: true, editor: true
   end
 
   component.register_resource(:dummy_resource) do |resource|

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
@@ -117,18 +117,20 @@ Decidim.register_component(:dummy) do |component|
   component.newsletter_participant_entities = ["Decidim::DummyResources::DummyResource"]
 
   component.settings(:global) do |settings|
-    settings.attribute :comments_enabled, type: :boolean, default: true
-    settings.attribute :resources_permissions_enabled, type: :boolean, default: true
-    settings.attribute :dummy_global_attribute_1, type: :boolean
-    settings.attribute :dummy_global_attribute_2, type: :boolean
-    settings.attribute :enable_pads_creation, type: :boolean, default: false
-    settings.attribute :amendments_enabled, type: :boolean, default: false
+    settings.attribute :comments_enabled, type: :boolean, default: true, required: false
+    settings.attribute :resources_permissions_enabled, type: :boolean, default: true, required: false
+    settings.attribute :dummy_global_attribute_1, type: :boolean, required: false
+    settings.attribute :dummy_global_attribute_2, type: :boolean, required: false
+    settings.attribute :enable_pads_creation, type: :boolean, default: false, required: false
+    settings.attribute :amendments_enabled, type: :boolean, default: false, required: false
+    settings.attribute :default_registration_terms, type: :text, translated: true, editor: true
   end
 
   component.settings(:step) do |settings|
-    settings.attribute :comments_blocked, type: :boolean, default: false
-    settings.attribute :dummy_step_attribute_1, type: :boolean
-    settings.attribute :dummy_step_attribute_2, type: :boolean
+    settings.attribute :announcement, type: :text, translated: true, editor: true
+    settings.attribute :comments_blocked, type: :boolean, default: false, required: false
+    settings.attribute :dummy_step_attribute_1, type: :boolean, required: false
+    settings.attribute :dummy_step_attribute_2, type: :boolean, required: false
   end
 
   component.register_resource(:dummy_resource) do |resource|

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
@@ -117,20 +117,20 @@ Decidim.register_component(:dummy) do |component|
   component.newsletter_participant_entities = ["Decidim::DummyResources::DummyResource"]
 
   component.settings(:global) do |settings|
-    settings.attribute :comments_enabled, type: :boolean, default: true, required: false
-    settings.attribute :resources_permissions_enabled, type: :boolean, default: true, required: false
-    settings.attribute :dummy_global_attribute_1, type: :boolean, required: false
-    settings.attribute :dummy_global_attribute_2, type: :boolean, required: false
-    settings.attribute :enable_pads_creation, type: :boolean, default: false, required: false
-    settings.attribute :amendments_enabled, type: :boolean, default: false, required: false
-    settings.attribute :dummy_global_translatable_text, type: :text, translated: true, editor: true
+    settings.attribute :comments_enabled, type: :boolean, default: true
+    settings.attribute :resources_permissions_enabled, type: :boolean, default: true
+    settings.attribute :dummy_global_attribute_1, type: :boolean
+    settings.attribute :dummy_global_attribute_2, type: :boolean
+    settings.attribute :enable_pads_creation, type: :boolean, default: false
+    settings.attribute :amendments_enabled, type: :boolean, default: false
+    settings.attribute :dummy_global_translatable_text, type: :text, translated: true, editor: true, required: true
   end
 
   component.settings(:step) do |settings|
-    settings.attribute :comments_blocked, type: :boolean, default: false, required: false
-    settings.attribute :dummy_step_attribute_1, type: :boolean, required: false
-    settings.attribute :dummy_step_attribute_2, type: :boolean, required: false
-    settings.attribute :dummy_step_translatable_text, type: :text, translated: true, editor: true
+    settings.attribute :comments_blocked, type: :boolean, default: false
+    settings.attribute :dummy_step_attribute_1, type: :boolean
+    settings.attribute :dummy_step_attribute_2, type: :boolean
+    settings.attribute :dummy_step_translatable_text, type: :text, translated: true, editor: true, required: true
   end
 
   component.register_resource(:dummy_resource) do |resource|

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiative_components_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiative_components_spec.rb
@@ -33,10 +33,20 @@ describe "Admin manages initiative components", type: :system do
         )
 
         within ".global-settings" do
+          fill_in_i18n_editor(
+            :component_settings_dummy_global_translatable_text,
+            "#global-settings-dummy_global_translatable_text-tabs",
+            en: "Dummy Text"
+          )
           all("input[type=checkbox]").last.click
         end
 
         within ".default-step-settings" do
+          fill_in_i18n_editor(
+            :component_default_step_settings_dummy_step_translatable_text,
+            "#default-step-settings-dummy_step_translatable_text-tabs",
+            en: "Dummy Text for Step"
+          )
           all("input[type=checkbox]").first.click
         end
 

--- a/decidim-participatory_processes/spec/controllers/admin/components_controller_spec.rb
+++ b/decidim-participatory_processes/spec/controllers/admin/components_controller_spec.rb
@@ -36,10 +36,12 @@ module Decidim
             {
               name_en: "Dummy component",
               settings: {
-                comments_enabled: true
+                comments_enabled: true,
+                dummy_global_translatable_text_en: "Dummy text"
               },
               default_step_settings: {
-                comments_blocked: true
+                comments_blocked: true,
+                dummy_step_translatable_text_en: "Dummy text"
               }
             }
           end

--- a/decidim-participatory_processes/spec/shared/manage_process_components_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_process_components_examples.rb
@@ -4,6 +4,7 @@ shared_examples "manage process components" do
   let!(:participatory_process) do
     create(:participatory_process, :with_steps, organization: organization)
   end
+  let(:step_id) { participatory_process.steps.first.id }
 
   before do
     switch_to_host(organization.host)
@@ -33,10 +34,20 @@ shared_examples "manage process components" do
           )
 
           within ".global-settings" do
+            fill_in_i18n_editor(
+              :component_settings_dummy_global_translatable_text,
+              "#global-settings-dummy_global_translatable_text-tabs",
+              en: "Dummy Text"
+            )
             all("input[type=checkbox]").last.click
           end
 
           within ".step-settings" do
+            fill_in_i18n_editor(
+              "component_step_settings_#{step_id}_dummy_step_translatable_text",
+              "#step-#{step_id}-settings-dummy_step_translatable_text-tabs",
+              en: "Dummy Text for Step"
+            )
             all("input[type=checkbox]").first.click
           end
 
@@ -96,10 +107,20 @@ shared_examples "manage process components" do
           )
 
           within ".global-settings" do
+            fill_in_i18n_editor(
+              :component_settings_dummy_global_translatable_text,
+              "#global-settings-dummy_global_translatable_text-tabs",
+              en: "Dummy Text"
+            )
             all("input[type=checkbox]").last.click
           end
 
           within ".default-step-settings" do
+            fill_in_i18n_editor(
+              :component_default_step_settings_dummy_step_translatable_text,
+              "#default-step-settings-dummy_step_translatable_text-tabs",
+              en: "Dummy Text for Step"
+            )
             all("input[type=checkbox]").first.click
           end
 
@@ -148,7 +169,14 @@ shared_examples "manage process components" do
     end
 
     let!(:component) do
-      create(:component, name: component_name, participatory_space: participatory_process)
+      create(
+        :component,
+        name: component_name,
+        participatory_space: participatory_process,
+        step_settings: {
+          step_id => { dummy_step_translatable_text: generate_localized_title }
+        }
+      )
     end
 
     before do


### PR DESCRIPTION
#### :tophat: What? Why?
>It's possible to create a Component even if the "required" fills are empty

`Decidim::Admin::ComponentForm` was only validating:
- the translatable attribute `:name`
- custom validation methods

but was not validating the "settings" attributes:
- `:settings`
- `:default_step_settings`
- `:step_settings`

Because in `Decidim::Admin::ComponentsController`, in the actions were the `@form.valid?` is called, the `@form` was being builded `#from_params`, and so the "settings" attributes were assigned a `Hash`, which caused `Rectify::Form#form_attributes_valid?` to ignore them as they did not `respond_to?(&:valid?)`. Also it caused the views to break if the `@form` was invalid (i.e. empty name), because the logic in the views depended on the form attributes to be of the correct type, which was only possible when it was builded `#from_model` (like in the controller actions `#new` and `#edit`).

This was fixed by processing the params before building the `@form` in the controller. Besides, I had to overwrite `Rectify::Form#form_attributes_valid?` in `Decidim::Admin::ComponentForm` anyways because the nested attributes inside `:step_settings` were not being reached.

Also, I encountered the problem that the `TranslatablePresenceValidator` used to validate translatable attributes expects the `record` to respond either to `#default_locale` or `#current_organization`, which wasn't the case. So I updated `Decidim::SettingsManifest#schema` to allow passing a `:default_locale`  argument.

#### Important
Because all of the component's settings default to `required: true`, and only a handful of them overwrite this default value, the component form validations was causing situations like the one in the gif, where a checkbox that supposedly gives a configuration option is required to be checked in order to pass the form validations, which means that is no longer an option to the user...

To fix the above, I opted for updating the default value to false in `Decidim::SettingsManifest::Atribute`. So I imagine that if this PR gets merged there will be component settings that will need to be updated to `required: true` to retain the expected behaviour. cc @decidim/product 

#### :pushpin: Related Issues
- Fixes #5118

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)
![component_form_meeting-optimized](https://user-images.githubusercontent.com/40306853/61187055-46253380-a66d-11e9-8853-e3f03a96e933.gif)