### PR TITLE
Fix the scopes picker rendereding escaped characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Due to [\#5553](https://github.com/decidim/decidim/pull/5553), SSL is turned on 
 - **decidim-core**: Do now allow uploading SVGs [\#5553](https://github.com/decidim/decidim/pull/5553)
 - **decidim-core**: Do not leak image processing errors [\#5553](https://github.com/decidim/decidim/pull/5553)
 - **decidim-core**, **decidim-proposals**, **decidim-participatory_processes**, **decidim-meetings**, **decidim-sortitions**: XSS sanitization [\#5553](https://github.com/decidim/decidim/pull/5553)
+- **decidim-core**: Fix the scopes picker rendereding escaped characters [#5939](https://github.com/decidim/decidim/pull/5939)
 
 ### Removed
 

--- a/decidim-core/app/assets/javascripts/decidim/data_picker.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/data_picker.js.es6
@@ -140,7 +140,7 @@
         let link = $("a", this.current.div);
         link.data("picker-value", data.value);
         link.attr("href", data.url);
-        link.text(dataText);
+        link.html(dataText);
       } else {
         let input = "hidden",
             name = this.current.name;


### PR DESCRIPTION
#### :tophat: What? Why?

When a value was already selected for the scopes picker, fix the rendering of the new selected value. Before there was double escaping of the string causing the output to look weird.

#### :pushpin: Related Issues
- Fixes Bad merge from #5793

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

