### PR TITLE
Fix: flaky test when mapping Rails timezone names to PostgreSQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 **Fixed**:
 
+- **decidim-participatory_processes**: Fix: flaky test when mapping Rails timezone names to PostgreSQL [\#5472](https://github.com/decidim/decidim/pull/5472)
 - **decidim-conferences**: Fix: Add pagination interface to some sections [\#5463](https://github.com/decidim/decidim/pull/5463)
 - **decidim-sortitions**: Fix: Don't include drafts in sortitions [\#5434](https://github.com/decidim/decidim/pull/5434)
 - **decidim-assemblies**: Fix: Fixed assembly parent_id when selecting itself [#5416](https://github.com/decidim/decidim/pull/5416)

--- a/decidim-participatory_processes/app/services/decidim/participatory_processes/participatory_process_search.rb
+++ b/decidim-participatory_processes/app/services/decidim/participatory_processes/participatory_process_search.rb
@@ -17,7 +17,8 @@ module Decidim
         when "upcoming"
           query.upcoming.order(start_date: :asc)
         else # Assume 'all'
-          query.order(Arel.sql("ABS(start_date - (CURRENT_DATE at time zone '#{Time.zone}')::date)"))
+          timezone = ActiveSupport::TimeZone.find_tzinfo(Time.zone.name).identifier
+          query.order(Arel.sql("ABS(start_date - (CURRENT_DATE at time zone '#{timezone}')::date)"))
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

Some tests in `decidim-participatory_processes/spec/system/filter_participatory_processes_spec.rb` no longer pass.

Followed this [stackoverflow answer](https://stackoverflow.com/questions/23420859/how-to-map-rails-timezone-names-to-postgresql#comment81719429_23421595) to fix it. 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests