### PR TITLE
Fix a flaky test in group profile conversations

### DIFF
--- a/decidim-core/spec/system/messaging/profile_conversations_spec.rb
+++ b/decidim-core/spec/system/messaging/profile_conversations_spec.rb
@@ -272,18 +272,14 @@ describe "ProfileConversations", type: :system do
         before do
           visit_profile_inbox
           click_link "conversation-#{conversation.id}"
-        end
-
-        it "show the sending form" do
-          expect(page).to have_selector("textarea#message_body")
-        end
-
-        it "sends a message", :slow do
-          fill_in "message_body", with: "Please reply!"
           expect(page).to have_content("Send")
+          fill_in "message_body", with: "Please reply!"
           click_button "Send"
+        end
 
-          expect(page).to have_selector("#messages .conversation-chat:last-child", text: "Please reply!")
+        it "appears as the last message", :slow do
+          click_button "Send"
+          expect(page).to have_selector(".conversation-chat:last-child", text: "Please reply!")
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

It seems that #5681 introduced a flaky test. This changes the test in profile conversations to behave exactly as the normal conversations.

#### :pushpin: Related Issues
- Related to #5681 
