### PR TITLE
Fix ip_hash not being saved in anonymous surveys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ The use case that originated this change is the persistence of the user's gender
 
 ### Fixed
 
+- **decidim-surveys**: Fix ip_hash not being saved in anonymous surveys. [\#6156](https://github.com/decidim/decidim/pull/6156)
 - **decidim-consultations**: Fix permissions in order to make components inside of questions accessible. [\#6079](https://github.com/decidim/decidim/pull/6079)
 - **decidim-core**: Patch various security alerts reported by GitHub. [\#6148](https://github.com/decidim/decidim/pull/6148)
 - **decidim-core**: Fix user's avatar icon in CSS. [\#5990](https://github.com/decidim/decidim/pull/5990)

--- a/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
+++ b/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
@@ -28,7 +28,7 @@ module Decidim
           def answer
             enforce_permission_to :answer, :questionnaire
 
-            @form = form(Decidim::Forms::QuestionnaireForm).from_params(params, session_token: session_token)
+            @form = form(Decidim::Forms::QuestionnaireForm).from_params(params, session_token: session_token, ip_hash: ip_hash)
 
             Decidim::Forms::AnswerQuestionnaire.call(@form, current_user, questionnaire) do
               on(:ok) do

--- a/decidim-surveys/spec/system/unregistered_user_survey_spec.rb
+++ b/decidim-surveys/spec/system/unregistered_user_survey_spec.rb
@@ -42,6 +42,8 @@ describe "Answer a survey", type: :system do
   end
 
   context "when the survey allow answers" do
+    let(:last_answer) { questionnaire.answers.last }
+
     before do
       component.update!(
         step_settings: {
@@ -72,6 +74,9 @@ describe "Answer a survey", type: :system do
       # Unregistered users are tracked with their session_id so they won't be allowed to repeat easily
       expect(page).to have_content("You have already answered this form.")
       expect(page).to have_no_i18n_content(question.body)
+
+      expect(last_answer.session_token).not_to be_empty
+      expect(last_answer.ip_hash).not_to be_empty
     end
 
     context "and honeypot is filled" do


### PR DESCRIPTION
#### :tophat: What? Why?

#4996 introduced the ability for unregistered users to answer questionnaires. As a safe guard, the remote IP was saved in the database as a hash. However, a bug was found that this was not being done.
This solves this and introduces a test to ensure it.

#### :pushpin: Related Issues
- Related to #4996 
- Fixes #5622

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
