### PR TITLE
Follow a meeting on registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Upgrade notes**:
 
 **Added**:
+**decidim-meetings**: Follow a meeting on registration [\#5615](https://github.com/decidim/decidim/pull/5615)
 
 **Changed**:
 

--- a/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
@@ -33,6 +33,7 @@ module Decidim
           notify_admin_over_percentage
           increment_score
         end
+        follow_meeting
         broadcast(:ok)
       end
 
@@ -104,6 +105,16 @@ module Decidim
 
       def increment_score
         Decidim::Gamification.increment_score(user, :attended_meetings)
+      end
+
+      def follow_meeting
+        Decidim::CreateFollow.call(follow_form, user)
+      end
+
+      def follow_form
+        Decidim::FollowForm
+          .from_params(followable_gid: meeting.to_signed_global_id.to_s)
+          .with_context(current_user: user)
       end
 
       def occupied_slots_over?(percentage)

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -412,7 +412,7 @@ en:
       registrations:
         create:
           invalid: There was a problem joining this meeting.
-          success: You have joined the meeting successfully.
+          success: You have joined the meeting successfully. Because you have registered for this meeting, you'll be notified if there are updates on it.
         decline_invitation:
           invalid: There was a problem declining the invitation.
           success: You have declined the invitation successfully.

--- a/decidim-meetings/spec/commands/join_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/join_meeting_spec.rb
@@ -87,7 +87,11 @@ module Decidim::Meetings
         expect { subject.call }.to change { Decidim::Gamification.status_for(user, :attended_meetings).score }.from(0).to(1)
       end
 
-      context "and exists and invite for the user" do
+      it "makes the user follow the meeting" do
+        expect { subject.call }.to change { Decidim::Follow.where(user: user, followable: meeting).count }.from(0).to(1)
+      end
+
+      context "and exists an invite for the user" do
         let!(:invite) { create(:invite, meeting: meeting, user: user) }
 
         it "marks the invite as accepted" do

--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -142,7 +142,7 @@ describe "Meeting registrations", type: :system do
         end
 
         context "and they ARE NOT part of a verified user group" do
-          it "they can join the meeting" do
+          it "they can join the meeting and automatically follow it" do
             visit_meeting
 
             within ".card.extra" do
@@ -158,6 +158,7 @@ describe "Meeting registrations", type: :system do
 
             expect(page).to have_css(".button", text: "GOING")
             expect(page).to have_text("19 slots remaining")
+            expect(page).to have_text("Stop following")
           end
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?
This Pr makes a user follow a meeting when they register to it.

#### :pushpin: Related Issues
- Related to #?
- Fixes #5604

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/491891/72064771-df5f9a80-32dc-11ea-9455-c50e2537cab4.png)

