### PR TITLE
Fix a flaky test in admin manages newsletters

### DIFF
--- a/decidim-admin/spec/system/admin_manages_newsletters_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_newsletters_spec.rb
@@ -168,7 +168,6 @@ describe "Admin manages newsletters", type: :system do
             accept_confirm { find("*", text: "Deliver").click }
           end
 
-          # page.execute_script "window.scrollBy(0,10000)"
           expect(page).to have_content("NEWSLETTERS")
           expect(page).to have_admin_callout("successfully")
         end
@@ -209,8 +208,7 @@ describe "Admin manages newsletters", type: :system do
             accept_confirm { find("*", text: "Deliver").click }
           end
 
-          # page.execute_script "window.scrollBy(0,10000)"
-          # expect(page).to have_content("NEWSLETTERS")
+          expect(page).to have_content("NEWSLETTERS")
           expect(page).to have_admin_callout("successfully")
         end
 
@@ -230,7 +228,7 @@ describe "Admin manages newsletters", type: :system do
         end
       end
 
-      it "sends to participants" do
+      it "sends to participants", :slow do
         visit decidim_admin.select_recipients_to_deliver_newsletter_path(newsletter)
         perform_enqueued_jobs do
           within(".newsletter_deliver") do
@@ -250,11 +248,7 @@ describe "Admin manages newsletters", type: :system do
             accept_confirm { find("*", text: "Deliver").click }
           end
 
-          within ".secondary-nav__title" do
-            expect(page).to have_content("NEWSLETTERS")
-          end
-          # page.execute_script "window.scrollBy(0,10000)"
-          # expect(page).to have_content("NEWSLETTERS")
+          expect(page).to have_content("NEWSLETTERS")
           expect(page).to have_admin_callout("successfully")
         end
 
@@ -281,7 +275,7 @@ describe "Admin manages newsletters", type: :system do
         end
       end
 
-      it "sends to followers and participants" do
+      it "sends to followers and participants", :slow do
         visit decidim_admin.select_recipients_to_deliver_newsletter_path(newsletter)
         perform_enqueued_jobs do
           within(".newsletter_deliver") do
@@ -301,7 +295,6 @@ describe "Admin manages newsletters", type: :system do
             accept_confirm { find("*", text: "Deliver").click }
           end
 
-          page.execute_script "window.scrollBy(0,10000)"
           expect(page).to have_content("NEWSLETTERS")
           expect(page).to have_admin_callout("successfully")
         end

--- a/decidim-admin/spec/system/admin_manages_newsletters_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_newsletters_spec.rb
@@ -168,13 +168,14 @@ describe "Admin manages newsletters", type: :system do
             accept_confirm { find("*", text: "Deliver").click }
           end
 
-          within ".secondary-nav__title" do
+          # using find here should wait until the element appears
+          within find(".secondary-nav__title") do
             expect(page).to have_content("NEWSLETTERS")
           end
-          # page.execute_script "window.scrollBy(0,10000)"
-          # expect(page).to have_content("NEWSLETTERS")
-          expect(page).to have_admin_callout("successfully")
         end
+        # page.execute_script "window.scrollBy(0,10000)"
+        # expect(page).to have_content("NEWSLETTERS")
+        expect(page).to have_admin_callout("successfully")
 
         within "tbody" do
           expect(page).to have_content("Has been sent to: All users")

--- a/decidim-admin/spec/system/admin_manages_newsletters_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_newsletters_spec.rb
@@ -168,7 +168,11 @@ describe "Admin manages newsletters", type: :system do
             accept_confirm { find("*", text: "Deliver").click }
           end
 
-          expect(page).to have_content("NEWSLETTERS")
+          within ".secondary-nav__title" do
+            expect(page).to have_content("NEWSLETTERS")
+          end
+          # page.execute_script "window.scrollBy(0,10000)"
+          # expect(page).to have_content("NEWSLETTERS")
           expect(page).to have_admin_callout("successfully")
         end
 
