### PR TITLE
Update SECURITY with the correct version number

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,8 +7,8 @@ version with security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.22.x  | :white_check_mark: |
-| <= 0.21 | :x:                |
+| 0.21.x  | :white_check_mark: |
+| <= 0.20 | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
#### :tophat: What? Why?

We have an error on the security policy, as it says that we only support version 0.22. The problem is that this version is unreleased. We only support the last released version. 