### PR TITLE
Allow postgres Docker image without password on docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     image: postgres
     volumes:
       - pg-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
   redis:
     image: redis
     volumes:


### PR DESCRIPTION
#### :tophat: What? Why?

There was a change on the last image of postgres that we're using and it broke our docker instructions for this repository.

#### :pushpin: Related Issues
- Related with #5741
- Fixes #5884

#### :clipboard: Subtasks
As this is something internal, I'm not adding it to the CHANGELOG file. 