### PR TITLE
Fix order to escape proposal content

### DIFF
--- a/decidim-proposals/app/presenters/decidim/proposals/collaborative_draft_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/collaborative_draft_presenter.rb
@@ -29,20 +29,21 @@ module Decidim
       end
 
       def title(links: false, extras: true, html_escape: false)
-        renderer = Decidim::ContentRenderers::HashtagRenderer.new(collaborative_draft.title)
-        text = renderer.render(links: links, extras: extras).html_safe
+        text = collaborative_draft.title
         text = decidim_html_escape(text) if html_escape
-        text
+
+        renderer = Decidim::ContentRenderers::HashtagRenderer.new(text)
+        renderer.render(links: links, extras: extras).html_safe
       end
 
       def body(links: false, extras: true, strip_tags: false)
-        renderer = Decidim::ContentRenderers::HashtagRenderer.new(collaborative_draft.body)
+        text = collaborative_draft.body
+        text = strip_tags(text) if strip_tags
+
+        renderer = Decidim::ContentRenderers::HashtagRenderer.new(text)
         text = renderer.render(links: links, extras: extras).html_safe
-        if strip_tags
-          text = strip_tags(text)
-          text = Anchored::Linker.auto_link(text, target: "_blank", rel: "noopener")
-        end
-        text
+
+        Anchored::Linker.auto_link(text, target: "_blank", rel: "noopener")
       end
     end
   end

--- a/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
@@ -43,20 +43,21 @@ module Decidim
       #
       # Returns a String.
       def title(links: false, extras: true, html_escape: false)
-        renderer = Decidim::ContentRenderers::HashtagRenderer.new(proposal.title)
-        text = renderer.render(links: links, extras: extras).html_safe
+        text = proposal.title
         text = decidim_html_escape(text) if html_escape
-        text
+
+        renderer = Decidim::ContentRenderers::HashtagRenderer.new(text)
+        renderer.render(links: links, extras: extras).html_safe
       end
 
       def body(links: false, extras: true, strip_tags: false)
-        renderer = Decidim::ContentRenderers::HashtagRenderer.new(proposal.body)
+        text = proposal.body
+        text = strip_tags(text) if strip_tags
+
+        renderer = Decidim::ContentRenderers::HashtagRenderer.new(text)
         text = renderer.render(links: links, extras: extras).html_safe
-        if strip_tags
-          text = strip_tags(text)
-          text = Anchored::Linker.auto_link(text, target: "_blank", rel: "noopener")
-        end
-        text
+
+        Anchored::Linker.auto_link(text, target: "_blank", rel: "noopener")
       end
     end
   end

--- a/decidim-proposals/spec/system/collaborative_drafts_spec.rb
+++ b/decidim-proposals/spec/system/collaborative_drafts_spec.rb
@@ -4,7 +4,6 @@ require "spec_helper"
 
 describe "Explore Collaborative Drafts", versioning: true, type: :system do
   include ActionView::Helpers::TextHelper
-  include Decidim::SanitizeHelper
 
   include_context "with a component"
 
@@ -83,10 +82,8 @@ describe "Explore Collaborative Drafts", versioning: true, type: :system do
         end
       end
 
-      let(:sanitized_title) { decidim_html_escape(collaborative_draft.title) }
-
       it "shows the title" do
-        expect(page).to have_content(sanitized_title)
+        expect(page).to have_content(collaborative_draft.title)
       end
 
       it "shows the body" do
@@ -116,7 +113,7 @@ describe "Explore Collaborative Drafts", versioning: true, type: :system do
         end
 
         it "shows the title" do
-          expect(page).to have_content(sanitized_title)
+          expect(page).to have_content(collaborative_draft.title)
         end
 
         it "shows the body" do

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -4,7 +4,6 @@ require "spec_helper"
 
 describe "Proposals", type: :system do
   include ActionView::Helpers::TextHelper
-  include Decidim::SanitizeHelper
   include_context "with a component"
   let(:manifest_name) { "proposals" }
 
@@ -47,7 +46,7 @@ describe "Proposals", type: :system do
 
       click_link proposal.title
 
-      expect(page).to have_content(decidim_html_escape(proposal.title))
+      expect(page).to have_content(proposal.title)
       expect(page).to have_content(strip_tags(proposal.body).strip)
       expect(page).to have_author(proposal.creator_author.name)
       expect(page).to have_content(proposal.reference)


### PR DESCRIPTION
#### :tophat: What? Why?

We need to escape & strip before executing the hashtag renderer to maintain the same workflow as before.

#### :pushpin: Related Issues
- Related to #5341 
