### PR TITLE
Use organization time zone when decidim-api is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Due to [\#5553](https://github.com/decidim/decidim/pull/5553), SSL is turned on 
 
 ### Added
 
+- **decidim-api**: Use organization time zone [\#6088](https://github.com/decidim/decidim/pull/6088)
 - **decidim-forms**: New question type "Matrix" [\#5948](https://github.com/decidim/decidim/pull/5948)
 - **decidim-core**: Notify admins o user_group created or updated. [\#5906](https://github.com/decidim/decidim/pull/5906)
 - **decidim-comments**: Notify user_group followers when it posts a comment. [\#5906](https://github.com/decidim/decidim/pull/5906)

--- a/decidim-api/app/controllers/decidim/api/application_controller.rb
+++ b/decidim-api/app/controllers/decidim/api/application_controller.rb
@@ -6,6 +6,7 @@ module Decidim
     class ApplicationController < ::DecidimController
       skip_before_action :verify_authenticity_token
       include NeedsOrganization
+      include UseOrganizationTimeZone
       include NeedsPermission
       include ImpersonateUsers
       include ForceAuthentication

--- a/decidim-api/spec/controllers/concerns/use_organization_time_zone_spec.rb
+++ b/decidim-api/spec/controllers/concerns/use_organization_time_zone_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Api
+    describe ApplicationController, type: :controller do
+      let(:utc_time_zone) { "UTC" }
+      let(:alt_time_zone) { "Hawaii" }
+      let(:organization) { create(:organization, time_zone: time_zone) }
+
+      before do
+        request.env["decidim.current_organization"] = organization
+      end
+
+      context "when time zone is UTC" do
+        let(:time_zone) { utc_time_zone }
+
+        it "controller uses UTC" do
+          expect(controller.organization_time_zone).to eq(utc_time_zone)
+        end
+
+        it "Time uses UTC zone within the controller scope" do
+          controller.use_organization_time_zone do
+            expect(Time.zone.name).to eq(utc_time_zone)
+          end
+        end
+
+        it "Time uses UTC outside the controller scope" do
+          expect(Time.zone.name).to eq(utc_time_zone)
+        end
+      end
+
+      context "when time zone is non-UTC" do
+        let(:time_zone) { alt_time_zone }
+
+        it "controller uses the custom time zone" do
+          expect(controller.organization_time_zone).to eq(alt_time_zone)
+        end
+
+        it "Time uses configured time zone within the controller scope" do
+          controller.use_organization_time_zone do
+            expect(Time.zone.name).to eq(alt_time_zone)
+          end
+        end
+
+        it "Time uses UTC outside the controller scope" do
+          expect(Time.zone.name).to eq(utc_time_zone)
+        end
+      end
+
+      context "when Rails is non-UTC", tz: "Azores" do
+        context "and organizations uses UTC" do
+          let(:time_zone) { utc_time_zone }
+
+          it "controller uses UTC" do
+            expect(controller.organization_time_zone).to eq(utc_time_zone)
+          end
+
+          it "Time uses UTC zone within the controller scope" do
+            controller.use_organization_time_zone do
+              expect(Time.zone.name).to eq(utc_time_zone)
+            end
+          end
+
+          it "Time uses Rails timezone outside the controller scope" do
+            expect(Time.zone.name).to eq("Azores")
+          end
+        end
+
+        context "and organizations uses non-UTC" do
+          let(:time_zone) { alt_time_zone }
+
+          it "controller uses UTC" do
+            expect(controller.organization_time_zone).to eq(alt_time_zone)
+          end
+
+          it "Time uses UTC zone within the controller scope" do
+            controller.use_organization_time_zone do
+              expect(Time.zone.name).to eq(alt_time_zone)
+            end
+          end
+
+          it "Time uses Rails timezone outside the controller scope" do
+            expect(Time.zone.name).to eq("Azores")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
As @microstudi stated, comments use the API to obtain the data, and its controller was not configured to use the organization time zone. This is why the comments were displaying a UTC based time zone instead of the organization's.

This pull request makes the base controller for decidim-api use the organization time zone.

#### :pushpin: Related Issues
- Related to #5607

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
