### PR TITLE
Remove HTML escaping on meetings

### DIFF
--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -27,7 +27,7 @@ module Decidim
         return unless meeting
 
         handle_locales(meeting.description, all_locales) do |content|
-          renderer = Decidim::ContentRenderers::HashtagRenderer.new(decidim_html_escape(content))
+          renderer = Decidim::ContentRenderers::HashtagRenderer.new(content)
           renderer.render(links: links).html_safe
         end
       end

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -27,7 +27,7 @@ module Decidim
         return unless meeting
 
         handle_locales(meeting.description, all_locales) do |content|
-          renderer = Decidim::ContentRenderers::HashtagRenderer.new(content)
+          renderer = Decidim::ContentRenderers::HashtagRenderer.new(decidim_sanitize(content))
           renderer.render(links: links).html_safe
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

Pr #5553 added an extra html filtering option in `MeetingPresenter` to the description of meetings. As meetings use the Quill editor, this causes Decidim to render the content as escaped html.

We should remove this filtering or the Quill editor (but this will break all existing meetings compatibility).

![image](https://user-images.githubusercontent.com/1401520/79269578-fd6d0600-7e9c-11ea-820b-de729391de44.png)

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry

I've skipped Changelog here because this change is not in any release yet so, it won't be a bug in the next release if we mix this before.

I Changelog line is still needed, please let me know.