### PR TITLE
Add missing defaults in initializer template

### DIFF
--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -137,6 +137,11 @@ module Decidim
     %w(en ar ca de el es es-MX es-PY eu fi-pl fi fr gl hu id it nl no pl pt pt-BR ru sv tr uk)
   end
 
+  # Exposes a configuration option: The application default locale.
+  config_accessor :default_locale do
+    :en
+  end
+
   # Exposes a configuration option: an array of symbols representing processors
   # that will be automatically executed when a content is parsed or rendered.
   #
@@ -152,11 +157,6 @@ module Decidim
   #   Decidim::ContentRenderers::UserRenderer < BaseRenderer
   config_accessor :content_processors do
     []
-  end
-
-  # Exposes a configuration option: The application default locale.
-  config_accessor :default_locale do
-    :en
   end
 
   # Exposes a configuration option: an object to configure geocoder
@@ -213,7 +213,7 @@ module Decidim
     5.megabytes
   end
 
-  # The number of reports which an object can receive before hiding it
+  # The number of reports which a resource can receive before hiding it
   config_accessor :max_reports_before_hiding do
     3
   end
@@ -249,38 +249,58 @@ module Decidim
   end
 
   # Exposes a configuration option: an object to configure Etherpad
-  config_accessor :etherpad
+  config_accessor :etherpad do
+    # {
+    #   server: <your url>,
+    #   api_key: <your key>,
+    #   api_version: <your version>
+    # }
+  end
 
   # A base path for the uploads. If set, make sure it ends in a slash.
   # Uploads will be set to `<base_path>/uploads/`. This can be useful if you
   # want to use the same uploads place for both staging and production
   # environments, but in different folders.
-  config_accessor :base_uploads_path
+  config_accessor :base_uploads_path do
+    nil
+  end
 
-  # Exposes a configuration option: an object to deliver SMS codes to users.
-  config_accessor :sms_gateway_service
+  # The name of the class to deliver SMS codes to users.
+  #
+  # Check the example in `decidim-verifications`.
+  config_accessor :sms_gateway_service do
+    # "MyGatewayClass"
+  end
 
-  # Exposes a configuration option: an object to generate a timestamp from a
-  # document
-  config_accessor :timestamp_service
+  # The name of the class used to generate a timestamp from a document.
+  #
+  # Check the example in `decidim-initiatives`
+  config_accessor :timestamp_service do
+    # "MyTimestampService"
+  end
 
-  # Exposes a configuration option: an object to process a pdf and add a
-  # signature to the document
-  config_accessor :pdf_signature_service
+  # The name of the class used to process a pdf and add a signature to the
+  # document.
+  #
+  # Check the example in `decidim-initiatives`
+  config_accessor :pdf_signature_service do
+    # "MyPDFSignatureService"
+  end
 
-  # Exposes a configuration option: Decidim::Exporters::CSV's default column separator
+  # The Decidim::Exporters::CSV's default column separator
   config_accessor :default_csv_col_sep do
     ";"
   end
 
-  # Exposes a configuration option: An Array of Strings with the roles of a Decidim::User.
+  # The list of roles a user can have, not considering the space-specific roles.
   config_accessor :user_roles do
     %w(admin user_manager)
   end
 
-  # Exposes a configuration option: An Array of Strings that serve both as
-  # locale keys and values to construct the input collection in
+  # The list of visibility options for amendments. An Array of Strings that
+  # serve both as locale keys and values to construct the input collection in
   # Decidim::Amendment::VisibilityStepSetting::options.
+  #
   # This collection is used in Decidim::Admin::SettingsHelper to generate a
   # radio buttons collection input field form for a Decidim::Component
   # step setting :amendments_visibility.

--- a/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
@@ -1,12 +1,28 @@
 # frozen_string_literal: true
 
 Decidim.configure do |config|
+  # The name of the application
   config.application_name = "My Application Name"
+
+  # The email that will be used as sender in all emails from Decidim
   config.mailer_sender = "change-me@domain.org"
 
-  # Change these lines to set your preferred locales
-  config.default_locale = :en
+  # Sets the list of available locales for the whole application.
+  #
+  # When an organization is created through the System area, system admins will
+  # be able to choose the available languages for that organization. That list
+  # of languages will be equal or a subset of the list in this file.
   config.available_locales = [:en, :ca, :es]
