### PR TITLE
Add: Additional sorting filters for proposals index

### DIFF
--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
@@ -16,10 +16,11 @@ module Decidim
         # Available orders based on enabled settings
         def available_orders
           @available_orders ||= begin
-            available_orders = %w(random recent most_followed with_more_authors)
+            available_orders = %w(random recent)
             available_orders << "most_voted" if most_voted_order_available?
             available_orders << "most_endorsed" if current_settings.endorsements_enabled?
             available_orders << "most_commented" if component_settings.comments_enabled?
+            available_orders << "most_followed" << "with_more_authors"
             available_orders
           end
         end

--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
@@ -16,8 +16,10 @@ module Decidim
         # Available orders based on enabled settings
         def available_orders
           @available_orders ||= begin
-            available_orders = %w(random recent)
+            available_orders = %w(random recent most_followed with_more_authors)
             available_orders << "most_voted" if most_voted_order_available?
+            available_orders << "most_endorsed" if current_settings.endorsements_enabled?
+            available_orders << "most_commented" if component_settings.comments_enabled?
             available_orders
           end
         end
@@ -40,12 +42,20 @@ module Decidim
 
         def reorder(proposals)
           case order
-          when "random"
-            proposals.order_randomly(random_seed)
+          when "most_commented"
+            proposals.left_joins(:comments).group(:id).order(Arel.sql("COUNT(decidim_comments_comments.id) DESC"))
+          when "most_endorsed"
+            proposals.order(proposal_endorsements_count: :desc)
+          when "most_followed"
+            proposals.left_joins(:follows).group(:id).order(Arel.sql("COUNT(decidim_follows.id) DESC"))
           when "most_voted"
             proposals.order(proposal_votes_count: :desc)
+          when "random"
+            proposals.order_randomly(random_seed)
           when "recent"
             proposals.order(published_at: :desc)
+          when "with_more_authors"
+            proposals.order(coauthorships_count: :desc)
           end
         end
       end

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -673,9 +673,13 @@ en:
           title: Create Your Proposal
         orders:
           label: 'Order proposals by:'
+          most_commented: Most commented
+          most_endorsed: Most endorsed
+          most_followed: Most followed
           most_voted: Most supported
           random: Random
           recent: Recent
+          with_more_authors: With more authors
         participatory_texts:
           index:
             document_index: Document index

--- a/decidim-proposals/spec/controllers/concerns/orderable_spec.rb
+++ b/decidim-proposals/spec/controllers/concerns/orderable_spec.rb
@@ -9,16 +9,30 @@ module Decidim
     end
 
     describe OrderableFakeController, type: :controller do
+      let(:component_settings) { double(comments_enabled?: comments_enabled) }
+      let(:comments_enabled) { nil }
+      let(:current_settings) do
+        double(:current_settings,
+               votes_enabled?: votes_enabled,
+               votes_hidden?: votes_hidden,
+               endorsements_enabled?: endorsements_enabled)
+      end
+      let(:votes_enabled) { nil }
+      let(:votes_hidden) { nil }
+      let(:endorsements_enabled) { nil }
+      let(:view) { controller.view_context }
+
       before do
+        allow(controller).to receive(:component_settings).and_return(component_settings)
         allow(controller).to receive(:current_settings).and_return(current_settings)
       end
 
-      let(:view) { controller.view_context }
-
       describe "#available_orders" do
         context "with votes enabled" do
+          let(:votes_enabled) { true }
+
           context "with votes hidden" do
-            let(:current_settings) { double(:current_settings, votes_enabled?: true, votes_hidden?: true) }
+            let(:votes_hidden) { true }
 
             it "does not show most_voted option to sort" do
               expect(view.available_orders).not_to include("most_voted")
@@ -26,7 +40,7 @@ module Decidim
           end
 
           context "with votes not hidden" do
-            let(:current_settings) { double(:current_settings, votes_enabled?: true, votes_hidden?: false) }
+            let(:votes_hidden) { false }
 
             it "shows most_voted option to sort" do
               expect(view.available_orders).to include("most_voted")
@@ -35,10 +49,42 @@ module Decidim
         end
 
         context "with votes disabled" do
-          let(:current_settings) { double(:current_settings, votes_enabled?: false) }
+          let(:votes_enabled) { false }
 
           it "doesn't show most_voted option to sort" do
             expect(view.available_orders).not_to include("most_voted")
+          end
+        end
+
+        context "with endorsements enabled" do
+          let(:endorsements_enabled) { true }
+
+          it "shows most_endorsed option to sort" do
+            expect(view.available_orders).to include("most_endorsed")
+          end
+        end
+
+        context "with endorsements disabled" do
+          let(:endorsements_enabled) { false }
+
+          it "doesn't show most_endorsed option to sort" do
+            expect(view.available_orders).not_to include("most_endorsed")
+          end
+        end
+
+        context "with comments enabled" do
+          let(:comments_enabled) { true }
+
+          it "shows most_commented option to sort" do
+            expect(view.available_orders).to include("most_commented")
+          end
+        end
+
+        context "with comments disabled" do
+          let(:comments_enabled) { false }
+
+          it "doesn't show most_commented option to sort" do
+            expect(view.available_orders).not_to include("most_commented")
           end
         end
       end

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -365,6 +365,22 @@ describe "Proposals", type: :system do
       end
     end
 
