### PR TITLE
Proposals: allow admins to set a predefined template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now sup
 - **decidim-core**: Add docs in how to fix metrics problems. [\#5587](https://github.com/decidim/decidim/pull/5587)
 - **decidim-core**: Data portability now supports AWS S3 storage. [\#5342](https://github.com/decidim/decidim/pull/5342)
 - **decidim-system**: Permit customizing omniauth settings for each tenant [#5516](https://github.com/decidim/decidim/pull/5516)
-**decidim-proposals**: Allow admins to set a predefined template [\#5613](https://github.com/decidim/decidim/pull/5613)
+- **decidim-proposals**: Allow admins to set a predefined template [\#5613](https://github.com/decidim/decidim/pull/5613)
 
 **Changed**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now sup
 - **decidim-core**: Add docs in how to fix metrics problems. [\#5587](https://github.com/decidim/decidim/pull/5587)
 - **decidim-core**: Data portability now supports AWS S3 storage. [\#5342](https://github.com/decidim/decidim/pull/5342)
 - **decidim-system**: Permit customizing omniauth settings for each tenant [#5516](https://github.com/decidim/decidim/pull/5516)
+**decidim-proposals**: Allow admins to set a predefined template [\#5613](https://github.com/decidim/decidim/pull/5613)
 
 **Changed**:
 

--- a/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
@@ -26,9 +26,14 @@ module Decidim
         if name == :amendments_visibility
           amendments_visibility_form_field(form, options)
         elsif attribute.translated?
-          form.send(:translated, form_method_for_attribute(attribute), name, options.merge(tabs_id: "#{options[:tabs_prefix]}-#{name}-tabs"))
+          form_method = form_method_for_attribute(attribute)
+          tab_options = { tabs_id: "#{options[:tabs_prefix]}-#{name}-tabs" }
+          extra_options = tab_options.merge(extra_options_for_type(form_method))
+          form.send(:translated, form_method, name, options.merge(extra_options))
         else
-          form.send(form_method_for_attribute(attribute), name, options.merge(extra_options_for(name)))
+          form_method = form_method_for_attribute(attribute)
+          extra_options = extra_options_for(name).merge(extra_options_for_type(form_method))
+          form.send(form_method, name, options.merge(extra_options))
         end
       end
 
@@ -73,6 +78,17 @@ module Decidim
             :amendment_reaction_enabled,
             :amendment_promotion_enabled
           amendments_extra_options
+        else
+          {}
+        end
+      end
+
+      # Handles special cases.
+      # Returns an empty Hash or a Hash with extra HTML options.
+      def extra_options_for_type(input_type)
+        case input_type
+        when :text_area
+          { rows: 6 }
         else
           {}
         end

--- a/decidim-admin/app/views/decidim/admin/components/_settings_fields.html.erb
+++ b/decidim-admin/app/views/decidim/admin/components/_settings_fields.html.erb
@@ -1,4 +1,5 @@
 <% manifest.settings(settings_name).attributes.each do |field_name, settings_attribute| %>
+<% # byebug if field_name == :new_proposal_template_text %>
   <%= settings_attribute_input(
     form,
     settings_attribute,

--- a/decidim-admin/app/views/decidim/admin/components/_settings_fields.html.erb
+++ b/decidim-admin/app/views/decidim/admin/components/_settings_fields.html.erb
@@ -1,5 +1,4 @@
 <% manifest.settings(settings_name).attributes.each do |field_name, settings_attribute| %>
-<% # byebug if field_name == :new_proposal_template_text %>
   <%= settings_attribute_input(
     form,
     settings_attribute,

--- a/decidim-admin/spec/helpers/settings_helper_spec.rb
+++ b/decidim-admin/spec/helpers/settings_helper_spec.rb
@@ -47,6 +47,7 @@ module Decidim
 
       describe "texts" do
         let(:type) { :text }
+        let(:options) { { rows: 6 } }
 
         it "is supported" do
           expect(form).to receive(:text_area).with(:test, options)

--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -65,7 +65,7 @@ module Decidim
         if proposal_draft.present?
           redirect_to edit_draft_proposal_path(proposal_draft, component_id: proposal_draft.component.id, question_slug: proposal_draft.component.participatory_space.slug)
         else
-          @form = form(ProposalWizardCreateStepForm).from_params(body: translated_proposal_template_text)
+          @form = form(ProposalWizardCreateStepForm).from_params(body: translated_proposal_body_template)
         end
       end
 
@@ -272,12 +272,12 @@ module Decidim
         @participatory_text = Decidim::Proposals::ParticipatoryText.find_by(component: current_component)
       end
 
-      def translated_proposal_template_text
-        translated_attribute component_settings.new_proposal_template_text
+      def translated_proposal_body_template
+        translated_attribute component_settings.new_proposal_body_template
       end
 
       def proposal_creation_params
-        params[:proposal].merge(body_template: translated_proposal_template_text)
+        params[:proposal].merge(body_template: translated_proposal_body_template)
       end
     end
   end

--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -65,14 +65,14 @@ module Decidim
         if proposal_draft.present?
           redirect_to edit_draft_proposal_path(proposal_draft, component_id: proposal_draft.component.id, question_slug: proposal_draft.component.participatory_space.slug)
         else
-          @form = form(ProposalWizardCreateStepForm).from_params({})
+          @form = form(ProposalWizardCreateStepForm).from_params(body: translated_proposal_template_text)
         end
       end
 
       def create
         enforce_permission_to :create, :proposal
         @step = :step_1
-        @form = form(ProposalWizardCreateStepForm).from_params(params)
+        @form = form(ProposalWizardCreateStepForm).from_params(proposal_creation_params)
 
         CreateProposal.call(@form, current_user) do
           on(:ok) do |proposal|
@@ -270,6 +270,14 @@ module Decidim
 
       def set_participatory_text
         @participatory_text = Decidim::Proposals::ParticipatoryText.find_by(component: current_component)
+      end
+
+      def translated_proposal_template_text
+        translated_attribute component_settings.new_proposal_template_text
+      end
+
+      def proposal_creation_params
+        params[:proposal].merge(body_template: translated_proposal_template_text)
       end
     end
   end

--- a/decidim-proposals/app/forms/decidim/proposals/proposal_wizard_create_step_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/proposal_wizard_create_step_form.rb
@@ -8,12 +8,14 @@ module Decidim
 
       attribute :title, String
       attribute :body, String
+      attribute :body_template, String
       attribute :user_group_id, Integer
 
       validates :title, :body, presence: true, etiquette: true
       validates :title, length: { maximum: 150 }
 
       validate :proposal_length
+      validate :body_is_not_bare_template
 
       alias component current_component
 
@@ -31,6 +33,12 @@ module Decidim
 
         length = current_component.settings.proposal_length
         errors.add(:body, :too_long, count: length) if body.length > length
+      end
+
+      def body_is_not_bare_template
+        return if body_template.blank?
+
+        errors.add(:body, :cant_be_equal_to_template) if body.presence == body_template.presence
       end
     end
   end

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -43,6 +43,7 @@ en:
             attachment:
               needs_to_be_reattached: Needs to be reattached
             body:
+              cant_be_equal_to_template: cannot be equal to the template
               identical: AND title cannot be identical
             title:
               identical: AND body cannot be identical
@@ -97,6 +98,7 @@ en:
             geocoding_enabled: Geocoding enabled
             minimum_votes_per_user: Minimum supports per user
             new_proposal_help_text: New proposal help text
+            new_proposal_template_text: New proposal template text
             official_proposals_enabled: Official proposals enabled
             participatory_texts_disabled_help: Cannot interact with this setting if there are existing proposals. Please, create a new `Proposals component` if you want to enable this feature or discard all imported proposals in the `Participatory Texts` menu if you want to disable it.
             participatory_texts_enabled: Participatory texts enabled

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -97,9 +97,9 @@ en:
             comments_enabled: Comments enabled
             geocoding_enabled: Geocoding enabled
             minimum_votes_per_user: Minimum supports per user
+            new_proposal_body_template: New proposal body template
+            new_proposal_body_template_help: You can define prefilled text that the new Proposals will have
             new_proposal_help_text: New proposal help text
-            new_proposal_template_text: New proposal body template
-            new_proposal_template_text_help: You can define prefilled text that the new Proposals will have
             official_proposals_enabled: Official proposals enabled
             participatory_texts_disabled_help: Cannot interact with this setting if there are existing proposals. Please, create a new `Proposals component` if you want to enable this feature or discard all imported proposals in the `Participatory Texts` menu if you want to disable it.
             participatory_texts_enabled: Participatory texts enabled

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -98,7 +98,8 @@ en:
             geocoding_enabled: Geocoding enabled
             minimum_votes_per_user: Minimum supports per user
             new_proposal_help_text: New proposal help text
-            new_proposal_template_text: New proposal template text
+            new_proposal_template_text: New proposal body template
+            new_proposal_template_text_help: You can define prefilled text that the new Proposals will have
             official_proposals_enabled: Official proposals enabled
             participatory_texts_disabled_help: Cannot interact with this setting if there are existing proposals. Please, create a new `Proposals component` if you want to enable this feature or discard all imported proposals in the `Participatory Texts` menu if you want to disable it.
             participatory_texts_enabled: Participatory texts enabled

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -40,8 +40,8 @@ Decidim.register_component(:proposals) do |component|
     settings.attribute :amendments_enabled, type: :boolean, default: false
     settings.attribute :amendments_wizard_help_text, type: :text, translated: true, editor: true, required: false
     settings.attribute :announcement, type: :text, translated: true, editor: true
+    settings.attribute :new_proposal_body_template, type: :text, translated: true, editor: false, required: false
     settings.attribute :new_proposal_help_text, type: :text, translated: true, editor: true
-    settings.attribute :new_proposal_template_text, type: :text, translated: true, editor: false, required: false
     settings.attribute :proposal_wizard_step_1_help_text, type: :text, translated: true, editor: true
     settings.attribute :proposal_wizard_step_2_help_text, type: :text, translated: true, editor: true
     settings.attribute :proposal_wizard_step_3_help_text, type: :text, translated: true, editor: true

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -41,6 +41,7 @@ Decidim.register_component(:proposals) do |component|
     settings.attribute :amendments_wizard_help_text, type: :text, translated: true, editor: true, required: false
     settings.attribute :announcement, type: :text, translated: true, editor: true
     settings.attribute :new_proposal_help_text, type: :text, translated: true, editor: true
+    settings.attribute :new_proposal_template_text, type: :text, translated: true, editor: false, required: false
     settings.attribute :proposal_wizard_step_1_help_text, type: :text, translated: true, editor: true
     settings.attribute :proposal_wizard_step_2_help_text, type: :text, translated: true, editor: true
     settings.attribute :proposal_wizard_step_3_help_text, type: :text, translated: true, editor: true

--- a/decidim-proposals/spec/controllers/decidim/proposals_controller_spec.rb
+++ b/decidim-proposals/spec/controllers/decidim/proposals_controller_spec.rb
@@ -9,11 +9,12 @@ module Decidim
 
       let(:user) { create(:user, :confirmed, organization: component.organization) }
 
-      let(:params) do
+      let(:proposal_params) do
         {
           component_id: component.id
         }
       end
+      let(:params) { { proposal: proposal_params } }
 
       before do
         request.env["decidim.current_organization"] = component.organization
@@ -97,12 +98,16 @@ module Decidim
 
         context "when creation is enabled" do
           let(:component) { create(:proposal_component, :with_creation_enabled) }
-
-          it "creates a proposal" do
-            post :create, params: params.merge(
+          let(:proposal_params) do
+            {
+              component_id: component.id,
               title: "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
               body: "Ut sed dolor vitae purus volutpat venenatis. Donec sit amet sagittis sapien. Curabitur rhoncus ullamcorper feugiat. Aliquam et magna metus."
-            )
+            }
+          end
+
+          it "creates a proposal" do
+            post :create, params: params
 
             expect(flash[:notice]).not_to be_empty
             expect(response).to have_http_status(:found)

--- a/decidim-proposals/spec/forms/decidim/proposals/proposal_wizard_create_step_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/proposal_wizard_create_step_form_spec.rb
@@ -11,6 +11,7 @@ module Decidim
         {
           title: title,
           body: body,
+          body_template: body_template,
           user_group_id: user_group.id
         }
       end
@@ -20,6 +21,7 @@ module Decidim
       let(:component) { create(:proposal_component, participatory_space: participatory_space) }
       let(:title) { "More sidewalks and less roads" }
       let(:body) { "Cities need more people, not more cars" }
+      let(:body_template) { nil }
       let(:author) { create(:user, organization: organization) }
       let(:user_group) { create(:user_group, :verified, users: [author], organization: organization) }
 
@@ -57,6 +59,18 @@ module Decidim
         let(:body) { "A body longer than the permitted" }
 
         it { is_expected.to be_invalid }
+      end
+
+      context "when there's a body template set" do
+        let(:body_template) { "This is the template" }
+
+        it { is_expected.to be_valid }
+
+        context "when the template and the body are the same" do
+          let(:body) { body_template }
+
+          it { is_expected.to be_invalid }
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR allows admins to set a predefined template for proposals. It also improves the appearance of translated, non-editor text areas in component settings forms, as they were appearing in a single row. I set it to 6 rows in height to make them appear the same as editor text areas.

#### :pushpin: Related Issues
- Fixes #5601

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
When trying to create a proposal without modifying the template:
![image](https://user-images.githubusercontent.com/491891/72057803-48d8ac80-32cf-11ea-9e21-4687589d2871.png)

Updated appearance of translated, non-editor text areas in component settings form:
![image](https://user-images.githubusercontent.com/491891/72057873-6d348900-32cf-11ea-950d-e678d68e49a5.png)

