### PR TITLE
Identify translatable resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,8 @@ The use case that originated this change is the persistence of the user's gender
 - **decidim-initiatives**: Allow admins to export initiatives [\#6070](https://github.com/decidim/decidim/pull/6070)
 - **decidim-elections**: Add questions and answers to elections [\#6129](https://github.com/decidim/decidim/pull/6129)
 - **decidim-forms**: Request confirmation when leaving the form half-answered [\#6118](https://github.com/decidim/decidim/pull/6118)
+- **decidim-forms**: Request confirmation when leaving the form half-answered [\#6118](https://github.com/decidim/decidim/pull/6118)
+- **decidim-initiatives**: Allow admins to export initiatives [/#6070](https://github.com/decidim/decidim/pull/6070)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,8 +102,6 @@ The use case that originated this change is the persistence of the user's gender
 - **decidim-initiatives**: Allow admins to export initiatives [\#6070](https://github.com/decidim/decidim/pull/6070)
 - **decidim-elections**: Add questions and answers to elections [\#6129](https://github.com/decidim/decidim/pull/6129)
 - **decidim-forms**: Request confirmation when leaving the form half-answered [\#6118](https://github.com/decidim/decidim/pull/6118)
-- **decidim-forms**: Request confirmation when leaving the form half-answered [\#6118](https://github.com/decidim/decidim/pull/6118)
-- **decidim-initiatives**: Allow admins to export initiatives [/#6070](https://github.com/decidim/decidim/pull/6070)
 
 ### Changed
 

--- a/decidim-accountability/app/models/decidim/accountability/result.rb
+++ b/decidim-accountability/app/models/decidim/accountability/result.rb
@@ -16,8 +16,11 @@ module Decidim
       include Decidim::DataPortability
       include Decidim::Randomable
       include Decidim::Searchable
+      include Decidim::TranslatableResource
 
       component_manifest_name "accountability"
+
+      translatable_fields :title, :description
 
       has_many :children, foreign_key: "parent_id", class_name: "Decidim::Accountability::Result", inverse_of: :parent, dependent: :destroy
       belongs_to :parent, foreign_key: "parent_id", class_name: "Decidim::Accountability::Result", inverse_of: :children, optional: true, counter_cache: :children_count

--- a/decidim-accountability/app/models/decidim/accountability/status.rb
+++ b/decidim-accountability/app/models/decidim/accountability/status.rb
@@ -6,8 +6,11 @@ module Decidim
     # key, a localized name, a localized description and and associated progress number.
     class Status < Accountability::ApplicationRecord
       include Decidim::HasComponent
+      include Decidim::TranslatableResource
 
       component_manifest_name "accountability"
+
+      translatable_fields :name, :description
 
       has_many :results, foreign_key: "decidim_accountability_status_id", class_name: "Decidim::Accountability::Result", inverse_of: :status, dependent: :nullify
 

--- a/decidim-accountability/app/models/decidim/accountability/timeline_entry.rb
+++ b/decidim-accountability/app/models/decidim/accountability/timeline_entry.rb
@@ -5,6 +5,9 @@ module Decidim
     # The data store for a TimelineEntry for a Result in the Decidim::Accountability component.
     # It stores a date, and localized description.
     class TimelineEntry < Accountability::ApplicationRecord
+      include Decidim::TranslatableResource
+
+      translatable_fields :description
       belongs_to :result, foreign_key: "decidim_accountability_result_id", class_name: "Decidim::Accountability::Result", inverse_of: :timeline_entries
     end
   end

--- a/decidim-assemblies/app/models/decidim/assemblies_type.rb
+++ b/decidim-assemblies/app/models/decidim/assemblies_type.rb
@@ -5,6 +5,9 @@ module Decidim
   class AssembliesType < ApplicationRecord
     include Decidim::Traceable
     include Decidim::Loggable
+    include Decidim::TranslatableResource
+
+    translatable_fields :title
 
     belongs_to :organization,
                foreign_key: "decidim_organization_id",

--- a/decidim-assemblies/app/models/decidim/assembly.rb
+++ b/decidim-assemblies/app/models/decidim/assembly.rb
@@ -32,9 +32,14 @@ module Decidim
     include Decidim::ParticipatorySpaceResourceable
     include Decidim::HasPrivateUsers
     include Decidim::Searchable
+    include Decidim::TranslatableResource
 
     SOCIAL_HANDLERS = [:twitter, :facebook, :instagram, :youtube, :github].freeze
     CREATED_BY = %w(city_council public others).freeze
+
+    translatable_fields :title, :subtitle, :short_description, :description, :developer_group, :meta_scope, :local_area,
+                        :target, :participatory_scope, :participatory_structure, :purpose_of_action, :composition, :created_by_other, :closing_date_reason,
+                        :internal_organisation, :special_features
 
     belongs_to :organization,
                foreign_key: "decidim_organization_id",

--- a/decidim-assemblies/app/models/decidim/assembly.rb
+++ b/decidim-assemblies/app/models/decidim/assembly.rb
@@ -38,8 +38,8 @@ module Decidim
     CREATED_BY = %w(city_council public others).freeze
 
     translatable_fields :title, :subtitle, :short_description, :description, :developer_group, :meta_scope, :local_area,
-                        :target, :participatory_scope, :participatory_structure, :purpose_of_action, :composition, :created_by_other, :closing_date_reason,
-                        :internal_organisation, :special_features
+                        :target, :participatory_scope, :participatory_structure, :purpose_of_action, :composition, :created_by_other,
+                        :closing_date_reason, :internal_organisation, :special_features
 
     belongs_to :organization,
                foreign_key: "decidim_organization_id",

--- a/decidim-blogs/app/models/decidim/blogs/post.rb
+++ b/decidim-blogs/app/models/decidim/blogs/post.rb
@@ -14,10 +14,13 @@ module Decidim
       include Decidim::Searchable
       include Decidim::Endorsable
       include Decidim::Followable
+      include Decidim::TranslatableResource
       include Traceable
       include Loggable
 
       component_manifest_name "blogs"
+
+      translatable_fields :title, :body
 
       validates :title, presence: true
 

--- a/decidim-budgets/app/models/decidim/budgets/project.rb
+++ b/decidim-budgets/app/models/decidim/budgets/project.rb
@@ -18,6 +18,9 @@ module Decidim
       include Decidim::Loggable
       include Decidim::Randomable
       include Decidim::Searchable
+      include Decidim::TranslatableResource
+
+      translatable_fields :title, :description
 
       component_manifest_name "budgets"
       has_many :line_items, class_name: "Decidim::Budgets::LineItem", foreign_key: "decidim_project_id", dependent: :destroy

--- a/decidim-conferences/app/controllers/decidim/conferences/admin/conferences_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/admin/conferences_controller.rb
@@ -9,12 +9,9 @@ module Decidim
         helper_method :current_conference, :current_participatory_space
         layout "decidim/admin/conferences"
         include Decidim::Conferences::Admin::Filterable
-        include Decidim::TranslatableResource
-
 
         def index
           enforce_permission_to :read, :conference_list
-          @list =Decidim::Conferences.translatable_attributes
           @conferences = filtered_collection
         end
 

--- a/decidim-conferences/app/controllers/decidim/conferences/admin/conferences_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/admin/conferences_controller.rb
@@ -9,9 +9,12 @@ module Decidim
         helper_method :current_conference, :current_participatory_space
         layout "decidim/admin/conferences"
         include Decidim::Conferences::Admin::Filterable
+        include Decidim::TranslatableResource
+
 
         def index
           enforce_permission_to :read, :conference_list
+          @list =Decidim::Conferences.translatable_attributes
           @conferences = filtered_collection
         end
 

--- a/decidim-conferences/app/forms/decidim/conferences/admin/conference_form.rb
+++ b/decidim-conferences/app/forms/decidim/conferences/admin/conference_form.rb
@@ -8,9 +8,6 @@ module Decidim
       #
       class ConferenceForm < Form
         include TranslatableAttributes
-        include TranslatableResource
-
-        translated_attributes :title
 
         translatable_attribute :title, String
         translatable_attribute :slogan, String

--- a/decidim-conferences/app/forms/decidim/conferences/admin/conference_form.rb
+++ b/decidim-conferences/app/forms/decidim/conferences/admin/conference_form.rb
@@ -8,6 +8,9 @@ module Decidim
       #
       class ConferenceForm < Form
         include TranslatableAttributes
+        include TranslatableResource
+
+        translated_attributes :title
 
         translatable_attribute :title, String
         translatable_attribute :slogan, String

--- a/decidim-conferences/app/models/decidim/conference.rb
+++ b/decidim-conferences/app/models/decidim/conference.rb
@@ -17,6 +17,10 @@ module Decidim
     include Decidim::Loggable
     include Decidim::ParticipatorySpaceResourceable
     include Decidim::Searchable
+    include Decidim::TranslatableResource
+
+    translatable_attributes :title
+
 
     belongs_to :organization,
                foreign_key: "decidim_organization_id",

--- a/decidim-conferences/app/models/decidim/conference.rb
+++ b/decidim-conferences/app/models/decidim/conference.rb
@@ -19,8 +19,7 @@ module Decidim
     include Decidim::Searchable
     include Decidim::TranslatableResource
 
-    translatable_attributes :title
-
+    translatable_fields :title, :slogan, :short_description, :description, :objectives, :registration_terms
 
     belongs_to :organization,
                foreign_key: "decidim_organization_id",

--- a/decidim-conferences/app/models/decidim/conference_speaker.rb
+++ b/decidim-conferences/app/models/decidim/conference_speaker.rb
@@ -6,6 +6,9 @@ module Decidim
   class ConferenceSpeaker < ApplicationRecord
     include Decidim::Traceable
     include Decidim::Loggable
+    include Decidim::TranslatableResource
+
+    translatable_fields :position, :affiliation, :short_bio
 
     belongs_to :user, foreign_key: "decidim_user_id", class_name: "Decidim::User", optional: true
     belongs_to :conference, foreign_key: "decidim_conference_id", class_name: "Decidim::Conference"

--- a/decidim-conferences/app/models/decidim/conferences/media_link.rb
+++ b/decidim-conferences/app/models/decidim/conferences/media_link.rb
@@ -6,6 +6,9 @@ module Decidim
     class MediaLink < ApplicationRecord
       include Decidim::Traceable
       include Decidim::Loggable
+      include Decidim::TranslatableResource
+
+      translatable_fields :title
 
       belongs_to :conference, foreign_key: "decidim_conference_id", class_name: "Decidim::Conference"
 

--- a/decidim-conferences/app/models/decidim/conferences/registration_type.rb
+++ b/decidim-conferences/app/models/decidim/conferences/registration_type.rb
@@ -7,6 +7,9 @@ module Decidim
       include Decidim::Publicable
       include Decidim::Traceable
       include Decidim::Loggable
+      include Decidim::TranslatableResource
+
+      translatable_fields :title, :description
 
       belongs_to :conference, foreign_key: "decidim_conference_id", class_name: "Decidim::Conference"
       has_many :conference_meeting_registration_types, dependent: :destroy

--- a/decidim-conferences/app/views/decidim/conferences/admin/conferences/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conferences/index.html.erb
@@ -19,9 +19,6 @@
         </thead>
         <tbody>
           <% @conferences.each do |conference| %>
-          <p> hihuuh </p>
-                              <% @list %>
-
             <tr>
               <td>
                 <% if conference.promoted? %>

--- a/decidim-conferences/app/views/decidim/conferences/admin/conferences/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conferences/index.html.erb
@@ -19,6 +19,9 @@
         </thead>
         <tbody>
           <% @conferences.each do |conference| %>
+          <p> hihuuh </p>
+                              <% @list %>
+
             <tr>
               <td>
                 <% if conference.promoted? %>

--- a/decidim-consultations/app/models/decidim/consultation.rb
+++ b/decidim-consultations/app/models/decidim/consultation.rb
@@ -12,6 +12,9 @@ module Decidim
     include Decidim::ParticipatorySpaceResourceable
     include Decidim::Randomable
     include Decidim::Searchable
+    include Decidim::TranslatableResource
+
+    translatable_fields :title, :subtitle, :description
 
     belongs_to :organization,
                foreign_key: "decidim_organization_id",

--- a/decidim-consultations/app/models/decidim/consultations/question.rb
+++ b/decidim-consultations/app/models/decidim/consultations/question.rb
@@ -16,6 +16,9 @@ module Decidim
       include Decidim::Loggable
       include Decidim::ParticipatorySpaceResourceable
       include Decidim::Randomable
+      include Decidim::TranslatableResource
+
+      translatable_fields :title, :subtitle, :what_is_decided, :promoter_group, :participatory_scope, :question_context, :origin_scope, :origin_title, :instructions
 
       belongs_to :consultation,
                  foreign_key: "decidim_consultation_id",

--- a/decidim-consultations/app/models/decidim/consultations/response.rb
+++ b/decidim-consultations/app/models/decidim/consultations/response.rb
@@ -3,6 +3,10 @@
 module Decidim
   module Consultations
     class Response < ApplicationRecord
+      include Decidim::TranslatableResource
+
+      translatable_fields :title
+
       belongs_to :question,
                  foreign_key: "decidim_consultations_questions_id",
                  class_name: "Decidim::Consultations::Question",

--- a/decidim-consultations/app/models/decidim/consultations/response_group.rb
+++ b/decidim-consultations/app/models/decidim/consultations/response_group.rb
@@ -3,6 +3,10 @@
 module Decidim
   module Consultations
     class ResponseGroup < ApplicationRecord
+      include Decidim::TranslatableResource
+
+      translatable_fields :title
+
       belongs_to :question,
                  foreign_key: "decidim_consultations_questions_id",
                  class_name: "Decidim::Consultations::Question",

--- a/decidim-core/app/models/decidim/area.rb
+++ b/decidim-core/app/models/decidim/area.rb
@@ -6,6 +6,9 @@ module Decidim
   class Area < ApplicationRecord
     include Traceable
     include Loggable
+    include Decidim::TranslatableResource
+
+    translatable_fields :name
 
     belongs_to :organization,
                foreign_key: "decidim_organization_id",

--- a/decidim-core/app/models/decidim/area_type.rb
+++ b/decidim-core/app/models/decidim/area_type.rb
@@ -4,6 +4,10 @@ module Decidim
   # Area types allows to use different types of areas in participatory space
   # (terriotrial, sectorial, etc.)
   class AreaType < ApplicationRecord
+    include Decidim::TranslatableResource
+
+    translatable_fields :name, :plural
+
     belongs_to :organization,
                foreign_key: "decidim_organization_id",
                class_name: "Decidim::Organization",

--- a/decidim-core/app/models/decidim/attachment.rb
+++ b/decidim-core/app/models/decidim/attachment.rb
@@ -4,6 +4,9 @@ module Decidim
   # Attachment can be any type of document or images related to a partcipatory
   # process.
   class Attachment < ApplicationRecord
+    include Decidim::TranslatableResource
+
+    translatable_fields :title, :description
     belongs_to :attachment_collection, class_name: "Decidim::AttachmentCollection", optional: true
     belongs_to :attached_to, polymorphic: true
 

--- a/decidim-core/app/models/decidim/attachment_collection.rb
+++ b/decidim-core/app/models/decidim/attachment_collection.rb
@@ -4,6 +4,9 @@ module Decidim
   # Categories serve as a taxonomy for attachments to use for while in the
   # context of a participatory space.
   class AttachmentCollection < ApplicationRecord
+    include Decidim::TranslatableResource
+
+    translatable_fields :name, :description
     belongs_to :collection_for, polymorphic: true
     has_many :attachments, foreign_key: "attachment_collection_id", class_name: "Decidim::Attachment", dependent: :nullify
 

--- a/decidim-core/app/models/decidim/category.rb
+++ b/decidim-core/app/models/decidim/category.rb
@@ -4,6 +4,10 @@ module Decidim
   # Categories serve as a taxonomy for components to use for while in the
   # context of a participatory process.
   class Category < ApplicationRecord
+    include Decidim::TranslatableResource
+
+    translatable_fields :name, :description
+
     belongs_to :participatory_space, foreign_key: "decidim_participatory_space_id", foreign_type: "decidim_participatory_space_type", polymorphic: true
     has_many :subcategories, foreign_key: "parent_id", class_name: "Decidim::Category", dependent: :destroy, inverse_of: :parent
     belongs_to :parent, class_name: "Decidim::Category", foreign_key: "parent_id", inverse_of: :subcategories, optional: true

--- a/decidim-core/app/models/decidim/contextual_help_section.rb
+++ b/decidim-core/app/models/decidim/contextual_help_section.rb
@@ -2,6 +2,10 @@
 
 module Decidim
   class ContextualHelpSection < ApplicationRecord
+    include Decidim::TranslatableResource
+
+    translatable_fields :content
+
     belongs_to :organization, class_name: "Decidim::Organization"
     validates :organization, presence: true
     validates :content, presence: true

--- a/decidim-core/app/models/decidim/newsletter.rb
+++ b/decidim-core/app/models/decidim/newsletter.rb
@@ -7,7 +7,7 @@ module Decidim
     include Decidim::Loggable
     include Decidim::TranslatableResource
 
-    translatable_fields :subject, :extended_data
+    translatable_fields :subject
 
     belongs_to :author, class_name: "User"
     belongs_to :organization

--- a/decidim-core/app/models/decidim/newsletter.rb
+++ b/decidim-core/app/models/decidim/newsletter.rb
@@ -5,6 +5,9 @@ module Decidim
   class Newsletter < ApplicationRecord
     include Decidim::Traceable
     include Decidim::Loggable
+    include Decidim::TranslatableResource
+
+    translatable_fields :subject, :extended_data
 
     belongs_to :author, class_name: "User"
     belongs_to :organization

--- a/decidim-core/app/models/decidim/organization.rb
+++ b/decidim-core/app/models/decidim/organization.rb
@@ -8,8 +8,14 @@ module Decidim
     include TranslationsHelper
     include Decidim::Traceable
     include Decidim::Loggable
+    include Decidim::TranslatableResource
 
     SOCIAL_HANDLERS = [:twitter, :facebook, :instagram, :youtube, :github].freeze
+
+    translatable_fields :description, :cta_button_text, :omnipresent_banner_title, :omnipresent_banner_short_description,
+                        :highlighted_content_banner_title, :highlighted_content_banner_short_description, :highlighted_content_banner_action_title,
+                        :highlighted_content_banner_action_subtitle, :welcome_notification_subject, :welcome_notification_body, :id_documents_explanation_text,
+                        :colors, :admin_terms_of_use_body
 
     has_many :static_pages, foreign_key: "decidim_organization_id", class_name: "Decidim::StaticPage", inverse_of: :organization, dependent: :destroy
     has_many :static_page_topics, foreign_key: "organization_id", class_name: "Decidim::StaticPageTopic", inverse_of: :organization, dependent: :destroy

--- a/decidim-core/app/models/decidim/resource_permission.rb
+++ b/decidim-core/app/models/decidim/resource_permission.rb
@@ -3,6 +3,10 @@
 module Decidim
   # A ResourcePermission allows to override component permissions for an specific resource.
   class ResourcePermission < ApplicationRecord
+    include Decidim::TranslatableResource
+
+    translatable_fields :permissions
+
     belongs_to :resource, polymorphic: true
   end
 end

--- a/decidim-core/app/models/decidim/scope.rb
+++ b/decidim-core/app/models/decidim/scope.rb
@@ -7,6 +7,9 @@ module Decidim
   class Scope < ApplicationRecord
     include Decidim::Traceable
     include Decidim::Loggable
+    include Decidim::TranslatableResource
+
+    translatable_fields :name
 
     belongs_to :organization,
                foreign_key: "decidim_organization_id",

--- a/decidim-core/app/models/decidim/scope_type.rb
+++ b/decidim-core/app/models/decidim/scope_type.rb
@@ -4,6 +4,9 @@ module Decidim
   # Scope types allows to use different types of scopes in participatory process
   # (municipalities, provinces, states, countries, etc.)
   class ScopeType < ApplicationRecord
+    include Decidim::TranslatableResource
+
+    translatable_fields :name, :plural
     belongs_to :organization,
                foreign_key: "decidim_organization_id",
                class_name: "Decidim::Organization",

--- a/decidim-core/app/models/decidim/static_page.rb
+++ b/decidim-core/app/models/decidim/static_page.rb
@@ -10,6 +10,9 @@ module Decidim
   class StaticPage < ApplicationRecord
     include Decidim::Traceable
     include Decidim::Loggable
+    include Decidim::TranslatableResource
+
+    translatable_fields :title, :content
 
     belongs_to :organization, foreign_key: "decidim_organization_id", class_name: "Decidim::Organization", inverse_of: :static_pages
     belongs_to :topic, foreign_key: "topic_id", class_name: "Decidim::StaticPageTopic", optional: true

--- a/decidim-core/app/models/decidim/static_page_topic.rb
+++ b/decidim-core/app/models/decidim/static_page_topic.rb
@@ -3,6 +3,9 @@
 module Decidim
   class StaticPageTopic < ApplicationRecord
     validates :title, presence: true
+    include Decidim::TranslatableResource
+
+    translatable_fields :title, :description
 
     default_scope { order(arel_table[:weight].asc) }
 

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -8,6 +8,7 @@ module Decidim
   autoload :Deprecations, "decidim/deprecations"
   autoload :ActsAsAuthor, "decidim/acts_as_author"
   autoload :TranslatableAttributes, "decidim/translatable_attributes"
+  autoload :TranslatableResource, "decidim/translatable_resource"
   autoload :JsonbAttributes, "decidim/jsonb_attributes"
   autoload :FormBuilder, "decidim/form_builder"
   autoload :AuthorizationFormBuilder, "decidim/authorization_form_builder"

--- a/decidim-core/lib/decidim/translatable_resource.rb
+++ b/decidim-core/lib/decidim/translatable_resource.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+	module TranslatableResource
+		extend ActiveSupport::Concern
+
+		included do
+			def self.translatable_attributes(list)
+				@translatable_attributes = list
+			end
+
+			def self.translatable_attributes_list
+				@translatable_attributes
+			end
+
+		end
+	end
+end

--- a/decidim-core/lib/decidim/translatable_resource.rb
+++ b/decidim-core/lib/decidim/translatable_resource.rb
@@ -3,18 +3,17 @@
 require "active_support/concern"
 
 module Decidim
-	module TranslatableResource
-		extend ActiveSupport::Concern
+  module TranslatableResource
+    extend ActiveSupport::Concern
 
-		included do
-			def self.translatable_attributes(list)
-				@translatable_attributes = list
-			end
+    included do
+      def self.translatable_fields(*list)
+        @translatable_fields = list
+      end
 
-			def self.translatable_attributes_list
-				@translatable_attributes
-			end
-
-		end
-	end
+      def self.translatable_fields_list
+        @translatable_fields
+      end
+    end
+  end
 end

--- a/decidim-core/spec/lib/translatable_resource_spec.rb
+++ b/decidim-core/spec/lib/translatable_resource_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe TranslatableResource do
+    subject { dummy_resource.class }
+
+    let(:dummy_resource) { build :dummy_resource }
+
+    describe "translatable_fields_list" do
+      it "gets the list of defined translatable fields" do
+        expect(subject.translatable_fields_list).to eq([:title])
+      end
+    end
+  end
+end

--- a/decidim-debates/app/models/decidim/debates/debate.rb
+++ b/decidim-debates/app/models/decidim/debates/debate.rb
@@ -20,6 +20,9 @@ module Decidim
       include Decidim::DataPortability
       include Decidim::NewsletterParticipant
       include Decidim::Searchable
+      include Decidim::TranslatableResource
+
+      translatable_fields :title, :description, :instructions, :information_updates
 
       component_manifest_name "debates"
 

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
@@ -66,7 +66,10 @@ module Decidim
       include Hashtaggable
       include ::Decidim::Endorsable
       include Decidim::HasAttachments
+      include Decidim::TranslatableResource
 
+
+      translatable_attributes :title
       searchable_fields(
         scope_id: { scope: :id },
         participatory_space: { component: :participatory_space },

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
@@ -68,8 +68,7 @@ module Decidim
       include Decidim::HasAttachments
       include Decidim::TranslatableResource
 
-
-      translatable_attributes :title
+      translatable_fields :title
       searchable_fields(
         scope_id: { scope: :id },
         participatory_space: { component: :participatory_space },

--- a/decidim-elections/app/models/decidim/elections/election.rb
+++ b/decidim-elections/app/models/decidim/elections/election.rb
@@ -7,8 +7,11 @@ module Decidim
     class Election < ApplicationRecord
       include Decidim::Resourceable
       include Decidim::HasComponent
+      include Decidim::TranslatableResource
       include Traceable
       include Loggable
+
+      translatable_fields :title, :description, :subtitle
 
       component_manifest_name "elections"
 

--- a/decidim-forms/app/models/decidim/forms/answer_choice.rb
+++ b/decidim-forms/app/models/decidim/forms/answer_choice.rb
@@ -3,6 +3,9 @@
 module Decidim
   module Forms
     class AnswerChoice < Forms::ApplicationRecord
+      include Decidim::TranslatableResource
+
+      translatable_fields :body
       belongs_to :answer,
                  class_name: "Answer",
                  foreign_key: "decidim_answer_id"

--- a/decidim-forms/app/models/decidim/forms/answer_option.rb
+++ b/decidim-forms/app/models/decidim/forms/answer_option.rb
@@ -3,7 +3,11 @@
 module Decidim
   module Forms
     class AnswerOption < Forms::ApplicationRecord
+      include Decidim::TranslatableResource
+
       default_scope { order(arel_table[:id].asc) }
+
+      translatable_fields :body
 
       belongs_to :question, class_name: "Question", foreign_key: "decidim_question_id"
     end

--- a/decidim-forms/app/models/decidim/forms/question.rb
+++ b/decidim-forms/app/models/decidim/forms/question.rb
@@ -4,9 +4,13 @@ module Decidim
   module Forms
     # The data store for a Question in the Decidim::Forms component.
     class Question < Forms::ApplicationRecord
+      include Decidim::TranslatableResource
+
       QUESTION_TYPES = %w(short_answer long_answer single_option multiple_option sorting matrix_single matrix_multiple).freeze
       SEPARATOR_TYPE = "separator"
       TYPES = (QUESTION_TYPES + [SEPARATOR_TYPE]).freeze
+
+      translatable_fields :body, :description
 
       belongs_to :questionnaire, class_name: "Questionnaire", foreign_key: "decidim_questionnaire_id"
 

--- a/decidim-forms/app/models/decidim/forms/question_matrix_row.rb
+++ b/decidim-forms/app/models/decidim/forms/question_matrix_row.rb
@@ -4,6 +4,9 @@ module Decidim
   module Forms
     # The data store for a QuestionMatrix in the Decidim::Forms component.
     class QuestionMatrixRow < Forms::ApplicationRecord
+      include Decidim::TranslatableResource
+
+      translatable_fields :body
       belongs_to :question, class_name: "Question", foreign_key: "decidim_question_id"
 
       delegate :answer_options, :mandatory, :max_choices, to: :question

--- a/decidim-forms/app/models/decidim/forms/questionnaire.rb
+++ b/decidim-forms/app/models/decidim/forms/questionnaire.rb
@@ -4,6 +4,9 @@ module Decidim
   module Forms
     # The data store for a Questionnaire in the Decidim::Forms component.
     class Questionnaire < Forms::ApplicationRecord
+      include Decidim::TranslatableResource
+
+      translatable_fields :title, :description, :tos
       belongs_to :questionnaire_for, polymorphic: true
 
       has_many :questions, -> { order(:position) }, class_name: "Question", foreign_key: "decidim_questionnaire_id", dependent: :destroy

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -19,6 +19,9 @@ module Decidim
     include Decidim::HasReference
     include Decidim::Randomable
     include Decidim::Searchable
+    include Decidim::TranslatableResource
+
+    translatable_fields :title, :description, :answer
 
     belongs_to :organization,
                foreign_key: "decidim_organization_id",

--- a/decidim-initiatives/app/models/decidim/initiatives_type.rb
+++ b/decidim-initiatives/app/models/decidim/initiatives_type.rb
@@ -4,6 +4,9 @@ module Decidim
   # Initiative type.
   class InitiativesType < ApplicationRecord
     include Decidim::HasResourcePermission
+    include Decidim::TranslatableResource
+
+    translatable_fields :title, :description, :extra_fields_legal_information
 
     belongs_to :organization,
                foreign_key: "decidim_organization_id",

--- a/decidim-meetings/app/models/decidim/meetings/agenda.rb
+++ b/decidim-meetings/app/models/decidim/meetings/agenda.rb
@@ -7,6 +7,9 @@ module Decidim
     class Agenda < Meetings::ApplicationRecord
       include Decidim::Traceable
       include Decidim::Loggable
+      include Decidim::TranslatableResource
+
+      translatable_fields :title
 
       belongs_to :meeting, foreign_key: "decidim_meeting_id", class_name: "Decidim::Meetings::Meeting"
       has_many :agenda_items, foreign_key: "decidim_agenda_id", class_name: "Decidim::Meetings::AgendaItem", dependent: :destroy, inverse_of: :agenda

--- a/decidim-meetings/app/models/decidim/meetings/agenda_item.rb
+++ b/decidim-meetings/app/models/decidim/meetings/agenda_item.rb
@@ -7,6 +7,9 @@ module Decidim
     class AgendaItem < Meetings::ApplicationRecord
       include Decidim::Traceable
       include Decidim::Loggable
+      include Decidim::TranslatableResource
+
+      translatable_fields :title, :description
 
       belongs_to :agenda, -> { order(:position) }, foreign_key: "decidim_agenda_id", class_name: "Decidim::Meetings::Agenda"
 

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -21,6 +21,9 @@ module Decidim
       include Decidim::Forms::HasQuestionnaire
       include Decidim::Paddable
       include Decidim::ActsAsAuthor
+      include Decidim::TranslatableResource
+
+      translatable_fields :title, :description, :location, :location_hints, :closing_report, :registration_terms, :services
 
       belongs_to :organizer, foreign_key: "organizer_id", class_name: "Decidim::User", optional: true
       has_many :registrations, class_name: "Decidim::Meetings::Registration", foreign_key: "decidim_meeting_id", dependent: :destroy

--- a/decidim-meetings/app/models/decidim/meetings/minutes.rb
+++ b/decidim-meetings/app/models/decidim/meetings/minutes.rb
@@ -6,6 +6,9 @@ module Decidim
     class Minutes < Meetings::ApplicationRecord
       include Decidim::Traceable
       include Decidim::Loggable
+      include Decidim::TranslatableResource
+
+      translatable_fields :description
 
       belongs_to :meeting, foreign_key: "decidim_meeting_id", class_name: "Decidim::Meetings::Meeting"
 

--- a/decidim-pages/app/models/decidim/pages/page.rb
+++ b/decidim-pages/app/models/decidim/pages/page.rb
@@ -9,6 +9,9 @@ module Decidim
       include Decidim::HasComponent
       include Decidim::Traceable
       include Decidim::Loggable
+      include Decidim::TranslatableResource
+
+      translatable_fields :body
 
       component_manifest_name "pages"
 

--- a/decidim-participatory_processes/app/models/decidim/participatory_process.rb
+++ b/decidim-participatory_processes/app/models/decidim/participatory_process.rb
@@ -19,6 +19,10 @@ module Decidim
     include Decidim::Loggable
     include Decidim::ParticipatorySpaceResourceable
     include Decidim::Searchable
+    include Decidim::TranslatableResource
+
+    translatable_fields :title, :subtitle, :short_description, :description, :developer_group, :meta_scope, :local_area,
+                        :target, :participatory_scope, :participatory_structure, :announcement
 
     belongs_to :organization,
                foreign_key: "decidim_organization_id",

--- a/decidim-participatory_processes/app/models/decidim/participatory_process_group.rb
+++ b/decidim-participatory_processes/app/models/decidim/participatory_process_group.rb
@@ -4,6 +4,9 @@ module Decidim
   class ParticipatoryProcessGroup < ApplicationRecord
     include Decidim::Resourceable
     include Decidim::Traceable
+    include Decidim::TranslatableResource
+
+    translatable_fields :name, :description
 
     has_many :participatory_processes,
              foreign_key: "decidim_participatory_process_group_id",

--- a/decidim-participatory_processes/app/models/decidim/participatory_process_step.rb
+++ b/decidim-participatory_processes/app/models/decidim/participatory_process_step.rb
@@ -5,8 +5,11 @@ module Decidim
   # components that will show up in the depending on what step is currently
   # active.
   class ParticipatoryProcessStep < ApplicationRecord
+    include Decidim::TranslatableResource
     include Traceable
     include Loggable
+
+    translatable_fields :title, :description, :cta_text
 
     belongs_to :participatory_process, foreign_key: "decidim_participatory_process_id", class_name: "Decidim::ParticipatoryProcess"
     has_one :organization, through: :participatory_process

--- a/decidim-proposals/app/models/decidim/proposals/collaborative_draft.rb
+++ b/decidim-proposals/app/models/decidim/proposals/collaborative_draft.rb
@@ -16,6 +16,9 @@ module Decidim
       include Decidim::Traceable
       include Decidim::Loggable
       include Decidim::Randomable
+      include Decidim::TranslatableResource
+
+      translatable_fields :title, :body, :state, :address
 
       has_many :collaborator_requests,
                class_name: "Decidim::Proposals::CollaborativeDraftCollaboratorRequest",

--- a/decidim-proposals/app/models/decidim/proposals/participatory_text.rb
+++ b/decidim-proposals/app/models/decidim/proposals/participatory_text.rb
@@ -8,6 +8,9 @@ module Decidim
       include Decidim::HasComponent
       include Decidim::Traceable
       include Decidim::Loggable
+      include Decidim::TranslatableResource
+
+      translatable_fields :title, :description
     end
   end
 end

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -26,6 +26,9 @@ module Decidim
       include Decidim::Randomable
       include Decidim::Endorsable
       include Decidim::Proposals::Valuatable
+      include Decidim::TranslatableResource
+
+      translatable_fields :title, :body, :state, :answer, :address
 
       POSSIBLE_STATES = %w(not_answered evaluating accepted rejected withdrawn).freeze
 

--- a/decidim-proposals/app/models/decidim/proposals/proposal_note.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal_note.rb
@@ -6,6 +6,9 @@ module Decidim
     class ProposalNote < ApplicationRecord
       include Decidim::Traceable
       include Decidim::Loggable
+      include Decidim::TranslatableResource
+
+      translatable_fields :body
 
       belongs_to :proposal, foreign_key: "decidim_proposal_id", class_name: "Decidim::Proposals::Proposal", counter_cache: true
       belongs_to :author, foreign_key: "decidim_author_id", class_name: "Decidim::User"

--- a/decidim-sortitions/app/models/decidim/sortitions/sortition.rb
+++ b/decidim-sortitions/app/models/decidim/sortitions/sortition.rb
@@ -13,8 +13,11 @@ module Decidim
       include Decidim::Loggable
       include Decidim::Comments::Commentable
       include Decidim::Randomable
+      include Decidim::TranslatableResource
 
       component_manifest_name "sortitions"
+
+      translatable_fields :title, :selected_proposals, :witnesses, :additional_info, :cancel_reason, :candidate_proposals
 
       belongs_to :decidim_proposals_component,
                  foreign_key: "decidim_proposals_component_id",

--- a/decidim-surveys/app/models/decidim/surveys/survey.rb
+++ b/decidim-surveys/app/models/decidim/surveys/survey.rb
@@ -7,8 +7,11 @@ module Decidim
       include Decidim::Resourceable
       include Decidim::Forms::HasQuestionnaire
       include Decidim::HasComponent
+      include Decidim::TranslatableResource
 
       component_manifest_name "surveys"
+
+      translatable_fields :title, :description, :tos
 
       validates :questionnaire, presence: true
     end


### PR DESCRIPTION
- Wrote a concern to list all the translatable fields.
- Added the concern to all the models that have  translatable fields.
This list can be used to verify,
[jsonb.txt](https://github.com/decidim/decidim/files/4719301/jsonb.txt)

I'm not sure about these:
I have skipped decidim_components - :settings, :permissions
I couldn't find models for decidim_surveys_survey_answer_options, decidim_surveys_survey_questions.

- Related to #6127

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask