### PR TITLE
Fix error 500 when showing new debate notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Due to [\#5553](https://github.com/decidim/decidim/pull/5553), SSL is turned on 
 
 ### Fixed
 
+- **decidim-debates**: Fix a notification failure when the creating a new debate event is fired. [\#5964](https://github.com/decidim/decidim/pull/5964)
 - **decidim-proposals**: Fix a migration failure when generalizing proposal endorsements. [\#5953](https://github.com/decidim/decidim/pull/5953)
 - **decidim-assemblies**: Fix parent-child loophole when setting a child as and parent and making assemblies disappear. [\#5807](https://github.com/decidim/decidim/pull/5807)
 - **decidim-forms**: Fixes a performance degradation when displaying forms in surveys. [\#5819](https://github.com/decidim/decidim/pull/5819)

--- a/decidim-debates/app/events/decidim/debates/create_debate_event.rb
+++ b/decidim-debates/app/events/decidim/debates/create_debate_event.rb
@@ -14,8 +14,6 @@ module Decidim
 
       i18n_attributes :space_title, :space_path
 
-      delegate :author, to: :resource
-
       def resource_text
         translated_attribute(resource.description)
       end


### PR DESCRIPTION
#### :tophat: What? Why?

The class `CreateDebateEvent` is overwriting the method `author` provided by the concern `AuthorEvent`. By doing so, it does not check if this author has all the methods required to be printable, specifically the method `nickname`.

As debates can be created by admins and, therefore, the author is the organization, the view is trying to call the method nickname without checking if it exists (as the `AuthorEvent` class does). This causes an error 500 in the notification area of the users if they are notificated by such event.

This PR removes the delegation of the method author.

### log trace:
![image](https://user-images.githubusercontent.com/1401520/79249683-eec32680-7e7d-11ea-92da-8711f3b8410a.png)

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

