### PR TITLE
Remove symbolic link

### DIFF
--- a/decidim-core/app/views/layouts/decidim/.#_application.html.erb
+++ b/decidim-core/app/views/layouts/decidim/.#_application.html.erb
@@ -1,1 +1,0 @@
-oriol@Oriols-MacBook-Pro.local.18957


### PR DESCRIPTION
#### :tophat: What? Why?
Remove useless symlink introduced by #5347 
