### PR TITLE
Backport the fix for using Decidim as a provider for omniauth authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - **decidim-core**: Fix broken puma version in generator's Gemfile. [\#6060](https://github.com/decidim/decidim/pull/6060)
+- **decidim-core,decidim-system**: Fix using Decidim as a provider for omniauth authentication. [\#6081](https://github.com/decidim/decidim/pull/6081)
 
 ### Removed
 

--- a/decidim-core/config/initializers/omniauth.rb
+++ b/decidim-core/config/initializers/omniauth.rb
@@ -8,7 +8,6 @@ def setup_provider_proc(provider, config_mapping = {})
 
     config_mapping.each do |option_key, config_key|
       env["omniauth.strategy"].options[option_key] = provider_config[config_key]
-      env["omniauth.strategy"].options[option_key] = provider_config[config_key]
     end
   end
 end
@@ -21,6 +20,13 @@ Rails.application.config.middleware.use OmniAuth::Builder do
       provider(
         :developer,
         fields: [:name, :nickname, :email]
+      )
+    end
+
+    if omniauth_config[:decidim].present?
+      provider(
+        :decidim,
+        setup: setup_provider_proc(:decidim, client_id: :client_id, client_secret: :client_secret, site: :site_url)
       )
     end
 

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -240,9 +240,7 @@ module Decidim
           # #call can be used in order to allow conditional checks (to allow non-SSL
           # redirects to localhost for example).
           #
-          # force_ssl_in_redirect_uri !Rails.env.development?
-          #
-          force_ssl_in_redirect_uri false
+          force_ssl_in_redirect_uri !Rails.env.development?
 
           # WWW-Authenticate Realm (default "Doorkeeper").
           realm "Decidim"

--- a/decidim-core/spec/models/decidim/organization_spec.rb
+++ b/decidim-core/spec/models/decidim/organization_spec.rb
@@ -61,9 +61,26 @@ module Decidim
     describe "enabled omniauth providers" do
       subject(:enabled_providers) { organization.enabled_omniauth_providers }
 
-      context "when no configuration" do
-        it "returns providers enabled in secrets.yml" do
-          expect(enabled_providers).to eq(omniauth_secrets)
+      context "when omniauth_settings are nil" do
+        context "when providers are enabled in secrets.yml" do
+          it "returns providers enabled in secrets.yml" do
+            expect(enabled_providers).to eq(omniauth_secrets)
+          end
+        end
+
+        context "when providers are not enabled in secrets.yml" do
+          before do
+            @previous_omniauth_secrets = Rails.application.secrets[:omniauth]
+            Rails.application.secrets[:omniauth] = nil
+          end
+
+          after do
+            Rails.application.secrets[:omniauth] = @previous_omniauth_secrets
+          end
+
+          it "returns no providers" do
+            expect(enabled_providers).to be_empty
+          end
         end
       end
 
@@ -76,15 +93,16 @@ module Decidim
             "omniauth_settings_facebook_app_secret" => Decidim::AttributeEncryptor.encrypt("overriden-app-secret"),
             "omniauth_settings_google_oauth2_enabled" => true,
             "omniauth_settings_google_oauth2_client_id" => Decidim::AttributeEncryptor.encrypt("overriden-client-id"),
-            "omniauth_settings_google_oauth2_client_secret" => Decidim::AttributeEncryptor.encrypt("overriden-client-secret")
+            "omniauth_settings_google_oauth2_client_secret" => Decidim::AttributeEncryptor.encrypt("overriden-client-secret"),
+            "omniauth_settings_twitter_enabled" => false
           }
         end
 
         before { organization.update!(omniauth_settings: omniauth_settings) }
 
-        it "returns the overriden settings" do
+        it "returns only the enabled settings" do
           expect(subject[:facebook][:app_id]).to eq("overriden-app-id")
-          expect(subject[:twitter][:api_key]).to eq("fake-twitter-api-key") # sacar a otra spec, no esta sobrescrito
+          expect(subject[:twitter]).to be(nil)
           expect(subject[:google_oauth2][:client_id]).to eq("overriden-client-id")
         end
       end

--- a/decidim-core/spec/models/decidim/organization_spec.rb
+++ b/decidim-core/spec/models/decidim/organization_spec.rb
@@ -69,13 +69,14 @@ module Decidim
         end
 
         context "when providers are not enabled in secrets.yml" do
+          let!(:previous_omniauth_secrets) { Rails.application.secrets[:omniauth] }
+
           before do
-            @previous_omniauth_secrets = Rails.application.secrets[:omniauth]
             Rails.application.secrets[:omniauth] = nil
           end
 
           after do
-            Rails.application.secrets[:omniauth] = @previous_omniauth_secrets
+            Rails.application.secrets[:omniauth] = previous_omniauth_secrets
           end
 
           it "returns no providers" do

--- a/decidim-system/app/controllers/decidim/system/organizations_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/organizations_controller.rb
@@ -5,7 +5,7 @@ module Decidim
     # Controller to manage Organizations (tenants).
     #
     class OrganizationsController < Decidim::System::ApplicationController
-      helper_method :current_organization
+      helper_method :current_organization, :provider_enabled?
       helper Decidim::OmniauthHelper
 
       def new
@@ -57,11 +57,17 @@ module Decidim
         end
       end
 
+      private
+
       # The current organization for the request.
       #
       # Returns an Organization.
       def current_organization
         @organization
+      end
+
+      def provider_enabled?(provider)
+        Rails.application.secrets.dig(:omniauth, provider, :enabled)
       end
     end
   end

--- a/decidim-system/app/views/decidim/system/organizations/_omniauth_provider.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/_omniauth_provider.html.erb
@@ -3,6 +3,10 @@
 <div class="card">
   <h5><%= provider_name(provider) %></h5>
 
+  <% if provider_enabled?(provider) %>
+    <p class="help-text"><%= t("enabled_by_default", scope: i18n_scope) %></p>
+  <% end %>
+
   <div class="card-section">
     <%= f.check_box(
           "omniauth_settings_#{provider}_enabled",

--- a/decidim-system/config/locales/en.yml
+++ b/decidim-system/config/locales/en.yml
@@ -64,11 +64,12 @@ en:
           secondary_hosts_hint: Enter each one of them in a new line
           title: New organization
         omniauth_settings:
-          enabled: Enabled
-          Decidim:
+          decidim:
             client_id: Client ID
             client_secret: Client secret
             site_url: Site URL
+          enabled: Enabled
+          enabled_by_default: This provider is enabled by default. It can be edited but not disabled.
           facebook:
             app_id: App ID
             app_secret: App secret

--- a/decidim-system/config/locales/en.yml
+++ b/decidim-system/config/locales/en.yml
@@ -65,6 +65,10 @@ en:
           title: New organization
         omniauth_settings:
           enabled: Enabled
+          Decidim:
+            client_id: Client ID
+            client_secret: Client secret
+            site_url: Site URL
           facebook:
             app_id: App ID
             app_secret: App secret


### PR DESCRIPTION
#### :tophat: What? Why?
Backport https://github.com/decidim/decidim/pull/6042 to Decidim `v0.21-stable`.
This PR fixes using Decidim as a provider for omniauth authentication after being broken when making omniauth providers configurable at Organization level (in System).

#### :pushpin: Related Issues
- Related to #6041 
- Fixes #5756

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
