### PR TITLE
Replace current meetings hook with highlighted elements hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ After this, `Decidim::Proposals::ProposalEndorsement` and the corresponding coun
 
 ### Changed
 
+- **decidim-assemblies**: Replace current meetings hook with highlighted elements hook [\#5897](https://github.com/decidim/decidim/pull/5897)
+
 ### Fixed
 
 - **decidim-proposals**: Fix relative path in mentioned proposal email [\#5852](https://github.com/decidim/decidim/pull/5852)

--- a/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
@@ -79,9 +79,10 @@ edit_link(
         </div>
       <% end %>
 
-      <%= render_hook(:current_participatory_space_meetings) %>
-
       <%= attachments_for current_participatory_space %>
+
+      <%= render_hook(:participatory_space_highlighted_elements) %>
+
       <% if current_participatory_space.children.visible_for(current_user).count.positive? %>
         <section id="assemblies-grid" class="section row collapse">
           <h4 class="section-heading"><%= t("children", scope: "decidim.assemblies.show") %></h4>

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -352,6 +352,7 @@ en:
         meetings_count: Meetings
         orders_count: Supports
         pages_count: Pages
+        posts_count: Posts
         projects_count: Projects
         proposals_count: Proposals
         results_count: Results

--- a/decidim-meetings/lib/decidim/meetings/engine.rb
+++ b/decidim-meetings/lib/decidim/meetings/engine.rb
@@ -54,10 +54,6 @@ module Decidim
           end
         end
 
-        Decidim.view_hooks.register(:current_participatory_space_meetings, priority: Decidim::ViewHooks::HIGH_PRIORITY) do |view_context|
-          view_context.cell("decidim/meetings/highlighted_meetings", view_context.current_participatory_space)
-        end
-
         # This view hook is used in card cells. It renders the next upcoming
         # meeting for the given participatory space.
         Decidim.view_hooks.register(:upcoming_meeting_for_card, priority: Decidim::ViewHooks::LOW_PRIORITY) do |view_context|


### PR DESCRIPTION
#### :tophat: What? Why?
This PR will include proposals, accountability and more elements apart from meetings in the assembly home page.

To do this, I've removed the hook added in #2942 and replaced it with the one that #2713 defines for participatory processes.

#### :pushpin: Related Issues
- Related to #2713 and #2942
- Fixes #5724

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![imagen](https://user-images.githubusercontent.com/453545/77524003-eda66700-6e86-11ea-85f3-25ca481de01c.png)
