### PR TITLE
Request confirmation to exit budgets component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ After this, `Decidim::Proposals::ProposalEndorsement` and the corresponding coun
 - **decidim-proposals**, **decidim-core**, **decidim-blogs**: Extract proposals' endorsements into a polymorphic concern that can now be applied no any resource. It has, in turn, been aplied to blog posts. [\#5542](https://github.com/decidim/decidim/pull/5542)
 - **decidim-proposals**, **decidim-core**, **decidim-blogs**: Apply generalized endorsements to the GraphQL API and add it to the blog posts query. [\#5847](https://github.com/decidim/decidim/pull/5847)
 - **decidim-budgets**: Allow projects to be sorted by different criteria [\#5808](https://github.com/decidim/decidim/pull/5808)
+- **decidim-budgets**: Request confirmation to exit budgets component [\#5765](https://github.com/decidim/decidim/pull/5765)
 
 ### Changed
 

--- a/decidim-budgets/app/assets/javascripts/decidim/budgets/projects.js.es6
+++ b/decidim-budgets/app/assets/javascripts/decidim/budgets/projects.js.es6
@@ -5,7 +5,7 @@ $(() => {
   const $projects = $("#projects, #project");
   const $budgetSummaryTotal = $(".budget-summary__total");
   const $budgetExceedModal = $("#budget-excess");
-
+  const $budgetSummary = $(".budget-summary__progressbox");
   const totalBudget = parseInt($budgetSummaryTotal.attr("data-total-budget"), 10);
 
   const cancelEvent = (event) => {
@@ -14,7 +14,7 @@ $(() => {
   };
 
   $projects.on("click", ".budget--list__action", (event) => {
-    const currentBudget = parseInt($(".budget-summary__progressbox").attr("data-current-budget"), 10);
+    const currentBudget = parseInt($budgetSummary.attr("data-current-budget"), 10);
     const $currentTarget = $(event.currentTarget);
     const projectBudget = parseInt($currentTarget.attr("data-budget"), 10);
 
@@ -26,4 +26,26 @@ $(() => {
       cancelEvent(event);
     }
   });
+
+  if ($("#order-progress [data-toggle=budget-confirm]").length > 0) {
+    const safeUrl = $(".budget-summary").attr("data-safe-url");
+    $(document).on("click", "a", (event) => {
+      window.exitUrl = event.currentTarget.href;
+    });
+    $(document).on("submit", "form", (event) => {
+      window.exitUrl = event.currentTarget.action;
+    });
+
+    window.onbeforeunload = () => {
+      const currentBudget = parseInt($budgetSummary.attr("data-current-budget"), 10);
+      const exitUrl = window.exitUrl;
+      window.exitUrl = null;
+
+      if (currentBudget === 0 || (exitUrl && exitUrl.startsWith(safeUrl))) {
+        return null;
+      }
+
+      return "";
+    }
+  }
 });

--- a/decidim-budgets/app/controllers/decidim/budgets/projects_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/projects_controller.rb
@@ -9,7 +9,7 @@ module Decidim
       include Orderable
       include Decidim::Budgets::Orderable
 
-      helper_method :projects, :project
+      helper_method :projects, :project, :component_base_url
 
       private
 
@@ -54,6 +54,10 @@ module Decidim
 
       def context_params
         { component: current_component, organization: current_organization }
+      end
+
+      def component_base_url
+        EngineRouter.main_proxy(current_component).root_url
       end
     end
   end

--- a/decidim-budgets/app/controllers/decidim/budgets/projects_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/projects_controller.rb
@@ -9,7 +9,7 @@ module Decidim
       include Orderable
       include Decidim::Budgets::Orderable
 
-      helper_method :projects, :project, :component_base_url
+      helper_method :projects, :project
 
       private
 
@@ -54,10 +54,6 @@ module Decidim
 
       def context_params
         { component: current_component, organization: current_organization }
-      end
-
-      def component_base_url
-        EngineRouter.main_proxy(current_component).root_url
       end
     end
   end

--- a/decidim-budgets/app/helpers/decidim/budgets/projects_helper.rb
+++ b/decidim-budgets/app/helpers/decidim/budgets/projects_helper.rb
@@ -23,6 +23,10 @@ module Decidim
       def current_order_can_be_checked_out?
         current_order&.can_checkout?
       end
+
+      def projects_base_url
+        URI.parse(root_url).tap { |uri| uri.query = uri.fragment = nil } .to_s
+      end
     end
   end
 end

--- a/decidim-budgets/app/views/decidim/budgets/projects/_budget_summary.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_budget_summary.html.erb
@@ -1,4 +1,4 @@
-<div class="card budget-summary" data-progress-reference data-safe-url="<%= root_url %>">
+<div class="card budget-summary" data-progress-reference data-safe-url="<%= component_base_url %>">
   <div class="card__content">
     <% if include_heading %>
       <% if current_order_checked_out? %>

--- a/decidim-budgets/app/views/decidim/budgets/projects/_budget_summary.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_budget_summary.html.erb
@@ -1,4 +1,4 @@
-<div class="card budget-summary" data-progress-reference data-safe-url="<%= component_base_url %>">
+<div class="card budget-summary" data-progress-reference data-safe-url="<%= projects_base_url %>">
   <div class="card__content">
     <% if include_heading %>
       <% if current_order_checked_out? %>

--- a/decidim-budgets/app/views/decidim/budgets/projects/_budget_summary.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_budget_summary.html.erb
@@ -1,4 +1,4 @@
-<div class="card budget-summary" data-progress-reference>
+<div class="card budget-summary" data-progress-reference data-safe-url="<%= root_url %>">
   <div class="card__content">
     <% if include_heading %>
       <% if current_order_checked_out? %>

--- a/decidim-budgets/spec/helpers/projects_helper_spec.rb
+++ b/decidim-budgets/spec/helpers/projects_helper_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Budgets
+    describe ProjectsHelper do
+      describe "#projects_base_url" do
+        subject { helper.projects_base_url }
+
+        before { allow(helper).to receive(:root_url).and_return("http://localhost:3000/processes/similique-odit/f/13/") }
+
+        it { is_expected.to eq("http://localhost:3000/processes/similique-odit/f/13/") }
+
+        context "when query string is present" do
+          before { allow(helper).to receive(:root_url).and_return("http://localhost:3000/processes/similique-odit/f/13/?locale=es&extra=1") }
+
+          it { is_expected.to eq("http://localhost:3000/processes/similique-odit/f/13/") }
+        end
+      end
+    end
+  end
+end

--- a/decidim-budgets/spec/system/orders_spec.rb
+++ b/decidim-budgets/spec/system/orders_spec.rb
@@ -110,6 +110,18 @@ describe "Orders", type: :system do
         expect(page).to have_no_selector ".budget-list__data--added"
       end
 
+      it "is alerted when trying to leave the component before completing" do
+        visit_component
+
+        expect(page).to have_content "ASSIGNED: €25,000,000"
+
+        dismiss_confirm do
+          page.find(".logo-wrapper a").click
+        end
+
+        expect(page).to have_current_path main_component_path(component)
+      end
+
       context "and try to vote a project that exceed the total budget" do
         let!(:expensive_project) { create(:project, component: component, budget: 250_000_000) }
 
@@ -180,6 +192,16 @@ describe "Orders", type: :system do
         within ".budget-summary" do
           expect(page).to have_no_selector(".cancel-order")
         end
+      end
+
+      it "is not alerted when trying to leave the component" do
+        visit_component
+
+        expect(page).to have_content("Budget vote completed")
+
+        page.find(".logo-wrapper a").click
+
+        expect(page).to have_current_path decidim.root_path
       end
     end
 

--- a/decidim-budgets/spec/system/orders_spec.rb
+++ b/decidim-budgets/spec/system/orders_spec.rb
@@ -17,6 +17,10 @@ describe "Orders", type: :system do
            participatory_space: participatory_process)
   end
 
+  before do
+    switch_to_host(organization.host)
+  end
+
   context "when the user is not logged in" do
     let!(:projects) { create_list(:project, 1, component: component, budget: 25_000_000) }
 

--- a/decidim-budgets/spec/system/orders_spec.rb
+++ b/decidim-budgets/spec/system/orders_spec.rb
@@ -17,10 +17,6 @@ describe "Orders", type: :system do
            participatory_space: participatory_process)
   end
 
-  before do
-    switch_to_host(organization.host)
-  end
-
   context "when the user is not logged in" do
     let!(:projects) { create_list(:project, 1, component: component, budget: 25_000_000) }
 


### PR DESCRIPTION
#### :tophat: What? Why?
Some users don't understand that they have to press VOTE to finish the process. So, they leave the budgets component before doing it.

This PR adds an alert message when the user tries to navigate after selecting projects. This alert doesn't shows up when the user is navigating to other pages of the same component, to allow user to browse and filter projects. 

Note: this feature is implemented using the [`beforeunload`](https://www.w3schools.com/jsref/event_onbeforeunload.asp) event, that doesn't allow to know what is the target URL or to change the alert message (only IE allows it).

#### :pushpin: Related Issues
- Fixes #5713

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [x] Add tests

### :camera: Screenshots (optional)
<img width="1293" alt="Captura de pantalla 2020-02-20 a las 13 51 57" src="https://user-images.githubusercontent.com/453545/74935247-38e0dc00-53e8-11ea-8306-d979918734f3.png">

