### PR TITLE
[WIP] Import categories from one space to another

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/import_categories_from_another_space.rb
+++ b/decidim-admin/app/commands/decidim/admin/import_categories_from_another_space.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # A command with all the business logic when an admin imports categories from
+    # one space to another.
+    class ImportCategoriesFromAnotherSpace < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # form - A form object with the params.
+      def initialize(form)
+        @form = form
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid.
+      # - :invalid if the form wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        return broadcast(:invalid) unless @form.valid?
+
+        broadcast(:ok, create_categories)
+      end
+
+      private
+
+      attr_reader :form
+
+      def create_categories
+        transaction do
+          parent_categories(origin_participatory_space).map do |original_parent_category|
+            new_parent_category = create_category(original_parent_category)
+            sub_categories(original_parent_category).map do |original_sub_category|
+              create_category(original_sub_category, new_parent_category)
+            end.compact
+          end.compact
+        end
+      end
+
+      def create_category(original_category, parent_category = nil)
+        category = Decidim::Category.new
+        category.participatory_space = current_participatory_space
+        category.name = original_category.name
+        category.description = original_category.description
+        category.parent = parent_category
+        category.save!
+        return category
+      end
+
+      def categories(space)
+        Decidim::Category.where(participatory_space: space)
+      end
+
+      def parent_categories(space)
+        categories(space).where(parent: nil)
+      end
+
+      def sub_categories(parent_category)
+        categories(parent_category.participatory_space).where(parent: parent_category)
+      end
+
+      def origin_participatory_space
+        @form.origin_participatory_space
+      end
+
+      def current_participatory_space
+        @form.current_participatory_space
+      end
+    end
+  end
+end

--- a/decidim-admin/app/controllers/decidim/admin/categories_imports_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/categories_imports_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    class CategoriesImportsController < Admin::ApplicationController
+      def new
+        enforce_permission_to :create, :category
+
+        @form = form(Admin::ImportCategoriesForm).instance
+      end
+
+      def create
+        enforce_permission_to :create, :category
+
+        @form = form(Admin::ImportCategoriesForm).from_params(params)
+        Admin::ImportCategoriesFromAnotherSpace.call(@form) do
+          on(:ok) do |categories|
+            flash[:notice] = I18n.t("categories.import.create.success", scope: "decidim.admin", number: categories.length)
+            redirect_to categories_path(current_participatory_space)
+          end
+
+          on(:invalid) do
+            flash[:alert] = I18n.t("categories.import.create.error", scope: "decidim.admin")
+            render action: "new"
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/app/forms/decidim/admin/import_categories_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/import_categories_form.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # A form object to be used when admin users want to import categories
+    # from a participatory space into another one.
+    class ImportCategoriesForm < Decidim::Form
+      mimic :categories_import
+
+      attribute :origin_participatory_space_slug, Integer
+
+      validates :origin_participatory_space_slug, :origin_participatory_space, :current_participatory_space, presence: true
+
+      def origin_participatory_space
+        @origin_participatory_space ||= origin_participatory_spaces.find { |space| space.slug == origin_participatory_space_slug }
+      end
+
+      def origin_participatory_spaces
+        @origin_participatory_spaces ||= participatory_spaces_with_categories
+        @origin_participatory_spaces.delete(current_participatory_space)
+        return @origin_participatory_spaces
+      end
+
+      def participatory_spaces_with_categories
+        current_organization.public_participatory_spaces.select { |space|  space.try(:categories) and space.categories.any?  }
+      end
+
+      def origin_participatory_spaces_collection
+        origin_participatory_spaces.map do |participatory_space|
+          [participatory_space.title[I18n.locale.to_s], participatory_space.slug]
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/app/views/decidim/admin/categories/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/categories/index.html.erb
@@ -4,6 +4,7 @@
       <%= t("categories.index.categories_title", scope: "decidim.admin") %>
       <% if allowed_to? :create, :category %>
         <%= link_to t("actions.new", scope: "decidim.admin", name: t("models.category.name", scope: "decidim.admin")), new_category_path(current_participatory_space), class: "button tiny button--title new" %>
+        <%= link_to t("actions.import", scope: "decidim.admin"), new_categories_import_path, class: "button tiny button--title" %>
       <% end %>
     </h2>
   </div>

