### PR TITLE
Update .simplecov to exclude db dir

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -12,7 +12,7 @@ SimpleCov.start do
 
   # We ignore some of the files because they are never tested
   add_filter "/config/"
-  add_filter "/migrate/"
+  add_filter "/db/"
   add_filter "/vendor/"
   add_filter "/spec/"
   add_filter "/test/"


### PR DESCRIPTION
#### :tophat: What? Why?

Previously codecov included [`seeds.rb`](https://codecov.io/gh/decidim/decidim/compare/5c6687d79f03672d4247498fe53a7c7f3d30311b...fb413a2215c44320b07c3600de5aeacb6fb6290e/src/decidim-core/db/seeds.rb) in the coverage report, this pr changes the exclude filter to exclude all the `db` directory, excluding migration and seed files.

#### :pushpin: Related Issues
- Related to #5934

#### :clipboard: Subtasks

### :camera: Screenshots (optional)

