### PR TITLE
Add cost to proposal answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now sup
 - **decidim-proposals**: Automatically link proposals and meetings when creating a proposal authored by a meeting [\#5674](https://github.com/decidim/decidim/pull/5674)
 - **decidim-proposals**: Add proposal page with all info in admin section [\#5671](https://github.com/decidim/decidim/pull/5671)
 - **decidim-proposals** and **decidim-budgets**: Improve navigation and visualization of proposals and projects by scope, category, origin and status [\#5654](https://github.com/decidim/decidim/pull/5654)
+- **decidim-proposals**: Let admins add cost reports to proposals [\#5695](https://github.com/decidim/decidim/pull/5695)
 
 **Changed**:
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -787,7 +787,7 @@ DEPENDENCIES
   web-console (~> 3.5)
 
 RUBY VERSION
-   ruby 2.6.2p47
+   ruby 2.5.3p105
 
 BUNDLED WITH
    1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -787,7 +787,7 @@ DEPENDENCIES
   web-console (~> 3.5)
 
 RUBY VERSION
-   ruby 2.5.3p105
+   ruby 2.6.2p47
 
 BUNDLED WITH
    1.17.3

--- a/decidim-admin/lib/decidim/admin/form_builder.rb
+++ b/decidim-admin/lib/decidim/admin/form_builder.rb
@@ -63,7 +63,7 @@ module Decidim
 
       # Calls Decidim::FormBuilder#editor with default options for admin.
       def editor(name, options = {})
-        super(name, options.merge(toolbar: :full, lines: 25))
+        super(name, { toolbar: :full, lines: 25 }.merge(options))
       end
     end
   end

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_typography.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_typography.scss
@@ -2,20 +2,26 @@
 
 /* Typography - Foundation overrides */
 button,
-input{
+input {
   font-family: inherit;
 }
 
-@mixin heading($heading){
+@mixin heading($heading) {
   line-height: 1.2;
-  font-size: map-get(map-get(map-get($header-styles, small), $heading), 'font-size') / 16 + em;
+  font-size: map-get(
+      map-get(map-get($header-styles, small), $heading),
+      "font-size"
+    ) / 16 + em;
 
-  @include breakpoint(medium){
-    font-size: map-get(map-get(map-get($header-styles, medium), $heading), 'font-size') / 16 + em;
+  @include breakpoint(medium) {
+    font-size: map-get(
+        map-get(map-get($header-styles, medium), $heading),
+        "font-size"
+      ) / 16 + em;
   }
 }
 
-.heading1{
+.heading1 {
   font-weight: 600;
 
   @include heading(h1);
@@ -23,7 +29,7 @@ input{
   line-height: 1.1;
 }
 
-.subheading1{
+.subheading1 {
   text-align: center;
   font-size: 1.25rem;
   margin: 0 auto;
@@ -32,156 +38,188 @@ input{
   margin-top: -3rem;
 }
 
-.heading2{
+.heading2 {
   @include heading(h2);
 }
 
-.heading3{
+.heading3 {
   @include heading(h3);
 }
 
-.heading4{
+.heading4 {
   @include heading(h4);
 }
 
-.heading5{
+.heading5 {
   @include heading(h5);
 }
 
-.heading6{
+.heading6 {
   text-transform: uppercase;
-  letter-spacing: .03em;
+  letter-spacing: 0.03em;
   font-weight: 600;
 
   @include heading(h6);
 }
 
-.heading-small{
+.heading-small {
   font-size: 1rem;
 }
 
-hr{
+hr {
   width: 50%;
 
-  &.reset{
+  &.reset {
     width: 100%;
   }
 }
 
 /* New typographic styles */
 
-.section-heading{
+.section-heading {
   position: relative;
   margin-bottom: 1rem;
   font-weight: 600;
   text-transform: uppercase;
   font-size: 1.125em;
-  letter-spacing: .05em;
+  letter-spacing: 0.05em;
 
-  &::before{
+  &::before {
     content: "";
     display: inline-block;
     width: 4px;
-    height: .8em;
+    height: 0.8em;
     background-color: var(--primary);
-    margin-right: .5rem;
-    margin-bottom: -.1rem;
+    margin-right: 0.5rem;
+    margin-bottom: -0.1rem;
   }
 
-  &.collapse{
+  &.collapse {
     margin: 0;
   }
 
-  span{
+  span {
     font-weight: normal;
   }
 }
 
-.mini-title{
+.mini-title {
   color: $muted;
   text-transform: uppercase;
-  font-size: .9rem;
-  letter-spacing: .01em;
+  font-size: 0.9rem;
+  letter-spacing: 0.01em;
   font-weight: 600;
   margin-bottom: 0;
 
-  &__strong{
+  &__strong {
     color: $body-font-color;
     font-size: 1.2rem;
     font-weight: 800;
   }
 
-  &__strong--highlight{
+  &__strong--highlight {
     font-size: 1.4rem;
   }
 }
 
-.page-title{
+.data-title {
+  &__over {
+    color: $muted;
+    text-transform: uppercase;
+    font-size: 0.9rem;
+    letter-spacing: 0.01em;
+    font-weight: 800;
+    margin-bottom: 0.5rem;
+  }
+
+  &__main {
+    font-size: 2rem;
+    line-height: 1;
+    letter-spacing: 0.01em;
+    font-weight: 800;
+    margin-bottom: 0;
+  }
+
+  &__sub {
+    color: $muted;
+    text-transform: uppercase;
+    font-size: 0.9rem;
+    letter-spacing: 0.01em;
+    line-height: 1;
+  }
+}
+
+.page-title {
   margin-bottom: 3rem;
 }
 
-.text-highlight{
+.text-highlight {
   margin-bottom: 0;
   color: $white;
-  text-shadow: 0 0 10px rgba(black, .8);
+  text-shadow: 0 0 10px rgba(black, 0.8);
 
-  &.heading1{
+  &.heading1 {
     font-weight: 800;
   }
 
-  > a{
+  > a {
     color: inherit;
 
-    &:hover{
+    &:hover {
       color: var(--primary);
     }
   }
 }
 
 // text status-color
-$map: map-merge($foundation-palette, (muted: $muted));
+$map: map-merge(
+  $foundation-palette,
+  (
+    muted: $muted,
+  )
+);
 
-@each $key, $value in $map{
-  .text-#{$key}{
+@each $key, $value in $map {
+  .text-#{$key} {
     color: $value;
   }
 
-  .bg-#{$key}{
+  .bg-#{$key} {
     background-color: lighten($value, 30);
   }
 }
 
-.text-large{
+.text-large {
   font-size: 130%;
 }
 
-.text-medium{
+.text-medium {
   font-size: 90%;
   color: $muted;
 }
 
-.text-small{
+.text-small {
   font-size: 80%;
   color: $muted;
 }
 
-.text-uppercase{
+.text-uppercase {
   text-transform: uppercase;
 }
 
-.text-lowercase{
+.text-lowercase {
   text-transform: lowercase;
 }
 
-.text-ellipsis{
+.text-ellipsis {
   @include ellipsis();
 }
 
-.text-compact{
+.text-compact {
   line-height: 1;
 }
 
-.word-wrapper{
+.word-wrapper {
   display: inline-block;
 }
 
@@ -217,6 +255,11 @@ sup,
 textarea,
 time,
 tt,
-var{
-  @include modifiers(color, (muted: $muted));
+var {
+  @include modifiers(
+    color,
+    (
+      muted: $muted,
+    )
+  );
 }

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_typography.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_typography.scss
@@ -2,26 +2,28 @@
 
 /* Typography - Foundation overrides */
 button,
-input {
+input{
   font-family: inherit;
 }
 
-@mixin heading($heading) {
+@mixin heading($heading){
   line-height: 1.2;
-  font-size: map-get(
+  font-size:
+    map-get(
       map-get(map-get($header-styles, small), $heading),
       "font-size"
     ) / 16 + em;
 
-  @include breakpoint(medium) {
-    font-size: map-get(
+  @include breakpoint(medium){
+    font-size:
+      map-get(
         map-get(map-get($header-styles, medium), $heading),
         "font-size"
       ) / 16 + em;
   }
 }
 
-.heading1 {
+.heading1{
   font-weight: 600;
 
   @include heading(h1);
@@ -29,7 +31,7 @@ input {
   line-height: 1.1;
 }
 
-.subheading1 {
+.subheading1{
   text-align: center;
   font-size: 1.25rem;
   margin: 0 auto;
@@ -38,134 +40,134 @@ input {
   margin-top: -3rem;
 }
 
-.heading2 {
+.heading2{
   @include heading(h2);
 }
 
-.heading3 {
+.heading3{
   @include heading(h3);
 }
 
-.heading4 {
+.heading4{
   @include heading(h4);
 }
 
-.heading5 {
+.heading5{
   @include heading(h5);
 }
 
-.heading6 {
+.heading6{
   text-transform: uppercase;
-  letter-spacing: 0.03em;
+  letter-spacing: .03em;
   font-weight: 600;
 
   @include heading(h6);
 }
 
-.heading-small {
+.heading-small{
   font-size: 1rem;
 }
 
-hr {
+hr{
   width: 50%;
 
-  &.reset {
+  &.reset{
     width: 100%;
   }
 }
 
 /* New typographic styles */
 
-.section-heading {
+.section-heading{
   position: relative;
   margin-bottom: 1rem;
   font-weight: 600;
   text-transform: uppercase;
   font-size: 1.125em;
-  letter-spacing: 0.05em;
+  letter-spacing: .05em;
 
-  &::before {
+  &::before{
     content: "";
     display: inline-block;
     width: 4px;
-    height: 0.8em;
+    height: .8em;
     background-color: var(--primary);
-    margin-right: 0.5rem;
-    margin-bottom: -0.1rem;
+    margin-right: .5rem;
+    margin-bottom: -.1rem;
   }
 
-  &.collapse {
+  &.collapse{
     margin: 0;
   }
 
-  span {
+  span{
     font-weight: normal;
   }
 }
 
-.mini-title {
+.mini-title{
   color: $muted;
   text-transform: uppercase;
-  font-size: 0.9rem;
-  letter-spacing: 0.01em;
+  font-size: .9rem;
+  letter-spacing: .01em;
   font-weight: 600;
   margin-bottom: 0;
 
-  &__strong {
+  &__strong{
     color: $body-font-color;
     font-size: 1.2rem;
     font-weight: 800;
   }
 
-  &__strong--highlight {
+  &__strong--highlight{
     font-size: 1.4rem;
   }
 }
 
-.data-title {
-  &__over {
+.data-title{
+  &__over{
     color: $muted;
     text-transform: uppercase;
-    font-size: 0.9rem;
-    letter-spacing: 0.01em;
+    font-size: .9rem;
+    letter-spacing: .01em;
     font-weight: 800;
-    margin-bottom: 0.5rem;
+    margin-bottom: .5rem;
   }
 
-  &__main {
+  &__main{
     font-size: 2rem;
     line-height: 1;
-    letter-spacing: 0.01em;
+    letter-spacing: .01em;
     font-weight: 800;
     margin-bottom: 0;
   }
 
-  &__sub {
+  &__sub{
     color: $muted;
     text-transform: uppercase;
-    font-size: 0.9rem;
-    letter-spacing: 0.01em;
+    font-size: .9rem;
+    letter-spacing: .01em;
     line-height: 1;
   }
 }
 
-.page-title {
+.page-title{
   margin-bottom: 3rem;
 }
 
-.text-highlight {
+.text-highlight{
   margin-bottom: 0;
   color: $white;
-  text-shadow: 0 0 10px rgba(black, 0.8);
+  text-shadow: 0 0 10px rgba(black, .8);
 
-  &.heading1 {
+  &.heading1{
     font-weight: 800;
   }
 
-  > a {
+  > a{
     color: inherit;
 
-    &:hover {
+    &:hover{
       color: var(--primary);
     }
   }
@@ -179,47 +181,47 @@ $map: map-merge(
   )
 );
 
-@each $key, $value in $map {
-  .text-#{$key} {
+@each $key, $value in $map{
+  .text-#{$key}{
     color: $value;
   }
 
-  .bg-#{$key} {
+  .bg-#{$key}{
     background-color: lighten($value, 30);
   }
 }
 
-.text-large {
+.text-large{
   font-size: 130%;
 }
 
-.text-medium {
+.text-medium{
   font-size: 90%;
   color: $muted;
 }
 
-.text-small {
+.text-small{
   font-size: 80%;
   color: $muted;
 }
 
-.text-uppercase {
+.text-uppercase{
   text-transform: uppercase;
 }
 
-.text-lowercase {
+.text-lowercase{
   text-transform: lowercase;
 }
 
-.text-ellipsis {
+.text-ellipsis{
   @include ellipsis();
 }
 
-.text-compact {
+.text-compact{
   line-height: 1;
 }
 
-.word-wrapper {
+.word-wrapper{
   display: inline-block;
 }
 
@@ -255,7 +257,7 @@ sup,
 textarea,
 time,
 tt,
-var {
+var{
   @include modifiers(
     color,
     (

--- a/decidim-core/app/assets/stylesheets/decidim/utils/_toggle-expand.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/utils/_toggle-expand.scss
@@ -7,3 +7,17 @@
     display: block;
   }
 }
+
+.expanded-text{
+  .text-toggle__short{
+    display: none;
+  }
+
+  .text-toggle__long{
+    display: block;
+  }
+}
+
+.text-toggle__long{
+  display: none;
+}

--- a/decidim-proposals/app/cells/decidim/proposals/cost_report/show.erb
+++ b/decidim-proposals/app/cells/decidim/proposals/cost_report/show.erb
@@ -1,0 +1,35 @@
+<div id="proposal-costs" class="card card--secondary" data-toggler=".expanded-text">
+  <div class="card__content">
+    <div class="mb-s">
+      <div class="data-title">
+        <h3 class="data-title__over">
+          <%= t("decidim.proposals.proposals.show.estimated_cost") %>
+        </h3>
+        <div>
+          <strong class="data-title__main">
+            <%= cost %>
+          </strong>
+        </div>
+        <div class="data-title__sub">
+          <%= execution_period %>
+        </div>
+      </div>
+    </div>
+    <div id="execution-cost-short" class="text-toggle__short">
+      <%= cost_report_short %>
+      <% if needs_text_toggle? %>
+      <button class="muted-link" data-toggle="proposal-costs">
+        <%= t("decidim.proposals.proposals.show.read_more") %>
+      </button>
+      <% end %>
+    </div>
+    <% if needs_text_toggle? %>
+    <div id="execution-cost-long" class="text-toggle__long">
+      <%= cost_report %>
+      <button class="muted-link" data-toggle="proposal-costs">
+        <%= t("decidim.proposals.proposals.show.read_less") %>
+      </button>
+    </div>
+    <% end %>
+  </div>
+</div>

--- a/decidim-proposals/app/cells/decidim/proposals/cost_report_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/cost_report_cell.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "cell/partial"
+
+module Decidim
+  module Proposals
+    # This cell renders the cost report for a proposal.
+    class CostReportCell < Decidim::ViewModel
+      include ActionView::Helpers::NumberHelper
+      include Decidim::SanitizeHelper
+      include Decidim::LayoutHelper
+      include ProposalCellsHelper
+
+      private
+
+      def cost
+        number_to_currency(model.cost)
+      end
+
+      def cost_report
+        decidim_sanitize(translated_attribute(model.cost_report).html_safe)
+      end
+
+      def needs_text_toggle?
+        cost_report != cost_report_short
+      end
+
+      def cost_report_short
+        decidim_sanitize(
+          html_truncate(
+            translated_attribute(model.cost_report).html_safe,
+            length: 200
+          )
+        )
+      end
+
+      def execution_period
+        decidim_sanitize(translated_attribute(model.execution_period).html_safe)
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/commands/decidim/proposals/admin/answer_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/answer_proposal.rb
@@ -40,11 +40,16 @@ module Decidim
             proposal,
             form.current_user
           ) do
-            proposal.update!(
+            attributes = {
               state: @form.state,
               answer: @form.answer,
-              answered_at: Time.current
-            )
+              answered_at: Time.current,
+              cost: @form.cost,
+              cost_report: @form.cost_report,
+              execution_period: @form.execution_period
+            }
+
+            proposal.update!(attributes)
           end
         end
 

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposal_answer_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposal_answer_form.rb
@@ -9,10 +9,29 @@ module Decidim
         mimic :proposal_answer
 
         translatable_attribute :answer, String
+        translatable_attribute :cost_report, String
+        translatable_attribute :execution_period, String
+        attribute :cost, Float
         attribute :state, String
 
         validates :state, presence: true, inclusion: { in: %w(accepted rejected evaluating) }
         validates :answer, translatable_presence: true, if: ->(form) { form.state == "rejected" }
+
+        with_options if: :costs_required? do
+          validates :cost, numericality: true, presence: true
+          validates :cost_report, translatable_presence: true
+          validates :execution_period, translatable_presence: true
+        end
+
+        def costs_required?
+          costs_enabled? && state == "accepted"
+        end
+
+        private
+
+        def costs_enabled?
+          current_component.current_settings.answers_with_costs?
+        end
       end
     end
   end

--- a/decidim-proposals/app/helpers/decidim/proposals/proposals_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/proposals_helper.rb
@@ -49,6 +49,12 @@ module Decidim
           ]
         )
       end
+
+      def proposal_has_costs?
+        @proposal.cost.present? &&
+          translated_attribute(@proposal.cost_report).present? &&
+          translated_attribute(@proposal.execution_period).present?
+      end
     end
   end
 end

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposal_answers/_form.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposal_answers/_form.html.erb
@@ -12,6 +12,20 @@
       <div class="row column">
         <%= f.translated :editor, :answer, autofocus: true, rows: 15 %>
       </div>
+
+      <% if current_component.current_settings.answers_with_costs? %>
+        <div class="row column">
+          <%= f.number_field :cost %>
+        </div>
+
+        <div class="row column">
+          <%= f.translated :editor, :cost_report, lines: 12 %>
+        </div>
+
+        <div class="row column">
+          <%= f.translated :editor, :execution_period, lines: 12 %>
+        </div>
+      <% end %>
     </div>
   </div>
 

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -87,6 +87,30 @@ edit_link(
       <% if component_settings.geocoding_enabled? %>
         <%= render partial: "decidim/shared/static_map", locals: { icon_name: "proposals", geolocalizable: @proposal } %>
       <% end %>
+      <% if proposal_has_costs? && current_settings.answers_with_costs? %>
+        <div class="card card--secondary">
+          <div class="card__content">
+              <div class="mb-s">
+                <div class="data-title">
+                  <h3 class="data-title__over">
+                    <%= t(".estimated_cost") %>
+                  </h3>
+                  <div>
+                    <strong class="data-title__main">
+                      <%= number_to_currency(@proposal.cost) %>
+                    </strong>
+                  </div>
+                  <div class="data-title__sub">
+                    <%= translated_attribute(@proposal.execution_period).html_safe %>
+                  </div>
+                </div>
+              </div>
+            <div>
+              <%= translated_attribute(@proposal.cost_report).html_safe %>
+            </div>
+          </div>
+        </div>
+      <% end %>
       <%= cell "decidim/proposals/proposal_tags", @proposal %>
     </div>
 

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -88,28 +88,7 @@ edit_link(
         <%= render partial: "decidim/shared/static_map", locals: { icon_name: "proposals", geolocalizable: @proposal } %>
       <% end %>
       <% if proposal_has_costs? && current_settings.answers_with_costs? %>
-        <div class="card card--secondary">
-          <div class="card__content">
-              <div class="mb-s">
-                <div class="data-title">
-                  <h3 class="data-title__over">
-                    <%= t(".estimated_cost") %>
-                  </h3>
-                  <div>
-                    <strong class="data-title__main">
-                      <%= number_to_currency(@proposal.cost) %>
-                    </strong>
-                  </div>
-                  <div class="data-title__sub">
-                    <%= translated_attribute(@proposal.execution_period).html_safe %>
-                  </div>
-                </div>
-              </div>
-            <div>
-              <%= translated_attribute(@proposal.cost_report).html_safe %>
-            </div>
-          </div>
-        </div>
+        <%= cell("decidim/proposals/cost_report", @proposal) %>
       <% end %>
       <%= cell "decidim/proposals/proposal_tags", @proposal %>
     </div>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -744,6 +744,7 @@ en:
           changes_at_title: Amendment to "%{title}"
           edit_proposal: Edit proposal
           endorsements_list: List of Endorsements
+          estimated_cost: Estimated cost
           hidden_endorsers_count:
             one: and %{count} more person
             other: and %{count} more people

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -757,6 +757,8 @@ en:
           proposal_accepted_reason: 'This proposal has been accepted because:'
           proposal_in_evaluation_reason: This proposal is being evaluated
           proposal_rejected_reason: 'This proposal has been rejected because:'
+          read_less: Read less
+          read_more: Read more
           report: Report
           withdraw_btn_hint: You can withdraw your proposal if you change your mind, as long as you have not received any support. The proposal is not deleted, it will appear in the list of withdrawn proposals.
           withdraw_confirmation: Are you sure you want to withdraw this proposal?

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -141,6 +141,7 @@ en:
             amendments_visibility: Amendment visibility
             amendments_visibility_help: If the option "Amendments are visible only to their authors" is selected, participant must be logged in to see the amendments made.
             announcement: Announcement
+            answers_with_costs: Enable costs on proposal answers
             automatic_hashtags: Hashtags added to all proposals
             comments_blocked: Comments blocked
             creation_enabled: Proposal creation enabled

--- a/decidim-proposals/db/migrate/20200210135152_add_costs_to_proposals.rb
+++ b/decidim-proposals/db/migrate/20200210135152_add_costs_to_proposals.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddCostsToProposals < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_proposals_proposals, :cost, :decimal
+    add_column :decidim_proposals_proposals, :cost_report, :jsonb
+    add_column :decidim_proposals_proposals, :execution_period, :jsonb
+  end
+end

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -57,6 +57,7 @@ Decidim.register_component(:proposals) do |component|
     settings.attribute :comments_blocked, type: :boolean, default: false
     settings.attribute :creation_enabled, type: :boolean
     settings.attribute :proposal_answering_enabled, type: :boolean, default: true
+    settings.attribute :answers_with_costs, type: :boolean, default: false
     settings.attribute :amendment_creation_enabled, type: :boolean, default: true
     settings.attribute :amendment_reaction_enabled, type: :boolean, default: true
     settings.attribute :amendment_promotion_enabled, type: :boolean, default: true

--- a/decidim-proposals/spec/commands/decidim/proposals/answer_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/answer_proposal_spec.rb
@@ -12,7 +12,11 @@ module Decidim
           let(:form) { ProposalAnswerForm.from_params(form_params).with_context(current_user: current_user) }
           let(:form_params) do
             {
-              state: "rejected", answer: { en: "Foo" }
+              state: "rejected",
+              answer: { en: "Foo" },
+              cost: 2000,
+              cost_report: { en: "Cost report" },
+              execution_period: { en: "Execution period" }
             }
           end
 

--- a/decidim-proposals/spec/forms/decidim/proposals/proposal_answer_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/proposal_answer_form_spec.rb
@@ -8,17 +8,22 @@ module Decidim
       describe ProposalAnswerForm do
         subject { form }
 
-        let(:organization) { create(:organization) }
+        let(:organization) { proposals_component.participatory_space.organization }
         let(:state) { "accepted" }
         let(:answer) { Decidim::Faker::Localized.sentence(3) }
+        let(:proposals_component) { create :proposal_component }
+        let(:cost) { nil }
+        let(:cost_report) { nil }
+        let(:execution_period) { nil }
         let(:params) do
           {
-            state: state, answer: answer
+            state: state, answer: answer, cost: cost, cost_report: cost_report, execution_period: execution_period
           }
         end
 
         let(:form) do
           described_class.from_params(params).with_context(
+            current_component: proposals_component,
             current_organization: organization
           )
         end
@@ -46,6 +51,32 @@ module Decidim
             let(:answer) { nil }
 
             it { is_expected.to be_invalid }
+          end
+        end
+
+        context "when accepting the proposal" do
+          let(:state) { "accepted" }
+
+          context "and costs are enabled" do
+            before do
+              proposals_component.update!(
+                step_settings: {
+                  proposals_component.participatory_space.active_step.id => {
+                    answers_with_costs: true
+                  }
+                }
+              )
+            end
+
+            it { is_expected.to be_invalid }
+
+            context "and cost data is filled" do
+              let(:cost) { 20000 }
+              let(:cost_report) { { en: "Cost report" } }
+              let(:execution_period) { { en: "Execution period" } }
+
+              it { is_expected.to be_valid }
+            end
           end
         end
       end

--- a/decidim-proposals/spec/forms/decidim/proposals/proposal_answer_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/proposal_answer_form_spec.rb
@@ -71,7 +71,7 @@ module Decidim
             it { is_expected.to be_invalid }
 
             context "and cost data is filled" do
-              let(:cost) { 20000 }
+              let(:cost) { 20_000 }
               let(:cost_report) { { en: "Cost report" } }
               let(:execution_period) { { en: "Execution period" } }
 

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -151,7 +151,7 @@ describe "Proposals", type: :system do
           :accepted,
           :with_answer,
           component: component,
-          cost: 20000,
+          cost: 20_000,
           cost_report: { en: "My cost report" },
           execution_period: { en: "My execution period" }
         )

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -144,6 +144,38 @@ describe "Proposals", type: :system do
       end
     end
 
+    context "when a proposal has costs" do
+      let!(:proposal) do
+        create(
+          :proposal,
+          :accepted,
+          :with_answer,
+          component: component,
+          cost: 20000,
+          cost_report: { en: "My cost report" },
+          execution_period: { en: "My execution period" }
+        )
+      end
+      let!(:author) { create(:user, :confirmed, organization: component.organization) }
+
+      it "shows the costs" do
+        component.update!(
+          step_settings: {
+            component.participatory_space.active_step.id => {
+              answers_with_costs: true
+            }
+          }
+        )
+
+        visit_component
+        click_link proposal.title
+
+        expect(page).to have_content("20,000.00")
+        expect(page).to have_content("MY EXECUTION PERIOD")
+        expect(page).to have_content("My cost report")
+      end
+    end
+
     context "when a proposal has been linked in a meeting" do
       let(:proposal) { create(:proposal, component: component) }
       let(:meeting_component) do

--- a/decidim_app-design/app/views/public/partials/_proposal_costs.html.erb
+++ b/decidim_app-design/app/views/public/partials/_proposal_costs.html.erb
@@ -1,0 +1,25 @@
+<div class="card card--secondary">
+  <div class="card__content">
+      <div class="mb-s">
+        <div class="data-title">
+          <h3 class="data-title__over">
+            Estimated cost
+          </h3>
+          <div>
+            <strong class="data-title__main">
+              20.000€
+            </strong>
+          </div>
+          <div class="data-title__sub">
+            March 2021 - July 2021
+          </div>
+        </div>
+      </div>
+    <p>
+      <%= Faker::Lorem.paragraph(8) %>…
+      <button class="muted-link">
+        Read more
+      </button>
+    </p>
+  </div>
+</div>

--- a/decidim_app-design/app/views/public/partials/_proposal_costs.html.erb
+++ b/decidim_app-design/app/views/public/partials/_proposal_costs.html.erb
@@ -15,11 +15,11 @@
           </div>
         </div>
       </div>
-    <p>
+    <div>
       <%= Faker::Lorem.paragraph(8) %>…
       <button class="muted-link">
         Read more
       </button>
-    </p>
+    </div>
   </div>
 </div>

--- a/decidim_app-design/app/views/public/proposals/proposal-view.html.erb
+++ b/decidim_app-design/app/views/public/proposals/proposal-view.html.erb
@@ -53,6 +53,9 @@
             urbanització per a l'accessibilitat d'acord amb les
             particularitats orogràfiques al barri de Roquetes.
           </p>
+
+          <%= partial "proposal_costs" %>
+
           <figure>
             <%= partial "proposal-tags-list" %>
           </figure>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds some fields to proposal answers. These new fields are only required if the proposal is accepted.

#### :pushpin: Related Issues
- Fixes #5631

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Fix proposal answer form tests and make sure fields are only required when answer is accepted.
- [x] Show fields in the admin UI
- [x] Remove `null: false` restriction from DB
- [x] Add frontend

### :camera: Screenshots (optional)
New fields in the proposal page in admin:
![image](https://user-images.githubusercontent.com/491891/74242833-e7956600-4cde-11ea-8445-e4eabaf88da8.png)

Costs in the public page:
![image](https://user-images.githubusercontent.com/491891/74327141-ecfcba00-4d8b-11ea-8997-57d7bca9d47e.png)

When cost report is long, a toggle appears by default:
![image](https://user-images.githubusercontent.com/491891/74327175-fc7c0300-4d8b-11ea-897c-a83e0c4a7f1f.png)

You can expand the toggle to read the full report:
![image](https://user-images.githubusercontent.com/491891/74327219-0e5da600-4d8c-11ea-921b-1cb20b834b26.png)
