### PR TITLE
feat(budgets): Projects filter by multiple categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Due to [\#5553](https://github.com/decidim/decidim/pull/5553), SSL is turned on 
 - **decidim-proposals**: Update rspec proposal_activity_cell_spec to check existence of card__content css class instead of car-data css class [#5779](https://github.com/decidim/decidim/issues/5779)
 - **decidim-comments**: Update rspec comment_activity_cell_spec to check existence of card__content css class instead of car-data css class[#5779](https://github.com/decidim/decidim/issues/5779)
 - **decidim-core**: Fix clearing the current_user after sign out [#5823](https://github.com/decidim/decidim/pull/5823)
+- **decidim-budgets**: Projects filter by multiple categories [/#5992](https://github.com/decidim/decidim/pull/5992)
 
 ### Changed
 

--- a/decidim-budgets/app/views/decidim/budgets/projects/_filters.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_filters.html.erb
@@ -16,14 +16,8 @@
     <%= form.check_boxes_tree :scope_id, filter_scopes_values, legend_title: t(".scope") %>
   <% end %>
 
-  <% if current_component.categories.any? %>
-    <%= form.categories_select :category_id,
-                               current_component.categories,
-                               legend_title: t(".category"),
-                               disable_parents: false,
-                               label: "",
-                               prompt: t(".category_prompt"),
-                               aria_label: t(".category") %>
+  <% if current_participatory_space.categories.any? %>
+    <%= form.check_boxes_tree :category_id, filter_categories_values, legend_title: t(".category") %>
   <% end %>
 
   <%= hidden_field_tag :order, order, id: nil, class: "order_filter" %>

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -94,7 +94,6 @@ en:
             other: "%{count} projects"
         filters:
           category: Category
-          category_prompt: Select a category
           scope: Scope
           search: Search
         filters_small_view:

--- a/decidim-budgets/spec/system/explore_projects_spec.rb
+++ b/decidim-budgets/spec/system/explore_projects_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Explore projects", :slow, type: :system do
+  include_context "with a component"
+  let(:manifest_name) { "budgets" }
+  let(:projects_count) { 5 }
+  let!(:projects) do
+    create_list(:project, projects_count, component: component)
+  end
+  let!(:project) { projects.first }
+  let(:categories) { create_list(:category, 3, participatory_space: component.participatory_space) }
+
+  describe "index" do
+    it "shows all resources for the given component" do
+      visit_component
+      within "#projects" do
+        expect(page).to have_selector(".card--list__item", count: projects_count)
+      end
+
+      projects.each do |project|
+        expect(page).to have_content(translated(project.title))
+      end
+    end
+
+    context "when filtering" do
+      it "allows searching by text" do
+        visit_component
+        within ".filters__search" do
+          fill_in "filter[search_text]", with: translated(project.title)
+
+          find(".button").click
+        end
+
+        within "#projects" do
+          expect(page).to have_css(".card--list__item", count: 1)
+          expect(page).to have_content(translated(project.title))
+        end
+      end
+
+      it "allows filtering by scope" do
+        scope = create(:scope, organization: organization)
+        project.scope = scope
+        project.save
+
+        visit_component
+
+        within ".scope_id_check_boxes_tree_filter" do
+          uncheck "All"
+          check translated(scope.name)
+        end
+
+        within "#projects" do
+          expect(page).to have_css(".card--list__item", count: 1)
+          expect(page).to have_content(translated(project.title))
+        end
+      end
+
+      it "allows filtering by category" do
+        category = categories.first
+        project.category = category
+        project.save
+
+        visit_component
+
+        within ".category_id_check_boxes_tree_filter" do
+          uncheck "All"
+          check translated(category.name)
+        end
+
+        within "#projects" do
+          expect(page).to have_css(".card--list__item", count: 1)
+          expect(page).to have_content(translated(project.title))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Add a checkbox tree for categories in the project filter to allow filtering by multiple categories.

#### :pushpin: Related Issues
- Related to #5654
- Fixes #5602

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests


### :camera: Screenshots (optional)

<img width="857" alt="Screenshot 2020-04-16 at 11 09 59" src="https://user-images.githubusercontent.com/210216/79449772-1c29e480-7fe4-11ea-964f-d0fbebf071c5.png">

before:
<img width="689" alt="Screenshot 2020-04-16 at 13 14 24" src="https://user-images.githubusercontent.com/210216/79449849-3cf23a00-7fe4-11ea-8a13-06ebdae5dfee.png">

