### PR TITLE
Fix for the proposals that have theirs state not published

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ## Fixed
 
+- **decidim-proposals**: Fix for the proposals that have theirs state not published [#5832](https://github.com/decidim/decidim/pull/5832)
+
 ## Removed
 
 ## Previous versions

--- a/decidim-proposals/db/migrate/20200306123652_publish_existing_proposals_state.rb
+++ b/decidim-proposals/db/migrate/20200306123652_publish_existing_proposals_state.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class PublishExistingProposalsState < ActiveRecord::Migration[5.2]
+  def up
+    execute <<-SQL.squish
+      UPDATE decidim_proposals_proposals SET state_published_at = COALESCE(answered_at, published_at) WHERE state IS NOT NULL
+    SQL
+  end
+
+  def down
+    execute <<-SQL.squish
+      UPDATE decidim_proposals_proposals SET state_published_at = NULL
+    SQL
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fix [a bug on #5810](https://github.com/decidim/decidim/pull/5810#discussion_r388868243): the proposals that have a state assigned in a Decidim installation before the release of that PR would not show their state after updating the application.

This PR updates the database to fix two similar scenarios:
* Publish the answers and the state of all the existing answered proposals, using the date of the answer.
* Publish the state of the proposals created from other modules without any answer, using the date when the proposal was published.

#### :pushpin: Related Issues
- Related to #5810

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
