### PR TITLE
Fix workflows to work from forks

### DIFF
--- a/.github/workflows/ci_accountability.yml
+++ b/.github/workflows/ci_accountability.yml
@@ -1,5 +1,5 @@
 name: "[CI] Accountability"
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: "true"

--- a/.github/workflows/ci_admin.yml
+++ b/.github/workflows/ci_admin.yml
@@ -1,5 +1,5 @@
 name: "[CI] Admin"
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: "true"

--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -1,5 +1,5 @@
 name: "[CI] Api"
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: "true"

--- a/.github/workflows/ci_assemblies.yml
+++ b/.github/workflows/ci_assemblies.yml
@@ -1,5 +1,5 @@
 name: "[CI] Assemblies"
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: "true"

--- a/.github/workflows/ci_blogs.yml
+++ b/.github/workflows/ci_blogs.yml
@@ -1,5 +1,5 @@
 name: "[CI] Blogs"
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: "true"

--- a/.github/workflows/ci_budgets.yml
+++ b/.github/workflows/ci_budgets.yml
@@ -1,5 +1,5 @@
 name: "[CI] Budgets"
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: "true"

--- a/.github/workflows/ci_comments.yml
+++ b/.github/workflows/ci_comments.yml
@@ -1,5 +1,5 @@
 name: "[CI] Comments"
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: "true"

--- a/.github/workflows/ci_conferences.yml
+++ b/.github/workflows/ci_conferences.yml
@@ -1,5 +1,5 @@
 name: "[CI] Conferences"
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: "true"

--- a/.github/workflows/ci_consultations.yml
+++ b/.github/workflows/ci_consultations.yml
@@ -1,5 +1,5 @@
 name: "[CI] Consultations"
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: "true"

--- a/.github/workflows/ci_core.yml
+++ b/.github/workflows/ci_core.yml
@@ -1,5 +1,5 @@
 name: "[CI] Core"
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: "true"

--- a/.github/workflows/ci_debates.yml
+++ b/.github/workflows/ci_debates.yml
@@ -1,5 +1,5 @@
 name: "[CI] Debates"
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: "true"

--- a/.github/workflows/ci_forms.yml
+++ b/.github/workflows/ci_forms.yml
@@ -1,5 +1,5 @@
 name: "[CI] Forms"
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: "true"

--- a/.github/workflows/ci_initiatives.yml
+++ b/.github/workflows/ci_initiatives.yml
@@ -1,5 +1,5 @@
 name: "[CI] Initiatives"
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: "true"

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -1,5 +1,5 @@
 name: "[CI] Main folder"
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: "true"

--- a/.github/workflows/ci_meetings.yml
+++ b/.github/workflows/ci_meetings.yml
@@ -1,5 +1,5 @@
 name: "[CI] Meetings"
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: "true"

--- a/.github/workflows/ci_pages.yml
+++ b/.github/workflows/ci_pages.yml
@@ -1,5 +1,5 @@
 name: "[CI] Pages"
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: "true"

--- a/.github/workflows/ci_participatory_processes.yml
+++ b/.github/workflows/ci_participatory_processes.yml
@@ -1,5 +1,5 @@
 name: "[CI] Participatory processes"
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: "true"

--- a/.github/workflows/ci_proposals_system_admin.yml
+++ b/.github/workflows/ci_proposals_system_admin.yml
@@ -1,5 +1,5 @@
 name: "[CI] Proposals (system admin)"
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: "true"

--- a/.github/workflows/ci_proposals_system_public.yml
+++ b/.github/workflows/ci_proposals_system_public.yml
@@ -1,5 +1,5 @@
 name: "[CI] Proposals (system public)"
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: "true"

--- a/.github/workflows/ci_proposals_unit_tests.yml
+++ b/.github/workflows/ci_proposals_unit_tests.yml
@@ -1,5 +1,5 @@
 name: "[CI] Proposals (unit tests)"
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: "true"

--- a/.github/workflows/ci_sortitions.yml
+++ b/.github/workflows/ci_sortitions.yml
@@ -1,5 +1,5 @@
 name: "[CI] Sortitions"
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: "true"

--- a/.github/workflows/ci_surveys.yml
+++ b/.github/workflows/ci_surveys.yml
@@ -1,5 +1,5 @@
 name: "[CI] Surveys"
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: "true"

--- a/.github/workflows/ci_system.yml
+++ b/.github/workflows/ci_system.yml
@@ -1,5 +1,5 @@
 name: "[CI] System"
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: "true"

--- a/.github/workflows/ci_verifications.yml
+++ b/.github/workflows/ci_verifications.yml
@@ -1,5 +1,5 @@
 name: "[CI] Verifications"
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: "true"

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -1,5 +1,5 @@
 name: "[CI] Lint"
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: "true"


### PR DESCRIPTION
#### :tophat: What? Why?
This PR should allow actions to run from forks.

Taken from this link:

https://github.community/t5/GitHub-Actions/Run-a-GitHub-action-on-pull-request-for-PR-opened-from-a-forked/m-p/31147#M690

I thought running the test suite at `push` events was enough, but it doesn't. Combining `push` and `pull_request` events helps us run the test suite for everyone, apparently.

#### :pushpin: Related Issues
- Related to #5843 

#### :clipboard: Subtasks
None