### PR TITLE
fix argument camel case definition to comply with graphql gem v1.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now sup
 
 **Fixed**:
 
+- **decidim-core** adapt API classes to the release of the graphql gem v1.10.4 [\#5829](https://github.com/decidim/decidim/pull/5829)
 - **decidim-core** Fixes the integration between the use of older and new versions of geocoder using HERE maps [\#5822](https://github.com/decidim/decidim/pull/5822)
 - **decidim-core** and **decidim-dev**: Solve puma's GHSA-84j7-475p-hp8v vulnerability, and nokogiri's CVE-2020-7595 vulnerability. [\#5820](https://github.com/decidim/decidim/pull/5820)
 - **decidim-core**: Do not allow invited users to sign up. [\#5803](https://github.com/decidim/decidim/pull/5803)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -410,7 +410,7 @@ GEM
     graphiql-rails (1.4.11)
       railties
       sprockets-rails
-    graphql (1.10.3)
+    graphql (1.10.4)
     hashdiff (1.0.0)
     hashie (4.1.0)
     highline (2.0.3)

--- a/decidim-core/app/types/decidim/core/component_input_filter.rb
+++ b/decidim-core/app/types/decidim/core/component_input_filter.rb
@@ -27,7 +27,7 @@ module Decidim
                             op.matches("%#{search}%")
                           end
                         end
-      argument :withGeolocationEnabled,
+      argument :with_geolocation_enabled,
                type: Boolean,
                description: "Returns components with geolocation activated (may be Proposals or Meetings)",
                required: false,
@@ -36,7 +36,7 @@ module Decidim
                    ["(settings->'global'->>'geocoding_enabled')::boolean is ? or manifest_name='meetings'", active]
                  end
                end
-      argument :withCommentsEnabled,
+      argument :with_comments_enabled,
                type: Boolean,
                description: "Returns components with comments enabled globally (can still be deactivated in the current step if the component has steps)",
                required: false,

--- a/decidim-core/app/types/decidim/core/has_publishable_input_filter.rb
+++ b/decidim-core/app/types/decidim/core/has_publishable_input_filter.rb
@@ -4,7 +4,7 @@ module Decidim
   module Core
     module HasPublishableInputFilter
       def self.included(child_class)
-        child_class.argument :publishedBefore,
+        child_class.argument :published_before,
                              type: String,
                              description: "List result published **before** (and **excluding**) this date. Expected format `YYYY-MM-DD`",
                              required: false,
@@ -13,7 +13,7 @@ module Decidim
                                  model_class.arel_table[:published_at].lt(date_to_iso8601(date, :publishedBefore))
                                end
                              end
-        child_class.argument :publishedSince,
+        child_class.argument :published_since,
                              type: String,
                              description: "List result published after (and **including**) this date. Expected format `YYYY-MM-DD`",
                              required: false,

--- a/decidim-core/app/types/decidim/core/has_publishable_input_sort.rb
+++ b/decidim-core/app/types/decidim/core/has_publishable_input_sort.rb
@@ -4,9 +4,9 @@ module Decidim
   module Core
     module HasPublishableInputSort
       def self.included(child_class)
-        child_class.argument :publishedAt, String, "Sort by date of publication, valid values are ASC or DESC", required: false
-        # child_class.argument :createdAt, String, "Sort by date of creation, valid values are ASC or DESC", required: false
-        # child_class.argument :updatedAt, String, "Sort by date of last modification, valid values are ASC or DESC", required: false
+        child_class.argument :published_at, String, "Sort by date of publication, valid values are ASC or DESC", required: false
+        # child_class.argument :created_at, String, "Sort by date of creation, valid values are ASC or DESC", required: false
+        # child_class.argument :updated_at, String, "Sort by date of last modification, valid values are ASC or DESC", required: false
       end
     end
   end

--- a/decidim-participatory_processes/app/types/decidim/participatory_processes/participatory_process_input_sort.rb
+++ b/decidim-participatory_processes/app/types/decidim/participatory_processes/participatory_process_input_sort.rb
@@ -9,7 +9,7 @@ module Decidim
       description "A type used for sorting participatory processess"
 
       argument :id, String, "Sort by ID, valid values are ASC or DESC", required: false
-      argument :startDate, String, "Sort by participatory process starting date, valid values are ASC or DESC", required: false
+      argument :start_date, String, "Sort by participatory process starting date, valid values are ASC or DESC", required: false
     end
   end
 end

--- a/decidim-proposals/app/types/decidim/proposals/proposal_input_sort.rb
+++ b/decidim-proposals/app/types/decidim/proposals/proposal_input_sort.rb
@@ -9,14 +9,14 @@ module Decidim
       description "A type used for sorting proposals"
 
       argument :id, String, "Sort by ID, valid values are ASC or DESC", required: false
-      argument :endorsementCount,
+      argument :endorsement_count,
                type: String,
                description: "Sort by number of endorsements, valid values are ASC or DESC",
                required: false,
                prepare: ->(value, _ctx) do
                           { proposal_endorsements_count: value }
                         end
-      argument :voteCount,
+      argument :vote_count,
                type: String,
                description: "Sort by number of votes, valid values are ASC or DESC. Will be ignored if votes are hidden",
                required: false,


### PR DESCRIPTION
#### :tophat: What? Why?

Version 1.10.4 has introduced a breaking change in how arguments have to be defined in graphql classes (see https://github.com/rmosolgo/graphql-ruby/pull/2792).

This PR adapts Decidim graphql to it

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
