### PR TITLE
Raise z-index of topbar dropdown menu to 701

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_navbar.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_navbar.scss
@@ -117,7 +117,7 @@ $navbar-active-shadow-medium: inset 0 4px 0 0 var(--primary);
   }
 
   .is-dropdown-submenu{
-    z-index: 2;
+    z-index: 701;
     text-align: left;
     padding: 0;
     background-color: $white;


### PR DESCRIPTION
#### :tophat: What? Why?
The leaflet container displaying the event map has a maximum z-index of 700 (see: https://github.com/Leaflet/Leaflet/pull/3591/files).
In order to not mess around with Leaflet (and possibly breaking the stacking of the map control buttons), the z-index of the topbar dropdown menu needs to be raised to 701.

### :camera: Screenshots (optional)
![topbar_menu_overlapping](https://user-images.githubusercontent.com/29982899/65493892-1d62bb00-deb4-11e9-98a3-df0931e71027.png)

