### PR TITLE
Add minimum projects rule to Budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Due to [\#5553](https://github.com/decidim/decidim/pull/5553), SSL is turned on 
 - **decidim-proposals**, **decidim-core**, **decidim-blogs**: Apply generalized endorsements to the GraphQL API and add it to the blog posts query. [\#5847](https://github.com/decidim/decidim/pull/5847)
 - **decidim-budgets**: Allow projects to be sorted by different criteria [\#5808](https://github.com/decidim/decidim/pull/5808)
 - **decidim-budgets**: Request confirmation to exit budgets component [\#5765](https://github.com/decidim/decidim/pull/5765)
+- **decidim-budgets**: Add minimum projects rule to Budgets [/#5865](https://github.com/decidim/decidim/pull/5865)
+
 - **decidim-admin**: Allow to see a participant's email from the admin panel [\#5849](https://github.com/decidim/decidim/pull/5849)
 - **decidim**: Add missing indexs on foreign keys on the DB [\#5885](https://github.com/decidim/decidim/pull/5885)
 

--- a/decidim-admin/app/assets/javascripts/decidim/admin/budget_rule_toggler.component.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/budget_rule_toggler.component.js.es6
@@ -6,42 +6,44 @@
     }
 
     _runAll() {
-      this.ruleCheckboxes.forEach((el) => {
-        this.bindEvent(el);
-        this.run(el);
-      });
+      this.ruleCheckboxes.
+        each((_i, checkbox) => {
+          this._bindEvent(checkbox);
+          this.run(checkbox);
+        });
+    }
+
+    _bindEvent(target) {
+      $(target).
+        on("change", (event) => {
+          this.run(event.target);
+        });
     }
 
     run(target) {
-      let otherCheckboxes = this.ruleCheckboxes.filter(
-        (checkbox) => {
-          return checkbox !== target;
-        });
+      this.toggleTextInput(target);
 
       if ($(target).prop("checked")) {
-        this.toggleInput(target)
-        otherCheckboxes.forEach((el) => {
-          $(el).prop("checked", false);
-          this.toggleInput(el);
-        });
-      } else {
-        this.toggleInput(target);
+        this.ruleCheckboxes.
+          filter(
+            (_i, checkbox) => {
+              return checkbox !== target;
+            }).
+          prop("checked", false).
+          each(
+            (_i, checkbox) => {
+              this.toggleTextInput(checkbox);
+            });
       }
     }
 
-    toggleInput(target) {
+    toggleTextInput(target) {
       let input = $(target).closest("label").next();
       if ($(target).prop("checked")) {
         input.slideDown();
       } else {
         input.slideUp();
       }
-    }
-
-    bindEvent(target) {
-      $(target).on("change", (event) => {
-        this.run(`#${event.target.id}`);
-      });
     }
   }
 

--- a/decidim-admin/app/assets/javascripts/decidim/admin/budget_rule_toggler.component.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/budget_rule_toggler.component.js.es6
@@ -1,0 +1,50 @@
+((exports) => {
+  class BudgetRuleTogglerComponent {
+    constructor(options = {}) {
+      this.ruleCheckboxes = options.ruleCheckboxes;
+      this._runAll();
+    }
+
+    _runAll() {
+      this.ruleCheckboxes.forEach((el) => {
+        this.bindEvent(el);
+        this.run(el);
+      });
+    }
+
+    run(target) {
+      let otherCheckboxes = this.ruleCheckboxes.filter(
+        (checkbox) => {
+          return checkbox !== target;
+        });
+
+      if ($(target).prop("checked")) {
+        this.toggleInput(target)
+        otherCheckboxes.forEach((el) => {
+          $(el).prop("checked", false);
+          this.toggleInput(el);
+        });
+      } else {
+        this.toggleInput(target);
+      }
+    }
+
+    toggleInput(target) {
+      let input = $(target).closest("label").next();
+      if ($(target).prop("checked")) {
+        input.slideDown();
+      } else {
+        input.slideUp();
+      }
+    }
+
+    bindEvent(target) {
+      $(target).on("change", (event) => {
+        this.run(`#${event.target.id}`);
+      });
+    }
+  }
+
+  exports.DecidimAdmin = exports.DecidimAdmin || {};
+  exports.DecidimAdmin.BudgetRuleTogglerComponent = BudgetRuleTogglerComponent;
+})(window);

--- a/decidim-admin/app/assets/javascripts/decidim/admin/form.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/form.js.es6
@@ -1,3 +1,16 @@
+// = require ./budget_rule_toggler.component
+
+((exports) => {
+  const { BudgetRuleTogglerComponent } = exports.DecidimAdmin;
+
+  const budgetRuleToggler = new BudgetRuleTogglerComponent({
+    // $( "input[id^='component_settings_vote_rule_threshold_percent_enabled']" )
+    ruleCheckboxes: ["#component_settings_vote_rule_threshold_percent_enabled", "#component_settings_vote_rule_minimum_budget_projects_enabled"]
+  });
+
+  budgetRuleToggler.run();
+})(window);
+
 // Checks if the form contains fields with special CSS classes added in
 // Decidim::Admin::SettingsHelper and acts accordingly.
 $(() => {

--- a/decidim-admin/app/assets/javascripts/decidim/admin/form.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/form.js.es6
@@ -4,8 +4,7 @@
   const { BudgetRuleTogglerComponent } = exports.DecidimAdmin;
 
   const budgetRuleToggler = new BudgetRuleTogglerComponent({
-    // $( "input[id^='component_settings_vote_rule_threshold_percent_enabled']" )
-    ruleCheckboxes: ["#component_settings_vote_rule_threshold_percent_enabled", "#component_settings_vote_rule_minimum_budget_projects_enabled"]
+    ruleCheckboxes: $("input[id^='component_settings_vote_rule_']")
   });
 
   budgetRuleToggler.run();

--- a/decidim-admin/app/controllers/decidim/admin/components_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/components_controller.rb
@@ -23,11 +23,11 @@ module Decidim
           participatory_space: current_participatory_space
         )
 
-        @form = form(ComponentForm).from_model(@component)
+        @form = form(@component.form_class).from_model(@component)
       end
 
       def create
-        @form = form(ComponentForm).from_params(component_params)
+        @form = form(manifest.component_form_class).from_params(component_params)
         enforce_permission_to :create, :component
 
         CreateComponent.call(@form) do
@@ -47,12 +47,12 @@ module Decidim
         @component = query_scope.find(params[:id])
         enforce_permission_to :update, :component, component: @component
 
-        @form = form(ComponentForm).from_model(@component)
+        @form = form(@component.form_class).from_model(@component)
       end
 
       def update
         @component = query_scope.find(params[:id])
-        @form = form(ComponentForm).from_params(component_params)
+        @form = form(@component.form_class).from_params(component_params)
         enforce_permission_to :update, :component, component: @component
 
         UpdateComponent.call(@form, @component) do
@@ -113,7 +113,7 @@ module Decidim
 
       private
 
-      # Processes the component params so Decidim::Admin::ComponentForm
+      # Processes the component params so the form object defined in the manifest (component_form_class_name)
       # can assign and validate the attributes when using #from_params.
       def component_params
         new_settings = proc { |name, data| Component.build_settings(manifest, name, data, current_organization) }

--- a/decidim-admin/app/forms/decidim/admin/component_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/component_form.rb
@@ -23,9 +23,6 @@ module Decidim
       attribute :default_step_settings, Object
       attribute :step_settings, Hash[String => Object]
 
-      validate :must_be_able_to_change_participatory_texts_setting
-      validate :amendments_visibility_options_must_be_valid
-
       def settings?
         settings.manifest.attributes.any?
       end
@@ -53,26 +50,6 @@ module Decidim
                          step_settings.each_value.map(&:errors).all?(&:empty?)
                        end
         validations.all?
-      end
-
-      # Validates setting `participatory_texts_enabled` is not changed when there are proposals for the component.
-      def must_be_able_to_change_participatory_texts_setting
-        return unless manifest&.name == :proposals && (component = Component.find_by(id: id))
-        return unless settings.participatory_texts_enabled != component.settings.participatory_texts_enabled
-
-        settings.errors.add(:participatory_texts_enabled) if Decidim::Proposals::Proposal.where(component: component).any?
-      end
-
-      # Validates setting `amendments_visibility` is included in Decidim::Amendment::VisibilityStepSetting.options.
-      def amendments_visibility_options_must_be_valid
-        return unless manifest&.name == :proposals && settings.amendments_enabled
-
-        visibility_options = Decidim::Amendment::VisibilityStepSetting.options.map(&:last)
-        step_settings.each do |step, settings|
-          next unless visibility_options.exclude? settings[:amendments_visibility]
-
-          step_settings[step].errors.add(:amendments_visibility, :inclusion)
-        end
       end
     end
   end

--- a/decidim-admin/app/forms/decidim/admin/component_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/component_form.rb
@@ -25,7 +25,6 @@ module Decidim
 
       validate :must_be_able_to_change_participatory_texts_setting
       validate :amendments_visibility_options_must_be_valid
-      validate :budget_voting_rule_enabled_setting, :budget_voting_rule_value_setting
 
       def settings?
         settings.manifest.attributes.any?
@@ -74,34 +73,6 @@ module Decidim
 
           step_settings[step].errors.add(:amendments_visibility, :inclusion)
         end
-      end
-
-      # Validations on budget settings:
-      # - a voting rule must be enabled.
-      def budget_voting_rule_enabled_setting
-        return unless manifest&.name == :budgets
-
-        i18n_error_scope = "decidim.components.budgets.settings.global.form.errors"
-        if settings.vote_rule_threshold_percent_enabled.blank? && settings.vote_rule_minimum_budget_projects_enabled.blank?
-          settings.errors.add(:vote_rule_threshold_percent_enabled, I18n.t(:budget_voting_rule_required, scope: i18n_error_scope))
-          settings.errors.add(:vote_rule_minimum_budget_projects_enabled, I18n.t(:budget_voting_rule_required, scope: i18n_error_scope))
-        end
-
-        if settings.vote_rule_threshold_percent_enabled && settings.vote_rule_minimum_budget_projects_enabled
-          settings.errors.add(:vote_rule_threshold_percent_enabled, I18n.t(:budget_voting_rule_only_one, scope: i18n_error_scope))
-          settings.errors.add(:vote_rule_minimum_budget_projects_enabled, I18n.t(:budget_voting_rule_only_one, scope: i18n_error_scope))
-        end
-      end
-
-      # - the value must be a valid number
-      def budget_voting_rule_value_setting
-        return unless manifest&.name == :budgets
-
-        invalid_percent_number = settings.vote_threshold_percent.blank? || settings.vote_threshold_percent.to_i.negative?
-        settings.errors.add(:vote_threshold_percent) if settings.vote_rule_threshold_percent_enabled && invalid_percent_number
-
-        invalid_minimum_number = settings.vote_minimum_budget_projects_number.blank? || (settings.vote_minimum_budget_projects_number.to_i < 1)
-        settings.errors.add(:vote_minimum_budget_projects_number) if settings.vote_rule_minimum_budget_projects_enabled && invalid_minimum_number
       end
     end
   end

--- a/decidim-admin/app/forms/decidim/admin/component_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/component_form.rb
@@ -86,6 +86,11 @@ module Decidim
           settings.errors.add(:vote_rule_threshold_percent_enabled, I18n.t(:budget_voting_rule_required, scope: i18n_error_scope))
           settings.errors.add(:vote_rule_minimum_budget_projects_enabled, I18n.t(:budget_voting_rule_required, scope: i18n_error_scope))
         end
+
+        if settings.vote_rule_threshold_percent_enabled && settings.vote_rule_minimum_budget_projects_enabled
+          settings.errors.add(:vote_rule_threshold_percent_enabled, I18n.t(:budget_voting_rule_only_one, scope: i18n_error_scope))
+          settings.errors.add(:vote_rule_minimum_budget_projects_enabled, I18n.t(:budget_voting_rule_only_one, scope: i18n_error_scope))
+        end
       end
 
       # - the value must be a valid number

--- a/decidim-admin/app/forms/decidim/admin/component_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/component_form.rb
@@ -90,6 +90,8 @@ module Decidim
 
       # - the value must be a valid number
       def budget_voting_rule_value_setting
+        return unless manifest&.name == :budgets
+
         invalid_percent_number = settings.vote_threshold_percent.blank? || settings.vote_threshold_percent.to_i.negative?
         settings.errors.add(:vote_threshold_percent) if settings.vote_rule_threshold_percent_enabled && invalid_percent_number
 

--- a/decidim-admin/app/forms/decidim/admin/component_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/component_form.rb
@@ -91,9 +91,7 @@ module Decidim
       # - the value must be a valid number
       def budget_voting_rule_value_setting
         invalid_percent_number = settings.vote_threshold_percent.blank? || settings.vote_threshold_percent.to_i.negative?
-        if settings.vote_rule_threshold_percent_enabled && invalid_percent_number
-          settings.errors.add(:vote_threshold_percent)
-        end
+        settings.errors.add(:vote_threshold_percent) if settings.vote_rule_threshold_percent_enabled && invalid_percent_number
 
         invalid_minimum_number = settings.vote_minimum_budget_projects_number.blank? || (settings.vote_minimum_budget_projects_number.to_i < 1)
         settings.errors.add(:vote_minimum_budget_projects_number) if settings.vote_rule_minimum_budget_projects_enabled && invalid_minimum_number

--- a/decidim-budgets/app/commands/decidim/budgets/add_line_item.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/add_line_item.rb
@@ -10,7 +10,7 @@ module Decidim
       # project - The the project to include in the order
       # current_user - The current user logged in
       def initialize(current_order, project, current_user)
-        @order = current_order
+        @order = current_order.persisted? ? current_order : nil
         @project = project
         @current_user = current_user
       end

--- a/decidim-budgets/app/commands/decidim/budgets/add_line_item.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/add_line_item.rb
@@ -10,7 +10,7 @@ module Decidim
       # project - The the project to include in the order
       # current_user - The current user logged in
       def initialize(current_order, project, current_user)
-        @order = current_order&.persisted? ? current_order : nil
+        @order = current_order
         @project = project
         @current_user = current_user
       end

--- a/decidim-budgets/app/commands/decidim/budgets/add_line_item.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/add_line_item.rb
@@ -10,7 +10,7 @@ module Decidim
       # project - The the project to include in the order
       # current_user - The current user logged in
       def initialize(current_order, project, current_user)
-        @order = current_order.persisted? ? current_order : nil
+        @order = current_order&.persisted? ? current_order : nil
         @project = project
         @current_user = current_user
       end

--- a/decidim-budgets/app/commands/decidim/budgets/checkout.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/checkout.rb
@@ -28,7 +28,7 @@ module Decidim
       private
 
       def checkout!
-        return unless @order
+        return unless @order && @order.valid?
 
         @order.with_lock do
           @order.checked_out_at = Time.current

--- a/decidim-budgets/app/controllers/concerns/decidim/budgets/needs_current_order.rb
+++ b/decidim-budgets/app/controllers/concerns/decidim/budgets/needs_current_order.rb
@@ -15,11 +15,15 @@ module Decidim
         #
         # Returns an Order.
         def current_order
-          @current_order ||= Order.includes(:projects).find_by(user: current_user, component: current_component) || Order.new(user: current_user, component: current_component)
+          @current_order ||= Order.includes(:projects).find_or_initialize_by(user: current_user, component: current_component)
         end
 
         def current_order=(order)
           @current_order = order
+        end
+
+        def persisted_current_order
+          current_order if current_order&.persisted?
         end
       end
     end

--- a/decidim-budgets/app/controllers/concerns/decidim/budgets/needs_current_order.rb
+++ b/decidim-budgets/app/controllers/concerns/decidim/budgets/needs_current_order.rb
@@ -15,7 +15,7 @@ module Decidim
         #
         # Returns an Order.
         def current_order
-          @current_order ||= Order.includes(:projects).find_by(user: current_user, component: current_component)
+          @current_order ||= Order.includes(:projects).find_by(user: current_user, component: current_component) || Order.new(user: current_user, component: current_component)
         end
 
         def current_order=(order)

--- a/decidim-budgets/app/controllers/decidim/budgets/line_items_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/line_items_controller.rb
@@ -12,7 +12,7 @@ module Decidim
         enforce_permission_to :vote, :project, project: project
 
         respond_to do |format|
-          AddLineItem.call(current_order, project, current_user) do
+          AddLineItem.call(persisted_current_order, project, current_user) do
             on(:ok) do |order|
               self.current_order = order
               format.html { redirect_to :back }

--- a/decidim-budgets/app/forms/decidim/budgets/admin/component_form.rb
+++ b/decidim-budgets/app/forms/decidim/budgets/admin/component_form.rb
@@ -3,8 +3,8 @@
 module Decidim
   module Budgets
     module Admin
-      # A form object for Budgets used to attach a component to a participatory process from the
-      # admin panel.
+      # A form object for the budgets component. Used to attach the component
+      # to a participatory process from the admin panel.
       #
       class ComponentForm < Decidim::Admin::ComponentForm
         validate :budget_voting_rule_enabled_setting, :budget_voting_rule_value_setting

--- a/decidim-budgets/app/forms/decidim/budgets/admin/component_form.rb
+++ b/decidim-budgets/app/forms/decidim/budgets/admin/component_form.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Budgets
+    module Admin
+      # A form object for Budgets used to attach a component to a participatory process from the
+      # admin panel.
+      #
+      class ComponentForm < Decidim::Admin::ComponentForm
+        validate :budget_voting_rule_enabled_setting, :budget_voting_rule_value_setting
+
+        private
+
+        # Validations on budget settings:
+        # - a voting rule must be enabled.
+        def budget_voting_rule_enabled_setting
+          return unless manifest&.name == :budgets
+
+          i18n_error_scope = "decidim.components.budgets.settings.global.form.errors"
+          if settings.vote_rule_threshold_percent_enabled.blank? && settings.vote_rule_minimum_budget_projects_enabled.blank?
+            settings.errors.add(:vote_rule_threshold_percent_enabled, I18n.t(:budget_voting_rule_required, scope: i18n_error_scope))
+            settings.errors.add(:vote_rule_minimum_budget_projects_enabled, I18n.t(:budget_voting_rule_required, scope: i18n_error_scope))
+          end
+
+          if settings.vote_rule_threshold_percent_enabled && settings.vote_rule_minimum_budget_projects_enabled
+            settings.errors.add(:vote_rule_threshold_percent_enabled, I18n.t(:budget_voting_rule_only_one, scope: i18n_error_scope))
+            settings.errors.add(:vote_rule_minimum_budget_projects_enabled, I18n.t(:budget_voting_rule_only_one, scope: i18n_error_scope))
+          end
+        end
+
+        # - the value must be a valid number
+        def budget_voting_rule_value_setting
+          return unless manifest&.name == :budgets
+
+          invalid_percent_number = settings.vote_threshold_percent.blank? || settings.vote_threshold_percent.to_i.negative?
+          settings.errors.add(:vote_threshold_percent) if settings.vote_rule_threshold_percent_enabled && invalid_percent_number
+
+          invalid_minimum_number = settings.vote_minimum_budget_projects_number.blank? || (settings.vote_minimum_budget_projects_number.to_i < 1)
+          settings.errors.add(:vote_minimum_budget_projects_number) if settings.vote_rule_minimum_budget_projects_enabled && invalid_minimum_number
+        end
+      end
+    end
+  end
+end

--- a/decidim-budgets/app/helpers/decidim/budgets/projects_helper.rb
+++ b/decidim-budgets/app/helpers/decidim/budgets/projects_helper.rb
@@ -26,7 +26,7 @@ module Decidim
       def budget_confirm_disabled_attr
         return if current_order_can_be_checked_out?
 
-        %( disabled= "disabled" )
+        %( disabled="disabled" )
       end
 
       # Return true if the current order is checked out

--- a/decidim-budgets/app/helpers/decidim/budgets/projects_helper.rb
+++ b/decidim-budgets/app/helpers/decidim/budgets/projects_helper.rb
@@ -16,6 +16,28 @@ module Decidim
         current_order&.budget_percent.to_f.floor
       end
 
+      # Return the minimum percentage of the current order budget from the total budget
+      def current_order_budget_percent_minimum
+        return 0 if current_order.minimum_projects_rule?
+
+        component_settings.vote_threshold_percent
+      end
+
+      # Return the minimum percentage of the current order budget from the total budget
+      def budget_rule_description
+        if current_order.minimum_projects_rule?
+          t(".description_minimum_projects_rule", minimum_number: current_order.minimum_projects)
+        else
+          t(".description", minimum_budget: budget_to_currency(current_order.minimum_budget))
+        end
+      end
+
+      def budget_confirm_disabled_attr
+        return if current_order_can_be_checked_out?
+
+        %( disabled= "disabled" )
+      end
+
       # Return true if the current order is checked out
       delegate :checked_out?, to: :current_order, prefix: true, allow_nil: true
 

--- a/decidim-budgets/app/helpers/decidim/budgets/projects_helper.rb
+++ b/decidim-budgets/app/helpers/decidim/budgets/projects_helper.rb
@@ -23,15 +23,6 @@ module Decidim
         component_settings.vote_threshold_percent
       end
 
-      # Return the minimum percentage of the current order budget from the total budget
-      def budget_rule_description
-        if current_order.minimum_projects_rule?
-          t(".description_minimum_projects_rule", minimum_number: current_order.minimum_projects)
-        else
-          t(".description", minimum_budget: budget_to_currency(current_order.minimum_budget))
-        end
-      end
-
       def budget_confirm_disabled_attr
         return if current_order_can_be_checked_out?
 

--- a/decidim-budgets/app/models/decidim/budgets/order.rb
+++ b/decidim-budgets/app/models/decidim/budgets/order.rb
@@ -27,6 +27,8 @@ module Decidim
         less_than_or_equal_to: :maximum_budget
       }
 
+      validate :reach_minimum_projects, if: :checked_out?
+
       scope :finished, -> { where.not(checked_out_at: nil) }
       scope :pending, -> { where(checked_out_at: nil) }
 
@@ -102,6 +104,12 @@ module Decidim
         return if !user || !organization
 
         errors.add(:user, :invalid) unless user.organization == organization
+      end
+
+      def reach_minimum_projects
+        return unless minimum_projects_rule?
+
+        errors.add(:projects, :invalid) if minimum_projects > projects.count
       end
     end
   end

--- a/decidim-budgets/app/models/decidim/budgets/order.rb
+++ b/decidim-budgets/app/models/decidim/budgets/order.rb
@@ -42,6 +42,8 @@ module Decidim
 
       # Public: Check if the order total budget is enough to checkout
       def can_checkout?
+        return minimum_projects <= projects.count if minimum_projects_rule?
+
         total_budget.to_f >= minimum_budget
       end
 
@@ -52,7 +54,7 @@ module Decidim
 
       # Public: Returns the required minimum budget to checkout
       def minimum_budget
-        return 0 unless component
+        return 0 unless component || minimum_projects_rule?
 
         component.settings.total_budget.to_f * (component.settings.vote_threshold_percent.to_f / 100)
       end
@@ -62,6 +64,20 @@ module Decidim
         return 0 unless component
 
         component.settings.total_budget.to_f
+      end
+
+      # Public: Returns if it is required a minimum projects limit to checkout
+      def minimum_projects_rule?
+        return unless component
+
+        component.settings.vote_rule_minimum_budget_projects_enabled
+      end
+
+      # Public: Returns the required minimum projects to checkout
+      def minimum_projects
+        return 0 unless component
+
+        component.settings.vote_minimum_budget_projects_number
       end
 
       def self.user_collection(user)

--- a/decidim-budgets/app/views/decidim/budgets/projects/_budget_summary.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_budget_summary.html.erb
@@ -8,7 +8,7 @@
         </p>
       <% else %>
         <h3 class="heading3"><%= t(".title") %></h3>
-        <p><%= t(".description", minimum_budget: budget_to_currency(current_order&.minimum_budget)) %></p>
+        <p><%= budget_rule_description %></p>
       <% end %>
     <% end %>
 

--- a/decidim-budgets/app/views/decidim/budgets/projects/_budget_summary.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_budget_summary.html.erb
@@ -8,7 +8,13 @@
         </p>
       <% else %>
         <h3 class="heading3"><%= t(".title") %></h3>
-        <p><%= budget_rule_description %></p>
+        <p>
+          <% if current_order.minimum_projects_rule? %>
+            <%= t(".description_minimum_projects_rule", minimum_number: current_order.minimum_projects) %>
+          <% else %>
+            <%= t(".description", minimum_budget: budget_to_currency(current_order.minimum_budget)) %>
+          <% end %>
+        </p>
       <% end %>
     <% end %>
 

--- a/decidim-budgets/app/views/decidim/budgets/projects/_order_progress.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_order_progress.html.erb
@@ -1,35 +1,27 @@
 <div id="order-progress">
   <div class="budget-summary__progressbox" data-current-budget="<%= current_order ? current_order.total_budget : 0 %>">
     <div class="progress budget-progress" role="progressbar" tabindex="0" aria-valuenow="<%= current_order_budget_percent %>" aria-valuemin="<%= component_settings.vote_threshold_percent %>" aria-valuetext="<%= current_order_budget_percent %>%" aria-valuemax="100">
-      <div class="progress-meter progress-meter--minimum" style="width: <%= 100 - current_order_budget_percent %>%"></div>
+      <div class="progress-meter progress-meter--minimum" style="width: <%= current_order_budget_percent_minimum %>%"></div>
       <!--Change width and text dynamically.-->
       <div class="progress-meter budget-progress__meter" style="width: <%= current_order_budget_percent %>%">
         <p class="progress-meter-text progress-meter-text--right"><%= current_order_budget_percent %>%</p>
       </div>
     </div>
     <% unless current_order_checked_out? %>
-      <% if current_order_can_be_checked_out? %>
-        <button class="button small button--sc" data-toggle="budget-confirm"><%= t(".vote") %></button>
-      <% else %>
-        <button class="button small button--sc" data-toggle="budget-confirm" disabled><%= t(".vote") %></button>
-      <% end %>
+      <button class="button small button--sc" data-toggle="budget-confirm" <%= budget_confirm_disabled_attr %> ><%= t(".vote") %></button>
     <% end %>
   </div>
 
   <div class="progressbox-fixed-wrapper" data-progressbox-fixed>
     <div class="budget-summary__progressbox budget-summary__progressbox--fixed">
       <div class="progress budget-progress budget-progress--fixed" role="progressbar" tabindex="0" aria-valuenow="<%= current_order_budget_percent %>" aria-valuemin="<%= component_settings.vote_threshold_percent %>" aria-valuetext="<%= current_order_budget_percent %>%" aria-valuemax="100">
-        <div class="progress-meter progress-meter--minimum" style="width: <%= 100 - current_order_budget_percent %>%"></div>
+        <div class="progress-meter progress-meter--minimum" style="width: <%= current_order_budget_percent_minimum %>%"></div>
         <div class="progress-meter budget-progress__meter" style="width: <%= current_order_budget_percent %>%">
           <p class="progress-meter-text progress-meter-text--right"><%= current_order_budget_percent %>%</p>
         </div>
       </div>
       <% unless current_order_checked_out? %>
-        <% if current_order_can_be_checked_out? %>
-          <button class="button small button--sc" data-toggle="budget-confirm"><%= t(".vote") %></button>
-        <% else %>
-          <button class="button small button--sc" data-toggle="budget-confirm" disabled><%= t(".vote") %></button>
-        <% end %>
+        <button class="button small button--sc" data-toggle="budget-confirm" <%= budget_confirm_disabled_attr %> ><%= t(".vote") %></button>
       <% end %>
     </div>
   </div>

--- a/decidim-budgets/app/views/decidim/budgets/projects/_order_progress.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_order_progress.html.erb
@@ -8,7 +8,7 @@
       </div>
     </div>
     <% unless current_order_checked_out? %>
-      <button class="button small button--sc" data-toggle="budget-confirm" <%= budget_confirm_disabled_attr %> ><%= t(".vote") %></button>
+      <button class="button small button--sc" data-toggle="budget-confirm" <%= budget_confirm_disabled_attr %>><%= t(".vote") %></button>
     <% end %>
   </div>
 
@@ -21,7 +21,7 @@
         </div>
       </div>
       <% unless current_order_checked_out? %>
-        <button class="button small button--sc" data-toggle="budget-confirm" <%= budget_confirm_disabled_attr %> ><%= t(".vote") %></button>
+        <button class="button small button--sc" data-toggle="budget-confirm" <%= budget_confirm_disabled_attr %>><%= t(".vote") %></button>
       <% end %>
     </div>
   </div>

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -139,6 +139,7 @@ en:
             comments_enabled: Comments enabled
             form:
               errors:
+                budget_voting_rule_only_one: Only one voting rule must be enabled
                 budget_voting_rule_required: One voting rule is required
             projects_per_page: Projects per page
             resources_permissions_enabled: Actions permissions can be set for each meeting

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -86,6 +86,7 @@ en:
             description: You've already voted for the budget. If you've changed your mind, you can %{cancel_link}.
             title: Budget vote completed
           description: What projects do you think we should allocate budget for? Assign at least %{minimum_budget} to the projects you want and vote with your preferences to define the budget.
+          description_minimum_projects_rule: What projects do you think we should allocate budget for? Select at least %{minimum_number} projects you want and vote with your preferences to define the budget.
           title: You decide the budget
         count:
           projects_count:
@@ -139,6 +140,9 @@ en:
             projects_per_page: Projects per page
             resources_permissions_enabled: Actions permissions can be set for each meeting
             total_budget: Total budget
+            vote_minimum_budget_projects_number: Minimum number of projects to vote
+            vote_rule_minimum_budget_projects_enabled: 'Enable rule: Minimum number of projects to be voted on'
+            vote_rule_threshold_percent_enabled: 'Enable rule: Minimum budget percentage'
             vote_threshold_percent: Vote threshold percent
           step:
             announcement: Announcement

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -137,6 +137,9 @@ en:
           global:
             announcement: Announcement
             comments_enabled: Comments enabled
+            form:
+              errors:
+                budget_voting_rule_required: One voting rule is required
             projects_per_page: Projects per page
             resources_permissions_enabled: Actions permissions can be set for each meeting
             total_budget: Total budget

--- a/decidim-budgets/lib/decidim/budgets/component.rb
+++ b/decidim-budgets/lib/decidim/budgets/component.rb
@@ -8,6 +8,7 @@ Decidim.register_component(:budgets) do |component|
   component.icon = "decidim/budgets/icon.svg"
   component.stylesheet = "decidim/budgets/budgets"
   component.permissions_class_name = "Decidim::Budgets::Permissions"
+  component.component_form_class_name = "Decidim::Budgets::Admin::ComponentForm"
 
   component.data_portable_entities = ["Decidim::Budgets::Order"]
 

--- a/decidim-budgets/lib/decidim/budgets/component.rb
+++ b/decidim-budgets/lib/decidim/budgets/component.rb
@@ -53,7 +53,10 @@ Decidim.register_component(:budgets) do |component|
   component.settings(:global) do |settings|
     settings.attribute :projects_per_page, type: :integer, default: 12
     settings.attribute :total_budget, type: :integer, default: 100_000_000
+    settings.attribute :vote_rule_threshold_percent_enabled, type: :boolean, default: true
     settings.attribute :vote_threshold_percent, type: :integer, default: 70
+    settings.attribute :vote_rule_minimum_budget_projects_enabled, type: :boolean, default: false
+    settings.attribute :vote_minimum_budget_projects_number, type: :integer, default: 1
     settings.attribute :comments_enabled, type: :boolean, default: true
     settings.attribute :resources_permissions_enabled, type: :boolean, default: true
     settings.attribute :announcement, type: :text, translated: true, editor: true

--- a/decidim-budgets/lib/decidim/budgets/test/factories.rb
+++ b/decidim-budgets/lib/decidim/budgets/test/factories.rb
@@ -15,13 +15,35 @@ FactoryBot.define do
     trait :with_total_budget_and_vote_threshold_percent do
       transient do
         total_budget { 100_000_000 }
+        vote_rule_threshold_percent_enabled { true }
+        vote_rule_minimum_budget_projects_enabled { false }
         vote_threshold_percent { 70 }
       end
 
       settings do
         {
           total_budget: total_budget,
+          vote_rule_threshold_percent_enabled: vote_rule_threshold_percent_enabled,
+          vote_rule_minimum_budget_projects_enabled: vote_rule_minimum_budget_projects_enabled,
           vote_threshold_percent: vote_threshold_percent
+        }
+      end
+    end
+
+    trait :with_total_budget_and_minimum_budget_projects do
+      transient do
+        total_budget { 100_000_000 }
+        vote_rule_threshold_percent_enabled { false }
+        vote_rule_minimum_budget_projects_enabled { true }
+        vote_minimum_budget_projects_number { 3 }
+      end
+
+      settings do
+        {
+          total_budget: total_budget,
+          vote_rule_threshold_percent_enabled: vote_rule_threshold_percent_enabled,
+          vote_rule_minimum_budget_projects_enabled: vote_rule_minimum_budget_projects_enabled,
+          vote_minimum_budget_projects_number: vote_minimum_budget_projects_number
         }
       end
     end

--- a/decidim-budgets/spec/lib/decidim/budgets/admin/component_spec.rb
+++ b/decidim-budgets/spec/lib/decidim/budgets/admin/component_spec.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Budgets component" do # rubocop:disable RSpec/DescribeClass
+  let!(:component) { create(:budget_component) }
+  let(:organization) { component.organization }
+  let!(:current_user) { create(:user, :admin, organization: organization) }
+
+  describe "on update" do
+    let(:manifest) { component.manifest }
+    let(:participatory_space) { component.participatory_space }
+
+    let(:form) do
+      Decidim::Admin::ComponentForm.from_params(
+        id: component.id,
+        weight: 0,
+        manifest: manifest,
+        participatory_space: participatory_space,
+        name: generate_localized_title,
+        default_step_settings: {},
+        settings: new_settings(:global, settings)
+      ).with_context(current_organization: organization)
+    end
+
+    let(:percent_enabled) { false }
+    let(:percent) { 70 }
+    let(:minimum_enabled) { false }
+    let(:minimum_number) { 3 }
+
+    let(:settings) do
+      {
+        total_budget: 100_000_000,
+        vote_rule_threshold_percent_enabled: percent_enabled,
+        vote_threshold_percent: percent,
+        vote_rule_minimum_budget_projects_enabled: minimum_enabled,
+        vote_minimum_budget_projects_number: minimum_number
+      }
+    end
+
+    def new_settings(name, data)
+      Decidim::Component.build_settings(manifest, name, data, organization)
+    end
+
+    describe "with minimum projects number to vote" do
+      let(:minimum_enabled) { true }
+
+      context "when the minimum projects number is valid" do
+        it "updates the component" do
+          expect do
+            Decidim::Admin::UpdateComponent.call(form, component)
+          end.to broadcast(:ok)
+        end
+      end
+
+      context "when the minimum projects number is NOT valid" do
+        let(:minimum_number) { 0 }
+
+        it "does NOT update the component" do
+          expect do
+            Decidim::Admin::UpdateComponent.call(form, component)
+          end.to broadcast(:invalid)
+        end
+      end
+    end
+
+    describe "with threshold percent enabled" do
+      let(:percent_enabled) { true }
+
+      context "when the threshold percent number is valid" do
+        it "updates the component" do
+          expect do
+            Decidim::Admin::UpdateComponent.call(form, component)
+          end.to broadcast(:ok)
+        end
+      end
+
+      context "when the threshold percent is NOT valid" do
+        let(:percent) { -1 }
+
+        it "does NOT update the component" do
+          expect do
+            Decidim::Admin::UpdateComponent.call(form, component)
+          end.to broadcast(:invalid)
+        end
+      end
+    end
+
+    describe "with more than one voting rule enabled" do
+      let(:percent_enabled) { true }
+      let(:minimum_enabled) { true }
+
+      it "does NOT update the component" do
+        expect do
+          Decidim::Admin::UpdateComponent.call(form, component)
+        end.to broadcast(:invalid)
+      end
+    end
+
+    describe "with no voting rule enabled" do
+      let(:percent_enabled) { false }
+      let(:minimum_enabled) { false }
+
+      it "does NOT update the component" do
+        expect do
+          Decidim::Admin::UpdateComponent.call(form, component)
+        end.to broadcast(:invalid)
+      end
+    end
+  end
+
+  describe "on edit", type: :system do
+    let(:edit_component_path) do
+      Decidim::EngineRouter.admin_proxy(component.participatory_space).edit_component_path(component.id)
+    end
+
+    before do
+      switch_to_host(organization.host)
+      login_as current_user, scope: :user
+    end
+
+    describe "Budget component settings" do
+      before do
+        visit edit_component_path
+      end
+
+      context "when minimum projects rule is checked" do
+        before do
+          check "Enable rule: Minimum number of projects to be voted on"
+        end
+
+        it "is shown the number input" do
+          expect(page).to have_content("Minimum number of projects to vote")
+          expect(page).to have_css("input#component_settings_vote_minimum_budget_projects_number")
+        end
+
+        it "is hidden the percent input" do
+          expect(page).to have_no_content("Vote threshold percent")
+          expect(page).to have_no_css("input#component_settings_vote_threshold_percent")
+        end
+      end
+
+      context "when threshold percent rule is checked" do
+        before do
+          check "Enable rule: Minimum budget percentage"
+        end
+
+        it "is shown the percent input" do
+          expect(page).to have_content("Vote threshold percent")
+          expect(page).to have_css("input#component_settings_vote_threshold_percent")
+        end
+
+        it "is hidden the number input" do
+          expect(page).to have_no_content("Minimum number of projects to vote")
+          expect(page).to have_no_css("input#component_settings_vote_minimum_budget_projects_number")
+        end
+      end
+      # context "when amendments_enabled global setting is NOT checked" do
+      #   it "is NOT shown the amendments_wizard_help_text global setting" do
+      #     expect(page).not_to have_content("Amendments Wizard help text")
+      #     expect(page).to have_css("div[data-tabs-content='global-settings-amendments_wizard_help_text-tabs']", visible: false)
+      #   end
+      #
+      #   it "is NOT shown the amendments step settings" do
+      #     expect(page).to have_css(".amendments_step_settings", visible: false)
+      #   end
+      # end
+    end
+  end
+end

--- a/decidim-budgets/spec/lib/decidim/budgets/admin/component_spec.rb
+++ b/decidim-budgets/spec/lib/decidim/budgets/admin/component_spec.rb
@@ -12,7 +12,7 @@ describe "Budgets component" do # rubocop:disable RSpec/DescribeClass
     let(:participatory_space) { component.participatory_space }
 
     let(:form) do
-      Decidim::Admin::ComponentForm.from_params(
+      Decidim::Budgets::Admin::ComponentForm.from_params(
         id: component.id,
         weight: 0,
         manifest: manifest,

--- a/decidim-budgets/spec/system/orders_spec.rb
+++ b/decidim-budgets/spec/system/orders_spec.rb
@@ -165,6 +165,92 @@ describe "Orders", type: :system do
           end
         end
       end
+
+      context "when the voting rule is set to threshold percent" do
+        before do
+          visit_component
+        end
+
+        it "shows the rule description" do
+          within ".card.budget-summary" do
+            expect(page).to have_content("Assign at least €70,000,000 to the projects you want and vote")
+          end
+        end
+
+        context "when the order total budget doesn't exceed the threshold" do
+          it "cannot vote" do
+            within "#order-progress" do
+              expect(page).to have_button("Vote", disabled: true)
+            end
+          end
+        end
+
+        context "when the order total budget exceeds the threshold" do
+          let(:projects) { create_list(:project, 2, component: component, budget: 36_000_000) }
+          let(:order_percent) { create(:order, user: user, component: component) }
+
+          before do
+            order.destroy!
+            order_percent.projects << projects
+            order_percent.save!
+          end
+
+          it "can vote" do
+            visit_component
+            within "#order-progress" do
+              expect(page).to have_button("Vote", disabled: false)
+            end
+          end
+        end
+      end
+
+      context "when the voting rule is set to minimum projects" do
+        before do
+          order.destroy!
+        end
+
+        let(:component) do
+          create(:budget_component,
+                 :with_total_budget_and_minimum_budget_projects,
+                 manifest: manifest,
+                 participatory_space: participatory_process)
+        end
+
+        let!(:order_min) { create(:order, user: user, component: component) }
+
+        it "shows the rule description" do
+          visit_component
+
+          within ".card.budget-summary" do
+            expect(page).to have_content("Select at least 3 projects you want and vote")
+          end
+        end
+
+        context "when the order total budget doesn't reach the minimum" do
+          it "cannot vote" do
+            visit_component
+
+            within "#order-progress" do
+              expect(page).to have_button("Vote", disabled: true)
+            end
+          end
+        end
+
+        context "when the order total budget exceeds the minimum" do
+          before do
+            order_min.projects = projects
+            order_min.save!
+          end
+
+          it "can vote" do
+            visit_component
+
+            within "#order-progress" do
+              expect(page).to have_button("Vote", disabled: false)
+            end
+          end
+        end
+      end
     end
 
     context "and has a finished order" do

--- a/decidim-core/app/models/decidim/component.rb
+++ b/decidim-core/app/models/decidim/component.rb
@@ -60,6 +60,13 @@ module Decidim
       }
     end
 
+    # Public: The Form Class for this component.
+    #
+    # Returns a ComponentForm.
+    def form_class
+      manifest.component_form_class
+    end
+
     # Public: Returns the value of the registered primary stat.
     def primary_stat
       @primary_stat ||= manifest.stats.filter(primary: true).with_context([self]).map { |name, value| [name, value] }.first&.last

--- a/decidim-core/lib/decidim/component_manifest.rb
+++ b/decidim-core/lib/decidim/component_manifest.rb
@@ -60,7 +60,7 @@ module Decidim
 
     # The name of the class that handles extra logic on settings for this component.
     # Optional class, that if present receives the settings and validates them.
-    # Probably have the form of `Decidim::<MyComponent>::Admin::ComponentForm`.
+    # The suggested naming is `Decidim::<MyComponent>::Admin::ComponentForm`.
     attribute :component_form_class_name, String, default: "Decidim::Admin::ComponentForm"
 
     # Does this component have specific data to serialize and import?

--- a/decidim-core/lib/decidim/component_manifest.rb
+++ b/decidim-core/lib/decidim/component_manifest.rb
@@ -58,6 +58,11 @@ module Decidim
     # probably have the form of `Decidim::<MyComponent>::Permissions`.
     attribute :permissions_class_name, String, default: "Decidim::DefaultPermissions"
 
+    # The name of the class that handles extra logic on settings for this component.
+    # Optional class, that if present receives the settings and validates them.
+    # Probably have the form of `Decidim::<MyComponent>::Admin::ComponentForm`.
+    attribute :component_form_class_name, String, default: "Decidim::Admin::ComponentForm"
+
     # Does this component have specific data to serialize and import?
     # Beyond the attributes in decidim_component table.
     attribute :serializes_specific_data, Boolean, default: false
@@ -213,6 +218,15 @@ module Decidim
     # Returns a Class.
     def permissions_class
       permissions_class_name&.constantize
+    end
+
+    # Public: Finds the form class from its component, using the
+    # `component_form_class_name` attribute. If the class does not exist,
+    # it raises an exception. If the class name is not set, it returns nil.
+    #
+    # Returns a Class.
+    def component_form_class
+      component_form_class_name&.constantize
     end
 
     # Public: Finds the specific data serializer class from its name, using the

--- a/decidim-proposals/app/forms/decidim/proposals/admin/component_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/component_form.rb
@@ -3,8 +3,8 @@
 module Decidim
   module Proposals
     module Admin
-      # A form object for Budgets used to attach a component to a participatory process from the
-      # admin panel.
+      # A form object for proposals components. Used to attach the component to
+      # a participatory process from the admin panel.
       #
       class ComponentForm < Decidim::Admin::ComponentForm
         validate :must_be_able_to_change_participatory_texts_setting

--- a/decidim-proposals/app/forms/decidim/proposals/admin/component_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/component_form.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    module Admin
+      # A form object for Budgets used to attach a component to a participatory process from the
+      # admin panel.
+      #
+      class ComponentForm < Decidim::Admin::ComponentForm
+        validate :must_be_able_to_change_participatory_texts_setting
+        validate :amendments_visibility_options_must_be_valid
+
+        private
+
+        # Validates setting `participatory_texts_enabled` is not changed when there are proposals for the component.
+        def must_be_able_to_change_participatory_texts_setting
+          return unless manifest&.name == :proposals && (component = Component.find_by(id: id))
+          return unless settings.participatory_texts_enabled != component.settings.participatory_texts_enabled
+
+          settings.errors.add(:participatory_texts_enabled) if Decidim::Proposals::Proposal.where(component: component).any?
+        end
+
+        # Validates setting `amendments_visibility` is included in Decidim::Amendment::VisibilityStepSetting.options.
+        def amendments_visibility_options_must_be_valid
+          return unless manifest&.name == :proposals && settings.amendments_enabled
+
+          visibility_options = Decidim::Amendment::VisibilityStepSetting.options.map(&:last)
+          step_settings.each do |step, settings|
+            next unless visibility_options.exclude? settings[:amendments_visibility]
+
+            step_settings[step].errors.add(:amendments_visibility, :inclusion)
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -20,6 +20,7 @@ Decidim.register_component(:proposals) do |component|
   component.query_type = "Decidim::Proposals::ProposalsType"
 
   component.permissions_class_name = "Decidim::Proposals::Permissions"
+  component.component_form_class_name = "Decidim::Proposals::Admin::ComponentForm"
 
   component.settings(:global) do |settings|
     settings.attribute :vote_limit, type: :integer, default: 0

--- a/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
@@ -38,7 +38,7 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
     let(:participatory_space) { component.participatory_space }
     let(:active_step_id) { participatory_space.active_step.id }
     let(:form) do
-      Decidim::Admin::ComponentForm.from_params(
+      Decidim::Proposals::Admin::ComponentForm.from_params(
         id: component.id,
         weight: 0,
         manifest: manifest,


### PR DESCRIPTION
#### :tophat: What? Why?

Add an option for admins so they can configure a Budget component rule to a minimum number of projects that participants must select to vote.

The participant has to select at least the minimum number of projects to vote.

#### :pushpin: Related Issues
- Fixes #5754

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests


### :camera: Screenshots (optional)

<img width="976" alt="Screenshot 2020-03-16 at 19 04 42" src="https://user-images.githubusercontent.com/210216/76787531-8539f480-67b9-11ea-8c86-a8ff92a01ce7.png">  

<img width="961" alt="Screenshot 2020-03-16 at 19 06 57" src="https://user-images.githubusercontent.com/210216/76787548-9256e380-67b9-11ea-9520-1498b1ac6e7a.png">

**Admin**

<img width="706" alt="Screenshot 2020-03-16 at 19 20 50" src="https://user-images.githubusercontent.com/210216/76788554-72c0ba80-67bb-11ea-8683-a8ae756fb12b.png">

<img width="708" alt="Screenshot 2020-03-17 at 12 56 03" src="https://user-images.githubusercontent.com/210216/76855942-810de580-6852-11ea-97ed-cc3bc5226d72.png">

<img width="705" alt="Screenshot 2020-03-17 at 12 56 45" src="https://user-images.githubusercontent.com/210216/76855956-88cd8a00-6852-11ea-8dbf-259d0922f8f7.png">


