### PR TITLE
Fix: ParticipatoryText workflow creates multiple versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 
 **Fixed**:
 
+- **decidim-proposals**: Fix: ParticipatoryText workflow creates multiple versions [#5399](https://github.com/decidim/decidim/pull/5399)
 - **decidim-assemblies**: Fix: show the Assemblies button to allow managing nested assemblies [#5386](https://github.com/decidim/decidim/pull/5386)
 - **decidim-admin**: Fix: Remove first `:header_snippets` field on organization admin apparence form. [#5352](https://github.com/decidim/decidim/pull/5352)
 - **decidim-accountability**, **decidim-core**, **decidim-proposals**, **decidim-dev**: Fix: diffing empty versions of translatable attributes [\#5312](https://github.com/decidim/decidim/pull/5312)

--- a/decidim-proposals/lib/decidim/proposals/markdown_to_proposals.rb
+++ b/decidim-proposals/lib/decidim/proposals/markdown_to_proposals.rb
@@ -126,6 +126,8 @@ module Decidim
 
       private
 
+      # Prevents PaperTrail from creating versions while producing proposals from a document.
+      # A first version will be created when publishing the Participatory Text.
       def create_proposal(title, body, participatory_text_level)
         attributes = {
           component: @component,
@@ -134,15 +136,17 @@ module Decidim
           participatory_text_level: participatory_text_level
         }
 
-        proposal = Decidim::Proposals::ProposalBuilder.create(
-          attributes: attributes,
-          author: @component.organization,
-          action_user: @current_user
-        )
+        PaperTrail.request(enabled: false) do
+          proposal = Decidim::Proposals::ProposalBuilder.create(
+            attributes: attributes,
+            author: @component.organization,
+            action_user: @current_user
+          )
 
-        @last_position = proposal.position
+          @last_position = proposal.position
 
-        proposal
+          proposal
+        end
       end
     end
   end

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/import_participatory_text_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/import_participatory_text_spec.rb
@@ -34,16 +34,27 @@ module Decidim
           let(:command) { described_class.new(form) }
 
           shared_examples "import participatory_text succeeds" do
+            let(:proposals) { Proposal.where(component: current_component) }
+
             it "broadcasts ok and creates the proposals" do
+              levels = Decidim::Proposals::ParticipatoryTextSection::LEVELS
               sections = 2
               sub_sections = 5
               expect { command.call }.to(
                 broadcast(:ok) &&
-                change { ParticipatoryText.where(component: current_component).count }.by(1) &&
-                change { Proposal.where(component: current_component, participatory_text_level: Decidim::Proposals::ParticipatoryTextSection::LEVELS[:section]).count }.by(sections) &&
-                change { Proposal.where(component: current_component, participatory_text_level: Decidim::Proposals::ParticipatoryTextSection::LEVELS[:sub_section]).count }.by(sub_sections) &&
-                change { Proposal.where(component: current_component, participatory_text_level: Decidim::Proposals::ParticipatoryTextSection::LEVELS[:article]).count }.by(articles)
+                change(proposals, :count).by(1) &&
+                change { proposals.where(participatory_text_level: levels[:section]).count }.by(sections) &&
+                change { proposals.where(participatory_text_level: levels[:sub_section]).count }.by(sub_sections) &&
+                change { proposals.where(participatory_text_level: levels[:article]).count }.by(articles)
               )
+            end
+
+            it "does not create a version for each proposal", versioning: true do
+              expect { command.call }.to broadcast(:ok)
+
+              proposals.each do |proposal|
+                expect(proposal.reload.versions.count).to be_zero
+              end
             end
           end
 

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/update_participatory_text_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/update_participatory_text_spec.rb
@@ -18,6 +18,7 @@ module Decidim
             proposals.each_with_index do |proposal, idx|
               level = Decidim::Proposals::ParticipatoryTextSection::LEVELS.keys[idx]
               proposal.update(participatory_text_level: level)
+              proposal.versions.destroy_all
             end
             proposals
           end
@@ -42,6 +43,14 @@ module Decidim
             )
           end
           let(:command) { described_class.new(form) }
+
+          it "does not create a version for each proposal", versioning: true do
+            expect { command.call }.to broadcast(:ok)
+
+            proposals.each do |proposal|
+              expect(proposal.reload.versions.count).to be_zero
+            end
+          end
 
           describe "when form modifies proposals" do
             context "with valid values" do


### PR DESCRIPTION
#### :tophat: What? Why?
`ParticipatoryText` workflow is creating multiple versions: when importing proposals from a document, when updating the imported proposals and when publishing the participatory text.

This PR prevents that so after a participatory text is published there's only one version for each proposal in the version control feature.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