--- a/decidim-admin/app/views/decidim/admin/categories_imports/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/categories_imports/new.html.erb
@@ -1,0 +1,23 @@
+<%= decidim_form_for(@form, url: categories_import_path, html: { class: "form import_categories" }) do |f| %>
+  <% if @form.origin_participatory_spaces.any? %>
+    <div class="card">
+      <div class="card-divider">
+        <h2 class="card-title"><%= t("actions.import", scope: "decidim.admin") %></h2>
+      </div>
+
+      <div class="card-section">
+        <div class="row column">
+          <%= f.select :origin_participatory_space_slug, @form.origin_participatory_spaces_collection,
+                      prompt: t("categories.import.new.select_participatory_space", scope: "decidim.admin"),
+                      label: t("categories.import.new.origin_space", scope: "decidim.admin") %>
+        </div>
+      </div>
+    </div>
+
+    <div class="button--double form-general-submit">
+      <%= f.submit t("categories.import.new.create", scope: "decidim.admin") %>
+    </div>
+  <% else %>
+      <p><%= t("categories.import.no_spaces", scope: "decidim.admin") %></p>
+  <% end %>
+<% end %>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -137,6 +137,7 @@ en:
         add: Add
         browse: Browse
         export: Export
+        import: Import categories from another space
         manage: Manage
         new: New %{name}
         permissions: Permissions
@@ -222,6 +223,15 @@ en:
         edit:
           title: Edit category
           update: Update
+        import:
+          create:
+            error: There was a problem importing the categories
+            success: "%{number} categories successfully imported"
+          new:
+            create: Import
+            no_spaces: There are no other spaces to import categories from.
+            origin_space: Origin participatory space
+            select_participatory_space: Please select a space
         index:
           categories_title: Categories
           category_used: This category cannot be removed because it is in use.

--- a/decidim-admin/spec/commands/decidim/admin/import_categories_from_another_space_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/import_categories_from_another_space_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Admin
+    describe ImportCategoriesFromAnotherSpace do
+      describe "call" do
+        let!(:categories) { create_list(:category, 3) }
+        let!(:category) { categories.first }
+
+        let(:current_space) { create(:participatory_process, organization: category.participatory_space.organization) }
+        let!(:current_user) { create(:user, :admin, organization: current_space.organization) }
+        let!(:organization) { current_space.organization }
+        let!(:form) do
+          instance_double(
+            ImportCategoriesForm,
+            origin_participatory_space: category.participatory_space,
+            current_participatory_space: current_space,
+            valid?: valid
+          )
+        end
+
+        let(:command) { described_class.new(form) }
+
+        describe "when the form is not valid" do
+          let(:valid) { false }
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+
+          it "doesn't create the category" do
+            expect do
+              command.call
+            end.to change(Category, :count).by(0)
+          end
+        end
+
+        describe "when the form is valid" do
+          let(:valid) { true }
+
+          it "broadcasts ok" do
+            expect { command.call }.to broadcast(:ok)
+          end
+
+          it "creates the categories" do
+            expect do
+              command.call
+            end.to change { Category.where(participatory_space: current_space).count }.by(1)
+          end
+
+          it "only imports wanted attributes" do
+            command.call
+
+            new_category = Category.where(participatory_space: current_space).last
+            expect(new_category.name).to eq(category.name)
+            expect(new_category.description).to eq(category.description)
+            expect(new_category.parent).to eq(category.parent)
+          end
+        end
+      end
+
+      def project_localized(text)
+        Decidim.available_locales.inject({}) do |result, locale|
+          result.update(locale => text)
+        end.with_indifferent_access
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/forms/import_categories_form_spec.rb
+++ b/decidim-admin/spec/forms/import_categories_form_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Admin
+    describe ImportCategoriesForm do
+      subject { form }
+
+      let(:category) { create(:category) }
+      let(:origin_space) { category.participatory_space }
+      let(:organization) { origin_space.organization }
+      let(:current_space) { create(:participatory_process, organization: organization) }
+
+      let(:another_category) { create(:category, participatory_space: current_space) }
+
+      let(:params) do
+        {
+          origin_participatory_space_slug: origin_space.try(:slug)
+        }
+      end
+
+      let(:form) do
+        described_class.from_params(params).with_context(
+          current_organization: organization,
+          current_participatory_space: current_space,
+        )
+      end
+
+      context "when everything is OK" do
+        it do
+          is_expected.to be_valid
+        end
+      end
+
+      context "when there's no origin participatory space" do
+        let(:origin_space) { nil }
+
+        it do
+          is_expected.to be_invalid
+        end
+      end
+
+      describe "origin_space" do
+        let(:another_organization) { create(:organization)}
+        let(:second_origin_space) { create(:assembly, organization: another_organization) }
+
+        it "ignores participatory spaces from other organisations" do
+          expect(form.origin_participatory_space).to be_nil
+        end
+      end
+
+      describe "origin_spaces" do
+        let(:origin_organization) { create(:organization)}
+        let(:second_origin_space) { create(:assembly, organization: origin_organization) }
+
+        it "returns available participatory spaces" do
+          expect(form.origin_participatory_spaces).to include(second_origin_space)
+          expect(form.origin_participatory_spaces.length).to eq(1)
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/shared/import_categories_from_another_space_examples.rb
+++ b/decidim-admin/spec/shared/import_categories_from_another_space_examples.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+shared_examples "import proposals to projects" do
+  let!(:proposals) { create_list :proposal, 3, :accepted, component: origin_component }
+  let!(:rejected_proposals) { create_list :proposal, 3, :rejected, component: origin_component }
+  let!(:origin_component) { create :proposal_component, participatory_space: current_component.participatory_space }
+  let!(:default_budget) { 2333 }
+  include Decidim::ComponentPathHelper
+
+  it "imports proposals from one component to a budget component" do
+    click_link "Import proposals to projects"
+
+    within ".import_proposals" do
+      select origin_component.name["en"], from: :proposals_import_origin_component_id
+      fill_in "Default budget", with: default_budget
+      check :proposals_import_import_all_accepted_proposals
+    end
+
+    click_button "Import proposals to projects"
+
+    expect(page).to have_content("3 proposals successfully imported")
+
+    proposals.each do |project|
+      expect(page).to have_content(project.title["en"])
+    end
+
+    expect(page).to have_current_path(manage_component_path(current_component))
+  end
+end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/categories_imports_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/categories_imports_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Assemblies
+    module Admin
+      # Controller that allows importing categories for assemblies.
+      #
+      class CategoriesImportsController < Decidim::Admin::CategoriesImportsController
+        include Concerns::AssemblyAdmin
+      end
+    end
+  end
+end

