### PR TITLE
Listen on all network interfaces when running in Docker

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -67,7 +67,7 @@ Then create a development application
 ```console
 d/bundle install
 d/rake development_app
-d/rails server
+d/rails server -b 0.0.0.0
 ```
 
 In general, to use the docker development environment, change any instruction in


### PR DESCRIPTION
#### :tophat: What? Why?
When starting decidim using the Docker setup, the server listens on 127.0.0.1 by default. This leads to connection reset errors when trying to access the application from outside the container, using http://localhost:3000 in a Browser. To fix this, tell the rails server to listen on all network interfaces (0.0.0.0) instead of just the loopback interface (127.0.0.1) when running in Docker.

#### :pushpin: Related Issues

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry (not necessary I think? This is just a documentation change)
- [x] Adapted "getting started with Docker" documentation

