### PR TITLE
Make behavior of proposal's related presenters more consistent

### DIFF
--- a/decidim-proposals/app/presenters/decidim/proposals/collaborative_draft_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/collaborative_draft_presenter.rb
@@ -43,7 +43,8 @@ module Decidim
         renderer = Decidim::ContentRenderers::HashtagRenderer.new(text)
         text = renderer.render(links: links, extras: extras).html_safe
 
-        Anchored::Linker.auto_link(text, target: "_blank", rel: "noopener")
+        text = Anchored::Linker.auto_link(text, target: "_blank", rel: "noopener") if links
+        text
       end
     end
   end

--- a/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
@@ -57,7 +57,8 @@ module Decidim
         renderer = Decidim::ContentRenderers::HashtagRenderer.new(text)
         text = renderer.render(links: links, extras: extras).html_safe
 
-        Anchored::Linker.auto_link(text, target: "_blank", rel: "noopener")
+        text = Anchored::Linker.auto_link(text, target: "_blank", rel: "noopener") if links
+        text
       end
     end
   end

--- a/decidim-proposals/spec/presenters/decidim/proposals/collaborative_draft_presenter_spec.rb
+++ b/decidim-proposals/spec/presenters/decidim/proposals/collaborative_draft_presenter_spec.rb
@@ -20,7 +20,7 @@ module Decidim
         EORESULT
 
         it "converts all URLs to links and strips attributes in anchors" do
-          expect(subject.body(strip_tags: true)).to eq(result)
+          expect(subject.body(links: true, strip_tags: true)).to eq(result)
         end
       end
     end

--- a/decidim-proposals/spec/presenters/decidim/proposals/proposal_presenter_spec.rb
+++ b/decidim-proposals/spec/presenters/decidim/proposals/proposal_presenter_spec.rb
@@ -20,7 +20,7 @@ module Decidim
         EORESULT
 
         it "converts all URLs to links and strips attributes in anchors" do
-          expect(subject.body(strip_tags: true)).to eq(result)
+          expect(subject.body(links: true, strip_tags: true)).to eq(result)
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Make the `link` argument apply to both, HashtagRenderer and Anchored::Linker.
Right now it was only applying to HashtagRenderer, but when false Anchored was still promoting URLs to links.

#### :pushpin: Related Issues
- Related to #5367  and #5341

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [x] Update tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![ezgif com-video-to-apng(3)](https://user-images.githubusercontent.com/199462/65757983-7f235f00-e118-11e9-9712-9d44217e8fce.png)

