### PR TITLE
Avoid n+1 query on Surveys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now sup
 
 **Added**:
 - **decidim-core**: Add new language: Greek [#5597](https://github.com/decidim/decidim/pull/5597)
-
 - **decidim-initiatives**: An admin can only send the initiative to technical validation if it has enough committee members. [\#5762](https://github.com/decidim/decidim/pull/5762)
 - **decidim-proposals**: Add images to proposal cards [\#5640](https://github.com/decidim/decidim/pull/5640)
 - **decidim-api**: Added documentation to use the API (newcomers friendly). [\#5582](https://github.com/decidim/decidim/pull/5582)
@@ -90,6 +89,7 @@ Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now sup
 
 **Fixed**:
 
+-**decidim-surveys**: Fix n+1 query on surveys. [\#5813](https://github.com/decidim/decidim/pull/5813)
 - **decidim-initiatives**: Fix initiative state bug [\#5805](https://github.com/decidim/decidim/pull/5805)
 - **decidim-admin**, **decidim-proposals**: Fix proposal card layout. [\#5783](https://github.com/decidim/decidim/pull/5783)
 - **decidim-core**: [FIX] Add description pop up required [\#5771](https://github.com/decidim/decidim/pull/5771)

--- a/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
+++ b/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
@@ -21,7 +21,7 @@ module Decidim
           invisible_captcha on_spam: :spam_detected
 
           def show
-            @form = form(Decidim::Forms::QuestionnaireForm).from_model(questionnaire)
+            @form = Decidim::Forms::QuestionnaireForm.new(answers: answers)
             render template: "decidim/forms/questionnaires/show"
           end
 
@@ -95,6 +95,12 @@ module Decidim
 
           def questionnaire
             @questionnaire ||= Questionnaire.includes(questions: :answer_options).find_by(questionnaire_for: questionnaire_for)
+          end
+
+          def answers
+            questionnaire.questions.map do |question|
+              AnswerForm.from_model(Decidim::Forms::Answer.new(question: question))
+            end
           end
 
           def spam_detected

--- a/decidim-forms/app/forms/decidim/forms/questionnaire_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/questionnaire_form.rb
@@ -6,20 +6,10 @@ module Decidim
     class QuestionnaireForm < Decidim::Form
       attribute :answers, Array[AnswerForm]
       attribute :user_group_id, Integer
-
       attribute :tos_agreement, Boolean
 
       validates :tos_agreement, allow_nil: false, acceptance: true
       validate :session_token_in_context
-
-      # Private: Create the answers from the questionnaire questions
-      #
-      # Returns nothing.
-      def map_model(model)
-        self.answers = model.questions.map do |question|
-          AnswerForm.from_model(Decidim::Forms::Answer.new(question: question))
-        end
-      end
 
       def session_token_in_context
         return if context&.session_token

--- a/decidim-forms/spec/forms/decidim/forms/questionnaire_form_spec.rb
+++ b/decidim-forms/spec/forms/decidim/forms/questionnaire_form_spec.rb
@@ -6,7 +6,13 @@ module Decidim
   module Forms
     describe QuestionnaireForm do
       subject do
-        described_class.from_model(questionnaire).with_context(context)
+        described_class.new(answers: answers).with_context(context)
+      end
+
+      let(:answers) do
+        questionnaire.questions.map do |question|
+          AnswerForm.from_model(Decidim::Forms::Answer.new(question: question))
+        end
       end
 
       let!(:questionnaire) { create(:questionnaire) }

--- a/decidim-meetings/spec/commands/join_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/join_meeting_spec.rb
@@ -206,7 +206,12 @@ module Decidim::Meetings
       let!(:questionnaire) { create(:questionnaire) }
       let!(:question) { create(:questionnaire_question, questionnaire: questionnaire) }
       let(:session_token) { "some-token" }
-      let(:registration_form) { Decidim::Forms::QuestionnaireForm.from_model(questionnaire).with_context(session_token: session_token) }
+      let(:answers) do
+        questionnaire.questions.map do |question|
+          Decidim::Forms::AnswerForm.from_model(Decidim::Forms::Answer.new(question: question))
+        end
+      end
+      let(:registration_form) { Decidim::Forms::QuestionnaireForm.new(answers: answers).with_context(session_token: session_token) }
 
       context "and the registration form is invalid" do
         it "broadcast invalid_form" do


### PR DESCRIPTION
#### :tophat: What? Why?
We noticed that the survey component was querying the whole answers table when instantiated.

In `decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb`:
```ruby
def show
  @form = form(Decidim::Forms::QuestionnaireForm).from_model(questionnaire)
  render template: "decidim/forms/questionnaires/show"
end
```

The consequence was the questionnaire answers were queried, and replaced by the questions.
For a 3370 answers survey, the number of queries needed to render the form was:
6486 request -> 52680 ms in local env

After this fix it was:
38 request -> 37 ms in local env

related to:
https://github.com/decidim/decidim/issues/5697

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)
before: 
<img width="1680" alt="Capture d’écran 2020-03-01 à 20 33 34" src="https://user-images.githubusercontent.com/20232956/75632405-f98e6880-5bfb-11ea-8f89-502c2e4b2f25.png">

After: 
![image](https://user-images.githubusercontent.com/20232956/75632414-175bcd80-5bfc-11ea-828f-5905de8f67ac.png)

