### PR TITLE
Fix duplicated actions workflows

### DIFF
--- a/.github/workflows/ci_accountability.yml
+++ b/.github/workflows/ci_accountability.yml
@@ -8,10 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
+      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_accountability.yml
+++ b/.github/workflows/ci_accountability.yml
@@ -1,5 +1,17 @@
 name: "[CI] Accountability"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_admin.yml
+++ b/.github/workflows/ci_admin.yml
@@ -8,10 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
+      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_admin.yml
+++ b/.github/workflows/ci_admin.yml
@@ -1,5 +1,17 @@
 name: "[CI] Admin"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -8,10 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
+      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -1,5 +1,17 @@
 name: "[CI] Api"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_assemblies.yml
+++ b/.github/workflows/ci_assemblies.yml
@@ -8,10 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
+      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_assemblies.yml
+++ b/.github/workflows/ci_assemblies.yml
@@ -1,5 +1,17 @@
 name: "[CI] Assemblies"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_blogs.yml
+++ b/.github/workflows/ci_blogs.yml
@@ -8,10 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
+      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_blogs.yml
+++ b/.github/workflows/ci_blogs.yml
@@ -1,5 +1,17 @@
 name: "[CI] Blogs"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_budgets.yml
+++ b/.github/workflows/ci_budgets.yml
@@ -8,10 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
+      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_budgets.yml
+++ b/.github/workflows/ci_budgets.yml
@@ -1,5 +1,17 @@
 name: "[CI] Budgets"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_comments.yml
+++ b/.github/workflows/ci_comments.yml
@@ -8,10 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
+      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_comments.yml
+++ b/.github/workflows/ci_comments.yml
@@ -1,5 +1,17 @@
 name: "[CI] Comments"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_conferences.yml
+++ b/.github/workflows/ci_conferences.yml
@@ -8,10 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
+      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_conferences.yml
+++ b/.github/workflows/ci_conferences.yml
@@ -1,5 +1,17 @@
 name: "[CI] Conferences"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_consultations.yml
+++ b/.github/workflows/ci_consultations.yml
@@ -1,5 +1,17 @@
 name: "[CI] Consultations"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_core.yml
+++ b/.github/workflows/ci_core.yml
@@ -8,10 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
+      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_core.yml
+++ b/.github/workflows/ci_core.yml
@@ -1,5 +1,17 @@
 name: "[CI] Core"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_debates.yml
+++ b/.github/workflows/ci_debates.yml
@@ -8,10 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
+      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_debates.yml
+++ b/.github/workflows/ci_debates.yml
@@ -1,5 +1,17 @@
 name: "[CI] Debates"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_forms.yml
+++ b/.github/workflows/ci_forms.yml
@@ -8,10 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
+      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_forms.yml
+++ b/.github/workflows/ci_forms.yml
@@ -1,5 +1,17 @@
 name: "[CI] Forms"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -8,10 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
+      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -1,5 +1,17 @@
 name: "[CI] Generators"
-on: [push]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_initiatives.yml
+++ b/.github/workflows/ci_initiatives.yml
@@ -8,10 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
+      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_initiatives.yml
+++ b/.github/workflows/ci_initiatives.yml
@@ -1,5 +1,17 @@
 name: "[CI] Initiatives"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -8,10 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
+      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -1,5 +1,17 @@
 name: "[CI] Main folder"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_meetings.yml
+++ b/.github/workflows/ci_meetings.yml
@@ -8,10 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
+      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_meetings.yml
+++ b/.github/workflows/ci_meetings.yml
@@ -1,5 +1,17 @@
 name: "[CI] Meetings"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_pages.yml
+++ b/.github/workflows/ci_pages.yml
@@ -8,10 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
+      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_pages.yml
+++ b/.github/workflows/ci_pages.yml
@@ -1,5 +1,17 @@
 name: "[CI] Pages"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_participatory_processes.yml
+++ b/.github/workflows/ci_participatory_processes.yml
@@ -8,10 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
+      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_participatory_processes.yml
+++ b/.github/workflows/ci_participatory_processes.yml
@@ -1,5 +1,17 @@
 name: "[CI] Participatory processes"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_proposals_system_admin.yml
+++ b/.github/workflows/ci_proposals_system_admin.yml
@@ -8,10 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
+      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_proposals_system_admin.yml
+++ b/.github/workflows/ci_proposals_system_admin.yml
@@ -1,5 +1,17 @@
 name: "[CI] Proposals (system admin)"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_proposals_system_public.yml
+++ b/.github/workflows/ci_proposals_system_public.yml
@@ -8,10 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
+      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_proposals_system_public.yml
+++ b/.github/workflows/ci_proposals_system_public.yml
@@ -1,5 +1,17 @@
 name: "[CI] Proposals (system public)"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_proposals_unit_tests.yml
+++ b/.github/workflows/ci_proposals_unit_tests.yml
@@ -8,10 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
+      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_proposals_unit_tests.yml
+++ b/.github/workflows/ci_proposals_unit_tests.yml
@@ -1,5 +1,17 @@
 name: "[CI] Proposals (unit tests)"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_sortitions.yml
+++ b/.github/workflows/ci_sortitions.yml
@@ -8,10 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
+      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_sortitions.yml
+++ b/.github/workflows/ci_sortitions.yml
@@ -1,5 +1,17 @@
 name: "[CI] Sortitions"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_surveys.yml
+++ b/.github/workflows/ci_surveys.yml
@@ -8,10 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
+      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_surveys.yml
+++ b/.github/workflows/ci_surveys.yml
@@ -1,5 +1,17 @@
 name: "[CI] Surveys"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_system.yml
+++ b/.github/workflows/ci_system.yml
@@ -8,10 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
+      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_system.yml
+++ b/.github/workflows/ci_system.yml
@@ -1,5 +1,17 @@
 name: "[CI] System"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_verifications.yml
+++ b/.github/workflows/ci_verifications.yml
@@ -8,10 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
+      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_verifications.yml
+++ b/.github/workflows/ci_verifications.yml
@@ -1,5 +1,17 @@
 name: "[CI] Verifications"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -8,10 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
+      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -1,5 +1,17 @@
 name: "[CI] Lint"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches:
+      - develop
+      - master
+      - release/*
+      - "*-stable"
 
 env:
   CI: "true"


### PR DESCRIPTION
#### :tophat: What? Why?

On PRs from the repo, the current setup was causing duplicated workflows after #5880. This should fix the issue.

An example of this is #5863 (commit 4f070a8732cd7ee96c8a41da01fccd7841de4467), where the whole suite was fired twice: once per push and once per pull-request update. 

We want the push events so that the test suite is ran when a PR is merged, and we want the pull-request event to run the tests from forks. Push events are not fired in the upstream repo when pushing to a PR from a fork, but they do if we create a PR from a branch in the repo, thus we have a duplicated test suite (one for the push event, another for the PR event).

@leio10 found https://github.com/microsoft/vscode/pull/83158 fixing the issue, so I copied the approach in this PR, adapting it so that the test suite is fired on any PR (in case we have a PR against another PR).

#### :pushpin: Related Issues
- Related to #5880

#### :clipboard: Subtasks
None