### PR TITLE
Add card image on oficial proposals

### DIFF
--- a/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
@@ -8,11 +8,20 @@ module Decidim
     class ProposalMCell < Decidim::CardMCell
       include ProposalCellsHelper
 
+      def has_image?
+        model.card_image.present? && model.component.settings.allow_card_image
+      end
+
       def badge
         render if has_badge?
       end
 
       private
+
+      def resource_image_path
+        return unless model.card_image.present? && model.component.settings.allow_card_image
+        model.card_image.url
+      end
 
       def title
         decidim_html_escape(present(model).title)

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
@@ -20,6 +20,7 @@ module Decidim
 
       def resource_image_path
         return unless model.card_image.present? && model.component.settings.allow_card_image
+
         model.card_image.url
       end
 

--- a/decidim-proposals/app/commands/decidim/proposals/admin/create_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/create_proposal.rb
@@ -37,6 +37,7 @@ module Decidim
 
           transaction do
             create_proposal
+            create_card_image if form.component.settings.allow_card_image?
             create_attachment if process_attachments?
             create_gallery if process_gallery?
             send_notification
@@ -58,6 +59,12 @@ module Decidim
           @attached_to = @proposal
         end
 
+        def create_card_image
+          @proposal.card_image = form.card_image
+          @proposal.remove_card_image = form.remove_card_image
+          @proposal.save
+        end
+
         def attributes
           {
             title: title_with_hashtags,
@@ -69,6 +76,7 @@ module Decidim
             latitude: form.latitude,
             longitude: form.longitude,
             created_in_meeting: form.created_in_meeting,
+            card_image: form.card_image,
             published_at: Time.current
           }
         end

--- a/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal.rb
@@ -76,7 +76,7 @@ module Decidim
           proposal.remove_card_image = form.remove_card_image
           proposal.save
         end
-        
+
         def update_proposal_author
           proposal.coauthorships.clear
           proposal.add_coauthor(form.author)

--- a/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal.rb
@@ -42,6 +42,7 @@ module Decidim
 
           transaction do
             update_proposal
+            update_card_image if form.component.settings.allow_card_image?
             update_proposal_author
             create_attachment if process_attachments?
             create_gallery if process_gallery?
@@ -70,6 +71,12 @@ module Decidim
           )
         end
 
+        def update_card_image
+          proposal.card_image = form.card_image
+          proposal.remove_card_image = form.remove_card_image
+          proposal.save
+        end
+        
         def update_proposal_author
           proposal.coauthorships.clear
           proposal.add_coauthor(form.author)

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
@@ -22,6 +22,8 @@ module Decidim
         attribute :suggested_hashtags, Array[String]
         attribute :photos, Array[String]
         attribute :add_photos, Array
+        attribute :card_image
+        attribute :remove_card_image
 
         validates :title, :body, presence: true
         validates :title, length: { maximum: 150 }
@@ -29,6 +31,8 @@ module Decidim
         validates :category, presence: true, if: ->(form) { form.category_id.present? }
         validates :scope, presence: true, if: ->(form) { form.scope_id.present? }
         validates :meeting_as_author, presence: true, if: ->(form) { form.created_in_meeting? }
+
+        validates :card_image, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } }
 
         validate :scope_belongs_to_participatory_space_scope
 

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -34,6 +34,8 @@ module Decidim
 
       component_manifest_name "proposals"
 
+      mount_uploader :card_image, Decidim::ImageUploader
+
       has_many :endorsements, foreign_key: "decidim_proposal_id", class_name: "ProposalEndorsement", dependent: :destroy, counter_cache: "proposal_endorsements_count"
 
       has_many :votes,

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
@@ -109,6 +109,14 @@
         </fieldset>
       </div>
     <% end %>
+
+    <% if component_settings.allow_card_image? %>
+      <div class="row column">
+        <fieldset>
+          <%= form.upload :card_image, optional: true %>
+        </fieldset>
+      </div>
+    <% end %>
   </div>
 </div>
 

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -86,6 +86,7 @@ en:
         name: Proposals
         settings:
           global:
+            allow_card_image: Allow card image
             amendments_enabled: Amendments enabled
             amendments_enabled_help: If active, configure Amendment features for each step.
             amendments_wizard_help_text: Amendments Wizard help text

