### PR TITLE
[Backport] Fix: diffing empty 18n versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **Fixed**:
 
+- **decidim-accountability**, **decidim-core**, **decidim-proposals**, **decidim-dev**: Fix: diffing empty versions of translatable attributes [\#5343](https://github.com/decidim/decidim/pull/5343)
 - **decidim-participatory_processes**: BACKPORT Fix: ParticipatoryProcessSearch#search_date [#5326](https://github.com/decidim/decidim/pull/5326)
 - **decidim-proposals**: Fix: prevent ransack gem to upgrade to 2.3 as breaks searches with amendments. [#5303](https://github.com/decidim/decidim/pull/5303)
 - **decidim-admin**, **decidim-forms**: Fix adding answer options to a new form [#5283](https://github.com/decidim/decidim/pull/5283)

--- a/decidim-accountability/app/services/decidim/accountability/diff_renderer.rb
+++ b/decidim-accountability/app/services/decidim/accountability/diff_renderer.rb
@@ -2,34 +2,10 @@
 
 module Decidim
   module Accountability
-    class DiffRenderer
-      def initialize(version)
-        @version = version
-      end
-
-      # Renders the diff of the given changeset. Takes into account translatable fields.
-      #
-      # Returns a Hash, where keys are the fields that have changed and values are an
-      # array, the first element being the previous value and the last being the new one.
-      def diff
-        version.changeset.inject({}) do |diff, (attribute, values)|
-          attribute = attribute.to_sym
-          type = attribute_types[attribute]
-
-          if type.blank?
-            diff
-          else
-            parse_changeset(attribute, values, type, diff)
-          end
-        end
-      end
-
+    class DiffRenderer < BaseDiffRenderer
       private
 
-      attr_reader :version
-
-      # Lists which attributes will be diffable and how
-      # they should be rendered.
+      # Lists which attributes will be diffable and how they should be rendered.
       def attribute_types
         {
           start_date: :date,
@@ -39,49 +15,6 @@ module Decidim
           decidim_scope_id: :scope,
           progress: :percentage
         }
-      end
-
-      def parse_i18n_changeset(attribute, values, type, diff)
-        values.last.each_key do |locale, _value|
-          first_value = values.first.try(:[], locale)
-          last_value = values.last.try(:[], locale)
-          next if first_value == last_value
-
-          attribute_locale = "#{attribute}_#{locale}".to_sym
-          diff.update(
-            attribute_locale => {
-              type: type,
-              label: generate_i18n_label(attribute, locale),
-              old_value: first_value,
-              new_value: last_value
-            }
-          )
-        end
-        diff
-      end
-
-      def parse_changeset(attribute, values, type, diff)
-        return parse_i18n_changeset(attribute, values, type, diff) if [:i18n, :i18n_html].include?(type)
-
-        diff.update(
-          attribute => {
-            type: type,
-            label: I18n.t(attribute, scope: "activemodel.attributes.result"),
-            old_value: values[0],
-            new_value: values[1]
-          }
-        )
-      end
-
-      def generate_i18n_label(attribute, locale)
-        label = I18n.t(attribute, scope: "activemodel.attributes.result")
-        locale_name = if I18n.available_locales.include?(locale.to_sym)
-                        I18n.t("locale.name", locale: locale)
-                      else
-                        locale
-                      end
-
-        "#{label} (#{locale_name})"
       end
     end
   end

--- a/decidim-core/app/cells/decidim/diff/attribute.erb
+++ b/decidim-core/app/cells/decidim/diff/attribute.erb
@@ -1,4 +1,4 @@
-<div class="diff-for-<%= data[:label].downcase %>">
+<div class="diff-for-<%= data[:label].parameterize %>">
   <div class="row">
     <h3 class="section-heading mediumlarge-12 columns">
       <%= data[:label] %>

--- a/decidim-core/app/cells/decidim/diff_cell.rb
+++ b/decidim-core/app/cells/decidim/diff_cell.rb
@@ -25,9 +25,11 @@ module Decidim
       model
     end
 
-    # DiffRenderer class for the current_version's item.
+    # DiffRenderer class for the current_version's item; falls back to `BaseDiffRenderer`.
     def diff_renderer_class
       "#{current_version.item_type.deconstantize}::DiffRenderer".constantize
+    rescue NameError
+      Decidim::BaseDiffRenderer
     end
 
     # Caches a DiffRenderer instance for the current_version.
@@ -49,7 +51,7 @@ module Decidim
     #
     # Returns an HTML-safe string.
     def output_unified_diff(data)
-      return unless data
+      return unless data && data[:new_value].present?
 
       Diffy::Diff.new(
         data[:old_value],
@@ -65,7 +67,7 @@ module Decidim
     #
     # Returns an HTML-safe string.
     def output_split_diff(data, direction)
-      return unless data && direction
+      return unless direction && data && data[:new_value].present?
 
       Diffy::SplitDiff.new(
         data[:old_value],

--- a/decidim-core/app/services/decidim/base_diff_renderer.rb
+++ b/decidim-core/app/services/decidim/base_diff_renderer.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This class holds common logic for diffing resources.
+  # It is supposed to be a base class for all other diff renderers,
+  # as it defines some helpful methods that later diff renderers can use.
+  class BaseDiffRenderer
+    def initialize(version)
+      @version = version
+    end
+
+    # Renders the diff of the given changeset. Takes into account translatable fields.
+    #
+    # Returns a Hash, where keys are the fields that have changed and values are an
+    # array, the first element being the previous value and the last being the new one.
+    def diff
+      version.changeset.inject({}) do |diff, (attribute, values)|
+        attribute = attribute.to_sym
+        type = attribute_types[attribute]
+
+        if type.blank?
+          diff
+        else
+          parse_changeset(attribute, values, type, diff)
+        end
+      end
+    end
+
+    private
+
+    attr_reader :version
+
+    # Lists which attributes will be diffable and how they should be rendered.
+    # It is supposed to be overwritten by sub classes.
+    def attribute_types
+      {}
+    end
+
+    def parse_i18n_changeset(attribute, values, type, diff)
+      values.last.each_key do |locale, _value|
+        first_value = values.first.try(:[], locale)
+        last_value = values.last.try(:[], locale)
+        next if first_value == last_value
+
+        attribute_locale = "#{attribute}_#{locale}".to_sym
+        diff.update(
+          attribute_locale => {
+            type: type,
+            label: generate_i18n_label(attribute, locale),
+            old_value: first_value,
+            new_value: last_value
+          }
+        )
+      end
+      diff
+    end
+
+    def parse_changeset(attribute, values, type, diff)
+      return parse_i18n_changeset(attribute, values, type, diff) if [:i18n, :i18n_html].include?(type)
+
+      diff.update(
+        attribute => {
+          type: type,
+          label: I18n.t(attribute, scope: i18n_scope),
+          old_value: values[0],
+          new_value: values[1]
+        }
+      )
+    end
+
+    # Returns a String.
+    def generate_i18n_label(attribute, locale)
+      label = I18n.t(attribute, scope: i18n_scope)
+      locale_name = if I18n.available_locales.include?(locale.to_sym)
+                      I18n.t("locale.name", locale: locale)
+                    else
+                      locale
+                    end
+
+      "#{label} (#{locale_name})"
+    end
+
+    # Returns a String.
+    def i18n_scope
+      model_name = version.item_type.constantize.model_name.singular_route_key
+      "activemodel.attributes.#{model_name}"
+    end
+  end
+end

--- a/decidim-core/spec/cells/decidim/diff_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/diff_cell_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/accountability/test/factories"
+
+describe Decidim::DiffCell, versioning: true, type: :cell do
+  subject { my_cell.call }
+
+  let(:my_cell) { cell("decidim/diff", model) }
+  let(:model) { result.versions.last }
+  let(:result) { create(:result, title: title) }
+
+  context "when diffing a translatable attribute that has empty strings" do
+    let(:title) do
+      {
+        en: "English title",
+        ca: "Catalan title",
+        es: ""
+      }
+    end
+
+    it "renders an empty diff for the empty attributes" do
+      expect(subject).to have_css(".diff-for-title-english .diff-data", text: "English title")
+      expect(subject).to have_css(".diff-for-title-catala .diff-data", text: "Catalan title")
+      expect(subject).to have_css(".diff-for-title-castellano .diff-data", exact_text: "\n          ")
+    end
+  end
+end

--- a/decidim-core/spec/services/decidim/base_diff_renderer_spec.rb
+++ b/decidim-core/spec/services/decidim/base_diff_renderer_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::BaseDiffRenderer, versioning: true do
+  let(:diff_renderer) { described_class.new(version) }
+  let(:version) { resource.versions.last }
+  let(:resource) { create(:dummy_resource) }
+
+  shared_examples "parsing a version changeset for a given attribute" do
+    it "calculates the fields that have changed" do
+      expect(subject.keys).to include(field_name)
+    end
+
+    it "has the old and new values for each field" do
+      expect(subject[field_name][:old_value]).to eq(old_value)
+      expect(subject[field_name][:new_value]).to eq(new_value)
+    end
+
+    it "has the type of each field" do
+      expect(subject[field_name]).to include(type: field_type)
+    end
+
+    it "generates the labels correctly" do
+      expect(subject[field_name]).to include(label: field_label)
+    end
+  end
+
+  describe "#diff" do
+    subject { diff_renderer.diff }
+
+    it { is_expected.to be_empty }
+
+    context "when an attribute_type is matched" do
+      before { allow(diff_renderer).to receive(:attribute_types).and_return(title: :string) }
+
+      it_behaves_like "parsing a version changeset for a given attribute" do
+        let(:field_name) { :title }
+        let(:field_type) { :string }
+        let(:field_label) { "Title" }
+        let(:old_value) { nil }
+        let(:new_value) { resource.title }
+      end
+    end
+
+    context "when a :i18n attribute_type is matched" do
+      before do
+        resource.update(translatable_text: { ca: "Catalan text" })
+        allow(diff_renderer).to receive(:attribute_types).and_return(translatable_text: :i18n)
+      end
+
+      it_behaves_like "parsing a version changeset for a given attribute" do
+        let(:field_name) { :translatable_text_ca }
+        let(:field_type) { :i18n }
+        let(:field_label) { "Translatable text (Català)" }
+        let(:old_value) { nil }
+        let(:new_value) { resource.translatable_text["ca"] }
+      end
+
+      context "when one of the locales is not available" do
+        let!(:available_locales) { I18n.available_locales }
+
+        before { I18n.available_locales = [:en] }
+
+        after { I18n.available_locales = available_locales }
+
+        it "generates the label with locale name" do
+          expect(subject[:translatable_text_ca]).to include(label: "Translatable text (ca)")
+        end
+      end
+    end
+  end
+end

--- a/decidim-dev/config/locales/en.yml
+++ b/decidim-dev/config/locales/en.yml
@@ -7,6 +7,7 @@ en:
         field: My field
         start_date: Start date
         title: Title
+        translatable_text: Translatable text
         updated_at: Updated at
   decidim:
     dummy:

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
@@ -161,6 +161,7 @@ RSpec.configure do |config|
     ActiveRecord::Migration.suppress_messages do
       unless ActiveRecord::Base.connection.data_source_exists?("decidim_dummy_resources_dummy_resources")
         ActiveRecord::Migration.create_table :decidim_dummy_resources_dummy_resources do |t|
+          t.jsonb :translatable_text
           t.string :title
           t.string :body
           t.text :address

--- a/decidim-proposals/app/services/decidim/proposals/diff_renderer.rb
+++ b/decidim-proposals/app/services/decidim/proposals/diff_renderer.rb
@@ -2,34 +2,10 @@
 
 module Decidim
   module Proposals
-    class DiffRenderer
-      def initialize(version)
-        @version = version
-      end
-
-      # Renders the diff of the given changeset. Doesn't take into account translatable fields.
-      #
-      # Returns a Hash, where keys are the fields that have changed and values are an
-      # array, the first element being the previous value and the last being the new one.
-      def diff
-        version.changeset.inject({}) do |diff, (attribute, values)|
-          attribute = attribute.to_sym
-          type = attribute_types[attribute]
-
-          if type.blank?
-            diff
-          else
-            parse_changeset(attribute, values, type, diff)
-          end
-        end
-      end
-
+    class DiffRenderer < BaseDiffRenderer
       private
 
-      attr_reader :version
-
-      # Lists which attributes will be diffable and how
-      # they should be rendered.
+      # Lists which attributes will be diffable and how they should be rendered.
       def attribute_types
         {
           title: :string,
@@ -41,17 +17,6 @@ module Decidim
           longitude: :string,
           state: :string
         }
-      end
-
-      def parse_changeset(attribute, values, type, diff)
-        diff.update(
-          attribute => {
-            type: type,
-            label: I18n.t(attribute, scope: "activemodel.attributes.collaborative_draft"),
-            old_value: values[0],
-            new_value: values[1]
-          }
-        )
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Backport #5312 to `0.18-stable` branch

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
