### PR TITLE
Require confirmation on exiting a survey mid-answering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Due to [\#5553](https://github.com/decidim/decidim/pull/5553), SSL is turned on 
 - **decidim-initiatives**: Add setting in `Decidim::InitiativesType` to enable users to set a custom signature end date in their initiatives. [\#5998](https://github.com/decidim/decidim/pull/5998)
 - **decidim-initiatives**: Sorting by publish date and supports count on admin, by publish date on front [/#6016](https://github.com/decidim/decidim/pull/6016)
 - **decidim-assemblies**: Added a setting for assemblies to enable or disable the visibility of the organization chart. [\#6040](https://github.com/decidim/decidim/pull/6040)
+- **decidim-forms**: Request confirmation when leaving the form half-answered [\#6118](https://github.com/decidim/decidim/pull/6118)
 
 ### Changed
 

--- a/decidim-forms/app/assets/javascripts/decidim/forms/forms.js.es6
+++ b/decidim-forms/app/assets/javascripts/decidim/forms/forms.js.es6
@@ -38,7 +38,7 @@
       $form.data("changed", true);
     });
 
-    const safeUrl = $form.data("safe-url");
+    const safePath = $form.data("safe-path");
     $(document).on("click", "a", (event) => {
       window.exitUrl = event.currentTarget.href;
     });
@@ -51,7 +51,7 @@
       const hasChanged = $form.data("changed");
       window.exitUrl = null;
 
-      if (!hasChanged || (exitUrl && exitUrl.startsWith(safeUrl))) {
+      if (!hasChanged || (exitUrl && exitUrl.includes(safePath))) {
         return null;
       }
 

--- a/decidim-forms/app/assets/javascripts/decidim/forms/forms.js.es6
+++ b/decidim-forms/app/assets/javascripts/decidim/forms/forms.js.es6
@@ -31,4 +31,31 @@
       wrapperField: $(el)
     })
   });
+
+  const $form = $("form.answer-questionnaire");
+  if ($form.length > 0) {
+    $form.find("input").on("change", () => {
+      $form.data("changed", true);
+    });
+
+    const safeUrl = $form.data("safe-url");
+    $(document).on("click", "a", (event) => {
+      window.exitUrl = event.currentTarget.href;
+    });
+    $(document).on("submit", "form", (event) => {
+      window.exitUrl = event.currentTarget.action;
+    });
+
+    window.onbeforeunload = () => {
+      const exitUrl = window.exitUrl;
+      const hasChanged = $form.data("changed");
+      window.exitUrl = null;
+
+      if (!hasChanged || (exitUrl && exitUrl.startsWith(safeUrl))) {
+        return null;
+      }
+
+      return "";
+    }
+  }
 })(window);

