### PR TITLE
Improvements participatory space private users

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/create_participatory_space_private_user.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_participatory_space_private_user.rb
@@ -10,10 +10,11 @@ module Decidim
       # form - A form object with the params.
       # private_user_to - The private_user_to that will hold the
       #   user role
-      def initialize(form, current_user, private_user_to)
+      def initialize(form, current_user, private_user_to, via_csv = false)
         @form = form
         @current_user = current_user
         @private_user_to = private_user_to
+        @via_csv = via_csv
       end
 
       # Executes the command. Broadcasts these events:
@@ -41,8 +42,9 @@ module Decidim
       attr_reader :form, :private_user_to, :current_user, :user
 
       def create_private_user
+        action = @via_csv ? "create_via_csv" : "create"
         Decidim.traceability.perform_action!(
-          :create,
+          action,
           Decidim::ParticipatorySpacePrivateUser,
           current_user,
           resource: {

--- a/decidim-admin/app/commands/decidim/admin/process_participatory_space_private_user_import_csv.rb
+++ b/decidim-admin/app/commands/decidim/admin/process_participatory_space_private_user_import_csv.rb
@@ -35,7 +35,7 @@ module Decidim
         CSV.foreach(@form.file.path) do |row|
           email = row[0]
           user_name = row[1]
-          
+
           ImportParticipatorySpacePrivateUserCsvJob.perform_later(email, user_name, @private_users_to, @current_user) if email.present? && user_name.present?
         end
       end

--- a/decidim-admin/app/commands/decidim/admin/process_participatory_space_private_user_import_csv.rb
+++ b/decidim-admin/app/commands/decidim/admin/process_participatory_space_private_user_import_csv.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module Decidim
+  module Admin
+    class ProcessParticipatorySpacePrivateUserImportCsv < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # form - the form object containing the uploaded file
+      # current_user - the user performing the action
+      # private_users_to - The private_users_to that will hold the user role
+      def initialize(form, current_user, private_users_to)
+        @form = form
+        @current_user = current_user
+        @private_users_to = private_users_to
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid.
+      # - :invalid if the form wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        return broadcast(:invalid) unless @form.valid?
+
+        process_csv
+        broadcast(:ok)
+      end
+
+      private
+
+      def process_csv
+        CSV.foreach(@form.file.path) do |row|
+          email = row[0]
+          user_name = row[1]
+          
+          ImportParticipatorySpacePrivateUserCsvJob.perform_later(email, user_name, @private_users_to, @current_user) if email.present? && user_name.present?
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/app/controllers/decidim/admin/concerns/has_private_users_csv_import.rb
+++ b/decidim-admin/app/controllers/decidim/admin/concerns/has_private_users_csv_import.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    module Concerns
+      # PrivateUsers can be related to any ParticipatorySpace, in order to
+      # import private users from csv for a given type, you should create a new
+      # controller and include this concern.
+      #
+      # The only requirement is to define a `privatable_to` method that
+      # returns an instance of the model to relate the private_user to.
+      module HasPrivateUsersCsvImport
+        extend ActiveSupport::Concern
+
+        included do
+          helper_method :privatable_to
+
+          def new
+            enforce_permission_to :csv_import, :space_private_user
+            @form = form(ParticipatorySpacePrivateUserCsvImportForm).from_params({}, privatable_to: privatable_to)
+            render template: "decidim/admin/participatory_space_private_users_csv_imports/new"
+          end
+
+          def create
+            enforce_permission_to :csv_import, :space_private_user
+            @form = form(ParticipatorySpacePrivateUserCsvImportForm).from_params(params, privatable_to: privatable_to)
+
+            ProcessParticipatorySpacePrivateUserImportCsv.call(@form, current_user, current_participatory_space) do
+              on(:ok) do
+                flash[:notice] = I18n.t("participatory_space_private_users_csv_imports.create.success", scope: "decidim.admin")
+                redirect_to after_import_path
+              end
+
+              on(:invalid) do
+                flash[:alert] = I18n.t("participatory_space_private_users_csv_imports.create.invalid", scope: "decidim.admin")
+                render template: "decidim/admin/participatory_space_private_users_csv_imports/new"
+              end
+            end
+          end
+
+          # Public: Returns a String or Object that will be passed to `redirect_to` after
+          # importing private users. By default it redirects to the privatable_to.
+          #
+          # It can be redefined at controller level if you need to redirect elsewhere.
+          def after_import_path
+            privatable_to
+          end
+
+          # Public: The only method to be implemented at the controller. You need to
+          # return the object where the attachment will be attached to.
+          def privatable_to
+            raise NotImplementedError
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/app/forms/decidim/admin/participatory_space_private_user_csv_import_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_space_private_user_csv_import_form.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # A form object used to upload CSV to batch participatory space private users.
+    # 
+    class ParticipatorySpacePrivateUserCsvImportForm < Form
+      attribute :file
+
+      validates :file, presence: true
+    end
+  end
+end

--- a/decidim-admin/app/forms/decidim/admin/participatory_space_private_user_csv_import_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_space_private_user_csv_import_form.rb
@@ -3,7 +3,7 @@
 module Decidim
   module Admin
     # A form object used to upload CSV to batch participatory space private users.
-    # 
+    #
     class ParticipatorySpacePrivateUserCsvImportForm < Form
       attribute :file
 

--- a/decidim-admin/app/jobs/decidim/admin/import_participatory_space_private_user_csv_job.rb
+++ b/decidim-admin/app/jobs/decidim/admin/import_participatory_space_private_user_csv_job.rb
@@ -9,6 +9,7 @@ module Decidim
 
       def perform(email, user_name, privatable_to, current_user)
         return if email.blank? && user_name.blank?
+
         params = {
           name: user_name,
           email: email.downcase.strip

--- a/decidim-admin/app/jobs/decidim/admin/import_participatory_space_private_user_csv_job.rb
+++ b/decidim-admin/app/jobs/decidim/admin/import_participatory_space_private_user_csv_job.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # Custom ApplicationJob scoped to the admin panel.
+    #
+    class ImportParticipatorySpacePrivateUserCsvJob < ApplicationJob
+      queue_as :default
+
+      def perform(email, user_name, privatable_to, current_user)
+        return if email.blank? && user_name.blank?
+        params = {
+          name: user_name,
+          email: email.downcase.strip
+        }
+        private_user_form = ParticipatorySpacePrivateUserForm.from_params(params, privatable_to: privatable_to).with_context(current_user: current_user, current_particiaptory_space: privatable_to)
+
+        Decidim::Admin::CreateParticipatorySpacePrivateUser.call(private_user_form, current_user, privatable_to, true)
+      end
+    end
+  end
+end

--- a/decidim-admin/app/views/decidim/admin/participatory_space_private_users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_space_private_users/index.html.erb
@@ -3,7 +3,8 @@
     <h2 class="card-title">
       <%= t(".title") %>
       <% if allowed_to? :create, :space_private_user %>
-         <%= link_to t("actions.new", scope: "decidim.admin", name: t("models.participatory_space_private_user.name", scope: "decidim.admin")), url_for(action: :new), class: "button tiny button--title new" %>
+        <%= link_to t(".import_via_csv"), new_participatory_space_private_users_csv_import_path, class: "button tiny button--title" %>
+        <%= link_to t("actions.new", scope: "decidim.admin", name: t("models.participatory_space_private_user.name", scope: "decidim.admin")), url_for(action: :new), class: "button tiny button--title new" %>
       <% end %>
     </h2>
   </div>

--- a/decidim-admin/app/views/decidim/admin/participatory_space_private_users_csv_imports/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_space_private_users_csv_imports/new.html.erb
@@ -1,0 +1,19 @@
+<div class="card" id='user-groups'>
+  <div class="card-divider">
+    <h2 class="card-title">
+      <%= t ".title" %>
+    </h2>
+  </div>
+  <div class="card-section">
+    <%= decidim_form_for(@form, url: participatory_space_private_users_csv_import_path, html: { class: "form" }) do |form| %>
+      <p><%= t(".explanation") %></p>
+      <div class="row column">
+        <%= form.upload :file, optional: false %>
+      </div>
+
+      <div class="button--double form-general-submit">
+        <%= form.submit t(".upload") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -573,10 +573,19 @@ en:
           error: There was a problem deleting a private participant for this participatory space.
           success: Participatory space private participant access successfully destroyed.
         index:
+          import_via_csv: Import via csv
           title: Participatory space private participant
         new:
           create: Create
           title: New Participatory Space private participant.
+      participatory_space_private_users_csv_imports:
+        create:
+          invalid: There was a problem reading the CSV file.
+          success: CSV file uploaded successfully, we're sending an invitation email to participants. This might take a while.
+        new:
+          explanation: Upload your CSV file. It must have two columns with name in the first column of the file and email in the last column of the file (name, email) of the users that you want to add to the participatory space, without headers.
+          title: Upload your CSV file
+          upload: Upload
       resource_permissions:
         edit:
           submit: Submit

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/participatory_space_private_users_csv_imports_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/participatory_space_private_users_csv_imports_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ParticipatoryProcesses
+    module Admin
+      # Controller that allows importing assembly private users
+      # on assembies
+      class ParticipatorySpacePrivateUsersCsvImportsController < Decidim::Admin::ApplicationController
+        include Concerns::ParticipatoryProcessAdmin
+        include Decidim::Admin::Concerns::HasPrivateUsersCsvImport
+
+        def after_import_path
+          participatory_space_private_users_path(current_assembly)
+        end
+
+        def privatable_to
+          current_participatory_process
+        end
+      end
+    end
+  end
+end

--- a/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
@@ -54,6 +54,9 @@ module Decidim
             member do
               post :resend_invitation, to: "participatory_space_private_users#resend_invitation"
             end
+            collection do
+              resource :participatory_space_private_users_csv_import, only: [:new, :create], path: "csv_import"
+            end
           end
         end
 

--- a/decidim-core/app/presenters/decidim/admin_log/participatory_space_private_user_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/participatory_space_private_user_presenter.rb
@@ -23,7 +23,7 @@ module Decidim
 
       def action_string
         case action
-        when "invite", "delete"
+        when "create", "create_via_csv", "delete"
           "decidim.admin_log.participatory_space_private_user.#{action}"
         else
           super

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -117,6 +117,7 @@ en:
         update: "%{user_name} updated the organization settings"
       participatory_space_private_user:
         create: "%{user_name} invited %{resource_name} to be a private participant"
+        create_via_csv: "%{user_name} invited %{resource_name} via csv to be a private participant"
         delete: "%{user_name} removed the participant %{resource_name} as a private participant"
       scope:
         create: "%{user_name} created the %{resource_name} scope"

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_space_private_users_csv_imports_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_space_private_users_csv_imports_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ParticipatoryProcesses
+    module Admin
+      # Controller that allows importing participatory process private users
+      # on participatory processes
+      class ParticipatorySpacePrivateUsersCsvImportsController < Decidim::Admin::ApplicationController
+        include Concerns::ParticipatoryProcessAdmin
+        include Decidim::Admin::Concerns::HasPrivateUsersCsvImport
+
+        def after_import_path
+          participatory_space_private_users_path(current_participatory_process)
+        end
+
+        def privatable_to
+          current_participatory_process
+        end
+      end
+    end
+  end
+end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
@@ -58,6 +58,9 @@ module Decidim
             member do
               post :resend_invitation, to: "participatory_space_private_users#resend_invitation"
             end
+            collection do
+              resource :participatory_space_private_users_csv_import, only: [:new, :create], path: "csv_import"
+            end
           end
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?
To have the ability to upload a CSV with names and emails to upload a group of participants together. In this way an assembly admin or a superadmin can manage the private participants in a more agile way.

#### :pushpin: Related Issues
- Related to https://meta.decidim.org/processes/roadmap/f/122/proposals/14699

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [x] Add documentation regarding the feature 
- [x] Upload a CSV with names and emails. 
- [x] Send notification to a previously registered participant. 
- [x] The management of private participants would be maintained. You can remove them, as well as upload more CSVs for new uploads.
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
