### PR TITLE
Fix: Duplicate results in Decidim::HasPrivateUsers::visible_for(user)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 **Fixed**:
 
+- **decidim-core**, **decidim-participatory_processes**: Fix: Duplicate results in `Decidim::HasPrivateUsers::visible_for(user)` [\#5462](https://github.com/decidim/decidim/pull/5462)
 - **decidim-sortitions**: Fix: Don't include drafts in sortitions [\#5434](https://github.com/decidim/decidim/pull/5434)
 - **decidim-assemblies**: Fix: Fixed assembly parent_id when selecting itself [#5416](https://github.com/decidim/decidim/pull/5416)
 

--- a/decidim-core/lib/decidim/core/test.rb
+++ b/decidim-core/lib/decidim/core/test.rb
@@ -42,3 +42,4 @@ require "decidim/core/test/shared_examples/amendable/amendment_accepted_event_ex
 require "decidim/core/test/shared_examples/amendable/amendment_rejected_event_examples"
 require "decidim/core/test/shared_examples/amendable/amendment_promoted_event_examples"
 require "decidim/core/test/shared_examples/uncommentable_component_examples"
+require "decidim/core/test/shared_examples/has_private_users"

--- a/decidim-core/lib/decidim/core/test/shared_examples/has_private_users.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/has_private_users.rb
@@ -47,14 +47,17 @@ shared_examples_for "has private users" do
     end
 
     context "when the space is both public and has private users" do
-      let(:user) { create(:user) } # Non-private user
+      # Visible spaces for non-private user.
+      let(:user) { create(:user) }
 
       before do
-        create_space_private_user(public_space) # Multiple users
-        create_space_private_user(public_space) # Multiple users
+        # Public space has multiple private users.
+        create_space_private_user(public_space)
+        create_space_private_user(public_space)
       end
 
-      it { expect(scope).to contain_exactly(public_space) } # Expect no duplicates
+      # Expect no duplicate results.
+      it { expect(scope).to contain_exactly(public_space) }
     end
   end
 end

--- a/decidim-core/lib/decidim/core/test/shared_examples/has_private_users.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/has_private_users.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+shared_examples_for "has private users" do
+  let(:factory_name) { described_class.name.demodulize.underscore.to_sym }
+
+  let!(:public_space) do
+    create(factory_name, private_space: false, published_at: Time.current)
+  end
+
+  let!(:private_space) do
+    create(factory_name, private_space: true, published_at: Time.current)
+  end
+
+  def create_space_private_user(space, user = create(:user, organization: space.organization))
+    Decidim::ParticipatorySpacePrivateUser.create(privatable_to: space, user: user)
+  end
+
+  describe ".public_spaces" do
+    let(:scope) { described_class.send(:public_spaces) }
+
+    it { expect(scope).to eq([public_space]) }
+  end
+
+  describe ".visible_for" do
+    let(:scope) { described_class.send(:visible_for, user) }
+
+    before { create_space_private_user(private_space) }
+
+    context "without user" do
+      let(:user) { nil }
+
+      it { expect(scope).to contain_exactly(public_space) }
+    end
+
+    context "with non-private user" do
+      let(:user) { create(:user) }
+
+      it { expect(scope).to contain_exactly(public_space) }
+    end
+
+    context "with private user" do
+      let(:user) { private_space.users.first }
+
+      it { expect(scope).to contain_exactly(public_space, private_space) }
+    end
+
+    context "when the space is both public and has private users" do
+      let(:user) { create(:user) } # Non-private user
+
+      before do
+        create_space_private_user(public_space) # Multiple users
+        create_space_private_user(public_space) # Multiple users
+      end
+
+      it { expect(scope).to contain_exactly(public_space) } # Expect no duplicates
+    end
+  end
+end

--- a/decidim-core/lib/decidim/has_private_users.rb
+++ b/decidim-core/lib/decidim/has_private_users.rb
@@ -22,10 +22,12 @@ module Decidim
         if user
           return all if user.admin?
 
-          left_outer_joins(:participatory_space_private_users).where(
-            %(private_space = false OR
-            decidim_participatory_space_private_users.decidim_user_id = ?), user.id
-          ).distinct
+          where(
+            id: public_spaces +
+                private_spaces
+                  .joins(:participatory_space_private_users)
+                  .where("decidim_participatory_space_private_users.decidim_user_id = ?", user.id)
+          )
         else
           public_spaces
         end

--- a/decidim-core/lib/decidim/has_private_users.rb
+++ b/decidim-core/lib/decidim/has_private_users.rb
@@ -25,7 +25,7 @@ module Decidim
           left_outer_joins(:participatory_space_private_users).where(
             %(private_space = false OR
             decidim_participatory_space_private_users.decidim_user_id = ?), user.id
-          )
+          ).distinct
         else
           public_spaces
         end

--- a/decidim-participatory_processes/spec/models/decidim/participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/models/decidim/participatory_process_spec.rb
@@ -12,7 +12,8 @@ module Decidim
 
     it { is_expected.to be_versioned }
 
-    include_examples "publicable"
+    it_behaves_like "publicable"
+    it_behaves_like "has private users"
 
     it "overwrites the log presenter" do
       expect(described_class.log_presenter_class_for(:foo))


### PR DESCRIPTION
#### :tophat: What? Why?
I introduced this bug in a refactor and there were no tests to catch it. Affected `ParticipatoryProcess`.

#### :pushpin: Related Issues
- Related to #3638 (This bug has already been fixed in the past)
- Related to #5047 (The refactor that introduced the bug —again)

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)
![duplicates-min](https://user-images.githubusercontent.com/40306853/67779689-494dff00-fa65-11e9-9b69-4fd386bd4cac.png)
