### PR TITLE
Parallelize rubocop on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
           command: mkdir ~/rspec && bundle exec rspec --format documentation --format RspecJunitFormatter -o ~/rspec/rspec.xml
       - run:
           name: Run rubocop
-          command: bundle exec rubocop
+          command: bundle exec rubocop -P
       - run:
           name: Run erblint
           command: /app/.circleci/run_erblint.sh


### PR DESCRIPTION
#### :tophat: What? Why?
This is a chore PR. 

I found `rubocop` can be parallelized with the `-P` flag, so I guess it's nice if we use it.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None (I don't think this needs a changelog entry, since it dfoesn't affect the end user or dev in any way)