### PR TITLE
Docs: fix install instructions on conferences

### DIFF
--- a/decidim-conferences/README.md
+++ b/decidim-conferences/README.md
@@ -27,6 +27,8 @@ And then execute:
 
 ```bash
 bundle
+bundle exec rails decidim_conferences:install:migrations
+bundle exec rails db:migrate
 ```
 
 ## Contributing


### PR DESCRIPTION
#### :tophat: What? Why?
Add migrations missing steps on module installation
 
#### :clipboard: Subtasks
N/A 
(Too small for making even a CHANGELOG entry IMHO) 
 