### PR TITLE
Make coverage reports more relevant

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -6,6 +6,7 @@ SimpleCov.start do
   track_files "**/*.rb"
 
   add_filter "decidim-dev/lib/decidim/dev/test/ext/screenshot_helper.rb"
+  add_filter "/config/"
   add_filter "/migrate/"
   add_filter "/spec/decidim_dummy_app/"
   add_filter "/vendor/"

--- a/.simplecov
+++ b/.simplecov
@@ -6,6 +6,8 @@ SimpleCov.start do
   add_filter "decidim-dev/lib/decidim/dev/test/ext/screenshot_helper.rb"
   add_filter "/spec/decidim_dummy_app/"
   add_filter "/vendor/"
+  add_filter "/spec/"
+  add_filter "/test/"
 end
 
 SimpleCov.command_name ENV["COMMAND_NAME"] || File.basename(Dir.pwd)

--- a/.simplecov
+++ b/.simplecov
@@ -3,6 +3,8 @@
 SimpleCov.start do
   root File.expand_path("..", ENV["ENGINE_ROOT"])
 
+  track_files "**/*.rb"
+
   add_filter "decidim-dev/lib/decidim/dev/test/ext/screenshot_helper.rb"
   add_filter "/spec/decidim_dummy_app/"
   add_filter "/vendor/"

--- a/.simplecov
+++ b/.simplecov
@@ -6,7 +6,9 @@ SimpleCov.start do
   root File.expand_path("..", ENV["ENGINE_ROOT"])
 
   # We make sure we track all Ruby files, to avoid skipping unrequired files
-  track_files "**/*.rb"
+  # We need to include the `../` section, otherwise it only tracks files from the
+  # `ENGINE_ROOT` folder for some reason.
+  track_files "../**/*.rb"
 
   # We ignore some of the files because they are never tested
   add_filter "/config/"

--- a/.simplecov
+++ b/.simplecov
@@ -3,8 +3,6 @@
 SimpleCov.start do
   root File.expand_path("..", ENV["ENGINE_ROOT"])
 
-  track_files "**/*.rb"
-
   add_filter "decidim-dev/lib/decidim/dev/test/ext/screenshot_helper.rb"
   add_filter "/config/"
   add_filter "/migrate/"
@@ -13,8 +11,6 @@ SimpleCov.start do
   add_filter "/spec/"
   add_filter "/test/"
 end
-
-SimpleCov.command_name ENV["COMMAND_NAME"] || File.basename(Dir.pwd)
 
 SimpleCov.merge_timeout 1800
 

--- a/.simplecov
+++ b/.simplecov
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
 SimpleCov.start do
+  # `ENGINE_ROOT` holds the name of the engine we're testing.
+  # This brings us to the main Decidim folder.
   root File.expand_path("..", ENV["ENGINE_ROOT"])
 
-  add_filter "decidim-dev/lib/decidim/dev/test/ext/screenshot_helper.rb"
+  # We make sure we track all Ruby files, to avoid skipping unrequired files
+  track_files "**/*.rb"
+
+  # We ignore some of the files because they are never tested
   add_filter "/config/"
   add_filter "/migrate/"
-  add_filter "/spec/decidim_dummy_app/"
   add_filter "/vendor/"
   add_filter "/spec/"
   add_filter "/test/"

--- a/.simplecov
+++ b/.simplecov
@@ -6,6 +6,7 @@ SimpleCov.start do
   track_files "**/*.rb"
 
   add_filter "decidim-dev/lib/decidim/dev/test/ext/screenshot_helper.rb"
+  add_filter "/migrate/"
   add_filter "/spec/decidim_dummy_app/"
   add_filter "/vendor/"
   add_filter "/spec/"


### PR DESCRIPTION
#### :tophat: What? Why?
This PR tries to make coverage reports more relevant by ignoring any not-relevant files.

##### Test files

For example, from current `develop` (as of 90b07de80d4d6cee45ce0b16f972c51a2174ebb0):

https://codecov.io/gh/decidim/decidim/tree/90b07de80d4d6cee45ce0b16f972c51a2174ebb0

![image](https://user-images.githubusercontent.com/491891/78667275-f2ccd280-78d8-11ea-936f-a0c844eefc27.png)

From this image, we see that 1120 lines in `decidim-core/lib/decidim/core/test` are counted as not covered, even though they are RSpec shared examples. 

I think counting specs files as coverage makes no sense, since test files are the ones providing coverage. Also, for some reason some test files are not being counted as covered, so they're affecting the final results.

##### Including all Ruby files

Once I included all Ruby files in the repo, I got these final results:

![image](https://user-images.githubusercontent.com/491891/78671694-eac46100-78df-11ea-9676-eac0a14586cf.png)
(https://codecov.io/gh/decidim/decidim/tree/be1a7ccd0178f59c9f1bdca18cf823a42b5019b6)

This change included all migrations, which are not tested, so this made the percentage go down:

![image](https://user-images.githubusercontent.com/491891/78671772-04fe3f00-78e0-11ea-9e7d-437252d8ea1d.png)

##### Excluding migrations and config files

Migrations and files in `config` are not tested, so we can skip them. This is the resulting coverage after these changes:

![image](https://user-images.githubusercontent.com/491891/78675067-d5056a80-78e4-11ea-9dd6-132f8f388193.png)
https://codecov.io/gh/decidim/decidim/tree/461ca2f7f980fabb6961ab344bef33d749cd123d

##### Conclusions

I think this PR has made code coverage more reliable. It has removed >54000 lines that were mostly tests, and it has added some files that were not being checked. Sadly, this means these newly-added files were not being directly tested.

For example, check the `decidim-admin/app/controllers/decidim/admin/components_controller.rb` file. It is never directly used, as each participatory space has its own `ComponentsController` inheriting from the one in `decidim-admin`. Since it's never directly used, it's marked as untested after these changes:

https://codecov.io/gh/decidim/decidim/src/461ca2f7f980fabb6961ab344bef33d749cd123d/decidim-admin/app/controllers/decidim/admin/components_controller.rb

But in the `develop` branch is not even present:

https://codecov.io/gh/decidim/decidim/tree/90b07de/decidim-admin/app/controllers/decidim/admin

Other files that are shown not to be tested directly are some presenters, for example. Something similar happens with cells, see the ones from `decidim-proposals`:

- After these changes: https://codecov.io/gh/decidim/decidim/tree/461ca2f7f980fabb6961ab344bef33d749cd123d/decidim-proposals/app/cells/decidim/proposals
- In `develop`: https://codecov.io/gh/decidim/decidim/tree/90b07de/decidim-proposals/app/cells/decidim/proposals

Sadly, after all these changes the overall percentage of coverage has dropped from a 95% to an 80%. 

I suggest you play around the final coverages in this branch, and see if the new coverages make sense to you.

#### :pushpin: Related Issues

None

#### :clipboard: Subtasks

- [x] Ignore test files for coverage reports. We are also ignoring any test files in `lib/` folders intended to be included by dependent gems (they're usually shared examples or shared contexts)
- [x] Manually track all Ruby files on coverage reports
- [x] Ignore migration files, since they're not tested
- [x] Ignore config files, since they're not tested
