### PR TITLE
Support node.js semver rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,8 +64,9 @@ For those who have not changed the Rails `config.time_zone` (thus using UTC glob
 Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now supports removal of user's data portability expired files from Amazon S3. Check out the [scheduled tasks in the getting started guide](https://github.com/decidim/decidim/blob/master/docs/getting_started.md#scheduled-tasks) for information in how to configure it.
 
 **Added**:
-- **decidim-core**: Add new language: Greek [#5597](https://github.com/decidim/decidim/pull/5597)
 
+- **decidim-core**: Support node.js semver rules for release candidates. [#5828](https://github.com/decidim/decidim/pull/5828)
+- **decidim-core**: Add new language: Greek [#5597](https://github.com/decidim/decidim/pull/5597)
 - **decidim-initiatives**: An admin can only send the initiative to technical validation if it has enough committee members. [\#5762](https://github.com/decidim/decidim/pull/5762)
 - **decidim-proposals**: Add images to proposal cards [\#5640](https://github.com/decidim/decidim/pull/5640)
 - **decidim-api**: Added documentation to use the API (newcomers friendly). [\#5582](https://github.com/decidim/decidim/pull/5582)

--- a/lib/decidim/gem_manager.rb
+++ b/lib/decidim/gem_manager.rb
@@ -157,7 +157,7 @@ module Decidim
       end
 
       def semver_friendly_version
-        version.gsub(/\.pre/, "-pre").gsub(/\.dev/, "-dev")
+        version.gsub(/\.pre/, "-pre").gsub(/\.dev/, "-dev").gsub(/.rc(\d*)/, "-rc\\1")
       end
 
       def version_file


### PR DESCRIPTION
#### :tophat: What? Why?
Node.js supports slightly different semver rules than bundler.
In order to support versions like "0.21.0.rc1" the GemManager should use node.js semver friendly versions when updating the package.json

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [x] use the following expression `version.gsub(/\.pre/, "-pre").gsub(/\.dev/, "-dev").gsub(/.rc(\d*)/, "-rc\\1")`