--- a/decidim-proposals/db/migrate/20191022133313_add_card_image_to_proposals.rb
+++ b/decidim-proposals/db/migrate/20191022133313_add_card_image_to_proposals.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCardImageToProposals < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_proposals_proposals, :card_image, :string
+  end
+end

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -34,6 +34,7 @@ Decidim.register_component(:proposals) do |component|
     settings.attribute :comments_enabled, type: :boolean, default: true
     settings.attribute :geocoding_enabled, type: :boolean, default: false
     settings.attribute :attachments_allowed, type: :boolean, default: false
+    settings.attribute :allow_card_image, type: :boolean, default: false
     settings.attribute :resources_permissions_enabled, type: :boolean, default: true
     settings.attribute :collaborative_drafts_enabled, type: :boolean, default: false
     settings.attribute :participatory_texts_enabled, type: :boolean, default: false

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -223,6 +223,14 @@ FactoryBot.define do
       end
     end
 
+    trait :with_card_image_allowed do
+      settings do
+        {
+          allow_card_image: true
+        }
+      end
+    end
+
     trait :with_extra_hashtags do
       transient do
         automatic_hashtags { "AutoHashtag AnotherAutoHashtag" }
@@ -341,6 +349,10 @@ FactoryBot.define do
       after :create do |proposal|
         create_list(:proposal_endorsement, 5, proposal: proposal)
       end
