### PR TITLE
Add nofollow to parsed links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now sup
 - **decidim-core**: Add docs in how to fix metrics problems. [\#5587](https://github.com/decidim/decidim/pull/5587)
 - **decidim-core**: Data portability now supports AWS S3 storage. [\#5342](https://github.com/decidim/decidim/pull/5342)
 - **decidim-system**: Permit customizing omniauth settings for each tenant [#5516](https://github.com/decidim/decidim/pull/5516)
+- **decidim-core**: Add the `nofollow` value to the `rel` attribute on parsed links [\#5651](https://github.com/decidim/decidim/pull/5651)
 
 **Changed**:
 

--- a/decidim-comments/spec/models/comment_spec.rb
+++ b/decidim-comments/spec/models/comment_spec.rb
@@ -142,7 +142,7 @@ module Decidim
             %(Content with <a href="http://urls.net" onmouseover="alert('hello')">URLs</a> of anchor type and text urls like https://decidim.org. And a malicous <a href="javascript:document.cookies">click me</a>)
           end
           let(:result) do
-            %(<p>Content with URLs of anchor type and text urls like <a href="https://decidim.org" target="_blank" rel="noopener">https://decidim.org</a>. And a malicous click me</p>)
+            %(<p>Content with URLs of anchor type and text urls like <a href="https://decidim.org" target="_blank" rel="nofollow noopener">https://decidim.org</a>. And a malicous click me</p>)
           end
 
           it "converts all URLs to links and strips attributes in anchors" do

--- a/decidim-core/lib/decidim/content_renderers/link_renderer.rb
+++ b/decidim-core/lib/decidim/content_renderers/link_renderer.rb
@@ -16,7 +16,7 @@ module Decidim
     # @see BaseRenderer Examples of how to use a content renderer
     class LinkRenderer < BaseRenderer
       # @return [String] the content ready to display (contains HTML)
-      def render(options = { target: "_blank", rel: "noopener" })
+      def render(options = { target: "_blank", rel: "nofollow noopener" })
         Anchored::Linker.auto_link(content, options)
       end
     end

--- a/decidim-proposals/spec/presenters/decidim/proposals/collaborative_draft_presenter_spec.rb
+++ b/decidim-proposals/spec/presenters/decidim/proposals/collaborative_draft_presenter_spec.rb
@@ -15,7 +15,7 @@ module Decidim
           And a malicous <a href="javascript:document.cookies">click me</a>
         EOCONTENT
         let(:result) { <<~EORESULT }
-          Content with URLs of anchor type and text urls like <a href="https://decidim.org" target="_blank" rel="noopener">https://decidim.org</a>.
+          Content with URLs of anchor type and text urls like <a href="https://decidim.org" target="_blank" rel="nofollow noopener">https://decidim.org</a>.
           And a malicous click me
         EORESULT
 

--- a/decidim-proposals/spec/presenters/decidim/proposals/proposal_presenter_spec.rb
+++ b/decidim-proposals/spec/presenters/decidim/proposals/proposal_presenter_spec.rb
@@ -15,7 +15,7 @@ module Decidim
           And a malicous <a href="javascript:document.cookies">click me</a>
         EOCONTENT
         let(:result) { <<~EORESULT }
-          Content with URLs of anchor type and text urls like <a href="https://decidim.org" target="_blank" rel="noopener">https://decidim.org</a>.
+          Content with URLs of anchor type and text urls like <a href="https://decidim.org" target="_blank" rel="nofollow noopener">https://decidim.org</a>.
           And a malicous click me
         EORESULT
 


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds the `nofollow` value to the `rel` attribute on parsed links, so they will now look like `<a hre="..." rel="nofollow noopener">...</a>`.

#### :pushpin: Related Issues

- Fixes #5610

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
