### PR TITLE
Fix visual CSS issues in admin proposal filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now sup
 
 **Fixed**:
 
+- **decidim-admin**: Fixed css visual issues with dynamic filters. [\#5801](https://github.com/decidim/decidim/pull/5801)
 - **decidim-admin**: Fixed dynamic filters showing ID. [\#5786](https://github.com/decidim/decidim/pull/5786)
 - **decidim-comments**: Fix rendering up to 4 levels of comments. [\#5707](https://github.com/decidim/decidim/pull/5707)
 - **decidim-proposals**: Render rich text in Proposals originated in Meetings. [\#5705](https://github.com/decidim/decidim/pull/5705)

--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_filters.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_filters.scss
@@ -24,7 +24,7 @@
   }
 
   .dropdown.menu{
-    z-index: 100;
+    z-index: 5;
 
     & > li.is-dropdown-submenu-parent > a{
       padding-right: 1rem;

--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_layout.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_layout.scss
@@ -63,11 +63,11 @@ body{
 .layout-content{
   flex-grow: 1;
   max-width: 100%;
+  overflow: scroll;
 }
 
 .container{
   padding: 1rem;
-  max-width: 1200px;
 
   @include breakpoint(mediumlarge){
     padding: 2rem;


### PR DESCRIPTION
#### :tophat: What? Why?

Fixes visual css issues in admin proposals filters reported in #5701 :
* Solve the z-index layout problem of the dropdown
* Solve the different width layout problem

As fixed second point's width layout problem, the layer-content now has to be horizontal scrolled when displayed width is minor than 1500px as a way to force keep inside parent container.

#### :pushpin: Related Issues
- Fixes #5701 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

* Solve the z-index layout problem of the dropdown: pending

**Before**
![image](https://user-images.githubusercontent.com/9702463/75361794-24a15100-58b8-11ea-8d2e-848ed9870524.png)

**After**
![image](https://user-images.githubusercontent.com/9702463/75362390-eeb09c80-58b8-11ea-8589-f88f9395d8fa.png)


* Solve the different width layout problem: pending

**Before**
![image](https://user-images.githubusercontent.com/9702463/75361968-5aded080-58b8-11ea-8d96-098356508c5e.png)

**After**
![image](https://user-images.githubusercontent.com/9702463/75362239-b7da8680-58b8-11ea-9ba2-c686399d56a9.png)

