### PR TITLE
fix move proposal endorsements migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Due to [\#5553](https://github.com/decidim/decidim/pull/5553), SSL is turned on 
 
 ### Fixed
 
+- **decidim-proposals**: Fix a migration failure when generalizing proposal endorsements. [\#5953](https://github.com/decidim/decidim/pull/5953)
 - **decidim-assemblies**: Fix parent-child loophole when setting a child as and parent and making assemblies disappear. [\#5807](https://github.com/decidim/decidim/pull/5807)
 - **decidim-forms**: Fixes a performance degradation when displaying forms in surveys. [\#5819](https://github.com/decidim/decidim/pull/5819)
 - **decidim-proposals**: Fix relative path in mentioned proposal email [\#5852](https://github.com/decidim/decidim/pull/5852)

--- a/decidim-proposals/db/migrate/20200120215928_move_proposal_endorsements_to_core_endorsements.rb
+++ b/decidim-proposals/db/migrate/20200120215928_move_proposal_endorsements_to_core_endorsements.rb
@@ -15,7 +15,7 @@ class MoveProposalEndorsementsToCoreEndorsements < ActiveRecord::Migration[5.2]
     ).group(:decidim_user_group_id).where.not(decidim_user_group_id: nil).map(&:id)
 
     ProposalEndorsement.where("id IN (?) OR decidim_user_group_id IS NULL", non_duplicated_group_endorsements).find_each do |prop_endorsement|
-      ::Decidim::Endorsement.create!(
+      Endorsement.create!(
         resource_type: Decidim::Proposals::Proposal.name,
         resource_id: prop_endorsement.decidim_proposal_id,
         decidim_author_type: prop_endorsement.decidim_author_type,


### PR DESCRIPTION
#### :tophat: What? Why?

I've just tested the develop in production and the migration introduced in https://github.com/decidim/decidim/pull/5542 failed with this message:

```
  == 20200409173432 MoveProposalEndorsementsToCoreEndorsements: migrating =======
  rake aborted!
  StandardError: An error has occurred, this and all later migrations canceled:
  
  Validation failed: Resource must exist
  /var/app/ondeck/db/migrate/20200409173432_move_proposal_endorsements_to_core_endorsements.decidim_proposals.rb:19:in `block in up'
  /var/app/ondeck/db/migrate/20200409173432_move_proposal_endorsements_to_core_endorsements.decidim_proposals.rb:18:in `up'
  /opt/rubies/ruby-2.6.5/bin/bundle:23:in `load'
  /opt/rubies/ruby-2.6.5/bin/bundle:23:in `<main>'
  
  Caused by:
  ActiveRecord::RecordInvalid: Validation failed: Resource must exist
  /var/app/ondeck/db/migrate/20200409173432_move_proposal_endorsements_to_core_endorsements.decidim_proposals.rb:19:in `block in up'
  /var/app/ondeck/db/migrate/20200409173432_move_proposal_endorsements_to_core_endorsements.decidim_proposals.rb:18:in `up'
  /opt/rubies/ruby-2.6.5/bin/bundle:23:in `load'
  /opt/rubies/ruby-2.6.5/bin/bundle:23:in `<main>'
  Tasks: TOP => db:migrate
  (See full trace by running task with --trace) (Executor::NonZeroExitStatus)

```

I had to manually substitute `::Decidim::Endorsement.` by `::Endorsement`, then everything ran as expected.


#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
