### PR TITLE
Fix undefined method includes for Array

### DIFF
--- a/decidim-core/app/helpers/decidim/check_boxes_tree_helper.rb
+++ b/decidim-core/app/helpers/decidim/check_boxes_tree_helper.rb
@@ -83,9 +83,9 @@ module Decidim
     end
 
     def filter_scopes_values
-      main_scopes = current_participatory_space.scope.present? ? [current_participatory_space.scope] : current_participatory_space.scopes.top_level
+      main_scopes = current_participatory_space.scope.present? ? [current_participatory_space.scope] : current_participatory_space.scopes.top_level.includes(:scope_type, :children)
 
-      scopes_values = main_scopes.includes(:scope_type, :children).flat_map do |scope|
+      scopes_values = main_scopes.flat_map do |scope|
         TreeNode.new(
           TreePoint.new(scope.id.to_s, translated_attribute(scope.name, current_participatory_space.organization)),
           scope_children_to_tree(scope)


### PR DESCRIPTION
#### :tophat: What? Why?

When setting a scope for a Participatory Process and visiting the public view index of Proposals, raises an undefined method includes for array, so this PR fixes this and removes the `includes` from the array.

#### :pushpin: Related Issues
- Related to #?


#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
<img width="1033" alt="bug_undefined_method_include" src="https://user-images.githubusercontent.com/210216/83237650-8615dc00-a195-11ea-90b8-9e1d553c17a5.png">

