### PR TITLE
fix geocoder compatibility with older versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@ Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now sup
 
 **Fixed**:
 
+- **decidim-core** Fixes the integration between the use of older and new versions of geocoder using HERE maps [\#5822](https://github.com/decidim/decidim/pull/5822)
 - **decidim-core** and **decidim-dev**: Solve puma's GHSA-84j7-475p-hp8v vulnerability, and nokogiri's CVE-2020-7595 vulnerability. [\#5820](https://github.com/decidim/decidim/pull/5820)
 - **decidim-core**: Do not allow invited users to sign up. [\#5803](https://github.com/decidim/decidim/pull/5803)
 - **decidim-initiatives**: Fix initiative state bug [\#5805](https://github.com/decidim/decidim/pull/5805)

--- a/decidim-core/app/services/decidim/static_map_generator.rb
+++ b/decidim-core/app/services/decidim/static_map_generator.rb
@@ -31,9 +31,15 @@ module Decidim
         z: @options[:zoom],
         w: @options[:width],
         h: @options[:height],
-        f: "1",
-        api_key: Decidim.geocoder.fetch(:here_api_key)
+        f: "1"
       }
+
+      if Decidim.geocoder[:here_api_key].present?
+        params[:apiKey] = Decidim.geocoder.fetch(:here_api_key)
+      else
+        params[:app_id] = Decidim.geocoder.fetch(:here_app_id)
+        params[:app_code] = Decidim.geocoder.fetch(:here_app_code)
+      end
 
       URI.parse(Decidim.geocoder.fetch(:static_map_url)).tap do |uri|
         uri.query = URI.encode_www_form params

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -115,7 +115,7 @@ module Decidim
           }
           # to use an API key:
           config[:api_key] = if Decidim.geocoder[:here_api_key].present?
-                               [Decidim.geocoder.fetch(:here_api_key)]
+                               Decidim.geocoder.fetch(:here_api_key)
                              else
                                [Decidim.geocoder.fetch(:here_app_id), Decidim.geocoder.fetch(:here_app_code)]
                              end

--- a/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
@@ -11,7 +11,7 @@ Decidim.configure do |config|
   # Geocoder configuration
   # config.geocoder = {
   #   static_map_url: "https://image.maps.ls.hereapi.com/mia/1.6/mapview",
-  #   here_api_key: Rails.application.secrets.geocoder[:here_api_key],
+  #   here_api_key: Rails.application.secrets.geocoder[:here_api_key]
   # }
 
   # Custom resource reference generator method

--- a/docs/services/geocoding.md
+++ b/docs/services/geocoding.md
@@ -10,7 +10,7 @@ After generating your app, you'll see that your `config/initializers/decidim.rb`
 # Geocoder configuration
 # config.geocoder = {
 #   static_map_url: "https://image.maps.ls.hereapi.com/mia/1.6/mapview",
-#   here_api_key: Rails.application.secrets.geocoder[:here_api_key],
+#   here_api_key: Rails.application.secrets.geocoder[:here_api_key]
 # }
 ```
 


### PR DESCRIPTION
PRs #5768 and #5644 needed to be tested mixed together. Compatibility with the uses of legacy `:app_id` `:app_code` wasn't working properly. Also, new URL from HERE requires the api key parameter to be called `apiKey` and not `api_key`. This provides this fixes.

#### :tophat: What? Why?

#### :pushpin: Related Issues
- Related to #5768 #5644

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
