### PR TITLE
Admin: fix "Answer Proposal" action tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now sup
 - **decidim-proposals**: Filtering by state working when searching amendments [#5703](https://github.com/decidim/decidim/pull/5703)
 - **decidim-core**: Fix: Display values on translated fields with hashtaggable option on edit forms [#5661](https://github.com/decidim/decidim/pull/5661)
 - **decidim-budgets**: Add a missing fix applied to proposals in [\#5654](https://github.com/decidim/decidim/pull/5654) but not to projects [\#5743](https://github.com/decidim/decidim/pull/5743)
+- **decidim-proposals**: Admin: fix "Answer Proposal" action tooltip [/#5750](https://github.com/decidim/decidim/pull/5750)
 
 **Removed**:
 

--- a/decidim-proposals/app/helpers/decidim/proposals/admin/proposals_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/admin/proposals_helper.rb
@@ -117,7 +117,7 @@ module Decidim
         end
 
         def icon_link_to_proposal_tr(proposal)
-          icon, tooltip = if allowed_to?(:create, :proposal_answer) && !proposal.emendation?
+          icon, tooltip = if allowed_to?(:create, :proposal_answer, proposal: proposal) && !proposal.emendation?
                             [
                               "comment-square",
                               t(:answer_proposal, scope: "decidim.proposals.actions")

--- a/decidim-proposals/app/helpers/decidim/proposals/admin/proposals_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/admin/proposals_helper.rb
@@ -128,7 +128,7 @@ module Decidim
                               t(:show, scope: "decidim.proposals.actions")
                             ]
                           end
-          icon_link_to(icon, proposal_path(proposal), tooltip, class: "icon--small")
+          icon_link_to(icon, proposal_path(proposal), tooltip, class: "icon--small action-icon--show-proposal")
         end
       end
     end

--- a/decidim-proposals/app/helpers/decidim/proposals/admin/proposals_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/admin/proposals_helper.rb
@@ -115,6 +115,15 @@ module Decidim
           end
           html.join(" ").html_safe
         end
+
+        def proposal_tr_tooltip(proposal)
+          i18n_key = if allowed_to?(:create, :proposal_answer) && !proposal.emendation?
+            :answer_proposal
+          else
+            :show
+          end
+          t(i18n_key, scope: "decidim.proposals.actions")
+        end
       end
     end
   end

--- a/decidim-proposals/app/helpers/decidim/proposals/admin/proposals_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/admin/proposals_helper.rb
@@ -116,7 +116,7 @@ module Decidim
           html.join(" ").html_safe
         end
 
-        def icon_link_to_proposal_tr(proposal)
+        def icon_with_link_to_proposal(proposal)
           icon, tooltip = if allowed_to?(:create, :proposal_answer, proposal: proposal) && !proposal.emendation?
                             [
                               "comment-square",

--- a/decidim-proposals/app/helpers/decidim/proposals/admin/proposals_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/admin/proposals_helper.rb
@@ -116,13 +116,19 @@ module Decidim
           html.join(" ").html_safe
         end
 
-        def proposal_tr_tooltip(proposal)
-          i18n_key = if allowed_to?(:create, :proposal_answer) && !proposal.emendation?
-            :answer_proposal
-          else
-            :show
-          end
-          t(i18n_key, scope: "decidim.proposals.actions")
+        def icon_link_to_proposal_tr(proposal)
+          icon, tooltip = if allowed_to?(:create, :proposal_answer) && !proposal.emendation?
+                            [
+                              "comment-square",
+                              t(:answer_proposal, scope: "decidim.proposals.actions")
+                            ]
+                          else
+                            [
+                              "info",
+                              t(:show, scope: "decidim.proposals.actions")
+                            ]
+                          end
+          icon_link_to(icon, proposal_path(proposal), tooltip, class: "icon--small")
         end
       end
     end

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
@@ -56,7 +56,7 @@
       <%= icon_link_to "pencil", edit_proposal_path(proposal), t("actions.edit_proposal", scope: "decidim.proposals"), class: "action-icon--edit-proposal" %>
     <% end %>
 
-    <%= icon_link_to "comment-square", proposal_path(proposal), proposal_tr_tooltip(proposal) , class: "icon--small" %>
+    <%= icon_link_to_proposal_tr(proposal) %>
 
     <%= resource_permissions_link(proposal) %>
 

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
@@ -56,7 +56,7 @@
       <%= icon_link_to "pencil", edit_proposal_path(proposal), t("actions.edit_proposal", scope: "decidim.proposals"), class: "action-icon--edit-proposal" %>
     <% end %>
 
-    <%= icon_link_to "comment-square", proposal_path(proposal), t("actions.show", scope: "decidim.proposals"), class: "icon--small" %>
+    <%= icon_link_to "comment-square", proposal_path(proposal), proposal_tr_tooltip(proposal) , class: "icon--small" %>
 
     <%= resource_permissions_link(proposal) %>
 

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
@@ -56,7 +56,7 @@
       <%= icon_link_to "pencil", edit_proposal_path(proposal), t("actions.edit_proposal", scope: "decidim.proposals"), class: "action-icon--edit-proposal" %>
     <% end %>
 
-    <%= icon_link_to_proposal_tr(proposal) %>
+    <%= icon_with_link_to_proposal(proposal) %>
 
     <%= resource_permissions_link(proposal) %>
 

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -319,6 +319,7 @@ en:
         see_all: See all (%{count})
     proposals:
       actions:
+        answer_proposal: Answer proposal
         edit_proposal: Edit proposal
         import: Import from another component
         new: New proposal

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -461,7 +461,7 @@ shared_examples "manage proposals" do
 
   def go_to_admin_proposal_page(proposal)
     within find("tr", text: proposal.title) do
-      click_link "Show"
+      find("a", class: "action-icon--show-proposal").click
     end
   end
 

--- a/decidim-proposals/spec/shared/view_proposal_details_from_admin_examples.rb
+++ b/decidim-proposals/spec/shared/view_proposal_details_from_admin_examples.rb
@@ -196,7 +196,7 @@ shared_examples "view proposal details from admin" do
 
   def go_to_admin_proposal_page(proposal)
     within find("tr", text: proposal.title) do
-      click_link "Show"
+      find("a", class: "action-icon--show-proposal").click
     end
   end
 end

--- a/decidim-proposals/spec/system/index_proposal_notes_spec.rb
+++ b/decidim-proposals/spec/system/index_proposal_notes_spec.rb
@@ -25,7 +25,7 @@ describe "Index Proposal Notes", type: :system do
 
   before do
     within find("tr", text: proposal.title) do
-      click_link "Show proposal"
+      click_link "Answer proposal"
     end
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?

When answering is enabled and the user has permission to answer the proposal replaces the tooltip "Show proposal" with "Answer proposal" and changes the link icon.

#### :pushpin: Related Issues
- Related to #5628, #5630, #5671
- Fixes #5748

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
- The `current_admin` has permission to **answer** the proposal:
  <img width="1069" alt="Screenshot 2020-02-18 at 12 06 51" src="https://user-images.githubusercontent.com/210216/74731116-b4575780-5247-11ea-93cf-6393bd0c1c72.png">

- Answering is disabled (from component settings) or `current_admin` **can't answer** (is an emendation):
  <img width="1056" alt="Screenshot 2020-02-18 at 12 06 57" src="https://user-images.githubusercontent.com/210216/74731145-c0431980-5247-11ea-99fa-ac41540d06b8.png">



