### PR TITLE
Core: Use SMTP env vars on seeds, if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now sup
 - **decidim-accountability**, **decidim-admin**, **decidim-budgets**, **decidim-core**, **decidim-debates**, **decidim-generators**, **decidim-meetings**, **decidim-proposals**, **decidim_app-design**: Change: Extend the capabilities of the Quill text editor. [\#5488](https://github.com/decidim/decidim/pull/5488)
 - **decidim-core**: Add docs in how to fix metrics problems. [\#5587](https://github.com/decidim/decidim/pull/5587)
 - **decidim-core**: Data portability now supports AWS S3 storage. [\#5342](https://github.com/decidim/decidim/pull/5342)
+- **decidim-core**: Use SMTP ENV variables on seeds, if present [\#5627](https://github.com/decidim/decidim/pull/5627)
 
 **Changed**:
 

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -24,11 +24,11 @@ if !Rails.env.production? || ENV["SEED"]
     youtube_handler: Faker::Hipster.word,
     github_handler: Faker::Hipster.word,
     smtp_settings: {
-      from: Faker::Internet.email,
-      user_name: Faker::Twitter.unique.screen_name,
-      encrypted_password: Decidim::AttributeEncryptor.encrypt(Faker::Internet.password(8)),
-      address: ENV["DECIDIM_HOST"] || "localhost",
-      port: ENV["DECIDIM_SMTP_PORT"] || "25"
+      from: ENV["EMAIL"] || Faker::Internet.email,
+      user_name: ENV["SMTP_USERNAME"] || Faker::Twitter.unique.screen_name,
+      encrypted_password: Decidim::AttributeEncryptor.encrypt(ENV["SMTP_PASSWORD"] || Faker::Internet.password(8)),
+      address: ENV["SMTP_ADDRESS"] || ENV["DECIDIM_HOST"] || "localhost",
+      port: ENV["SMTP_PORT"] || "25"
     },
     host: ENV["DECIDIM_HOST"] || "localhost",
     description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do


### PR DESCRIPTION
#### :tophat: What? Why?
This PR builds on top of #4698. 

In our case, when creating new Decidim installations sometimes we want to seed the database in production. Seeding requires being able to send some emails (on user registration). The changes from #4698 do not take into account the env variables, so this PR makes the seed process use those env variables when setting an organization, if they're present.

The changes would not affect development apps, and should not affect other installations since seeding in production is not a common thing, and the installations would only be affected if those env variables were actually set.

#### :pushpin: Related Issues
- Related to #4698

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

