### PR TITLE
Add docs about the settings of the initiatives module

### DIFF
--- a/decidim-initiatives/README.md
+++ b/decidim-initiatives/README.md
@@ -42,6 +42,28 @@ The database requires the extension pg_trgm enabled. Contact your DBA to enable 
 CREATE EXTENSION pg_trgm;
 ```
 
+## Deactivating authorization requirement and other module settings
+
+Some of the settings of the module need to be set in the code of your app, for example in the file `config/initializers/decidim.rb`.
+
+This is the case if you want to enable the creation of initiatives even when no authorization method is set.
+
+Just use the following line:
+```
+Decidim::Initiatives.do_not_require_authorization = true
+```
+
+All the settings and their default values which can be overriden can be found in the file [`lib/decidim/initiatives.rb`](https://github.com/decidim/decidim/blob/master/decidim-initiatives/lib/decidim/initiatives.rb).
+
+For example, you can also change the minimum number of required committee members to 1 (default is 2) by adding this line:
+```
+Decidim::Initiatives.minimum_committee_members = 1
+```
+Or change the number of days given to gather signatures to 365 (default is 120) with:
+```
+Decidim::Initiatives.default_signature_time_period_length = 365
+```
+
 ## Rake tasks
 
 This engine comes with three rake tasks that should be executed on daily basis. The best


### PR DESCRIPTION
#### :tophat: What? Why?

It took me way too long to figure out why I couldn't create initiatives after installing the module. I first read somewhere that I needed authorisation methods but it still didn't really work even after setting some. Finally, I realised that instances such as MetaDecidim had just overridden the default setting called `do_not_require_authorization`.

I couldn't find it anywhere in the docs so I added a paragraph to help others who might be in the same situation.

Further on, I guess it would be nice if these settings were available through the admin panel. For example, it would be nice to be able to disable creation without having to push new code, and even nicer to be able to do it at the initiative level.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Add documentation regarding the feature 

### :camera: Screenshots (optional)