### PR TITLE
Change: Promote URLs in plain text to HTML anchors in comments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 **Changed**:
 
+- **decidim-comments**: Change: Promote URLs in plain text to HTML anchors in comments.[\#5401](https://github.com/decidim/decidim/pull/5401)
 - **decidim-core**: Promote URLs in plain text to HTML anchors after strip_tags. [\#5341](https://github.com/decidim/decidim/pull/5341)
 - **decidim-accountability**, **decidim-assemblies**, **decidim-consultations**, **decidim-core**, **decidim-proposals**, **decidim-debates**, **decidim-dev**, **decidim-generators**, **decidim-initiatives**, **decidim-meetings**, **decidim-participatory_processes**, **decidim-proposals**, **decidim-sortitions**, **decidim_app-design**: Change: social share button default sites [\#5270](https://github.com/decidim/decidim/pull/5270)
 - **decidim-core**: Changes default format date [#5330](https://github.com/decidim/decidim/pull/5330)

--- a/decidim-comments/app/models/decidim/comments/comment.rb
+++ b/decidim-comments/app/models/decidim/comments/comment.rb
@@ -92,10 +92,7 @@ module Decidim
 
       # Public: Returns the comment message ready to display (it is expected to include HTML)
       def formatted_body
-        @formatted_body ||= begin
-          text = Decidim::ContentProcessor.render(sanitized_body)
-          Anchored::Linker.auto_link(text, target: "_blank", rel: "noopener")
-        end
+        @formatted_body ||= Decidim::ContentProcessor.render(sanitized_body)
       end
 
       def self.export_serializer

--- a/decidim-comments/app/models/decidim/comments/comment.rb
+++ b/decidim-comments/app/models/decidim/comments/comment.rb
@@ -92,7 +92,10 @@ module Decidim
 
       # Public: Returns the comment message ready to display (it is expected to include HTML)
       def formatted_body
-        @formatted_body ||= Decidim::ContentProcessor.render(sanitized_body)
+        @formatted_body ||= begin
+          text = Decidim::ContentProcessor.render(sanitized_body)
+          Anchored::Linker.auto_link(text, target: "_blank", rel: "noopener")
+        end
       end
 
       def self.export_serializer

--- a/decidim-comments/spec/models/comment_spec.rb
+++ b/decidim-comments/spec/models/comment_spec.rb
@@ -114,7 +114,8 @@ module Decidim
       end
 
       describe "#formatted_body" do
-        let(:comment) { create(:comment, commentable: commentable, author: author, body: "<b>bold text</b> *lorem* <a href='https://example.com'>link</a>") }
+        let(:comment) { create(:comment, commentable: commentable, author: author, body: body) }
+        let(:body) { "<b>bold text</b> *lorem* <a href='https://example.com'>link</a>" }
 
         before do
           allow(Decidim).to receive(:content_processors).and_return([:dummy_foo])
@@ -132,6 +133,19 @@ module Decidim
 
         it "returns the body sanitized and processed" do
           expect(comment.formatted_body).to eq("<p>bold text <em>neque dicta enim quasi</em> link</p>")
+        end
+
+        describe "when body contains urls" do
+          let(:body) do
+            %(Content with <a href="http://urls.net" onmouseover="alert('hello')">URLs</a> of anchor type and text urls like https://decidim.org. And a malicous <a href="javascript:document.cookies">click me</a>)
+          end
+          let(:result) do
+            %(<p>Content with URLs of anchor type and text urls like <a href="https://decidim.org" target="_blank" rel="noopener">https://decidim.org</a>. And a malicous click me</p>)
+          end
+
+          it "converts all URLs to links and strips attributes in anchors" do
+            expect(comment.formatted_body).to eq(result)
+          end
         end
       end
 

--- a/decidim-comments/spec/models/comment_spec.rb
+++ b/decidim-comments/spec/models/comment_spec.rb
@@ -135,7 +135,9 @@ module Decidim
           expect(comment.formatted_body).to eq("<p>bold text <em>neque dicta enim quasi</em> link</p>")
         end
 
-        describe "when body contains urls" do
+        describe "when the body contains urls" do
+          before { allow(Decidim).to receive(:content_processors).and_return([:link]) }
+
           let(:body) do
             %(Content with <a href="http://urls.net" onmouseover="alert('hello')">URLs</a> of anchor type and text urls like https://decidim.org. And a malicous <a href="javascript:document.cookies">click me</a>)
           end

--- a/decidim-core/lib/decidim/content_parsers.rb
+++ b/decidim-core/lib/decidim/content_parsers.rb
@@ -6,5 +6,6 @@ module Decidim
     autoload :UserParser, "decidim/content_parsers/user_parser"
     autoload :HashtagParser, "decidim/content_parsers/hashtag_parser"
     autoload :NewlineParser, "decidim/content_parsers/newline_parser"
+    autoload :LinkParser, "decidim/content_parsers/link_parser"
   end
 end

--- a/decidim-core/lib/decidim/content_parsers/link_parser.rb
+++ b/decidim-core/lib/decidim/content_parsers/link_parser.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ContentParsers
+    # As recommended here: decidim-core/lib/decidim/content_processor.rb
+    # We are declaring the class and leaving it empty as we only want the renderer.
+    class LinkParser < BaseParser
+    end
+  end
+end

--- a/decidim-core/lib/decidim/content_renderers.rb
+++ b/decidim-core/lib/decidim/content_renderers.rb
@@ -5,5 +5,6 @@ module Decidim
     autoload :BaseRenderer, "decidim/content_renderers/base_renderer"
     autoload :UserRenderer, "decidim/content_renderers/user_renderer"
     autoload :HashtagRenderer, "decidim/content_renderers/hashtag_renderer"
+    autoload :LinkRenderer, "decidim/content_renderers/link_renderer"
   end
 end

--- a/decidim-core/lib/decidim/content_renderers/link_renderer.rb
+++ b/decidim-core/lib/decidim/content_renderers/link_renderer.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ContentRenderers
+    # A renderer that converts URLs to links and strips attributes in anchors.
+    #
+    # Examples:
+    # `<a href="http://urls.net" onmouseover="alert('hello')">URLs</a>`
+    # Gets rendered as:
+    # `<a href="https://decidim.org" target="_blank" rel="noopener">https://decidim.org</a>`
+    # And:
+    # `<a href="javascript:document.cookies">click me</a>`
+    # Gets rendered as:
+    # `click me`
+    #
+    # @see BaseRenderer Examples of how to use a content renderer
+    class LinkRenderer < BaseRenderer
+      # @return [String] the content ready to display (contains HTML)
+      def render(options = { target: "_blank", rel: "noopener" })
+        Anchored::Linker.auto_link(content, options)
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -191,7 +191,7 @@ module Decidim
 
       initializer "decidim.content_processors" do |_app|
         Decidim.configure do |config|
-          config.content_processors += [:user, :hashtag]
+          config.content_processors += [:user, :hashtag, :link]
         end
       end
 

--- a/decidim-proposals/app/presenters/decidim/proposals/collaborative_draft_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/collaborative_draft_presenter.rb
@@ -43,7 +43,7 @@ module Decidim
         renderer = Decidim::ContentRenderers::HashtagRenderer.new(text)
         text = renderer.render(links: links, extras: extras).html_safe
 
-        text = Anchored::Linker.auto_link(text, target: "_blank", rel: "noopener") if links
+        text = Decidim::ContentRenderers::LinkRenderer.new(text).render if links
         text
       end
     end

--- a/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
@@ -59,7 +59,7 @@ module Decidim
         renderer = Decidim::ContentRenderers::HashtagRenderer.new(text)
         text = renderer.render(links: links, extras: extras).html_safe
 
-        text = Anchored::Linker.auto_link(text, target: "_blank", rel: "noopener") if links
+        text = Decidim::ContentRenderers::LinkRenderer.new(text).render if links
         text
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Promote URLs to links in comments.

#### :pushpin: Related Issues
- Related to #5341 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)
![comment_anchor](https://user-images.githubusercontent.com/40306853/66313368-903b4f80-e912-11e9-8fdb-7b04134a359a.png)

