### PR TITLE
Order checkout edge case fix with minimum project rule

### DIFF
--- a/decidim-budgets/app/models/decidim/budgets/order.rb
+++ b/decidim-budgets/app/models/decidim/budgets/order.rb
@@ -44,9 +44,11 @@ module Decidim
 
       # Public: Check if the order total budget is enough to checkout
       def can_checkout?
-        return minimum_projects <= projects.count if minimum_projects_rule?
-
-        total_budget.to_f >= minimum_budget
+        if minimum_projects_rule?
+          projects.count >= minimum_projects
+        else
+          total_budget.to_f >= minimum_budget
+        end
       end
 
       # Public: Returns the order budget percent from the settings total budget
@@ -56,7 +58,8 @@ module Decidim
 
       # Public: Returns the required minimum budget to checkout
       def minimum_budget
-        return 0 unless component || minimum_projects_rule?
+        return 0 unless component
+        return 0 if minimum_projects_rule?
 
         component.settings.total_budget.to_f * (component.settings.vote_threshold_percent.to_f / 100)
       end

--- a/decidim-budgets/spec/models/order_spec.rb
+++ b/decidim-budgets/spec/models/order_spec.rb
@@ -2,46 +2,71 @@
 
 require "spec_helper"
 
+shared_examples "an order" do
+  describe "validations" do
+    it "is valid" do
+      expect(subject).to be_valid
+    end
+
+    it "is invalid when user is not present" do
+      subject.user = nil
+      expect(subject).to be_invalid
+    end
+
+    it "is invalid when component is not present" do
+      subject.component = nil
+      expect(subject).to be_invalid
+    end
+
+    it "is unique for each user and component" do
+      subject.save
+      new_order = build :order, user: subject.user, component: subject.component
+      expect(new_order).to be_invalid
+    end
+
+    it "can't exceed a maximum order value" do
+      project1 = create(:project, component: subject.component, budget: 100)
+      project2 = create(:project, component: subject.component, budget: 20)
+
+      subject.projects << project1
+      subject.projects << project2
+
+      subject.component.settings = {
+        "total_budget" => 100, "vote_threshold" => 50
+      }
+
+      expect(subject).to be_invalid
+    end
+  end
+
+  describe "#total_budget" do
+    it "returns the sum of project budgets" do
+      subject.projects << build(:project, component: subject.component)
+
+      expect(subject.total_budget).to eq(subject.projects.sum(&:budget))
+    end
+  end
+
+  describe "#checked_out?" do
+    it "returns true if the checked_out_at attribute is present" do
+      subject.checked_out_at = Time.current
+      expect(subject).to be_checked_out
+    end
+  end
+end
+
 module Decidim::Budgets
   describe Order do
     subject { order }
 
-    let!(:order) { create :order, component: create(:budget_component) }
+    let(:component) { create :budget_component, voting_rule }
+    let(:order) { create :order, component: component }
+    let(:voting_rule) { :with_total_budget_and_vote_threshold_percent }
 
-    describe "validations" do
-      it "is valid" do
-        expect(subject).to be_valid
-      end
+    describe "with component with a vote threshold percent rule" do
+      let!(:order) { create :order, component: component }
 
-      it "is invalid when user is not present" do
-        subject.user = nil
-        expect(subject).to be_invalid
-      end
-
-      it "is invalid when component is not present" do
-        subject.component = nil
-        expect(subject).to be_invalid
-      end
-
-      it "is unique for each user and component" do
-        subject.save
-        new_order = build :order, user: subject.user, component: subject.component
-        expect(new_order).to be_invalid
-      end
-
-      it "can't exceed a maximum order value" do
-        project1 = create(:project, component: subject.component, budget: 100)
-        project2 = create(:project, component: subject.component, budget: 20)
-
-        subject.projects << project1
-        subject.projects << project2
-
-        subject.component.settings = {
-          "total_budget" => 100, "vote_threshold" => 50
-        }
-
-        expect(subject).to be_invalid
-      end
+      it_behaves_like "an order"
 
       it "can't be lower than a minimum order value when checked out" do
         project1 = create(:project, component: subject.component, budget: 20)
@@ -58,18 +83,31 @@ module Decidim::Budgets
       end
     end
 
-    describe "#total_budget" do
-      it "returns the sum of project budgets" do
-        subject.projects << build(:project, component: subject.component)
+    describe "with component with a minimum projects rule" do
+      let!(:order) { create :order, component: component }
+      let(:voting_rule) { :with_total_budget_and_minimum_budget_projects }
+      let(:vote_minimum_budget_projects_number) { 5 }
 
-        expect(subject.total_budget).to eq(subject.projects.sum(&:budget))
-      end
-    end
+      it_behaves_like "an order"
 
-    describe "#checked_out?" do
-      it "returns true if the checked_out_at attribute is present" do
+      it "can't be lower than a minimum projects number when checked out" do
+        project1 = create(:project, component: subject.component, budget: 100)
+
+        subject.projects << project1
+
+        expect(subject).to be_valid
         subject.checked_out_at = Time.current
-        expect(subject).to be_checked_out
+        expect(subject).to be_invalid
+      end
+
+      it "has to reach the minimum projects number when checked out" do
+        projects = create_list(:project, 3, component: component, budget: 100)
+
+        subject.projects << projects
+
+        expect(subject).to be_valid
+        subject.checked_out_at = Time.current
+        expect(subject).to be_valid
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

Fixes an edge case in decidim-budgets in the order checkout, when the minimum project rule is enabled. It also adds more specs. 

Found while developing Budgets complex votings #5993

#### :pushpin: Related Issues
- Related to #5865

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [x] Add tests


### :camera: Screenshots (optional)
![Description](URL)
