### PR TITLE
Add global unique index migration and add validates uniqueness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 **Fixed**:
 
+- **decidim-core**: Fix: Add uniq index to `decidim_metrics` table [#5362](https://github.com/decidim/decidim/pull/5362)
 - **decidim-accountability**, **decidim-core**, **decidim-proposals**, **decidim-dev**: Fix: diffing empty versions of translatable attributes [\#5343](https://github.com/decidim/decidim/pull/5343)
 - **decidim-participatory_processes**: BACKPORT Fix: ParticipatoryProcessSearch#search_date [#5326](https://github.com/decidim/decidim/pull/5326)
 - **decidim-proposals**: Fix: prevent ransack gem to upgrade to 2.3 as breaks searches with amendments. [#5303](https://github.com/decidim/decidim/pull/5303)

--- a/decidim-core/app/models/decidim/metric.rb
+++ b/decidim-core/app/models/decidim/metric.rb
@@ -9,5 +9,16 @@ module Decidim
     belongs_to :participatory_space, foreign_key: "participatory_space_id", foreign_type: "participatory_space_type", polymorphic: true, optional: true
     belongs_to :related_object, foreign_key: "related_object_id", foreign_type: "related_object_type", polymorphic: true, optional: true
     belongs_to :category, foreign_key: "decidim_category_id", class_name: "Decidim::Category", optional: true
+
+    validates :day, uniqueness: { scope:
+                                  [
+                                    :metric_type,
+                                    :decidim_organization_id,
+                                    :participatory_space_type,
+                                    :participatory_space_id,
+                                    :related_object_type,
+                                    :related_object_id,
+                                    :decidim_category_id
+                                  ] }
   end
 end

--- a/decidim-core/db/migrate/20190925091507_add_uniq_index_to_decidim_metrics.rb
+++ b/decidim-core/db/migrate/20190925091507_add_uniq_index_to_decidim_metrics.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class AddUniqIndexToDecidimMetrics < ActiveRecord::Migration[5.2]
+  def change
+    add_index(
+      :decidim_metrics, [
+        :day,
+        :metric_type,
+        :decidim_organization_id,
+        :participatory_space_type,
+        :participatory_space_id,
+        :related_object_type,
+        :related_object_id,
+        :decidim_category_id
+      ],
+      unique: true,
+      name: "idx_metric_by_day_type_org_space_object_category"
+    )
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR is a backport of https://github.com/decidim/decidim/pull/5314 and adds an unique index migration for decidim metrics to avoid duplicates.

#### :pushpin: Related Issues
- Related to #4979 5268
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add index to decidim-metrics table

### :camera: Screenshots (optional)
![Description](URL)
