### PR TITLE
Backport fix error 500 when showing new debate notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@ Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now sup
 
 **Fixed**:
 
+- **decidim-debates**: Fix a notification failure when the creating a new debate event is fired. [\#6017](https://github.com/decidim/decidim/pull/6017)
 - **decidim-proposals**: Fix proposals that have their state not published. [\#5833](https://github.com/decidim/decidim/pull/5833)
 - **decidim-core** adapt API classes to the release of the graphql gem v1.10.4 [\#5829](https://github.com/decidim/decidim/pull/5829)
 - **decidim-core** Fixes the integration between the use of older and new versions of geocoder using HERE maps [\#5822](https://github.com/decidim/decidim/pull/5822)

--- a/decidim-debates/app/events/decidim/debates/create_debate_event.rb
+++ b/decidim-debates/app/events/decidim/debates/create_debate_event.rb
@@ -14,8 +14,6 @@ module Decidim
 
       i18n_attributes :space_title, :space_path
 
-      delegate :author, to: :resource
-
       def resource_text
         translated_attribute(resource.description)
       end


### PR DESCRIPTION
## :tophat: What? Why?

This is a backport for #5964 for the 0.21 branch which is affected with this bug.

#### :pushpin: Related Issues
- Related to #5964

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
