### PR TITLE
Add CircleCI skip for Crowdin

### DIFF
--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -1,3 +1,4 @@
+commit_message: "[ci skip]"
 files:
   - source: /**/locales/en.yml
     translation: /**/locales/%locale%.yml


### PR DESCRIPTION
#### :tophat: What? Why?

This adds the CircleCI skip for Crowdin configuration. See [documentation on Crowdin](https://support.crowdin.com/configuration-file/#configuration-file-for-vcs-integrations).

As this is something internal I think it's better to not reflect it on the CHANGELOG as it's noise. 

I have some doubts regarding the format, as it doesn't seem exactly the same as the Crowdin docs.
