### PR TITLE
Add documentation in how Etherpads are integrated with Meetings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now sup
 
 **Added**:
 
+- **documentation**: Added documentation in how Etherpad Lite integrates with the Meetings component. [\#5652](https://github.com/decidim/decidim/pull/5652)
 - **decidim-meetings**: GraphQL API: Complete Meetings specification. [\#5563](https://github.com/decidim/decidim/pull/5563)
 - **decidim-meetings**: Follow a meeting on registration [\#5615](https://github.com/decidim/decidim/pull/5615)
 - **decidim-consultations**: GraphQL API: Create fields for consultations types and specs. [\#5550](https://github.com/decidim/decidim/pull/5550)

--- a/docs/services/etherpad.md
+++ b/docs/services/etherpad.md
@@ -1,6 +1,10 @@
 # Etherpad
 
-Decidim can be integrated with Etherpad so meetings can have their own pads.
+On some cases, users need to have near real time collaborative writing, for instance for having the minutes on a presencial meeting.
+
+To ease online/offline participation, Decidim can be integrated with Etherpad so meetings can have their own pads.
+
+## Integration
 
 In order to use it you need to have your own Etherpad deployment, you can do it
 with the Docker compose using the provided `docker-compose-etherpad.yml`.
@@ -34,3 +38,15 @@ and then in `config/secrets.yml`:
     api_key: <%= ENV["ETHERPAD_API_KEY"] %>
     api_version: <%= ENV["ETHERPAD_API_VERSION"] %>
 ```
+
+## How is Etherpad feature integrated in Meetings?
+
+To better understand this feature, the final idea is to have the three moments of a meeting covered on Decidim itself by default:
+
+- Before, you let know that the meeting is going to happen, where, when and what is gonna be talked
+- During, you can take notes on a collaborative way
+- After, you upload the notes, metadata and pictures for having memory on what was talked
+
+Pad creation can be enabled by administrators in each `Meetings` component.
+
+The pad iframe is only accesible for 24 hours before and 72 hours after the meeting. After the meeting only the read only URL for this pad is shown.

--- a/docs/services/etherpad.md
+++ b/docs/services/etherpad.md
@@ -45,7 +45,7 @@ To better understand this feature, the final idea is to have the three moments o
 
 - **Before the meeting**, you let know that the meeting is going to happen, where, when and what is going to be discussed
 - **During the meeting**, notes can be taken on a collaborative way
-- After, you upload the notes, metadata and pictures for having memory on what was talked
+- **After the meeting**, you upload the notes, minutes, metadata and/or pictures to have a record on what was discussed
 
 Pad creation can be enabled by administrators in each `Meetings` component. When enabled, the public view of a Meeting renders an iframe which encapsulates the integrated Pad. This Pad is automatically created before rendering, so there's nothing the user or the administrators has to do to see the Pad.
 

--- a/docs/services/etherpad.md
+++ b/docs/services/etherpad.md
@@ -39,7 +39,7 @@ and then in `config/secrets.yml`:
     api_version: <%= ENV["ETHERPAD_API_VERSION"] %>
 ```
 
-## How is Etherpad feature integrated in Meetings?
+## How is Etherpad Lite integrated in Meetings?
 
 To better understand this feature, the final idea is to have the three moments of a meeting covered on Decidim itself by default:
 
@@ -47,6 +47,6 @@ To better understand this feature, the final idea is to have the three moments o
 - During, you can take notes on a collaborative way
 - After, you upload the notes, metadata and pictures for having memory on what was talked
 
-Pad creation can be enabled by administrators in each `Meetings` component.
+Pad creation can be enabled by administrators in each `Meetings` component. When enabled, the public view of a Meeting renders an iframe which encapsulates the integrated Pad. This Pad is automatically created before rendering, so there's nothing the user or the administrators has to do to see the Pad.
 
 The pad iframe is only accesible for 24 hours before and 72 hours after the meeting. After the meeting only the read only URL for this pad is shown.

--- a/docs/services/etherpad.md
+++ b/docs/services/etherpad.md
@@ -49,4 +49,4 @@ To better understand this feature, the final idea is to have the three moments o
 
 Pad creation can be enabled by administrators in each `Meetings` component. When enabled, the public view of a Meeting renders an iframe which encapsulates the integrated Pad. This Pad is automatically created before rendering, so there's nothing the user or the administrators has to do to see the Pad.
 
-The pad iframe is only accesible for 24 hours before and 72 hours after the meeting. After the meeting only the read only URL for this pad is shown.
+The pad iframe is only accessible for 24 hours before and 72 hours after the meeting. After the meeting only the read only URL for this pad is shown.

--- a/docs/services/etherpad.md
+++ b/docs/services/etherpad.md
@@ -1,6 +1,6 @@
 # Etherpad
 
-On some cases, users need to have near real time collaborative writing, for instance for having the minutes on a presencial meeting.
+On some cases, users need to have near real time collaborative writing, for instance for having the minutes on a physical meeting.
 
 To ease online/offline participation, Decidim can be integrated with Etherpad so meetings can have their own pads.
 

--- a/docs/services/etherpad.md
+++ b/docs/services/etherpad.md
@@ -44,7 +44,7 @@ and then in `config/secrets.yml`:
 To better understand this feature, the final idea is to have the three moments of a meeting covered on Decidim itself by default:
 
 - **Before the meeting**, you let know that the meeting is going to happen, where, when and what is going to be discussed
-- During, you can take notes on a collaborative way
+- **During the meeting**, notes can be taken on a collaborative way
 - After, you upload the notes, metadata and pictures for having memory on what was talked
 
 Pad creation can be enabled by administrators in each `Meetings` component. When enabled, the public view of a Meeting renders an iframe which encapsulates the integrated Pad. This Pad is automatically created before rendering, so there's nothing the user or the administrators has to do to see the Pad.

--- a/docs/services/etherpad.md
+++ b/docs/services/etherpad.md
@@ -43,7 +43,7 @@ and then in `config/secrets.yml`:
 
 To better understand this feature, the final idea is to have the three moments of a meeting covered on Decidim itself by default:
 
-- Before, you let know that the meeting is going to happen, where, when and what is gonna be talked
+- **Before the meeting**, you let know that the meeting is going to happen, where, when and what is going to be discussed
 - During, you can take notes on a collaborative way
 - After, you upload the notes, metadata and pictures for having memory on what was talked
 


### PR DESCRIPTION
#### :tophat: What? Why?
There was no documentation in how Etherpads are integrated with Decidim. At least at a functional level. This PR adds the functional documentation about the conditions when an Etherpad is rendered in a Meeting.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
