### PR TITLE
Design for "EPIC: Improve the Comments component"

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_comments.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_comments.scss
@@ -11,30 +11,30 @@ $comment-form-bg: $light-gray;
 
 /* Comments */
 
-.comments {
+.comments{
   padding-top: 3rem;
 }
 
-.comment-thread {
+.comment-thread{
   @extend .card;
 }
 
-.comment-thread__title {
+.comment-thread__title{
   font-weight: normal;
   font-size: 90%;
   text-transform: none;
   color: $muted;
 }
 
-.comment__header {
+.comment__header{
   padding: $comment-padding;
   display: flex;
 }
 
-.comment__content {
+.comment__content{
   padding: 0 $comment-padding;
 
-  > :last-child {
+  > :last-child{
     margin-bottom: 0;
   }
 
@@ -46,6 +46,7 @@ $comment-form-bg: $light-gray;
 .comment__additionalreply{
   padding: $comment-padding;
   font-size: 90%;
+
   @include clearfix;
 }
 
@@ -63,11 +64,11 @@ $comment-form-bg: $light-gray;
   margin: $comment-padding;
   padding-bottom: 1px;
 
-  &.comment--nested--alt {
+  &.comment--nested--alt{
     background: $comment-nested-alt-bg;
   }
 
-  &:first-of-type {
+  &:first-of-type{
     margin-top: 0;
   }
 }
@@ -95,63 +96,59 @@ $comment-form-bg: $light-gray;
   }
 }
 
-.comment__votes {
+.comment__votes{
   float: right;
-<<<<<<< HEAD
   margin-top: .5rem;
-=======
-  margin-top: 0.5rem;
->>>>>>> e2b77fe26... Improved comments - design proposal
 }
 
-.comment__votes--up {
+.comment__votes--up{
   color: $muted;
 
-  .icon {
+  .icon{
     color: $comment-vote-up-color;
   }
 
   &:hover,
-  &.is-vote-selected {
+  &.is-vote-selected{
     color: darken($comment-vote-up-color, 10);
 
-    .icon {
+    .icon{
       color: inherit;
     }
   }
 
-  &.is-vote-notselected {
+  &.is-vote-notselected{
     color: $muted;
-    opacity: 0.3;
+    opacity: .3;
 
-    .icon {
+    .icon{
       color: inherit;
     }
   }
 }
 
-.comment__votes--down {
+.comment__votes--down{
   color: $muted;
-  padding-left: 0.3rem;
+  padding-left: .3rem;
 
-  .icon {
+  .icon{
     color: $comment-vote-down-color;
   }
 
   &:hover,
-  &.is-vote-selected {
+  &.is-vote-selected{
     color: darken($comment-vote-down-color, 10);
 
-    .icon {
+    .icon{
       color: inherit;
     }
   }
 
-  &.is-vote-notselected {
+  &.is-vote-notselected{
     color: $muted;
-    opacity: 0.3;
+    opacity: .3;
 
-    .icon {
+    .icon{
       color: inherit;
     }
   }
@@ -175,30 +172,31 @@ $comment-form-bg: $light-gray;
 
 /* Comment form */
 
-.comment__quote {
+.comment__quote{
   border-left-width: 6px;
   font-size: 80%;
-  background-color: rgba(0, 0, 0, 0.03);
+  background-color: rgba(0, 0, 0, .03);
   padding: 1rem;
   margin-bottom: 1rem;
-  > p:last-child {
+
+  > p:last-child{
     margin-bottom: 0;
   }
 }
 
-.add-comment {
+.add-comment{
   background: $comment-form-bg;
   padding: $comment-padding;
 
-  .button {
+  .button{
     margin-bottom: 0;
   }
 }
 
-.add-comment--reply {
+.add-comment--reply{
   display: none;
 
-  &.is-active {
+  &.is-active{
     display: block;
   }
 }

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_comments.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_comments.scss
@@ -11,30 +11,30 @@ $comment-form-bg: $light-gray;
 
 /* Comments */
 
-.comments{
+.comments {
   padding-top: 3rem;
 }
 
-.comment-thread{
+.comment-thread {
   @extend .card;
 }
 
-.comment-thread__title{
+.comment-thread__title {
   font-weight: normal;
   font-size: 90%;
   text-transform: none;
   color: $muted;
 }
 
-.comment__header{
+.comment__header {
   padding: $comment-padding;
   display: flex;
 }
 
-.comment__content{
+.comment__content {
   padding: 0 $comment-padding;
 
-  > :last-child{
+  > :last-child {
     margin-bottom: 0;
   }
 
@@ -46,7 +46,6 @@ $comment-form-bg: $light-gray;
 .comment__additionalreply{
   padding: $comment-padding;
   font-size: 90%;
-
   @include clearfix;
 }
 
@@ -64,11 +63,11 @@ $comment-form-bg: $light-gray;
   margin: $comment-padding;
   padding-bottom: 1px;
 
-  &.comment--nested--alt{
+  &.comment--nested--alt {
     background: $comment-nested-alt-bg;
   }
 
-  &:first-of-type{
+  &:first-of-type {
     margin-top: 0;
   }
 }
@@ -96,59 +95,63 @@ $comment-form-bg: $light-gray;
   }
 }
 
-.comment__votes{
+.comment__votes {
   float: right;
+<<<<<<< HEAD
   margin-top: .5rem;
+=======
+  margin-top: 0.5rem;
+>>>>>>> e2b77fe26... Improved comments - design proposal
 }
 
-.comment__votes--up{
+.comment__votes--up {
   color: $muted;
 
-  .icon{
+  .icon {
     color: $comment-vote-up-color;
   }
 
   &:hover,
-  &.is-vote-selected{
+  &.is-vote-selected {
     color: darken($comment-vote-up-color, 10);
 
-    .icon{
+    .icon {
       color: inherit;
     }
   }
 
-  &.is-vote-notselected{
+  &.is-vote-notselected {
     color: $muted;
-    opacity: .3;
+    opacity: 0.3;
 
-    .icon{
+    .icon {
       color: inherit;
     }
   }
 }
 
-.comment__votes--down{
+.comment__votes--down {
   color: $muted;
-  padding-left: .3rem;
+  padding-left: 0.3rem;
 
-  .icon{
+  .icon {
     color: $comment-vote-down-color;
   }
 
   &:hover,
-  &.is-vote-selected{
+  &.is-vote-selected {
     color: darken($comment-vote-down-color, 10);
 
-    .icon{
+    .icon {
       color: inherit;
     }
   }
 
-  &.is-vote-notselected{
+  &.is-vote-notselected {
     color: $muted;
-    opacity: .3;
+    opacity: 0.3;
 
-    .icon{
+    .icon {
       color: inherit;
     }
   }
@@ -172,19 +175,30 @@ $comment-form-bg: $light-gray;
 
 /* Comment form */
 
-.add-comment{
-  background: $comment-form-bg;
-  padding: $comment-padding;
-
-  .button{
+.comment__quote {
+  border-left-width: 6px;
+  font-size: 80%;
+  background-color: rgba(0, 0, 0, 0.03);
+  padding: 1rem;
+  margin-bottom: 1rem;
+  > p:last-child {
     margin-bottom: 0;
   }
 }
 
-.add-comment--reply{
+.add-comment {
+  background: $comment-form-bg;
+  padding: $comment-padding;
+
+  .button {
+    margin-bottom: 0;
+  }
+}
+
+.add-comment--reply {
   display: none;
 
-  &.is-active{
+  &.is-active {
     display: block;
   }
 }

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_layout.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_layout.scss
@@ -1,12 +1,12 @@
-.wrapper{
+.wrapper {
   padding: 1.2rem 1rem;
   position: relative;
 
-  @include breakpoint(medium){
+  @include breakpoint(medium) {
     padding: 5rem 1.5rem 3rem;
   }
 
-  @include breakpoint(large){
+  @include breakpoint(large) {
     padding-left: 4rem;
     padding-right: 4rem;
   }
@@ -31,44 +31,44 @@
 }
 
 //Flexbox sticky footer
-html{
+html {
   height: 100%;
 }
 
-body{
+body {
   display: flex;
   flex-direction: column;
   height: auto;
   min-height: 100%;
 
-  @include breakpoint(smallmedium down){
+  @include breakpoint(smallmedium down) {
     background-color: $dark-gray;
   }
 }
 
-.footer-separator{
+.footer-separator {
   flex-grow: 1;
 }
 
 //fixes for off-canvas wrappers
-.off-canvas-wrapper{
+.off-canvas-wrapper {
   background-color: $light-gray;
 }
 
 .off-canvas-wrapper,
 .off-canvas-wrapper-inner,
-.off-canvas-content{
+.off-canvas-content {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
 }
 
-.off-canvas{
+.off-canvas {
   background-color: $dark-gray;
 
-  .close-button{
+  .close-button {
     color: $light-gray;
-    padding: .2rem .5rem;
-    margin-right: -.5rem;
+    padding: 0.2rem 0.5rem;
+    margin-right: -0.5rem;
   }
 }

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_layout.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_layout.scss
@@ -1,12 +1,12 @@
-.wrapper {
+.wrapper{
   padding: 1.2rem 1rem;
   position: relative;
 
-  @include breakpoint(medium) {
+  @include breakpoint(medium){
     padding: 5rem 1.5rem 3rem;
   }
 
-  @include breakpoint(large) {
+  @include breakpoint(large){
     padding-left: 4rem;
     padding-right: 4rem;
   }
@@ -31,44 +31,44 @@
 }
 
 //Flexbox sticky footer
-html {
+html{
   height: 100%;
 }
 
-body {
+body{
   display: flex;
   flex-direction: column;
   height: auto;
   min-height: 100%;
 
-  @include breakpoint(smallmedium down) {
+  @include breakpoint(smallmedium down){
     background-color: $dark-gray;
   }
 }
 
-.footer-separator {
+.footer-separator{
   flex-grow: 1;
 }
 
 //fixes for off-canvas wrappers
-.off-canvas-wrapper {
+.off-canvas-wrapper{
   background-color: $light-gray;
 }
 
 .off-canvas-wrapper,
 .off-canvas-wrapper-inner,
-.off-canvas-content {
+.off-canvas-content{
   display: flex;
   flex-direction: column;
   flex-grow: 1;
 }
 
-.off-canvas {
+.off-canvas{
   background-color: $dark-gray;
 
-  .close-button {
+  .close-button{
     color: $light-gray;
-    padding: 0.2rem 0.5rem;
-    margin-right: -0.5rem;
+    padding: .2rem .5rem;
+    margin-right: -.5rem;
   }
 }

--- a/decidim_app-design/app/views/public/index.html.erb
+++ b/decidim_app-design/app/views/public/index.html.erb
@@ -70,7 +70,7 @@
         <h2 class="section-heading">Comments</h2>
         <ul>
           <li>
-            <%= link_to "Detalle de comentario", page_path("proposals/comment-view#single-comment") %>
+            <%= link_to "Detalle de comentario", page_path("proposals/comment-view") + "#single-comment" %>
           </li>
         </ul>
         <h2 class="section-heading">Amendments</h2>

--- a/decidim_app-design/app/views/public/index.html.erb
+++ b/decidim_app-design/app/views/public/index.html.erb
@@ -67,6 +67,12 @@
             </ul>
           </li>
         </ul>
+        <h2 class="section-heading">Comments</h2>
+        <ul>
+          <li>
+            <%= link_to "Detalle de comentario", page_path("proposals/comment-view") %>
+          </li>
+        </ul>
         <h2 class="section-heading">Amendments</h2>
         <ul>
           <li><%= link_to "Propuesta con botón de enmienda", page_path("amendments/proposal-view-with-amendment-button") %></li>

--- a/decidim_app-design/app/views/public/index.html.erb
+++ b/decidim_app-design/app/views/public/index.html.erb
@@ -70,7 +70,7 @@
         <h2 class="section-heading">Comments</h2>
         <ul>
           <li>
-            <%= link_to "Detalle de comentario", page_path("proposals/comment-view") %>
+            <%= link_to "Detalle de comentario", page_path("proposals/comment-view#single-comment") %>
           </li>
         </ul>
         <h2 class="section-heading">Amendments</h2>

--- a/decidim_app-design/app/views/public/partials/_comment-single.html.erb
+++ b/decidim_app-design/app/views/public/partials/_comment-single.html.erb
@@ -17,7 +17,7 @@
           </div>
           <div class="author-data__extra">
             <%= partial "flag_empty" %>
-            <a href="comment-view">
+            <a href="comment-view" title="Enlace permamente">
               <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
             </a>
           </div>

--- a/decidim_app-design/app/views/public/partials/_comment-single.html.erb
+++ b/decidim_app-design/app/views/public/partials/_comment-single.html.erb
@@ -1,5 +1,11 @@
-<section class="comments">
+<section class="comments" id="single-comment">
   <h4 class="section-heading">Detalle de comentario</h4>
+  <div class="callout primary">
+    <h5>Estás viendo un detalle de comentario</h5>
+    <p>
+      Puedes <a href="proposal-view">ver el resto de comentarios aquí</a>.
+    </p>
+  </div>
   <div class="comment-thread comment--pinned">
     <article class="comment">
       <div class="comment__header">
@@ -17,7 +23,7 @@
           </div>
           <div class="author-data__extra">
             <%= partial "flag_empty" %>
-            <a href="comment-view" title="Enlace permamente">
+            <a href="comment-view#single-comment" title="Enlace permamente">
               <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
             </a>
           </div>

--- a/decidim_app-design/app/views/public/partials/_comment-single.html.erb
+++ b/decidim_app-design/app/views/public/partials/_comment-single.html.erb
@@ -1,0 +1,53 @@
+<section class="comments">
+  <h4 class="section-heading">Detalle de comentario</h4>
+  <div class="comment-thread comment--pinned">
+    <article class="comment">
+      <div class="comment__header">
+        <div class="author-data">
+          <div class="author-data__main">
+            <div class="author author--inline">
+              <a href="#" class="author__avatar">
+                <%= image_tag "demo-avatar.jpg" %>
+              </a>
+              <a href="#" class="author__name">
+                Marc Serres
+              </a>
+              <time datetime="2016-08-01T19:47Z">1-08-2016 21:47</time>
+            </div>
+          </div>
+          <div class="author-data__extra">
+            <%= partial "flag_empty" %>
+            <a href="comment-view">
+              <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
+            </a>
+          </div>
+        </div>
+      </div>
+      <div class="comment__content">
+        <p>
+          <span class="success label">A favor</span>
+          Quan sento parlar de contaminació acústica, penso que no hi ha veïns
+          en tota la ciutat més perjudicats que nosaltres, els que vivim al Pg
+          de la Vall d'Hebron des del 198 al 208. Per no parlar de la
+          contaminació atmosfèrica, els tubs d'escapament dels vehicles gairabé
+          s'evacuarien directament al nostre menjador si no fos que mantenim les
+          finestres i terrasses tencades de manera permanent.</p>
+      </div>
+      <div class="comment__footer">
+        <a href="" class="comment__reply muted-link">
+          Ver comentario</a>
+        <div class="comment__votes">
+          <a href="" class="comment__votes--up is-vote-selected">
+            <%= icon "chevron-top", class: "icon--small", aria_label: "Votar a favor", role: "img" %>
+            257
+          </a>
+          <a href="" class="comment__votes--down is-vote-notselected">
+            <%= icon "chevron-bottom", class: "icon--small", aria_label: "Votar en contra", role: "img" %>
+            257
+          </a>
+        </div>
+      </div>
+
+    </article>
+  </div>
+</section>

--- a/decidim_app-design/app/views/public/partials/_comment-single.html.erb
+++ b/decidim_app-design/app/views/public/partials/_comment-single.html.erb
@@ -23,7 +23,7 @@
           </div>
           <div class="author-data__extra">
             <%= partial "flag_empty" %>
-            <a href="<%= page_path("proposals/comment-view")+'#single-comment' %>" title="Enlace permamente">
+            <a href="<%= page_path("proposals/comment-view") + "#single-comment" %>" title="Enlace permamente">
               <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
             </a>
           </div>

--- a/decidim_app-design/app/views/public/partials/_comment-single.html.erb
+++ b/decidim_app-design/app/views/public/partials/_comment-single.html.erb
@@ -23,7 +23,7 @@
           </div>
           <div class="author-data__extra">
             <%= partial "flag_empty" %>
-            <a href="comment-view#single-comment" title="Enlace permamente">
+            <a href="<%= page_path("proposals/comment-view")+'#single-comment' %>" title="Enlace permamente">
               <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
             </a>
           </div>

--- a/decidim_app-design/app/views/public/partials/_comments.html.erb
+++ b/decidim_app-design/app/views/public/partials/_comments.html.erb
@@ -17,7 +17,7 @@
           </div>
           <div class="author-data__extra">
             <%= partial "flag_empty" %>
-            <a href="comment-view" title="Enlace permamente">
+            <a href="comment-view#single-comment" title="Enlace permamente">
               <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
             </a>
           </div>
@@ -70,7 +70,7 @@
           </div>
           <div class="author-data__extra">
             <%= partial "flag_empty" %>
-            <a href="comment-view" title="Enlace permamente">
+            <a href="comment-view#single-comment" title="Enlace permamente">
               <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
             </a>
           </div>
@@ -133,7 +133,7 @@
           </div>
           <div class="author-data__extra">
             <%= partial "flag_empty" %>
-            <a href="comment-view" title="Enlace permamente">
+            <a href="comment-view#single-comment" title="Enlace permamente">
               <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
             </a>
           </div>
@@ -196,7 +196,7 @@
               </div>
               <div class="author-data__extra">
                 <%= partial "flag_empty" %>
-                <a href="comment-view" title="Enlace permamente">
+                <a href="comment-view#single-comment" title="Enlace permamente">
                   <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
                 </a>
               </div>
@@ -248,7 +248,7 @@
               </div>
               <div class="author-data__extra">
                 <%= partial "flag_empty" %>
-                <a href="comment-view" title="Enlace permamente">
+                <a href="comment-view#single-comment" title="Enlace permamente">
                   <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
                 </a>
               </div>
@@ -295,7 +295,7 @@
                 </div>
                 <div class="author-data__extra">
                   <%= partial "flag_empty" %>
-                  <a href="comment-view" title="Enlace permamente">
+                  <a href="comment-view#single-comment" title="Enlace permamente">
                     <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
                   </a>
                 </div>
@@ -342,7 +342,7 @@
               </div>
               <div class="author-data__extra">
                 <%= partial "flag_empty" %>
-                <a href="comment-view" title="Enlace permamente">
+                <a href="comment-view#single-comment" title="Enlace permamente">
                   <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
                 </a>
               </div>
@@ -388,7 +388,7 @@
                 </div>
                 <div class="author-data__extra">
                   <%= partial "flag_empty" %>
-                  <a href="comment-view" title="Enlace permamente">
+                  <a href="comment-view#single-comment" title="Enlace permamente">
                     <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
                   </a>
                 </div>

--- a/decidim_app-design/app/views/public/partials/_comments.html.erb
+++ b/decidim_app-design/app/views/public/partials/_comments.html.erb
@@ -157,10 +157,6 @@
             <%= icon "pencil", class: "icon--small", aria_label: "Responder", role: "img" %>
             Responder
           </button>
-          <button class="comment__reply muted-link" data-toggle="comment2-quote">
-            <%= icon "double-quote-serif-left", class: "icon--small", aria_label: "Citar", role: "img" %>
-            Citar
-          </button>
         </div>
 
         <div class="comment__votes">
@@ -180,15 +176,6 @@
           <label class="show-for-sr" for="add-comment-2">Resposta</label>
           <textarea id="add-comment-2"
             placeholder="Respon a aquest comentari"></textarea>
-          <input type="submit" class="button small hollow" value="Enviar">
-        </form>
-      </div>
-      <div class="add-comment add-comment--reply" id="comment2-quote"
-           data-toggler=".is-active">
-        <form>
-          <label class="show-for-sr" for="add-comment-2-q">Resposta</label>
-          <textarea id="add-comment-2-q" rows="4"
-            placeholder="Respon a aquest comentari">&gt;Treure l'àrea per a gossos de la platja de llevant i posar-la a una platja més centrica amb millor comunicació amb el transport públic i amb més espai.</textarea>
           <input type="submit" class="button small hollow" value="Enviar">
         </form>
       </div>

--- a/decidim_app-design/app/views/public/partials/_comments.html.erb
+++ b/decidim_app-design/app/views/public/partials/_comments.html.erb
@@ -88,7 +88,9 @@
       </div>
       <div class="comment__footer">
         <button class="comment__reply muted-link" data-toggle="comment1-reply">
-          Responder</button>
+          <%= icon "pencil", class: "icon--small", aria_label: "Responder", role: "img" %>
+          Responder
+        </button>
         <div class="comment__votes">
           <a href="" class="comment__votes--up is-vote-notselected">
             <%= icon "chevron-top", class: "icon--small", aria_label: "Votar a favor", role: "img" %>
@@ -145,9 +147,22 @@
           amb més espai.</p>
       </div>
       <div class="comment__footer">
-        <button class="comment__reply muted-link">
-          Responder
-        </button>
+        <div class="comment__actions">
+          <button id="comments-level-1-trigger" class="comment__reply muted-link" data-toggler=".comment__is-open" data-toggle="comments-level-1 comments-level-1-trigger comments-level-1-reply">
+            <%= icon "comment-square", class: "icon--small" %>
+            <span class="comment__text-is-closed">Mostrar 15 respuestas</span>
+            <span class="comment__text-is-open">Ocultar respuestas</span>
+          </button>
+          <button class="comment__reply muted-link" data-toggle="comment2-reply">
+            <%= icon "pencil", class: "icon--small", aria_label: "Responder", role: "img" %>
+            Responder
+          </button>
+          <button class="comment__reply muted-link" data-toggle="comment2-quote">
+            <%= icon "double-quote-serif-left", class: "icon--small", aria_label: "Citar", role: "img" %>
+            Citar
+          </button>
+        </div>
+
         <div class="comment__votes">
           <a href="" class="comment__votes--up">
             <%= icon "chevron-top", class: "icon--small", aria_label: "Votar a favor", role: "img" %>
@@ -159,99 +174,26 @@
           </a>
         </div>
       </div>
-      <article class="comment comment--highlight comment--nested">
-        <div class="comment__header">
-          <div class="author-data">
-            <div class="author-data__main">
-              <div class="author author--inline">
-                <a href="#" class="author__avatar">
-                  <%= image_tag "demo-avatar.jpg" %>
-                </a>
-                <a href="#" class="author__name">
-                  Ajuntament de Barcelona
-                </a>
-                <time datetime="2016-08-01T19:47Z">1-08-2016 21:47</time>
-              </div>
-            </div>
-            <div class="author-data__extra">
-              <%= partial "flag_empty" %>
-              <a href="comment-view">
-                <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
-              </a>
-            </div>
-          </div>
-        </div>
-        <div class="comment__content">
-          <p>Quan sento parlar de contaminació acústica, penso que no hi ha
-            veïns en tota la ciutat més perjudicats que nosaltres, els que vivim
-            al Pg de la Vall d'Hebron des del 198 al 208. Per no parlar de la
-            contaminació atmosfèrica, els tubs d'escapament dels vehicles
-            gairabé s'evacuarien directament al nostre menjador si no fos que
-            mantenim les finestres i terrasses tencades de manera permanent.</p>
-        </div>
-        <div class="comment__footer">
-          <button class="comment__reply muted-link">
-            Responder
-          </button>
-          <div class="comment__votes">
-            <a href="" class="comment__votes--up">
-              <%= icon "chevron-top", class: "icon--small", aria_label: "Votar a favor", role: "img" %>
-              257
-            </a>
-            <a href="" class="comment__votes--down">
-              <%= icon "chevron-bottom", class: "icon--small", aria_label: "Votar en contra", role: "img" %>
-              257
-            </a>
-          </div>
-        </div>
-      </article>
-      <article class="comment comment--nested">
-        <div class="comment__header">
-          <div class="author-data">
-            <div class="author-data__main">
-              <div class="author author--inline">
-                <a href="#" class="author__avatar">
-                  <%= image_tag "demo-avatar.jpg" %>
-                </a>
-                <a href="#" class="author__name">
-                  Joan Pèrez
-                </a>
-                <time datetime="2016-08-01T19:47Z">1-08-2016 21:47</time>
-              </div>
-            </div>
-            <div class="author-data__extra">
-              <%= partial "flag_empty" %>
-              <a href="comment-view">
-                <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
-              </a>
-            </div>
-          </div>
-        </div>
-        <div class="comment__content">
-          <p>Al meu entendre, en l'actualitat es requereix un ús provisional per
-            al solar d'Avinguda Piferrer (Gràcia). Per aquest motiu, considero
-            que provisionalment es podria oferir l'espai als memebres del Banc
-            Expropiat. Hem d'aturar aquest conflicte. L'institut Vallcarca es
-            absolutament necessàri, pero aquesta resposta immediata podria tenir
-            un fort impacte en la pau social del barri, sense representar una
-            demóra sustancial en la construcció de l'institut.</p>
-        </div>
-        <div class="comment__footer">
-          <button class="comment__reply muted-link">
-            Responder
-          </button>
-          <div class="comment__votes">
-            <a href="" class="comment__votes--up">
-              <%= icon "chevron-top", class: "icon--small", aria_label: "Votar a favor", role: "img" %>
-              257
-            </a>
-            <a href="" class="comment__votes--down">
-              <%= icon "chevron-bottom", class: "icon--small", aria_label: "Votar en contra", role: "img" %>
-              257
-            </a>
-          </div>
-        </div>
-        <article class="comment comment--nested comment--nested--alt">
+      <div class="add-comment add-comment--reply" id="comment2-reply"
+           data-toggler=".is-active">
+        <form>
+          <label class="show-for-sr" for="add-comment-2">Resposta</label>
+          <textarea id="add-comment-2"
+            placeholder="Respon a aquest comentari"></textarea>
+          <input type="submit" class="button small hollow" value="Enviar">
+        </form>
+      </div>
+      <div class="add-comment add-comment--reply" id="comment2-quote"
+           data-toggler=".is-active">
+        <form>
+          <label class="show-for-sr" for="add-comment-2-q">Resposta</label>
+          <textarea id="add-comment-2-q" rows="4"
+            placeholder="Respon a aquest comentari">&gt;Treure l'àrea per a gossos de la platja de llevant i posar-la a una platja més centrica amb millor comunicació amb el transport públic i amb més espai.</textarea>
+          <input type="submit" class="button small hollow" value="Enviar">
+        </form>
+      </div>
+      <div class="hide" id="comments-level-1" data-toggler=".hide">
+        <article class="comment comment--highlight comment--nested">
           <div class="comment__header">
             <div class="author-data">
               <div class="author-data__main">
@@ -260,98 +202,7 @@
                     <%= image_tag "demo-avatar.jpg" %>
                   </a>
                   <a href="#" class="author__name">
-                    Maria Garcia
-                  </a>
-                  <time datetime="2016-08-01T19:47Z">1-08-2016 21:47</time>
-                </div>
-              </div>
-              <div class="author-data__extra">
-                <%= partial "flag_empty" %>
-                <a href="comment-view">
-                  <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
-                </a>
-              </div>
-            </div>
-        </div>
-        <div class="comment__content">
-          <p>Quan sento parlar de contaminació acústica, penso que no hi ha veïns
-          en tota la ciutat més perjudicats que nosaltres, els que vivim al Pg
-          de la Vall d'Hebron des del 198 al 208. Per no parlar de la
-          contaminació atmosfèrica, els tubs d'escapament dels vehicles gairabé
-          s'evacuarien directament al nostre menjador si no fos que mantenim les
-          finestres i terrasses tencades de manera permanent.</p>
-        </div>
-        <div class="comment__footer">
-          <button class="comment__reply muted-link">
-            Responder
-          </button>
-          <div class="comment__votes">
-            <a href="" class="comment__votes--up">
-              <%= icon "chevron-top", class: "icon--small", aria_label: "Votar a favor", role: "img" %>
-              257
-            </a>
-            <a href="" class="comment__votes--down">
-              <%= icon "chevron-bottom", class: "icon--small", aria_label: "Votar en contra", role: "img" %>
-              257
-            </a>
-          </div>
-        </div>
-      </article>
-      <article class="comment comment--nested comment--nested--alt">
-        <div class="comment__header">
-          <div class="author-data">
-            <div class="author-data__main">
-              <div class="author author--inline">
-                <a href="#" class="author__avatar">
-                  <%= image_tag "demo-avatar.jpg" %>
-                </a>
-                <a href="#" class="author__name">
-                  Judith Asensi
-                </a>
-                <time datetime="2016-08-01T19:47Z">1-08-2016 21:47</time>
-              </div>
-            </div>
-            <div class="author-data__extra">
-              <%= partial "flag_empty" %>
-              <a href="comment-view">
-                <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
-              </a>
-            </div>
-          </div>
-        </div>
-        <div class="comment__content">
-          <p>Quan sento parlar de contaminació acústica, penso que no hi ha veïns
-          en tota la ciutat més perjudicats que nosaltres, els que vivim al Pg
-          de la Vall d'Hebron des del 198 al 208. Per no parlar de la
-          contaminació atmosfèrica, els tubs d'escapament dels vehicles gairabé
-          s'evacuarien directament al nostre menjador si no fos que mantenim les
-          finestres i terrasses tencades de manera permanent.</p>
-        </div>
-        <div class="comment__footer">
-          <button class="comment__reply muted-link">
-            Responder
-          </button>
-          <div class="comment__votes">
-            <a href="" class="comment__votes--up">
-              <%= icon "chevron-top", class: "icon--small", aria_label: "Votar a favor", role: "img" %>
-              257
-            </a>
-            <a href="" class="comment__votes--down">
-              <%= icon "chevron-bottom", class: "icon--small", aria_label: "Votar en contra", role: "img" %>
-              257
-            </a>
-          </div>
-        </div>
-        <article class="comment comment--nested">
-          <div class="comment__header">
-            <div class="author-data">
-              <div class="author-data__main">
-                <div class="author author--inline">
-                  <a href="#" class="author__avatar">
-                    <%= image_tag "demo-avatar.jpg" %>
-                  </a>
-                  <a href="#" class="author__name">
-                    Maria Garcia
+                    Ajuntament de Barcelona
                   </a>
                   <time datetime="2016-08-01T19:47Z">1-08-2016 21:47</time>
                 </div>
@@ -365,15 +216,21 @@
             </div>
           </div>
           <div class="comment__content">
+            <blockquote class="comment__quote">
+              <p>
+                Treure l'àrea per a gossos de la platja de llevant i posar-la a una platja més centrica amb millor comunicació amb el transport públic i amb més espai.
+              </p>
+            </blockquote>
             <p>Quan sento parlar de contaminació acústica, penso que no hi ha
-              veïns tota la ciutat més perjudicats que nosaltres, els que vivim
-              al Pg la Vall d'Hebron des del 198 al 208. Per no parlar de la
+              veïns en tota la ciutat més perjudicats que nosaltres, els que vivim
+              al Pg de la Vall d'Hebron des del 198 al 208. Per no parlar de la
               contaminació atmosfèrica, els tubs d'escapament dels vehicles
               gairabé s'evacuarien directament al nostre menjador si no fos que
               mantenim les finestres i terrasses tencades de manera permanent.</p>
           </div>
           <div class="comment__footer">
             <button class="comment__reply muted-link">
+              <%= icon "pencil", class: "icon--small", aria_label: "Responder", role: "img" %>
               Responder
             </button>
             <div class="comment__votes">
@@ -388,17 +245,206 @@
             </div>
           </div>
         </article>
-        <div class="show-more">
-          <button class="muted-link">
-            Ver más comentarios
-          </button>
-        </div>
+        <article class="comment comment--nested">
+          <div class="comment__header">
+            <div class="author-data">
+              <div class="author-data__main">
+                <div class="author author--inline">
+                  <a href="#" class="author__avatar">
+                    <%= image_tag "demo-avatar.jpg" %>
+                  </a>
+                  <a href="#" class="author__name">
+                    Joan Pèrez
+                  </a>
+                  <time datetime="2016-08-01T19:47Z">1-08-2016 21:47</time>
+                </div>
+              </div>
+              <div class="author-data__extra">
+                <%= partial "flag_empty" %>
+                <a href="comment-view">
+                  <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
+                </a>
+              </div>
+            </div>
+          </div>
+          <div class="comment__content">
+            <p>Al meu entendre, en l'actualitat es requereix un ús provisional per
+              al solar d'Avinguda Piferrer (Gràcia). Per aquest motiu, considero
+              que provisionalment es podria oferir l'espai als memebres del Banc
+              Expropiat. Hem d'aturar aquest conflicte. L'institut Vallcarca es
+              absolutament necessàri, pero aquesta resposta immediata podria tenir
+              un fort impacte en la pau social del barri, sense representar una
+              demóra sustancial en la construcció de l'institut.</p>
+          </div>
+          <div class="comment__footer">
+            <button class="comment__reply muted-link">
+              <%= icon "pencil", class: "icon--small", aria_label: "Responder", role: "img" %>
+              Responder
+            </button>
+            <div class="comment__votes">
+              <a href="" class="comment__votes--up">
+                <%= icon "chevron-top", class: "icon--small", aria_label: "Votar a favor", role: "img" %>
+                257
+              </a>
+              <a href="" class="comment__votes--down">
+                <%= icon "chevron-bottom", class: "icon--small", aria_label: "Votar en contra", role: "img" %>
+                257
+              </a>
+            </div>
+          </div>
+          <article class="comment comment--nested comment--nested--alt">
+            <div class="comment__header">
+              <div class="author-data">
+                <div class="author-data__main">
+                  <div class="author author--inline">
+                    <a href="#" class="author__avatar">
+                      <%= image_tag "demo-avatar.jpg" %>
+                    </a>
+                    <a href="#" class="author__name">
+                      Maria Garcia
+                    </a>
+                    <time datetime="2016-08-01T19:47Z">1-08-2016 21:47</time>
+                  </div>
+                </div>
+                <div class="author-data__extra">
+                  <%= partial "flag_empty" %>
+                  <a href="comment-view">
+                    <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
+                  </a>
+                </div>
+              </div>
+          </div>
+          <div class="comment__content">
+            <p>Quan sento parlar de contaminació acústica, penso que no hi ha veïns
+            en tota la ciutat més perjudicats que nosaltres, els que vivim al Pg
+            de la Vall d'Hebron des del 198 al 208. Per no parlar de la
+            contaminació atmosfèrica, els tubs d'escapament dels vehicles gairabé
+            s'evacuarien directament al nostre menjador si no fos que mantenim les
+            finestres i terrasses tencades de manera permanent.</p>
+          </div>
+          <div class="comment__footer">
+            <button class="comment__reply muted-link">
+              <%= icon "pencil", class: "icon--small", aria_label: "Responder", role: "img" %>
+              Responder
+            </button>
+            <div class="comment__votes">
+              <a href="" class="comment__votes--up">
+                <%= icon "chevron-top", class: "icon--small", aria_label: "Votar a favor", role: "img" %>
+                257
+              </a>
+              <a href="" class="comment__votes--down">
+                <%= icon "chevron-bottom", class: "icon--small", aria_label: "Votar en contra", role: "img" %>
+                257
+              </a>
+            </div>
+          </div>
+        </article>
+        <article class="comment comment--nested comment--nested--alt">
+          <div class="comment__header">
+            <div class="author-data">
+              <div class="author-data__main">
+                <div class="author author--inline">
+                  <a href="#" class="author__avatar">
+                    <%= image_tag "demo-avatar.jpg" %>
+                  </a>
+                  <a href="#" class="author__name">
+                    Judith Asensi
+                  </a>
+                  <time datetime="2016-08-01T19:47Z">1-08-2016 21:47</time>
+                </div>
+              </div>
+              <div class="author-data__extra">
+                <%= partial "flag_empty" %>
+                <a href="comment-view">
+                  <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
+                </a>
+              </div>
+            </div>
+          </div>
+          <div class="comment__content">
+            <p>Quan sento parlar de contaminació acústica, penso que no hi ha veïns
+            en tota la ciutat més perjudicats que nosaltres, els que vivim al Pg
+            de la Vall d'Hebron des del 198 al 208. Per no parlar de la
+            contaminació atmosfèrica, els tubs d'escapament dels vehicles gairabé
+            s'evacuarien directament al nostre menjador si no fos que mantenim les
+            finestres i terrasses tencades de manera permanent.</p>
+          </div>
+          <div class="comment__footer">
+            <button class="comment__reply muted-link">
+              <%= icon "pencil", class: "icon--small", aria_label: "Responder", role: "img" %>
+              Responder
+            </button>
+            <div class="comment__votes">
+              <a href="" class="comment__votes--up">
+                <%= icon "chevron-top", class: "icon--small", aria_label: "Votar a favor", role: "img" %>
+                257
+              </a>
+              <a href="" class="comment__votes--down">
+                <%= icon "chevron-bottom", class: "icon--small", aria_label: "Votar en contra", role: "img" %>
+                257
+              </a>
+            </div>
+          </div>
+          <article class="comment comment--nested">
+            <div class="comment__header">
+              <div class="author-data">
+                <div class="author-data__main">
+                  <div class="author author--inline">
+                    <a href="#" class="author__avatar">
+                      <%= image_tag "demo-avatar.jpg" %>
+                    </a>
+                    <a href="#" class="author__name">
+                      Maria Garcia
+                    </a>
+                    <time datetime="2016-08-01T19:47Z">1-08-2016 21:47</time>
+                  </div>
+                </div>
+                <div class="author-data__extra">
+                  <%= partial "flag_empty" %>
+                  <a href="comment-view">
+                    <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
+                  </a>
+                </div>
+              </div>
+            </div>
+            <div class="comment__content">
+              <p>Quan sento parlar de contaminació acústica, penso que no hi ha
+                veïns tota la ciutat més perjudicats que nosaltres, els que vivim
+                al Pg la Vall d'Hebron des del 198 al 208. Per no parlar de la
+                contaminació atmosfèrica, els tubs d'escapament dels vehicles
+                gairabé s'evacuarien directament al nostre menjador si no fos que
+                mantenim les finestres i terrasses tencades de manera permanent.</p>
+            </div>
+            <div class="comment__footer">
+              <button class="comment__reply muted-link">
+                <%= icon "pencil", class: "icon--small", aria_label: "Responder", role: "img" %>
+                Responder
+              </button>
+              <div class="comment__votes">
+                <a href="" class="comment__votes--up">
+                  <%= icon "chevron-top", class: "icon--small", aria_label: "Votar a favor", role: "img" %>
+                  257
+                </a>
+                <a href="" class="comment__votes--down">
+                  <%= icon "chevron-bottom", class: "icon--small", aria_label: "Votar en contra", role: "img" %>
+                  257
+                </a>
+              </div>
+            </div>
+          </article>
+          <div class="show-more">
+            <button class="muted-link">
+              Ver más comentarios
+            </button>
+          </div>
+        </article>
       </article>
-    </article>
-    <div class="comment__additionalreply">
-      <a href="" class="comment__reply muted-link">
+    </div>
+    <div id="comments-level-1-reply" data-toggler=".hide" class="comment__additionalreply hide">
+      <button class="comment__reply muted-link">
+        <%= icon "pencil", class: "icon--small", aria_label: "Responder", role: "img" %>
         Responder
-      </a>
+      </button>
     </div>
     </article>
   </div>

--- a/decidim_app-design/app/views/public/partials/_comments.html.erb
+++ b/decidim_app-design/app/views/public/partials/_comments.html.erb
@@ -17,6 +17,9 @@
           </div>
           <div class="author-data__extra">
             <%= partial "flag_empty" %>
+            <a href="comment-view">
+              <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
+            </a>
           </div>
         </div>
       </div>
@@ -67,8 +70,7 @@
           </div>
           <div class="author-data__extra">
             <%= partial "flag_empty" %>
-            <!-- optional permalink; should launch a modal with the link -->
-            <a href="#">
+            <a href="comment-view">
               <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
             </a>
           </div>
@@ -129,6 +131,9 @@
           </div>
           <div class="author-data__extra">
             <%= partial "flag_empty" %>
+            <a href="comment-view">
+              <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
+            </a>
           </div>
         </div>
       </div>
@@ -170,6 +175,9 @@
             </div>
             <div class="author-data__extra">
               <%= partial "flag_empty" %>
+              <a href="comment-view">
+                <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
+              </a>
             </div>
           </div>
         </div>
@@ -213,6 +221,9 @@
             </div>
             <div class="author-data__extra">
               <%= partial "flag_empty" %>
+              <a href="comment-view">
+                <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
+              </a>
             </div>
           </div>
         </div>
@@ -256,6 +267,9 @@
               </div>
               <div class="author-data__extra">
                 <%= partial "flag_empty" %>
+                <a href="comment-view">
+                  <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
+                </a>
               </div>
             </div>
         </div>
@@ -299,6 +313,9 @@
             </div>
             <div class="author-data__extra">
               <%= partial "flag_empty" %>
+              <a href="comment-view">
+                <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
+              </a>
             </div>
           </div>
         </div>
@@ -341,6 +358,9 @@
               </div>
               <div class="author-data__extra">
                 <%= partial "flag_empty" %>
+                <a href="comment-view">
+                  <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
+                </a>
               </div>
             </div>
           </div>

--- a/decidim_app-design/app/views/public/partials/_comments.html.erb
+++ b/decidim_app-design/app/views/public/partials/_comments.html.erb
@@ -17,7 +17,7 @@
           </div>
           <div class="author-data__extra">
             <%= partial "flag_empty" %>
-            <a href="comment-view">
+            <a href="comment-view" title="Enlace permamente">
               <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
             </a>
           </div>
@@ -70,7 +70,7 @@
           </div>
           <div class="author-data__extra">
             <%= partial "flag_empty" %>
-            <a href="comment-view">
+            <a href="comment-view" title="Enlace permamente">
               <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
             </a>
           </div>
@@ -133,7 +133,7 @@
           </div>
           <div class="author-data__extra">
             <%= partial "flag_empty" %>
-            <a href="comment-view">
+            <a href="comment-view" title="Enlace permamente">
               <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
             </a>
           </div>
@@ -209,7 +209,7 @@
               </div>
               <div class="author-data__extra">
                 <%= partial "flag_empty" %>
-                <a href="comment-view">
+                <a href="comment-view" title="Enlace permamente">
                   <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
                 </a>
               </div>
@@ -261,7 +261,7 @@
               </div>
               <div class="author-data__extra">
                 <%= partial "flag_empty" %>
-                <a href="comment-view">
+                <a href="comment-view" title="Enlace permamente">
                   <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
                 </a>
               </div>
@@ -308,7 +308,7 @@
                 </div>
                 <div class="author-data__extra">
                   <%= partial "flag_empty" %>
-                  <a href="comment-view">
+                  <a href="comment-view" title="Enlace permamente">
                     <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
                   </a>
                 </div>
@@ -355,7 +355,7 @@
               </div>
               <div class="author-data__extra">
                 <%= partial "flag_empty" %>
-                <a href="comment-view">
+                <a href="comment-view" title="Enlace permamente">
                   <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
                 </a>
               </div>
@@ -401,7 +401,7 @@
                 </div>
                 <div class="author-data__extra">
                   <%= partial "flag_empty" %>
-                  <a href="comment-view">
+                  <a href="comment-view" title="Enlace permamente">
                     <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
                   </a>
                 </div>

--- a/decidim_app-design/app/views/public/partials/_comments.html.erb
+++ b/decidim_app-design/app/views/public/partials/_comments.html.erb
@@ -17,7 +17,7 @@
           </div>
           <div class="author-data__extra">
             <%= partial "flag_empty" %>
-            <a href="comment-view#single-comment" title="Enlace permamente">
+            <a href="<%= page_path("proposals/comment-view")+'#single-comment' %>" title="Enlace permamente">
               <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
             </a>
           </div>
@@ -70,7 +70,7 @@
           </div>
           <div class="author-data__extra">
             <%= partial "flag_empty" %>
-            <a href="comment-view#single-comment" title="Enlace permamente">
+            <a href="<%= page_path("proposals/comment-view")+'#single-comment' %>" title="Enlace permamente">
               <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
             </a>
           </div>
@@ -133,7 +133,7 @@
           </div>
           <div class="author-data__extra">
             <%= partial "flag_empty" %>
-            <a href="comment-view#single-comment" title="Enlace permamente">
+            <a href="<%= page_path("proposals/comment-view")+'#single-comment' %>" title="Enlace permamente">
               <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
             </a>
           </div>
@@ -196,7 +196,7 @@
               </div>
               <div class="author-data__extra">
                 <%= partial "flag_empty" %>
-                <a href="comment-view#single-comment" title="Enlace permamente">
+                <a href="<%= page_path("proposals/comment-view")+'#single-comment' %>" title="Enlace permamente">
                   <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
                 </a>
               </div>
@@ -248,7 +248,7 @@
               </div>
               <div class="author-data__extra">
                 <%= partial "flag_empty" %>
-                <a href="comment-view#single-comment" title="Enlace permamente">
+                <a href="<%= page_path("proposals/comment-view")+'#single-comment' %>" title="Enlace permamente">
                   <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
                 </a>
               </div>
@@ -295,7 +295,7 @@
                 </div>
                 <div class="author-data__extra">
                   <%= partial "flag_empty" %>
-                  <a href="comment-view#single-comment" title="Enlace permamente">
+                  <a href="<%= page_path("proposals/comment-view")+'#single-comment' %>" title="Enlace permamente">
                     <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
                   </a>
                 </div>
@@ -342,7 +342,7 @@
               </div>
               <div class="author-data__extra">
                 <%= partial "flag_empty" %>
-                <a href="comment-view#single-comment" title="Enlace permamente">
+                <a href="<%= page_path("proposals/comment-view")+'#single-comment' %>" title="Enlace permamente">
                   <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
                 </a>
               </div>
@@ -388,7 +388,7 @@
                 </div>
                 <div class="author-data__extra">
                   <%= partial "flag_empty" %>
-                  <a href="comment-view#single-comment" title="Enlace permamente">
+                  <a href="<%= page_path("proposals/comment-view")+'#single-comment' %>" title="Enlace permamente">
                     <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
                   </a>
                 </div>

--- a/decidim_app-design/app/views/public/partials/_comments.html.erb
+++ b/decidim_app-design/app/views/public/partials/_comments.html.erb
@@ -17,7 +17,7 @@
           </div>
           <div class="author-data__extra">
             <%= partial "flag_empty" %>
-            <a href="<%= page_path("proposals/comment-view")+'#single-comment' %>" title="Enlace permamente">
+            <a href="<%= page_path("proposals/comment-view") + "#single-comment" %>" title="Enlace permamente">
               <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
             </a>
           </div>
@@ -70,7 +70,7 @@
           </div>
           <div class="author-data__extra">
             <%= partial "flag_empty" %>
-            <a href="<%= page_path("proposals/comment-view")+'#single-comment' %>" title="Enlace permamente">
+            <a href="<%= page_path("proposals/comment-view") + "#single-comment" %>" title="Enlace permamente">
               <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
             </a>
           </div>
@@ -133,7 +133,7 @@
           </div>
           <div class="author-data__extra">
             <%= partial "flag_empty" %>
-            <a href="<%= page_path("proposals/comment-view")+'#single-comment' %>" title="Enlace permamente">
+            <a href="<%= page_path("proposals/comment-view") + "#single-comment" %>" title="Enlace permamente">
               <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
             </a>
           </div>
@@ -196,7 +196,7 @@
               </div>
               <div class="author-data__extra">
                 <%= partial "flag_empty" %>
-                <a href="<%= page_path("proposals/comment-view")+'#single-comment' %>" title="Enlace permamente">
+                <a href="<%= page_path("proposals/comment-view") + "#single-comment" %>" title="Enlace permamente">
                   <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
                 </a>
               </div>
@@ -248,7 +248,7 @@
               </div>
               <div class="author-data__extra">
                 <%= partial "flag_empty" %>
-                <a href="<%= page_path("proposals/comment-view")+'#single-comment' %>" title="Enlace permamente">
+                <a href="<%= page_path("proposals/comment-view") + "#single-comment" %>" title="Enlace permamente">
                   <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
                 </a>
               </div>
@@ -295,7 +295,7 @@
                 </div>
                 <div class="author-data__extra">
                   <%= partial "flag_empty" %>
-                  <a href="<%= page_path("proposals/comment-view")+'#single-comment' %>" title="Enlace permamente">
+                  <a href="<%= page_path("proposals/comment-view") + "#single-comment" %>" title="Enlace permamente">
                     <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
                   </a>
                 </div>
@@ -342,7 +342,7 @@
               </div>
               <div class="author-data__extra">
                 <%= partial "flag_empty" %>
-                <a href="<%= page_path("proposals/comment-view")+'#single-comment' %>" title="Enlace permamente">
+                <a href="<%= page_path("proposals/comment-view") + "#single-comment" %>" title="Enlace permamente">
                   <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
                 </a>
               </div>
@@ -388,7 +388,7 @@
                 </div>
                 <div class="author-data__extra">
                   <%= partial "flag_empty" %>
-                  <a href="<%= page_path("proposals/comment-view")+'#single-comment' %>" title="Enlace permamente">
+                  <a href="<%= page_path("proposals/comment-view") + "#single-comment" %>" title="Enlace permamente">
                     <%= icon "link-intact", class: "icon--small", aria_label: "Enlace permanente" %>
                   </a>
                 </div>

--- a/decidim_app-design/app/views/public/proposals/comment-view.html.erb
+++ b/decidim_app-design/app/views/public/proposals/comment-view.html.erb
@@ -1,0 +1,37 @@
+<%
+@title = "Comentario -- Decidim Barcelona"
+@activesection = "processes"
+@activepage = "proposals"
+%>
+
+<%= partial "template_top" %>
+
+<main>
+  <%= partial "process_header" %>
+  <div class="wrapper-mini">
+    <div class="row column view-header">
+      <h2 class="heading2"><a href="proposal-view">Cobriment de la Ronda de Dalt al seu pas per la Vall d'Hebrón</a></h2>
+      <%= partial "author_data", { extra: true } %>
+    </div>
+    <div class="row column">
+      <div class="callout secondary">
+        <h5>Estás viendo un detalle de comentario</h5>
+        <p>
+          Puedes <a href="proposal-view">ver el resto de comentarios aquí</a>.
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div class="expanded">
+    <div class="wrapper wrapper--inner">
+      <div class="row">
+        <div class="columns large-9" id="comments">
+          <%= partial "comment-single" %>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>
+
+<%= partial "template_bottom" %>

--- a/decidim_app-design/app/views/public/proposals/comment-view.html.erb
+++ b/decidim_app-design/app/views/public/proposals/comment-view.html.erb
@@ -8,17 +8,66 @@
 
 <main>
   <%= partial "process_header" %>
-  <div class="wrapper-mini">
+  <div class="wrapper">
     <div class="row column view-header">
-      <h2 class="heading2"><a href="proposal-view">Cobriment de la Ronda de Dalt al seu pas per la Vall d'Hebrón</a></h2>
+      <h2 class="heading2">Cobriment de la Ronda de Dalt al seu pas per la Vall d'Hebrón</h2>
       <%= partial "author_data", { extra: true } %>
     </div>
-    <div class="row column">
-      <div class="callout secondary">
-        <h5>Estás viendo un detalle de comentario</h5>
-        <p>
-          Puedes <a href="proposal-view">ver el resto de comentarios aquí</a>.
-        </p>
+    <div class="row">
+      <div class="columns section view-side mediumlarge-4 mediumlarge-push-8
+        large-3 large-push-9">
+        <div class="card">
+          <div class="card__content">
+            <%= partial "progress_bar", { vertical: true } %>
+            <button class="button expanded light button--sc">Apoyar</button>
+            <%= partial "adhesion_buttons", { status: "secondary" } %>
+          </div>
+        </div>
+        <%= partial "followme" %>
+        <%= partial "share" %>
+        <div class="text-center">
+          <small>Referencia: BCN-2016-01-173</small>
+        </div>
+      </div>
+      <div class="columns mediumlarge-8 mediumlarge-pull-4">
+        <div class="section">
+          <span class="success label proposal-status">Acceptada</span>
+          <p>
+            Millores en un conjunt de carrers dels barris del districte que
+            incorporin la renovació integral de les seves infraestructures
+            (voreres, accessibilitat, asfaltat, enllumenat, clavegueram,
+            arbrat, mobiliari urbà...), Interiors de Canyelles, Guineueta
+            i Aiguablava-Portlligat i Amilcar-Cartellà-Av. de Borbó-Maragall,
+            connexió del carrer Pedraforca amb Agudes, accessibilitat i
+            enllumenat a Renfe Meridiana, urbanització de Nou Pins, Mina de la
+            ciutat, Canfranc, Oristà i Almansa, pèrgola del Campillo de la
+            virgen i del parc de Serra Martí, redacció del projecte del
+            passeig de la Peira, reforma de les escales de Matagalls, millores
+            a l'Av. de Borbó i projecte d'intervenció a la Font Pla de
+            Fornells. Millores en el Parc de la Guineueta incloent un espai
+            d'aparells per a la gent gran. Estudi de la viabilitat tècnica
+            d'instal·lar escales mecàniques entre Ciutat Meridiana i Torre
+            Baró per millorar la connectivitat entre els dos barris o millora
+            de l'escala actual. Millores d'accessibilitat, arranjaments i
+            enllumenat en l'àmbit de Renfe Meridiana. Millores en la
+            urbanització per a l'accessibilitat d'acord amb les
+            particularitats orogràfiques al barri de Roquetes.
+          </p>
+          <figure>
+            <figcaption class="text-uppercase"><strong>Arxivat a</strong></figcaption>
+            <ul>
+              <li><a href="">Transició ecológica</a>&nbsp;<small class="text-small">(ha canviat de <u>Justícia Climàtica</u> per un administrador)</small></li>
+              <li><a href="">Mobilitat sostenible</a></li>
+              <li><a href="">Barri de Sarrià</a></li>
+            </ul>
+          </figure>
+        </div>
+        <div class="section">
+          <%= partial "related_actions" %>
+        </div>
+        <div class="section">
+          <%= partial "related_meetings" %>
+        </div>
       </div>
     </div>
   </div>
@@ -35,3 +84,4 @@
 </main>
 
 <%= partial "template_bottom" %>
+

--- a/decidim_app-design/app/views/public/proposals/comment-view.html.erb
+++ b/decidim_app-design/app/views/public/proposals/comment-view.html.erb
@@ -84,4 +84,3 @@
 </main>
 
 <%= partial "template_bottom" %>
-


### PR DESCRIPTION
#### :tophat: What? Why?
Improved comments design proposal. Adds comment permalink, toggle comment theads, quote user in comment.

#### :pushpin: Related Issues
- Related to issues #5606 #5609 #5608
- Related to PRs #5655 #5662 #5647
- Fixes #5637

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
Show comments:
<img width="868" alt="Screenshot 2020-01-20 at 20 18 29" src="https://user-images.githubusercontent.com/468685/72752328-365d4d80-3bc2-11ea-8769-eec8b0fe608a.png">

Hide comments:
<img width="867" alt="Screenshot 2020-01-20 at 20 18 38" src="https://user-images.githubusercontent.com/468685/72752330-365d4d80-3bc2-11ea-9d7c-8e4f932eaf27.png">

Quote in comments:
<img width="812" alt="Screenshot 2020-01-20 at 20 18 51" src="https://user-images.githubusercontent.com/468685/72752332-365d4d80-3bc2-11ea-80d9-9e1f7c1099dc.png">

Quoting option:
<img width="824" alt="Screenshot 2020-01-20 at 20 19 03" src="https://user-images.githubusercontent.com/468685/72752333-365d4d80-3bc2-11ea-83fc-3cb51d052524.png">

Permalink:
<img width="297" alt="Screenshot 2020-01-20 at 20 19 18" src="https://user-images.githubusercontent.com/468685/72752334-36f5e400-3bc2-11ea-8158-cf43aa6e7a53.png">

Permalink icon:
<img width="37" alt="Screenshot 2020-01-20 at 20 19 33" src="https://user-images.githubusercontent.com/468685/72752335-36f5e400-3bc2-11ea-92dc-5a844ef8b28b.png">

Single comment view (permalink):
<img width="820" alt="Screenshot 2020-01-20 at 20 22 18" src="https://user-images.githubusercontent.com/468685/72752481-9227d680-3bc2-11ea-8e0e-2ea650f0b34f.png">






