### PR TITLE
Update proposal filters order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now sup
 - **decidim-meetings**: Add width and height to meetings component icon [\#5614](https://github.com/decidim/decidim/pull/5614)
 - **decidim-proposals**: Versions box is removed and placed after the reference ID, and using the same styles. [\#5594](https://github.com/decidim/decidim/pull/5594)
 - **decidim-participatory_processes**, **decidim-conferences**, **decidim-assemblies**, **decidim-initiatives**: Use cardM cell in space embed [#5589](https://github.com/decidim/decidim/pull/5589)
+- **decidim-proposals**: Update proposal filters order [\#5649](https://github.com/decidim/decidim/pull/5649)
 
 **Fixed**:
 

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
@@ -12,24 +12,8 @@
     </div>
   </div>
 
-  <% if @proposals.only_emendations.any? %>
-    <%= form.collection_radio_buttons :type, filter_type_values, :first, :last, legend_title: t(".amendment_type") %>
-  <% end %>
-
-  <% if component_settings.official_proposals_enabled %>
-    <%= form.collection_radio_buttons :origin, filter_origin_values, :first, :last, legend_title: t(".origin") %>
-  <% end %>
-
   <% if component_settings.proposal_answering_enabled && current_settings.proposal_answering_enabled %>
     <%= form.collection_radio_buttons :state, filter_state_values, :first, :last, legend_title: t(".state") %>
-  <% end %>
-
-  <% if linked_classes_for(Decidim::Proposals::Proposal).any? %>
-    <%= form.collection_radio_buttons :related_to, linked_classes_filter_values_for(Decidim::Proposals::Proposal), :first, :last, legend_title: t(".related_to") %>
-  <% end %>
-
-  <% if current_user %>
-    <%= form.collection_radio_buttons :activity, activity_filter_values, :first, :last, legend_title: t(".activity") %>
   <% end %>
 
   <% if current_participatory_space.has_subscopes? %>
@@ -38,6 +22,22 @@
 
   <% if current_component.categories.any? %>
     <%= form.categories_select :category_id, current_component.categories, legend_title: t(".category"), disable_parents: false, label: false, prompt: t(".category_prompt") %>
+  <% end %>
+
+  <% if component_settings.official_proposals_enabled %>
+    <%= form.collection_radio_buttons :origin, filter_origin_values, :first, :last, legend_title: t(".origin") %>
+  <% end %>
+
+  <% if current_user %>
+    <%= form.collection_radio_buttons :activity, activity_filter_values, :first, :last, legend_title: t(".activity") %>
+  <% end %>
+
+  <% if @proposals.only_emendations.any? %>
+    <%= form.collection_radio_buttons :type, filter_type_values, :first, :last, legend_title: t(".amendment_type") %>
+  <% end %>
+
+  <% if linked_classes_for(Decidim::Proposals::Proposal).any? %>
+    <%= form.collection_radio_buttons :related_to, linked_classes_filter_values_for(Decidim::Proposals::Proposal), :first, :last, legend_title: t(".related_to") %>
   <% end %>
 
   <%= hidden_field_tag :order, order, id: nil, class: "order_filter" %>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR updates the proposal filters order, as specified in #5602.

#### :pushpin: Related Issues
- Related to #5602

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
Screenshot of how it looks using the development seed data:

![image](https://user-images.githubusercontent.com/491891/72982327-16ef3c00-3ddf-11ea-9ef1-0372580e8a1a.png)

