### PR TITLE
Initiatives promoter committee invitation enhancement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Due to [\#5553](https://github.com/decidim/decidim/pull/5553), SSL is turned on 
 
 ### Changed
 
+- **decidim-initiatives**: Change initiatives committee request permission to prevent homepage redirection. [\#6115](https://github.com/decidim/decidim/pull/6115)
 - **decidim-accountability**, **decidim-core**, **decidim-meetings**, **decidim-proposals**: Optimize queries for performance in Homepage, process page, proposals page and coauthorable cell. [\#5903](https://github.com/decidim/decidim/pull/5903)
 - **decidim-assemblies**: Replace current meetings hook with highlighted elements hook [\#5897](https://github.com/decidim/decidim/pull/5897)
 - **decidim-core**: Change the map marker color to the Decidim primary color [\#5870](https://github.com/decidim/decidim/pull/5870)

--- a/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
+++ b/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
@@ -279,6 +279,12 @@ describe Decidim::Initiatives::Permissions do
 
           it { is_expected.to eq true }
         end
+
+        context "when user is not connected" do
+          let(:user) { nil }
+
+          it { is_expected.to eq true }
+        end
       end
     end
   end

--- a/decidim-initiatives/spec/system/committee_request_spec.rb
+++ b/decidim-initiatives/spec/system/committee_request_spec.rb
@@ -45,5 +45,23 @@ describe "Decidim::Initiatives::CommitteeRequestController", type: :system do
         expect(page).to have_content("You are not authorized to perform this action")
       end
     end
+
+    context "and user is not connected" do
+      before do
+        switch_to_host(organization.host)
+        visit decidim_initiatives.new_initiative_committee_request_path(initiative.to_param)
+      end
+
+      it "are allowed to request membership" do
+        expect(page).to have_content("You are about to request becoming a member of the promoter committee of this initiative")
+      end
+
+      context "when requesting membership" do
+        it "an authentication modal is opened" do
+          click_link "Continue"
+          expect(page).to have_content("Please sign in")
+        end
+      end
+    end
   end
 end

--- a/decidim-initiatives/spec/system/committee_request_spec.rb
+++ b/decidim-initiatives/spec/system/committee_request_spec.rb
@@ -53,6 +53,7 @@ describe "Decidim::Initiatives::CommitteeRequestController", type: :system do
       end
 
       it "are allowed to request membership" do
+        expect(page).to have_current_path decidim_initiatives.new_initiative_committee_request_path(initiative.to_param)
         expect(page).to have_content("You are about to request becoming a member of the promoter committee of this initiative")
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Prevent not registered nor connected user to be redirected to homepage when navigating to committee invitation link. When the user requests access to the committee, a modal appears to ask sign in or sign up.

#### :pushpin: Related Issues
- Metadecidim proposal https://meta.decidim.org/processes/roadmap/f/122/proposals/15283

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Update initiatives committee request permissions 
- [x] Add tests

### :camera: Screenshots (optional)
![Description](https://meta-decidim-production.s3.amazonaws.com/uploads/decidim/attachment/file/2637/big_PM_Modal.png)
