### PR TITLE
Participant renewable verifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Due to [\#5553](https://github.com/decidim/decidim/pull/5553), SSL is turned on 
 - **decidim-comments**: Comments can mention groups and its members are notified. [\#5763](https://github.com/decidim/decidim/pull/5763)
 - **decidim-core**: Now messages inside conversations have their urls identified as links. [\#5755](https://github.com/decidim/decidim/pull/5755)
 - **decidim-verifications**: Added Verification's Revocation [\#5814](https://github.com/decidim/decidim/pull/5814)
+- **decidim-verifications**: Participants can renew verifications [\#5854](https://github.com/decidim/decidim/pull/5854)
 - **decidim-core**: Support node.js semver rules for release candidates. [\#5828](https://github.com/decidim/decidim/pull/5828)
 - **decidim-proposals**, **decidim-core**, **decidim-blogs**: Extract proposals' endorsements into a polymorphic concern that can now be applied no any resource. It has, in turn, been aplied to blog posts. [\#5542](https://github.com/decidim/decidim/pull/5542)
 - **decidim-proposals**, **decidim-core**, **decidim-blogs**: Apply generalized endorsements to the GraphQL API and add it to the blog posts query. [\#5847](https://github.com/decidim/decidim/pull/5847)

--- a/decidim-core/app/assets/javascripts/decidim/ajax_modals.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/ajax_modals.js.es6
@@ -11,6 +11,9 @@ $(() => {
         const $html = $(html);
         $modal.html($html);
         $html.foundation();
+      },
+      error: function (request, status, error) {
+        $modal.html(`<h3>${status}</h3><p>${error}</p>`);
       }
     });
   });

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
@@ -505,8 +505,8 @@ $datetime-bg: var(--primary);
 
 /* Card list */
 .card--list {
-  .card--list__item:not(:last-of-type),
-  *:not(:last-of-type) .card--list__item {
+  .card--list__item:not(:last-child),
+  *:not(:last-child) .card--list__item {
     border-bottom: $border;
   }
 }

--- a/decidim-core/app/models/decidim/authorization.rb
+++ b/decidim-core/app/models/decidim/authorization.rb
@@ -55,13 +55,6 @@ module Decidim
       workflow_manifest.renewable
     end
 
-    # for development pourposes, to be removed
-    def wait_time
-      return unless renewable?
-
-      "#{workflow_manifest.renewable}: renewable_at: #{renewable_at} | time_between_renews: #{workflow_manifest.time_between_renews}"
-    end
-
     # Calculates at when this authorization will expire, if it needs to.
     #
     # Returns nil if the authorization does not expire.
@@ -89,10 +82,10 @@ module Decidim
 
     # Calculates when this authorization can be reseted, if desired.
     #
-    # time_between_renews defaults to zero
+    # time_between_renewals defaults to zero
     # Returns an ActiveSupport::TimeWithZone.
     def renewable_at
-      (granted_at || created_at) + workflow_manifest.time_between_renews
+      (granted_at || created_at) + workflow_manifest.time_between_renewals
     end
   end
 end

--- a/decidim-core/app/models/decidim/authorization.rb
+++ b/decidim-core/app/models/decidim/authorization.rb
@@ -49,9 +49,16 @@ module Decidim
 
     # Returns true if the authorization is renewable by the participant
     def renewable?
-      return unless workflow_manifest && renewable_at < Time.current
+      return unless workflow_manifest
 
-      workflow_manifest.renewable
+      workflow_manifest.renewable && renewable_at < Time.current
+    end
+
+    # Returns a String, the cell to be used to render the metadata
+    def cell_metadata
+      return unless workflow_manifest
+
+      workflow_manifest.cell_metadata
     end
 
     # Calculates at when this authorization will expire, if it needs to.

--- a/decidim-core/app/models/decidim/authorization.rb
+++ b/decidim-core/app/models/decidim/authorization.rb
@@ -49,8 +49,7 @@ module Decidim
 
     # Returns true if the authorization is renewable by the participant
     def renewable?
-      return unless workflow_manifest
-      return unless renewable_at < Time.current
+      return unless workflow_manifest && renewable_at < Time.current
 
       workflow_manifest.renewable
     end

--- a/decidim-core/app/models/decidim/authorization.rb
+++ b/decidim-core/app/models/decidim/authorization.rb
@@ -47,6 +47,21 @@ module Decidim
       !granted_at.nil?
     end
 
+    # Returns true if the authorization is renewable by the participant
+    def renewable?
+      return unless workflow_manifest
+      return unless renewable_at < Time.current
+
+      workflow_manifest.renewable
+    end
+
+    # for development pourposes, to be removed
+    def wait_time
+      return unless renewable?
+
+      "#{workflow_manifest.renewable}: renewable_at: #{renewable_at} | time_between_renews: #{workflow_manifest.time_between_renews}"
+    end
+
     # Calculates at when this authorization will expire, if it needs to.
     #
     # Returns nil if the authorization does not expire.
@@ -70,6 +85,14 @@ module Decidim
 
     def workflow_manifest
       @workflow_manifest ||= Decidim::Verifications.find_workflow_manifest(name)
+    end
+
+    # Calculates when this authorization can be reseted, if desired.
+    #
+    # time_between_renews defaults to zero
+    # Returns an ActiveSupport::TimeWithZone.
+    def renewable_at
+      (granted_at || created_at) + workflow_manifest.time_between_renews
     end
   end
 end

--- a/decidim-core/app/models/decidim/authorization.rb
+++ b/decidim-core/app/models/decidim/authorization.rb
@@ -55,10 +55,10 @@ module Decidim
     end
 
     # Returns a String, the cell to be used to render the metadata
-    def cell_metadata
+    def metadata_cell
       return unless workflow_manifest
 
-      workflow_manifest.cell_metadata
+      workflow_manifest.metadata_cell
     end
 
     # Calculates at when this authorization will expire, if it needs to.
@@ -88,7 +88,8 @@ module Decidim
 
     # Calculates when this authorization can be reseted, if desired.
     #
-    # time_between_renewals defaults to zero
+    # **time_between_renewals** is defined in `workflow_manifest.time_between_renewals`
+    # defaults to 1 day
     # Returns an ActiveSupport::TimeWithZone.
     def renewable_at
       (granted_at || created_at) + workflow_manifest.time_between_renewals

--- a/decidim-core/app/permissions/decidim/permissions.rb
+++ b/decidim-core/app/permissions/decidim/permissions.rb
@@ -75,7 +75,7 @@ module Decidim
       when :update, :destroy
         toggle_allow(authorization.user == user && !authorization.granted?)
       when :renew
-        toggle_allow(authorization.user == user && authorization.granted?)
+        toggle_allow(authorization.user == user && authorization.granted? && authorization.renewable?)
       end
     end
 

--- a/decidim-core/app/permissions/decidim/permissions.rb
+++ b/decidim-core/app/permissions/decidim/permissions.rb
@@ -72,10 +72,10 @@ module Decidim
       case permission_action.action
       when :create
         toggle_allow(authorization.user == user && not_already_active?(authorization))
-      when :update
+      when :update, :destroy
         toggle_allow(authorization.user == user && !authorization.granted?)
-      when :destroy
-        toggle_allow(authorization.user == user && !authorization.granted?)
+      when :renew
+        toggle_allow(authorization.user == user && authorization.granted?)
       end
     end
 

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -258,6 +258,7 @@ en:
         explanation: Get verified by introducing a passport number starting with "A"
         fields:
           passport_number: Passport number
+          postal_code: Postal code
         name: Another example authorization
       dummy_authorization_handler:
         explanation: Get verified by introducing a document number ending with "X"

--- a/decidim-core/spec/models/decidim/authorization_spec.rb
+++ b/decidim-core/spec/models/decidim/authorization_spec.rb
@@ -19,5 +19,17 @@ module Decidim
         expect(authorization).not_to be_valid
       end
     end
+
+    context "when verification is granted" do
+      let!(:authorization) { create(:authorization, name: "dummy_authorization_handler") }
+
+      it "has renewable? method" do
+        expect(authorization).to be_renewable
+      end
+
+      it "has cell_metadata" do
+        expect(authorization.cell_metadata).to be_kind_of String
+      end
+    end
   end
 end

--- a/decidim-core/spec/models/decidim/authorization_spec.rb
+++ b/decidim-core/spec/models/decidim/authorization_spec.rb
@@ -27,8 +27,8 @@ module Decidim
         expect(authorization).to be_renewable
       end
 
-      it "has cell_metadata" do
-        expect(authorization.cell_metadata).to be_kind_of String
+      it "has metadata_cell" do
+        expect(authorization.metadata_cell).to be_kind_of String
       end
     end
   end

--- a/decidim-core/spec/permissions/decidim/permissions_spec.rb
+++ b/decidim-core/spec/permissions/decidim/permissions_spec.rb
@@ -102,6 +102,142 @@ describe Decidim::Permissions do
     it_behaves_like "permission is not set"
   end
 
+  context "when subject is on authorization" do
+    let(:context) { { authorization: authorization } }
+    let(:user) { authorization.user }
+    let(:action_name) { nil }
+    let(:action) do
+      { scope: :public, action: action_name, subject: :authorization }
+    end
+
+    context "with a create action" do
+      let(:authorization) { build(:authorization) }
+      let(:action_name) { :create }
+
+      it { is_expected.to eq true }
+    end
+
+    context "with an update action" do
+      let(:action_name) { :update }
+
+      context "and the authorization is granted" do
+        let(:authorization) { create(:authorization, :granted) }
+
+        it { is_expected.to eq false }
+      end
+
+      context "and the authorization is pending" do
+        let(:authorization) { create(:authorization, :pending) }
+
+        it { is_expected.to eq true }
+      end
+    end
+
+    context "with a destroy action" do
+      let(:action_name) { :destroy }
+
+      context "and the authorization is granted" do
+        let(:authorization) { create(:authorization, :granted) }
+
+        it { is_expected.to eq false }
+      end
+
+      context "and the authorization is pending" do
+        let(:authorization) { create(:authorization, :pending) }
+
+        it { is_expected.to eq true }
+      end
+    end
+
+    context "with a renew action" do
+      before do
+        allow(authorization).to receive(:renewable?).and_return(true)
+      end
+
+      let(:action_name) { :renew }
+
+      context "and the authorization is granted" do
+        let(:authorization) { create(:authorization, :granted) }
+
+        it { is_expected.to eq true }
+      end
+
+      context "and the authorization is pending" do
+        let(:authorization) { create(:authorization, :pending) }
+
+        it { is_expected.to eq false }
+      end
+    end
+  end
+
+  context "when an amend action" do
+    let(:component) { create :component, :published, organization: user.organization, settings: settings }
+    let(:settings) { { amendments_enabled: amendments_enabled } }
+    let(:amendment) { create :amendment }
+    let(:user) { amendment.amender }
+    let(:context) { { current_component: component } }
+    let(:action_name) { nil }
+    let(:action) do
+      { scope: :public, action: action_name, subject: :amendment }
+    end
+
+    context "with amendments enabled settings" do
+      let(:amendments_enabled) { true }
+
+      context "with a create action" do
+        let(:action_name) { :create }
+
+        it { is_expected.to eq true }
+      end
+
+      context "with a accept action" do
+        let(:action_name) { :accept }
+
+        it { is_expected.to eq true }
+      end
+
+      context "with a reject action" do
+        let(:action_name) { :reject }
+
+        it { is_expected.to eq true }
+      end
+
+      context "with a promote action" do
+        let(:action_name) { :promote }
+
+        it { is_expected.to eq true }
+      end
+    end
+
+    context "with amendments disabled" do
+      let(:amendments_enabled) { false }
+
+      context "with a create action" do
+        let(:action_name) { :create }
+
+        it { is_expected.to eq false }
+      end
+
+      context "with a accept action" do
+        let(:action_name) { :accept }
+
+        it { is_expected.to eq false }
+      end
+
+      context "with a reject action" do
+        let(:action_name) { :reject }
+
+        it { is_expected.to eq false }
+      end
+
+      context "with a promote action" do
+        let(:action_name) { :promote }
+
+        it { is_expected.to eq false }
+      end
+    end
+  end
+
   context "with a user" do
     let(:user) { create :user }
 

--- a/decidim-core/spec/permissions/decidim/permissions_spec.rb
+++ b/decidim-core/spec/permissions/decidim/permissions_spec.rb
@@ -102,7 +102,7 @@ describe Decidim::Permissions do
     it_behaves_like "permission is not set"
   end
 
-  context "when subject is on authorization" do
+  context "when subject is an authorization" do
     let(:context) { { authorization: authorization } }
     let(:user) { authorization.user }
     let(:action_name) { nil }

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/authorization.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/authorization.rb
@@ -14,6 +14,7 @@ module Decidim
         routes do
           root to: proc { [200, {}, ["DUMMY VERIFICATION ENGINE"]] }
           get :edit_authorization, to: proc { [200, {}, ["CONTINUE YOUR VERIFICATION"]] }
+          get :renew_authorization, to: proc { [200, {}, ["RENEW YOUR VERIFICATION"]] }
         end
       end
     end
@@ -23,6 +24,8 @@ end
 Decidim::Verifications.register_workflow(:dummy_authorization_workflow) do |workflow|
   workflow.engine = Decidim::Verifications::DummyVerification::Engine
   workflow.expires_in = 1.hour
+  workflow.renewable = true
+  workflow.time_between_renewals = 5.minutes
 end
 
 RSpec.configure do |config|

--- a/decidim-generators/lib/decidim/generators/app_templates/verifications_initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/verifications_initializer.rb
@@ -4,6 +4,8 @@ Decidim::Verifications.register_workflow(:dummy_authorization_handler) do |workf
   workflow.form = "DummyAuthorizationHandler"
   workflow.action_authorizer = "DummyAuthorizationHandler::DummyActionAuthorizer"
   workflow.expires_in = 1.hour
+  workflow.renewable = true
+  workflow.time_between_renews = 5.minutes
 
   workflow.options do |options|
     options.attribute :postal_code, type: :string, default: "08001", required: false

--- a/decidim-generators/lib/decidim/generators/app_templates/verifications_initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/verifications_initializer.rb
@@ -5,7 +5,7 @@ Decidim::Verifications.register_workflow(:dummy_authorization_handler) do |workf
   workflow.action_authorizer = "DummyAuthorizationHandler::DummyActionAuthorizer"
   workflow.expires_in = 1.hour
   workflow.renewable = true
-  workflow.time_between_renews = 5.minutes
+  workflow.time_between_renewals = 5.minutes
 
   workflow.options do |options|
     options.attribute :postal_code, type: :string, default: "08001", required: false

--- a/decidim-verifications/README.md
+++ b/decidim-verifications/README.md
@@ -62,7 +62,7 @@ Decidim implements two type of authorization methods:
   # config/initializers/decidim.rb
 
   Decidim::Verifications.register_workflow(:census) do |workflow|
-    workflow.form = "<myAuthorizationHandlerClass"
+    workflow.form = "<myAuthorizationHandlerClass>"
   end
   ```
 
@@ -98,7 +98,9 @@ Decidim implements two type of authorization methods:
     authorization process.
 
 * _Renewable authorizations_.  
-  By default a participant can't renew its authorization, but this can be enabled when registering the workflow, the time between renewals can be configured (one day by default):
+  By default a participant can't renew its authorization, but this can be enabled when registering the workflow, the time between renewals can be configured (one day by default).
+
+  Optionally to change the renew modal content part of the data stored, you can set a new value for the cell used to render the metadata.
 
   ```ruby
   # config/initializers/decidim.rb
@@ -107,8 +109,10 @@ Decidim implements two type of authorization methods:
     workflow.form = "myAuthorizationHandlerClass"
     workflow.renewable = true
     workflow.time_between_renewals = 1.day
+    workflow.cell_metadata = "decidim/verifications/authorization_metadata"
   end
   ```
+
 ### SMS verification
 
 Decidim comes with a verification workflow designed to verify users by sending

--- a/decidim-verifications/README.md
+++ b/decidim-verifications/README.md
@@ -106,7 +106,7 @@ Decidim implements two type of authorization methods:
   Decidim::Verifications.register_workflow(:census) do |workflow|
     workflow.form = "myAuthorizationHandlerClass"
     workflow.renewable = true
-    workflow.time_between_renews = 5.minutes
+    workflow.time_between_renewals = 5.minutes
   end
   ```
 ### SMS verification

--- a/decidim-verifications/README.md
+++ b/decidim-verifications/README.md
@@ -97,6 +97,18 @@ Decidim implements two type of authorization methods:
   * `edit_authorization_path`: This is the entry point to resume an existing
     authorization process.
 
+* _Renewable authorizations_.  
+  By default a participant can't renew its authorization, but this can be enabled when registering the workflow, a time between renews can be configured (zero by default):
+
+  ```ruby
+  # config/initializers/decidim.rb
+
+  Decidim::Verifications.register_workflow(:census) do |workflow|
+    workflow.form = "myAuthorizationHandlerClass"
+    workflow.renewable = true
+    workflow.time_between_renews = 5.minutes
+  end
+  ```
 ### SMS verification
 
 Decidim comes with a verification workflow designed to verify users by sending

--- a/decidim-verifications/README.md
+++ b/decidim-verifications/README.md
@@ -98,7 +98,7 @@ Decidim implements two type of authorization methods:
     authorization process.
 
 * _Renewable authorizations_.  
-  By default a participant can't renew its authorization, but this can be enabled when registering the workflow, a time between renews can be configured (zero by default):
+  By default a participant can't renew its authorization, but this can be enabled when registering the workflow, the time between renewals can be configured (one day by default):
 
   ```ruby
   # config/initializers/decidim.rb
@@ -106,7 +106,7 @@ Decidim implements two type of authorization methods:
   Decidim::Verifications.register_workflow(:census) do |workflow|
     workflow.form = "myAuthorizationHandlerClass"
     workflow.renewable = true
-    workflow.time_between_renewals = 5.minutes
+    workflow.time_between_renewals = 1.day
   end
   ```
 ### SMS verification

--- a/decidim-verifications/README.md
+++ b/decidim-verifications/README.md
@@ -109,7 +109,7 @@ Decidim implements two type of authorization methods:
     workflow.form = "myAuthorizationHandlerClass"
     workflow.renewable = true
     workflow.time_between_renewals = 1.day
-    workflow.cell_metadata = "decidim/verifications/authorization_metadata"
+    workflow.metadata_cell = "decidim/verifications/authorization_metadata"
   end
   ```
 

--- a/decidim-verifications/app/cells/decidim/verifications/authorization_metadata/show.erb
+++ b/decidim-verifications/app/cells/decidim/verifications/authorization_metadata/show.erb
@@ -1,0 +1,13 @@
+<p>
+  <%= t("authorization_metadata.info", scope: "decidim.verifications.authorizations") %>
+</p>
+
+<ul>
+  <% if model.metadata.present? %>
+    <% model.metadata.each do |data| %>
+        <%= metadata(data) %>
+    <% end %>
+  <% else %>
+    <li> <%= t("authorization_metadata.no_data_stored", scope: "decidim.verifications.authorizations") %></li>
+  <% end %>
+</ul>

--- a/decidim-verifications/app/cells/decidim/verifications/authorization_metadata_cell.rb
+++ b/decidim-verifications/app/cells/decidim/verifications/authorization_metadata_cell.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Verifications
+    # This cell is to render the authorization metadata in the renew modal
+    class AuthorizationMetadataCell < Decidim::ViewModel
+      private
+
+      def metadata(data)
+        "<li>#{metadata_key(data)} <strong>#{metadata_value(data)}</strong></li>"
+      end
+
+      def metadata_key(data)
+        "#{t("#{model.name}.fields.#{data.first}", scope: "decidim.authorization_handlers")}:"
+      end
+
+      def metadata_value(data)
+        data.second
+      end
+    end
+  end
+end

--- a/decidim-verifications/app/commands/decidim/verifications/destroy_user_authorization.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/destroy_user_authorization.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Verifications
+    # A command to Destroy the Authorization of a user.
+    class DestroyUserAuthorization < Rectify::Command
+      def initialize(authorization)
+        @authorization = authorization
+      end
+
+      def call
+        return broadcast(:invalid) unless authorization
+
+        authorization.destroy!
+
+        broadcast(:ok, authorization)
+      end
+
+      private
+
+      attr_reader :authorization
+    end
+  end
+end

--- a/decidim-verifications/app/controllers/concerns/decidim/verifications/renewable.rb
+++ b/decidim-verifications/app/controllers/concerns/decidim/verifications/renewable.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  module Verifications
+    # Common logic to renew authorizations
+    module Renewable
+      extend ActiveSupport::Concern
+      included do
+        def renew
+          enforce_permission_to :renew, :authorization, authorization: authorization
+
+          DestroyUserAuthorization.call(authorization) do
+            on(:ok, authorization) do
+              flash[:notice] = t("authorizations.destroy.success", scope: "decidim.verifications")
+              redirect_to new_authorization_path(handler: authorization.name)
+            end
+
+            on(:invalid) do
+              flash[:alert] = t("authorizations.destroy.error", scope: "decidim.verifications")
+              redirect_to authorizations_path
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-verifications/app/controllers/concerns/decidim/verifications/renewable.rb
+++ b/decidim-verifications/app/controllers/concerns/decidim/verifications/renewable.rb
@@ -23,6 +23,14 @@ module Decidim
             end
           end
         end
+
+        def renew_modal
+          enforce_permission_to :renew, :authorization, authorization: authorization
+
+          respond_to do |format|
+            format.html { render layout: nil }
+          end
+        end
       end
     end
   end

--- a/decidim-verifications/app/controllers/decidim/verifications/application_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/application_controller.rb
@@ -5,13 +5,17 @@ module Decidim
     class ApplicationController < Decidim::ApplicationController
       include NeedsPermission
 
-      before_action :confirmed_user, only: [:new, :create]
+      before_action :confirmed_user, only: [:new, :create, :renew]
 
       def new
         raise NotImplementedError
       end
 
       def create
+        raise NotImplementedError
+      end
+
+      def renew
         raise NotImplementedError
       end
 

--- a/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
@@ -5,7 +5,7 @@ module Decidim
     # This controller allows users to create and destroy their authorizations. It
     # shouldn't be necessary to expand it to add new authorization schemes.
     class AuthorizationsController < ApplicationController
-      helper_method :handler, :unauthorized_methods
+      helper_method :handler, :unauthorized_methods, :authorization_method, :authorization
       before_action :valid_handler, only: [:new, :create]
 
       include Decidim::UserProfile
@@ -48,6 +48,12 @@ module Decidim
       end
 
       protected
+
+      def authorization_method(authorization)
+        return unless authorization
+
+        Decidim::Verifications::Adapter.from_element(authorization.name)
+      end
 
       def handler
         @handler ||= Decidim::AuthorizationHandler.handler_for(handler_name, handler_params)
@@ -99,7 +105,7 @@ module Decidim
       def authorization
         @authorization ||= Decidim::Authorization.find_by(
           user: current_user,
-          name: handler.handler_name
+          name: handler_name
         )
       end
     end

--- a/decidim-verifications/app/controllers/decidim/verifications/csv_census/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/csv_census/authorizations_controller.rb
@@ -12,7 +12,7 @@ module Decidim
 
         def new
           @form = CensusForm.from_params(user: current_user)
-          ConfirmCensusAuthorization.call(@authorization, @form) do
+          ConfirmCensusAuthorization.call(@authorization, @form, session) do
             on(:ok) do
               flash[:notice] = t("authorizations.new.success", scope: "decidim.verifications.csv_census")
             end

--- a/decidim-verifications/app/controllers/decidim/verifications/csv_census/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/csv_census/authorizations_controller.rb
@@ -4,6 +4,8 @@ module Decidim
   module Verifications
     module CsvCensus
       class AuthorizationsController < Decidim::ApplicationController
+        include Decidim::Verifications::Renewable
+
         helper_method :authorization
 
         before_action :load_authorization

--- a/decidim-verifications/app/controllers/decidim/verifications/id_documents/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/id_documents/authorizations_controller.rb
@@ -7,6 +7,8 @@ module Decidim
       # Handles verification by identity document upload
       #
       class AuthorizationsController < ApplicationController
+        include Decidim::Verifications::Renewable
+
         helper_method :authorization, :verification_type, :using_offline?, :using_online?, :available_methods
 
         before_action :load_authorization

--- a/decidim-verifications/app/controllers/decidim/verifications/postal_letter/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/postal_letter/authorizations_controller.rb
@@ -4,6 +4,8 @@ module Decidim
   module Verifications
     module PostalLetter
       class AuthorizationsController < ApplicationController
+        include Decidim::Verifications::Renewable
+
         helper_method :authorization
 
         before_action :load_authorization

--- a/decidim-verifications/app/controllers/decidim/verifications/sms/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/sms/authorizations_controller.rb
@@ -4,6 +4,8 @@ module Decidim
   module Verifications
     module Sms
       class AuthorizationsController < ApplicationController
+        include Decidim::Verifications::Renewable
+
         helper_method :authorization
 
         def new

--- a/decidim-verifications/app/views/decidim/verifications/authorizations/_granted_authorization.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/authorizations/_granted_authorization.html.erb
@@ -4,7 +4,7 @@
     <h5 class="card--list__heading">
       <%= t("#{authorization.name}.name", scope: "decidim.authorization_handlers") %>
     </h5>
-    <span class="text-small">
+    <span class="text-small <%= "alert" if authorization.expired? %>">
       <% if authorization.expired? %>
         <%= t("expired_at", scope: "decidim.authorization_handlers", timestamp: l(authorization.expires_at, format: :long)) %>
       <% else %>

--- a/decidim-verifications/app/views/decidim/verifications/authorizations/_granted_authorization.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/authorizations/_granted_authorization.html.erb
@@ -1,27 +1,35 @@
-<div class="card--list__item">
-  <div class="card--list__text">
-    <%= icon "lock-locked", class: "card--list__icon", role: "img" %>
-    <div>
-      <h5 class="card--list__heading">
-        <%= t("#{authorization.name}.name", scope: "decidim.authorization_handlers") %>
-      </h5>
-      <span class="text-small">
-        <% if authorization.expired? %>
-          <%= t("expired_at", scope: "decidim.authorization_handlers", timestamp: l(authorization.expires_at, format: :long)) %>
-        <% else %>
-          <%= t("granted_at", scope: "decidim.authorization_handlers", timestamp: l(authorization.granted_at, format: :long)) %>
-          <% if authorization.expires_at.present? %>
-            <%= t("expires_at", scope: "decidim.authorization_handlers", timestamp: l(authorization.expires_at, format: :long)) %>
-          <% end %>
+<div class="card--list__text">
+  <%= icon "lock-locked", class: "card--list__icon", role: "img" %>
+  <div>
+    <h5 class="card--list__heading">
+      <%= t("#{authorization.name}.name", scope: "decidim.authorization_handlers") %>
+    </h5>
+    <span class="text-small">
+      <% if authorization.expired? %>
+        <%= t("expired_at", scope: "decidim.authorization_handlers", timestamp: l(authorization.expires_at, format: :long)) %>
+      <% else %>
+        <%= t("granted_at", scope: "decidim.authorization_handlers", timestamp: l(authorization.granted_at, format: :long)) %>
+        <% if authorization.expires_at.present? %>
+          <%= t("expires_at", scope: "decidim.authorization_handlers", timestamp: l(authorization.expires_at, format: :long)) %>
         <% end %>
-      </span>
-    </div>
+      <% end %>
+      <br>
+      <%= authorization.wait_time %>
+    </span>
   </div>
-  <% if authorization.expired? %>
-    <div class="card--list__data">
-      <span class="card--list__data__icon">
-        <%= icon "reload", role: "img" %>
-      </span>
-    </div>
-  <% end %>
 </div>
+
+<% if authorization.expired? %>
+  <div class="card--list__data">
+    <span class="card--list__data__icon">
+      <%= icon "reload", role: "img" %>
+    </span>
+  </div>
+<% elsif authorization.renewable? %>
+  <div class="card--list__data">
+    <span class="card--list__data__icon">
+      <%= icon "reload", role: "img" %>
+    </span>
+    -renew-
+  </div>
+<% end %>

--- a/decidim-verifications/app/views/decidim/verifications/authorizations/_granted_authorization.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/authorizations/_granted_authorization.html.erb
@@ -13,8 +13,6 @@
           <%= t("expires_at", scope: "decidim.authorization_handlers", timestamp: l(authorization.expires_at, format: :long)) %>
         <% end %>
       <% end %>
-      <br>
-      <%= authorization.wait_time %>
     </span>
   </div>
 </div>

--- a/decidim-verifications/app/views/decidim/verifications/authorizations/_granted_authorization.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/authorizations/_granted_authorization.html.erb
@@ -28,6 +28,5 @@
     <span class="card--list__data__icon">
       <%= icon "reload", role: "img" %>
     </span>
-    -renew-
   </div>
 <% end %>

--- a/decidim-verifications/app/views/decidim/verifications/authorizations/index.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/authorizations/index.html.erb
@@ -9,7 +9,9 @@
               <% render partial: "granted_authorization", locals: { authorization: authorization } %>
             <% end %>
           <% elsif authorization.renewable? %>
-            <%= link_to authorization_method.renew_path, title: t(".renew_verification"), class: "card--list__item authorization-renewable" do %>
+            <% authorization_name = t("#{authorization.name}.name", scope: "decidim.authorization_handlers") %>
+            <%= link_to authorization_method.renew_path, title: t(".renew_verification"), class: "card--list__item authorization-renewable",
+             "data-confirm": t(".confirm_renewal", authorization_name: authorization_name) do %>
               <%= render partial: "granted_authorization", locals: { authorization: authorization } %>
             <% end %>
           <% else %>

--- a/decidim-verifications/app/views/decidim/verifications/authorizations/index.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/authorizations/index.html.erb
@@ -3,16 +3,13 @@
     <% if @granted_authorizations.any? %>
       <div class="card card--list">
         <% @granted_authorizations.each do |authorization| %>
-          <% authorization_method = Decidim::Verifications::Adapter.from_element(authorization.name) %>
           <% if authorization.expired? %>
-            <%= link_to authorization_method.root_path, title: t(".expired_verification"), class: "card--list__item" do %>
+            <%= link_to authorization_method(authorization).root_path, title: t(".expired_verification"), class: "card--list__item" do %>
               <% render partial: "granted_authorization", locals: { authorization: authorization } %>
             <% end %>
           <% elsif authorization.renewable? %>
-            <% authorization_name = t("#{authorization.name}.name", scope: "decidim.authorization_handlers") %>
-            <%= link_to authorization_method.renew_path, title: t(".renew_verification"), class: "card--list__item authorization-renewable",
-             "data-confirm": t(".confirm_renewal", authorization_name: authorization_name) do %>
-              <%= render partial: "granted_authorization", locals: { authorization: authorization } %>
+            <%= link_to "#", title: t(".show_renew_info"), data: { open: "renew-modal", "open-url": renew_modal_authorizations_path(handler: authorization.name) }, class: "card--list__item authorization-renewable" do %>
+               <%= render partial: "granted_authorization", locals: { authorization: authorization } %>
             <% end %>
           <% else %>
             <div class="card--list__item">
@@ -21,13 +18,14 @@
           <% end %>
         <% end %>
       </div>
+
+      <div id="renew-modal" data-reveal class="reveal" aria-labelledby="<%= t("renew_modal.title", scope: "decidim.verifications.authorizations") %>" aria-hidden="true" role="dialog"></div>
     <% end %>
 
     <% if @pending_authorizations.any? %>
       <div class="card card--list">
         <% @pending_authorizations.each do |authorization| %>
-          <% authorization_method = Decidim::Verifications::Adapter.from_element(authorization.name) %>
-          <%= link_to authorization_method.resume_authorization_path do %>
+          <%= link_to authorization_method(authorization).resume_authorization_path do %>
             <div class="card--list__item">
               <div class="card--list__text">
                 <%= icon "reload", class: "card--list__icon", role: "img" %>

--- a/decidim-verifications/app/views/decidim/verifications/authorizations/index.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/authorizations/index.html.erb
@@ -3,13 +3,19 @@
     <% if @granted_authorizations.any? %>
       <div class="card card--list">
         <% @granted_authorizations.each do |authorization| %>
+          <% authorization_method = Decidim::Verifications::Adapter.from_element(authorization.name) %>
           <% if authorization.expired? %>
-            <% authorization_method = Decidim::Verifications::Adapter.from_element(authorization.name) %>
-            <%= link_to authorization_method.root_path do %>
+            <%= link_to authorization_method.root_path, title: t(".expired_verification"), class: "card--list__item" do %>
               <% render partial: "granted_authorization", locals: { authorization: authorization } %>
             <% end %>
+          <% elsif authorization.renewable? %>
+            <%= link_to authorization_method.renew_path, title: t(".renew_verification"), class: "card--list__item authorization-renewable" do %>
+              <%= render partial: "granted_authorization", locals: { authorization: authorization } %>
+            <% end %>
           <% else %>
-            <%= render partial: "granted_authorization", locals: { authorization: authorization } %>
+            <div class="card--list__item">
+              <%= render partial: "granted_authorization", locals: { authorization: authorization } %>
+            </div>
           <% end %>
         <% end %>
       </div>

--- a/decidim-verifications/app/views/decidim/verifications/authorizations/renew_modal.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/authorizations/renew_modal.html.erb
@@ -1,0 +1,38 @@
+<div class="reveal__header">
+  <h3 class="reveal__title">
+    <%= t("renew_modal.title", scope: "decidim.verifications.authorizations") %>
+  </h3>
+
+  <button class="close-button" data-close aria-label="<%= t("renew_modal.close", scope: "decidim.verifications.authorizations") %>"
+    type="button">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+
+<div class="row">
+  <p>
+    <strong>
+      <%= t("#{authorization.name}.name", scope: "decidim.authorization_handlers") %>
+    </strong>
+    <br>
+    <span class="text-muted">
+      <%= t("#{authorization.name}.explanation", scope: "decidim.authorization_handlers") %>
+    </span>
+  </p>
+
+  <%= cell(authorization.cell_metadata, authorization) %>
+
+  <p>
+    <%= t("renew_modal.info_renew", scope: "decidim.verifications.authorizations") %>
+  </p>
+</div>
+
+<div class="row">
+  <div class="column flex-center">
+    <button class="clear button secondary expanded" data-close type="button">
+      <%= t("renew_modal.cancel", scope: "decidim.verifications.authorizations") %>
+    </button>
+
+    <%= link_to t("renew_modal.continue", scope: "decidim.verifications.authorizations"), authorization_method(authorization).renew_path, class: "button expanded" %>
+  </div>
+</div>

--- a/decidim-verifications/app/views/decidim/verifications/authorizations/renew_modal.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/authorizations/renew_modal.html.erb
@@ -20,7 +20,7 @@
     </span>
   </p>
 
-  <%= cell(authorization.cell_metadata, authorization) %>
+  <%= cell(authorization.metadata_cell, authorization) %>
 
   <p>
     <%= t("renew_modal.info_renew", scope: "decidim.verifications.authorizations") %>

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -97,8 +97,9 @@ en:
           title: Verify your identity
           verify_with_these_options: 'These are the available options to verify your identity:'
         index:
+          confirm_renewal: Do you wan't to request a new verification for %{authorization_name}?
           expired_verification: Verification expired
-          renew_verification: Renew verification
+          renew_verification: Click to renew verification
         new:
           authorize: Send
           authorize_with: Verify with %{authorizer}

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -96,7 +96,7 @@ en:
             dummy_authorization_workflow: Verify against the example authorization workflow
             id_documents: Get verified by uploading your identity document
             postal_letter: Get verified by receiving a verification code through postal mail
-            sms: sms
+            sms: Get verified by receiving a SMS verification code
           title: Verify your identity
           verify_with_these_options: 'These are the available options to verify your identity:'
         index:

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -97,7 +97,7 @@ en:
           title: Verify your identity
           verify_with_these_options: 'These are the available options to verify your identity:'
         index:
-          confirm_renewal: Do you wan't to request a new verification for %{authorization_name}?
+          confirm_renewal: Do you want to request a new verification for %{authorization_name}?
           expired_verification: Verification expired
           renew_verification: Click to renew verification
         new:

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -78,6 +78,9 @@ en:
         name: Code by postal letter
     verifications:
       authorizations:
+        authorization_metadata:
+          info: 'This is the data of the current verification:'
+          no_data_stored: No data stored.
         create:
           error: There was a problem creating the authorization.
           success: You've been successfully authorized.
@@ -97,12 +100,17 @@ en:
           title: Verify your identity
           verify_with_these_options: 'These are the available options to verify your identity:'
         index:
-          confirm_renewal: Do you want to request a new verification for %{authorization_name}?
           expired_verification: Verification expired
-          renew_verification: Click to renew verification
+          show_renew_info: Click to renew verification
         new:
           authorize: Send
           authorize_with: Verify with %{authorizer}
+        renew_modal:
+          cancel: Cancel
+          close: close
+          continue: Continue
+          info_renew: If you want to update the data, continue with the renewal
+          title: Renew Verification
         skip_verification: You can skip this for now and %{link}
         start_exploring: start exploring
       csv_census:

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -82,6 +82,9 @@ en:
           error: There was a problem creating the authorization.
           success: You've been successfully authorized.
           unconfirmed: You need to confirm your email in order to authorize yourself.
+        destroy:
+          error: There was a problem deleting the authorization.
+          success: You've successfully deleted the authorization.
         first_login:
           actions:
             another_dummy_authorization_handler: Verify against another example of authorization handler
@@ -93,6 +96,9 @@ en:
             sms: sms
           title: Verify your identity
           verify_with_these_options: 'These are the available options to verify your identity:'
+        index:
+          expired_verification: Verification expired
+          renew_verification: Renew verification
         new:
           authorize: Send
           authorize_with: Verify with %{authorizer}

--- a/decidim-verifications/lib/decidim/verifications/adapter.rb
+++ b/decidim-verifications/lib/decidim/verifications/adapter.rb
@@ -64,6 +64,18 @@ module Decidim
       end
 
       #
+      # In the case of renewable authorizations, route to renew an authorization
+      # process.
+      #
+      def renew_path(redirect_url: nil)
+        if manifest.type == "direct"
+          decidim_verifications.renew_authorizations_path(redirect_params(handler: name, redirect_url: redirect_url))
+        else
+          main_engine.send(:renew_authorization_path, redirect_params(redirect_url: redirect_url))
+        end
+      end
+
+      #
       # Administrational entry point for the verification engine
       #
       def admin_root_path

--- a/decidim-verifications/lib/decidim/verifications/csv_census/engine.rb
+++ b/decidim-verifications/lib/decidim/verifications/csv_census/engine.rb
@@ -10,7 +10,9 @@ module Decidim
         paths["lib/tasks"] = nil
 
         routes do
-          resource :authorization, only: [:new], as: :authorization
+          resource :authorization, only: [:new], as: :authorization do
+            get :renew, on: :collection
+          end
           root to: "authorizations#new"
         end
       end

--- a/decidim-verifications/lib/decidim/verifications/engine.rb
+++ b/decidim-verifications/lib/decidim/verifications/engine.rb
@@ -11,6 +11,7 @@ module Decidim
           resources :authorizations, only: [:new, :create, :index] do
             collection do
               get :first_login
+              get :renew_modal
               get :renew
             end
           end

--- a/decidim-verifications/lib/decidim/verifications/engine.rb
+++ b/decidim-verifications/lib/decidim/verifications/engine.rb
@@ -11,6 +11,7 @@ module Decidim
           resources :authorizations, only: [:new, :create, :index] do
             collection do
               get :first_login
+              get :renew
             end
           end
 

--- a/decidim-verifications/lib/decidim/verifications/id_documents/engine.rb
+++ b/decidim-verifications/lib/decidim/verifications/id_documents/engine.rb
@@ -14,6 +14,7 @@ module Decidim
           resource :authorizations, only: [:new, :create, :edit, :update], as: :authorization do
             collection do
               get :choose
+              get :renew
             end
           end
 

--- a/decidim-verifications/lib/decidim/verifications/postal_letter/engine.rb
+++ b/decidim-verifications/lib/decidim/verifications/postal_letter/engine.rb
@@ -11,7 +11,9 @@ module Decidim
         paths["lib/tasks"] = nil
 
         routes do
-          resource :authorizations, only: [:new, :create, :edit, :update], as: :authorization
+          resource :authorizations, only: [:new, :create, :edit, :update], as: :authorization do
+            get :renew, on: :collection
+          end
 
           root to: "authorizations#new"
         end

--- a/decidim-verifications/lib/decidim/verifications/sms/engine.rb
+++ b/decidim-verifications/lib/decidim/verifications/sms/engine.rb
@@ -11,7 +11,7 @@ module Decidim
         paths["lib/tasks"] = nil
 
         routes do
-          resource :authorizations, only: [:new, :create, :edit, :update, :destroy, :renewal], as: :authorization do
+          resource :authorizations, only: [:new, :create, :edit, :update, :destroy], as: :authorization do
             get :renew, on: :collection
           end
 

--- a/decidim-verifications/lib/decidim/verifications/sms/engine.rb
+++ b/decidim-verifications/lib/decidim/verifications/sms/engine.rb
@@ -11,7 +11,9 @@ module Decidim
         paths["lib/tasks"] = nil
 
         routes do
-          resource :authorizations, only: [:new, :create, :edit, :update, :destroy], as: :authorization
+          resource :authorizations, only: [:new, :create, :edit, :update, :destroy, :renewal], as: :authorization do
+            get :renew, on: :collection
+          end
 
           root to: "authorizations#new"
         end

--- a/decidim-verifications/lib/decidim/verifications/workflow_manifest.rb
+++ b/decidim-verifications/lib/decidim/verifications/workflow_manifest.rb
@@ -34,7 +34,8 @@ module Decidim
       attribute :form, String
       attribute :expires_in, ActiveSupport::Duration, default: 0.minutes
       attribute :action_authorizer, String
-
+      attribute :renewable, Boolean, default: false
+      attribute :time_between_renews, ActiveSupport::Duration, default: 0.minutes
       validate :engine_or_form
 
       attribute :name, String

--- a/decidim-verifications/lib/decidim/verifications/workflow_manifest.rb
+++ b/decidim-verifications/lib/decidim/verifications/workflow_manifest.rb
@@ -34,8 +34,9 @@ module Decidim
       attribute :form, String
       attribute :expires_in, ActiveSupport::Duration, default: 0.minutes
       attribute :action_authorizer, String
-      attribute :renewable, Boolean, default: false
+      attribute :renewable, Boolean, default: true
       attribute :time_between_renewals, ActiveSupport::Duration, default: 1.day
+      attribute :cell_metadata, String, default: "decidim/verifications/authorization_metadata"
 
       validate :engine_or_form
 

--- a/decidim-verifications/lib/decidim/verifications/workflow_manifest.rb
+++ b/decidim-verifications/lib/decidim/verifications/workflow_manifest.rb
@@ -35,7 +35,8 @@ module Decidim
       attribute :expires_in, ActiveSupport::Duration, default: 0.minutes
       attribute :action_authorizer, String
       attribute :renewable, Boolean, default: false
-      attribute :time_between_renewals, ActiveSupport::Duration, default: 0.minutes
+      attribute :time_between_renewals, ActiveSupport::Duration, default: 1.day
+
       validate :engine_or_form
 
       attribute :name, String

--- a/decidim-verifications/lib/decidim/verifications/workflow_manifest.rb
+++ b/decidim-verifications/lib/decidim/verifications/workflow_manifest.rb
@@ -35,7 +35,7 @@ module Decidim
       attribute :expires_in, ActiveSupport::Duration, default: 0.minutes
       attribute :action_authorizer, String
       attribute :renewable, Boolean, default: false
-      attribute :time_between_renews, ActiveSupport::Duration, default: 0.minutes
+      attribute :time_between_renewals, ActiveSupport::Duration, default: 0.minutes
       validate :engine_or_form
 
       attribute :name, String

--- a/decidim-verifications/lib/decidim/verifications/workflow_manifest.rb
+++ b/decidim-verifications/lib/decidim/verifications/workflow_manifest.rb
@@ -36,7 +36,7 @@ module Decidim
       attribute :action_authorizer, String
       attribute :renewable, Boolean, default: true
       attribute :time_between_renewals, ActiveSupport::Duration, default: 1.day
-      attribute :cell_metadata, String, default: "decidim/verifications/authorization_metadata"
+      attribute :metadata_cell, String, default: "decidim/verifications/authorization_metadata"
 
       validate :engine_or_form
 

--- a/decidim-verifications/lib/decidim/verifications/workflows.rb
+++ b/decidim-verifications/lib/decidim/verifications/workflows.rb
@@ -28,7 +28,7 @@ module Decidim
       end
 
       #
-      # Registers a verification workflow using the workflow manifest API
+      # Unregisters a verification workflow using the workflow manifest API
       #
       def unregister_workflow(name)
         manifest = find_workflow_manifest(name)

--- a/decidim-verifications/spec/cells/decidim/verifications/authorization_metadata_cell_spec.rb
+++ b/decidim-verifications/spec/cells/decidim/verifications/authorization_metadata_cell_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Verifications::AuthorizationMetadataCell, type: :cell do
+  controller ::Decidim::ApplicationController
+
+  subject { cell("decidim/verifications/authorization_metadata", model).call }
+
+  let(:metadata) { nil }
+  let(:model) { create(:authorization, :granted, metadata: metadata, name: "another_dummy_authorization_handler") }
+
+  it "renders the information text" do
+    expect(subject).to have_content("This is the data of the current verification:")
+  end
+
+  context "when rendering with no metadata" do
+    it "renders the link wrapper" do
+      expect(subject).to have_content("No data stored")
+    end
+  end
+
+  context "when rendering with existing metadata" do
+    let(:metadata) do
+      { postal_code: "123456" }
+    end
+
+    it "renders the metadata" do
+      expect(subject).to have_content("Postal code")
+      expect(subject).to have_content("123456")
+    end
+  end
+end

--- a/decidim-verifications/spec/commands/decidim/verifications/destroy_user_authorization_spec.rb
+++ b/decidim-verifications/spec/commands/decidim/verifications/destroy_user_authorization_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Verifications
+  describe DestroyUserAuthorization do
+    subject { described_class.new(authorization) }
+
+    let(:user) { create(:user, :confirmed) }
+
+    let(:authorizations) { Authorizations.new(organization: user.organization, user: user, granted: true) }
+
+    context "when no authorization" do
+      let(:authorization) { nil }
+
+      it "is not valid" do
+        expect { subject.call }.to broadcast(:invalid)
+      end
+    end
+
+    context "when everything is ok" do
+      let!(:authorization) { create(:authorization, :granted, user: user) }
+
+      it "destroys the authorization for the user" do
+        expect { subject.call }.to change(authorizations, :count).by(-1)
+      end
+    end
+  end
+end

--- a/decidim-verifications/spec/lib/decidim/verifications/adapter_spec.rb
+++ b/decidim-verifications/spec/lib/decidim/verifications/adapter_spec.rb
@@ -13,6 +13,7 @@ describe Decidim::Verifications::Adapter do
         expect(wrapper.name).to eq("dummy_authorization_handler")
         expect(wrapper.key).to eq("dummy_authorization_handler")
         expect(wrapper.root_path).to eq("/authorizations/new?handler=dummy_authorization_handler")
+        expect(wrapper.renew_path).to eq("/authorizations/renew?handler=dummy_authorization_handler")
       end
     end
 
@@ -25,6 +26,7 @@ describe Decidim::Verifications::Adapter do
         expect(wrapper.name).to eq("dummy_authorization_workflow")
         expect(wrapper.key).to eq("dummy_authorization_workflow")
         expect(wrapper.root_path).to eq("/dummy_authorization_workflow/")
+        expect(wrapper.renew_path).to eq("/dummy_authorization_workflow/renew_authorization")
       end
     end
   end

--- a/decidim-verifications/spec/system/authorizations_spec.rb
+++ b/decidim-verifications/spec/system/authorizations_spec.rb
@@ -135,6 +135,46 @@ describe "Authorizations", type: :system, with_authorization_workflows: ["dummy_
         end
       end
 
+      context "when the authorization is renewable" do
+        describe "and still not over the waiting period" do
+          let!(:authorization) do
+            create(:authorization, name: "dummy_authorization_handler", user: user, granted_at: 1.minute.ago)
+          end
+
+          it "can't be renewed yet" do
+            within_user_menu do
+              click_link "My account"
+            end
+
+            click_link "Authorizations"
+
+            within ".authorizations-list" do
+              expect(page).to have_no_link("Example authorization")
+              expect(page).to have_no_css(".authorization-renewable")
+            end
+          end
+        end
+
+        describe "and passed the time between renewals" do
+          let!(:authorization) do
+            create(:authorization, name: "dummy_authorization_handler", user: user, granted_at: 6.minutes.ago)
+          end
+
+          it "can be renewed" do
+            within_user_menu do
+              click_link "My account"
+            end
+
+            click_link "Authorizations"
+
+            within ".authorizations-list" do
+              expect(page).to have_link("Example authorization")
+              expect(page).to have_css(".authorization-renewable")
+            end
+          end
+        end
+      end
+
       context "when the authorization has not expired yet" do
         let!(:authorization) do
           create(:authorization, name: "dummy_authorization_handler", user: user, granted_at: 2.seconds.ago)

--- a/decidim-verifications/spec/system/authorizations_spec.rb
+++ b/decidim-verifications/spec/system/authorizations_spec.rb
@@ -172,6 +172,38 @@ describe "Authorizations", type: :system, with_authorization_workflows: ["dummy_
               expect(page).to have_css(".authorization-renewable")
             end
           end
+
+          it "shows a modal with renew information" do
+            within_user_menu do
+              click_link "My account"
+            end
+
+            click_link "Authorizations"
+            click_link "Example authorization"
+
+            within "#renew-modal" do
+              expect(page).to have_content("Example authorization")
+              expect(page).to have_content("This is the data of the current verification:")
+              expect(page).to have_content("Continue")
+              expect(page).to have_content("Cancel")
+            end
+          end
+
+          describe "and clicks on the button to renew" do
+            it "shows the verification form to start again" do
+              within_user_menu do
+                click_link "My account"
+              end
+              click_link "Authorizations"
+              click_link "Example authorization"
+              within "#renew-modal" do
+                click_link "Continue"
+              end
+
+              expect(page).to have_content("Document number")
+              expect(page).to have_button "Send"
+            end
+          end
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Adds the ability to participants to renew verifications, from the account > authorizations.
Once clicked in the verification, opens a modal gives more info to the participant and shows the data used previously, if possible as sometimes data is not stored.

To facilitate developers to show the data of custom authorization methods, the `authorization_metadata` is easy to customize through the `workflow.cell_metadata` setting.

Each authorization workflow can be configured to be renewable and the time between renewals.

#### :pushpin: Related Issues

- Fixes #5721

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add documentation regarding the feature 
- [x] Modify `decidim-generator` verifications initializer
- [x] Add tests


### :camera: Screenshots (optional)
- <img width="951" alt="decidim-renew-1" src="https://user-images.githubusercontent.com/210216/76596414-6956fa00-64fe-11ea-800d-60d26117df6a.png">
- <img width="1187" alt="Screenshot 2020-03-26 at 09 03 18" src="https://user-images.githubusercontent.com/210216/77663110-fe390900-6f7c-11ea-9fe0-82720fd04e4d.png">
- <img width="952" alt="decidim-renew-3" src="https://user-images.githubusercontent.com/210216/76596444-7a077000-64fe-11ea-92d9-3efdf086d7d1.png">



