### PR TITLE
Fix email notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - **decidim-accountability**, **decidim-core**, **decidim-proposals**, **decidim-dev**, **decidim-admin**, **decidim-consultations**, **decidim-initiatives**, **decidim-meetings**, **decidim-proposals**: Multiple bugfixes [\#5329](https://github.com/decidim/decidim/pull/5329)
 - **decidim-core**: Fix rendering when custom colors exist [#5347](https://github.com/decidim/decidim/pull/5347)
 - **decidim-core**: Fix component generator [#5348](https://github.com/decidim/decidim/pull/5348)
+- **decidim-core**: Fix email notifications [#5370](https://github.com/decidim/decidim/pull/5370)
 
 **Removed**:
 

--- a/decidim-core/app/jobs/decidim/event_publisher_job.rb
+++ b/decidim-core/app/jobs/decidim/event_publisher_job.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Decidim
+  class EventPublisherJob < ApplicationJob
+    queue_as :events
+
+    attr_reader :resource
+
+    def perform(event_name, data)
+      @resource = data[:resource]
+
+      return unless notifiable?
+
+      EmailNotificationGeneratorJob.perform_later(
+        event_name,
+        data[:event_class],
+        data[:resource],
+        data[:followers],
+        data[:affected_users],
+        data[:extra]
+      )
+
+      NotificationGeneratorJob.perform_later(
+        event_name,
+        data[:event_class],
+        data[:resource],
+        data[:followers],
+        data[:affected_users],
+        data[:extra]
+      )
+    end
+
+    private
+
+    # Whether this event should be notified or not. Useful when you want the
+    # event to decide based on the params.
+    #
+    # It returns false when the resource or any element in the chain is a
+    # `Decidim::Publicable` and it isn't published or participatory_space
+    # is a `Decidim::Participable` and the user can't participate.
+    def notifiable?
+      return false if resource.is_a?(Decidim::Publicable) && !resource.published?
+      return false if participatory_space.is_a?(Decidim::Publicable) && !participatory_space&.published?
+      return false if component && !component.published?
+
+      true
+    end
+
+    def component
+      return resource.component if resource.is_a?(Decidim::HasComponent)
+      return resource if resource.is_a?(Decidim::Component)
+    end
+
+    def participatory_space
+      return resource if resource.is_a?(Decidim::ParticipatorySpaceResourceable)
+
+      component&.participatory_space
+    end
+  end
+end

--- a/decidim-core/app/services/decidim/email_notification_generator.rb
+++ b/decidim-core/app/services/decidim/email_notification_generator.rb
@@ -65,6 +65,7 @@ module Decidim
     def send_email_to(recipient, user_role:)
       return unless recipient
       return unless recipient.email_on_notification?
+      return if resource.respond_to?(:can_participate?) && !resource.can_participate?(recipient)
 
       NotificationMailer
         .event_received(

--- a/decidim-core/app/services/decidim/notification_generator.rb
+++ b/decidim-core/app/services/decidim/notification_generator.rb
@@ -50,6 +50,8 @@ module Decidim
     attr_reader :event, :event_class, :resource, :followers, :affected_users, :extra
 
     def generate_notification_for(recipient, user_role:)
+      return if resource.respond_to?(:can_participate?) && !resource.can_participate?(recipient)
+
       NotificationGeneratorForRecipientJob.perform_later(
         event,
         event_class.name,

--- a/decidim-core/app/services/decidim/notification_generator_for_recipient.rb
+++ b/decidim-core/app/services/decidim/notification_generator_for_recipient.rb
@@ -30,7 +30,6 @@ module Decidim
       return unless event_class
       return unless resource
       return unless recipient
-      return unless notification.event_class_instance.notifiable?
 
       notification.save!
     end

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -185,22 +185,7 @@ module Decidim
 
       initializer "decidim.notifications" do
         Decidim::EventsManager.subscribe(/^decidim\.events\./) do |event_name, data|
-          EmailNotificationGeneratorJob.perform_later(
-            event_name,
-            data[:event_class],
-            data[:resource],
-            data[:followers],
-            data[:affected_users],
-            data[:extra]
-          )
-          NotificationGeneratorJob.perform_later(
-            event_name,
-            data[:event_class],
-            data[:resource],
-            data[:followers],
-            data[:affected_users],
-            data[:extra]
-          )
+          EventPublisherJob.perform_later(event_name, data)
         end
       end
 

--- a/decidim-core/lib/decidim/events/base_event.rb
+++ b/decidim-core/lib/decidim/events/base_event.rb
@@ -67,22 +67,6 @@ module Decidim
         @resource_url ||= resource_locator.url
       end
 
-      # Whether this event should be notified or not. Useful when you want the
-      # event to decide based on the params.
-      #
-      # It returns false when the resource or any element in the chain is a
-      # `Decidim::Publicable` and it isn't published or participatory_space
-      # is a `Decidim::Participable` and the user can't participate.
-      def notifiable?
-        return false if resource.is_a?(Decidim::Publicable) && !resource.published?
-        return false if participatory_space.is_a?(Decidim::Publicable) && !participatory_space&.published?
-        return false if component && !component.published?
-
-        return false if participatory_space.is_a?(Decidim::Participable) && !participatory_space.can_participate?(user)
-
-        true
-      end
-
       def resource_text; end
 
       def resource_title
@@ -101,18 +85,19 @@ module Decidim
 
       private
 
-      attr_reader :event_name, :resource, :user, :user_role, :extra
-
       def component
-        return resource.component if resource.is_a?(Decidim::HasComponent)
         return resource if resource.is_a?(Decidim::Component)
+
+        resource.try(:component)
       end
 
       def participatory_space
-        return resource if resource.is_a?(Decidim::ParticipatorySpaceResourceable)
+        return resource if resource.is_a?(Decidim::Participable)
 
-        component&.participatory_space
+        resource.try(:participatory_space)
       end
+
+      attr_reader :event_name, :resource, :user, :user_role, :extra
     end
   end
 end

--- a/decidim-core/spec/jobs/decidim/event_publisher_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/event_publisher_job_spec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::EventPublisherJob do
+  subject { described_class }
+
+  describe "queue" do
+    it "is queued to events" do
+      expect(subject.queue_name).to eq "events"
+    end
+  end
+
+  describe "perform" do
+    subject do
+      described_class.perform_now(event_name, data)
+    end
+
+    let(:event_name) { "some_event" }
+    let(:data) do
+      {
+        resource: resource
+      }
+    end
+
+    context "when the resource is publicable" do
+      let(:resource) { build(:dummy_resource) }
+
+      context "when it is published" do
+        before do
+          resource.published_at = Time.current
+        end
+
+        it "enqueues the jobs" do
+          expect(Decidim::EmailNotificationGeneratorJob).to receive(:perform_later)
+          expect(Decidim::NotificationGeneratorJob).to receive(:perform_later)
+
+          subject
+        end
+      end
+
+      context "when it is not published" do
+        before do
+          resource.published_at = nil
+        end
+
+        it "doesn't enqueue the jobs" do
+          expect(Decidim::EmailNotificationGeneratorJob).not_to receive(:perform_later)
+          expect(Decidim::NotificationGeneratorJob).not_to receive(:perform_later)
+
+          subject
+        end
+      end
+    end
+
+    context "when there's a component" do
+      let(:resource) { build(:dummy_resource) }
+
+      context "when it is published" do
+        before do
+          resource.published_at = Time.current
+          resource.component.published_at = Time.current
+        end
+
+        it "enqueues the jobs" do
+          expect(Decidim::EmailNotificationGeneratorJob).to receive(:perform_later)
+          expect(Decidim::NotificationGeneratorJob).to receive(:perform_later)
+
+          subject
+        end
+      end
+
+      context "when it is not published" do
+        before do
+          resource.published_at = Time.current
+          resource.component.published_at = nil
+        end
+
+        it "doesn't enqueue the jobs" do
+          expect(Decidim::EmailNotificationGeneratorJob).not_to receive(:perform_later)
+          expect(Decidim::NotificationGeneratorJob).not_to receive(:perform_later)
+
+          subject
+        end
+      end
+    end
+
+    context "when there's a participatory space" do
+      let(:resource) { build(:dummy_resource) }
+
+      context "when it is published" do
+        before do
+          resource.published_at = Time.current
+          resource.component.participatory_space.published_at = Time.current
+        end
+
+        it "enqueues the jobs" do
+          expect(Decidim::EmailNotificationGeneratorJob).to receive(:perform_later)
+          expect(Decidim::NotificationGeneratorJob).to receive(:perform_later)
+
+          subject
+        end
+      end
+
+      context "when it is not published" do
+        before do
+          resource.published_at = Time.current
+          resource.component.participatory_space.published_at = nil
+        end
+
+        it "doesn't enqueue the jobs" do
+          expect(Decidim::EmailNotificationGeneratorJob).not_to receive(:perform_later)
+          expect(Decidim::NotificationGeneratorJob).not_to receive(:perform_later)
+
+          subject
+        end
+      end
+    end
+
+    context "when the resource is a component" do
+      let(:resource) { build(:component) }
+
+      it "enqueues the jobs" do
+        expect(Decidim::EmailNotificationGeneratorJob).to receive(:perform_later)
+        expect(Decidim::NotificationGeneratorJob).to receive(:perform_later)
+
+        subject
+      end
+
+      context "when it is not published" do
+        let(:resource) { build(:component, :unpublished) }
+
+        it "doesn't enqueue the jobs" do
+          expect(Decidim::EmailNotificationGeneratorJob).not_to receive(:perform_later)
+          expect(Decidim::NotificationGeneratorJob).not_to receive(:perform_later)
+
+          subject
+        end
+      end
+    end
+
+    context "when the resource is a participatory space" do
+      let(:resource) { build(:participatory_process) }
+
+      it "enqueues the jobs" do
+        expect(Decidim::EmailNotificationGeneratorJob).to receive(:perform_later)
+        expect(Decidim::NotificationGeneratorJob).to receive(:perform_later)
+
+        subject
+      end
+
+      context "when it is not published" do
+        let(:resource) { build(:participatory_process, :unpublished) }
+
+        it "doesn't enqueue the jobs" do
+          expect(Decidim::EmailNotificationGeneratorJob).not_to receive(:perform_later)
+          expect(Decidim::NotificationGeneratorJob).not_to receive(:perform_later)
+
+          subject
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/lib/events/base_event_spec.rb
+++ b/decidim-core/spec/lib/events/base_event_spec.rb
@@ -4,6 +4,15 @@ require "spec_helper"
 
 module Decidim
   describe Events::BaseEvent do
+    subject do
+      described_class.new(
+        resource: resource,
+        event_name: "some.event",
+        user: user,
+        extra: {}
+      )
+    end
+
     let(:user) { build(:user) }
 
     describe ".types" do
@@ -14,137 +23,18 @@ module Decidim
       end
     end
 
-    describe "notifiable?" do
-      subject do
-        described_class.new(
-          resource: resource,
-          event_name: "some.event",
-          user: user,
-          extra: {}
-        )
+    context "when the resource is hashtaggable" do
+      let(:resource) { build(:dummy_resource) }
+
+      before do
+        title = "Proposal with #myhashtag"
+        parsed_title = Decidim::ContentProcessor.parse(title, current_organization: resource.organization)
+        resource.title = parsed_title.rewrite
       end
 
-      context "when the resource is publicable" do
-        let(:resource) { build(:dummy_resource) }
-
-        context "when it is published" do
-          before do
-            resource.published_at = Time.current
-          end
-
-          it { is_expected.to be_notifiable }
-        end
-
-        context "when it is not published" do
-          before do
-            resource.published_at = nil
-          end
-
-          it { is_expected.not_to be_notifiable }
-        end
-      end
-
-      context "when there's a component" do
-        let(:resource) { build(:dummy_resource) }
-
-        context "when it is published" do
-          before do
-            resource.published_at = Time.current
-            resource.component.published_at = Time.current
-          end
-
-          it { is_expected.to be_notifiable }
-        end
-
-        context "when it is not published" do
-          before do
-            resource.published_at = Time.current
-            resource.component.published_at = nil
-          end
-
-          it { is_expected.not_to be_notifiable }
-        end
-      end
-
-      context "when there's a participatory space" do
-        let(:resource) { build(:dummy_resource) }
-
-        context "when it is published" do
-          before do
-            resource.published_at = Time.current
-            resource.component.participatory_space.published_at = Time.current
-          end
-
-          it { is_expected.to be_notifiable }
-        end
-
-        context "when it is not published" do
-          before do
-            resource.published_at = Time.current
-            resource.component.participatory_space.published_at = nil
-          end
-
-          it { is_expected.not_to be_notifiable }
-        end
-
-        context "and participatory space is participable" do
-          before do
-            resource.published_at = Time.current
-            resource.component.published_at = Time.current
-            resource.component.participatory_space.published_at = Time.current
-          end
-
-          context "and the user can participate" do
-            it { is_expected.to be_notifiable }
-          end
-
-          context "and the user can't participate" do
-            before do
-              allow(resource.component.participatory_space).to receive(:can_participate?).with(user).and_return(false)
-            end
-
-            it { is_expected.not_to be_notifiable }
-          end
-        end
-      end
-
-      context "when the resource is a component" do
-        let(:resource) { build(:component) }
-
-        it { is_expected.to be_notifiable }
-
-        context "when it is not published" do
-          let(:resource) { build(:component, :unpublished) }
-
-          it { is_expected.not_to be_notifiable }
-        end
-      end
-
-      context "when the resource is a participatory space" do
-        let(:resource) { build(:participatory_process) }
-
-        it { is_expected.to be_notifiable }
-
-        context "when it is not published" do
-          let(:resource) { build(:participatory_process, :unpublished) }
-
-          it { is_expected.not_to be_notifiable }
-        end
-      end
-
-      context "when the resource is hashtaggable" do
-        let(:resource) { build(:dummy_resource) }
-
-        before do
-          title = "Proposal with #myhashtag"
-          parsed_title = Decidim::ContentProcessor.parse(title, current_organization: resource.organization)
-          resource.title = parsed_title.rewrite
-        end
-
-        it "returns the text correctly" do
-          expect(subject.resource_title).not_to include("gid://")
-          expect(subject.resource_title).to include("#myhashtag")
-        end
+      it "returns the text correctly" do
+        expect(subject.resource_title).not_to include("gid://")
+        expect(subject.resource_title).to include("#myhashtag")
       end
     end
   end

--- a/decidim-core/spec/services/decidim/email_notification_generator_spec.rb
+++ b/decidim-core/spec/services/decidim/email_notification_generator_spec.rb
@@ -49,13 +49,55 @@ describe Decidim::EmailNotificationGenerator do
             .to receive(:event_received)
             .with(event, event_class_name, resource, recipient, :affected_user.to_s, extra)
             .and_return(mailer)
+
           expect(Decidim::NotificationMailer)
             .to receive(:event_received)
             .with(event, event_class_name, resource, follower, :follower.to_s, extra)
             .and_return(mailer)
+
           expect(mailer).to receive(:deliver_later)
 
           subject.generate
+        end
+      end
+
+      context "when participatory space is participable" do
+        before do
+          resource.published_at = Time.current
+          resource.component.published_at = Time.current
+          resource.component.participatory_space.published_at = Time.current
+          resource.save!
+        end
+
+        context "and the user can participate" do
+          it "enqueues the job" do
+            expect(Decidim::NotificationMailer)
+              .to receive(:event_received)
+              .with(event, event_class_name, resource, recipient, :affected_user.to_s, extra)
+              .and_return(mailer)
+
+            expect(Decidim::NotificationMailer)
+              .to receive(:event_received)
+              .with(event, event_class_name, resource, follower, :follower.to_s, extra)
+              .and_return(mailer)
+
+            expect(mailer).to receive(:deliver_later)
+
+            subject.generate
+          end
+        end
+
+        context "and the user can't participate" do
+          before do
+            allow(resource).to receive(:can_participate?).with(kind_of(Decidim::User)).and_return(false)
+          end
+
+          it "doesn't schedule a job" do
+            expect(Decidim::NotificationMailer)
+              .not_to receive(:event_received)
+
+            subject.generate
+          end
         end
       end
     end
@@ -65,7 +107,7 @@ describe Decidim::EmailNotificationGenerator do
         allow(event_class).to receive(:types).and_return([])
       end
 
-      it "schedules a job for each recipient" do
+      it "doesn't schedule a job for each recipient" do
         expect(Decidim::NotificationMailer)
           .not_to receive(:event_received)
 

--- a/decidim-core/spec/services/decidim/notification_generator_for_recipient_spec.rb
+++ b/decidim-core/spec/services/decidim/notification_generator_for_recipient_spec.rb
@@ -24,20 +24,5 @@ describe Decidim::NotificationGeneratorForRecipient do
       expect(notification.resource).to eq resource
       expect(notification.extra["received_as"]).to eq "affected_user"
     end
-
-    context "when the event is not notifiable" do
-      class NonNotifiableEvent < Decidim::Events::BaseEvent
-        def notifiable?
-          false
-        end
-      end
-      let(:event_class) { NonNotifiableEvent }
-
-      it "does not create the notification" do
-        expect do
-          subject.generate
-        end.not_to change(Decidim::Notification, :count)
-      end
-    end
   end
 end

--- a/decidim-debates/app/models/decidim/debates/debate.rb
+++ b/decidim-debates/app/models/decidim/debates/debate.rb
@@ -91,11 +91,6 @@ module Decidim
         self.class.name
       end
 
-      # Public: Overrides the `notifiable?` Notifiable concern method.
-      def notifiable?(_context)
-        false
-      end
-
       # Public: Override Commentable concern method `users_to_notify_on_comment_created`
       def users_to_notify_on_comment_created
         return Decidim::User.where(id: followers).or(Decidim::User.where(id: component.participatory_space.admins)).distinct if official?


### PR DESCRIPTION
#### :tophat: What? Why?

We were only preventing the creation of notifications, but an email was sent when a resource wasn't published.

#### :pushpin: Related Issues
- Fixes #5125

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
