### PR TITLE
Add helpful info to install docs for seed errors during installation process

### DIFF
--- a/decidim-core/config/locales/fr.yml
+++ b/decidim-core/config/locales/fr.yml
@@ -1059,7 +1059,7 @@ fr:
       invalid: '%{authentication_keys} ou mot de passe invalide.'
       invited: Vous avez une invitation en attente, acceptez-la pour terminer la création de votre compte.
       last_attempt: Vous avez encore une tentative avant que votre compte soit verrouillé.
-      locked: Ton compte est bloqué.
+      locked: Votre compte est bloqué.
       not_found_in_database: '%{authentication_keys} ou mot de passe invalide.'
       timeout: Votre session a expiré. Veuillez vous connecter à nouveau pour continuer.
       unauthenticated: Vous devez vous connecter ou vous inscrire avant de continuer.
@@ -1124,7 +1124,7 @@ fr:
       unlock_instructions:
         action: Débloquer mon compte
         greeting: Bonjour %{recipient}!
-        instruction: 'Cliquez sur le lien ci-dessous pour débloquer votre compte:'
+        instruction: 'Cliquez sur le lien ci-dessous pour débloquer votre compte :'
         message: Votre compte a été verrouillé en raison d'une quantité excessive de tentatives de connexion infructueuses.
         subject: Instructions de déverrouillage
     omniauth_callbacks:
@@ -1174,7 +1174,7 @@ fr:
       links:
         back: Retour
         didn_t_receive_confirmation_instructions: Vous n'avez pas reçu d'instructions de confirmation?
-        didn_t_receive_unlock_instructions: Vous n'avez pas reçu d'instructions de confirmation?
+        didn_t_receive_unlock_instructions: Si la plateforme vous indique que votre compte est bloqué, cliquez ici pour recevoir les instructions de déblocage
         forgot_your_password: Mot de passe oublié?
         sign_in: S'identifier
         sign_in_with_provider: Se connecter avec %{provider}

--- a/decidim-core/config/locales/hu.yml
+++ b/decidim-core/config/locales/hu.yml
@@ -581,6 +581,7 @@ hu:
       create:
         button: Követés
         error: Hiba történt az erőforrás követése során.
+        participatory_space: Már követed a részvételi teret
       destroy:
         button: Követés törlése
         error: Hiba történt az erőforrás követésének visszavonásakor.

--- a/decidim-proposals/config/locales/hu.yml
+++ b/decidim-proposals/config/locales/hu.yml
@@ -103,6 +103,7 @@ hu:
         name: Javaslatok
         settings:
           global:
+            allow_card_image: Kártyakép engedélyezése
             amendments_enabled: A módosítások engedélyezve vannak
             amendments_enabled_help: Ha aktív, minden lépéshez konfigurálja a Módosítás funkciókat.
             amendments_wizard_help_text: Módosítások Varázsló súgószöveg
@@ -140,6 +141,7 @@ hu:
             amendments_visibility: A módosítás láthatósága
             amendments_visibility_help: Ha a „Módosítások csak a szerzőik számára láthatóak” opciót választják, akkor a résztvevőnek be kell jelentkeznie a módosítások megtekintéséhez.
             announcement: Közlemény
+            answers_with_costs: Költségek engedélyezése javaslati válaszoknál
             automatic_hashtags: Hashtagek hozzáadva minden javaslathoz
             comments_blocked: Megjegyzések letiltva
             creation_enabled: Javaslat létrehozása engedélyezve
@@ -742,6 +744,7 @@ hu:
           changes_at_title: A (z) "%{title}" módosítása
           edit_proposal: Javaslat szerkesztése
           endorsements_list: Jóváhagyások listája
+          estimated_cost: Becsült költség
           hidden_endorsers_count:
             one: és még %{count} személy
             other: és még %{count} ember
@@ -754,6 +757,8 @@ hu:
           proposal_accepted_reason: 'Ezt a javaslatot elfogadták, mert:'
           proposal_in_evaluation_reason: Javaslat értékelése folyamatban
           proposal_rejected_reason: 'Ezt a javaslatot elutasították, mert:'
+          read_less: Rövidebben
+          read_more: Bővebben
           report: Jelentés
           withdraw_btn_hint: Ha meggondoltad magad, az első támogatás megszerzéséig bármikor visszavonhatod a javaslatod. A javaslat nem törlődik automatikusan, hanem a visszavont javaslatok listájára kerül.
           withdraw_confirmation: Biztosan visszavonod ezt a javaslatot?

--- a/docs/manual-installation.md
+++ b/docs/manual-installation.md
@@ -122,6 +122,10 @@ This data won't be created in production environments, if you still want to do i
 SEED=true rails db:setup
 ```
 
+#### Notes
+
+When you run `bin/rails db:migrate` you should see a lot of output. If you don't, or if you run into errors seeding your database, try runnning `bin/rake decidim:upgrade` before.
+
 You can now start your server!
 
 ```bash


### PR DESCRIPTION
#5391 

## :tophat: What? Why?

I ran into errors when I was trying to seed my database. I found the answer in [this thread](https://github.com/decidim/decidim/issues/4357) . To help users down the line, I wanted to add the caveat to the installation docs.
