### PR TITLE
Fix incorrect detection of exit confirmation in forms

### DIFF
--- a/decidim-budgets/app/assets/javascripts/decidim/budgets/projects.js.es6
+++ b/decidim-budgets/app/assets/javascripts/decidim/budgets/projects.js.es6
@@ -28,7 +28,7 @@ $(() => {
   });
 
   if ($("#order-progress [data-toggle=budget-confirm]").length > 0) {
-    const safeUrl = $(".budget-summary").attr("data-safe-url");
+    const safeUrl = $(".budget-summary").attr("data-safe-url").split("?")[0];
     $(document).on("click", "a", (event) => {
       window.exitUrl = event.currentTarget.href;
     });

--- a/decidim-forms/app/assets/javascripts/decidim/forms/forms.js.es6
+++ b/decidim-forms/app/assets/javascripts/decidim/forms/forms.js.es6
@@ -38,7 +38,7 @@
       $form.data("changed", true);
     });
 
-    const safePath = $form.data("safe-path");
+    const safePath = $form.data("safe-path").split("?")[0];
     $(document).on("click", "a", (event) => {
       window.exitUrl = event.currentTarget.href;
     });


### PR DESCRIPTION
#### :tophat: What? Why?

There is a situation when the javascript method `beforeunload` asks the user if he wants to abandon the page when it shouldn't.

This behaviour was introduced in #6118. The problem only happens when the url has some query string, which it is typically the locale.

This PR removes the querystring part from theses checks so any route at the component level will be valid. 

I haven't added a changelog entry because that PR is not in any release yet.

#### :pushpin: Related Issues
- Related to #6118 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
