### PR TITLE
[CI] Allow postgres Docker image without password

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ defaults: &defaults
     - image: postgres
       environment:
         POSTGRES_USER: postgres
+        POSTGRES_HOST_AUTH_METHOD: trust
   working_directory: /app
 
 references:


### PR DESCRIPTION
#### :tophat: What? Why?
In CircleCI we always use the latest PostgreSQL Docker image. This weekend a new version was released, and it added a breaking change that prevented the image from starting.

This PR fixes the breaking change.

Info:

- https://discuss.circleci.com/t/postgres-just-stopped-working/34511/4
- https://github.com/docker-library/postgres/issues/681

#### :pushpin: Related Issues
None specifically, but as an example see this build from master failing due to this error:

https://circleci.com/workflow-run/f6618da8-ce9c-4509-b006-0f6eaaf81a4a

#### :clipboard: Subtasks
None
