### PR TITLE
Remove all tests for i18n PRs (#6061)

### DIFF
--- a/.github/workflows/ci_accountability.yml
+++ b/.github/workflows/ci_accountability.yml
@@ -20,6 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_admin.yml
+++ b/.github/workflows/ci_admin.yml
@@ -20,6 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -20,6 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_assemblies.yml
+++ b/.github/workflows/ci_assemblies.yml
@@ -20,6 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_blogs.yml
+++ b/.github/workflows/ci_blogs.yml
@@ -20,6 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_budgets.yml
+++ b/.github/workflows/ci_budgets.yml
@@ -20,6 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_comments.yml
+++ b/.github/workflows/ci_comments.yml
@@ -21,6 +21,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_conferences.yml
+++ b/.github/workflows/ci_conferences.yml
@@ -20,6 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_consultations.yml
+++ b/.github/workflows/ci_consultations.yml
@@ -20,6 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_core.yml
+++ b/.github/workflows/ci_core.yml
@@ -20,6 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_debates.yml
+++ b/.github/workflows/ci_debates.yml
@@ -20,6 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_forms.yml
+++ b/.github/workflows/ci_forms.yml
@@ -20,6 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -20,6 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_initiatives.yml
+++ b/.github/workflows/ci_initiatives.yml
@@ -20,6 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -20,6 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
         if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"

--- a/.github/workflows/ci_meetings.yml
+++ b/.github/workflows/ci_meetings.yml
@@ -20,6 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_pages.yml
+++ b/.github/workflows/ci_pages.yml
@@ -20,6 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_participatory_processes.yml
+++ b/.github/workflows/ci_participatory_processes.yml
@@ -20,6 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_proposals_system_admin.yml
+++ b/.github/workflows/ci_proposals_system_admin.yml
@@ -20,6 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_proposals_system_public.yml
+++ b/.github/workflows/ci_proposals_system_public.yml
@@ -20,6 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_proposals_unit_tests.yml
+++ b/.github/workflows/ci_proposals_unit_tests.yml
@@ -20,6 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_sortitions.yml
+++ b/.github/workflows/ci_sortitions.yml
@@ -20,6 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_surveys.yml
+++ b/.github/workflows/ci_surveys.yml
@@ -20,6 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_system.yml
+++ b/.github/workflows/ci_system.yml
@@ -20,6 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_verifications.yml
+++ b/.github/workflows/ci_verifications.yml
@@ -20,6 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -20,6 +20,7 @@ jobs:
   lint:
     name: Lint code
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'l10n_')"
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
         if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"


### PR DESCRIPTION
#### :tophat: What? Why?
This PR backports #6061 to `0.21-stable` so we don't get test runs for locale PRs.

#### :pushpin: Related Issues
None