+    end
+
+    trait :with_card_image do
+      card_image { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
     end
   end
 

--- a/decidim-proposals/spec/cells/decidim/proposals/collaborative_draft_cell_spec.rb
+++ b/decidim-proposals/spec/cells/decidim/proposals/collaborative_draft_cell_spec.rb
@@ -67,6 +67,7 @@ describe Decidim::Proposals::CollaborativeDraftCell, type: :cell do
           expect(subject).to have_css(".author-data--small", count: 3)
         end
       end
+
       it "renders the see_more link" do
         within ".card__content" do
           expect.to have_link(".collapsible-list__see-more")
@@ -80,6 +81,7 @@ describe Decidim::Proposals::CollaborativeDraftCell, type: :cell do
       it "renders the card with the .success class" do
         expect(subject).to have_css(".card.success")
       end
+
       it "renders the open state" do
         within ".card__text" do
           expect(subject).to have_css(".success.card__text--status")
@@ -94,6 +96,7 @@ describe Decidim::Proposals::CollaborativeDraftCell, type: :cell do
       it "renders the card with the .alert class" do
         expect(subject).to have_css(".card.alert")
       end
+
       it "renders the open state" do
         within ".card__text" do
           expect(subject).to have_css(".alert.card__text--status")
@@ -108,6 +111,7 @@ describe Decidim::Proposals::CollaborativeDraftCell, type: :cell do
       it "renders the card with the .secondary class" do
         expect(subject).to have_css(".card.secondary")
       end
+
       it "renders the open state" do
         within ".card__text" do
           expect(subject).to have_css(".secondary.card__text--status")

--- a/decidim-proposals/spec/forms/decidim/proposals/admin_proposal_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/admin_proposal_form_spec.rb
@@ -8,6 +8,7 @@ module Decidim
       describe ProposalForm do
         it_behaves_like "a proposal form", skip_etiquette_validation: true
         it_behaves_like "a proposal form with meeting as author", skip_etiquette_validation: true
+        it_behaves_like "a proposal form with card image allowed", skip_etiquette_validation: true
       end
     end
   end

--- a/decidim-proposals/spec/lib/decidim/content_parsers/proposal_parser_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/content_parsers/proposal_parser_spec.rb
@@ -30,6 +30,7 @@ module Decidim
           let(:content) { nil }
 
           it { is_expected.to eq("") }
+
           it "has empty metadata" do
             subject
             expect(parser.metadata).to be_a(Decidim::ContentParsers::ProposalParser::Metadata)
@@ -41,6 +42,7 @@ module Decidim
           let(:content) { "" }
 
           it { is_expected.to eq("") }
+
           it "has empty metadata" do
             subject
             expect(parser.metadata).to be_a(Decidim::ContentParsers::ProposalParser::Metadata)
@@ -52,6 +54,7 @@ module Decidim
           let(:content) { "whatever content with @mentions and #hashes but no links." }
 
           it { is_expected.to eq(content) }
+
           it "has empty metadata" do
             subject
             expect(parser.metadata).to be_a(Decidim::ContentParsers::ProposalParser::Metadata)
@@ -81,6 +84,7 @@ module Decidim
           end
 
           it { is_expected.to eq("This content references proposal #{proposal.to_global_id}.") }
+
           it "has metadata with the proposal" do
             subject
             expect(parser.metadata).to be_a(Decidim::ContentParsers::ProposalParser::Metadata)
@@ -95,6 +99,7 @@ module Decidim
           end
 
           it { is_expected.to eq(content) }
+
           it "has metadata with the proposal" do
             subject
             expect(parser.metadata).to be_a(Decidim::ContentParsers::ProposalParser::Metadata)
@@ -114,6 +119,7 @@ module Decidim
           end
 
           it { is_expected.to eq("This content references the following proposals: #{proposal1.to_global_id}, #{proposal2.to_global_id} and #{proposal3.to_global_id}. Great?I like them!") }
+
           it "has metadata with all linked proposals" do
             subject
             expect(parser.metadata).to be_a(Decidim::ContentParsers::ProposalParser::Metadata)
@@ -129,6 +135,7 @@ module Decidim
           end
 
           it { is_expected.to eq(content) }
+
           it "has metadata with no reference to the proposal" do
             subject
             expect(parser.metadata).to be_a(Decidim::ContentParsers::ProposalParser::Metadata)
@@ -145,6 +152,7 @@ module Decidim
           end
 
           it { is_expected.to eq(content) }
+
           it "has empty metadata" do
             subject
             expect(parser.metadata).to be_a(Decidim::ContentParsers::ProposalParser::Metadata)
@@ -161,6 +169,7 @@ module Decidim
           end
 
           it { is_expected.to eq("This content references proposal #{url}.") }
+
           it "has empty metadata" do
             subject
             expect(parser.metadata).to be_a(Decidim::ContentParsers::ProposalParser::Metadata)
@@ -173,6 +182,7 @@ module Decidim
           let(:content) { "This content references proposal ~#{proposal.id}." }
 
           it { is_expected.to eq("This content references proposal #{proposal.to_global_id}.") }
+
           it "has metadata with the proposal" do
             subject
             expect(parser.metadata).to be_a(Decidim::ContentParsers::ProposalParser::Metadata)

--- a/decidim-proposals/spec/system/collaborative_drafts_spec.rb
+++ b/decidim-proposals/spec/system/collaborative_drafts_spec.rb
@@ -265,11 +265,13 @@ describe "Explore Collaborative Drafts", versioning: true, type: :system do
                 expect(page).to have_css("#request_#{user.id}")
               end
             end
+
             it "shows the button to accept the request" do
               within ".card.extra" do
                 expect(page).to have_css(".button.hollow.secondary.small", text: "Accept")
               end
             end
+
             it "shows the button to reject the request" do
               within ".card.extra" do
                 expect(page).to have_css(".icon--x")

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -97,7 +97,6 @@ describe "Proposals", type: :system do
       it "shows the author as official" do
         visit_component
         within "#proposal_#{official_proposal.id}" do
-          # expect(page).to have_content("image")
           expect(page).to have_selector(".card__image")
         end
       end

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -84,6 +84,25 @@ describe "Proposals", type: :system do
       end
     end
 
+    context "when it is an official proposal with card image enable" do
+      let!(:component) do
+        create(:proposal_component,
+               :with_card_image_allowed,
+               manifest: manifest,
+               participatory_space: participatory_process)
+      end
+
+      let!(:official_proposal) { create(:proposal, :official, :with_card_image, component: component) }
+
+      it "shows the author as official" do
+        visit_component
+        within "#proposal_#{official_proposal.id}" do
+          # expect(page).to have_content("image")
+          expect(page).to have_selector(".card__image")
+        end
+      end
+    end
+
     context "when it is an official meeting proposal" do
       let!(:official_meeting_proposal) { create(:proposal, :official_meeting, component: component) }
 


### PR DESCRIPTION
#### :tophat: What? Why?

Possibility of adding images to the card of proposals in order to make the proposals more visual.

#### :pushpin: Related Issues
- Related to https://meta.decidim.org/processes/roadmap/f/122/proposals/14877

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)

Design applied from:

https://decidim-design.herokuapp.com/public/library/pattern-library#patternCardsM

![captura_2](https://user-images.githubusercontent.com/42737720/68294427-6fd8ef00-0090-11ea-9b5d-e997c285f364.png)
