### PR TITLE
[backport] Force absolute namespace for admin AttachmentForm.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **Fixed**:
 
+- **decidim-meetings**: Admin HasAttachments forces the absolute namespace for the AttachmentForm to `::Decidim::Admin::AttachmentForm`.[\#5510](https://github.com/decidim/decidim/pull/5510)
 - **decidim-participatory_processes**: Fix: flaky test when mapping Rails timezone names to PostgreSQL [\#5484](https://github.com/decidim/decidim/pull/5484)
 - **decidim-core**: Fix metrics graphql query [\#5442](https://github.com/decidim/decidim/pull/5442)
 

--- a/decidim-admin/app/controllers/decidim/admin/concerns/has_attachments.rb
+++ b/decidim-admin/app/controllers/decidim/admin/concerns/has_attachments.rb
@@ -23,13 +23,13 @@ module Decidim
 
           def new
             enforce_permission_to :create, :attachment, attached_to: attached_to
-            @form = form(AttachmentForm).from_params({}, attached_to: attached_to)
+            @form = form(::Decidim::Admin::AttachmentForm).from_params({}, attached_to: attached_to)
             render template: "decidim/admin/attachments/new"
           end
 
           def create
             enforce_permission_to :create, :attachment, attached_to: attached_to
-            @form = form(AttachmentForm).from_params(params, attached_to: attached_to)
+            @form = form(::Decidim::Admin::AttachmentForm).from_params(params, attached_to: attached_to)
 
             CreateAttachment.call(@form, attached_to) do
               on(:ok) do
@@ -47,14 +47,14 @@ module Decidim
           def edit
             @attachment = collection.find(params[:id])
             enforce_permission_to :update, :attachment, attachment: attachment
-            @form = form(AttachmentForm).from_model(@attachment, attached_to: attached_to)
+            @form = form(::Decidim::Admin::AttachmentForm).from_model(@attachment, attached_to: attached_to)
             render template: "decidim/admin/attachments/edit"
           end
 
           def update
             @attachment = collection.find(params[:id])
             enforce_permission_to :update, :attachment, attachment: attachment
-            @form = form(AttachmentForm).from_params(attachment_params, attached_to: attached_to)
+            @form = form(::Decidim::Admin::AttachmentForm).from_params(attachment_params, attached_to: attached_to)
 
             UpdateAttachment.call(@attachment, @form) do
               on(:ok) do


### PR DESCRIPTION
#### :tophat: What? Why?
In some installations the admin HasAttachments doesn't resolve the correct class for AttachmentForm.
We've forced the absolute namespace for the AttachmentForm to `::Decidim::Admin::AttachmentForm`.

#### :pushpin: Related Issues
- Related to #5511

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [x] apply fix

### :camera: Screenshots (optional)
![Description](URL)
