### PR TITLE
Render rich text in Proposals originated in Meetings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now sup
 
 **Fixed**:
 
+- **decidim-proposals**: Render rich text in Proposals originated in Meetings. [\#5705](https://github.com/decidim/decidim/pull/5705)
 - **decidim-admin**: Avoid user_manager permissions to shadow space admin permissions. [\#5698](https://github.com/decidim/decidim/pull/5698)
 - **decidim-core**: Fix: display the correct google brand log in omniauth login view. [\#5685](https://github.com/decidim/decidim/pull/5685)
 - **decidim-core**: Fix \#5342, when the fog provider is aws there were some fixes to be done. [\#5660](https://github.com/decidim/decidim/pull/5660)

--- a/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
@@ -92,7 +92,7 @@ module Decidim
       # the proposal comes from a collaborative_draft or a participatory_text.
       def safe_content?
         rich_text_editor_in_public_views? && not_from_collaborative_draft(@proposal) ||
-          @proposal.official? && not_from_participatory_text(@proposal)
+          (@proposal.official? || @proposal.official_meeting?) && not_from_participatory_text(@proposal)
       end
 
       # If the content is safe, HTML tags are sanitized, otherwise, they are stripped.

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -114,19 +114,15 @@ describe "Proposals", type: :system do
     end
 
     context "when it is an official meeting proposal" do
-      let!(:official_meeting_proposal) { create(:proposal, :official_meeting, body: content, component: component) }
-      let!(:proposal) { official_meeting_proposal }
+      let!(:proposal) { create(:proposal, :official_meeting, body: content, component: component) }
 
       before do
-        # organization.update(rich_text_editor_in_public_views: true)
         visit_component
         click_link proposal.title
       end
 
       it "shows the author as meeting" do
-        visit_component
-        click_link official_meeting_proposal.title
-        expect(page).to have_content(translated(official_meeting_proposal.authors.first.title))
+        expect(page).to have_content(translated(proposal.authors.first.title))
       end
 
       it_behaves_like "rendering safe content", ".columns.mediumlarge-8.mediumlarge-pull-4"

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -114,6 +114,7 @@ describe "Proposals", type: :system do
     end
 
     context "when it is an official meeting proposal" do
+      include_context "with rich text editor content"
       let!(:proposal) { create(:proposal, :official_meeting, body: content, component: component) }
 
       before do

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -114,13 +114,22 @@ describe "Proposals", type: :system do
     end
 
     context "when it is an official meeting proposal" do
-      let!(:official_meeting_proposal) { create(:proposal, :official_meeting, component: component) }
+      let!(:official_meeting_proposal) { create(:proposal, :official_meeting, body: content, component: component) }
+      let!(:proposal) { official_meeting_proposal }
+
+      before do
+        # organization.update(rich_text_editor_in_public_views: true)
+        visit_component
+        click_link proposal.title
+      end
 
       it "shows the author as meeting" do
         visit_component
         click_link official_meeting_proposal.title
         expect(page).to have_content(translated(official_meeting_proposal.authors.first.title))
       end
+
+      it_behaves_like "rendering safe content", ".columns.mediumlarge-8.mediumlarge-pull-4"
     end
 
     context "when a proposal has comments" do


### PR DESCRIPTION
#### :tophat: What? Why?
PR #5488 did not took into account to render as rich text in the case when a Proposal is originated from a Meeting.

#### :pushpin: Related Issues
- Fixes #5488

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [x] Add tests
- [x] Fix

### :camera: Screenshots (optional)
![Description](URL)
![imatge](https://user-images.githubusercontent.com/199462/74385775-9d060d80-4df4-11ea-8750-d1d2822be029.png)