+
+  # Sets the default locale for new organizations. When creating a new
+  # organization from the System area, system admins will be able to overwrite
+  # this value for that specific organization.
+  config.default_locale = :en
+
+  # Defines a list of custom content processors. They are used to parse and
+  # render specific tags inside some user-provided content. Check the docs for
+  # more info.
+  # config.content_processors = []
 
   # Geocoder configuration
   # config.geocoder = {
@@ -14,7 +30,7 @@ Decidim.configure do |config|
   #   here_api_key: Rails.application.secrets.geocoder[:here_api_key]
   # }
 
-  # Custom resource reference generator method
+  # Custom resource reference generator method. Check the docs for more info.
   # config.reference_generator = lambda do |resource, component|
   #   # Implement your custom method to generate resources references
   #   "1234-#{resource.id}"
@@ -23,7 +39,17 @@ Decidim.configure do |config|
   # Currency unit
   # config.currency_unit = "€"
 
-  # The number of reports which an object can receive before hiding it
+  # Defines the quality of image uploads after processing. Image uploads are
+  # processed by Decidim, this value helps reduce the size of the files.
+  # config.image_uploader_quality = 80
+
+  # The maximum file size of an attachment
+  # config.maximum_attachment_size = 10.megabytes
+
+  # The maximum file size for a user avatar
+  # config.maximum_avatar_size = 10.megabytes
+
+  # The number of reports which a resource can receive before hiding it
   # config.max_reports_before_hiding = 3
 
   # Custom HTML Header snippets
@@ -40,6 +66,36 @@ Decidim.configure do |config|
   # take over user accounts.
   #
   config.enable_html_header_snippets = false
+
+  # Allow organizations admins to track newsletter links.
+  # config.track_newsletter_links = true
+
+  # Amount of time that the data portability files will be available in the server.
+  # config.data_portability_expiry_time = 7.days
+
+  # Max requests in a time period to prevent DoS attacks. Only applied on production.
+  # config.throttling_max_requests = 100
+
+  # Time window in which the throttling is applied.
+  # config.throttling_period = 1.minute
+
+  # Time window were users can access the website even if their email is not confirmed.
+  # config.unconfirmed_access_for = 2.days
+
+  # Etherpad configuration. Check the docs for more info.
+  # config.etherpad = {
+  #   server: <your url>,
+  #   api_key: <your key>,
+  #   api_version: <your version>
+  # }
+
+  # A base path for the uploads. If set, make sure it ends in a slash.
+  # Uploads will be set to `<base_path>/uploads/`. This can be useful if you
+  # want to use the same uploads place for both staging and production
+  # environments, but in different folders.
+  #
+  # If not set, it will be ignored.
+  # config.base_uploads_path = nil
 
   # SMS gateway configuration
   #
@@ -121,6 +177,22 @@ Decidim.configure do |config|
   #   api_key: Rails.application.secrets.etherpad[:api_key],
   #   api_version: Rails.application.secrets.etherpad[:api_version]
   # }
+
+  # Sets Decidim::Exporters::CSV's default column separator
+  # config.default_csv_col_sep = ";"
+
+  # The list of roles a user can have, not considering the space-specific roles.
+  # config.user_roles = %w(admin user_manager)
+
+  # The list of visibility options for amendments. An Array of Strings that
+  # serve both as locale keys and values to construct the input collection in
+  # Decidim::Amendment::VisibilityStepSetting::options.
+  #
+  # This collection is used in Decidim::Admin::SettingsHelper to generate a
+  # radio buttons collection input field form for a Decidim::Component
+  # step setting :amendments_visibility.
+  # config.amendments_visibility_options = %w(all participants)
+
 end
 
 Rails.application.config.i18n.available_locales = Decidim.available_locales

--- a/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
@@ -192,7 +192,6 @@ Decidim.configure do |config|
   # radio buttons collection input field form for a Decidim::Component
   # step setting :amendments_visibility.
   # config.amendments_visibility_options = %w(all participants)
-
 end
 
 Rails.application.config.i18n.available_locales = Decidim.available_locales


### PR DESCRIPTION
#### :tophat: What? Why?

When you install Decidim to a Rails app, it adds an initializer with some examples of available configuration. Those examples are not complete (some config options are missing). This PR updates the Decidim initializer template so that all available options are listed.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
I'm not sure if this requires a Changelog entry.