### PR TITLE
Fix/import export participatory processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 **Fixed**:
 
+- **decidim-participatory_processes**: Fix participatory process import when some imported elements are null [\#5496](https://github.com/decidim/decidim/pull/5496)
 - **decidim-core**: Upgrade dependecies, specially loofah. [\#5493](https://github.com/decidim/decidim/pull/5493)
 - **decidim-core**: Fix: mispelling when selecting the meetings presenter. [\#5482](https://github.com/decidim/decidim/pull/5482)
 - **decidim-core**, **decidim-participatory_processes**: Fix: Duplicate results in `Decidim::HasPrivateUsers::visible_for(user)` [\#5462](https://github.com/decidim/decidim/pull/5462)

--- a/decidim-dev/lib/decidim/dev/assets/participatory_processes_with_null.json
+++ b/decidim-dev/lib/decidim/dev/assets/participatory_processes_with_null.json
@@ -1,0 +1,103 @@
+[
+  {
+    "id": 1,
+    "title": {
+      "ca": "Laborum totam et nisi autem.",
+      "en": "Tempora esse debitis in ut.",
+      "es": "Eum quia ut maiores officia."
+    },
+    "subtitle": {
+      "ca": "Sit ut.",
+      "en": "Consequatur sed.",
+      "es": "In laudantium."
+    },
+    "slug": "distinctio-cupiditate",
+    "hashtag": "harum",
+    "short_description": {
+      "ca": "<p>Harum magnam id.</p>",
+      "en": "<p>Aut quam doloribus.</p>",
+      "es": "<p>Vel eaque voluptatem.</p>"
+    },
+    "description": {
+      "ca": "<p>Eius velit earum. Dolorem consequuntur ullam. Atque autem non.</p>",
+      "en": "<p>Ad quaerat consequuntur. Voluptas dignissimos eos. Eos saepe et.</p>",
+      "es": "<p>Omnis similique illo. Expedita adipisci qui. Voluptas cupiditate qui.</p>"
+    },
+    "announcement": null,
+    "start_date": "2019-10-02",
+    "end_date": "2019-12-02",
+    "remote_hero_image_url": "http://localhost:3000/uploads/decidim/participatory_process/hero_image/1/city.jpeg",
+    "remote_banner_image_url": "http://localhost:3000/uploads/decidim/participatory_process/banner_image/1/city2.jpeg",
+    "developer_group": {
+      "ca": "Reiciendis.",
+      "en": "Nostrum.",
+      "es": "Aut."
+    },
+    "local_area": {
+      "ca": "Eum necessitatibus.",
+      "en": "Aspernatur perspiciatis.",
+      "es": "A laudantium."
+    },
+    "meta_scope": {
+      "ca": "sint",
+      "en": "voluptas",
+      "es": "ullam"
+    },
+    "participatory_scope": {
+      "ca": "Ad.",
+      "en": "Amet.",
+      "es": "Excepturi."
+    },
+    "participatory_structure": {
+      "ca": "Eos est.",
+      "en": "Quaerat mollitia.",
+      "es": "Vel iusto."
+    },
+    "target": {
+      "ca": "Ratione amet harum.",
+      "en": "Deserunt nulla modi.",
+      "es": "Aut quae ipsa."
+    },
+    "area": {
+      "id": null,
+      "name": {
+        "en": "",
+        "ca": "",
+        "es": ""
+      }
+    },
+    "participatory_process_group": {
+      "id": 1,
+      "name": {
+        "ca": "Molestias pariatur eaque.",
+        "en": "Iure iusto ut.",
+        "es": "Pariatur culpa reprehenderit."
+      },
+      "description": {
+        "ca": "<p>Et accusamus debitis. Sint voluptatem velit. Quia architecto at.</p>",
+        "en": "<p>Sunt eius labore. Odit fugiat numquam. Et consequatur pariatur.</p>",
+        "es": "<p>Rerum aperiam omnis. Optio est quo. Odit est eveniet.</p>"
+      },
+      "remote_hero_image_url": "http://localhost:3000/uploads/decidim/participatory_process_group/hero_image/1/city.jpeg"
+    },
+    "scope": {
+      "id": 1,
+      "name": {
+        "ca": "South Carolina",
+        "en": "South Carolina",
+        "es": "South Carolina"
+      }
+    },
+    "private_space": false,
+    "promoted": true,
+    "scopes_enabled": true,
+    "show_statistics": true,
+    "participatory_process_steps": null,
+    "participatory_process_categories": null,
+    "attachments": {
+      "attachment_collections": null,
+      "files": null
+    },
+    "components": null
+  }
+]

--- a/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
+++ b/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
@@ -64,6 +64,8 @@ module Decidim
       end
 
       def import_participatory_process_steps(steps)
+        return if steps.nil?
+
         steps.map do |step_attributes|
           Decidim.traceability.create!(
             ParticipatoryProcessStep,
@@ -80,6 +82,8 @@ module Decidim
       end
 
       def import_categories(categories)
+        return if categories.nil?
+
         categories.map do |category_attributes|
           category = Decidim.traceability.create!(
             Category,
@@ -105,6 +109,8 @@ module Decidim
       end
 
       def import_folders_and_attachments(attachments)
+        return if attachments["files"].nil?
+
         attachments["files"].map do |file|
           next unless remote_file_exists?(file["remote_file_url"])
 
@@ -135,6 +141,8 @@ module Decidim
 
       # +components+: An Array of Hashes, each corresponding with the settings of a Decidim::Component.
       def import_components(components)
+        return if components.nil?
+
         importer = Decidim::Importers::ParticipatorySpaceComponentsImporter.new(@imported_process)
         importer.import(components, @user)
       end

--- a/decidim-participatory_processes/spec/commands/decidim/participatory_processes/admin/import_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/commands/decidim/participatory_processes/admin/import_participatory_process_spec.rb
@@ -76,6 +76,21 @@ module Decidim::ParticipatoryProcesses
       end
     end
 
+    describe "when import_components exists" do
+      let(:import_components) { true }
+
+      it "imports a participatory process and the steps" do
+        expect { subject.call }.to change { Decidim::Component.count }.by(3)
+        expect(Decidim::Component.where(participatory_space_id: Decidim::ParticipatoryProcess.last).count).to eq 3
+      end
+
+      context "when participatory process steps are null" do
+        let(:document_name) { "participatory_processes_with_null.json" }
+
+        it_behaves_like "import participatory_process succeeds"
+      end
+    end
+
     describe "when import_steps exists" do
       let(:import_steps) { true }
 
@@ -87,6 +102,12 @@ module Decidim::ParticipatoryProcesses
 
         expect(imported_participatory_process_step.title).to eq("ca" => "Quo.", "en" => "Magni.", "es" => "Praesentium.")
         expect(imported_participatory_process_step.description).not_to be_nil
+      end
+
+      context "when participatory process steps are null" do
+        let(:document_name) { "participatory_processes_with_null.json" }
+
+        it_behaves_like "import participatory_process succeeds"
       end
     end
 
@@ -105,6 +126,12 @@ module Decidim::ParticipatoryProcesses
         )
         expect(imported_participatory_process_category.participatory_space).to eq(Decidim::ParticipatoryProcess.last)
       end
+
+      context "when categories are null" do
+        let(:document_name) { "participatory_processes_with_null.json" }
+
+        it_behaves_like "import participatory_process succeeds"
+      end
     end
 
     describe "when import_attachments exists" do
@@ -117,6 +144,12 @@ module Decidim::ParticipatoryProcesses
           expect(imported_participatory_process_collection.name).to eq("ca" => "assumenda", "en" => "cumque", "es" => "rem")
           expect(imported_participatory_process_collection.collection_for).to eq(Decidim::ParticipatoryProcess.last)
         end
+      end
+
+      context "when attachments are null" do
+        let(:document_name) { "participatory_processes_with_null.json" }
+
+        it_behaves_like "import participatory_process succeeds"
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Using the new import-export features of participatory processes, I noticed that an error was removed if the exported process did not contain components but it was requested to import components.

In investigating, I found that this problem applied to categories, attachments, and steps.

I would suggest that the user should choose whether or not to import these elements, but that no errors should be raised if they are not present.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
