### PR TITLE
Ignore metadata['extras'] key when signing initiatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - **New "extras" key in authorization metadata**
 
-[\#xxxx](https://github.com/decidim/decidim/pull/xxxx) adds the possibility to have an "extras" key in the Authentication metadata that will be ignored. For example when
+[\#6097](https://github.com/decidim/decidim/pull/6097) adds the possibility to have an "extras" key in the Authentication metadata that will be ignored. For example when
 signing an initiative (decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb) or on Authorization renewal (decidim-verifications/app/cells/decidim/verifications/authorization_metadata/show.erb).
 
 This key may be used to persist whatever information related to the user's authentication that should not be used for authenticating her.
@@ -14,7 +14,7 @@ The use case that originated this change is the persistence of the user's gender
 
 ### Added
 
-- **decidim-initiatives**: Ignore new "extras" key when checking authorization/variation metadata [\#xxxx](https://github.com/decidim/decidim/pull/xxxx)
+- **decidim-initiatives**: Ignore new "extras" key when checking authorization/variation metadata [\#6097](https://github.com/decidim/decidim/pull/6097)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,19 @@
 
 ## [Unreleased](https://github.com/decidim/decidim/tree/HEAD)
 
+### Upgrade notes
+
+- **New "extras" key in authorization metadata**
+
+[\#xxxx](https://github.com/decidim/decidim/pull/xxxx) adds the possibility to have an "extras" key in the Authentication metadata that will be ignored. For example when
+signing an initiative (decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb) or on Authorization renewal (decidim-verifications/app/cells/decidim/verifications/authorization_metadata/show.erb).
+
+This key may be used to persist whatever information related to the user's authentication that should not be used for authenticating her.
+The use case that originated this change is the persistence of the user's gender for statistical uses.
+
 ### Added
+
+- **decidim-initiatives**: Ignore new "extras" key when checking authorization/variation metadata [\#xxxx](https://github.com/decidim/decidim/pull/xxxx)
 
 ### Changed
 

--- a/decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb
@@ -96,7 +96,9 @@ module Decidim
 
         errors.add(:base, :invalid) unless authorized? &&
                                            authorization_handler &&
-                                           authorization_handler_metadata_variations.any? { |variation| authorization.metadata.symbolize_keys == variation.symbolize_keys }
+                                           authorization_handler_metadata_variations.any? do |variation|
+                                             authorization.metadata.symbolize_keys.except(:extras) == variation.symbolize_keys.except(:extras)
+                                           end
       end
 
       def author

--- a/decidim-verifications/app/services/decidim/authorization_handler.rb
+++ b/decidim-verifications/app/services/decidim/authorization_handler.rb
@@ -56,6 +56,10 @@ module Decidim
     # params the user sent with the authorization form want to be persisted for
     # future use.
     #
+    # As a convention, an 'extras' key can be used to store information not
+    # directly related with authorization. Thus, everything inside this key
+    # can be easily ignored by consumers of this data.
+    #
     # Returns a Hash.
     def metadata
       {}


### PR DESCRIPTION
#### :tophat: What? Why?
This PR backports #6044 to v0.21-stable. This new feature is required to bugfix decidim-barcelona in combination with https://github.com/AjuntamentdeBarcelona/decidim-barcelona/pull/303.

#### :pushpin: Related Issues
- Related to #6044

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] If there's a new public field, add it to GraphQL API
- [x] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
