### PR TITLE
Fix: current_participatory_space raises error in ConsultationsController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 **Fixed**:
 
+- **decidim-consultations**: Fix: current_participatory_space raises error in ConsultationsController.[\#5513](https://github.com/decidim/decidim/pull/5513)
 - **decidim-admin**: Admin HasAttachments forces the absolute namespace for the AttachmentForm to `::Decidim::Admin::AttachmentForm`.[\#5511](https://github.com/decidim/decidim/pull/5511)
 - **decidim-participatory_processes**: Fix participatory process import when some imported elements are null [\#5496](https://github.com/decidim/decidim/pull/5496)
 - **decidim-core**: Upgrade dependecies, specially loofah. [\#5493](https://github.com/decidim/decidim/pull/5493)

--- a/decidim-consultations/app/controllers/decidim/consultations/consultations_controller.rb
+++ b/decidim-consultations/app/controllers/decidim/consultations/consultations_controller.rb
@@ -7,11 +7,11 @@ module Decidim
     class ConsultationsController < Decidim::Consultations::ApplicationController
       layout "layouts/decidim/consultation", only: :show
 
+      include ParticipatorySpaceContext
       include NeedsConsultation
       include FilterResource
       include Paginable
       include Decidim::Consultations::Orderable
-      include ParticipatorySpaceContext
 
       helper_method :collection, :consultations, :finished_consultations, :active_consultations, :filter
 

--- a/decidim-consultations/spec/controllers/decidim/consultations/consultations_controller_spec.rb
+++ b/decidim-consultations/spec/controllers/decidim/consultations/consultations_controller_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Consultations::ConsultationsController, type: :controller do
+  it "does not raise error to call current_participatory_space" do
+    expect { controller.send(:current_participatory_space) }.not_to raise_error
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
The order in which the modules are being included in 
`Decidim::Consultations::ConsultationsController` causes this method:
```ruby
# decidim-core/app/controllers/concerns/decidim/participatory_space_context.rb

def current_participatory_space
  raise NotImplementedError
end
```

to override this method:
```ruby
# decidim-consultations/app/controllers/concerns/decidim/consultations/needs_consultation.rb

alias current_participatory_space current_consultation
```

#### :pushpin: Related Issues
- Fixes https://github.com/mainio/decidim-module-term_customizer/issues/28

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
