### PR TITLE
Enforce singular group endorsements even with different users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Decidim::Blogs::Post.find_each(&:add_to_index_as_search_resource)
 - **decidim-core**: Fix: Search box on mobile (menu) [#5502](https://github.com/decidim/decidim/pull/5502)
 - **decidim-core**: Fix dynamic controller extensions (undefined method `current_user`) [#5533](https://github.com/decidim/decidim/pull/5533)
 - **decidim-proposals**: Standardize proposal answer callout styles [#5530](https://github.com/decidim/decidim/pull/5530)
+- **decidim-proposals**: Enforce singular group endorsements even with different users [#5579](https://github.com/decidim/decidim/pull/5579)
 
 **Removed**:
 

--- a/decidim-proposals/app/commands/decidim/proposals/endorse_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/endorse_proposal.rb
@@ -19,9 +19,12 @@ module Decidim
       #
       # - :ok when everything is valid, together with the proposal vote.
       # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if someone in the same user group already endorsed
       #
       # Returns nothing.
       def call
+        return broadcast(:invalid) if existing_group_endorsement?
+
         endorsement = build_proposal_endorsement
         if endorsement.save
           notify_endorser_followers
@@ -32,6 +35,10 @@ module Decidim
       end
 
       private
+
+      def existing_group_endorsement?
+        @current_group_id.present? && @proposal.endorsements.exists?(decidim_user_group_id: @current_group_id)
+      end
 
       def build_proposal_endorsement
         endorsement = @proposal.endorsements.build(author: @current_user)

--- a/decidim-proposals/db/migrate/20191217053731_remove_duplicate_group_endorsements.rb
+++ b/decidim-proposals/db/migrate/20191217053731_remove_duplicate_group_endorsements.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class RemoveDuplicateGroupEndorsements < ActiveRecord::Migration[5.2]
+  def change
+    valid_group_endorsements = Decidim::Proposals::ProposalEndorsement.select(
+      "MIN(id) as id, decidim_user_group_id"
+    ).group(:decidim_user_group_id).where.not(decidim_user_group_id: nil)
+
+    duplicates = Decidim::Proposals::ProposalEndorsement.where(
+      "id NOT IN (?) AND decidim_user_group_id IS NOT NULL", valid_group_endorsements.map(&:id)
+    )
+
+    duplicates.destroy_all
+  end
+end

--- a/decidim-proposals/spec/commands/decidim/proposals/endorse_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/endorse_proposal_spec.rb
@@ -77,6 +77,26 @@ module Decidim
           end
         end
 
+        context "when someone from the same organization had already endorsed" do
+          let(:user_group) { create(:user_group, verified_at: Time.current, users: [current_user, another_user]) }
+          let(:another_user) { create(:user, organization: proposal.component.organization) }
+          let(:command) { described_class.new(proposal, current_user, user_group.id) }
+
+          before do
+            described_class.new(proposal, another_user, user_group.id).call
+          end
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+
+          it "does not increase the endorsements counter" do
+            expect do
+              command.call
+            end.not_to change(ProposalEndorsement, :count)
+          end
+        end
+
         context "when the endorsement is not valid" do
           before do
             proposal.update(answered_at: Time.current, state: "rejected")

--- a/decidim-proposals/spec/migrations/remove_duplicate_group_endorsements_spec.rb
+++ b/decidim-proposals/spec/migrations/remove_duplicate_group_endorsements_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../../db/migrate/20191217053731_remove_duplicate_group_endorsements"
+
+describe RemoveDuplicateGroupEndorsements do
+  let!(:organization) { create(:organization) }
+  let!(:component) { create(:component, organization: organization, manifest_name: "proposals") }
+  let!(:participatory_process) { create(:participatory_process, organization: organization) }
+
+  let!(:author) { create(:user, organization: organization) }
+  let!(:another_author) { create(:user, organization: organization) }
+
+  let!(:individual_author) { create(:user, organization: organization) }
+  let!(:another_individual_author) { create(:user, organization: organization) }
+
+  let!(:user_group) { create(:user_group, verified_at: Time.current, organization: organization, users: [author, another_author]) }
+
+  let!(:proposal) { create(:proposal, component: component, users: [author]) }
+
+  let!(:group_endorsement) do
+    create(:proposal_endorsement, proposal: proposal, author: author,
+                                  user_group: user_group)
+  end
+
+  let!(:duplicate_group_endorsement) do
+    create(:proposal_endorsement, proposal: proposal, author: another_author,
+                                  user_group: user_group)
+  end
+
+  let!(:personal_endorsement) do
+    create(:proposal_endorsement, proposal: proposal, author: individual_author)
+  end
+
+  let!(:another_personal_endorsement) do
+    create(:proposal_endorsement, proposal: proposal, author: another_individual_author)
+  end
+
+  it "removes duplicate group endorsements, leaving the first one" do
+    RemoveDuplicateGroupEndorsements.new.change
+
+    expect(Decidim::Proposals::ProposalEndorsement.where(id: group_endorsement.id)).to exist
+    expect(Decidim::Proposals::ProposalEndorsement.where(id: duplicate_group_endorsement.id)).not_to exist
+  end
+
+  it "does not remove personal endorsements" do
+    RemoveDuplicateGroupEndorsements.new.change
+
+    expect(Decidim::Proposals::ProposalEndorsement.where(id: personal_endorsement.id)).to exist
+    expect(Decidim::Proposals::ProposalEndorsement.where(id: another_personal_endorsement.id)).to exist
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

When two users from the same user group endorsed the same proposal, two endorsements were created, whereas only one should be valid.

#### :pushpin: Related Issues
- Fixes #5406 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add migration to remove any pre-existing duplicate group endorsements