### PR TITLE
Add alt attribute to fix accessibility issue

### DIFF
--- a/decidim-core/app/views/layouts/decidim/_logo.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_logo.html.erb
@@ -1,7 +1,7 @@
 <% if organization %>
   <%= link_to decidim.root_url(host: organization.host) do %>
     <% if organization.logo.present? %>
-      <%= image_tag organization.logo.medium.url %>
+      <%= image_tag organization.logo.medium.url, alt: organization.name %>
     <% else %>
       <span><%= organization.name %></span>
       <style>


### PR DESCRIPTION
#### :tophat: Right logo image doesn't have have "alt" attribute giving accessibility warnings.


#### :pushpin: Related Issues
- Related to none

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
