### PR TITLE
API/Component-Proposals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now sup
 
 **Added**:
 
+- **proposals**: GraphQL API: Complete Proposals specification. [\#5537](https://github.com/decidim/decidim/pull/5537)
 - **decidim-participatory_processes**: GraphQL API: Add participatory process groups specification. [\#5540](https://github.com/decidim/decidim/pull/5540)
 - **decidim-participatory_processes**: GraphQL API: Complete fields for participatory processes. [\#5562](https://github.com/decidim/decidim/pull/5562)
 - **decidim-admin** Add terms of use for admin. [#5507](https://github.com/decidim/decidim/pull/5507)
@@ -31,17 +32,6 @@ Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now sup
 - **decidim-accountability**, **decidim-admin**, **decidim-budgets**, **decidim-core**, **decidim-debates**, **decidim-generators**, **decidim-meetings**, **decidim-proposals**, **decidim_app-design**: Change: Extend the capabilities of the Quill text editor. [\#5488](https://github.com/decidim/decidim/pull/5488)
 - **decidim-core**: Add docs in how to fix metrics problems. [\#5587](https://github.com/decidim/decidim/pull/5587)
 - **decidim-core**: Data portability now supports AWS S3 storage. [\#5342](https://github.com/decidim/decidim/pull/5342)
-- **proposals**: GraphQL API: Complete Proposals specification. [\#5537](https://github.com/decidim/decidim/pull/5537)
-- **many modules**: Added all spaces and many entities to global search, see Upgrade notes for more detail. [\#5469](https://github.com/decidim/decidim/pull/5469)
-- **decidim-core**: Add weight to categories and sort them by that field. [\#5505](https://github.com/decidim/decidim/pull/5505)
-- **decidim-proposals**: Add: Additional sorting filters for proposals index. [\#5506](https://github.com/decidim/decidim/pull/5506)
-- **decidim-core**: Add a searchable users endpoint to the GraphQL api and enable drop-down @mentions helper in comments. [\#5474](https://github.com/decidim/decidim/pull/5474)
-- **decidim-consultations**: Create groups of responses in multi-choices question consultations. [\#5387](https://github.com/decidim/decidim/pull/5387)
-- **decidim-core**, **decidim-participatory_processes**: Export/import space components feature, applied to for ParticipatoryProcess. [#5424](https://github.com/decidim/decidim/pull/5424)
-- **decidim-participatory_processes**: Export/import feature for ParticipatoryProcess. [#5422](https://github.com/decidim/decidim/pull/5422)
-- **decidim-surveys**: Added a setting to surveys to allow unregistered (aka: anonymous) users to answer a survey. [\#4996](https://github.com/decidim/decidim/pull/4996)
-- **decidim-core**: Added Devise :lockable to Users [#5478](https://github.com/decidim/decidim/pull/5478)
-- **decidim-meetings**: Added help texts for meetings forms to solve doubts about Geocoder fields. [\# #5487](https://github.com/decidim/decidim/pull/5487)
 
 **Changed**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now sup
 - **decidim-accountability**, **decidim-admin**, **decidim-budgets**, **decidim-core**, **decidim-debates**, **decidim-generators**, **decidim-meetings**, **decidim-proposals**, **decidim_app-design**: Change: Extend the capabilities of the Quill text editor. [\#5488](https://github.com/decidim/decidim/pull/5488)
 - **decidim-core**: Add docs in how to fix metrics problems. [\#5587](https://github.com/decidim/decidim/pull/5587)
 - **decidim-core**: Data portability now supports AWS S3 storage. [\#5342](https://github.com/decidim/decidim/pull/5342)
+- **proposals**: GraphQL API: Complete Proposals specification. [\#5537](https://github.com/decidim/decidim/pull/5537)
+- **many modules**: Added all spaces and many entities to global search, see Upgrade notes for more detail. [\#5469](https://github.com/decidim/decidim/pull/5469)
+- **decidim-core**: Add weight to categories and sort them by that field. [\#5505](https://github.com/decidim/decidim/pull/5505)
+- **decidim-proposals**: Add: Additional sorting filters for proposals index. [\#5506](https://github.com/decidim/decidim/pull/5506)
+- **decidim-core**: Add a searchable users endpoint to the GraphQL api and enable drop-down @mentions helper in comments. [\#5474](https://github.com/decidim/decidim/pull/5474)
+- **decidim-consultations**: Create groups of responses in multi-choices question consultations. [\#5387](https://github.com/decidim/decidim/pull/5387)
+- **decidim-core**, **decidim-participatory_processes**: Export/import space components feature, applied to for ParticipatoryProcess. [#5424](https://github.com/decidim/decidim/pull/5424)
+- **decidim-participatory_processes**: Export/import feature for ParticipatoryProcess. [#5422](https://github.com/decidim/decidim/pull/5422)
+- **decidim-surveys**: Added a setting to surveys to allow unregistered (aka: anonymous) users to answer a survey. [\#4996](https://github.com/decidim/decidim/pull/4996)
+- **decidim-core**: Added Devise :lockable to Users [#5478](https://github.com/decidim/decidim/pull/5478)
+- **decidim-meetings**: Added help texts for meetings forms to solve doubts about Geocoder fields. [\# #5487](https://github.com/decidim/decidim/pull/5487)
 
 **Changed**:
 

--- a/decidim-core/app/types/decidim/core/amendment_type.rb
+++ b/decidim-core/app/types/decidim/core/amendment_type.rb
@@ -18,11 +18,8 @@ module Decidim
         property :decidim_emendation_type
       end
 
-      # Currently there are only proposals, when this changes
-      # we will have to take a look at unions:
-      # https://github.com/rmosolgo/graphql-ruby/blob/master/guides/type_definitions/unions.md
-      field :amendable, !Decidim::Proposals::ProposalType, "The original amended resource (currently, a proposal only)"
-      field :emendation, !Decidim::Proposals::ProposalType, "The emendation (currently, a proposal only)"
+      field :amendable, !AmendableEntityInterface, "The original amended resource (currently, a proposal only)"
+      field :emendation, !AmendableEntityInterface, "The emendation (currently, a proposal only)"
     end
   end
 end

--- a/decidim-core/app/types/decidim/core/amendment_type.rb
+++ b/decidim-core/app/types/decidim/core/amendment_type.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Core
+    AmendmentType = GraphQL::ObjectType.define do
+      name "Amendment"
+      description "An amendment"
+
+      field :state, !types.String, "The status of this amendment"
+      field :amender, !Decidim::Core::AuthorInterface, "The author of this amendment"
+
+      field :amendableType, !types.String do
+        description "Type of the amendable object"
+        property :decidim_amendable_type
+      end
+      field :emendationType, !types.String do
+        description "Type of the emendation object"
+        property :decidim_emendation_type
+      end
+
+      # Currently there are only proposals, when this changes
+      # we will have to take a look at unions:
+      # https://github.com/rmosolgo/graphql-ruby/blob/master/guides/type_definitions/unions.md
+      field :amendable, !Decidim::Proposals::ProposalType, "The original amended resource (currently, a proposal only)"
+      field :emendation, !Decidim::Proposals::ProposalType, "The emendation (currently, a proposal only)"
+    end
+  end
+end

--- a/decidim-core/app/types/decidim/core/amendment_type.rb
+++ b/decidim-core/app/types/decidim/core/amendment_type.rb
@@ -6,6 +6,7 @@ module Decidim
       name "Amendment"
       description "An amendment"
 
+      field :id, !types.ID, "The id of this amendment"
       field :state, !types.String, "The status of this amendment"
       field :amender, !Decidim::Core::AuthorInterface, "The author of this amendment"
 

--- a/decidim-core/app/types/decidim/core/fingerprint_type.rb
+++ b/decidim-core/app/types/decidim/core/fingerprint_type.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Core
+    FingerprintType = GraphQL::ObjectType.define do
+      name "Fingerprint"
+      description "A fingerprint object"
+
+      field :value, !types.String, "The the hash value for the fingerprint"
+      field :source, !types.String do
+        description "Returns the source String (usually a json) from which the fingerprint is generated."
+      end
+    end
+  end
+end

--- a/decidim-core/app/types/decidim/core/trace_version_type.rb
+++ b/decidim-core/app/types/decidim/core/trace_version_type.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Core
+    TraceVersionType = GraphQL::ObjectType.define do
+      name "TraceVersion"
+      description "A trace version type"
+
+      field :id, !types.ID, "The ID of the version"
+      field :createdAt, Decidim::Core::DateTimeType do
+        description "The date and time this version was created"
+        property :created_at
+      end
+      field :editor, !Decidim::Core::AuthorInterface do
+        description "The editor/author of this version"
+        resolve ->(obj, _args, _ctx) {
+          Decidim.traceability.version_editor(obj)
+        }
+      end
+      field :changeset, GraphQL::Types::JSON do
+        description "Object with the changes in this version"
+        resolve ->(obj, _args, _ctx) {
+          obj.changeset
+        }
+      end
+    end
+  end
+end

--- a/decidim-core/app/types/decidim/core/trace_version_type.rb
+++ b/decidim-core/app/types/decidim/core/trace_version_type.rb
@@ -11,7 +11,7 @@ module Decidim
         description "The date and time this version was created"
         property :created_at
       end
-      field :editor, !Decidim::Core::AuthorInterface do
+      field :editor, Decidim::Core::AuthorInterface do
         description "The editor/author of this version"
         resolve ->(obj, _args, _ctx) {
           Decidim.traceability.version_editor(obj)

--- a/decidim-core/app/types/decidim/core/trace_version_type.rb
+++ b/decidim-core/app/types/decidim/core/trace_version_type.rb
@@ -14,7 +14,8 @@ module Decidim
       field :editor, Decidim::Core::AuthorInterface do
         description "The editor/author of this version"
         resolve ->(obj, _args, _ctx) {
-          Decidim.traceability.version_editor(obj)
+          author = Decidim.traceability.version_editor(obj)
+          author if author.is_a?(Decidim::User) || author.is_a?(Decidim::UserGroup)
         }
       end
       field :changeset, GraphQL::Types::JSON do

--- a/decidim-core/lib/decidim/api/amendable_entity_interface.rb
+++ b/decidim-core/lib/decidim/api/amendable_entity_interface.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Core
+    # This interface should be implemented by any Type that can used as amendment
+    # The only requirement is to have an ID and the Type name be the class.name + Type
+    AmendableEntityInterface = GraphQL::InterfaceType.define do
+      name "AmendableEntityInterface"
+      description "An interface that can be used in objects with amendments"
+
+      field :id, !types.ID, "ID of this entity"
+
+      resolve_type ->(obj, _ctx) {
+        "#{obj.class.name}Type".constantize
+      }
+    end
+  end
+end

--- a/decidim-core/lib/decidim/api/amendable_entity_interface.rb
+++ b/decidim-core/lib/decidim/api/amendable_entity_interface.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module Core
-    # This interface should be implemented by any Type that can used as amendment
+    # This interface should be implemented by any Type that can be used as amendment
     # The only requirement is to have an ID and the Type name be the class.name + Type
     AmendableEntityInterface = GraphQL::InterfaceType.define do
       name "AmendableEntityInterface"

--- a/decidim-core/lib/decidim/api/amendable_interface.rb
+++ b/decidim-core/lib/decidim/api/amendable_interface.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Core
+    # This interface represents an amendable object.
+    AmendableInterface = GraphQL::InterfaceType.define do
+      name "AmendableInterface"
+      description "An interface that can be used in objects with amendments"
+
+      field :amendments, !types[Decidim::Core::AmendmentType] do
+        description "This object's amendments"
+        resolve lambda { |obj, _args, ctx|
+          obj.visible_amendments_for(ctx[:current_user])
+        }
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/api/attachable_interface.rb
+++ b/decidim-core/lib/decidim/api/attachable_interface.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module Core
-    # This interface represents a commentable object.
+    # This interface represents a attachable object.
     AttachableInterface = GraphQL::InterfaceType.define do
       name "AttachableInterface"
       description "An interface that can be used in objects with attachments"

--- a/decidim-core/lib/decidim/api/categorizable_interface.rb
+++ b/decidim-core/lib/decidim/api/categorizable_interface.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module Core
-    # This interface represents a commentable object.
+    # This interface represents a categorizable object.
     CategorizableInterface = GraphQL::InterfaceType.define do
       name "CategorizableInterface"
       description "An interface that can be used in categorizable objects."

--- a/decidim-core/lib/decidim/api/coauthorable_interface.rb
+++ b/decidim-core/lib/decidim/api/coauthorable_interface.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Core
+    # This interface represents a coauthorable object.
+    CoauthorableInterface = GraphQL::InterfaceType.define do
+      name "CoauthorableInterface"
+      description "An interface that can be used in coauthorable objects."
+
+      field :coAuthorsCount, types.Int do
+        description "The total amount of co-authors that contributed to the proposal. Note that this field may include also non-user authors like meetings or the organization"
+        property :coauthorships_count
+      end
+
+      field :author, Decidim::Core::AuthorInterface do
+        description "The resource author. Note that this can be null on official proposals or meeting-proposals"
+        resolve ->(resource, _, _) {
+          author = resource.creator_identity
+          author if author.is_a?(Decidim::User) || author.is_a?(Decidim::UserGroup)
+        }
+      end
+
+      field :authors, !types[Decidim::Core::AuthorInterface] do
+        description "The resource co-authors. Include only users or groups of users"
+        property :user_identities
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/api/coauthorable_interface.rb
+++ b/decidim-core/lib/decidim/api/coauthorable_interface.rb
@@ -7,7 +7,7 @@ module Decidim
       name "CoauthorableInterface"
       description "An interface that can be used in coauthorable objects."
 
-      field :coAuthorsCount, types.Int do
+      field :authorsCount, types.Int do
         description "The total amount of co-authors that contributed to the proposal. Note that this field may include also non-user authors like meetings or the organization"
         property :coauthorships_count
       end

--- a/decidim-core/lib/decidim/api/fingerprint_interface.rb
+++ b/decidim-core/lib/decidim/api/fingerprint_interface.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Core
+    # This interface represents a fingerprintable object.
+    FingerprintInterface = GraphQL::InterfaceType.define do
+      name "FingerprintInterface"
+      description "An interface that can be used in fingerprintable objects."
+
+      field :fingerprint, !Decidim::Core::FingerprintType, "This object's fingerprint"
+    end
+  end
+end

--- a/decidim-core/lib/decidim/api/scopable_interface.rb
+++ b/decidim-core/lib/decidim/api/scopable_interface.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module Core
-    # This interface represents a commentable object.
+    # This interface represents a scopable object.
     ScopableInterface = GraphQL::InterfaceType.define do
       name "ScopableInterface"
       description "An interface that can be used in scopable objects."

--- a/decidim-core/lib/decidim/api/traceable_interface.rb
+++ b/decidim-core/lib/decidim/api/traceable_interface.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Core
+    # This interface represents an traceable object.
+    TraceableInterface = GraphQL::InterfaceType.define do
+      name "TraceableInterface"
+      description "An interface that can be used in objects with traceability (versions)"
+
+      field :versionsCount, !types.Int, "Total number of versions", property: :versions_count
+      field :versions, !types[Decidim::Core::TraceVersionType], "This object's versions"
+    end
+  end
+end

--- a/decidim-core/lib/decidim/coauthorable.rb
+++ b/decidim-core/lib/decidim/coauthorable.rb
@@ -72,11 +72,18 @@ module Decidim
         coauthorships.where(author: author).exists?
       end
 
-      # Returns the identities for the authors, whether they are user groups or users.
+      # Returns the identities for the authors, whether they are user groups, users or others.
       #
-      # Returns an Array of User and/or UserGroups.
+      # Returns an Array of User, UserGroups or any other entity capable object (such as Organization).
       def identities
         coauthorships.order(:created_at).collect(&:identity)
+      end
+
+      # Returns the identities for the authors, only if they are user groups or users.
+      #
+      # Returns an Array of User and/or UserGroups.
+      def user_identities
+        coauthorships.where(decidim_author_type: "Decidim::UserBaseEntity").order(:created_at).collect(&:identity)
       end
 
       # Syntactic sugar to access first coauthor as a Coauthorship.

--- a/decidim-core/lib/decidim/core/api.rb
+++ b/decidim-core/lib/decidim/core/api.rb
@@ -13,6 +13,7 @@ module Decidim
     autoload :HashtagInterface, "decidim/api/hashtag_interface"
     autoload :FingerprintInterface, "decidim/api/fingerprint_interface"
     autoload :AmendableInterface, "decidim/api/amendable_interface"
+    autoload :AmendableEntityInterface, "decidim/api/amendable_entity_interface"
     autoload :TraceableInterface, "decidim/api/traceable_interface"
   end
 end

--- a/decidim-core/lib/decidim/core/api.rb
+++ b/decidim-core/lib/decidim/core/api.rb
@@ -6,9 +6,13 @@ module Decidim
     autoload :ComponentInterface, "decidim/api/component_interface"
     autoload :AuthorInterface, "decidim/api/author_interface"
     autoload :AuthorableInterface, "decidim/api/authorable_interface"
+    autoload :CoauthorableInterface, "decidim/api/coauthorable_interface"
     autoload :CategorizableInterface, "decidim/api/categorizable_interface"
     autoload :ScopableInterface, "decidim/api/scopable_interface"
     autoload :AttachableInterface, "decidim/api/attachable_interface"
     autoload :HashtagInterface, "decidim/api/hashtag_interface"
+    autoload :FingerprintInterface, "decidim/api/fingerprint_interface"
+    autoload :AmendableInterface, "decidim/api/amendable_interface"
+    autoload :TraceableInterface, "decidim/api/traceable_interface"
   end
 end

--- a/decidim-core/lib/decidim/core/test/shared_examples/amendable_interface_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/amendable_interface_examples.rb
@@ -4,38 +4,11 @@ require "spec_helper"
 
 shared_examples_for "amendable interface" do
   describe "amendments" do
-    let(:query) { "{ amendments { state amendable { title } amendableType emendation { title } emendationType amender { name } } }" }
+    let(:query) { "{ amendments { id } }" }
 
-    it "includes the amendments states" do
-      amendments_states = response["amendments"].map { |amendment| amendment["state"] }
-      expect(amendments_states).to include(*model.amendments.map(&:state))
-    end
-
-    it "amendable types matches Proposals Type" do
-      response["amendments"].each do |amendment|
-        expect(amendment["amendableType"]).to eq("Decidim::Proposals::Proposal")
-      end
-    end
-
-    it "emendation types matches Proposals Type" do
-      response["amendments"].each do |amendment|
-        expect(amendment["emendationType"]).to eq("Decidim::Proposals::Proposal")
-      end
-    end
-
-    it "returns amendable as parent proposal" do
-      amendment_amendables = response["amendments"].map { |amendment| amendment["amendable"] }
-      expect(amendment_amendables).to include(*model.amendments.map(&:amendable).map { |p| { "title" => p.title } })
-    end
-
-    it "returns emendations received" do
-      amendment_emendations = response["amendments"].map { |amendment| amendment["emendation"] }
-      expect(amendment_emendations).to include(*model.amendments.map(&:emendation).map { |p| { "title" => p.title } })
-    end
-
-    it "returns amender as emendation author" do
-      amendment_amenders = response["amendments"].map { |amendment| amendment["amender"] }
-      expect(amendment_amenders).to include(*model.amendments.map(&:amender).map { |p| { "name" => p.name } })
+    it "includes the amendments id" do
+      amendments_ids = response["amendments"].map { |amendment| amendment["id"].to_i }
+      expect(amendments_ids).to include(*model.amendments.map(&:id))
     end
   end
 end

--- a/decidim-core/lib/decidim/core/test/shared_examples/amendable_interface_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/amendable_interface_examples.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+shared_examples_for "amendable interface" do
+  describe "amendments" do
+    let(:query) { "{ amendments { state amendable { title } amendableType emendation { title } emendationType amender { name } } }" }
+
+    it "includes the amendments states" do
+      amendments_states = response["amendments"].map { |amendment| amendment["state"] }
+      expect(amendments_states).to include(*model.amendments.map(&:state))
+    end
+
+    it "amendable types matches Proposals Type" do
+      response["amendments"].each do |amendment|
+        expect(amendment["amendableType"]).to eq("Decidim::Proposals::Proposal")
+      end
+    end
+
+    it "emendation types matches Proposals Type" do
+      response["amendments"].each do |amendment|
+        expect(amendment["emendationType"]).to eq("Decidim::Proposals::Proposal")
+      end
+    end
+
+    it "returns amendable as parent proposal" do
+      amendment_amendables = response["amendments"].map { |amendment| amendment["amendable"] }
+      expect(amendment_amendables).to include(*model.amendments.map(&:amendable).map { |p| { "title" => p.title } })
+    end
+
+    it "returns emendations received" do
+      amendment_emendations = response["amendments"].map { |amendment| amendment["emendation"] }
+      expect(amendment_emendations).to include(*model.amendments.map(&:emendation).map { |p| { "title" => p.title } })
+    end
+
+    it "returns amender as emendation author" do
+      amendment_amenders = response["amendments"].map { |amendment| amendment["amender"] }
+      expect(amendment_amenders).to include(*model.amendments.map(&:amender).map { |p| { "name" => p.name } })
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core/test/shared_examples/amendable_proposals_interface_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/amendable_proposals_interface_examples.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+shared_examples_for "amendable proposals interface" do
+  describe "amendments" do
+    let(:query) do
+      "{ amendments {
+      state
+      amendable { ...on Proposal { title } }
+      amendableType
+      emendation { ...on Proposal { title } }
+      emendationType
+      amender { name }
+    } }"
+    end
+
+    it "includes the amendments states" do
+      amendments_states = response["amendments"].map { |amendment| amendment["state"] }
+      expect(amendments_states).to include(*model.amendments.map(&:state))
+    end
+
+    it "amendable types matches Proposals Type" do
+      response["amendments"].each do |amendment|
+        expect(amendment["amendableType"]).to eq("Decidim::Proposals::Proposal")
+      end
+    end
+
+    it "emendation types matches Proposals Type" do
+      response["amendments"].each do |amendment|
+        expect(amendment["emendationType"]).to eq("Decidim::Proposals::Proposal")
+      end
+    end
+
+    it "returns amendable as parent proposal" do
+      amendment_amendables = response["amendments"].map { |amendment| amendment["amendable"] }
+      expect(amendment_amendables).to include(*model.amendments.map(&:amendable).map { |p| { "title" => p.title } })
+    end
+
+    it "returns emendations received" do
+      amendment_emendations = response["amendments"].map { |amendment| amendment["emendation"] }
+      expect(amendment_emendations).to include(*model.amendments.map(&:emendation).map { |p| { "title" => p.title } })
+    end
+
+    it "returns amender as emendation author" do
+      amendment_amenders = response["amendments"].map { |amendment| amendment["amender"] }
+      expect(amendment_amenders).to include(*model.amendments.map(&:amender).map { |p| { "name" => p.name } })
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core/test/shared_examples/coauthorable_interface_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/coauthorable_interface_examples.rb
@@ -27,5 +27,65 @@ shared_examples_for "coauthorable interface" do
         expect(response["author"]["name"]).to eq(user_group.name)
       end
     end
+
+    describe "with a several coauthors" do
+      let(:query) { "{ author { name } authors { name } authorsCount }" }
+      let(:coauthor) { create(:user, :confirmed, organization: model.participatory_space.organization) }
+
+      before do
+        model.add_coauthor coauthor
+        model.save!
+      end
+
+      context "when both are users" do
+        it "returns 2 total co-authors" do
+          expect(response["authorsCount"]).to eq(2)
+        end
+
+        it "returns an array of authors" do
+          expect(response["authors"].count).to eq(2)
+          expect(response["authors"]).to include("name" => author.name)
+          expect(response["authors"]).to include("name" => coauthor.name)
+        end
+
+        it "returns a main author" do
+          expect(response["author"]["name"]).to eq(author.name)
+        end
+      end
+
+      context "when author is the organization" do
+        let(:model) { create(:proposal, :official, component: component) }
+
+        it "returns 2 total co-authors" do
+          expect(response["authorsCount"]).to eq(2)
+        end
+
+        it "returns 1 author in authors array" do
+          expect(response["authors"].count).to eq(1)
+          expect(response["authors"]).to include("name" => coauthor.name)
+        end
+
+        it "do not return a main author" do
+          expect(response["author"]).to eq(nil)
+        end
+      end
+
+      context "when author is a meeting" do
+        let(:model) { create(:proposal, :official_meeting, component: component) }
+
+        it "returns 2 total co-authors" do
+          expect(response["authorsCount"]).to eq(2)
+        end
+
+        it "returns 1 author in authors array" do
+          expect(response["authors"].count).to eq(1)
+          expect(response["authors"]).to include("name" => coauthor.name)
+        end
+
+        it "do not return a main author" do
+          expect(response["author"]).to eq(nil)
+        end
+      end
+    end
   end
 end

--- a/decidim-core/lib/decidim/core/test/shared_examples/fingerprintable_interface_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/fingerprintable_interface_examples.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+shared_examples_for "fingerprintable interface" do
+  describe "fingerprint" do
+    let(:query) { "{ fingerprint { value source } }" }
+
+    it "returns the fingerprint value" do
+      expect(response["fingerprint"]["value"]).to eq(model.fingerprint.value)
+    end
+
+    it "returns the fingerprint source" do
+      expect(response["fingerprint"]["source"]).to eq(model.fingerprint.source)
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core/test/shared_examples/traceable_interface_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/traceable_interface_examples.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+shared_examples_for "traceable interface" do
+  describe "traceable", versioning: true do
+    before do
+      Decidim.traceability.update!(model, model.creator_identity, title: "test")
+    end
+
+    context "when field createdAt" do
+      let(:query) { "{ versions { createdAt } }" }
+
+      it "returns created_at field of the version to iso format" do
+        dates = response["versions"].map { |version| version["createdAt"] }
+        expect(dates).to include(*model.versions.map { |version| version.created_at.to_time.iso8601 })
+      end
+    end
+
+    context "when field id" do
+      let(:query) { "{ versions { id } }" }
+
+      it "returns ID field of the version" do
+        ids = response["versions"].map { |version| version["id"].to_i }
+        expect(ids).to include(*model.versions.map(&:id))
+      end
+    end
+
+    context "when field editor" do
+      let(:query) { "{ versions { editor { name } } }" }
+
+      it "returns editor field of the versions" do
+        editors = response["versions"].map { |version| version["editor"]["name"] if version["editor"] }
+        expect(editors).to include(*model.versions.map { |version| version.editor.name if version.respond_to? :editor })
+      end
+    end
+
+    context "when field changeset" do
+      let(:query) { "{ versions { changeset } }" }
+
+      it "returns changeset field of the versions" do
+        changesets = response["versions"].map { |version| version["changeset"] }
+        expect(changesets).to include(*model.versions.map(&:changeset))
+      end
+    end
+  end
+end

--- a/decidim-core/spec/types/amendment_type_spec.rb
+++ b/decidim-core/spec/types/amendment_type_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/api/test/type_context"
+
+module Decidim
+  module Core
+    describe AmendmentType do
+      include_context "with a graphql type"
+
+      let(:model) do
+        double(
+          state: "some_status",
+          decidim_amendable_type: "type1",
+          decidim_emendation_type: "type2",
+          amender: user,
+          amendable: amendable,
+          emendation: emendation
+        )
+      end
+      let(:user) { create(:user) }
+      let(:amendable) { create(:proposal) }
+      let(:emendation) { create(:proposal) }
+
+      describe "amender" do
+        let(:query) { "{ amender { name } }" }
+
+        it "returns the user" do
+          expect(response["amender"]["name"]).to eq(user.name)
+        end
+      end
+
+      describe "state" do
+        let(:query) { "{ state }" }
+
+        it "returns the status as a string" do
+          expect(response["state"]).to eq("some_status")
+        end
+      end
+
+      describe "amendableType" do
+        let(:query) { "{ amendableType }" }
+
+        it "returns the amendableType as a string" do
+          expect(response["amendableType"]).to eq("type1")
+        end
+      end
+
+      describe "emendationType" do
+        let(:query) { "{ emendationType }" }
+
+        it "returns the emendationType as a string" do
+          expect(response["emendationType"]).to eq("type2")
+        end
+      end
+
+      describe "emendation" do
+        let(:query) { "{ emendation { title } }" }
+
+        it "returns the emendation as a string" do
+          expect(response["emendation"]["title"]).to eq(emendation.title)
+        end
+      end
+
+      describe "amendable" do
+        let(:query) { "{ amendable { title } }" }
+
+        it "returns the amendable as a string" do
+          expect(response["amendable"]["title"]).to eq(amendable.title)
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/types/amendment_type_spec.rb
+++ b/decidim-core/spec/types/amendment_type_spec.rb
@@ -10,6 +10,7 @@ module Decidim
 
       let(:model) do
         double(
+          id: 1101,
           state: "some_status",
           decidim_amendable_type: "type1",
           decidim_emendation_type: "type2",
@@ -21,6 +22,14 @@ module Decidim
       let(:user) { create(:user) }
       let(:amendable) { create(:proposal) }
       let(:emendation) { create(:proposal) }
+
+      describe "id" do
+        let(:query) { "{ id }" }
+
+        it "returns the user" do
+          expect(response["id"]).to eq(model.id.to_s)
+        end
+      end
 
       describe "amender" do
         let(:query) { "{ amender { name } }" }
@@ -55,7 +64,7 @@ module Decidim
       end
 
       describe "emendation" do
-        let(:query) { "{ emendation { title } }" }
+        let(:query) { "{ emendation { ...on Proposal { title } } }" }
 
         it "returns the emendation as a string" do
           expect(response["emendation"]["title"]).to eq(emendation.title)
@@ -63,7 +72,7 @@ module Decidim
       end
 
       describe "amendable" do
-        let(:query) { "{ amendable { title } }" }
+        let(:query) { "{ amendable { ...on Proposal { title } } }" }
 
         it "returns the amendable as a string" do
           expect(response["amendable"]["title"]).to eq(amendable.title)

--- a/decidim-core/spec/types/fingerprint_type_spec.rb
+++ b/decidim-core/spec/types/fingerprint_type_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/api/test/type_context"
+
+module Decidim
+  module Core
+    describe FingerprintType do
+      include_context "with a graphql type"
+
+      let(:model) do
+        double(
+          value: "some_value",
+          source: { "test" => "test object" }
+        )
+      end
+
+      describe "value" do
+        let(:query) { "{ value }" }
+
+        it "returns value as a string" do
+          expect(response["value"]).to eq("some_value")
+        end
+      end
+
+      describe "source" do
+        let(:query) { "{ source }" }
+
+        it "returns source as a string" do
+          expect(response["source"]).to eq("{\"test\"=>\"test object\"}")
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/types/trace_version_type_spec.rb
+++ b/decidim-core/spec/types/trace_version_type_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/api/test/type_context"
+
+module Decidim
+  module Core
+    describe TraceVersionType do
+      include_context "with a graphql type"
+
+      let(:user) { create(:user) }
+      let(:change) do
+        {
+          "test" => "test object"
+        }
+      end
+      let(:model) do
+        double(
+          created_at: Time.new(2018, 2, 22, 9, 47, 0, "+01:00"),
+          id: 1,
+          whodunnit: user,
+          changeset: change
+        )
+      end
+
+      describe "id" do
+        let(:query) { "{ id }" }
+
+        it "returns a string" do
+          expect(response["id"]).to eq("1")
+        end
+      end
+
+      describe "created_at" do
+        let(:query) { "{ createdAt }" }
+
+        it "returns the formatted date" do
+          expect(response["createdAt"]).to eq("2018-02-22T09:47:00+01:00")
+        end
+      end
+
+      describe "editor" do
+        let(:query) { "{ editor { name } }" }
+
+        context "when last editor is a user" do
+          it "returns the user" do
+            expect(response["editor"]["name"]).to eq(user.name)
+          end
+        end
+
+        context "when last editor is a string" do
+          let(:user) { "test suite" }
+
+          it "returns nil" do
+            expect(response["editor"]).to eq(nil)
+          end
+        end
+      end
+
+      describe "changeset" do
+        let(:query) { "{ changeset }" }
+
+        it "returns a Json object" do
+          expect(response["changeset"]).to eq("test" => "test object")
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/types/decidim/proposals/proposal_type.rb
+++ b/decidim-proposals/app/types/decidim/proposals/proposal_type.rb
@@ -8,22 +8,62 @@ module Decidim
 
       interfaces [
         -> { Decidim::Comments::CommentableInterface },
-        -> { Decidim::Core::AuthorableInterface },
+        # -> { Decidim::Core::AuthorableInterface }, # to remove
+        -> { Decidim::Core::CoauthorableInterface },
         -> { Decidim::Core::CategorizableInterface },
         -> { Decidim::Core::ScopableInterface },
-        -> { Decidim::Core::AttachableInterface }
+        -> { Decidim::Core::AttachableInterface },
+        -> { Decidim::Core::FingerprintInterface },
+        -> { Decidim::Core::AmendableInterface },
+        -> { Decidim::Core::TraceableInterface }
       ]
 
       field :id, !types.ID
       field :title, !types.String, "This proposal's title"
       field :body, types.String, "This proposal's body"
-      field :state, types.String, "The state in which proposal is in"
       field :address, types.String, "The physical address (location) of this proposal"
-      field :reference, types.String, "This proposa'ls unique reference"
+      field :coordinates, Decidim::Core::CoordinatesType, "Physical coordinates for this proposal" do
+        resolve ->(proposal, _args, _ctx) {
+          [proposal.latitude, proposal.longitude]
+        }
+      end
+      field :reference, types.String, "This proposal's unique reference"
+      field :state, types.String, "The answer status in which proposal is in"
+      field :answer, Decidim::Core::TranslatedFieldType, "The answer feedback for the status for this proposal"
+
+      field :createdAt, Decidim::Core::DateTimeType do
+        description "The date and time this proposal was created"
+        property :created_at
+      end
+
+      field :upatedAt, Decidim::Core::DateTimeType do
+        description "The date and time this proposal was upated"
+        property :upated_at
+      end
+
+      field :answeredAt, Decidim::Core::DateTimeType do
+        description "The date and time this proposal was answered"
+        property :answered_at
+      end
 
       field :publishedAt, Decidim::Core::DateTimeType do
         description "The date and time this proposal was published"
         property :published_at
+      end
+
+      field :participatoryTextLevel, types.String do
+        description "If it is a participatory text, the level indicates the type of paragraph"
+        property :participatory_text_level
+      end
+      field :position, types.Int, "Position of this proposal in the participatory text"
+
+      field :official, types.Boolean, "Whether this proposal is official or not", property: :official?
+      field :createdInMeeting, types.Boolean, "Whether this proposal comes from a meeting or not", property: :official_meeting?
+      field :meeting, Decidim::Meetings::MeetingType do
+        description "If the proposal comes from a meeting, the related meeting"
+        resolve ->(proposal, _, _) {
+          proposal.authors.first if proposal.official_meeting?
+        }
       end
 
       field :endorsements, !types[Decidim::Core::AuthorInterface], "The endorsements of this proposal." do

--- a/decidim-proposals/app/types/decidim/proposals/proposal_type.rb
+++ b/decidim-proposals/app/types/decidim/proposals/proposal_type.rb
@@ -35,9 +35,9 @@ module Decidim
         property :created_at
       end
 
-      field :upatedAt, Decidim::Core::DateTimeType do
+      field :updatedAt, Decidim::Core::DateTimeType do
         description "The date and time this proposal was upated"
-        property :upated_at
+        property :updated_at
       end
 
       field :answeredAt, Decidim::Core::DateTimeType do

--- a/decidim-proposals/app/types/decidim/proposals/proposal_type.rb
+++ b/decidim-proposals/app/types/decidim/proposals/proposal_type.rb
@@ -14,6 +14,7 @@ module Decidim
         -> { Decidim::Core::AttachableInterface },
         -> { Decidim::Core::FingerprintInterface },
         -> { Decidim::Core::AmendableInterface },
+        -> { Decidim::Core::AmendableEntityInterface },
         -> { Decidim::Core::TraceableInterface }
       ]
 

--- a/decidim-proposals/app/types/decidim/proposals/proposal_type.rb
+++ b/decidim-proposals/app/types/decidim/proposals/proposal_type.rb
@@ -8,7 +8,6 @@ module Decidim
 
       interfaces [
         -> { Decidim::Comments::CommentableInterface },
-        # -> { Decidim::Core::AuthorableInterface }, # to remove
         -> { Decidim::Core::CoauthorableInterface },
         -> { Decidim::Core::CategorizableInterface },
         -> { Decidim::Core::ScopableInterface },

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -360,7 +360,7 @@ FactoryBot.define do
     author { build(:user, organization: proposal.organization) }
   end
 
-  factory :proposal_amendment, class: "Decidim::Core::Amendment" do
+  factory :proposal_amendment, class: "Decidim::Amendment" do
     amendable { build(:proposal) }
     emendation { build(:proposal, component: amendable.component) }
     amender { build(:user, organization: amendable.component.participatory_space.organization) }

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -342,6 +342,12 @@ FactoryBot.define do
         create_list(:proposal_endorsement, 5, proposal: proposal)
       end
     end
+
+    trait :with_amendments do
+      after :create do |proposal|
+        create_list(:proposal_amendment, 5, amendable: proposal)
+      end
+    end
   end
 
   factory :proposal_vote, class: "Decidim::Proposals::ProposalVote" do
@@ -352,6 +358,13 @@ FactoryBot.define do
   factory :proposal_endorsement, class: "Decidim::Proposals::ProposalEndorsement" do
     proposal { build(:proposal) }
     author { build(:user, organization: proposal.organization) }
+  end
+
+  factory :proposal_amendment, class: "Decidim::Core::Amendment" do
+    amendable { build(:proposal) }
+    emendation { build(:proposal, component: amendable.component) }
+    amender { build(:user, organization: amendable.component.participatory_space.organization) }
+    state { Decidim::Amendment::STATES.sample }
   end
 
   factory :user_group_proposal_endorsement, class: "Decidim::Proposals::ProposalEndorsement" do

--- a/decidim-proposals/spec/types/proposal_type_spec.rb
+++ b/decidim-proposals/spec/types/proposal_type_spec.rb
@@ -5,19 +5,22 @@ require "decidim/api/test/type_context"
 require "decidim/core/test/shared_examples/categorizable_interface_examples"
 require "decidim/core/test/shared_examples/scopable_interface_examples"
 require "decidim/core/test/shared_examples/attachable_interface_examples"
+require "decidim/core/test/shared_examples/authorable_interface_examples"
 require "decidim/core/test/shared_examples/coauthorable_interface_examples"
+require "decidim/core/test/shared_examples/amendable_interface_examples"
 
 module Decidim
   module Proposals
     describe ProposalType, type: :graphql do
       include_context "with a graphql type"
       let(:component) { create(:proposal_component) }
-      let(:model) { create(:proposal, :with_votes, :with_endorsements, component: component) }
+      let(:model) { create(:proposal, :with_votes, :with_endorsements, :with_amendments, component: component) }
 
       include_examples "categorizable interface"
       include_examples "scopable interface"
       include_examples "attachable interface"
       include_examples "coauthorable interface"
+      include_examples "amendable interface"
 
       describe "id" do
         let(:query) { "{ id }" }

--- a/decidim-proposals/spec/types/proposal_type_spec.rb
+++ b/decidim-proposals/spec/types/proposal_type_spec.rb
@@ -9,6 +9,7 @@ require "decidim/core/test/shared_examples/authorable_interface_examples"
 require "decidim/core/test/shared_examples/coauthorable_interface_examples"
 require "decidim/core/test/shared_examples/fingerprintable_interface_examples"
 require "decidim/core/test/shared_examples/amendable_interface_examples"
+require "decidim/core/test/shared_examples/amendable_proposals_interface_examples"
 require "decidim/core/test/shared_examples/traceable_interface_examples"
 
 module Decidim
@@ -24,6 +25,7 @@ module Decidim
       include_examples "coauthorable interface"
       include_examples "fingerprintable interface"
       include_examples "amendable interface"
+      include_examples "amendable proposals interface"
       include_examples "traceable interface"
 
       describe "id" do

--- a/decidim-proposals/spec/types/proposal_type_spec.rb
+++ b/decidim-proposals/spec/types/proposal_type_spec.rb
@@ -7,7 +7,9 @@ require "decidim/core/test/shared_examples/scopable_interface_examples"
 require "decidim/core/test/shared_examples/attachable_interface_examples"
 require "decidim/core/test/shared_examples/authorable_interface_examples"
 require "decidim/core/test/shared_examples/coauthorable_interface_examples"
+require "decidim/core/test/shared_examples/fingerprintable_interface_examples"
 require "decidim/core/test/shared_examples/amendable_interface_examples"
+require "decidim/core/test/shared_examples/traceable_interface_examples"
 
 module Decidim
   module Proposals
@@ -20,7 +22,9 @@ module Decidim
       include_examples "scopable interface"
       include_examples "attachable interface"
       include_examples "coauthorable interface"
+      include_examples "fingerprintable interface"
       include_examples "amendable interface"
+      include_examples "traceable interface"
 
       describe "id" do
         let(:query) { "{ id }" }
@@ -81,6 +85,46 @@ module Decidim
         end
       end
 
+      context "when is answered" do
+        before do
+          model.answer = { en: "Some answer" }
+          model.answered_at = Time.current
+          model.save!
+        end
+
+        describe "answer" do
+          let(:query) { '{ answer { translation(locale:"en") } }' }
+
+          it "returns the proposal's answer" do
+            expect(response["answer"]["translation"]).to eq(model.answer["en"])
+          end
+        end
+
+        describe "answeredAt" do
+          let(:query) { "{ answeredAt }" }
+
+          it "returns when was this query answered at" do
+            expect(response["answeredAt"]).to eq(model.answered_at.to_time.iso8601)
+          end
+        end
+      end
+
+      describe "createdAt" do
+        let(:query) { "{ createdAt }" }
+
+        it "returns when was this query created at" do
+          expect(response["createdAt"]).to eq(model.created_at.to_time.iso8601)
+        end
+      end
+
+      describe "updatedAt" do
+        let(:query) { "{ updatedAt }" }
+
+        it "returns when was this query updated at" do
+          expect(response["updatedAt"]).to eq(model.updated_at.to_time.iso8601)
+        end
+      end
+
       describe "publishedAt" do
         let(:query) { "{ publishedAt }" }
 
@@ -94,6 +138,56 @@ module Decidim
 
         it "returns the address of this proposal" do
           expect(response["address"]).to eq(model.address)
+        end
+      end
+
+      describe "coordinates" do
+        let(:query) { "{ coordinates { latitude longitude } }" }
+
+        before do
+          model.latitude = 2
+          model.longitude = 40
+          model.save!
+        end
+
+        it "returns the meeting's address" do
+          expect(response["coordinates"]).to include(
+            "latitude" => model.latitude,
+            "longitude" => model.longitude
+          )
+        end
+      end
+
+      describe "participatory_text_level" do
+        let(:query) { "{ participatoryTextLevel }" }
+
+        it "returns the participatory_text_level of this proposal" do
+          expect(response["participatoryTextLevel"]).to eq(model.participatory_text_level)
+        end
+      end
+
+      describe "position" do
+        let(:query) { "{ position }" }
+
+        it "returns the position of this proposal" do
+          expect(response["position"]).to eq(model.position)
+        end
+      end
+
+      describe "created_in_meeting" do
+        let(:query) { "{ createdInMeeting }" }
+
+        it "returns the created_in_meeting of this proposal" do
+          expect(response["createdInMeeting"]).to eq(model.created_in_meeting)
+        end
+      end
+
+      describe "meeting" do
+        let(:query) { '{ meeting { title { translation(locale:"en") } } }' }
+        let(:model) { create(:proposal, :official_meeting, component: component) }
+
+        it "returns the meeting of this proposal" do
+          expect(response["meeting"]["title"]["translation"]).to eq(model.authors.first.title["en"])
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR completes the specification for proposals (public fields) in the Graphql API.
More PR related to components are coming, to facilitate reviews we will try to send each one with a reasonable amount of changes only.

Added:
- amendments
- versions (traceability)
- fingerprint
- coauthors
- some missing fields (like latitude/longitude)

#### :pushpin: Related Issues
- Related to #2623 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [x] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
![imatge](https://user-images.githubusercontent.com/1401520/69942992-453e5280-14e5-11ea-9849-c7def1987609.png)