@@ -208,7 +212,11 @@ describe "Admin manages newsletters", type: :system do
             accept_confirm { find("*", text: "Deliver").click }
           end
 
-          expect(page).to have_content("NEWSLETTERS")
+          within ".secondary-nav__title" do
+            expect(page).to have_content("NEWSLETTERS")
+          end
+          # page.execute_script "window.scrollBy(0,10000)"
+          # expect(page).to have_content("NEWSLETTERS")
           expect(page).to have_admin_callout("successfully")
         end
 
@@ -248,7 +256,11 @@ describe "Admin manages newsletters", type: :system do
             accept_confirm { find("*", text: "Deliver").click }
           end
 
-          expect(page).to have_content("NEWSLETTERS")
+          within ".secondary-nav__title" do
+            expect(page).to have_content("NEWSLETTERS")
+          end
+          # page.execute_script "window.scrollBy(0,10000)"
+          # expect(page).to have_content("NEWSLETTERS")
           expect(page).to have_admin_callout("successfully")
         end
 
@@ -295,6 +307,7 @@ describe "Admin manages newsletters", type: :system do
             accept_confirm { find("*", text: "Deliver").click }
           end
 
+          page.execute_script "window.scrollBy(0,10000)"
           expect(page).to have_content("NEWSLETTERS")
           expect(page).to have_admin_callout("successfully")
         end

--- a/decidim-admin/spec/system/admin_manages_newsletters_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_newsletters_spec.rb
@@ -153,7 +153,7 @@ describe "Admin manages newsletters", type: :system do
     context "when all users are selected" do
       let(:recipients_count) { deliverable_users.size }
 
-      it "sends to all users" do
+      it "sends to all users", :slow do
         visit decidim_admin.select_recipients_to_deliver_newsletter_path(newsletter)
         perform_enqueued_jobs do
           within(".newsletter_deliver") do
@@ -168,14 +168,10 @@ describe "Admin manages newsletters", type: :system do
             accept_confirm { find("*", text: "Deliver").click }
           end
 
-          # using find here should wait until the element appears
-          within find(".secondary-nav__title") do
-            expect(page).to have_content("NEWSLETTERS")
-          end
+          # page.execute_script "window.scrollBy(0,10000)"
+          expect(page).to have_content("NEWSLETTERS")
+          expect(page).to have_admin_callout("successfully")
         end
-        # page.execute_script "window.scrollBy(0,10000)"
-        # expect(page).to have_content("NEWSLETTERS")
-        expect(page).to have_admin_callout("successfully")
 
         within "tbody" do
           expect(page).to have_content("Has been sent to: All users")
@@ -193,7 +189,7 @@ describe "Admin manages newsletters", type: :system do
       end
       let(:recipients_count) { followers.size }
 
-      it "sends to followers" do
+      it "sends to followers", :slow do
         visit decidim_admin.select_recipients_to_deliver_newsletter_path(newsletter)
         perform_enqueued_jobs do
           within(".newsletter_deliver") do
@@ -213,9 +209,6 @@ describe "Admin manages newsletters", type: :system do
             accept_confirm { find("*", text: "Deliver").click }
           end
 
-          within ".secondary-nav__title" do
-            expect(page).to have_content("NEWSLETTERS")
-          end
           # page.execute_script "window.scrollBy(0,10000)"
           # expect(page).to have_content("NEWSLETTERS")
           expect(page).to have_admin_callout("successfully")


### PR DESCRIPTION
#### :tophat: What? Why?

It seems that after merged PRs #5888 or #6096 it could have introduced a flaky test. 
This changes the test in admin manages newsletters to resolve it.

#### :pushpin: Related Issues
- Related to #5888 or #6096 

### :camera: Screenshots (optional)

![image](https://user-images.githubusercontent.com/9702463/83153167-ee65ae80-a0fe-11ea-8d12-c46d5382feb5.png)
