### PR TITLE
Don't use button for date displays

### DIFF
--- a/decidim-conferences/app/assets/stylesheet/decidim/conferences/conferences.scss
+++ b/decidim-conferences/app/assets/stylesheet/decidim/conferences/conferences.scss
@@ -1,0 +1,3 @@
+.conference--date{
+  cursor: default;
+}

--- a/decidim-conferences/app/views/layouts/decidim/_conference_hero.html.erb
+++ b/decidim-conferences/app/views/layouts/decidim/_conference_hero.html.erb
@@ -19,10 +19,10 @@
     <div class="row">
       <div class="row column medium-8 text-left mt-m">
         <div class="column medium-6">
-          <button type="button" class="button hollow light expanded">
+          <div class="conference--date button hollow light expanded">
             <%= participatory_space_helpers.render_date(current_participatory_space) %>
             <%= current_participatory_space.location %>
-          </button>
+          </div>
         </div>
         <% if current_participatory_space.registrations_enabled? %>
           <div class="column medium-3 end">

--- a/decidim-conferences/lib/decidim/conferences/participatory_space.rb
+++ b/decidim-conferences/lib/decidim/conferences/participatory_space.rb
@@ -3,6 +3,7 @@
 Decidim.register_participatory_space(:conferences) do |participatory_space|
   participatory_space.icon = "decidim/conferences/conference.svg"
   participatory_space.model_class_name = "Decidim::Conference"
+  participatory_space.stylesheet = "decidim/conferences/conferences"
 
   participatory_space.participatory_spaces do |organization|
     Decidim::Conferences::OrganizationConferences.new(organization).query


### PR DESCRIPTION
#### :tophat: What? Why?
The date display on the conference hero displays a pointer that indicates a click action. It's confusing because the button is not clickable. This PR fixes this little problem 

#### :pushpin: Related Issues
- Fixes https://github.com/OpenSourcePolitics/decidim/issues/796

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/20232956/64704423-8eff3a00-d4ae-11e9-9c0c-ce45dff9cb91.png)