### PR TITLE
Fix: show the Assemblies button to allow managing nested assemblies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 **Fixed**:
 
+- **decidim-assemblies**: Fix: show the Assemblies button to allow managing nested assemblies [#5386](https://github.com/decidim/decidim/pull/5386)
 - **decidim-admin**: Fix: Remove first `:header_snippets` field on organization admin apparence form. [#5352](https://github.com/decidim/decidim/pull/5352)
 - **decidim-accountability**, **decidim-core**, **decidim-proposals**, **decidim-dev**: Fix: diffing empty versions of translatable attributes [\#5312](https://github.com/decidim/decidim/pull/5312)
 - **decidim-core**: Fix: WhatsApp url button [#5317](https://github.com/decidim/decidim/pull/5317)

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.html.erb
@@ -80,7 +80,7 @@
                   <%= icon_link_to "pencil", edit_assembly_path(assembly), t("actions.configure", scope: "decidim.admin"), class: "action-icon--new" %>
                 <% end %>
 
-                <% if assembly.parent.blank? && (assembly.children.count.positive? || allowed_to?(:create, :assembly)) %>
+                <% if assembly.children.count.positive? || allowed_to?(:create, :assembly) %>
                   <%= icon_link_to "dial",
                       decidim_admin_assemblies.assemblies_path(parent_id: assembly.id),
                       t("decidim.admin.titles.assemblies"),

--- a/decidim-assemblies/spec/shared/manage_assemblies_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assemblies_examples.rb
@@ -158,4 +158,8 @@ shared_examples "manage assemblies" do
       expect(page).to have_admin_callout("successfully")
     end
   end
+
+  it "shows the Assemblies link to manage nested assemblies" do
+    expect(page).to have_link("Assemblies", href: decidim_admin_assemblies.assemblies_path(parent_id: assembly.id))
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

> The "sub-assemblies" button isn't available to the admin after 1 generation of assemblies, even though he can create at least 4 generations. 

#### :pushpin: Related Issues
- Related to #5068
- Fixes [The "sub-assemblies" button isn't available to the admin after 1 generation of assemblies](https://meta.decidim.org/processes/bug-report/f/210/proposals/14769#comment_22136)

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
