### PR TITLE
Fix issues after version bump

### DIFF
--- a/decidim-blogs/spec/commands/decidim/blogs/admin/update_post_spec.rb
+++ b/decidim-blogs/spec/commands/decidim/blogs/admin/update_post_spec.rb
@@ -47,6 +47,7 @@ module Decidim
             subject.call
             expect(translated(post.title)).to eq title
           end
+
           it "updates the body" do
             subject.call
             expect(translated(post.body)).to eq body

--- a/decidim-core/app/assets/javascripts/decidim/vizzs/metrics.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/vizzs/metrics.js.es6
@@ -9,12 +9,12 @@ $(() => {
   const metricsParams = {};
 
   const query = () => {
-    let metricsQuery = `metrics(names: [${metricsParams.names}], space_type: "${metricsParams.spaceType}", space_id: ${metricsParams.spaceId}) { name history { key value } }`;
+    let metricsQuery = `metrics(names: ${metricsParams.names}, space_type: "${metricsParams.spaceType}", space_id: ${metricsParams.spaceId}) { name history { key value } }`;
     return {query: `{ ${metricsQuery} }`};
   }
 
   const parameterize = (metrics) => {
-    metricsParams.names = metrics.join(" ");
+    metricsParams.names = JSON.stringify(metrics || []);
     metricsParams.spaceType = $("#metrics #metrics-space_type").val() || null;
     metricsParams.spaceId = $("#metrics #metrics-space_id").val() || null;
   }

--- a/decidim-core/spec/cells/decidim/tags_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/tags_cell_spec.rb
@@ -47,16 +47,19 @@ describe Decidim::TagsCell, type: :cell do
       expect(html).to have_css(".tags.tags--proposal")
       expect(html).to have_content(translated(scope.name))
     end
+
     it "renders the subscope of a proposal" do
       html = cell("decidim/tags", proposal_subscoped, context: { extra_classes: ["tags--proposal"] }).call
       expect(html).to have_css(".tags.tags--proposal")
       expect(html).to have_content(translated(subscope.name))
     end
+
     it "renders the scope of a meeting" do
       html = cell("decidim/tags", meeting_scoped, context: { extra_classes: ["tags--meeting"] }).call
       expect(html).to have_css(".tags.tags--meeting")
       expect(html).to have_content(translated(scope.name))
     end
+
     it "renders the subscope of a meeting" do
       html = cell("decidim/tags", meeting_subscoped, context: { extra_classes: ["tags--meeting"] }).call
       expect(html).to have_css(".tags.tags--meeting")
@@ -70,6 +73,7 @@ describe Decidim::TagsCell, type: :cell do
       expect(html).to have_css(".tags.tags--proposal")
       expect(html).to have_content(translated(category.name))
     end
+
     it "renders the subcategory of a proposal" do
       html = cell("decidim/tags", proposal_subcategorized, context: { extra_classes: ["tags--proposal"] }).call
       expect(html).to have_css(".tags.tags--proposal")
@@ -81,6 +85,7 @@ describe Decidim::TagsCell, type: :cell do
       expect(html).to have_css(".tags.tags--meeting")
       expect(html).to have_content(translated(category.name))
     end
+
     it "renders the subcategory of a meeting" do
       html = cell("decidim/tags", meeting_subcategorized, context: { extra_classes: ["tags--meeting"] }).call
       expect(html).to have_css(".tags.tags--meeting")
@@ -95,6 +100,7 @@ describe Decidim::TagsCell, type: :cell do
       expect(html).to have_content(translated(scope.name))
       expect(html).to have_content(translated(category.name))
     end
+
     it "renders the scope and category of a meeting" do
       html = cell("decidim/tags", meeting_scoped_categorized, context: { extra_classes: ["tags--meeting"] }).call
       expect(html).to have_css(".tags.tags--meeting")

--- a/decidim-core/spec/controllers/concerns/locale_switcher_spec.rb
+++ b/decidim-core/spec/controllers/concerns/locale_switcher_spec.rb
@@ -19,11 +19,13 @@ module Decidim
       it "detected locale is empty" do
         expect(controller.detect_locale.to_s).to be_empty
       end
+
       it "application uses default language" do
         controller.switch_locale do
           expect(I18n.locale.to_s).to eq(default_locale)
         end
       end
+
       context "with alternate default locale" do
         let(:default_locale) { alt_locale }
 

--- a/decidim-core/spec/lib/search_resource_fields_mapper_spec.rb
+++ b/decidim-core/spec/lib/search_resource_fields_mapper_spec.rb
@@ -131,6 +131,7 @@ module Decidim
           subject.set_index_condition(:create, true)
           expect(subject).to be_index_on_create(nil)
         end
+
         it "does NOT index the resource if false is setted" do
           subject.set_index_condition(:create, false)
           expect(subject).not_to be_index_on_create(nil)
@@ -152,6 +153,7 @@ module Decidim
           subject.set_index_condition(:update, true)
           expect(subject).to be_index_on_update(nil)
         end
+
         it "does NOT index the resource if false is setted" do
           subject.set_index_condition(:update, false)
           expect(subject).not_to be_index_on_update(nil)

--- a/decidim-core/spec/models/decidim/permission_action_spec.rb
+++ b/decidim-core/spec/models/decidim/permission_action_spec.rb
@@ -18,9 +18,11 @@ module Decidim
       it "has different scope" do
         expect(permission_action.matches?(:testing, :check, :result)).to be false
       end
+
       it "has different action" do
         expect(permission_action.matches?(:test, :match, :result)).to be false
       end
+
       it "has different subject" do
         expect(permission_action.matches?(:test, :check, :asdf)).to be false
       end

--- a/decidim-proposals/spec/cells/decidim/proposals/collaborative_draft_cell_spec.rb
+++ b/decidim-proposals/spec/cells/decidim/proposals/collaborative_draft_cell_spec.rb
@@ -67,6 +67,7 @@ describe Decidim::Proposals::CollaborativeDraftCell, type: :cell do
           expect(subject).to have_css(".author-data--small", count: 3)
         end
       end
+
       it "renders the see_more link" do
         within ".card__content" do
           expect.to have_link(".collapsible-list__see-more")
@@ -80,6 +81,7 @@ describe Decidim::Proposals::CollaborativeDraftCell, type: :cell do
       it "renders the card with the .success class" do
         expect(subject).to have_css(".card.success")
       end
+
       it "renders the open state" do
         within ".card__text" do
           expect(subject).to have_css(".success.card__text--status")
@@ -94,6 +96,7 @@ describe Decidim::Proposals::CollaborativeDraftCell, type: :cell do
       it "renders the card with the .alert class" do
         expect(subject).to have_css(".card.alert")
       end
+
       it "renders the open state" do
         within ".card__text" do
           expect(subject).to have_css(".alert.card__text--status")
@@ -108,6 +111,7 @@ describe Decidim::Proposals::CollaborativeDraftCell, type: :cell do
       it "renders the card with the .secondary class" do
         expect(subject).to have_css(".card.secondary")
       end
+
       it "renders the open state" do
         within ".card__text" do
           expect(subject).to have_css(".secondary.card__text--status")

--- a/decidim-proposals/spec/lib/decidim/content_parsers/proposal_parser_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/content_parsers/proposal_parser_spec.rb
@@ -30,6 +30,7 @@ module Decidim
           let(:content) { nil }
 
           it { is_expected.to eq("") }
+
           it "has empty metadata" do
             subject
             expect(parser.metadata).to be_a(Decidim::ContentParsers::ProposalParser::Metadata)
@@ -41,6 +42,7 @@ module Decidim
           let(:content) { "" }
 
           it { is_expected.to eq("") }
+
           it "has empty metadata" do
             subject
             expect(parser.metadata).to be_a(Decidim::ContentParsers::ProposalParser::Metadata)
@@ -52,6 +54,7 @@ module Decidim
           let(:content) { "whatever content with @mentions and #hashes but no links." }
 
           it { is_expected.to eq(content) }
+
           it "has empty metadata" do
             subject
             expect(parser.metadata).to be_a(Decidim::ContentParsers::ProposalParser::Metadata)
@@ -81,6 +84,7 @@ module Decidim
           end
 
           it { is_expected.to eq("This content references proposal #{proposal.to_global_id}.") }
+
           it "has metadata with the proposal" do
             subject
             expect(parser.metadata).to be_a(Decidim::ContentParsers::ProposalParser::Metadata)
@@ -95,6 +99,7 @@ module Decidim
           end
 
           it { is_expected.to eq(content) }
+
           it "has metadata with the proposal" do
             subject
             expect(parser.metadata).to be_a(Decidim::ContentParsers::ProposalParser::Metadata)
@@ -114,6 +119,7 @@ module Decidim
           end
 
           it { is_expected.to eq("This content references the following proposals: #{proposal1.to_global_id}, #{proposal2.to_global_id} and #{proposal3.to_global_id}. Great?I like them!") }
+
           it "has metadata with all linked proposals" do
             subject
             expect(parser.metadata).to be_a(Decidim::ContentParsers::ProposalParser::Metadata)
@@ -129,6 +135,7 @@ module Decidim
           end
 
           it { is_expected.to eq(content) }
+
           it "has metadata with no reference to the proposal" do
             subject
             expect(parser.metadata).to be_a(Decidim::ContentParsers::ProposalParser::Metadata)
@@ -145,6 +152,7 @@ module Decidim
           end
 
           it { is_expected.to eq(content) }
+
           it "has empty metadata" do
             subject
             expect(parser.metadata).to be_a(Decidim::ContentParsers::ProposalParser::Metadata)
@@ -161,6 +169,7 @@ module Decidim
           end
 
           it { is_expected.to eq("This content references proposal #{url}.") }
+
           it "has empty metadata" do
             subject
             expect(parser.metadata).to be_a(Decidim::ContentParsers::ProposalParser::Metadata)
@@ -173,6 +182,7 @@ module Decidim
           let(:content) { "This content references proposal ~#{proposal.id}." }
 
           it { is_expected.to eq("This content references proposal #{proposal.to_global_id}.") }
+
           it "has metadata with the proposal" do
             subject
             expect(parser.metadata).to be_a(Decidim::ContentParsers::ProposalParser::Metadata)

--- a/decidim-proposals/spec/system/collaborative_drafts_spec.rb
+++ b/decidim-proposals/spec/system/collaborative_drafts_spec.rb
@@ -265,11 +265,13 @@ describe "Explore Collaborative Drafts", versioning: true, type: :system do
                 expect(page).to have_css("#request_#{user.id}")
               end
             end
+
             it "shows the button to accept the request" do
               within ".card.extra" do
                 expect(page).to have_css(".button.hollow.secondary.small", text: "Accept")
               end
             end
+
             it "shows the button to reject the request" do
               within ".card.extra" do
                 expect(page).to have_css(".icon--x")


### PR DESCRIPTION
#### :tophat: What? Why?

I'm not sure how/why but after the 0.19 release it seems there are some rubocop offenses. This PR fixes them (all related to specs, no need to changelog).

Also, a fix in [graphql-ruby](https://github.com/rmosolgo/graphql-ruby/pull/2505) made no longer acceptable sending `[a b c d]` instead of `["a", "b", "c", "d"]` as part of a query (which was wrong from the beginning), and made metrics crash.
