### PR TITLE
Remove class "heading1" from 'Sign In' headline

### DIFF
--- a/decidim-core/app/views/decidim/devise/sessions/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/sessions/new.html.erb
@@ -4,7 +4,7 @@
   <div class="row collapse">
     <div class="row collapse">
       <div class="columns large-8 large-centered text-center page-title">
-        <h1 class="heading1"><%= t("devise.sessions.new.sign_in") %></h1>
+        <h1><%= t("devise.sessions.new.sign_in") %></h1>
         <% if current_organization.sign_up_enabled? %>
           <p>
             <%= t(".are_you_new?") %>


### PR DESCRIPTION
#### :tophat: What? Why?
The 'Sign In' page is the solely devise page with headline class "heading1". In order to match the style of the other pages (Sign Up, Forgot Password, etc.), the class should be removed.

```
decidim@decidim:~/decidim/decidim-core/app/views/decidim/devise$ grep -r "<h1"
confirmations/new.html.erb:      <h1><%=t("devise.confirmations.new.resend_confirmation_instructions") %></h1>
invitations/edit.html.erb:      <h1><%= t "devise.invitations.edit.header" %></h1>
omniauth_registrations/new.html.erb:      <h1><%= t(".sign_up") %></h1>
sessions/new.html.erb:        <h1 class="heading1"><%= t("devise.sessions.new.sign_in") %></h1>
registrations/new.html.erb:      <h1><%= t(".sign_up") %></h1>
passwords/edit.html.erb:      <h1><%= t("devise.passwords.edit.change_your_password") %></h1>
passwords/new.html.erb:      <h1><%= t("devise.passwords.new.forgot_your_password") %></h1>
```

