### PR TITLE
Allow customizing Oauth providers for each tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,16 +36,6 @@ Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now sup
 - **decidim-accountability**, **decidim-admin**, **decidim-budgets**, **decidim-core**, **decidim-debates**, **decidim-generators**, **decidim-meetings**, **decidim-proposals**, **decidim_app-design**: Change: Extend the capabilities of the Quill text editor. [\#5488](https://github.com/decidim/decidim/pull/5488)
 - **decidim-core**: Add docs in how to fix metrics problems. [\#5587](https://github.com/decidim/decidim/pull/5587)
 - **decidim-core**: Data portability now supports AWS S3 storage. [\#5342](https://github.com/decidim/decidim/pull/5342)
-- **decidim-proposals, decidim-debates and decidim-initiatives**: Added all spaces and many entities to global search, see Upgrade notes for more detail. [\#5469](https://github.com/decidim/decidim/pull/5469)
-- **decidim-core**: Add weight to categories and sort them by that field. [\#5505](https://github.com/decidim/decidim/pull/5505)
-- **decidim-proposals**: Add: Additional sorting filters for proposals index. [\#5506](https://github.com/decidim/decidim/pull/5506)
-- **decidim-core**: Add a searchable users endpoint to the GraphQL api and enable drop-down @mentions helper in comments. [\#5474](https://github.com/decidim/decidim/pull/5474)
-- **decidim-consultations**: Create groups of responses in multi-choices question consultations. [\#5387](https://github.com/decidim/decidim/pull/5387)
-- **decidim-core**, **decidim-participatory_processes**: Export/import space components feature, applied to for ParticipatoryProcess. [#5424](https://github.com/decidim/decidim/pull/5424)
-- **decidim-participatory_processes**: Export/import feature for ParticipatoryProcess. [#5422](https://github.com/decidim/decidim/pull/5422)
-- **decidim-surveys**: Added a setting to surveys to allow unregistered (aka: anonymous) users to answer a survey. [\#4996](https://github.com/decidim/decidim/pull/4996)
-- **decidim-core**: Added Devise :lockable to Users [#5478](https://github.com/decidim/decidim/pull/5478)
-- **decidim-meetings**: Added help texts for meetings forms to solve doubts about Geocoder fields. [\# #5487](https://github.com/decidim/decidim/pull/5487)
 - **decidim-system**: Permit customizing omniauth settings for each tenant [#5516](https://github.com/decidim/decidim/pull/5516)
 
 **Changed**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,17 @@ Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now sup
 - **decidim-accountability**, **decidim-admin**, **decidim-budgets**, **decidim-core**, **decidim-debates**, **decidim-generators**, **decidim-meetings**, **decidim-proposals**, **decidim_app-design**: Change: Extend the capabilities of the Quill text editor. [\#5488](https://github.com/decidim/decidim/pull/5488)
 - **decidim-core**: Add docs in how to fix metrics problems. [\#5587](https://github.com/decidim/decidim/pull/5587)
 - **decidim-core**: Data portability now supports AWS S3 storage. [\#5342](https://github.com/decidim/decidim/pull/5342)
+- **decidim-proposals, decidim-debates and decidim-initiatives**: Added all spaces and many entities to global search, see Upgrade notes for more detail. [\#5469](https://github.com/decidim/decidim/pull/5469)
+- **decidim-core**: Add weight to categories and sort them by that field. [\#5505](https://github.com/decidim/decidim/pull/5505)
+- **decidim-proposals**: Add: Additional sorting filters for proposals index. [\#5506](https://github.com/decidim/decidim/pull/5506)
+- **decidim-core**: Add a searchable users endpoint to the GraphQL api and enable drop-down @mentions helper in comments. [\#5474](https://github.com/decidim/decidim/pull/5474)
+- **decidim-consultations**: Create groups of responses in multi-choices question consultations. [\#5387](https://github.com/decidim/decidim/pull/5387)
+- **decidim-core**, **decidim-participatory_processes**: Export/import space components feature, applied to for ParticipatoryProcess. [#5424](https://github.com/decidim/decidim/pull/5424)
+- **decidim-participatory_processes**: Export/import feature for ParticipatoryProcess. [#5422](https://github.com/decidim/decidim/pull/5422)
+- **decidim-surveys**: Added a setting to surveys to allow unregistered (aka: anonymous) users to answer a survey. [\#4996](https://github.com/decidim/decidim/pull/4996)
+- **decidim-core**: Added Devise :lockable to Users [#5478](https://github.com/decidim/decidim/pull/5478)
+- **decidim-meetings**: Added help texts for meetings forms to solve doubts about Geocoder fields. [\# #5487](https://github.com/decidim/decidim/pull/5487)
+- **decidim-system**: Permit customizing omniauth settings for each tenant [#5516](https://github.com/decidim/decidim/pull/5516)
 
 **Changed**:
 **decidim-meetings**: Add width and height to meetings component icon [\#5614](https://github.com/decidim/decidim/pull/5614)

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -123,6 +123,7 @@ ignore_unused:
   - decidim.proposals.proposals.show.proposal_rejected_reason
   - decidim.resource_links.*
   - decidim.system.default_pages.placeholders.*
+  - decidim.system.organizations.omniauth_settings.*
   - decidim.verifications.id_documents.{dni,nie,passport}
   - errors.messages.*
   - invisible_captcha.*

--- a/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
@@ -66,7 +66,7 @@ module Decidim
       end
 
       def action_missing(action_name)
-        return send(:create) if devise_mapping.omniauthable? && User.omniauth_providers.include?(action_name.to_sym)
+        return send(:create) if devise_mapping.omniauthable? && current_organization.enabled_omniauth_providers.keys.include?(action_name.to_sym)
 
         raise AbstractController::ActionNotFound, "The action '#{action_name}' could not be found for Decidim::Devise::OmniauthCallbacksController"
       end

--- a/decidim-core/app/helpers/decidim/omniauth_helper.rb
+++ b/decidim-core/app/helpers/decidim/omniauth_helper.rb
@@ -3,18 +3,6 @@
 module Decidim
   # Helper that provides methods to enable or disable omniauth buttons
   module OmniauthHelper
-    # Public: returns true if the social provider is enabled
-    def social_provider_enabled?(provider)
-      Rails.application.secrets.dig(:omniauth, provider.to_sym, :enabled)
-    end
-
-    # Public: returns true if any provider is enabled
-    def any_social_provider_enabled?
-      User.omniauth_providers.any? do |provider|
-        social_provider_enabled? provider
-      end
-    end
-
     # Public: normalize providers names to they can be used for buttons
     # and icons.
     def normalize_provider_name(provider)
@@ -23,7 +11,7 @@ module Decidim
 
     # Public: icon for omniauth buttons
     def oauth_icon(provider)
-      info = Rails.application.secrets.dig(:omniauth, provider.to_sym)
+      info = current_organization.enabled_omniauth_providers[provider.to_sym]
 
       if info
         icon_path = info[:icon_path]
@@ -34,6 +22,11 @@ module Decidim
 
       name ||= normalize_provider_name(provider)
       icon(name)
+    end
+
+    # Public: pretty print provider name
+    def provider_name(provider)
+      provider.to_s.gsub(/_|-/, " ").camelize
     end
   end
 end

--- a/decidim-core/app/models/decidim/omniauth_provider.rb
+++ b/decidim-core/app/models/decidim/omniauth_provider.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Decidim
+  class OmniauthProvider
+    def self.available
+      Rails.application.secrets[:omniauth] || {}
+    end
+
+    def self.enabled
+      available.select do |_provider, settings|
+        settings[:enabled] == true
+      end
+    end
+
+    def self.extract_provider_key(enabled_setting_key)
+      enabled_setting_key.gsub("omniauth_settings_", "")
+                         .gsub("_enabled", "").to_sym
+    end
+
+    def self.extract_setting_key(setting_key, provider)
+      setting_key.gsub("omniauth_settings_#{provider}_", "").to_sym
+    end
+
+    def self.value_defined?(value)
+      value.is_a?(String) && value.present?
+    end
+  end
+end

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -11,8 +11,6 @@ module Decidim
     include Decidim::Searchable
     include Decidim::ActsAsAuthor
 
-    OMNIAUTH_PROVIDERS = [:facebook, :twitter, :google_oauth2, (:developer if Rails.env.development?)].compact
-
     class Roles
       def self.all
         Decidim.config.user_roles
@@ -22,7 +20,7 @@ module Decidim
     devise :invitable, :database_authenticatable, :registerable, :confirmable, :timeoutable,
            :recoverable, :rememberable, :trackable, :lockable,
            :decidim_validatable, :decidim_newsletterable,
-           :omniauthable, omniauth_providers: OMNIAUTH_PROVIDERS,
+           :omniauthable, omniauth_providers: Decidim::OmniauthProvider.available.keys,
                           request_keys: [:env], reset_password_keys: [:decidim_organization_id, :email],
                           confirmation_keys: [:decidim_organization_id, :email]
 

--- a/decidim-core/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
+++ b/decidim-core/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
@@ -1,17 +1,15 @@
-<% if Devise.mappings[:user].omniauthable? && any_social_provider_enabled? %>
+<% if Devise.mappings[:user].omniauthable? && current_organization.enabled_omniauth_providers.any? %>
   <div class="row">
     <div class="columns large-4 mediumlarge-6 medium-8 medium-centered">
-      <%- Decidim::User.omniauth_providers.each do |provider| %>
-        <% if social_provider_enabled? provider %>
-          <div class="social-register">
-            <%= link_to decidim.send("user_#{provider}_omniauth_authorize_path"), class: "button button--social button--#{normalize_provider_name(provider)}", method: :post do %>
-              <span class="button--social__icon">
-                <%= oauth_icon provider %>
-              </span>
-              <%= t("devise.shared.links.sign_in_with_provider", provider: normalize_provider_name(provider).titleize) %>
-            <% end %>
-          </div>
-        <% end %>
+      <%- current_organization.enabled_omniauth_providers.keys.each do |provider| %>
+        <div class="social-register">
+          <%= link_to decidim.send("user_#{provider}_omniauth_authorize_path"), class: "button button--social button--#{normalize_provider_name(provider)}", method: :post do %>
+            <span class="button--social__icon">
+              <%= oauth_icon provider %>
+            </span>
+            <%= t("devise.shared.links.sign_in_with_provider", provider: normalize_provider_name(provider).titleize) %>
+          <% end %>
+        </div>
       <% end %>
       <%- if current_organization.sign_in_enabled? %>
         <span class="register__separator">

--- a/decidim-core/app/views/decidim/devise/shared/_omniauth_buttons_mini.html.erb
+++ b/decidim-core/app/views/decidim/devise/shared/_omniauth_buttons_mini.html.erb
@@ -1,17 +1,15 @@
-<% if Devise.mappings[:user].omniauthable? && any_social_provider_enabled? %>
+<% if Devise.mappings[:user].omniauthable? && current_organization.enabled_omniauth_providers.any? %>
   <div class="row">
     <div class="columns medium-8 medium-centered">
       <span class="register__separator">
         <span class="register__separator__text"><%= t("or", scope: "decidim.devise.shared.omniauth_buttons") %></span>
       </span>
       <div class="text-center">
-        <%- Decidim::User.omniauth_providers.each do |provider| %>
-          <% if social_provider_enabled? provider %>
-            <%= link_to decidim.send("user_#{provider}_omniauth_authorize_path"), class: "button button--social button--#{normalize_provider_name(provider)} button--social--mini", method: :post do %>
-              <span class="button--social__icon">
-                <%= oauth_icon provider %>
-              </span>
-            <% end %>
+        <%- current_organization.enabled_omniauth_providers.keys.each do |provider| %>
+          <%= link_to decidim.send("user_#{provider}_omniauth_authorize_path"), class: "button button--social button--#{normalize_provider_name(provider)} button--social--mini", method: :post do %>
+            <span class="button--social__icon">
+              <%= oauth_icon provider %>
+            </span>
           <% end %>
         <% end %>
       </div>

--- a/decidim-core/config/initializers/devise.rb
+++ b/decidim-core/config/initializers/devise.rb
@@ -297,28 +297,6 @@ Devise.setup do |config|
   # The default HTTP method used to sign out a resource. Default is :delete.
   config.sign_out_via = :delete
 
-  # ==> OmniAuth
-  # Add a new OmniAuth provider. Check the wiki for more information on setting
-  # up on your models and hooks.
-  config.omniauth :developer, fields: [:name, :nickname, :email] if Rails.application.secrets.dig(:omniauth, :developer).present?
-  if Rails.application.secrets.dig(:omniauth, :facebook).present?
-    config.omniauth :facebook,
-                    Rails.application.secrets.omniauth[:facebook][:app_id],
-                    Rails.application.secrets.omniauth[:facebook][:app_secret],
-                    scope: :email,
-                    info_fields: "name,email,verified"
-  end
-  if Rails.application.secrets.dig(:omniauth, :twitter).present?
-    config.omniauth :twitter,
-                    Rails.application.secrets.omniauth[:twitter][:api_key],
-                    Rails.application.secrets.omniauth[:twitter][:api_secret]
-  end
-  if Rails.application.secrets.dig(:omniauth, :google_oauth2).present?
-    config.omniauth :google_oauth2,
-                    Rails.application.secrets.omniauth[:google_oauth2][:client_id],
-                    Rails.application.secrets.omniauth[:google_oauth2][:client_secret]
-  end
-
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.

--- a/decidim-core/config/initializers/omniauth.rb
+++ b/decidim-core/config/initializers/omniauth.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+def setup_provider_proc(provider, config_mapping = {})
+  lambda do |env|
+    request = Rack::Request.new(env)
+    organization = Decidim::Organization.find_by(host: request.host)
+    provider_config = organization.enabled_omniauth_providers[provider]
+
+    config_mapping.each do |option_key, config_key|
+      env["omniauth.strategy"].options[option_key] = provider_config[config_key]
+      env["omniauth.strategy"].options[option_key] = provider_config[config_key]
+    end
+  end
+end
+
+Rails.application.config.middleware.use OmniAuth::Builder do
+  omniauth_config = Rails.application.secrets.dig(:omniauth)
+
+  if omniauth_config
+    if omniauth_config[:developer].present?
+      provider(
+        :developer,
+        fields: [:name, :nickname, :email]
+      )
+    end
+
+    if omniauth_config[:facebook].present?
+      provider(
+        :facebook,
+        setup: setup_provider_proc(:facebook, client_id: :app_id, client_secret: :app_secret),
+        scope: :email,
+        info_fields: "name,email,verified"
+      )
+    end
+
+    if omniauth_config[:twitter].present?
+      provider(
+        :twitter,
+        setup: setup_provider_proc(:twitter, consumer_key: :api_key, consumer_secret: :api_secret)
+      )
+    end
+
+    if omniauth_config[:google_oauth2].present?
+      provider(
+        :google_oauth2,
+        setup: setup_provider_proc(:google_oauth2, client_id: :client_id, client_secret: :client_secret)
+      )
+    end
+  end
+end

--- a/decidim-core/db/migrate/20191113092826_add_omniauth_settings_to_decidim_organization.rb
+++ b/decidim-core/db/migrate/20191113092826_add_omniauth_settings_to_decidim_organization.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOmniauthSettingsToDecidimOrganization < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_organizations, :omniauth_settings, :jsonb
+  end
+end

--- a/decidim-core/spec/helpers/decidim/omniauth_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/omniauth_helper_spec.rb
@@ -19,27 +19,6 @@ module Decidim
       allow(Rails.application).to receive(:secrets).and_return(secrets)
     end
 
-    describe "#social_provider_enabled?" do
-      describe "when the facebook provider is enabled" do
-        it { expect(helper).to be_social_provider_enabled(:facebook) }
-      end
-
-      describe "when the facebook provider is not enabled" do
-        let(:facebook_enabled) { false }
-
-        it { expect(helper).not_to be_social_provider_enabled(:facebook) }
-      end
-    end
-
-    describe "#any_social_provider_enabled?" do
-      let(:facebook_enabled) { false }
-      let(:twitter_enabled) { false }
-
-      describe "when all providers are disabled" do
-        it { expect(helper).not_to be_any_social_provider_enabled }
-      end
-    end
-
     describe "#normalize_provider_name" do
       describe "when provider is google_oauth2" do
         it "returns just google" do

--- a/decidim-core/spec/models/decidim/omniauth_provider_spec.rb
+++ b/decidim-core/spec/models/decidim/omniauth_provider_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe OmniauthProvider do
+    let(:omniauth_secrets) do
+      {
+        facebook: {
+          enabled: true,
+          app_id: "fake-facebook-app-id",
+          app_secret: "fake-facebook-app-secret"
+        },
+        twitter: {
+          enabled: true,
+          api_key: "fake-twitter-api-key",
+          api_secret: "fake-twitter-api-secret"
+        },
+        google_oauth2: {
+          enabled: false,
+          client_id: nil,
+          client_secret: nil
+        }
+      }
+    end
+
+    describe "available" do
+      subject(:available_providers) { Decidim::OmniauthProvider.available }
+
+      it "returns all providers" do
+        expect(available_providers.size).to eq(3)
+        expect(available_providers[:facebook]).to eq(omniauth_secrets[:facebook])
+      end
+    end
+
+    describe "extract_provider_key" do
+      subject(:provider_key) do
+        Decidim::OmniauthProvider.extract_provider_key("omniauth_settings_facebook_enabled")
+      end
+
+      it "returns provider key" do
+        expect(provider_key).to eq(:facebook)
+      end
+    end
+
+    describe "extract_setting_key" do
+      subject do
+        Decidim::OmniauthProvider.extract_setting_key(setting_key, provider)
+      end
+
+      let(:setting_key) { "omniauth_settings_facebook_app_id" }
+      let(:provider) { :facebook }
+
+      it "returns the setting key without namespaces" do
+        expect(subject).to eq(:app_id)
+      end
+    end
+  end
+end

--- a/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb
+++ b/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb
@@ -47,10 +47,16 @@ test:
   omniauth:
     facebook:
       enabled: true
+      app_id: fake-facebook-app-id
+      app_secret: fake-facebook-app-secret
     twitter:
       enabled: true
+      api_key: fake-twitter-api-key
+      api_secret: fake-twitter-api-secret
     google_oauth2:
       enabled: true
+      client_id:
+      client_secret:
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.

--- a/decidim-system/app/commands/decidim/system/register_organization.rb
+++ b/decidim-system/app/commands/decidim/system/register_organization.rb
@@ -57,6 +57,7 @@ module Decidim
           badges_enabled: true,
           user_groups_enabled: true,
           default_locale: form.default_locale,
+          omniauth_settings: form.encrypted_omniauth_settings,
           smtp_settings: form.encrypted_smtp_settings,
           send_welcome_notification: true
         )

--- a/decidim-system/app/commands/decidim/system/update_organization.rb
+++ b/decidim-system/app/commands/decidim/system/update_organization.rb
@@ -47,6 +47,7 @@ module Decidim
         organization.force_users_to_authenticate_before_access_organization = form.force_users_to_authenticate_before_access_organization
         organization.available_authorizations = form.clean_available_authorizations
         organization.users_registration_mode = form.users_registration_mode
+        organization.omniauth_settings = form.encrypted_omniauth_settings
         organization.smtp_settings = form.encrypted_smtp_settings
 
         organization.save!

--- a/decidim-system/app/controllers/decidim/system/organizations_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/organizations_controller.rb
@@ -6,6 +6,7 @@ module Decidim
     #
     class OrganizationsController < Decidim::System::ApplicationController
       helper_method :current_organization
+      helper Decidim::OmniauthHelper
 
       def new
         @form = form(RegisterOrganizationForm).instance

--- a/decidim-system/app/forms/decidim/system/update_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/update_organization_form.rb
@@ -28,6 +28,18 @@ module Decidim
         [:enable_starttls_auto, Boolean]
       ]
 
+      OMNIATH_PROVIDERS_ATTRIBUTES = Decidim::User.omniauth_providers.map do |provider|
+        Rails.application.secrets.dig(:omniauth, provider).keys.map do |setting|
+          if setting == :enabled
+            ["omniauth_settings_#{provider}_enabled".to_sym, Boolean]
+          else
+            ["omniauth_settings_#{provider}_#{setting}".to_sym, String]
+          end
+        end
+      end.flatten(1)
+
+      jsonb_attribute :omniauth_settings, OMNIATH_PROVIDERS_ATTRIBUTES
+
       attr_writer :password
 
       validates :name, :host, :users_registration_mode, presence: true
@@ -36,6 +48,9 @@ module Decidim
 
       def map_model(model)
         self.secondary_hosts = model.secondary_hosts.join("\n")
+        self.omniauth_settings = Hash[(model.omniauth_settings || []).map do |k, v|
+          [k, Decidim::OmniauthProvider.value_defined?(v) ? Decidim::AttributeEncryptor.decrypt(v) : v]
+        end]
       end
 
       def clean_secondary_hosts
@@ -56,6 +71,12 @@ module Decidim
 
       def encrypted_smtp_settings
         smtp_settings.merge(encrypted_password: Decidim::AttributeEncryptor.encrypt(@password))
+      end
+
+      def encrypted_omniauth_settings
+        Hash[omniauth_settings.map do |k, v|
+          [k, Decidim::OmniauthProvider.value_defined?(v) ? Decidim::AttributeEncryptor.encrypt(v) : v]
+        end]
       end
 
       private

--- a/decidim-system/app/views/decidim/system/devise/shared/_links.html.erb
+++ b/decidim-system/app/views/decidim/system/devise/shared/_links.html.erb
@@ -19,7 +19,7 @@
 <% end -%>
 
 <%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
+  <%- current_organization.enabled_omniauth_providers.keys.each do |provider| %>
     <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %><br>
   <% end -%>
 <% end -%>

--- a/decidim-system/app/views/decidim/system/organizations/_omniauth_provider.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/_omniauth_provider.html.erb
@@ -1,0 +1,19 @@
+<% i18n_scope = "decidim.system.organizations.omniauth_settings" %>
+
+<div class="card">
+  <h5><%= provider_name(provider) %></h5>
+
+  <div class="card-section">
+    <%= f.check_box(
+          "omniauth_settings_#{provider}_enabled",
+          label: t("enabled", scope: i18n_scope)
+        ) %>
+
+    <% Rails.application.secrets.dig(:omniauth, provider.to_sym).keys.select { |k| k != :enabled }.each do |setting| %>
+        <%= f.text_field("omniauth_settings_#{provider}_#{setting}", label: I18n.t(
+              ".#{setting}",
+              scope: [:icon, :icon_path].include?(setting) ? i18n_scope : "#{i18n_scope}.#{provider}"
+            )) %>
+    <% end %>
+  </div>
+</div>

--- a/decidim-system/app/views/decidim/system/organizations/_omniauth_settings.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/_omniauth_settings.html.erb
@@ -1,0 +1,11 @@
+<div class="fieldset">
+  <h4><%= t("decidim.system.models.organization.fields.omniauth_settings") %></h4>
+
+  <%= f.fields_for :omniauth_settings do %>
+    <% providers = Decidim::OmniauthProvider.available.keys %>
+
+    <% providers.each do |provider| %>
+      <%= render partial: "omniauth_provider", locals: { f: f, provider: provider } %>
+    <% end %>
+  <% end %>
+</div>

--- a/decidim-system/app/views/decidim/system/organizations/edit.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/edit.html.erb
@@ -31,6 +31,7 @@
   </div>
 
   <%= render partial: "smtp_settings", locals: { f: f } %>
+  <%= render partial: "omniauth_settings", locals: { f: f } %>
 
   <div class="actions">
     <%= f.submit t("decidim.system.actions.save") %>

--- a/decidim-system/app/views/decidim/system/organizations/new.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/new.html.erb
@@ -72,6 +72,7 @@
   </div>
 
   <%= render partial: "smtp_settings", locals: { f: f } %>
+  <%= render partial: "omniauth_settings", locals: { f: f } %>
 
   <div class="actions">
     <%= f.submit t("decidim.system.models.organization.actions.save_and_invite") %>

--- a/decidim-system/config/locales/en.yml
+++ b/decidim-system/config/locales/en.yml
@@ -48,6 +48,7 @@ en:
           fields:
             created_at: Created at
             name: Name
+            omniauth_settings: Omniauth settings
             smtp_settings: SMTP settings
           name: Organization
       organizations:
@@ -62,6 +63,19 @@ en:
           reference_prefix_hint: The reference prefix is used to uniquely identify resources across all organization
           secondary_hosts_hint: Enter each one of them in a new line
           title: New organization
+        omniauth_settings:
+          enabled: Enabled
+          facebook:
+            app_id: App ID
+            app_secret: App secret
+          google_oauth2:
+            client_id: Client ID
+            client_secret: Client secret
+          icon: Icon
+          icon_path: Icon path
+          twitter:
+            api_key: API key
+            api_secret: API secret
         update:
           error: There was a problem updating this organization.
           success: Organization successfully updated.

--- a/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
@@ -31,7 +31,10 @@ module Decidim
                 "user_name" => "f.laguardia",
                 "password" => Decidim::AttributeEncryptor.encrypt("password"),
                 "from" => "decide@gotham.gov"
-              }
+              },
+              omniauth_settings_facebook_enabled: true,
+              omniauth_settings_facebook_app_id: "facebook-app-id",
+              omniauth_settings_facebook_app_secret: "facebook-app-secret"
             }
           end
 
@@ -46,6 +49,14 @@ module Decidim
             expect(organization.name).to eq("Gotham City")
             expect(organization.host).to eq("decide.gotham.gov")
             expect(organization.secondary_hosts).to match_array(["foo.gotham.gov", "bar.gotham.gov"])
+
+            expect(organization.omniauth_settings["omniauth_settings_facebook_enabled"]).to eq(true)
+            expect(
+              Decidim::AttributeEncryptor.decrypt(organization.omniauth_settings["omniauth_settings_facebook_app_id"])
+            ).to eq("facebook-app-id")
+            expect(
+              Decidim::AttributeEncryptor.decrypt(organization.omniauth_settings["omniauth_settings_facebook_app_secret"])
+            ).to eq("facebook-app-secret")
           end
 
           it "invites a user as organization admin" do

--- a/decidim-system/spec/commands/decidim/system/update_organization_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/update_organization_spec.rb
@@ -20,7 +20,10 @@ module Decidim
               host: "decide.gotham.gov",
               secondary_hosts: "foo.gotham.gov\r\n\r\nbar.gotham.gov",
               force_users_to_authenticate_before_access_organization: false,
-              users_registration_mode: "existing"
+              users_registration_mode: "existing",
+              omniauth_settings_facebook_enabled: true,
+              omniauth_settings_facebook_app_id: "facebook-app-id",
+              omniauth_settings_facebook_app_secret: "facebook-app-secret"
             }
           end
 
@@ -36,6 +39,14 @@ module Decidim
             expect(organization.host).to eq("decide.gotham.gov")
             expect(organization.secondary_hosts).to match_array(["foo.gotham.gov", "bar.gotham.gov"])
             expect(organization.users_registration_mode).to eq("existing")
+
+            expect(organization.omniauth_settings["omniauth_settings_facebook_enabled"]).to eq(true)
+            expect(
+              Decidim::AttributeEncryptor.decrypt(organization.omniauth_settings["omniauth_settings_facebook_app_id"])
+            ).to eq("facebook-app-id")
+            expect(
+              Decidim::AttributeEncryptor.decrypt(organization.omniauth_settings["omniauth_settings_facebook_app_secret"])
+            ).to eq("facebook-app-secret")
           end
         end
 

--- a/decidim-system/spec/forms/decidim/system/update_organization_form_spec.rb
+++ b/decidim-system/spec/forms/decidim/system/update_organization_form_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::System
+  describe UpdateOrganizationForm do
+    subject do
+      described_class.new(
+        name: "Gotham City",
+        host: "decide.gotham.gov",
+        secondary_hosts: "foo.gotham.gov\r\n\r\nbar.gotham.gov",
+        reference_prefix: "JKR",
+        organization_admin_name: "Fiorello Henry La Guardia",
+        organization_admin_email: "f.laguardia@gotham.gov",
+        available_locales: ["en"],
+        default_locale: "en",
+        users_registration_mode: "enabled",
+        force_users_to_authenticate_before_access_organization: "false",
+        smtp_settings: {
+          "address" => "mail.gotham.gov",
+          "port" => "25",
+          "user_name" => "f.laguardia",
+          "password" => Decidim::AttributeEncryptor.encrypt("password"),
+          "from" => "decide@gotham.gov"
+        },
+        omniauth_settings: {
+          "omniauth_settings_facebook_enabled" => true,
+          "omniauth_settings_facebook_app_id" => facebook_app_id,
+          "omniauth_settings_facebook_app_secret" => facebook_app_secret
+        }
+      )
+    end
+
+    let(:facebook_app_id) { "plain-text-facebook-app-id" }
+    let(:facebook_app_secret) { "plain-text-facebook-app-secret" }
+
+    context "when everything is OK" do
+      it { is_expected.to be_valid }
+
+      describe "omniauth_settings" do
+        it "contains attributes as plain text" do
+          expect(subject.omniauth_settings_facebook_enabled).to eq(true)
+          expect(subject.omniauth_settings_facebook_app_id).to eq(facebook_app_id)
+          expect(subject.omniauth_settings_facebook_app_secret).to eq(facebook_app_secret)
+        end
+      end
+
+      describe "encrypted_omniauth_settings" do
+        it "encrypts sensible attributes" do
+          encrypted_settings = subject.encrypted_omniauth_settings
+
+          expect(encrypted_settings["omniauth_settings_facebook_enabled"]).to eq(true)
+          expect(
+            Decidim::AttributeEncryptor.decrypt(encrypted_settings["omniauth_settings_facebook_app_id"])
+          ).to eq(facebook_app_id)
+          expect(
+            Decidim::AttributeEncryptor.decrypt(encrypted_settings["omniauth_settings_facebook_app_secret"])
+          ).to eq(facebook_app_secret)
+        end
+      end
+    end
+  end
+end

--- a/decidim-system/spec/system/organizations_spec.rb
+++ b/decidim-system/spec/system/organizations_spec.rb
@@ -78,6 +78,11 @@ describe "Organizations", type: :system do
         fill_in "Secondary hosts", with: "foobar.citizen.corp\n\rbar.citizen.corp"
         choose "Don't allow participants to register, but allow existing participants to login"
         check "Example authorization (Direct)"
+
+        check "organization_omniauth_settings_facebook_enabled"
+        fill_in "organization_omniauth_settings_facebook_app_id", with: "facebook-app-id"
+        fill_in "organization_omniauth_settings_facebook_app_secret", with: "facebook-app-secret"
+
         click_button "Save"
 
         expect(page).to have_css("div.flash.success")

--- a/docs/services/social_providers.md
+++ b/docs/services/social_providers.md
@@ -1,6 +1,18 @@
 # Social providers integration
 
-If you want to enable sign up through social providers like Facebook you will need to generate app credentials and write them into the Rails secrets file: `config/secrets.yml`.
+If you want to enable sign up through social providers like Facebook you will need to generate app credentials and store them in one of the following places:
+
+- In the Rails secrets file: `config/secrets.yml`. This configuration will be shared by all tenants.
+- In the site configuration (ex. system/organizations/1/edit). This configuration overrides the one in `config/secrets.yml`.
+
+Take into account that for a social provider integration appearing in the organization form, it must also be defined in `config/secrets.yml` (but the values are optional). For example:
+
+```yaml
+twitter:
+  enabled: false # disabled by default, unless activated in the organization
+  api_key:
+  api_secret:
+```
 
 ## Facebook
 
@@ -12,7 +24,7 @@ If you want to enable sign up through social providers like Facebook you will ne
 1. Validate the captcha.
 1. Ignore the source code and fill in the URL field with `https://YOUR_DECIDIM_HOST/users/auth/facebook/callback`
 1. Navigate to the application dashboard and copy the APP_ID and APP_SECRET
-1. Paste credentials in `config/secrets.yml`. Ensure the `enabled` attribute is `true`.
+1. Paste credentials in `config/secrets.yml` or in the organization configuration. Ensure the `enabled` attribute is `true`.
 
 ## Twitter
 
@@ -24,7 +36,7 @@ If you want to enable sign up through social providers like Facebook you will ne
 1. Check the 'Developer Agreement' checkbox and click the 'Create your Twitter application' button.
 1. Navigate to the "Keys and Access Tokens" tab and copy the API_KEY and API_SECRET.
 1. (Optional) Navigate to the "Permissions" tab and check the "Request email addresses from users" checkbox.
-1. Paste credentials in `config/secrets.yml`. Ensure the `enabled` attribute is `true`.
+1. Paste credentials in `config/secrets.yml` or in the organization configuration. Ensure the `enabled` attribute is `true`.
 
 ## Google
 
@@ -38,7 +50,7 @@ If you want to enable sign up through social providers like Facebook you will ne
 1. Click on `Credentials` tab and click on "Create credentials" button. Select `OAuth client ID`.
 1. Select `Web applications`. Fill in the `Authorized Javascript origins` with your url. Then fill in the `Authorized redirect URIs` with your url and append the path `/users/auth/google_oauth2/callback`.
 1. Copy the CLIENT_ID AND CLIENT_SECRET
-1. Paste credentials in `config/secrets.yml`. Ensure the `enabled` attribute is `true`.
+1. Paste credentials in `config/secrets.yml` or in the organization configuration. Ensure the `enabled` attribute is `true`.
 
 ## Custom providers
 
@@ -46,7 +58,7 @@ If you want to enable sign up through social providers like Facebook you will ne
 * The provider should implement an [OmniAuth](https://github.com/omniauth/omniauth) strategy.
 * You can use any of the [existing OnmiAuth strategies](https://github.com/omniauth/omniauth/wiki/List-of-Strategies).
 * Or you can create a new strategy, as the [Decidim OmniAuth Strategy](https://github.com/decidim/omniauth-decidim). This strategy allow users from a Decidim instance to login in other Decidim instance. For example, this strategy is used to allow [decidim.barcelona](https://decidim.barcelona) users to log into [meta.decidim.barcelona](https://meta.decidim.barcelona).
-* Once you have defined your strategy, you can configure it in the `config/secrets.yml`, as it is done for the built-in providers.
+* Once you have defined your strategy, you can configure it in the `config/secrets.yml` or in the organization configuration, as it is done for the built-in providers.
 * By default, Decidim will search in its icons library for an icon named as the provider. You can change this adding an `icon` or `icon_path` attribute to the provider configuration. The `icon` attribute sets the icon name to look for in the Decidim's icons library. The `icon_path` attribute sets the route to the image that should be used.
 * Here is an example of the configuration section for the Decidim strategy, using an icon located on the application's `app/assets/images` folder:
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR allows customizing the omniauth settings for each tenant, overriding the settings present in `secrets.yml` in case those were defined also.

#### :pushpin: Related Issues

- https://meta.decidim.org/processes/roadmap/f/122/proposals/14875
- https://github.com/OpenSourcePolitics/dev/issues/10

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add documentation regarding the feature 
- [x] Add tests

### :camera: Screenshots (optional)

![image](https://user-images.githubusercontent.com/9287468/69523646-b7062180-0f64-11ea-9f19-ce3df7ab17a6.png)

