### PR TITLE
Changes default format date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 **Changed**:
 
 - **decidim-accountability**, **decidim-assemblies**, **decidim-consultations**, **decidim-core**, **decidim-proposals**, **decidim-debates**, **decidim-dev**, **decidim-generators**, **decidim-initiatives**, **decidim-meetings**, **decidim-participatory_processes**, **decidim-proposals**, **decidim-sortitions**, **decidim_app-design**: Change: social share button default sites [\#5270](https://github.com/decidim/decidim/pull/5270)
+- **decidim-core**: Changes default format date [#5330](https://github.com/decidim/decidim/pull/5330)
 
 **Fixed**:
 

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1316,10 +1316,13 @@ en:
       day_of_year: "%d.%m.%y"
       decidim_day_of_year: "%d %B %Y"
       decidim_short: "%d/%m/%Y %H:%M"
+      default: "%a, %d %b %Y %H:%M:%S %z"
       devise:
         mailer:
           invitation_instructions:
             accept_until_format: "%B %d, %Y %I:%M %p"
+      long: "%B %d, %Y %H:%M"
+      short: "%d/%m/%Y %H:%M"
       time_of_day: "%H:%M"
   versions:
     directions:

--- a/decidim-verifications/spec/system/postal_letter/postal_letter_admin_spec.rb
+++ b/decidim-verifications/spec/system/postal_letter/postal_letter_admin_spec.rb
@@ -68,7 +68,7 @@ describe "Postal letter management", type: :system do
 
     within "table tbody tr", text: letter_not_sent.user.name do
       expect(page).not_to have_selector("td a.action-icon--verify")
-      expect(page).to have_selector("td", text: /\d+ \w+ \d+:\d+/)
+      expect(page).to have_selector("td", text: %r{\d+/\d+/\d+ \d+:\d+})
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Changes default short format date to show the year.
It doesn't make sense to not show the year, as it's really
difficult to work on the admin without this information.
Default is:
>  short: "%d %b %H:%M"

#### :pushpin: Related Issues
- Fixes #5201 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![imatge](https://user-images.githubusercontent.com/717367/64852819-62683100-d61a-11e9-97f8-e1fc0cb872a0.png)

