### PR TITLE
Fix participatory text newline absence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ The use case that originated this change is the persistence of the user's gender
 
 ### Fixed
 
+- **decidim-proposals**: Fix participatory text newline absence. [\#6158](https://github.com/decidim/decidim/pull/6158)
 - **decidim-consultations**: Fix permissions in order to make components inside of questions accessible. [\#6079](https://github.com/decidim/decidim/pull/6079)
 - **decidim-core**: Fix user's avatar icon in CSS. [\#5990](https://github.com/decidim/decidim/pull/5990)
 - **decidim-core**: Use internal Organization class in migration. [\#6052](https://github.com/decidim/decidim/pull/6052)

--- a/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
@@ -51,7 +51,11 @@ module Decidim
 
       def body(links: false, extras: true, strip_tags: false)
         text = proposal.body
-        text = strip_tags(text) if strip_tags
+
+        if strip_tags
+          text = text.gsub(/<\/p>/, "\n\n")
+          text = strip_tags(text)
+        end
 
         renderer = Decidim::ContentRenderers::HashtagRenderer.new(text)
         text = renderer.render(links: links, extras: extras).html_safe

--- a/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
@@ -53,7 +53,7 @@ module Decidim
         text = proposal.body
 
         if strip_tags
-          text = text.gsub(/<\/p>/, "\n\n")
+          text = text.gsub(%r(<\/p>), "\n\n")
           text = strip_tags(text)
         end
 

--- a/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
@@ -53,7 +53,7 @@ module Decidim
         text = proposal.body
 
         if strip_tags
-          text = text.gsub(%r(<\/p>), "\n\n")
+          text = text.gsub(%r{<\/p>}, "\n\n")
           text = strip_tags(text)
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?
The participatory text was showing itself without newlines when it should.
This PR fixes this by replacing the paragraph closing tags (\</p>) with line feeds (\n) before stripping the tags.

#### :pushpin: Related Issues
- Fixes DECIDIM-140 (Jira)

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry