### PR TITLE
Upgrade notes related with custom omniauth providers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ To make it clear, installations with custom Omniauth providers must remove the p
 The recommended way to go is to configure `config/secrets.yml` with the variables needed (can be filled with dummy data) and then go to `yourinstallation.tld/system` to configure the valid values for the tenant.
 
 ```
-# This block should be kept
+# The following should be removed from any initializer and moved into Rails secrets
 if Rails.application.secrets.dig(:omniauth, :decidim, :enabled)
   Devise.setup do |config|
     config.omniauth :decidim,
@@ -55,9 +55,12 @@ if Rails.application.secrets.dig(:omniauth, :decidim, :enabled)
                     scope: :public
   end
 end
-# this line should be removed
 Decidim::User.omniauth_providers << :decidim
 ```
+
+Maintainers of custom omniauth providers will need to add translations for the translatable settings names in organization's system administration panel.
+
+Documentation regarding oauth providers has been updated: https://github.com/decidim/decidim/blob/develop/docs/services/social_providers.md
 
 - **Geocoder**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,30 @@ PR [\#5768](https://github.com/decidim/decidim/pull/5768) introduced a deprecati
 
 ### Upgrade notes
 
+- **Omniauth settings for each tenant**
+
+Thanks to [\#5516](https://github.com/decidim/decidim/pull/5516) it is now possible to customize which omniauth providers are enabled on each of the organizations in a multitenant installation.
+
+This modification changes the way devise omniauth providers are activated. It is now automatic, so all providers declared in the secrets file are loaded into `Decidim::OmniauthProvider#available` and then activated in `Decidim::User` `devise` declaration.
+
+To make it clear, installations with custom Omniauth providers must remove the provider configuration from the corresponding `config/initializer/omniauth_xxx.rb` (just remove the whole file if it is the only thing declared there). 
+The recommended way to go is to configure `config/secrets.yml` with the variables needed (can be filled with dummy data) and then go to `yourinstallation.tld/system` to configure the valid values for the tenant.
+
+```
+# This block should be kept
+if Rails.application.secrets.dig(:omniauth, :decidim, :enabled)
+  Devise.setup do |config|
+    config.omniauth :decidim,
+                    Rails.application.secrets.dig(:omniauth, :decidim, :client_id),
+                    Rails.application.secrets.dig(:omniauth, :decidim, :client_secret),
+                    Rails.application.secrets.dig(:omniauth, :decidim, :site_url),
+                    scope: :public
+  end
+end
+# this line should be removed
+Decidim::User.omniauth_providers << :decidim
+```
+
 - **Geocoder**
 
 Here maps API has changed, including the way clients authenticate. Thus, former `app_id` and `app_code` credentials are now deprecated in favour of a unique `api_key` token. For your current application to continue working with Here maps services generate an `api_key` and configure it as explained in [Decidim's geocoding documentation](https://github.com/decidim/decidim/blob/master/docs/services/geocoding.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,13 +39,26 @@ PR [\#5768](https://github.com/decidim/decidim/pull/5768) introduced a deprecati
 
 Thanks to [\#5516](https://github.com/decidim/decidim/pull/5516) it is now possible to customize which omniauth providers are enabled on each of the organizations in a multitenant installation.
 
-This modification changes the way devise omniauth providers are activated. It is now automatic, so all providers declared in the secrets file are loaded into `Decidim::OmniauthProvider#available` and then activated in `Decidim::User` `devise` declaration.
+This modification changes the way Devise omniauth providers are activated. It is now automatic, so all providers declared in the secrets file are loaded into `Decidim::OmniauthProvider#available` and then activated in `Decidim::User` `devise` declaration.
 
-To make it clear, installations with custom Omniauth providers must remove the provider configuration from the corresponding `config/initializer/omniauth_xxx.rb` (just remove the whole file if it is the only thing declared there). 
-The recommended way to go is to configure `config/secrets.yml` with the variables needed (can be filled with dummy data) and then go to `yourinstallation.tld/system` to configure the valid values for the tenant.
+If you want to enable sign up through social providers like Facebook you will need to generate app credentials and store them in one of the following places:
+
+- In the Rails secrets file: `config/secrets.yml`. This configuration will be shared by all tenants.
+- In the organization's configuration (ex. system/organizations/1/edit). This configuration overrides the one in `config/secrets.yml`.
+
+Take into account that for a social provider integration to appear in the organization form, it must also be defined in `config/secrets.yml` (but the values are optional). For example:
+
+```yaml
+twitter:
+  enabled: false # disabled by default, unless activated in the organization
+  api_key:
+  api_secret:
+```
+
+Installations with custom Omniauth providers must remove the provider configuration from the corresponding `config/initializer/omniauth_xxx.rb` (just remove the whole file if it is the only thing declared there). Then copy the required values in `config/secrets.yml` or go to `yourinstallation.tld/system` to configure the valid values for the tenant (this requires to have at least the provider with `enabled: false` in the `config/secrets.yml`).
 
 ```
-# The following should be removed from any initializer and moved into Rails secrets
+# The following should be removed from any initializer or Rails will crash when starting
 if Rails.application.secrets.dig(:omniauth, :decidim, :enabled)
   Devise.setup do |config|
     config.omniauth :decidim,
@@ -58,7 +71,7 @@ end
 Decidim::User.omniauth_providers << :decidim
 ```
 
-Maintainers of custom omniauth providers will need to add translations for the translatable settings names in organization's system administration panel.
+Maintainers of custom omniauth providers will need to add translations for the translatable settings names in organization's system administration panel, see https://github.com/decidim/decidim/pull/6042 for context.
 
 Documentation regarding oauth providers has been updated: https://github.com/decidim/decidim/blob/develop/docs/services/social_providers.md
 

--- a/docs/services/social_providers.md
+++ b/docs/services/social_providers.md
@@ -54,13 +54,13 @@ twitter:
 
 ## Custom providers
 
-* You can define your own provider, to allow users from other external applications to login into Decidim.
-* The provider should implement an [OmniAuth](https://github.com/omniauth/omniauth) strategy.
-* You can use any of the [existing OnmiAuth strategies](https://github.com/omniauth/omniauth/wiki/List-of-Strategies).
-* Or you can create a new strategy, as the [Decidim OmniAuth Strategy](https://github.com/decidim/omniauth-decidim). This strategy allow users from a Decidim instance to login in other Decidim instance. For example, this strategy is used to allow [decidim.barcelona](https://decidim.barcelona) users to log into [meta.decidim.barcelona](https://meta.decidim.barcelona).
-* Once you have defined your strategy, you can configure it in the `config/secrets.yml` or in the organization configuration, as it is done for the built-in providers.
-* By default, Decidim will search in its icons library for an icon named as the provider. You can change this adding an `icon` or `icon_path` attribute to the provider configuration. The `icon` attribute sets the icon name to look for in the Decidim's icons library. The `icon_path` attribute sets the route to the image that should be used.
-* Here is an example of the configuration section for the Decidim strategy, using an icon located on the application's `app/assets/images` folder:
+- You can define your own provider, to allow users from other external applications to login into Decidim.
+- The provider should implement an [OmniAuth](https://github.com/omniauth/omniauth) strategy.
+- You can use any of the [existing OnmiAuth strategies](https://github.com/omniauth/omniauth/wiki/List-of-Strategies).
+- Or you can create a new strategy, as the [Decidim OmniAuth Strategy](https://github.com/decidim/omniauth-decidim). This strategy allow users from a Decidim instance to login in other Decidim instance. For example, this strategy is used to allow [decidim.barcelona](https://decidim.barcelona) users to log into [meta.decidim.barcelona](https://meta.decidim.barcelona).
+- Once you have defined your strategy, you can configure it in the `config/secrets.yml` or in the organization configuration, as it is done for the built-in providers.
+- By default, Decidim will search in its icons library for an icon named as the provider. You can change this adding an `icon` or `icon_path` attribute to the provider configuration. The `icon` attribute sets the icon name to look for in the Decidim's icons library. The `icon_path` attribute sets the route to the image that should be used.
+- Here is an example of the configuration section for the Decidim strategy, using an icon located on the application's `app/assets/images` folder:
 
 ```yaml
     decidim:
@@ -70,3 +70,31 @@ twitter:
       site_url: <%= ENV["DECIDIM_SITE_URL"] %>
       icon_path: decidim-logo.svg
 ```
+
+- You will need a custom initializer for your provider in order to pass the proper params to the OmniaAuth Builder.
+
+An example of custom initializer could be written as:
+
+```ruby
+#config/initializers/omniauth_myprovider.rb
+
+if Rails.application.secrets.dig(:omniauth, :myprovider).present?
+  Rails.application.config.middleware.use OmniAuth::Builder do
+    provider(
+      :myprovider,
+      setup: ->(env) {
+          request = Rack::Request.new(env)
+          organization = Decidim::Organization.find_by(host: request.host)
+          provider_config = organization.enabled_omniauth_providers[:myprovider]
+
+          env["omniauth.strategy"].options[:client_id] = provider_config[:client_id]
+          env["omniauth.strategy"].options[:client_secret] = provider_config[:client_secret]
+          env["omniauth.strategy"].options[:site] = provider_config[:site_url]
+        },
+      scope: :public
+    )
+  end
+end
+```
+
+The custom provider may have different configuration options, instead of `client_id`, `client_secret` and `site`.


### PR DESCRIPTION
#### :tophat: What? Why?
Thanks to [\#5516](https://github.com/decidim/decidim/pull/5516) it is now possible to customize which omniauth providers are enabled on each of the organizations in a multitenant installation.

But this also changes how this providers are configured in each installation.

This PR adds Upgrade notes to make developers/sysadmins aware of the required configuration change.

#### :pushpin: Related Issues
- Related to #5516 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [x] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
