### PR TITLE
Admin can bulk update proposal's scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now sup
 - **decidim-participatory_processes**: Add Valuator role [\#5687](https://github.com/decidim/decidim/pull/5687)
 - **decidim-proposals**: Let Valuators only answer and leave private notes on proposals [\#5687](https://github.com/decidim/decidim/pull/5687)
 - **decidim-core**: Let exporters filter collection by user triggering the action [\#5687](https://github.com/decidim/decidim/pull/5687)
+- **decidim-admin**: Admin can bulk update proposal's scope [\5759](https://github.com/decidim/decidim/pull/5759)
 
 **Changed**:
 

--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_cards.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_cards.scss
@@ -23,6 +23,12 @@ $card-padding-small: 1rem;
       text-transform: uppercase;
     }
   }
+  .data-picker{
+    font-weight: normal;
+    letter-spacing: 0;
+    margin-bottom: 0;
+    text-transform: none;
+  }
 }
 
 .card-footer{

--- a/decidim-admin/app/helpers/decidim/admin/bulk_actions_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/bulk_actions_helper.rb
@@ -56,6 +56,35 @@ module Decidim
         prompt = t("decidim.proposals.admin.proposals.index.select_component")
         select(:target_component_id, nil, options_for_select(components, selected: []), prompt: prompt)
       end
+
+      # Public: Generates a select field with the scopes.
+      #
+      #
+      # Returns a String.
+      def bulk_scopes_select
+        # raise
+        # scopes = siblings.map do |component|
+        #   [translated_attribute(component.name, component.organization), component.id]
+        # end
+        if current_component.participatory_space.scope
+          # scopes = []
+          # scopes << [translated_attribute(current_component.participatory_space.scope.name, current_component.organization), current_component.participatory_space.scope.id]
+          scopes = current_component.participatory_space.scope.children.map do |scope|
+            [translated_attribute(scope.name, current_component.organization), scope.id]
+          end
+          scopes
+        else
+          scopes = []
+          scopes << ["global", nil]
+          scopes << current_component.participatory_space.scopes.map do |scope|
+            [translated_attribute(scope.name, current_component.organization), scope.id]
+          end
+          scopes
+        end
+
+        prompt = t("decidim.proposals.admin.proposals.index.change_scope")
+        select(:scope, nil, options_for_select(scopes, selected: []), prompt: prompt)
+      end
     end
   end
 end

--- a/decidim-admin/app/helpers/decidim/admin/bulk_actions_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/bulk_actions_helper.rb
@@ -56,35 +56,6 @@ module Decidim
         prompt = t("decidim.proposals.admin.proposals.index.select_component")
         select(:target_component_id, nil, options_for_select(components, selected: []), prompt: prompt)
       end
-
-      # Public: Generates a select field with the scopes.
-      #
-      #
-      # Returns a String.
-      def bulk_scopes_select
-        # raise
-        # scopes = siblings.map do |component|
-        #   [translated_attribute(component.name, component.organization), component.id]
-        # end
-        if current_component.participatory_space.scope
-          # scopes = []
-          # scopes << [translated_attribute(current_component.participatory_space.scope.name, current_component.organization), current_component.participatory_space.scope.id]
-          scopes = current_component.participatory_space.scope.children.map do |scope|
-            [translated_attribute(scope.name, current_component.organization), scope.id]
-          end
-          scopes
-        else
-          scopes = []
-          scopes << ["global", nil]
-          scopes << current_component.participatory_space.scopes.map do |scope|
-            [translated_attribute(scope.name, current_component.organization), scope.id]
-          end
-          scopes
-        end
-
-        prompt = t("decidim.proposals.admin.proposals.index.change_scope")
-        select(:scope, nil, options_for_select(scopes, selected: []), prompt: prompt)
-      end
     end
   end
 end

--- a/decidim-core/lib/decidim/scopable.rb
+++ b/decidim-core/lib/decidim/scopable.rb
@@ -56,6 +56,16 @@ module Decidim
       scope && !scope.ancestor_of?(subscope)
     end
 
+    # If any, gets the previous scope of the object.
+    #
+    #
+    # Returns a Decidim::Scope
+    def previous_scope
+      return if scope.versions.count <= 1
+
+      Decidim::Scope.find_by(id: scope.versions.last.reify.decidim_scope_id)
+    end
+
     private
 
     def scope_belongs_to_organization

--- a/decidim-core/lib/decidim/scopable.rb
+++ b/decidim-core/lib/decidim/scopable.rb
@@ -61,9 +61,9 @@ module Decidim
     #
     # Returns a Decidim::Scope
     def previous_scope
-      return if scope.versions.count <= 1
+      return if versions.count <= 1
 
-      Decidim::Scope.find_by(id: scope.versions.last.reify.decidim_scope_id)
+      Decidim::Scope.find_by(id: versions.last.reify.decidim_scope_id)
     end
 
     private

--- a/decidim-proposals/app/assets/javascripts/decidim/proposals/admin/proposals.es6
+++ b/decidim-proposals/app/assets/javascripts/decidim/proposals/admin/proposals.es6
@@ -24,7 +24,7 @@ $(document).ready(function () {
     }
   }
 
-  let hideBulkActionsButton = function(force = false) {
+  window.hideBulkActionsButton = function(force = false) {
     if(selectedProposalsCount() == 0 || force == true){
       $("#js-bulk-actions-button").addClass('hide');
       $("#js-bulk-actions-dropdown").removeClass('is-open');
@@ -35,12 +35,12 @@ $(document).ready(function () {
     $("#js-other-actions-wrapper").removeClass('hide');
   }
 
-  let hideOtherActionsButtons = function() {
+  window.hideOtherActionsButtons = function() {
     $("#js-other-actions-wrapper").addClass('hide');
   }
 
   window.hideBulkActionForms = function() {
-    return $(".js-bulk-action-form").addClass('hide');
+    $(".js-bulk-action-form").addClass('hide');
   }
 
   if ($('.js-bulk-action-form').length) {
@@ -57,8 +57,8 @@ $(document).ready(function () {
         })
 
         $(`#js-${action}-actions`).removeClass('hide');
-        hideBulkActionsButton(true);
-        hideOtherActionsButtons();
+        window.hideBulkActionsButton(true);
+        window.hideOtherActionsButtons();
       }
     })
 
@@ -71,7 +71,7 @@ $(document).ready(function () {
         showBulkActionsButton();
       } else {
         $(".js-check-all-proposal").closest('tr').removeClass('selected');
-        hideBulkActionsButton();
+        window.hideBulkActionsButton();
       }
 
       selectedProposalsCountUpdate();
@@ -96,12 +96,12 @@ $(document).ready(function () {
         showBulkActionsButton();
         $(this).closest('tr').addClass('selected');
       } else {
-        hideBulkActionsButton();
+        window.hideBulkActionsButton();
         $(this).closest('tr').removeClass('selected');
       }
 
       if ($('.js-check-all-proposal:checked').length === 0) {
-        hideBulkActionsButton();
+        window.hideBulkActionsButton();
       }
 
       $('.js-bulk-action-form').find(".js-proposal-id-"+proposal_id).prop('checked', checked);

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_tags/show.erb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_tags/show.erb
@@ -1,5 +1,5 @@
 <figure>
-  <ul class="tags tags--proposal">
+  <ul class="tags tags--proposal tags--list">
     <% if category.present? %>
       <li>
         <%= link_to translated_attribute(category.name), resource_locator(model).index(filter: { category_id: [category.id.to_s] }) %>

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_tags/show.erb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_tags/show.erb
@@ -6,7 +6,7 @@
         <% if previous_category.present? && show_previous_category? %>
           &nbsp;
           <small class="text-small">
-            <%= t("changed_from", scope: "decidim.proposals.proposals.tags", previous_category: "#{previous_category.translated_name}").html_safe %>
+            <%= t("changed_from", scope: "decidim.proposals.proposals.tags", previous_name: "#{previous_category.translated_name}").html_safe %>
           </small>
         <% end %>
       </li>
@@ -18,7 +18,7 @@
         <% if previous_scope.present? && show_previous_scope? %>
           &nbsp;
           <small class="text-small">
-            <%= t("changed_from", scope: "decidim.proposals.proposals.tags", previous_scope: "#{previous_scope.translated_name}").html_safe %>
+            <%= t("changed_from", scope: "decidim.proposals.proposals.tags", previous_name: "#{translated_attribute(previous_scope.name)}").html_safe %>
           </small>
         <% end %>
       </li>

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_tags/show.erb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_tags/show.erb
@@ -13,7 +13,15 @@
     <% end %>
 
     <% if has_visible_scopes?(model) %>
-      <li><%= link_to translated_attribute(scope.name), resource_locator(model).index(filter: { scope_id: [scope.id] }) %></li>
+      <li>
+        <%= link_to translated_attribute(scope.name), resource_locator(model).index(filter: { scope_id: [scope.id] }) %>
+        <% if previous_scope.present? && show_previous_scope? %>
+          &nbsp;
+          <small class="text-small">
+            <%= t("changed_from", scope: "decidim.proposals.proposals.tags", previous_scope: "#{previous_scope.translated_name}").html_safe %>
+          </small>
+        <% end %>
+      </li>
     <% end %>
   </ul>
 </figure>

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_tags_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_tags_cell.rb
@@ -11,6 +11,7 @@ module Decidim
       property :category
       property :previous_category
       property :scope
+      property :previous_scope
 
       def show
         render if has_category_or_scopes?
@@ -20,6 +21,10 @@ module Decidim
 
       def show_previous_category?
         options[:show_previous_category].to_s != "false"
+      end
+
+      def show_previous_scope?
+        options[:show_previous_scope].to_s != "false"
       end
 
       def has_category_or_scopes?

--- a/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal_scope.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal_scope.rb
@@ -30,7 +30,7 @@ module Decidim
           return broadcast(:invalid_scope) if @scope.blank?
           return broadcast(:invalid_proposal_ids) if @proposal_ids.blank?
 
-          @response[:scope_name] = @scope.translated_name
+          @response[:scope_name] = translated_attribute(@scope.name)
           Proposal.where(id: @proposal_ids).find_each do |proposal|
             if @scope == proposal.scope
               @response[:errored] << proposal.title

--- a/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal_scope.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal_scope.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    module Admin
+      #  A command with all the business logic when an admin batch updates proposals scope.
+      class UpdateProposalScope < Rectify::Command
+        # Public: Initializes the command.
+        #
+        # scope_id - the scope id to update
+        # proposal_ids - the proposals ids to update.
+        def initialize(scope_id, proposal_ids)
+          @scope = Decidim::Scope.find_by id: scope_id
+          @proposal_ids = proposal_ids
+          @response = { scope_name: "", successful: [], errored: [] }
+        end
+
+        # Executes the command. Broadcasts these events:
+        #
+        # - :update_proposals_scope - when everything is ok, returns @response.
+        # - :invalid_scope - if the scope is blank.
+        # - :invalid_proposal_ids - if the proposal_ids is blank.
+        #
+        # Returns @response hash:
+        #
+        # - :scope_name - the translated_name of the scope assigned
+        # - :successful - Array of names of the updated proposals
+        # - :errored - Array of names of the proposals not updated because they already had the scope assigned
+        def call
+          return broadcast(:invalid_scope) if @scope.blank?
+          return broadcast(:invalid_proposal_ids) if @proposal_ids.blank?
+
+          @response[:scope_name] = @scope.translated_name
+          Proposal.where(id: @proposal_ids).find_each do |proposal|
+            if @scope == proposal.scope
+              @response[:errored] << proposal.title
+            else
+              transaction do
+                update_proposal_scope proposal
+                notify_author proposal if proposal.coauthorships.any?
+              end
+              @response[:successful] << proposal.title
+            end
+          end
+
+          broadcast(:update_proposals_scope, @response)
+        end
+
+        private
+
+        def update_proposal_scope(proposal)
+          proposal.update!(
+            scope: @scope
+          )
+        end
+
+        def notify_author(proposal)
+          Decidim::EventsManager.publish(
+            event: "decidim.events.proposals.proposal_update_scope",
+            event_class: Decidim::Proposals::Admin::UpdateProposalScopeEvent,
+            resource: proposal,
+            affected_users: proposal.notifiable_identities
+          )
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
@@ -76,16 +76,16 @@ module Decidim
           enforce_permission_to :update, :proposal_scope
           @proposal_ids = params[:proposal_ids]
 
-          Admin::UpdateProposalScope.call(params[:category][:id], params[:proposal_ids]) do
+          Admin::UpdateProposalScope.call(params[:scope][:id], params[:proposal_ids]) do
             on(:invalid_scope) do
-              flash.now[:error] = I18n.t(
+              flash.now[:error] = t(
                 "proposals.update_scope.select_a_scope",
                 scope: "decidim.proposals.admin"
               )
             end
 
             on(:invalid_proposal_ids) do
-              flash.now[:alert] = I18n.t(
+              flash.now[:alert] = t(
                 "proposals.update_scope.select_a_proposal",
                 scope: "decidim.proposals.admin"
               )
@@ -114,12 +114,12 @@ module Decidim
           @form = form(Admin::ProposalForm).from_params(params)
           Admin::UpdateProposal.call(@form, @proposal) do
             on(:ok) do |_proposal|
-              flash[:notice] = I18n.t("proposals.update.success", scope: "decidim")
+              flash[:notice] = t("proposals.update.success", scope: "decidim")
               redirect_to proposals_path
             end
 
             on(:invalid) do
-              flash.now[:alert] = I18n.t("proposals.update.error", scope: "decidim")
+              flash.now[:alert] = t("proposals.update.error", scope: "decidim")
               render :edit
             end
           end
@@ -142,9 +142,9 @@ module Decidim
         def update_proposals_bulk_response_successful(response, subject)
           return if response[:successful].blank?
 
-          I18n.t(
+          t(
             "proposals.update_#{subject}.success",
-            "#{subject}": response[:"#{subject}_name"],
+            subject_name: response[:"#{subject}_name"],
             proposals: response[:successful].to_sentence,
             scope: "decidim.proposals.admin"
           )
@@ -153,9 +153,9 @@ module Decidim
         def update_proposals_bulk_response_errored(response, subject)
           return if response[:errored].blank?
 
-          I18n.t(
+          t(
             "proposals.update_#{subject}.invalid",
-            "#{subject}": response[:"#{subject}_name"],
+            subject_name: response[:"#{subject}_name"],
             proposals: response[:errored].to_sentence,
             scope: "decidim.proposals.admin"
           )

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
@@ -76,7 +76,7 @@ module Decidim
           enforce_permission_to :update, :proposal_scope
           @proposal_ids = params[:proposal_ids]
 
-          Admin::UpdateProposalScope.call(params[:scope][:id], params[:proposal_ids]) do
+          Admin::UpdateProposalScope.call(params[:scope_id], params[:proposal_ids]) do
             on(:invalid_scope) do
               flash.now[:error] = t(
                 "proposals.update_scope.select_a_scope",
@@ -142,23 +142,41 @@ module Decidim
         def update_proposals_bulk_response_successful(response, subject)
           return if response[:successful].blank?
 
-          t(
-            "proposals.update_#{subject}.success",
-            subject_name: response[:"#{subject}_name"],
-            proposals: response[:successful].to_sentence,
-            scope: "decidim.proposals.admin"
-          )
+          if subject == :category
+            t(
+              "proposals.update_category.success",
+              subject_name: response[:subject_name],
+              proposals: response[:successful].to_sentence,
+              scope: "decidim.proposals.admin"
+            )
+          elsif subject == :scope
+            t(
+              "proposals.update_scope.success",
+              subject_name: response[:subject_name],
+              proposals: response[:successful].to_sentence,
+              scope: "decidim.proposals.admin"
+            )
+          end
         end
 
         def update_proposals_bulk_response_errored(response, subject)
           return if response[:errored].blank?
 
-          t(
-            "proposals.update_#{subject}.invalid",
-            subject_name: response[:"#{subject}_name"],
-            proposals: response[:errored].to_sentence,
-            scope: "decidim.proposals.admin"
-          )
+          if subject == :category
+            t(
+              "proposals.update_category.invalid",
+              subject_name: response[:subject_name],
+              proposals: response[:errored].to_sentence,
+              scope: "decidim.proposals.admin"
+            )
+          elsif subject == :scope
+            t(
+              "proposals.update_scope.invalid",
+              subject_name: response[:subject_name],
+              proposals: response[:errored].to_sentence,
+              scope: "decidim.proposals.admin"
+            )
+          end
         end
 
         def form_presenter

--- a/decidim-proposals/app/events/decidim/proposals/admin/update_proposal_scope_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/admin/update_proposal_scope_event.rb
@@ -1,0 +1,11 @@
+# frozen-string_literal: true
+
+module Decidim
+  module Proposals
+    module Admin
+      class UpdateProposalScopeEvent < Decidim::Events::SimpleEvent
+        include Decidim::Events::AuthorEvent
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/permissions/decidim/proposals/admin/permissions.rb
+++ b/decidim-proposals/app/permissions/decidim/proposals/admin/permissions.rb
@@ -33,6 +33,9 @@ module Decidim
           # Every user allowed by the space can update the category of the proposal
           allow! if permission_action.subject == :proposal_category && permission_action.action == :update
 
+          # Every user allowed by the space can update the category of the proposal
+          allow! if permission_action.subject == :proposal_scope && permission_action.action == :update
+
           # Every user allowed by the space can import proposals from another_component
           allow! if permission_action.subject == :proposals && permission_action.action == :import
 

--- a/decidim-proposals/app/permissions/decidim/proposals/admin/permissions.rb
+++ b/decidim-proposals/app/permissions/decidim/proposals/admin/permissions.rb
@@ -33,7 +33,7 @@ module Decidim
           # Every user allowed by the space can update the category of the proposal
           allow! if permission_action.subject == :proposal_category && permission_action.action == :update
 
-          # Every user allowed by the space can update the category of the proposal
+          # Every user allowed by the space can update the scope of the proposal
           allow! if permission_action.subject == :proposal_scope && permission_action.action == :update
 
           # Every user allowed by the space can import proposals from another_component

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_bulk-actions.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_bulk-actions.html.erb
@@ -17,6 +17,7 @@
   </div>
 
   <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/recategorize" %>
+  <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/scope-change" %>
   <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/merge" %>
   <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/split" %>
   <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/assign_to_valuator" %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_dropdown.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_dropdown.html.erb
@@ -22,6 +22,11 @@
         </button>
       </li>
       <li>
+        <button type="button" data-action="scope-change-proposals">
+          <%= t("decidim.proposals.admin.proposals.index.change_scope") %>
+        </button>
+      </li>
+      <li>
         <button type="button" data-action="merge-proposals">
           <%= t("decidim.proposals.admin.proposals.index.merge") %>
         </button>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_scope-change.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_scope-change.html.erb
@@ -6,9 +6,17 @@
       <% end %>
     </div>
 
-    <%= scopes_picker_tag(:scope_id, try(:current_participatory_space)&.scope) %>
+    <%= scopes_picker_tag(
+          :scope_id,
+          try(:current_participatory_space)&.scope,
+          field: t("models.proposal.fields.scope", scope: "decidim.proposals")
+        ) %>
 
-    <%= submit_tag(t("decidim.proposals.admin.proposals.index.update_scope_button"), id: "js-submit-scope-change-proposals", class: "button small button--simple float-left") %>
+    <%= submit_tag(
+          t("decidim.proposals.admin.proposals.index.update_scope_button"),
+          id: "js-submit-scope-change-proposals",
+          class: "button small button--simple float-left"
+        ) %>
 
     <button id="js-cancel-scope-change-proposals" class="button tiny clear compact js-cancel-bulk-action" type="button">
       <%= t("decidim.proposals.admin.proposals.index.cancel") %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_scope-change.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_scope-change.html.erb
@@ -6,8 +6,7 @@
       <% end %>
     </div>
 
-    <%= bulk_scopes_select # current_component.participatory_space.scopes
-    %>
+    <%= scopes_picker_tag(:scope_id, try(:current_participatory_space)&.scope) %>
 
     <%= submit_tag(t("decidim.proposals.admin.proposals.index.update_scope_button"), id: "js-submit-scope-change-proposals", class: "button small button--simple float-left") %>
 

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_scope-change.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_scope-change.html.erb
@@ -1,0 +1,18 @@
+<div id="js-scope-change-proposals-actions" class="hide js-bulk-action-form">
+  <%= form_tag(update_scope_proposals_path, method: :post, remote: true, id: "js-form-scope-change-proposals", class: "flex--cc flex-gap--1") do %>
+    <div class="checkboxes hide">
+      <% proposals.each do |proposal| %>
+        <%= check_box_tag "proposal_ids[]", proposal.id, false, class: "js-check-all-proposal js-proposal-id-#{proposal.id}" %>
+      <% end %>
+    </div>
+
+    <%= bulk_scopes_select # current_component.participatory_space.scopes
+    %>
+
+    <%= submit_tag(t("decidim.proposals.admin.proposals.index.update_scope_button"), id: "js-submit-scope-change-proposals", class: "button small button--simple float-left") %>
+
+    <button id="js-cancel-scope-change-proposals" class="button tiny clear compact js-cancel-bulk-action" type="button">
+      <%= t("decidim.proposals.admin.proposals.index.cancel") %>
+    </button>
+  <% end %>
+</div>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
@@ -35,7 +35,7 @@
     </div>
 
     <div class="row column">
-      <strong><%= t ".body" %>:</strong>  <%= simple_format(present(proposal).body(strip_tags: true)) %>
+      <strong><%= t ".body" %>:</strong> <%= simple_format(present(proposal).body(strip_tags: true)) %>
     </div>
 
     <div class="row column">

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/update_category.js.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/update_category.js.erb
@@ -20,6 +20,7 @@
   $(".js-check-all").prop('checked', false);
   $(".js-check-all-proposal").prop('checked', false);
   window.hideBulkActionsButton();
+  window.hideBulkActionForms();
   window.showOtherActionsButtons();
   window.selectedProposalsCountUpdate();
 <% end %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/update_scope.js.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/update_scope.js.erb
@@ -1,10 +1,10 @@
 <% if flash.now[:error].present? %>
-  $("#js-form-recategorize-proposals #category_id").addClass("is-invalid-input")
+  $("#js-form-scope-change-proposals #scope_id").addClass("is-invalid-input")
   $("<%= escape_javascript(render partial: %q{js-callout}, locals: { css: %q{alert}, text: flash.now[:error] }) %>").appendTo(".callout-wrapper");
 <% end %>
 
 <% if flash.now[:alert].present? %>
-  $("#js-form-recategorize-proposals #category_id").removeClass("is-invalid-input")
+  $("#js-form-scope-change-proposals #scope_id").removeClass("is-invalid-input")
   $("<%= escape_javascript(render partial: %q{js-callout}, locals: { css: %q{warning}, text: flash.now[:alert] }) %>").appendTo(".callout-wrapper");
 <% end %>
 
@@ -16,7 +16,7 @@
       .replaceWith("<%= escape_javascript(render partial: %q{proposal-tr}, locals: { proposal: proposal_find(id) }) %>");
   <% end %>
 
-  $("#js-form-recategorize-proposals #category_id").removeClass("is-invalid-input")
+  $("#js-form-scope-change-proposals #scope_id").removeClass("is-invalid-input")
   $(".js-check-all").prop('checked', false);
   $(".js-check-all-proposal").prop('checked', false);
   window.hideBulkActionsButton();

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/update_scope.js.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/update_scope.js.erb
@@ -19,6 +19,8 @@
   $("#js-form-scope-change-proposals #scope_id").removeClass("is-invalid-input")
   $(".js-check-all").prop('checked', false);
   $(".js-check-all-proposal").prop('checked', false);
+
+  window.hideBulkActionForms();
   window.hideBulkActionsButton();
   window.showOtherActionsButtons();
   window.selectedProposalsCountUpdate();

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -258,6 +258,11 @@ en:
           email_outro: You have received this notification because you are the author of the proposal.
           email_subject: The %{resource_title} proposal category has been updated
           notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal category has been updated by an admin.
+        proposal_update_scope:
+          email_intro: 'An admin has updated the scope of your proposal "%{resource_title}", check it out in this page:'
+          email_outro: You have received this notification because you are the author of the proposal.
+          email_subject: The %{resource_title} proposal scope has been updated
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal scope has been updated by an admin.
         voting_enabled:
           email_intro: 'You can support proposals in %{participatory_space_title}! Start participating in this page:'
           email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
@@ -412,6 +417,7 @@ en:
             assign_to_valuator_button: Assign
             cancel: Cancel
             change_category: Change category
+            change_scope: Change scope
             merge: Merge into a new one
             merge_button: Merge
             select_component: Select a component
@@ -422,6 +428,7 @@ en:
             unassign_from_valuator: Unassign from valuator
             unassign_from_valuator_button: Unassign
             update: Update
+            update_scope_button: Update Scope
           new:
             create: Create
             title: Create proposal
@@ -457,6 +464,11 @@ en:
             select_a_category: Please select a category
             select_a_proposal: Please select a proposal
             success: 'Proposals successfully updated to the %{category} category: %{proposals}.'
+          update_scope:
+            invalid: 'These proposals already had the %{scope} scope: %{proposals}.'
+            select_a_category: Please select a scope
+            select_a_proposal: Please select a proposal
+            success: 'Proposals successfully updated to the %{scope} scope: %{proposals}.'
         proposals_imports:
           create:
             invalid: There was a problem importing the proposals

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -53,6 +53,7 @@ en:
     models:
       decidim/proposals/accepted_proposal_event: Proposal accepted
       decidim/proposals/admin/update_proposal_category_event: Proposal category changed
+      decidim/proposals/admin/update_proposal_scope_event: Proposal scope changed
       decidim/proposals/creation_enabled_event: Proposal creation enabled
       decidim/proposals/endorsing_enabled_event: Proposal endorsing enabled
       decidim/proposals/evaluating_proposal_event: Proposal is being evaluated
@@ -466,8 +467,8 @@ en:
             success: 'Proposals successfully updated to the %{subject_name} category: %{proposals}.'
           update_scope:
             invalid: 'These proposals already had the %{subject_name} scope: %{proposals}.'
-            select_a_scope: Please select a scope
             select_a_proposal: Please select a proposal
+            select_a_scope: Please select a scope
             success: 'Proposals successfully updated to the %{subject_name} scope: %{proposals}.'
         proposals_imports:
           create:

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -460,15 +460,15 @@ en:
             votes_count: Supports count
             votes_ranking: Ranking by supports
           update_category:
-            invalid: 'These proposals already had the %{category} category: %{proposals}.'
+            invalid: 'These proposals already had the %{subject_name} category: %{proposals}.'
             select_a_category: Please select a category
             select_a_proposal: Please select a proposal
-            success: 'Proposals successfully updated to the %{category} category: %{proposals}.'
+            success: 'Proposals successfully updated to the %{subject_name} category: %{proposals}.'
           update_scope:
-            invalid: 'These proposals already had the %{scope} scope: %{proposals}.'
-            select_a_category: Please select a scope
+            invalid: 'These proposals already had the %{subject_name} scope: %{proposals}.'
+            select_a_scope: Please select a scope
             select_a_proposal: Please select a proposal
-            success: 'Proposals successfully updated to the %{scope} scope: %{proposals}.'
+            success: 'Proposals successfully updated to the %{subject_name} scope: %{proposals}.'
         proposals_imports:
           create:
             invalid: There was a problem importing the proposals
@@ -804,7 +804,7 @@ en:
           withdraw_confirmation: Are you sure you want to withdraw this proposal?
           withdraw_proposal: Withdraw proposal
         tags:
-          changed_from: "(changed from <u>%{previous_category}</u> by an administrator)"
+          changed_from: "(changed from <u>%{previous_name}</u> by an administrator)"
         vote_button:
           already_voted: Already supported
           already_voted_hover: Withdraw support

--- a/decidim-proposals/lib/decidim/proposals/admin_engine.rb
+++ b/decidim-proposals/lib/decidim/proposals/admin_engine.rb
@@ -14,6 +14,7 @@ module Decidim
           resources :valuation_assignments, only: [:destroy]
           collection do
             post :update_category
+            post :update_scope
             resource :proposals_import, only: [:new, :create]
             resource :proposals_merge, only: [:create]
             resource :proposals_split, only: [:create]

--- a/decidim-proposals/spec/commands/decidim/proposals/admin_update_proposal_scope_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin_update_proposal_scope_spec.rb
@@ -7,12 +7,10 @@ module Decidim
     module Admin
       describe UpdateProposalScope do
         describe "call" do
-          let(:organization) { create(:organization) }
-
           let!(:proposal) { create :proposal }
           let!(:proposals) { create_list(:proposal, 3, component: proposal.component) }
-          let!(:scope_one) { create :scope, participatory_space: proposal.component.participatory_space }
-          let!(:scope) { create :scope, participatory_space: proposal.component.participatory_space }
+          let!(:scope_one) { create :scope, organization: proposal.organization }
+          let!(:scope) { create :scope, organization: proposal.organization }
 
           context "with no scope" do
             it "broadcasts invalid_scope" do

--- a/decidim-proposals/spec/commands/decidim/proposals/admin_update_proposal_scope_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin_update_proposal_scope_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Proposals
+    module Admin
+      describe UpdateProposalScope do
+        describe "call" do
+          let(:organization) { create(:organization) }
+
+          let!(:proposal) { create :proposal }
+          let!(:proposals) { create_list(:proposal, 3, component: proposal.component) }
+          let!(:scope_one) { create :scope, participatory_space: proposal.component.participatory_space }
+          let!(:scope) { create :scope, participatory_space: proposal.component.participatory_space }
+
+          context "with no scope" do
+            it "broadcasts invalid_scope" do
+              expect { described_class.call(nil, proposal.id) }.to broadcast(:invalid_scope)
+            end
+          end
+
+          context "with no proposals" do
+            it "broadcasts invalid_proposal_ids" do
+              expect { described_class.call(scope.id, nil) }.to broadcast(:invalid_proposal_ids)
+            end
+          end
+
+          describe "with a scope and proposals" do
+            context "when the scope is the same as the proposal's scope" do
+              before do
+                proposal.update!(scope: scope)
+              end
+
+              it "doesn't update the proposal" do
+                expect(proposal).not_to receive(:update!)
+                described_class.call(proposal.scope.id, proposal.id)
+              end
+            end
+
+            context "when the scope is diferent from the proposal's scope" do
+              before do
+                proposals.each { |p| p.update!(scope: scope_one) }
+              end
+
+              it "broadcasts update_proposals_scope" do
+                expect { described_class.call(scope.id, proposals.pluck(:id)) }.to broadcast(:update_proposals_scope)
+              end
+
+              it "updates the proposal" do
+                described_class.call(scope.id, proposal.id)
+
+                expect(proposal.reload.scope).to eq(scope)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/events/decidim/proposals/admin/update_proposal_scope_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/admin/update_proposal_scope_event_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Proposals::Admin::UpdateProposalScopeEvent do
+  let(:resource) { create :proposal, title: "My super proposal" }
+  let(:event_name) { "decidim.events.proposals.proposal_update_scope" }
+
+  include_context "when a simple event"
+  it_behaves_like "a simple event"
+
+  describe "email_subject" do
+    it "is generated correctly" do
+      expect(subject.email_subject).to eq("The #{resource.title} proposal scope has been updated")
+    end
+  end
+
+  describe "email_intro" do
+    it "is generated correctly" do
+      expect(subject.email_intro)
+        .to eq("An admin has updated the scope of your proposal \"#{resource.title}\", check it out in this page:")
+    end
+  end
+
+  describe "email_outro" do
+    it "is generated correctly" do
+      expect(subject.email_outro)
+        .to eq("You have received this notification because you are the author of the proposal.")
+    end
+  end
+
+  describe "notification_title" do
+    it "is generated correctly" do
+      expect(subject.notification_title)
+        .to include("The <a href=\"#{resource_path}\">#{resource.title}</a> proposal scope has been updated by an admin.")
+    end
+  end
+end

--- a/decidim-proposals/spec/shared/manage_proposals_scope_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_scope_examples.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 shared_examples "when managing proposals scope as an admin" do
-  let(:parent_scope) { create :scope, participatory_space: participatory_process }
-  let(:scope) { create :scope, participatory_space: participatory_process, parent_id: parent_scope.id }
-  let!(:my_scope) { create :scope, participatory_space: participatory_process, parent_id: parent_scope.id }
-  let!(:proposal_first) { reportables.first }
-  let!(:proposal_last) { reportables.last }
-
   context "when in the Proposals list page" do
     it "shows a checkbox to select each proposal" do
       expect(page).to have_css(".table-list tbody .js-proposal-list-check", count: 4)
@@ -50,26 +44,11 @@ shared_examples "when managing proposals scope as an admin" do
         end
 
         it "shows the scope select" do
-          expect(page).to have_css("select#scope_id", count: 1)
+          expect(page).to have_css("#scope_id.data-picker.picker-single", count: 1)
         end
 
         it "shows an update button" do
-          expect(page).to have_css("button#js-submit-edit-scope", count: 1)
-        end
-      end
-
-      context "when submiting form" do
-        before do
-          click_button "Actions"
-          click_button "Change scope"
-          within "#js-form-recategorize-proposals" do
-            select translated(scope.name), from: :scope_id
-            page.find("button#js-submit-edit-scope").click
-          end
-        end
-
-        it "changes to selected scope" do
-          expect(page).to have_selector(".success")
+          expect(page).to have_css("button#js-submit-scope-change-proposals", count: 1)
         end
       end
     end

--- a/decidim-proposals/spec/shared/manage_proposals_scope_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_scope_examples.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+shared_examples "when managing proposals scope as an admin" do
+  let(:parent_scope) { create :scope, participatory_space: participatory_process }
+  let(:scope) { create :scope, participatory_space: participatory_process, parent_id: parent_scope.id }
+  let!(:my_scope) { create :scope, participatory_space: participatory_process, parent_id: parent_scope.id }
+  let!(:proposal_first) { reportables.first }
+  let!(:proposal_last) { reportables.last }
+
+  context "when in the Proposals list page" do
+    it "shows a checkbox to select each proposal" do
+      expect(page).to have_css(".table-list tbody .js-proposal-list-check", count: 4)
+    end
+
+    it "shows a checkbox to (des)select all proposal" do
+      expect(page).to have_css(".table-list thead .js-check-all", count: 1)
+    end
+
+    context "when selecting proposals" do
+      before do
+        page.find("#proposals_bulk.js-check-all").set(true)
+      end
+
+      it "shows the number of selected proposals" do
+        expect(page).to have_css("span#js-selected-proposals-count", count: 1)
+      end
+
+      it "shows the bulk actions button" do
+        expect(page).to have_css("#js-bulk-actions-button", count: 1)
+      end
+
+      context "when click the bulk action button" do
+        before do
+          click_button "Actions"
+        end
+
+        it "shows the bulk actions dropdown" do
+          expect(page).to have_css("#js-bulk-actions-dropdown", count: 1)
+        end
+
+        it "shows the change action option" do
+          expect(page).to have_selector(:link_or_button, "Change scope")
+        end
+      end
+
+      context "when change scope is selected from actions dropdown" do
+        before do
+          click_button "Actions"
+          click_button "Change scope"
+        end
+
+        it "shows the scope select" do
+          expect(page).to have_css("select#scope_id", count: 1)
+        end
+
+        it "shows an update button" do
+          expect(page).to have_css("button#js-submit-edit-scope", count: 1)
+        end
+      end
+
+      context "when submiting form" do
+        before do
+          click_button "Actions"
+          click_button "Change scope"
+          within "#js-form-recategorize-proposals" do
+            select translated(scope.name), from: :scope_id
+            page.find("button#js-submit-edit-scope").click
+          end
+        end
+
+        it "changes to selected scope" do
+          expect(page).to have_selector(".success")
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/shared/merge_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/merge_proposals_examples.rb
@@ -26,7 +26,7 @@ shared_examples "merge proposals" do
 
       context "when less than one proposal is checked" do
         before do
-          page.find("#proposals_bulk.js-check-all").set(false)
+          visit current_path
           page.first(".js-proposal-list-check").set(true)
         end
 

--- a/decidim-proposals/spec/system/admin_manages_proposals_spec.rb
+++ b/decidim-proposals/spec/system/admin_manages_proposals_spec.rb
@@ -20,6 +20,7 @@ describe "Admin manages proposals", type: :system do
   it_behaves_like "manage proposals help texts"
   it_behaves_like "manage proposal wizard steps help texts"
   it_behaves_like "when managing proposals category as an admin"
+  it_behaves_like "when managing proposals scope as an admin"
   it_behaves_like "import proposals"
   it_behaves_like "manage proposals permissions"
   it_behaves_like "merge proposals"


### PR DESCRIPTION
#### :tophat: What? Why?

Add ability to administrators to assign a different scope to one or more proposals, a bulk action like categories.

Visitor can see the scope changed made by an administrator in the version control of the proposal.

Notifiable (co)authors will be notified, that an admin changed the proposal(s) scope.

#### :pushpin: Related Issues
- Fixes #5719
- Fixes #5747 (related to #5646)

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add/modify seeds
- [x] Add tests

### :camera: Screenshots (optional)

- Admin: select proposals -> actions menu -> change scope: 
  <img width="1093" alt="Screenshot 2020-02-28 at 18 58 09" src="https://user-images.githubusercontent.com/210216/75573221-ad58f200-5a5c-11ea-9c29-8fa47d5c8320.png">

- Admin select scope to update proposals scope: 
  <img width="1085" alt="Screenshot 2020-02-26 at 07 54 28" src="https://user-images.githubusercontent.com/210216/75319667-68bb3400-586d-11ea-9bc3-ca38dd1610ec.png">  
  <img width="1291" alt="Screenshot 2020-02-28 at 18 58 30" src="https://user-images.githubusercontent.com/210216/75573276-c95c9380-5a5c-11ea-8f86-2c65752a3acd.png">

- Visitor can see previous scope:
  <img width="1280" alt="Screenshot 2020-02-20 at 17 18 27" src="https://user-images.githubusercontent.com/210216/74955652-3f318100-5405-11ea-890e-3eceb50f840b.png">

- Author receives a notification:  
  <img width="748" alt="Screenshot 2020-02-26 at 09 41 24" src="https://user-images.githubusercontent.com/210216/75327290-67ddce80-587c-11ea-9d28-02003ec5f66e.png">



