### PR TITLE
Send email with order summary on order checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Due to [\#5553](https://github.com/decidim/decidim/pull/5553), SSL is turned on 
 - **decidim-proposals**: Update rspec proposal_activity_cell_spec to check existence of card__content css class instead of car-data css class [#5779](https://github.com/decidim/decidim/issues/5779)
 - **decidim-comments**: Update rspec comment_activity_cell_spec to check existence of card__content css class instead of car-data css class[#5779](https://github.com/decidim/decidim/issues/5779)
 - **decidim-core**: Fix clearing the current_user after sign out [#5823](https://github.com/decidim/decidim/pull/5823)
+- **decidim-budgets**: Send email with summary on order checkout [\#6006](https://github.com/decidim/decidim/pull/6006)
 
 ### Changed
 

--- a/decidim-budgets/app/commands/decidim/budgets/checkout.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/checkout.rb
@@ -31,6 +31,7 @@ module Decidim
         return unless @order && @order.valid?
 
         @order.with_lock do
+          SendOrderSummaryJob.perform_later(@order)
           @order.checked_out_at = Time.current
           @order.save
         end

--- a/decidim-budgets/app/jobs/decidim/budgets/send_order_summary_job.rb
+++ b/decidim-budgets/app/jobs/decidim/budgets/send_order_summary_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Budgets
+    class SendOrderSummaryJob < ApplicationJob
+      queue_as :default
+
+      def perform(order)
+        return unless order
+        return unless order.user
+        return if order.user.email.blank?
+
+        OrderSummaryMailer.order_summary(order).deliver_now
+      end
+    end
+  end
+end

--- a/decidim-budgets/app/jobs/decidim/budgets/send_order_summary_job.rb
+++ b/decidim-budgets/app/jobs/decidim/budgets/send_order_summary_job.rb
@@ -6,7 +6,7 @@ module Decidim
       queue_as :default
 
       def perform(order)
-        return unless order&.user&.email.present?
+        return if order&.user&.email.blank?
 
         OrderSummaryMailer.order_summary(order).deliver_now
       end

--- a/decidim-budgets/app/jobs/decidim/budgets/send_order_summary_job.rb
+++ b/decidim-budgets/app/jobs/decidim/budgets/send_order_summary_job.rb
@@ -6,9 +6,7 @@ module Decidim
       queue_as :default
 
       def perform(order)
-        return unless order
-        return unless order.user
-        return if order.user.email.blank?
+        return unless order&.user&.email.present?
 
         OrderSummaryMailer.order_summary(order).deliver_now
       end

--- a/decidim-budgets/app/mailers/decidim/budgets/order_summary_mailer.rb
+++ b/decidim-budgets/app/mailers/decidim/budgets/order_summary_mailer.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Budgets
+    class OrderSummaryMailer < Decidim::ApplicationMailer
+      include Decidim::TranslationsHelper
+      include Decidim::SanitizeHelper
+
+      helper Decidim::TranslationsHelper
+
+      # Send an email to an user with the summary of the order.
+      #
+      # order - the order that was just created
+      def order_summary(order)
+        user = order.user
+
+        with_user(user) do
+          @user = user
+          @order = order
+          @space = order.participatory_space
+          @component = order.component
+          @organization = order.participatory_space.organization
+
+          subject = I18n.t(
+            "order_summary.subject",
+            scope: "decidim.budgets.order_summary_mailer",
+            space_name: translated_attribute(@space.title)
+          )
+          mail(to: user.email, subject: subject)
+        end
+      end
+    end
+  end
+end

--- a/decidim-budgets/app/views/decidim/budgets/order_summary_mailer/order_summary.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/order_summary_mailer/order_summary.html.erb
@@ -1,4 +1,4 @@
-<% if @component.try(:scope) %>
+<% if @component.try(:scopes_enabled) %>
 <%= t(
   ".voted_on_space_with_scope",
   space_name: translated_attribute(@space.title),

--- a/decidim-budgets/app/views/decidim/budgets/order_summary_mailer/order_summary.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/order_summary_mailer/order_summary.html.erb
@@ -1,0 +1,20 @@
+<% if @component.try(:scope) %>
+<%= t(
+  ".voted_on_space_with_scope",
+  space_name: translated_attribute(@space.title),
+  scope_name: translated_attribute(@component.scope.name)
+) %>
+<% else %>
+<%= t(
+  ".voted_on_space",
+  space_name: translated_attribute(@space.title)
+) %>
+<% end %>
+
+<p><%= t(".selected_projects") %></p>
+
+<ul>
+<% @order.projects.each do |project| %>
+  <li><%= translated_attribute(project.title) %></li>
+<% end %>
+</ul>

--- a/decidim-budgets/app/views/decidim/budgets/order_summary_mailer/order_summary.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/order_summary_mailer/order_summary.html.erb
@@ -2,7 +2,8 @@
 <%= t(
   ".voted_on_space_with_scope",
   space_name: translated_attribute(@space.title),
-  scope_name: translated_attribute(@component.scope.name)
+  scope_name: translated_attribute(@component.scope.name),
+  scope_type: translated_attribute(@component.scope.scope_type.name)
 ) %>
 <% else %>
 <%= t(

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -66,6 +66,12 @@ en:
         project:
           fields:
             title: Title
+      order_summary_mailer:
+        order_summary:
+          selected_projects: 'The projects that you have selected are:'
+          subject: You have voted on the %{space_name} participatory space
+          voted_on_space: You have voted on the budets for the %{space_name} participatory space.
+          voted_on_space_with_scope: You have voted on the budets for the %{space_name} participatory space on the %{scope_name} district.
       projects:
         budget_confirm:
           are_you_sure: Do you agree? Once you have confirmed your vote, you can not change it.

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -70,8 +70,8 @@ en:
         order_summary:
           selected_projects: 'The projects that you have selected are:'
           subject: You have voted on the %{space_name} participatory space
-          voted_on_space: You have voted on the budets for the %{space_name} participatory space.
-          voted_on_space_with_scope: You have voted on the budets for the %{space_name} participatory space on the %{scope_name} district.
+          voted_on_space: You have voted on the budgets for the %{space_name} participatory space.
+          voted_on_space_with_scope: You have voted on the budgets for the %{space_name} participatory space on %{scope_name} (%{scope_type}).
       projects:
         budget_confirm:
           are_you_sure: Do you agree? Once you have confirmed your vote, you can not change it.

--- a/decidim-budgets/spec/commands/checkout_spec.rb
+++ b/decidim-budgets/spec/commands/checkout_spec.rb
@@ -37,6 +37,12 @@ module Decidim::Budgets
         order.reload
         expect(order.checked_out_at).not_to be_nil
       end
+
+      it "schedules a job to send an email with the summary" do
+        expect(SendOrderSummaryJob).to receive(:perform_later).with(order)
+
+        subject.call
+      end
     end
 
     context "when the order is not present" do

--- a/decidim-budgets/spec/jobs/decidim/budgets/send_order_summary_job_spec.rb
+++ b/decidim-budgets/spec/jobs/decidim/budgets/send_order_summary_job_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Budgets::SendOrderSummaryJob do
+  subject { described_class }
+
+  let(:order) { create :order }
+  let(:user) { order.user }
+
+  describe "queue" do
+    it "is queued to events" do
+      expect(subject.queue_name).to eq "default"
+    end
+  end
+
+  describe "when everything is OK" do
+    let(:mailer) { double :mailer }
+
+    it "sends an email" do
+      expect(Decidim::Budgets::OrderSummaryMailer)
+        .to receive(:order_summary)
+        .with(order)
+        .and_return(mailer)
+      expect(mailer)
+        .to receive(:deliver_now)
+
+      subject.perform_now(order)
+    end
+  end
+
+  describe "when no order" do
+    let(:order) { nil }
+
+    it" doesn't send the email" do
+      expect(Decidim::Budgets::OrderSummaryMailer)
+        .not_to receive(:order_summary)
+
+      subject.perform_now(order)
+    end
+  end
+
+  describe "when no user" do
+    it" doesn't send the email" do
+      user.destroy
+      order.reload
+
+      expect(Decidim::Budgets::OrderSummaryMailer)
+        .not_to receive(:order_summary)
+
+      subject.perform_now(order)
+    end
+  end
+
+  describe "when user as no email" do
+    it" doesn't send the email" do
+      user.update(email: "")
+
+      expect(Decidim::Budgets::OrderSummaryMailer)
+        .not_to receive(:order_summary)
+
+      subject.perform_now(order)
+    end
+  end
+end

--- a/decidim-budgets/spec/mailers/decidim/budgets/order_summary_mailer_spec.rb
+++ b/decidim-budgets/spec/mailers/decidim/budgets/order_summary_mailer_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Budgets
+  describe OrderSummaryMailer, type: :mailer do
+    let(:order) { create :order }
+    let(:user) { order.user }
+    let(:space) { order.participatory_space }
+    let(:organization) { space.participatory_space.organization }
+
+    describe "order_summary" do
+      let(:mail) { described_class.order_summary(order) }
+
+      it "delivers the email to the user" do
+        expect(mail.to).to eq([user.email])
+      end
+
+      it "includes the organization data" do
+        expect(mail.body.encoded).to include(user.organization.name)
+      end
+
+      it "includes the participatory space title" do
+        expect(mail.body).to include(translated(space.title))
+      end
+
+      it "includes the projects names" do
+        order.projects.each do |project|
+          expect(mail.body).to include(translated(project.name))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds an email with the summary of the voted budgets projects on order checkout.

#### :pushpin: Related Issues
- Related to #5712

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Send email with summary on order checkout
- [x] Add tests for email

### :camera: Screenshots (optional)
Email from a component not related to a scope:

![image](https://user-images.githubusercontent.com/491891/79849676-0f7e0580-83c3-11ea-84f1-f6b44c935e52.png)

Email from a component _related_ to a scope (see #5941):

![image](https://user-images.githubusercontent.com/491891/79875952-b0cc8200-83ea-11ea-811a-f60fd26adda7.png)


