### PR TITLE
fix search box on mobile (menu)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - **decidim-conferences**: Fix: Add pagination interface to some sections [\#5463](https://github.com/decidim/decidim/pull/5463)
 - **decidim-sortitions**: Fix: Don't include drafts in sortitions [\#5434](https://github.com/decidim/decidim/pull/5434)
 - **decidim-assemblies**: Fix: Fixed assembly parent_id when selecting itself [#5416](https://github.com/decidim/decidim/pull/5416)
+- **decidim-core**: Fix: Search box on mobile (menu) [#5502](https://github.com/decidim/decidim/pull/5502)
 
 **Removed**:
 

--- a/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
@@ -24,6 +24,8 @@ end
       <div class="hide-for-medium" data-set="nav-holder"></div>
       <div class="hide-for-medium usermenu-off-canvas-holder"
            data-set="nav-login-holder"></div>
+      <div class="hide-for-medium mt-s ml-s mr-s search-off-canvas-holder"
+           data-set="nav-search-holder"></div>
     </div>
     <div class="off-canvas-content" data-off-canvas-content>
       <div class="footer-separator">

--- a/decidim-core/spec/system/search_spec.rb
+++ b/decidim-core/spec/system/search_spec.rb
@@ -29,4 +29,22 @@ describe "Search", type: :system do
       expect(page).to have_selector(".filters__section")
     end
   end
+
+  context "when the device is a mobile" do
+    before do
+      driven_by(:iphone)
+      switch_to_host(organization.host)
+      visit decidim.root_path
+
+      within ".topbar .topbar__menu" do
+        page.find("button").click
+      end
+    end
+
+    it "shows the mobile version of the search form" do
+      within ".off-canvas .search-off-canvas-holder" do
+        expect(page).to have_css("#form-search_topbar")
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Makes able to use the search from mobile devices as in https://decidim-design.herokuapp.com/public/search

#### :pushpin: Related Issues
- Fixes #5470

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)
![Captura de pantalla de 2019-11-18 11-14-02](https://user-images.githubusercontent.com/210216/69044096-984bdc00-09f4-11ea-8978-e0b6ca7f8b90.png)
