### PR TITLE
Disable RSpec/RepeatedExampleGroupDescription

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1242,6 +1242,8 @@ RSpec/NamedSubject:
 RSpec/RepeatedExampleGroupDescription:
   Enabled: false
 
+RSpec/RepeatedExampleGroupBody:
+  Enabled: false
 RSpec/VerifiedDoubles:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1239,6 +1239,9 @@ RSpec/NestedGroups:
 RSpec/NamedSubject:
   Enabled: false
 
+RSpec/RepeatedExampleGroupDescription:
+  Enabled: false
+
 RSpec/VerifiedDoubles:
   Enabled: false
 


### PR DESCRIPTION
#### :tophat: What? Why?
Disabling this cop until there are resources to refactor the code.

The v1.38 `rubocop-rspec` version introduces the `RSpec/RepeatedExampleGroupDescription` cop.
This cop has found that we have 20 cases of code duplication. Until there are resources to tackle this, the cop is going to be disabled.


#### :pushpin: Related Issues
- Fixes #5773 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

