### PR TITLE
Fix/collapse floating helper block on init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now sup
 
 - **decidim-verifications**: Fix: Missing method email_regexp [#5560](https://github.com/decidim/decidim/pull/5560)
 - **decidim-core**: Fix: use incrementing date when rebuilding since one date. [\#5541](https://github.com/decidim/decidim/pull/5541)
+- **decidim-core**: Fix: Collapse floating-helper-block element on access to processes index screen [\#5626](https://github.com/decidim/decidim/pull/5626)
 
 **Removed**:
 

--- a/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
@@ -98,6 +98,7 @@ Decidim.register_participatory_space(:assemblies) do |participatory_space|
       ) do
         Decidim::Assembly.create!(params)
       end
+      assembly.add_to_index_as_search_resource
 
       # Create users with specific roles
       Decidim::AssemblyUserRole::ROLES.each do |role|

--- a/decidim-core/app/views/decidim/shared/_floating_help.html.erb
+++ b/decidim-core/app/views/decidim/shared/_floating_help.html.erb
@@ -1,7 +1,7 @@
 <div class="floating-helper-container" data-help-id="floating-help-<%= id %>">
-  <div class="floating-helper" id="floating-helper-tip" data-toggler=".hide">
+  <div class="floating-helper hide" id="floating-helper-tip" data-toggler=".hide">
     <div class="floating-helper__layout">
-      <div class="floating-helper__trigger" data-toggle="floating-helper-block floating-helper-tip">
+      <div class="floating-helper__trigger" data-toggle="floating-helper-block floating-helper-tip" data-target="collapse">
         <div class="floating-helper__text">
           <%= t ".help" %>
         </div>
@@ -12,7 +12,7 @@
     </div>
   </div>
 
-  <div id="floating-helper-block" class="floating-helper__wrapper row column hide" data-toggler=".hide">
+  <div id="floating-helper-block" class="floating-helper__wrapper row column collapse" data-toggler=".hide">
     <div class="floating-helper__content">
       <div class="floating-helper__content-inner">
         <div class="floating-helper__icon-big show-for-medium">


### PR DESCRIPTION
#### :tophat: What? Why?

Fix: Collapse floating-helper-block element on access to processes index screen