### PR TITLE
Adapt class of 'data-portability' and 'urlShare' button

### DIFF
--- a/decidim-core/app/views/decidim/data_portability/show.html.erb
+++ b/decidim-core/app/views/decidim/data_portability/show.html.erb
@@ -1,5 +1,5 @@
 <div class="row data-portability">
   <strong><%= t(".download_data") %></strong>
   <p><%= t(".download_data_description", user_email: current_user.email).html_safe %></p>
-  <%= button_to t(".request_data"), export_data_portability_path, class: "button secondary", data: { disable: true } %>
+  <%= button_to t(".request_data"), export_data_portability_path, class: "button", data: { disable: true } %>
 </div>

--- a/decidim-core/app/views/decidim/shared/_share_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_share_modal.html.erb
@@ -17,7 +17,7 @@
         image: decidim_meta_image_url,
         desc: h(decidim_meta_description),
         via: decidim_meta_twitter_handler) %>
-    <a class="button secondary" data-open="urlShare">
+    <a class="button" data-open="urlShare">
       <%= icon "link-intact" %>
     </a>
   </div>


### PR DESCRIPTION
#### :tophat: What? Why?
The class of the 'data-portability' button should be "button" instead of "button secondary" in order to match the style of the submit buttons on the other profile subpages.

The class of the 'urlShare' button should be "button" instead of "button secondary" in order to match the style of the social share buttons (white symbol on colored background).

### :camera: Screenshots (optional)
![Button on 'My intersets'](https://imgur.com/lO67OqX.png)
![Button on 'My data'](https://imgur.com/lN5Nr3k.png)

**And with class 'button':**

![Button on 'My data' with class 'button'](https://imgur.com/D4yKm9s.png)

**Class 'button':**
![button](https://user-images.githubusercontent.com/29982899/65428454-af1aeb80-de14-11e9-9756-e7d9d1f3a3af.png)

vs class 'button secondary':
![button_secondary](https://user-images.githubusercontent.com/29982899/65428503-c5c14280-de14-11e9-9d07-49bf0430993c.png)

