### PR TITLE
Fix form_builder required hint next to label when rich editor enabled in public views

### DIFF
--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -181,7 +181,7 @@ module Decidim
 
       content_tag(:div, class: "editor #{"hashtags__container" if options[:hashtaggable]}") do
         template = ""
-        template += label(name, options[:label].to_s || name) + required_for_attribute(name) if options[:label] != false
+        template += label(name, label_for(name) + required_for_attribute(name)) unless options[:label] == false
         template += hidden_field(name, options)
         template += content_tag(:div, nil, class: "editor-container #{"js-hashtags" if options[:hashtaggable]}", data: {
                                   toolbar: options[:toolbar],

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -181,7 +181,7 @@ module Decidim
 
       content_tag(:div, class: "editor #{"hashtags__container" if options[:hashtaggable]}") do
         template = ""
-        template += label(name, label_for(name) + required_for_attribute(name)) unless options[:label] == false
+        template += label(name, label_for(name) + required_for_attribute(name)) if options.fetch(:label, true)
         template += hidden_field(name, options)
         template += content_tag(:div, nil, class: "editor-container #{"js-hashtags" if options[:hashtaggable]}", data: {
                                   toolbar: options[:toolbar],


### PR DESCRIPTION
#### :tophat: What? Why?

Fixes a PX issue, when rich text editor is enabled in public views and required, the asterisk appears below the label instead of beside.

See screenshots.

#### :pushpin: Related Issues
- Related to #6095


#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry

### :camera: Screenshots (optional)

When in the Admin rich text editor is enabled:
<img width="594" alt="admin_rich_text_enabled" src="https://user-images.githubusercontent.com/210216/83173697-94bead80-a119-11ea-80a3-672a03826977.png">

- Before:  
  <img width="560" alt="before_rich_text_hint" src="https://user-images.githubusercontent.com/210216/83173789-b61f9980-a119-11ea-95e8-0b66ba29be91.png">
- After:  
  <img width="556" alt="after_rich_text_hint" src="https://user-images.githubusercontent.com/210216/83173841-c6d00f80-a119-11ea-99bc-75cf894e2649.png">

 