+    shared_examples "ordering proposals by selected option" do |selected_option|
+      before do
+        visit_component
+        within ".order-by" do
+          expect(page).to have_selector("ul[data-dropdown-menu$=dropdown-menu]", text: "Random")
+          page.find("a", text: "Random").click
+          click_link(selected_option)
+        end
+      end
+
+      it "lists the proposals ordered by selected option" do
+        expect(page).to have_selector("#proposals .card-grid .column:first-child", text: first_proposal.title)
+        expect(page).to have_selector("#proposals .card-grid .column:last-child", text: last_proposal.title)
+      end
+    end
+
     context "when ordering by 'most_voted'" do
       let!(:component) do
         create(:proposal_component,
@@ -372,40 +388,67 @@ describe "Proposals", type: :system do
                manifest: manifest,
                participatory_space: participatory_process)
       end
+      let!(:most_voted_proposal) { create(:proposal, component: component) }
+      let!(:votes) { create_list(:proposal_vote, 3, proposal: most_voted_proposal) }
+      let!(:less_voted_proposal) { create(:proposal, component: component) }
 
-      it "lists the proposals ordered by votes" do
-        most_voted_proposal = create(:proposal, component: component)
-        create_list(:proposal_vote, 3, proposal: most_voted_proposal)
-        less_voted_proposal = create(:proposal, component: component)
-
-        visit_component
-
-        within ".order-by" do
-          expect(page).to have_selector("ul[data-dropdown-menu$=dropdown-menu]", text: "Random")
-          page.find("a", text: "Random").click
-          click_link "Most supported"
-        end
-
-        expect(page).to have_selector("#proposals .card-grid .column:first-child", text: most_voted_proposal.title)
-        expect(page).to have_selector("#proposals .card-grid .column:last-child", text: less_voted_proposal.title)
+      it_behaves_like "ordering proposals by selected option", "Most supported" do
+        let(:first_proposal) { most_voted_proposal }
+        let(:last_proposal) { less_voted_proposal }
       end
     end
 
     context "when ordering by 'recent'" do
-      it "lists the proposals ordered by created at" do
-        older_proposal = create(:proposal, component: component, created_at: 1.month.ago)
-        recent_proposal = create(:proposal, component: component)
+      let!(:older_proposal) { create(:proposal, component: component, created_at: 1.month.ago) }
+      let!(:recent_proposal) { create(:proposal, component: component) }
 
-        visit_component
+      it_behaves_like "ordering proposals by selected option", "Recent" do
+        let(:first_proposal) { recent_proposal }
+        let(:last_proposal) { older_proposal }
+      end
+    end
 
-        within ".order-by" do
-          expect(page).to have_selector("ul[data-dropdown-menu$=dropdown-menu]", text: "Random")
-          page.find("a", text: "Random").click
-          click_link "Recent"
-        end
+    context "when ordering by 'most_followed'" do
+      let!(:most_followed_proposal) { create(:proposal, component: component) }
+      let!(:follows) { create_list(:follow, 3, followable: most_followed_proposal) }
+      let!(:less_followed_proposal) { create(:proposal, component: component) }
 
-        expect(page).to have_selector("#proposals .card-grid .column:first-child", text: recent_proposal.title)
-        expect(page).to have_selector("#proposals .card-grid .column:last-child", text: older_proposal.title)
+      it_behaves_like "ordering proposals by selected option", "Most followed" do
+        let(:first_proposal) { most_followed_proposal }
+        let(:last_proposal) { less_followed_proposal }
+      end
+    end
+
+    context "when ordering by 'most_commented'" do
+      let!(:most_commented_proposal) { create(:proposal, component: component, created_at: 1.month.ago) }
+      let!(:comments) { create_list(:comment, 3, commentable: most_commented_proposal) }
+      let!(:less_commented_proposal) { create(:proposal, component: component) }
+
+      it_behaves_like "ordering proposals by selected option", "Most commented" do
+        let(:first_proposal) { most_commented_proposal }
+        let(:last_proposal) { less_commented_proposal }
+      end
+    end
+
+    context "when ordering by 'most_endorsed'" do
+      let!(:most_endorsed_proposal) { create(:proposal, component: component, created_at: 1.month.ago) }
+      let!(:endorsements) { create_list(:proposal_endorsement, 3, proposal: most_endorsed_proposal) }
+      let!(:less_endorsed_proposal) { create(:proposal, component: component) }
+
+      it_behaves_like "ordering proposals by selected option", "Most endorsed" do
+        let(:first_proposal) { most_endorsed_proposal }
+        let(:last_proposal) { less_endorsed_proposal }
+      end
+    end
+
+    context "when ordering by 'with_more_authors'" do
+      let!(:most_authored_proposal) { create(:proposal, component: component, created_at: 1.month.ago) }
+      let!(:coauthorships) { create_list(:coauthorship, 3, coauthorable: most_authored_proposal) }
+      let!(:less_authored_proposal) { create(:proposal, component: component) }
+
+      it_behaves_like "ordering proposals by selected option", "With more authors" do
+        let(:first_proposal) { most_authored_proposal }
+        let(:last_proposal) { less_authored_proposal }
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

> As a participant, I want to be able to sort proposals by
> 
> - Random
> - Recent
> - Most suported
> - Most endorsed
> - Most commented
> - Most followed
> - With More authors

#### :pushpin: Related Issues
- Related to #5489

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)
![Description](URL)
