### PR TITLE
Avoid decidim-core to depend upon other modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@
 
 **Changed**:
 
+- **decidim-core**: Introduce the ActsAsAuthor concern. [\#5482](https://github.com/decidim/decidim/pull/5482)
 - **decidim-core**: Extract footers into partials. [#5461](https://github.com/decidim/decidim/pull/5461)
 - **decidim-initiatives**: UX improvements to initiatives [#5369](https://github.com/decidim/decidim/pull/5369)
 - **decidim-core**: Update to JQuery 3 [#5433](https://github.com/decidim/decidim/pull/5433)
 
 **Fixed**:
 
+- **decidim-core**: Fix: mispelling when selecting the meetings presenter. [\#5482](https://github.com/decidim/decidim/pull/5482)
 - **decidim-core**, **decidim-participatory_processes**: Fix: Duplicate results in `Decidim::HasPrivateUsers::visible_for(user)` [\#5462](https://github.com/decidim/decidim/pull/5462)
 - **decidim-participatory_processes**: Fix: flaky test when mapping Rails timezone names to PostgreSQL [\#5472](https://github.com/decidim/decidim/pull/5472)
 - **decidim-conferences**: Fix: Add pagination interface to some sections [\#5463](https://github.com/decidim/decidim/pull/5463)

--- a/decidim-core/app/cells/decidim/coauthorships_cell.rb
+++ b/decidim-core/app/cells/decidim/coauthorships_cell.rb
@@ -54,11 +54,7 @@ module Decidim
       if official?
         "#{model.class.parent}::OfficialAuthorPresenter".constantize.new
       elsif authorable.user_group
-        Decidim::UserGroupPresenter.new(authorable.user_group)
-      elsif authorable.author.is_a?(Decidim::User)
-        Decidim::UserPresenter.new(authorable.author)
-      elsif authorable.author.is_a?(Decidim::Meeting)
-        Decidim::MeetingPresenter.new(authorable.author)
+        authorable.author.presenter
       end
     end
 

--- a/decidim-core/app/cells/decidim/coauthorships_cell.rb
+++ b/decidim-core/app/cells/decidim/coauthorships_cell.rb
@@ -53,8 +53,8 @@ module Decidim
     def presenter_for_author(authorable)
       if official?
         "#{model.class.parent}::OfficialAuthorPresenter".constantize.new
-      elsif authorable.user_group
-        authorable.author.presenter
+      else
+        authorable.user_group&.presenter || authorable.author.presenter
       end
     end
 

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -9,6 +9,7 @@ module Decidim
   class User < UserBaseEntity
     include Decidim::DataPortability
     include Decidim::Searchable
+    include Decidim::ActsAsAuthor
 
     OMNIAUTH_PROVIDERS = [:facebook, :twitter, :google_oauth2, (:developer if Rails.env.development?)].compact
 
@@ -80,6 +81,12 @@ module Decidim
     #
     # Returns a String.
     attr_accessor :invitation_instructions
+
+    # Returns the presenter for this author, to be used in the views.
+    # Required by ActsAsAuthor.
+    def presenter
+      Decidim::UserPresenter.new(self)
+    end
 
     def self.log_presenter_class_for(_log)
       Decidim::AdminLog::UserPresenter

--- a/decidim-core/app/models/decidim/user_group.rb
+++ b/decidim-core/app/models/decidim/user_group.rb
@@ -8,6 +8,7 @@ module Decidim
   class UserGroup < UserBaseEntity
     include Decidim::Traceable
     include Decidim::DataPortability
+    include Decidim::ActsAsAuthor
 
     has_many :memberships, class_name: "Decidim::UserGroupMembership", foreign_key: :decidim_user_group_id, dependent: :destroy
     has_many :users, through: :memberships, class_name: "Decidim::User", foreign_key: :decidim_user_id
@@ -33,6 +34,12 @@ module Decidim
     def self.with_document_number(organization, number)
       where(decidim_organization_id: organization.id)
         .where("extended_data->>'document_number' = ?", number)
+    end
+
+    # Returns the presenter for this author, to be used in the views.
+    # Required by ActsAsAuthor.
+    def presenter
+      Decidim::UserGroupPresenter.new(self)
     end
 
     def self.log_presenter_class_for(_log)

--- a/decidim-core/lib/decidim/acts_as_author.rb
+++ b/decidim-core/lib/decidim/acts_as_author.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This concern contains the logic related to being an author.
+  #
+  # it mainly declares abstract methods to be implemented by artifacts
+  # including it in its inheritance hierarchy.
+  #
+  module ActsAsAuthor
+    extend ActiveSupport::Concern
+
+    included do
+      # Authors of Authorables must provide its presenters.
+      #
+      # Return: The presenter for the current author.
+      def presenter
+        raise NotImlementedError, "Authors must return an instance of its Presenter via this method."
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -5,6 +5,7 @@ require "decidim/core/api"
 require "decidim/core/version"
 # Decidim configuration.
 module Decidim
+  autoload :ActsAsAuthor, "decidim/acts_as_author"
   autoload :TranslatableAttributes, "decidim/translatable_attributes"
   autoload :JsonbAttributes, "decidim/jsonb_attributes"
   autoload :FormBuilder, "decidim/form_builder"

--- a/decidim-core/lib/decidim/core/test.rb
+++ b/decidim-core/lib/decidim/core/test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "decidim/core/test/shared_examples/acts_as_author_examples"
 require "decidim/core/test/shared_examples/authorable"
 require "decidim/core/test/shared_examples/coauthorable"
 require "decidim/core/test/shared_examples/publicable"

--- a/decidim-core/lib/decidim/core/test/shared_examples/acts_as_author_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/acts_as_author_examples.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# users of this test should delare the `subject` variable.
+shared_examples "acts as author" do
+  describe "presenter" do
+    it "returns an instance of the presenter for this author" do
+      expect(subject.presenter).to be_present
+    end
+  end
+end

--- a/decidim-core/spec/lib/user_acts_as_author_spec.rb
+++ b/decidim-core/spec/lib/user_acts_as_author_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe User do
+    let(:subject) { create(:user) }
+
+    it_behaves_like "acts as author"
+  end
+end

--- a/decidim-core/spec/lib/user_group_acts_as_author_spec.rb
+++ b/decidim-core/spec/lib/user_group_acts_as_author_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe User do
+    let(:subject) { create(:user_group) }
+
+    it_behaves_like "acts as author"
+  end
+end

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -20,6 +20,7 @@ module Decidim
       include Decidim::Hashtaggable
       include Decidim::Forms::HasQuestionnaire
       include Decidim::Paddable
+      include Decidim::ActsAsAuthor
 
       belongs_to :organizer, foreign_key: "organizer_id", class_name: "Decidim::User", optional: true
       has_many :registrations, class_name: "Decidim::Meetings::Registration", foreign_key: "decidim_meeting_id", dependent: :destroy
@@ -59,6 +60,12 @@ module Decidim
       # Return registrations of a particular meeting made by users representing a group
       def user_group_registrations
         registrations.where.not(decidim_user_group_id: nil)
+      end
+
+      # Returns the presenter for this author, to be used in the views.
+      # Required by ActsAsAuthor.
+      def presenter
+        Decidim::Meetings::MeetingPresenter.new(self)
       end
 
       def self.log_presenter_class_for(_log)

--- a/decidim-meetings/spec/lib/decidim/meetings/meeting_acts_as_author_spec.rb
+++ b/decidim-meetings/spec/lib/decidim/meetings/meeting_acts_as_author_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe User do
+    let(:subject) { create(:meeting) }
+
+    it_behaves_like "acts as author"
+  end
+end

--- a/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
@@ -16,7 +16,7 @@ module Decidim
                       Decidim::Proposals::OfficialAuthorPresenter.new
                     else
                       coauthorship = coauthorships.first
-                      coauthorship.user_group.presenter || coauthorship.author.presenter
+                      coauthorship.user_group&.presenter || coauthorship.author.presenter
                     end
       end
 

--- a/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
@@ -16,13 +16,7 @@ module Decidim
                       Decidim::Proposals::OfficialAuthorPresenter.new
                     else
                       coauthorship = coauthorships.first
-                      if coauthorship.user_group
-                        Decidim::UserGroupPresenter.new(coauthorship.user_group)
-                      elsif coauthorship.author.is_a?(Decidim::User)
-                        Decidim::UserPresenter.new(coauthorship.author)
-                      elsif coauthorship.author.is_a?(Decidim::Meeting)
-                        Decidim::MeetingPresenter.new(coauthorship.author)
-                      end
+                      coauthorship.user_group.presenter || coauthorship.author.presenter
                     end
       end
 

--- a/docs/advanced/authorship.md
+++ b/docs/advanced/authorship.md
@@ -1,0 +1,15 @@
+# Authorship
+
+Regarging authorship of Decidim resources/entities, there are three concerns
+involved directly:
+
+- `Decidim::ActsAsAuthor`: which defines how an author should behave.
+- `Decidim::Authorable` and `Decidim::Coauthorable`: which define the behaviour
+around who authored a resource.
+
+But the presenters for the classes including `ActsAsAuthor` should also behave
+in a certain maneer. This has been resolved using the duck typing strategy
+(remember, if it quaks as as duck, then it is a duck). Thus, there's not any
+interface declaring which are the methods to be implemented by the presenter
+of an author. Anyway one of the `OfficialAuthorPresenter`s may be used as a
+reference.


### PR DESCRIPTION
#### :tophat: What? Why?
This PR has started as a fix for bugfix https://github.com/decidim/decidim/pull/5383/commits/35b69c9cb80fba850109ca9fce0edb97b5280856, but ended up with a refactoring.

So, what is the refactoring about? It is related with the fact that we can not reference artifacts from external modules from core. This is, `decidim-core` can not have dependencies to other modules.

So to solve the dependency problem I've implemented an `ActsAsAuthor` module that all authors must include, and this will force them to define a `presenter` method which will return the current presenter for the author. This will avoid the `decidim-core` module to know anything about which is the presenter for each author, except for the official authorships.

#### :pushpin: Related Issues
- Fixes #5383 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [x] Add tests
- [x] Another subtask