--- a/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
@@ -31,7 +31,11 @@ module Decidim
         end
 
         scope "/assemblies/:assembly_slug" do
-          resources :categories
+          resources :categories do
+            collection do
+              resource :categories_import, only: [:new, :create]
+            end
+          end
 
           resources :components do
             resource :permissions, controller: "component_permissions"

--- a/decidim-budgets/app/views/decidim/budgets/admin/proposals_imports/new.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/proposals_imports/new.html.erb
@@ -2,7 +2,7 @@
   <% if @form.origin_components.any? %>
     <div class="card">
       <div class="card-divider">
-        <h2 class="card-title"><%= title %></h2>
+        <h2 class="card-title"><%= t(".create") %></h2>
       </div>
 
       <div class="card-section">

--- a/decidim-conferences/app/controllers/decidim/conferences/admin/categories_imports_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/admin/categories_imports_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Conferences
+    module Admin
+      # Controller that allows importing categories for conferences.
+      #
+      class CategoriesImportsController < Decidim::Admin::CategoriesImportsController
+        include Concerns::ConferenceAdmin
+      end
+    end
+  end
+end

--- a/decidim-conferences/lib/decidim/conferences/admin_engine.rb
+++ b/decidim-conferences/lib/decidim/conferences/admin_engine.rb
@@ -51,7 +51,11 @@ module Decidim
         end
 
         scope "/conferences/:conference_slug" do
-          resources :categories
+          resources :categories do
+            collection do
+              resource :categories_import, only: [:new, :create]
+            end
+          end
 
           resources :components do
             resource :permissions, controller: "component_permissions"

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/categories_imports_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/categories_imports_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ParticipatoryProcesses
+    module Admin
+      # Controller that allows importing categories for participatory processes.
+      #
+      class CategoriesImportsController < Decidim::Admin::CategoriesImportsController
+        include Concerns::ParticipatoryProcessAdmin
+      end
+    end
+  end
+end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
@@ -36,7 +36,11 @@ module Decidim
         end
 
         scope "/participatory_processes/:participatory_process_slug" do
-          resources :categories
+          resources :categories do
+            collection do
+              resource :categories_import, only: [:new, :create]
+            end
+          end
 
           resources :components do
             resource :permissions, controller: "component_permissions"


### PR DESCRIPTION
#### :tophat: What? Why?

As an admin, I want to be able to import categories from one existing participatory space into another so I don't need to recreate them manually.

This is still WIP.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests

### :camera: Screenshots (optional)
![Description](URL)
