### PR TITLE
Fix a test in initiatives

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/select_initiative_type.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/select_initiative_type.html.erb
@@ -22,7 +22,6 @@
             <% initiative_types_each do |type| %>
               <li class="tabs-title <%= "is-active" if type == default_type %>">
                 <%= link_to "#initiativeType#{type.id}" do %>
-                  <%# Quiero crear un <strong><%= translated_attribute type.title %1></strong> %>
                   <%= t(".choose_html", title: translated_attribute(type.title)) %>
                 <% end %>
               </li>

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -236,19 +236,19 @@ describe "Initiative", type: :system do
               expect(page).to have_content("End of signature collection period")
             end
           end
-        end
 
-        context "when the initiative type does not enable area" do
-          it "does not show the area" do
-            expect(page).not_to have_content("Area")
+          context "when the initiative type does not enable area" do
+            it "does not show the area" do
+              expect(page).not_to have_content("Area")
+            end
           end
-        end
 
-        context "when the initiative type enables area" do
-          let(:initiative_type) { create(:initiatives_type, :area_enabled, organization: organization, minimum_committee_members: initiative_type_minimum_committee_members, signature_type: "offline") }
+          context "when the initiative type enables area" do
+            let(:initiative_type) { create(:initiatives_type, :area_enabled, organization: organization, minimum_committee_members: initiative_type_minimum_committee_members, signature_type: "offline") }
 
-          it "shows the area" do
-            expect(page).to have_content("Area")
+            it "shows the area" do
+              expect(page).to have_content("Area")
+            end
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

#5835 has introduced an error in a initiative spec when checking if the area is selectable by the user.
This moves the example to the appropriated block.

This error is causing all current rebase with `develop` to fail.

#### :pushpin: Related Issues
- Related to #5835 
