### PR TITLE
fix: indeterminate checkboxes state is not consistent between browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ After this, `Decidim::Proposals::ProposalEndorsement` and the corresponding coun
 - **decidim-core**: Fix missing tribute source map [\#5869](https://github.com/decidim/decidim/pull/5869)
 - **decidim-api**: Force signin on API if the organization requires it [\#5859](https://github.com/decidim/decidim/pull/5859)
 - **decidim-core**: Apply security patch for GHSA-65cv-r6x7-79hv [\#5896](https://github.com/decidim/decidim/pull/5896)
+- **decidim-core**: Fix proposals filtering by scope in Chrome [\#5901](https://github.com/decidim/decidim/pull/5901)
 
 ### Removed
 

--- a/decidim-core/app/assets/javascripts/decidim/check_boxes_tree.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/check_boxes_tree.js.es6
@@ -99,9 +99,9 @@
         const checkedInputs = document.querySelectorAll(
           `#${checksContext} input[type='checkbox']:checked`
         );
-        const indeterminateInputs = Array.from(checkedInputs).filter((checkbox) => checkbox.indeterminate)
+        const indeterminateInputs = Array.from(totalInputs).filter((checkbox) => checkbox.indeterminate)
 
-        if (checkedInputs.length === 0) {
+        if (checkedInputs.length === 0 && indeterminateInputs.length === 0) {
           global.checked = false;
           global.indeterminate = false;
         } else if (checkedInputs.length === totalInputs.length && indeterminateInputs.length === 0) {
@@ -152,9 +152,9 @@
       const checkedSiblings = document.querySelectorAll(
         `#${checkBoxContext} > div > [data-children-checkbox] > input:checked, #${checkBoxContext} > [data-children-checkbox] > input:checked`
       );
-      const indeterminateSiblings = Array.from(checkedSiblings).filter((checkbox) => checkbox.indeterminate)
+      const indeterminateSiblings = Array.from(totalCheckSiblings).filter((checkbox) => checkbox.indeterminate)
 
-      if (checkedSiblings.length === 0) {
+      if (checkedSiblings.length === 0 && indeterminateSiblings.length === 0) {
         parentCheck.checked = false;
         parentCheck.indeterminate = false;
       } else if (checkedSiblings.length === totalCheckSiblings.length && indeterminateSiblings.length === 0) {


### PR DESCRIPTION
#### :tophat: What? Why?
It seems that Firefox can have indeterminate checked checkboxes while Chrome doesn't.

#### :pushpin: Related Issues
- Related to #5654
- Fixes #5881

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![Description](URL)
