### PR TITLE
Fix missing tribute source map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ After this, `Decidim::Proposals::ProposalEndorsement` and the corresponding coun
 - **decidim-sortitions**: Fix incorrect proposals sortition. [\#5620](https://github.com/decidim/decidim/pull/5620)
 - **decidim-admin**: Fix: let components without step settings be added [\#5568](https://github.com/decidim/decidim/pull/5568)
 - **decidim-proposals**: Fix proposals that have their state not published [\#5832](https://github.com/decidim/decidim/pull/5832)
+- **decidim-core**: Fix missing tribute source map [\#5869](https://github.com/decidim/decidim/pull/5869)
 
 ### Removed
 

--- a/decidim-core/vendor/assets/javascripts/tribute.js
+++ b/decidim-core/vendor/assets/javascripts/tribute.js
@@ -1878,4 +1878,3 @@ if (window && typeof window.CustomEvent !== "function") {
 
 },{}]},{},[6])(6)
 });
-//# sourceMappingURL=tribute.js.map


### PR DESCRIPTION
#### :tophat: What? Why?
Chrome shows an error with missing Tribute source map. I believe this only happens in development since I think the sourcemap comment is removed by the JavaScript compiler.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![fix-tribute-source-map](https://user-images.githubusercontent.com/864340/77051464-ffde5c00-69d3-11ea-9ee9-b62460d4940d.png)