### PR TITLE
Remove HTML escaping on proposals

### DIFF
--- a/decidim-proposals/app/cells/decidim/proposals/collaborative_draft_m_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/collaborative_draft_m_cell.rb
@@ -23,7 +23,7 @@ module Decidim
       end
 
       def description
-        decidim_html_escape(present(model).body).truncate(100, separator: /\s/)
+        present(model).body.truncate(100, separator: /\s/)
       end
 
       def has_badge?

--- a/decidim-proposals/app/cells/decidim/proposals/collaborative_draft_m_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/collaborative_draft_m_cell.rb
@@ -23,7 +23,7 @@ module Decidim
       end
 
       def description
-        present(model).body.truncate(100, separator: /\s/)
+        decidim_sanitize(present(model).body.truncate(100, separator: /\s/))
       end
 
       def has_badge?

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
@@ -19,7 +19,7 @@ module Decidim
       end
 
       def body
-        decidim_html_escape(present(model).body)
+        present(model).body
       end
 
       def has_state?

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
@@ -19,7 +19,7 @@ module Decidim
       end
 
       def body
-        present(model).body
+        decidim_sanitize(present(model).body)
       end
 
       def has_state?


### PR DESCRIPTION
#### :tophat: What? Why?

Pr #5553 added an extra html filtering option in proposals cards. This breaks compatibility with old exising proposals as will present content in an ugly way:

![image](https://user-images.githubusercontent.com/1401520/79761629-ff621980-8321-11ea-9fce-97e5fb930f94.png)

This PR reverts this. I personally think that if this is a necessary thing to do, what should be done is to strip html instead of escaping it.

#### :pushpin: Related Issues
- Related to #5965

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add XSS injections tests
