### PR TITLE
Add from label to organization form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Due to [\#5553](https://github.com/decidim/decidim/pull/5553), SSL is turned on 
 
 ### Added
 
+- **decidim-system**: Add from_label to Organization SMTP settings. [#\6122](https://github.com/decidim/decidim/pull/6122)
 - **decidim-proposals**: Improve proposal preview: Use proposal card when previewing a proposal draft. [\#6064](https://github.com/decidim/decidim/pull/6064)
 - **decidim-core**: Allow groups to have private conversations with other users or groups. [\#6009](https://github.com/decidim/decidim/pull/6009)
 - **decidim-api**: Use organization time zone [\#6088](https://github.com/decidim/decidim/pull/6088)

--- a/decidim-system/app/forms/decidim/system/update_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/update_organization_form.rb
@@ -20,6 +20,8 @@ module Decidim
       attribute :users_registration_mode, String
       jsonb_attribute :smtp_settings, [
         [:from, String],
+        [:from_email, String],
+        [:from_label, String],
         [:user_name, String],
         [:encrypted_password, String],
         [:address, String],
@@ -70,7 +72,15 @@ module Decidim
       end
 
       def encrypted_smtp_settings
+        set_from
+
         smtp_settings.merge(encrypted_password: Decidim::AttributeEncryptor.encrypt(@password))
+      end
+
+      def set_from
+        email = smtp_settings["from_email"]
+        label = smtp_settings["from_label"].presence || email
+        smtp_settings["from"] = "#{label} <#{email}>"
       end
 
       def encrypted_omniauth_settings

--- a/decidim-system/app/views/decidim/system/organizations/_smtp_settings.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/_smtp_settings.html.erb
@@ -2,7 +2,11 @@
   <h4><%= t("decidim.system.models.organization.fields.smtp_settings") %></h4>
   <%= f.fields_for :smtp_settings do %>
     <div class="field">
-      <%= f.email_field :from %>
+      <%= f.email_field :from_email, placeholder: t(".placeholder.from_email") %>
+    </div>
+    <div class="field">
+      <%= f.email_field :from_label, placeholder: t(".placeholder.from_label") %>
+      <p><%= t(".instructions.from_label") %></p>
     </div>
     <div class="field">
       <%= f.text_field :user_name %>

--- a/decidim-system/config/locales/en.yml
+++ b/decidim-system/config/locales/en.yml
@@ -52,6 +52,12 @@ en:
             smtp_settings: SMTP settings
           name: Organization
       organizations:
+        smtp_settings:
+          placeholder:
+            from_email: your-organization@your-provider.org
+            from_label: your-organization-name
+          instructions:
+            from_label: "Email sender will be: \"your-organization-name <your-organization@your-provider.org>\". Leave blank to use the 'from_email' as label"
         create:
           error: There was a problem creating a new organization.
           success: Organization successfully created.

--- a/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
@@ -13,6 +13,8 @@ module Decidim
         let(:command) { described_class.new(form) }
 
         context "when the form is valid" do
+          let(:from_label) { "Decide Gotham" }
+
           let(:params) do
             {
               name: "Gotham City",
@@ -30,7 +32,8 @@ module Decidim
                 "port" => "25",
                 "user_name" => "f.laguardia",
                 "password" => Decidim::AttributeEncryptor.encrypt("password"),
-                "from" => "decide@gotham.gov"
+                "from_email" => "decide@gotham.gov",
+                "from_label" => from_label
               },
               omniauth_settings_facebook_enabled: true,
               omniauth_settings_facebook_app_id: "facebook-app-id",
@@ -49,7 +52,7 @@ module Decidim
             expect(organization.name).to eq("Gotham City")
             expect(organization.host).to eq("decide.gotham.gov")
             expect(organization.secondary_hosts).to match_array(["foo.gotham.gov", "bar.gotham.gov"])
-
+            expect(organization.smtp_settings["from"]).to eq("Decide Gotham <decide@gotham.gov>")
             expect(organization.omniauth_settings["omniauth_settings_facebook_enabled"]).to eq(true)
             expect(
               Decidim::AttributeEncryptor.decrypt(organization.omniauth_settings["omniauth_settings_facebook_app_id"])
@@ -96,6 +99,19 @@ module Decidim
 
             expect(organization.tos_version).not_to be_nil
             expect(organization.tos_version).to eq(tos_page.updated_at)
+          end
+
+          describe "encrypted smtp settings" do
+            context "when from_label is empty" do
+              let(:from_label) { "" }
+
+              it "sets the label from email" do
+                command.call
+                organization = Organization.last
+
+                expect(organization.smtp_settings["from"]).to eq("decide@gotham.gov <decide@gotham.gov>")
+              end
+            end
           end
         end
 

--- a/decidim-system/spec/commands/decidim/system/update_organization_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/update_organization_spec.rb
@@ -14,6 +14,7 @@ module Decidim
         let(:command) { described_class.new(organization.id, form) }
 
         context "when the form is valid" do
+          let(:from_label) { "Decide Gotham" }
           let(:params) do
             {
               name: "Gotham City",
@@ -21,6 +22,14 @@ module Decidim
               secondary_hosts: "foo.gotham.gov\r\n\r\nbar.gotham.gov",
               force_users_to_authenticate_before_access_organization: false,
               users_registration_mode: "existing",
+              smtp_settings: {
+                "address" => "mail.gotham.gov",
+                "port" => "25",
+                "user_name" => "f.laguardia",
+                "password" => Decidim::AttributeEncryptor.encrypt("password"),
+                "from_email" => "decide@gotham.gov",
+                "from_label" => from_label
+              },
               omniauth_settings_facebook_enabled: true,
               omniauth_settings_facebook_app_id: "facebook-app-id",
               omniauth_settings_facebook_app_secret: "facebook-app-secret"
@@ -39,7 +48,7 @@ module Decidim
             expect(organization.host).to eq("decide.gotham.gov")
             expect(organization.secondary_hosts).to match_array(["foo.gotham.gov", "bar.gotham.gov"])
             expect(organization.users_registration_mode).to eq("existing")
-
+            expect(organization.smtp_settings["from"]).to eq("Decide Gotham <decide@gotham.gov>")
             expect(organization.omniauth_settings["omniauth_settings_facebook_enabled"]).to eq(true)
             expect(
               Decidim::AttributeEncryptor.decrypt(organization.omniauth_settings["omniauth_settings_facebook_app_id"])
@@ -47,6 +56,19 @@ module Decidim
             expect(
               Decidim::AttributeEncryptor.decrypt(organization.omniauth_settings["omniauth_settings_facebook_app_secret"])
             ).to eq("facebook-app-secret")
+          end
+
+          describe "encrypted smtp settings" do
+            context "when from_label is empty" do
+              let(:from_label) { "" }
+
+              it "sets the label from email" do
+                command.call
+                organization = Organization.last
+
+                expect(organization.smtp_settings["from"]).to eq("decide@gotham.gov <decide@gotham.gov>")
+              end
+            end
           end
         end
 

--- a/decidim-system/spec/forms/decidim/system/update_organization_form_spec.rb
+++ b/decidim-system/spec/forms/decidim/system/update_organization_form_spec.rb
@@ -21,7 +21,8 @@ module Decidim::System
           "port" => "25",
           "user_name" => "f.laguardia",
           "password" => Decidim::AttributeEncryptor.encrypt("password"),
-          "from" => "decide@gotham.gov"
+          "from_email" => "decide@gotham.gov",
+          "from_label" => "Decide Gotham"
         },
         omniauth_settings: {
           "omniauth_settings_facebook_enabled" => true,


### PR DESCRIPTION
#### :tophat: What? Why?
When configuring SMTP settings for a tenant, we can just configure the sender email adress, but not the label of the sender.

This dev is already available on OSP v0.18. Describe the solution you'd like

As a super admin, when configuring SMTP settings in /system, I want to be able to enter a "From label" so the participants receiving notifications can easily identify the platform.


#### :pushpin: Related Issues
- Related to https://meta.decidim.org/processes/roadmap/f/122/proposals/15281

#### :clipboard: Subtasks
- [X] Add `CHANGELOG` entry
- [x] Add tests
