### PR TITLE
fix: make codecov report to work on jobs re-run

### DIFF
--- a/.github/upload_coverage.sh
+++ b/.github/upload_coverage.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+REPORT_NAME=$1
+EVENT_PAYLOAD_FILE=$2
+
+PRID=`jq ".number + .check_run.pull_requests[0].number" $EVENT_PAYLOAD_FILE`
+SHA=`jq -r ".pull_request.head.sha + .check_run.head_sha + .after" $EVENT_PAYLOAD_FILE`
+
+if [ $PRID = "null" ]
+then
+  bash <(curl -s https://codecov.io/bash) -n $REPORT_NAME -C $SHA
+else
+  bash <(curl -s https://codecov.io/bash) -n $REPORT_NAME -C $SHA -P $PRID
+fi

--- a/.github/upload_coverage.sh
+++ b/.github/upload_coverage.sh
@@ -3,8 +3,8 @@
 REPORT_NAME=$1
 EVENT_PAYLOAD_FILE=$2
 
-PRID=`jq ".number + .check_run.pull_requests[0].number" $EVENT_PAYLOAD_FILE`
-SHA=`jq -r ".pull_request.head.sha + .check_run.head_sha + .after" $EVENT_PAYLOAD_FILE`
+PRID=`jq ".number // .check_run.pull_requests[0].number" $EVENT_PAYLOAD_FILE`
+SHA=`jq -r ".pull_request.head.sha // .check_run.head_sha // .after" $EVENT_PAYLOAD_FILE`
 
 if [ $PRID = "null" ]
 then

--- a/.github/workflows/ci_accountability.yml
+++ b/.github/workflows/ci_accountability.yml
@@ -65,10 +65,8 @@ jobs:
       - run: bundle exec rake
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage/coverage.xml
-          name: ${{ env.DECIDIM_MODULE }}
+      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
+        name: Upload coverage
       - uses: actions/upload-artifact@v2-preview
         if: always()
         with:

--- a/.github/workflows/ci_admin.yml
+++ b/.github/workflows/ci_admin.yml
@@ -65,10 +65,8 @@ jobs:
       - run: bundle exec rake
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage/coverage.xml
-          name: ${{ env.DECIDIM_MODULE }}
+      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
+        name: Upload coverage
       - uses: actions/upload-artifact@v2-preview
         if: always()
         with:

--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -65,10 +65,8 @@ jobs:
       - run: bundle exec rake
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage/coverage.xml
-          name: ${{ env.DECIDIM_MODULE }}
+      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
+        name: Upload coverage
       - uses: actions/upload-artifact@v2-preview
         if: always()
         with:

--- a/.github/workflows/ci_assemblies.yml
+++ b/.github/workflows/ci_assemblies.yml
@@ -65,10 +65,8 @@ jobs:
       - run: bundle exec rake
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage/coverage.xml
-          name: ${{ env.DECIDIM_MODULE }}
+      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
+        name: Upload coverage
       - uses: actions/upload-artifact@v2-preview
         if: always()
         with:

--- a/.github/workflows/ci_blogs.yml
+++ b/.github/workflows/ci_blogs.yml
@@ -65,10 +65,8 @@ jobs:
       - run: bundle exec rake
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage/coverage.xml
-          name: ${{ env.DECIDIM_MODULE }}
+      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
+        name: Upload coverage
       - uses: actions/upload-artifact@v2-preview
         if: always()
         with:

--- a/.github/workflows/ci_budgets.yml
+++ b/.github/workflows/ci_budgets.yml
@@ -65,10 +65,8 @@ jobs:
       - run: bundle exec rake
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage/coverage.xml
-          name: ${{ env.DECIDIM_MODULE }}
+      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
+        name: Upload coverage
       - uses: actions/upload-artifact@v2-preview
         if: always()
         with:

--- a/.github/workflows/ci_comments.yml
+++ b/.github/workflows/ci_comments.yml
@@ -73,10 +73,8 @@ jobs:
       - run: bundle exec rake
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage/coverage.xml
-          name: ${{ env.DECIDIM_MODULE }}
+      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
+        name: Upload coverage
       - uses: actions/upload-artifact@v2-preview
         if: always()
         with:

--- a/.github/workflows/ci_conferences.yml
+++ b/.github/workflows/ci_conferences.yml
@@ -65,10 +65,8 @@ jobs:
       - run: bundle exec rake
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage/coverage.xml
-          name: ${{ env.DECIDIM_MODULE }}
+      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
+        name: Upload coverage
       - uses: actions/upload-artifact@v2-preview
         if: always()
         with:

--- a/.github/workflows/ci_consultations.yml
+++ b/.github/workflows/ci_consultations.yml
@@ -68,10 +68,8 @@ jobs:
       - run: bundle exec rake
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage/coverage.xml
-          name: ${{ env.DECIDIM_MODULE }}
+      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
+        name: Upload coverage
       - uses: actions/upload-artifact@v2-preview
         if: always()
         with:

--- a/.github/workflows/ci_core.yml
+++ b/.github/workflows/ci_core.yml
@@ -65,10 +65,8 @@ jobs:
       - run: bundle exec rake
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage/coverage.xml
-          name: ${{ env.DECIDIM_MODULE }}
+      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
+        name: Upload coverage
       - uses: actions/upload-artifact@v2-preview
         if: always()
         with:

--- a/.github/workflows/ci_debates.yml
+++ b/.github/workflows/ci_debates.yml
@@ -65,10 +65,8 @@ jobs:
       - run: bundle exec rake
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage/coverage.xml
-          name: ${{ env.DECIDIM_MODULE }}
+      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
+        name: Upload coverage
       - uses: actions/upload-artifact@v2-preview
         if: always()
         with:

--- a/.github/workflows/ci_forms.yml
+++ b/.github/workflows/ci_forms.yml
@@ -65,10 +65,8 @@ jobs:
       - run: bundle exec rake
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage/coverage.xml
-          name: ${{ env.DECIDIM_MODULE }}
+      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
+        name: Upload coverage
       - uses: actions/upload-artifact@v2-preview
         if: always()
         with:

--- a/.github/workflows/ci_initiatives.yml
+++ b/.github/workflows/ci_initiatives.yml
@@ -65,10 +65,8 @@ jobs:
       - run: bundle exec rake
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage/coverage.xml
-          name: ${{ env.DECIDIM_MODULE }}
+      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
+        name: Upload coverage
       - uses: actions/upload-artifact@v2-preview
         if: always()
         with:

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -49,7 +49,3 @@ jobs:
         name: Install JS deps
       - run: bundle exec rspec
         name: RSpec
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage/coverage.xml
-          name: main-folder

--- a/.github/workflows/ci_meetings.yml
+++ b/.github/workflows/ci_meetings.yml
@@ -65,10 +65,8 @@ jobs:
       - run: bundle exec rake
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage/coverage.xml
-          name: ${{ env.DECIDIM_MODULE }}
+      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
+        name: Upload coverage
       - uses: actions/upload-artifact@v2-preview
         if: always()
         with:

--- a/.github/workflows/ci_pages.yml
+++ b/.github/workflows/ci_pages.yml
@@ -65,10 +65,8 @@ jobs:
       - run: bundle exec rake
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage/coverage.xml
-          name: ${{ env.DECIDIM_MODULE }}
+      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
+        name: Upload coverage
       - uses: actions/upload-artifact@v2-preview
         if: always()
         with:

--- a/.github/workflows/ci_participatory_processes.yml
+++ b/.github/workflows/ci_participatory_processes.yml
@@ -65,10 +65,8 @@ jobs:
       - run: bundle exec rake
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage/coverage.xml
-          name: ${{ env.DECIDIM_MODULE }}
+      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
+        name: Upload coverage
       - uses: actions/upload-artifact@v2-preview
         if: always()
         with:

--- a/.github/workflows/ci_proposals_system_admin.yml
+++ b/.github/workflows/ci_proposals_system_admin.yml
@@ -65,10 +65,8 @@ jobs:
       - run: bundle exec rspec spec/system/admin
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage/coverage.xml
-          name: decidim-proposals-system-admin
+      - run: ./.github/upload_coverage.sh decidim-proposals-system-admin $GITHUB_EVENT_PATH
+        name: Upload coverage
       - uses: actions/upload-artifact@v2-preview
         if: always()
         with:

--- a/.github/workflows/ci_proposals_system_public.yml
+++ b/.github/workflows/ci_proposals_system_public.yml
@@ -65,10 +65,8 @@ jobs:
       - run: bundle exec rspec spec/system/ --exclude-pattern 'spec/system/admin/**/*_spec.rb'
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage/coverage.xml
-          name: decidim-proposals-system-public
+      - run: ./.github/upload_coverage.sh decidim-proposals-system-public $GITHUB_EVENT_PATH
+        name: Upload coverage
       - uses: actions/upload-artifact@v2-preview
         if: always()
         with:

--- a/.github/workflows/ci_proposals_unit_tests.yml
+++ b/.github/workflows/ci_proposals_unit_tests.yml
@@ -65,10 +65,8 @@ jobs:
       - run: bundle exec rspec --exclude-pattern 'spec/system/**/*_spec.rb'
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage/coverage.xml
-          name: ${{ env.DECIDIM_MODULE }}
+      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
+        name: Upload coverage
       - uses: actions/upload-artifact@v2-preview
         if: always()
         with:

--- a/.github/workflows/ci_sortitions.yml
+++ b/.github/workflows/ci_sortitions.yml
@@ -65,7 +65,7 @@ jobs:
       - run: bundle exec rake
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
-      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH>
+      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2-preview
         if: always()

--- a/.github/workflows/ci_sortitions.yml
+++ b/.github/workflows/ci_sortitions.yml
@@ -65,10 +65,8 @@ jobs:
       - run: bundle exec rake
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage/coverage.xml
-          name: ${{ env.DECIDIM_MODULE }}
+      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH>
+        name: Upload coverage
       - uses: actions/upload-artifact@v2-preview
         if: always()
         with:

--- a/.github/workflows/ci_surveys.yml
+++ b/.github/workflows/ci_surveys.yml
@@ -65,7 +65,7 @@ jobs:
       - run: bundle exec rake
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
-      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH>
+      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2-preview
         if: always()

--- a/.github/workflows/ci_surveys.yml
+++ b/.github/workflows/ci_surveys.yml
@@ -65,10 +65,8 @@ jobs:
       - run: bundle exec rake
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage/coverage.xml
-          name: ${{ env.DECIDIM_MODULE }}
+      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH>
+        name: Upload coverage
       - uses: actions/upload-artifact@v2-preview
         if: always()
         with:

--- a/.github/workflows/ci_system.yml
+++ b/.github/workflows/ci_system.yml
@@ -65,10 +65,8 @@ jobs:
       - run: bundle exec rake
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage/coverage.xml
-          name: ${{ env.DECIDIM_MODULE }}
+      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
+        name: Upload coverage
       - uses: actions/upload-artifact@v2-preview
         if: always()
         with:

--- a/.github/workflows/ci_verifications.yml
+++ b/.github/workflows/ci_verifications.yml
@@ -65,10 +65,8 @@ jobs:
       - run: bundle exec rake
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage/coverage.xml
-          name: ${{ env.DECIDIM_MODULE }}
+      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
+        name: Upload coverage
       - uses: actions/upload-artifact@v2-preview
         if: always()
         with:


### PR DESCRIPTION
#### :tophat: What? Why?
[Github Actions env variables differ when a check is triggered by different events](https://help.github.com/en/actions/reference/events-that-trigger-workflows). This makes the coverage report upload process to fail when a developer forces to re-run a job, as the event is `check_run` instead of `pull_request`.

This PR replaces the codecov's github action with a direct call to the [Codecov bash script](https://codecov.io/bash), customizing the parameters used (commit SHA and PR identifier) with [information extracted directly from the workflow payload](https://help.github.com/en/actions/reference/events-that-trigger-workflows), regardless of the event that triggered it. The created script uses `jq` queries to recover the information from the workflow payload and supports the `pull_request`, `push` and `check_run` events.

#### :pushpin: Related Issues
- Related to #5954

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![Description](URL)