--- a/decidim-forms/app/assets/javascripts/decidim/forms/forms.js.es6
+++ b/decidim-forms/app/assets/javascripts/decidim/forms/forms.js.es6
@@ -34,7 +34,7 @@
 
   const $form = $("form.answer-questionnaire");
   if ($form.length > 0) {
-    $form.find("input").on("change", () => {
+    $form.find("input, textarea, select").on("change", () => {
       $form.data("changed", true);
     });
 

--- a/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
+++ b/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
@@ -16,7 +16,7 @@ module Decidim
           helper Decidim::Forms::ApplicationHelper
           include FormFactory
 
-          helper_method :questionnaire_for, :questionnaire, :allow_answers?, :visitor_can_answer?, :visitor_already_answered?, :update_url
+          helper_method :questionnaire_for, :questionnaire, :allow_answers?, :visitor_can_answer?, :visitor_already_answered?, :update_url, :form_url
 
           invisible_captcha on_spam: :spam_detected
 
@@ -79,6 +79,15 @@ module Decidim
           # where the questionnaire will be submitted.
           def update_url
             url_for([questionnaire_for, action: :answer])
+          end
+
+          # Points to the shortest URL accessing the current form. This will be
+          # used to detect whether a user is leaving the form with some partial
+          # answers, so that we can warn them.
+          #
+          # Overwrite this method at the controller.
+          def form_url
+            url_for([questionnaire_for])
           end
 
           # Public: Method to be implemented at the controller. You need to

--- a/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
+++ b/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
@@ -16,7 +16,7 @@ module Decidim
           helper Decidim::Forms::ApplicationHelper
           include FormFactory
 
-          helper_method :questionnaire_for, :questionnaire, :allow_answers?, :visitor_can_answer?, :visitor_already_answered?, :update_url, :form_url
+          helper_method :questionnaire_for, :questionnaire, :allow_answers?, :visitor_can_answer?, :visitor_already_answered?, :update_url, :form_path
 
           invisible_captcha on_spam: :spam_detected
 
@@ -81,13 +81,13 @@ module Decidim
             url_for([questionnaire_for, action: :answer])
           end
 
-          # Points to the shortest URL accessing the current form. This will be
+          # Points to the shortest path accessing the current form. This will be
           # used to detect whether a user is leaving the form with some partial
           # answers, so that we can warn them.
           #
           # Overwrite this method at the controller.
-          def form_url
-            url_for([questionnaire_for])
+          def form_path
+            url_for([questionnaire_for, only_path: true])
           end
 
           # Public: Method to be implemented at the controller. You need to

--- a/decidim-forms/app/views/decidim/forms/questionnaires/show.html.erb
+++ b/decidim-forms/app/views/decidim/forms/questionnaires/show.html.erb
@@ -40,7 +40,7 @@
                   </div>
                 <% end %>
 
-                <%= decidim_form_for(@form, url: update_url, method: :post, html: { class: "form answer-questionnaire" }) do |form| %>
+                <%= decidim_form_for(@form, url: update_url, method: :post, html: { class: "form answer-questionnaire" }, data: { "safe-url" => form_url }) do |form| %>
                   <%= invisible_captcha %>
                   <% answer_idx = 0 %>
                   <% cleaned_answer_idx = 0 %>

--- a/decidim-forms/app/views/decidim/forms/questionnaires/show.html.erb
+++ b/decidim-forms/app/views/decidim/forms/questionnaires/show.html.erb
@@ -40,7 +40,7 @@
                   </div>
                 <% end %>
 
-                <%= decidim_form_for(@form, url: update_url, method: :post, html: { class: "form answer-questionnaire" }, data: { "safe-url" => form_url }) do |form| %>
+                <%= decidim_form_for(@form, url: update_url, method: :post, html: { class: "form answer-questionnaire" }, data: { "safe-path" => form_path }) do |form| %>
                   <%= invisible_captcha %>
                   <% answer_idx = 0 %>
                   <% cleaned_answer_idx = 0 %>

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
@@ -35,7 +35,9 @@ shared_examples_for "has questionnaire" do
 
       check "questionnaire_tos_agreement"
 
-      accept_confirm { click_button "Submit" }
+      accept_confirm do
+        click_button "Submit"
+      end
 
       within ".success.flash" do
         expect(page).to have_content("successfully")

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
@@ -102,6 +102,18 @@ shared_examples_for "has questionnaire" do
       end
     end
 
+    it "requires confirmation when exiting mid-answering" do
+      visit questionnaire_public_path
+
+      fill_in question.body["en"], with: "My first answer"
+
+      dismiss_confirm do
+        page.find(".logo-wrapper a").click
+      end
+
+      expect(page).to have_current_path main_component_path(component)
+    end
+
     context "when the questionnaire has already been answered by someone else" do
       let!(:question) do
         create(

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
@@ -113,7 +113,7 @@ shared_examples_for "has questionnaire" do
         page.find(".logo-wrapper a").click
       end
 
-      expect(page).to have_current_path questionnaire_public_path(component)
+      expect(page).to have_current_path questionnaire_public_path
     end
 
     context "when the questionnaire has already been answered by someone else" do

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
@@ -113,7 +113,7 @@ shared_examples_for "has questionnaire" do
         page.find(".logo-wrapper a").click
       end
 
-      expect(page).to have_current_path main_component_path(component)
+      expect(page).to have_current_path questionnaire_public_path(component)
     end
 
     context "when the questionnaire has already been answered by someone else" do

--- a/decidim-surveys/app/controllers/decidim/surveys/surveys_controller.rb
+++ b/decidim-surveys/app/controllers/decidim/surveys/surveys_controller.rb
@@ -5,6 +5,7 @@ module Decidim
     # Exposes the survey resource so users can view and answer them.
     class SurveysController < Decidim::Surveys::ApplicationController
       include Decidim::Forms::Concerns::HasQuestionnaire
+      include Decidim::ComponentPathHelper
       helper Decidim::Surveys::SurveyHelper
 
       delegate :allow_answers?, :allow_unregistered?, to: :current_settings
@@ -17,6 +18,10 @@ module Decidim
 
       def questionnaire_for
         survey
+      end
+
+      def form_url
+        main_component_url(current_component)
       end
 
       private

--- a/decidim-surveys/app/controllers/decidim/surveys/surveys_controller.rb
+++ b/decidim-surveys/app/controllers/decidim/surveys/surveys_controller.rb
@@ -20,8 +20,8 @@ module Decidim
         survey
       end
 
-      def form_url
-        main_component_url(current_component)
+      def form_path
+        main_component_path(current_component)
       end
 
       private


### PR DESCRIPTION
#### :tophat: What? Why?
Adapts the work on #5765 for surveys.

#### :pushpin: Related Issues
- Related to #5728

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/491891/82816596-b874c000-9e9b-11ea-8220-41a46b59e846.png)

