### PR TITLE
Add missing indexs on foreign keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,9 @@ After this, `Decidim::Proposals::ProposalEndorsement` and the corresponding coun
 - **decidim-proposals**, **decidim-core**, **decidim-blogs**: Apply generalized endorsements to the GraphQL API and add it to the blog posts query. [\#5847](https://github.com/decidim/decidim/pull/5847)
 - **decidim-budgets**: Allow projects to be sorted by different criteria [\#5808](https://github.com/decidim/decidim/pull/5808)
 - **decidim-budgets**: Request confirmation to exit budgets component [\#5765](https://github.com/decidim/decidim/pull/5765)
-
 - **decidim-admin**: Allow to see a participant's email from the admin panel [\#5849](https://github.com/decidim/decidim/pull/5849)
+- **decidim**: Add missing indexs on foreign keys on the DB [\#5885](https://github.com/decidim/decidim/pull/5885)
+
 ### Changed
 
 ### Fixed

--- a/decidim-accountability/db/migrate/20200320105903_index_foreign_keys_in_decidim_accountability_results.rb
+++ b/decidim-accountability/db/migrate/20200320105903_index_foreign_keys_in_decidim_accountability_results.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class IndexForeignKeysInDecidimAccountabilityResults < ActiveRecord::Migration[5.2]
+  def change
+    add_index :decidim_accountability_results, :external_id
+  end
+end

--- a/decidim-assemblies/db/migrate/20200320105906_index_foreign_keys_in_decidim_assemblies.rb
+++ b/decidim-assemblies/db/migrate/20200320105906_index_foreign_keys_in_decidim_assemblies.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class IndexForeignKeysInDecidimAssemblies < ActiveRecord::Migration[5.2]
+  def change
+    add_index :decidim_assemblies, :decidim_scope_id
+  end
+end

--- a/decidim-assemblies/db/migrate/20200320105907_index_foreign_keys_in_decidim_assembly_user_roles.rb
+++ b/decidim-assemblies/db/migrate/20200320105907_index_foreign_keys_in_decidim_assembly_user_roles.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class IndexForeignKeysInDecidimAssemblyUserRoles < ActiveRecord::Migration[5.2]
+  def change
+    add_index :decidim_assembly_user_roles, :decidim_user_id
+  end
+end

--- a/decidim-blogs/db/migrate/20200320105910_index_foreign_keys_in_decidim_blogs_posts.rb
+++ b/decidim-blogs/db/migrate/20200320105910_index_foreign_keys_in_decidim_blogs_posts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class IndexForeignKeysInDecidimBlogsPosts < ActiveRecord::Migration[5.2]
+  def change
+    add_index :decidim_blogs_posts, :decidim_user_group_id
+  end
+end

--- a/decidim-comments/db/migrate/20200320105911_index_foreign_keys_in_decidim_comments_comments.rb
+++ b/decidim-comments/db/migrate/20200320105911_index_foreign_keys_in_decidim_comments_comments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class IndexForeignKeysInDecidimCommentsComments < ActiveRecord::Migration[5.2]
+  def change
+    add_index :decidim_comments_comments, :decidim_user_group_id
+  end
+end

--- a/decidim-conferences/db/migrate/20200320105913_index_foreign_keys_in_decidim_conferences.rb
+++ b/decidim-conferences/db/migrate/20200320105913_index_foreign_keys_in_decidim_conferences.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class IndexForeignKeysInDecidimConferences < ActiveRecord::Migration[5.2]
+  def change
+    add_index :decidim_conferences, :decidim_scope_id
+  end
+end

--- a/decidim-conferences/db/migrate/20200320105914_index_foreign_keys_in_decidim_conferences_conference_invites.rb
+++ b/decidim-conferences/db/migrate/20200320105914_index_foreign_keys_in_decidim_conferences_conference_invites.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class IndexForeignKeysInDecidimConferencesConferenceInvites < ActiveRecord::Migration[5.2]
+  def change
+    add_index :decidim_conferences_conference_invites, :decidim_conference_registration_type_id, name: "ixd_conferences_on_registration_type_id"
+  end
+end

--- a/decidim-conferences/db/migrate/20200320105915_index_foreign_keys_in_decidim_conferences_conference_registrations.rb
+++ b/decidim-conferences/db/migrate/20200320105915_index_foreign_keys_in_decidim_conferences_conference_registrations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class IndexForeignKeysInDecidimConferencesConferenceRegistrations < ActiveRecord::Migration[5.2]
+  def change
+    add_index :decidim_conferences_conference_registrations, :decidim_conference_registration_type_id, name: "idx_conferences_registrations_on_registration_type_id"
+  end
+end

--- a/decidim-consultations/db/migrate/20200320105916_index_foreign_keys_in_decidim_consultations_votes.rb
+++ b/decidim-consultations/db/migrate/20200320105916_index_foreign_keys_in_decidim_consultations_votes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class IndexForeignKeysInDecidimConsultationsVotes < ActiveRecord::Migration[5.2]
+  def change
+    add_index :decidim_consultations_votes, :decidim_user_group_id
+  end
+end

--- a/decidim-core/db/migrate/20200320105904_index_foreign_keys_in_decidim_action_logs.rb
+++ b/decidim-core/db/migrate/20200320105904_index_foreign_keys_in_decidim_action_logs.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class IndexForeignKeysInDecidimActionLogs < ActiveRecord::Migration[5.2]
+  def change
+    add_index :decidim_action_logs, :decidim_area_id
+    add_index :decidim_action_logs, :decidim_scope_id
+    add_index :decidim_action_logs, :version_id
+  end
+end

--- a/decidim-core/db/migrate/20200320105905_index_foreign_keys_in_decidim_amendments.rb
+++ b/decidim-core/db/migrate/20200320105905_index_foreign_keys_in_decidim_amendments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class IndexForeignKeysInDecidimAmendments < ActiveRecord::Migration[5.2]
+  def change
+    add_index :decidim_amendments, :decidim_emendation_id
+  end
+end

--- a/decidim-core/db/migrate/20200320105909_index_foreign_keys_in_decidim_authorizations.rb
+++ b/decidim-core/db/migrate/20200320105909_index_foreign_keys_in_decidim_authorizations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class IndexForeignKeysInDecidimAuthorizations < ActiveRecord::Migration[5.2]
+  def change
+    add_index :decidim_authorizations, :unique_id
+  end
+end

--- a/decidim-core/db/migrate/20200320105917_index_foreign_keys_in_decidim_contextual_help_sections.rb
+++ b/decidim-core/db/migrate/20200320105917_index_foreign_keys_in_decidim_contextual_help_sections.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class IndexForeignKeysInDecidimContextualHelpSections < ActiveRecord::Migration[5.2]
+  def change
+    add_index :decidim_contextual_help_sections, :section_id
+  end
+end

--- a/decidim-core/db/migrate/20200320105919_index_foreign_keys_in_decidim_endorsements.rb
+++ b/decidim-core/db/migrate/20200320105919_index_foreign_keys_in_decidim_endorsements.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class IndexForeignKeysInDecidimEndorsements < ActiveRecord::Migration[5.2]
+  def change
+    add_index :decidim_endorsements, :decidim_user_group_id
+  end
+end

--- a/decidim-core/db/migrate/20200320105923_index_foreign_keys_in_decidim_notifications.rb
+++ b/decidim-core/db/migrate/20200320105923_index_foreign_keys_in_decidim_notifications.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class IndexForeignKeysInDecidimNotifications < ActiveRecord::Migration[5.2]
+  def change
+    add_index :decidim_notifications, :decidim_resource_id
+  end
+end

--- a/decidim-core/db/migrate/20200320105927_index_foreign_keys_in_oauth_access_grants.rb
+++ b/decidim-core/db/migrate/20200320105927_index_foreign_keys_in_oauth_access_grants.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class IndexForeignKeysInOAuthAccessGrants < ActiveRecord::Migration[5.2]
+  def change
+    add_index :oauth_access_grants, :resource_owner_id
+  end
+end

--- a/decidim-debates/db/migrate/20200320105918_index_foreign_keys_in_decidim_debates_debates.rb
+++ b/decidim-debates/db/migrate/20200320105918_index_foreign_keys_in_decidim_debates_debates.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class IndexForeignKeysInDecidimDebatesDebates < ActiveRecord::Migration[5.2]
+  def change
+    add_index :decidim_debates_debates, :decidim_user_group_id
+  end
+end

--- a/decidim-initiatives/db/migrate/20200320105920_index_foreign_keys_in_decidim_initiatives.rb
+++ b/decidim-initiatives/db/migrate/20200320105920_index_foreign_keys_in_decidim_initiatives.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class IndexForeignKeysInDecidimInitiatives < ActiveRecord::Migration[5.2]
+  def change
+    add_index :decidim_initiatives, :decidim_user_group_id
+    add_index :decidim_initiatives, :scoped_type_id
+  end
+end

--- a/decidim-initiatives/db/migrate/20200320105921_index_foreign_keys_in_decidim_initiatives_votes.rb
+++ b/decidim-initiatives/db/migrate/20200320105921_index_foreign_keys_in_decidim_initiatives_votes.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class IndexForeignKeysInDecidimInitiativesVotes < ActiveRecord::Migration[5.2]
+  def change
+    add_index :decidim_initiatives_votes, :decidim_user_group_id
+    add_index :decidim_initiatives_votes, :hash_id
+  end
+end

--- a/decidim-meetings/db/migrate/20200320105922_index_foreign_keys_in_decidim_meetings_registrations.rb
+++ b/decidim-meetings/db/migrate/20200320105922_index_foreign_keys_in_decidim_meetings_registrations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class IndexForeignKeysInDecidimMeetingsRegistrations < ActiveRecord::Migration[5.2]
+  def change
+    add_index :decidim_meetings_registrations, :decidim_user_group_id
+  end
+end

--- a/decidim-participatory_processes/db/migrate/20200320105908_index_foreign_keys_in_decidim_attachments.rb
+++ b/decidim-participatory_processes/db/migrate/20200320105908_index_foreign_keys_in_decidim_attachments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class IndexForeignKeysInDecidimAttachments < ActiveRecord::Migration[5.2]
+  def change
+    add_index :decidim_attachments, :attachment_collection_id
+  end
+end

--- a/decidim-participatory_processes/db/migrate/20200320105924_index_foreign_keys_in_decidim_participatory_process_user_roles.rb
+++ b/decidim-participatory_processes/db/migrate/20200320105924_index_foreign_keys_in_decidim_participatory_process_user_roles.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class IndexForeignKeysInDecidimParticipatoryProcessUserRoles < ActiveRecord::Migration[5.2]
+  def change
+    add_index :decidim_participatory_process_user_roles, :decidim_user_id, name: "idx_proces_user_role_on_user_id"
+  end
+end

--- a/decidim-participatory_processes/db/migrate/20200320105925_index_foreign_keys_in_decidim_participatory_processes.rb
+++ b/decidim-participatory_processes/db/migrate/20200320105925_index_foreign_keys_in_decidim_participatory_processes.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class IndexForeignKeysInDecidimParticipatoryProcesses < ActiveRecord::Migration[5.2]
+  def change
+    add_index :decidim_participatory_processes, :decidim_participatory_process_group_id, name: "idx_process_on_process_group_id"
+    add_index :decidim_participatory_processes, :decidim_scope_id, name: "idx_process_on_scope_id"
+  end
+end

--- a/decidim-sortitions/db/migrate/20200320105926_index_foreign_keys_in_decidim_sortitions_sortitions.rb
+++ b/decidim-sortitions/db/migrate/20200320105926_index_foreign_keys_in_decidim_sortitions_sortitions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class IndexForeignKeysInDecidimSortitionsSortitions < ActiveRecord::Migration[5.2]
+  def change
+    add_index :decidim_sortitions_sortitions, :cancelled_by_user_id
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR uses part of https://github.com/gregnavis/active_record_doctor to generate migrations to add missing indexs on foreign keys.

The gem has more features, but I've only used part of them.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

