### PR TITLE
Blog attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 **Added**:
 
+- **decidim-blog**: Allow attachments to blog posts. [\#5336](https://github.com/decidim/decidim/pull/5336)
 - **decidim-admin**, **decidim-assemblies**, **decidim-participatory-processes**: Add CSV Import to Participatory Space Private Users. [\#5304](https://github.com/decidim/decidim/pull/5304)
 - **decidim-participatory-processes**: Add: process group presenter [#5289](https://github.com/decidim/decidim/pull/5289)
 - **decidim-consultations**: Allow to restrict voting to a question by adding verifications permissions [#5274](https://github.com/decidim/decidim/pull/5274)

--- a/decidim-blogs/app/controllers/decidim/blogs/admin/attachment_collections_controller.rb
+++ b/decidim-blogs/app/controllers/decidim/blogs/admin/attachment_collections_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Blogs
+    module Admin
+      # Controller that allows managing all the attachment collections for an assembly.
+      #
+      class AttachmentCollectionsController < Admin::ApplicationController
+        include Decidim::Admin::Concerns::HasAttachmentCollections
+
+        def after_destroy_path
+          post_attachment_collections_path(post, post.component, current_participatory_space)
+        end
+
+        def collection_for
+          post
+        end
+
+        def post
+          @post ||= posts.find(params[:post_id])
+        end
+      end
+    end
+  end
+end

--- a/decidim-blogs/app/controllers/decidim/blogs/admin/attachments_controller.rb
+++ b/decidim-blogs/app/controllers/decidim/blogs/admin/attachments_controller.rb
@@ -10,7 +10,7 @@ module Decidim
         include Decidim::Admin::Concerns::HasAttachments
 
         def after_destroy_path
-          post_path
+          post_attachments_path
         end
 
         def attached_to

--- a/decidim-blogs/app/controllers/decidim/blogs/admin/attachments_controller.rb
+++ b/decidim-blogs/app/controllers/decidim/blogs/admin/attachments_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Blogs
+    module Admin
+      # Controller that allows managing all the attachments for a participatory
+      # process.
+      #
+      class AttachmentsController < Decidim::Blogs::Admin::ApplicationController
+        include Decidim::Admin::Concerns::HasAttachments
+
+        def after_destroy_path
+          post_path
+        end
+
+        def attached_to
+          post
+        end
+
+        def post
+          @post ||= posts.find(params[:post_id])
+        end
+      end
+    end
+  end
+end

--- a/decidim-blogs/app/models/decidim/blogs/post.rb
+++ b/decidim-blogs/app/models/decidim/blogs/post.rb
@@ -6,6 +6,8 @@ module Decidim
     # title, description and any other useful information to render a blog.
     class Post < Blogs::ApplicationRecord
       include Decidim::Resourceable
+      include Decidim::HasAttachments
+      include Decidim::HasAttachmentCollections
       include Decidim::HasComponent
       include Decidim::Authorable
       include Decidim::Comments::Commentable

--- a/decidim-blogs/app/views/decidim/blogs/admin/posts/index.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/admin/posts/index.html.erb
@@ -39,6 +39,14 @@
                   <%= icon_link_to "pencil", edit_post_path(post), t("actions.edit", scope: "decidim.blogs"), class: "action-icon--edit" %>
                 <% end %>
 
+                <% if allowed_to? :update, :blogpost, blog_post: post %>
+                    <%= icon_link_to "folder", post_attachment_collections_path(post), t("actions.attachment_collections", scope: "decidim.meetings"), class: "action-icon--attachment_collections" %>
+                <% end %>
+
+                <% if allowed_to? :update, :blogpost, blog_post: post %>
+                  <%= icon_link_to "paperclip", post_attachments_path(post), t("actions.attachments", scope: "decidim.meetings"), class: "action-icon--attachments" %>
+                <% end %>
+
                 <% if allowed_to? :destroy, :blogpost, blog_post: post %>
                   <%= icon_link_to "circle-x", post_path(post), t("actions.destroy", scope: "decidim.blogs"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.blogs") } %>
                 <% end %>

--- a/decidim-blogs/app/views/decidim/blogs/posts/show.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/posts/show.html.erb
@@ -28,5 +28,5 @@
     <%= render partial: "sidebar_blog", locals: { posts: posts_most_commented } %>
   </div>
 </div>
-
+<%= attachments_for post %>
 <%= comments_for post %>

--- a/decidim-blogs/lib/decidim/blogs/admin_engine.rb
+++ b/decidim-blogs/lib/decidim/blogs/admin_engine.rb
@@ -11,7 +11,10 @@ module Decidim
       paths["lib/tasks"] = nil
 
       routes do
-        resources :posts
+        resources :posts do
+          resources :attachment_collections
+          resources :attachments
+        end
         root to: "posts#index"
       end
 

--- a/decidim-blogs/spec/shared/manage_attachment_collections_examples.rb
+++ b/decidim-blogs/spec/shared/manage_attachment_collections_examples.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+shared_examples "manage posts attachment collections" do
+  let(:collection_for) { post }
+
+  before do
+    within find("tr", text: translated(post.title)) do
+      click_link "Folders"
+    end
+  end
+
+  it_behaves_like "manage attachment collections examples"
+end

--- a/decidim-blogs/spec/shared/manage_attachments_examples.rb
+++ b/decidim-blogs/spec/shared/manage_attachments_examples.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+shared_examples "manage posts attachments" do
+  let(:attached_to) { post }
+  let(:attachment_collection) { create(:attachment_collection, collection_for: post) }
+
+  before do
+    within find("tr", text: translated(post.title)) do
+      click_link "Attachments"
+    end
+  end
+
+  it_behaves_like "manage attachments examples"
+end

--- a/decidim-blogs/spec/system/admin_manages_posts_attachment_collections_spec.rb
+++ b/decidim-blogs/spec/system/admin_manages_posts_attachment_collections_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin manages posts attachment collections", type: :system do
+  include_context "with a component"
+  let(:manifest_name) { "blogs" }
+  let!(:post) { create :post, component: current_component, title: { en: "Post title 1" } }
+
+  include_context "when managing a component as an admin"
+
+  it_behaves_like "manage posts attachment collections"
+end

--- a/decidim-blogs/spec/system/admin_manages_posts_attachments_spec.rb
+++ b/decidim-blogs/spec/system/admin_manages_posts_attachments_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin manages posts attachments", type: :system do
+  include_context "with a component"
+  let(:manifest_name) { "blogs" }
+  let!(:post) { create :post, component: current_component, title: { en: "Post title 1" } }
+
+  include_context "when managing a component as an admin"
+
+  it_behaves_like "manage posts attachments"
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Blog posts could benefit from having attachments or images. This PR adds this feature same way as other components in the admin (meetings for instance).

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [x] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

Admin:

![image](https://user-images.githubusercontent.com/1401520/64952660-2be01f80-d881-11e9-9316-70f3ba5514c9.png)


User view:

![image](https://user-images.githubusercontent.com/1401520/64952590-0a7f3380-d881-11e9-8371-3bce6d320975.png)

