### PR TITLE
Fix sortition categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 **Fixed**:
 
+- **decidim-sortitions**: Fix: Creating a Sortition ignores categories [#5412](https://github.com/decidim/decidim/pull/5412)
 - **decidim-proposals**: Fix: ParticipatoryText workflow creates multiple versions [#5399](https://github.com/decidim/decidim/pull/5399)
 - **decidim-assemblies**: Fix: show the Assemblies button to allow managing nested assemblies [#5386](https://github.com/decidim/decidim/pull/5386)
 - **decidim-admin**: Fix: Remove first `:header_snippets` field on organization admin apparence form. [#5352](https://github.com/decidim/decidim/pull/5352)

--- a/decidim-sortitions/app/commands/decidim/sortitions/admin/create_sortition.rb
+++ b/decidim-sortitions/app/commands/decidim/sortitions/admin/create_sortition.rb
@@ -58,6 +58,8 @@ module Decidim
             decidim_category_id: form.decidim_category_id,
             categorizable: sortition
           )
+          # reload sortition model to make it aware of the category
+          sortition.reload
         end
 
         def select_proposals_for(sortition)

--- a/decidim-sortitions/app/commands/decidim/sortitions/admin/create_sortition.rb
+++ b/decidim-sortitions/app/commands/decidim/sortitions/admin/create_sortition.rb
@@ -54,7 +54,7 @@ module Decidim
         end
 
         def category
-          Decidim::Category.find(form.decidim_category_id) if form.decidim_category_id
+          Decidim::Category.find(form.decidim_category_id) if form.decidim_category_id.present?
         end
 
         def select_proposals_for(sortition)

--- a/decidim-sortitions/app/commands/decidim/sortitions/admin/create_sortition.rb
+++ b/decidim-sortitions/app/commands/decidim/sortitions/admin/create_sortition.rb
@@ -23,7 +23,6 @@ module Decidim
 
           ActiveRecord::Base.transaction do
             sortition = create_sortition
-            categorize(sortition) if form.decidim_category_id.present?
             select_proposals_for(sortition)
             send_notification(sortition)
 
@@ -49,17 +48,13 @@ module Decidim
             witnesses: form.witnesses,
             additional_info: form.additional_info,
             selected_proposals: [],
-            candidate_proposals: []
+            candidate_proposals: [],
+            category: category
           )
         end
 
-        def categorize(sortition)
-          Decidim::Categorization.create!(
-            decidim_category_id: form.decidim_category_id,
-            categorizable: sortition
-          )
-          # reload sortition model to make it aware of the category
-          sortition.reload_category
+        def category
+          Decidim::Category.find(form.decidim_category_id) if form.decidim_category_id
         end
 
         def select_proposals_for(sortition)

--- a/decidim-sortitions/app/commands/decidim/sortitions/admin/create_sortition.rb
+++ b/decidim-sortitions/app/commands/decidim/sortitions/admin/create_sortition.rb
@@ -59,7 +59,7 @@ module Decidim
             categorizable: sortition
           )
           # reload sortition model to make it aware of the category
-          sortition.reload
+          sortition.reload_category
         end
 
         def select_proposals_for(sortition)

--- a/decidim-sortitions/spec/commands/decidim/sortitions/admin/create_sortition_spec.rb
+++ b/decidim-sortitions/spec/commands/decidim/sortitions/admin/create_sortition_spec.rb
@@ -16,10 +16,11 @@ module Decidim
         let(:additional_info) { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
         let(:title) { Decidim::Faker::Localized.sentence(3) }
         let(:category) { create(:category, participatory_space: participatory_process) }
+        let(:category_id) { nil }
         let(:params) do
           {
             decidim_proposals_component_id: proposal_component.id,
-            decidim_category_id: category.id,
+            decidim_category_id: category_id,
             dice: dice,
             title: title,
             target_items: target_items,
@@ -100,10 +101,38 @@ module Decidim
             expect(sortition.candidate_proposals).not_to be_empty
           end
 
-          it "Has a category" do
+          it "Has no category" do
             command.call
             sortition = Sortition.where(component: sortition_component).last
-            expect(sortition.category).to eq(category)
+            expect(sortition.category).to eq(nil)
+          end
+
+          context "when restricted to a category without proposals" do
+            let(:category_id) { category.id }
+
+            it "Has a category" do
+              command.call
+              sortition = Sortition.where(component: sortition_component).last
+              expect(sortition.category).to eq(category)
+            end
+
+            it "The created sortition has not proposals" do
+              command.call
+              sortition = Sortition.where(component: sortition_component).last
+              expect(sortition.selected_proposals).to be_empty
+            end
+          end
+
+          context "when restricted to a category with proposals" do
+            let(:category_id) { category.id }
+            let!(:proposal) { create(:proposal, component: proposal_component, category: category) }
+
+            it "The created sortition contains proposals" do
+              command.call
+              sortition = Sortition.where(component: sortition_component).last
+              expect(sortition.selected_proposals).not_to be_empty
+              expect(sortition.selected_proposals.first).to eq(proposal.id)
+            end
           end
 
           it "Has a reference" do

--- a/decidim-sortitions/spec/commands/decidim/sortitions/admin/create_sortition_spec.rb
+++ b/decidim-sortitions/spec/commands/decidim/sortitions/admin/create_sortition_spec.rb
@@ -72,7 +72,7 @@ module Decidim
             expect { command.call }.to broadcast(:ok)
           end
 
-          it "Creates a sortition" do
+          it "creates a sortition" do
             expect do
               command.call
             end.to change { Sortition.where(component: sortition_component).count }.by(1)
@@ -89,19 +89,19 @@ module Decidim
             expect(action_log.version).to be_present
           end
 
-          it "The created sortition contains a list of selected proposals" do
+          it "the created sortition contains a list of selected proposals" do
             command.call
             sortition = Sortition.where(component: sortition_component).last
             expect(sortition.selected_proposals).not_to be_empty
           end
 
-          it "The created sortition contains a list of candidate proposals" do
+          it "the created sortition contains a list of candidate proposals" do
             command.call
             sortition = Sortition.where(component: sortition_component).last
             expect(sortition.candidate_proposals).not_to be_empty
           end
 
-          it "Has no category" do
+          it "has no category" do
             command.call
             sortition = Sortition.where(component: sortition_component).last
             expect(sortition.category).to eq(nil)
@@ -110,13 +110,13 @@ module Decidim
           context "when restricted to a category without proposals" do
             let(:category_id) { category.id }
 
-            it "Has a category" do
+            it "has a category" do
               command.call
               sortition = Sortition.where(component: sortition_component).last
               expect(sortition.category).to eq(category)
             end
 
-            it "The created sortition has not proposals" do
+            it "the created sortition has not proposals" do
               command.call
               sortition = Sortition.where(component: sortition_component).last
               expect(sortition.selected_proposals).to be_empty
@@ -127,7 +127,7 @@ module Decidim
             let(:category_id) { category.id }
             let!(:proposal) { create(:proposal, component: proposal_component, category: category) }
 
-            it "The created sortition contains proposals" do
+            it "the created sortition contains proposals" do
               command.call
               sortition = Sortition.where(component: sortition_component).last
               expect(sortition.selected_proposals).not_to be_empty
@@ -135,7 +135,7 @@ module Decidim
             end
           end
 
-          it "Has a reference" do
+          it "has a reference" do
             command.call
             sortition = Sortition.where(component: sortition_component).last
             expect(sortition.reference).not_to be_blank


### PR DESCRIPTION
#### :tophat: What? Why?
There's a bug in the sortition component: 
When creating a new sortition restricted to a specific category, it chooses between all the proposals anyway.
That's because the model `sortition` is created before the categorization and the association `category` is somehow cached and not updated. This relation is used later on to choose the proposals, because is empty the sortition takes place among all the proposals no matter the category.

I've created a test to evidence this condition, the fix is simply reload the model after creating the categorization. If there's a better way let me know.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [x] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
