### PR TITLE
Fix generator Gemfile after puma upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Due to [\#5553](https://github.com/decidim/decidim/pull/5553), SSL is turned on 
 
 ### Fixed
 
+- **decidim-core**: Fix broken puma version in generator's Gemfile. [\#6060](https://github.com/decidim/decidim/pull/6060)
 - **decidim-core,decidim-system**: Fix using Decidim as a provider for omniauth authentication. [\#6042](https://github.com/decidim/decidim/pull/6042)
 - **decidim-proposals**: Fix missing values for filter values in proposals admin. [\#6013](https://github.com/decidim/decidim/pull/6013)
 - **decidim-api**: Fix broken documentation if using Decidim from a Gem. [\#5996](https://github.com/decidim/decidim/pull/5996)

--- a/decidim-generators/lib/decidim/generators/component_templates/Gemfile.erb
+++ b/decidim-generators/lib/decidim/generators/component_templates/Gemfile.erb
@@ -8,6 +8,7 @@ gem "decidim", git: "https://github.com/decidim/decidim"
 gem "decidim-<%= component_name %>", path: "."
 
 gem "puma", ">= 4.3"
+gem "bootsnap", "~> 1.4"
 gem "uglifier", "~> 4.1"
 
 group :development, :test do

--- a/decidim-generators/lib/decidim/generators/component_templates/Gemfile.erb
+++ b/decidim-generators/lib/decidim/generators/component_templates/Gemfile.erb
@@ -7,7 +7,7 @@ ruby RUBY_VERSION
 gem "decidim", git: "https://github.com/decidim/decidim"
 gem "decidim-<%= component_name %>", path: "."
 
-gem "puma", "~> 3.12.2"
+gem "puma", ">= 4.3"
 gem "uglifier", "~> 4.1"
 
 group :development, :test do


### PR DESCRIPTION
#### :tophat: What? Why?

The version in puma is out of date after its upgrade to version 4.3. This causes the module generator to fail.
Also, `bootsnap` is required to start the `development_app` so I'd include it in the Gemfile.
This affects version 0.21 as well.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
