### PR TITLE
Backport 0.19 fix/flaky test when mapping rails timezone names to postgre sql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **Fixed**:
 
+- **decidim-participatory_processes**: Fix: flaky test when mapping Rails timezone names to PostgreSQL [\#5484](https://github.com/decidim/decidim/pull/5484)
 - **decidim-core**: Fix metrics graphql query [\#5442](https://github.com/decidim/decidim/pull/5442)
 
 **Removed**:

--- a/decidim-participatory_processes/app/services/decidim/participatory_processes/participatory_process_search.rb
+++ b/decidim-participatory_processes/app/services/decidim/participatory_processes/participatory_process_search.rb
@@ -17,7 +17,8 @@ module Decidim
         when "upcoming"
           query.upcoming.order(start_date: :asc)
         else # Assume 'all'
-          query.order(Arel.sql("ABS(start_date - (CURRENT_DATE at time zone '#{Time.zone}')::date)"))
+          timezone = ActiveSupport::TimeZone.find_tzinfo(Time.zone.name).identifier
+          query.order(Arel.sql("ABS(start_date - (CURRENT_DATE at time zone '#{timezone}')::date)"))
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Port https://github.com/decidim/decidim/pull/5472 to version 0.19.

#### :pushpin: Related Issues
- Related to #5472

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [x] Another subtask
