### PR TITLE
Fix the edit link test failing seemingly randomly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,7 @@ The use case that originated this change is the persistence of the user's gender
 - **decidim-core**: Avoid server hanging up when rendering newsletter templates previews on develoment or test env [\#6096](https://github.com/decidim/decidim/pull/6096)
 - **decidim-initiatives**: Fix attachments related module inclusion [\#6140](https://github.com/decidim/decidim/pull/6140)
 - **decidim-core**: Fix scopes filter when a participatory space scope has subscopes [\#6110](https://github.com/decidim/decidim/pull/6110)
+- **decidim-core**, **decidim-assemblies**: Fix the edit link test failing seemingly randomly [\#6161](https://github.com/decidim/decidim/pull/6161)
 
 ### Removed
 

--- a/decidim-admin/spec/system/static_pages_spec.rb
+++ b/decidim-admin/spec/system/static_pages_spec.rb
@@ -15,18 +15,22 @@ describe "Content pages", type: :system do
   describe "Showing pages" do
     let!(:decidim_pages) { create_list(:static_page, 5, :with_topic, organization: organization) }
 
-    before do
-      visit decidim.pages_path
+    it_behaves_like "editable content for admins" do
+      let(:target_path) { decidim.pages_path }
     end
 
-    it_behaves_like "editable content for admins"
+    context "when requesting the pages path" do
+      before do
+        visit decidim.pages_path
+      end
 
-    it "shows the list of all the pages" do
-      decidim_pages.each do |decidim_page|
-        expect(page).to have_css(
-          "a[href=\"#{decidim.page_path(decidim_page)}\"]",
-          text: decidim_page.title[I18n.locale.to_s]
-        )
+      it "shows the list of all the pages" do
+        decidim_pages.each do |decidim_page|
+          expect(page).to have_css(
+            "a[href=\"#{decidim.page_path(decidim_page)}\"]",
+            text: decidim_page.title[I18n.locale.to_s]
+          )
+        end
       end
     end
   end

--- a/decidim-consultations/spec/system/consultation_spec.rb
+++ b/decidim-consultations/spec/system/consultation_spec.rb
@@ -9,104 +9,111 @@ describe "Consultation", type: :system do
 
   before do
     switch_to_host(organization.host)
-    visit decidim_consultations.consultation_path(consultation)
   end
 
-  it_behaves_like "editable content for admins"
-
-  it "Shows the basic consultation data" do
-    expect(page).to have_i18n_content(consultation.title)
-    expect(page).to have_i18n_content(consultation.subtitle)
-    expect(page).to have_i18n_content(consultation.description)
+  it_behaves_like "editable content for admins" do
+    let(:target_path) { decidim_consultations.consultation_path(consultation) }
   end
 
-  context "when the consultation is unpublished" do
-    let!(:consultation) do
-      create(:consultation, :unpublished, organization: organization)
-    end
-
+  context "when requesting the consultation path" do
     before do
-      switch_to_host(organization.host)
       visit decidim_consultations.consultation_path(consultation)
     end
 
-    it "redirects to root path" do
-      expect(page).to have_current_path("/")
-    end
-  end
-
-  context "when highlighted questions" do
-    let!(:question) { create(:question, :published, consultation: consultation, scope: consultation.highlighted_scope) }
-
-    before do
-      switch_to_host(organization.host)
-      visit decidim_consultations.consultation_path(consultation)
+    it "Shows the basic consultation data" do
+      expect(page).to have_i18n_content(consultation.title)
+      expect(page).to have_i18n_content(consultation.subtitle)
+      expect(page).to have_i18n_content(consultation.description)
     end
 
-    it "Shows the highlighted questions section" do
-      expect(page).to have_content("Questions from #{translated consultation.highlighted_scope.name}".upcase)
-    end
+    context "when the consultation is unpublished" do
+      let!(:consultation) do
+        create(:consultation, :unpublished, organization: organization)
+      end
 
-    it "shows highlighted question details" do
-      expect(page).to have_i18n_content(question.title)
-      expect(page).to have_i18n_content(question.subtitle)
-    end
-  end
-
-  context "when regular questions" do
-    let!(:scope) { create(:scope, organization: organization) }
-    let!(:question) { create(:question, :published, consultation: consultation, scope: scope) }
-
-    before do
-      switch_to_host(organization.host)
-      visit decidim_consultations.consultation_path(consultation)
-    end
-
-    it "Shows the regular questions section" do
-      expect(page).to have_content("QUESTIONS FOR THIS CONSULTATION")
-    end
-
-    it "shows the scope name" do
-      expect(page).to have_content(scope.name["en"].upcase)
-    end
-
-    it "shows the question details" do
-      expect(page).to have_i18n_content(question.title)
-      expect(page).to have_i18n_content(question.subtitle)
-    end
-  end
-
-  context "when showing the button that links to the question" do
-    let!(:question) { create(:question, :published, consultation: consultation, scope: consultation.highlighted_scope) }
-
-    context "when the user is not logged in" do
       before do
         switch_to_host(organization.host)
         visit decidim_consultations.consultation_path(consultation)
       end
 
-      it "shows the `take part` button" do
-        expect(page).to have_content("TAKE PART")
+      it "redirects to root path" do
+        expect(page).to have_current_path("/")
       end
     end
 
-    context "when the user is logged in" do
+    context "when highlighted questions" do
+      let!(:question) { create(:question, :published, consultation: consultation, scope: consultation.highlighted_scope) }
+
       before do
         switch_to_host(organization.host)
-        login_as user, scope: :user
+        visit decidim_consultations.consultation_path(consultation)
       end
 
-      it "shows the `take part` button if the user has not voted yet" do
-        visit decidim_consultations.consultation_path(consultation)
-
-        expect(page).to have_content("TAKE PART")
+      it "Shows the highlighted questions section" do
+        expect(page).to have_content("Questions from #{translated consultation.highlighted_scope.name}".upcase)
       end
 
-      it "shows the `already voted` button if the user has already voted" do
-        question.votes.create(author: user, response: Decidim::Consultations::Response.new)
-        visit decidim_consultations.consultation_path(consultation)
+      it "shows highlighted question details" do
+        expect(page).to have_i18n_content(question.title)
+        expect(page).to have_i18n_content(question.subtitle)
+      end
+    end
 
-        expect(page).to have_content("ALREADY VOTED")
+    context "when regular questions" do
+      let!(:scope) { create(:scope, organization: organization) }
+      let!(:question) { create(:question, :published, consultation: consultation, scope: scope) }
+
+      before do
+        switch_to_host(organization.host)
+        visit decidim_consultations.consultation_path(consultation)
+      end
+
+      it "Shows the regular questions section" do
+        expect(page).to have_content("QUESTIONS FOR THIS CONSULTATION")
+      end
+
+      it "shows the scope name" do
+        expect(page).to have_content(scope.name["en"].upcase)
+      end
+
+      it "shows the question details" do
+        expect(page).to have_i18n_content(question.title)
+        expect(page).to have_i18n_content(question.subtitle)
+      end
+    end
+
+    context "when showing the button that links to the question" do
+      let!(:question) { create(:question, :published, consultation: consultation, scope: consultation.highlighted_scope) }
+
+      context "when the user is not logged in" do
+        before do
+          switch_to_host(organization.host)
+          visit decidim_consultations.consultation_path(consultation)
+        end
+
+        it "shows the `take part` button" do
+          expect(page).to have_content("TAKE PART")
+        end
+      end
+
+      context "when the user is logged in" do
+        before do
+          switch_to_host(organization.host)
+          login_as user, scope: :user
+        end
+
+        it "shows the `take part` button if the user has not voted yet" do
+          visit decidim_consultations.consultation_path(consultation)
+
+          expect(page).to have_content("TAKE PART")
+        end
+
+        it "shows the `already voted` button if the user has already voted" do
+          question.votes.create(author: user, response: Decidim::Consultations::Response.new)
+          visit decidim_consultations.consultation_path(consultation)
+
+          expect(page).to have_content("ALREADY VOTED")
+        end
       end
     end
   end

--- a/decidim-consultations/spec/system/consultations_spec.rb
+++ b/decidim-consultations/spec/system/consultations_spec.rb
@@ -26,20 +26,27 @@ describe "Consultations", type: :system do
 
     before do
       switch_to_host(organization.host)
-      visit decidim_consultations.consultations_path
     end
 
-    it_behaves_like "editable content for admins"
+    it_behaves_like "editable content for admins" do
+      let(:target_path) { visit decidim_consultations.consultations_path }
+    end
 
-    it "lists the consultations ordered by created at" do
-      within ".order-by" do
-        expect(page).to have_selector("ul[data-dropdown-menu$=dropdown-menu]", text: "Random")
-        page.find("a", text: "Random").click
-        click_link "Most recent"
+    context "when requesting the consultations path" do
+      before do
+        visit decidim_consultations.consultations_path
       end
 
-      expect(page).to have_selector("#consultations .card-grid .column:first-child", text: recent_consultation.title[:en])
-      expect(page).to have_selector("#consultations .card-grid .column:last-child", text: older_consultation.title[:en])
+      it "lists the consultations ordered by created at" do
+        within ".order-by" do
+          expect(page).to have_selector("ul[data-dropdown-menu$=dropdown-menu]", text: "Random")
+          page.find("a", text: "Random").click
+          click_link "Most recent"
+        end
+
+        expect(page).to have_selector("#consultations .card-grid .column:first-child", text: recent_consultation.title[:en])
+        expect(page).to have_selector("#consultations .card-grid .column:last-child", text: older_consultation.title[:en])
+      end
     end
   end
 

--- a/decidim-core/lib/decidim/core/test/shared_examples/edit_link_shared_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/edit_link_shared_examples.rb
@@ -4,7 +4,7 @@ shared_examples "editable content for admins" do
   describe "edit link" do
     before do
       relogin_as user
-      visit current_path
+      visit target_path
     end
 
     context "when I'm an admin user" do

--- a/decidim-core/lib/decidim/core/test/shared_examples/edit_link_shared_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/edit_link_shared_examples.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# When using these shared examples, make sure there are no prior requests within
+# the same group of examples where this is included. Otherwise you may end up
+# in race conditions that cause these to fail as explained at:
+# https://github.com/decidim/decidim/pull/6161
 shared_examples "editable content for admins" do
   describe "edit link" do
     before do

--- a/decidim-core/spec/system/homepage_spec.rb
+++ b/decidim-core/spec/system/homepage_spec.rb
@@ -28,322 +28,329 @@ describe "Homepage", type: :system do
       create :content_block, organization: organization, scope_name: :homepage, manifest_name: :footer_sub_hero
 
       switch_to_host(organization.host)
-      visit decidim.root_path
     end
 
-    it_behaves_like "editable content for admins"
-
-    it "includes the official organization links and images" do
-      expect(page).to have_selector("a.logo-cityhall[href='#{official_url}']")
-      expect(page).to have_selector("a.main-footer__badge[href='#{official_url}']")
+    it_behaves_like "editable content for admins" do
+      let(:target_path) { visit decidim.root_path }
     end
 
-    context "and the organization has the omnipresent banner enabled" do
-      let(:organization) do
-        create(:organization,
-               official_url: official_url,
-               enable_omnipresent_banner: true,
-               omnipresent_banner_url: "#{official_url}/processes",
-               omnipresent_banner_title: Decidim::Faker::Localized.sentence(3),
-               omnipresent_banner_short_description: Decidim::Faker::Localized.sentence(3))
-      end
-
+    context "when requesting the root path" do
       before do
-        switch_to_host(organization.host)
         visit decidim.root_path
       end
 
-      it "shows the omnipresent banner's title" do
-        expect(page).to have_i18n_content(organization.omnipresent_banner_title)
+      it "includes the official organization links and images" do
+        expect(page).to have_selector("a.logo-cityhall[href='#{official_url}']")
+        expect(page).to have_selector("a.main-footer__badge[href='#{official_url}']")
       end
 
-      it "shows the omnipresent banner's short description" do
-        expect(page).to have_i18n_content(organization.omnipresent_banner_short_description)
-      end
-    end
-
-    describe "call to action" do
-      let!(:participatory_process) { create :participatory_process, :published }
-      let!(:organization) { participatory_process.organization }
-
-      before do
-        switch_to_host(organization.host)
-        visit decidim.root_path
-      end
-
-      context "when the organization has the CTA button text customized" do
-        let(:cta_button_text) { { en: "Sign up", es: "Regístrate", ca: "Registra't" } }
-        let(:organization) { create(:organization, cta_button_text: cta_button_text) }
-
-        it "uses the custom values for the CTA button text" do
-          within ".hero" do
-            expect(page).to have_selector("a.hero-cta", text: "SIGN UP")
-            click_link "Sign up"
-          end
-
-          expect(page).to have_current_path decidim.new_user_registration_path
+      context "and the organization has the omnipresent banner enabled" do
+        let(:organization) do
+          create(:organization,
+                 official_url: official_url,
+                 enable_omnipresent_banner: true,
+                 omnipresent_banner_url: "#{official_url}/processes",
+                 omnipresent_banner_title: Decidim::Faker::Localized.sentence(3),
+                 omnipresent_banner_short_description: Decidim::Faker::Localized.sentence(3))
         end
-      end
 
-      context "when the organization has the CTA button link customized" do
-        let(:organization) { create(:organization, cta_button_path: "users/sign_in") }
-
-        it "uses the custom values for the CTA button" do
-          within ".hero" do
-            expect(page).to have_selector("a.hero-cta", text: "PARTICIPATE")
-            click_link "Participate"
-          end
-
-          expect(page).to have_current_path decidim.new_user_session_path
-          expect(page).to have_content("Sign in")
-          expect(page).to have_content("New to the platform?")
-        end
-      end
-
-      context "when the organization does not have it customized" do
-        it "uses the default values for the CTA button" do
-          visit decidim.root_path
-
-          within ".hero" do
-            expect(page).to have_selector("a.hero-cta", text: "PARTICIPATE")
-            click_link "Participate"
-          end
-
-          expect(page).to have_current_path decidim_participatory_processes.participatory_processes_path
-        end
-      end
-    end
-
-    context "with header snippets" do
-      let(:snippet) { "<meta data-hello=\"This is the organization header_snippet field\">" }
-      let(:organization) { create(:organization, official_url: official_url, header_snippets: snippet) }
-
-      it "does not include the header snippets" do
-        expect(page).not_to have_selector("meta[data-hello]", visible: false)
-      end
-
-      context "when header snippets are enabled" do
         before do
-          allow(Decidim).to receive(:enable_html_header_snippets).and_return(true)
+          switch_to_host(organization.host)
           visit decidim.root_path
         end
 
-        it "includes the header snippets" do
-          expect(page).to have_selector("meta[data-hello]", visible: false)
+        it "shows the omnipresent banner's title" do
+          expect(page).to have_i18n_content(organization.omnipresent_banner_title)
+        end
+
+        it "shows the omnipresent banner's short description" do
+          expect(page).to have_i18n_content(organization.omnipresent_banner_short_description)
         end
       end
-    end
 
-    it "welcomes the user" do
-      expect(page).to have_content(organization.name)
-    end
+      describe "call to action" do
+        let!(:participatory_process) { create :participatory_process, :published }
+        let!(:organization) { participatory_process.organization }
 
-    context "when there are static pages" do
-      let!(:static_page_1) { create(:static_page, organization: organization, show_in_footer: true) }
-      let!(:static_page_2) { create(:static_page, organization: organization, show_in_footer: true) }
-      let!(:static_page_3) { create(:static_page, organization: organization, show_in_footer: false) }
+        before do
+          switch_to_host(organization.host)
+          visit decidim.root_path
+        end
 
-      before do
-        visit current_path
+        context "when the organization has the CTA button text customized" do
+          let(:cta_button_text) { { en: "Sign up", es: "Regístrate", ca: "Registra't" } }
+          let(:organization) { create(:organization, cta_button_text: cta_button_text) }
+
+          it "uses the custom values for the CTA button text" do
+            within ".hero" do
+              expect(page).to have_selector("a.hero-cta", text: "SIGN UP")
+              click_link "Sign up"
+            end
+
+            expect(page).to have_current_path decidim.new_user_registration_path
+          end
+        end
+
+        context "when the organization has the CTA button link customized" do
+          let(:organization) { create(:organization, cta_button_path: "users/sign_in") }
+
+          it "uses the custom values for the CTA button" do
+            within ".hero" do
+              expect(page).to have_selector("a.hero-cta", text: "PARTICIPATE")
+              click_link "Participate"
+            end
+
+            expect(page).to have_current_path decidim.new_user_session_path
+            expect(page).to have_content("Sign in")
+            expect(page).to have_content("New to the platform?")
+          end
+        end
+
+        context "when the organization does not have it customized" do
+          it "uses the default values for the CTA button" do
+            visit decidim.root_path
+
+            within ".hero" do
+              expect(page).to have_selector("a.hero-cta", text: "PARTICIPATE")
+              click_link "Participate"
+            end
+
+            expect(page).to have_current_path decidim_participatory_processes.participatory_processes_path
+          end
+        end
       end
 
-      it "includes links to them" do
-        within ".main-footer" do
-          [static_page_1, static_page_2].each do |static_page|
-            expect(page).to have_content(static_page.title["en"])
+      context "with header snippets" do
+        let(:snippet) { "<meta data-hello=\"This is the organization header_snippet field\">" }
+        let(:organization) { create(:organization, official_url: official_url, header_snippets: snippet) }
+
+        it "does not include the header snippets" do
+          expect(page).not_to have_selector("meta[data-hello]", visible: false)
+        end
+
+        context "when header snippets are enabled" do
+          before do
+            allow(Decidim).to receive(:enable_html_header_snippets).and_return(true)
+            visit decidim.root_path
           end
 
-          expect(page).to have_no_content(static_page_3.title["en"])
-        end
-
-        click_link static_page_1.title["en"]
-        expect(page).to have_i18n_content(static_page_1.title)
-
-        expect(page).to have_i18n_content(static_page_1.content)
-      end
-
-      it "includes the footer sub_hero with the current organization name" do
-        expect(page).to have_css(".footer__subhero")
-
-        within ".footer__subhero" do
-          expect(page).to have_content(organization.name)
-        end
-      end
-    end
-
-    describe "includes statistics" do
-      let!(:users) { create_list(:user, 4, :confirmed, organization: organization) }
-      let!(:participatory_process) do
-        create_list(
-          :participatory_process,
-          2,
-          :published,
-          organization: organization,
-          description: { en: "Description", ca: "Descripció", es: "Descripción" },
-          short_description: { en: "Short description", ca: "Descripció curta", es: "Descripción corta" }
-        )
-      end
-
-      context "when organization show_statistics attribute is false" do
-        let(:organization) { create(:organization, show_statistics: false) }
-
-        it "does not show the statistics block" do
-          expect(page).to have_no_content("Current state of #{organization.name}")
+          it "includes the header snippets" do
+            expect(page).to have_selector("meta[data-hello]", visible: false)
+          end
         end
       end
 
-      context "when organization show_statistics attribute is true" do
-        let(:organization) { create(:organization, show_statistics: true) }
+      it "welcomes the user" do
+        expect(page).to have_content(organization.name)
+      end
+
+      context "when there are static pages" do
+        let!(:static_page_1) { create(:static_page, organization: organization, show_in_footer: true) }
+        let!(:static_page_2) { create(:static_page, organization: organization, show_in_footer: true) }
+        let!(:static_page_3) { create(:static_page, organization: organization, show_in_footer: false) }
 
         before do
           visit current_path
         end
 
-        it "shows the statistics block" do
-          within "#statistics" do
-            expect(page).to have_content("Current state of #{organization.name}")
-            expect(page).to have_content("PROCESSES")
-            expect(page).to have_content("PARTICIPANTS")
-          end
-        end
-
-        it "has the correct values for the statistics" do
-          within ".users_count" do
-            expect(page).to have_content("4")
-          end
-
-          within ".processes_count" do
-            expect(page).to have_content("2")
-          end
-        end
-      end
-    end
-
-    describe "includes metrics" do
-      context "when organization show_statistics attribute is false" do
-        let(:organization) { create(:organization, show_statistics: false) }
-
-        it "does not show the statistics block" do
-          expect(page).to have_no_content("Participation in figures")
-        end
-      end
-
-      context "when organization show_statistics attribute is true" do
-        let(:organization) { create(:organization, show_statistics: true) }
-        let(:metrics) do
-          Decidim.metrics_registry.all.each do |metric_registry|
-            create(:metric, metric_type: metric_registry.metric_name, day: Time.zone.today, organization: organization, cumulative: 5, quantity: 2)
-          end
-        end
-
-        context "and have metric records" do
-          before do
-            metrics
-            visit current_path
-          end
-
-          it "shows the metrics block" do
-            within "#metrics" do
-              expect(page).to have_content("Metrics")
-              Decidim.metrics_registry.filtered(highlight: true, scope: "home").each do |metric_registry|
-                expect(page).to have_css(%(##{metric_registry.metric_name}_chart), visible: false)
-              end
-              Decidim.metrics_registry.filtered(highlight: false, scope: "home").each do |metric_registry|
-                expect(page).to have_css(%(##{metric_registry.metric_name}_chart), visible: false)
-              end
+        it "includes links to them" do
+          within ".main-footer" do
+            [static_page_1, static_page_2].each do |static_page|
+              expect(page).to have_content(static_page.title["en"])
             end
+
+            expect(page).to have_no_content(static_page_3.title["en"])
+          end
+
+          click_link static_page_1.title["en"]
+          expect(page).to have_i18n_content(static_page_1.title)
+
+          expect(page).to have_i18n_content(static_page_1.content)
+        end
+
+        it "includes the footer sub_hero with the current organization name" do
+          expect(page).to have_css(".footer__subhero")
+
+          within ".footer__subhero" do
+            expect(page).to have_content(organization.name)
+          end
+        end
+      end
+
+      describe "includes statistics" do
+        let!(:users) { create_list(:user, 4, :confirmed, organization: organization) }
+        let!(:participatory_process) do
+          create_list(
+            :participatory_process,
+            2,
+            :published,
+            organization: organization,
+            description: { en: "Description", ca: "Descripció", es: "Descripción" },
+            short_description: { en: "Short description", ca: "Descripció curta", es: "Descripción corta" }
+          )
+        end
+
+        context "when organization show_statistics attribute is false" do
+          let(:organization) { create(:organization, show_statistics: false) }
+
+          it "does not show the statistics block" do
+            expect(page).to have_no_content("Current state of #{organization.name}")
           end
         end
 
-        context "and does not have metric records" do
+        context "when organization show_statistics attribute is true" do
+          let(:organization) { create(:organization, show_statistics: true) }
+
           before do
             visit current_path
           end
 
-          it "shows the metrics block empty" do
-            within "#metrics" do
-              expect(page).to have_content("Metrics")
-              Decidim.metrics_registry.highlighted.each do |metric_registry|
-                expect(page).to have_no_css("##{metric_registry.metric_name}_chart")
+          it "shows the statistics block" do
+            within "#statistics" do
+              expect(page).to have_content("Current state of #{organization.name}")
+              expect(page).to have_content("PROCESSES")
+              expect(page).to have_content("PARTICIPANTS")
+            end
+          end
+
+          it "has the correct values for the statistics" do
+            within ".users_count" do
+              expect(page).to have_content("4")
+            end
+
+            within ".processes_count" do
+              expect(page).to have_content("2")
+            end
+          end
+        end
+      end
+
+      describe "includes metrics" do
+        context "when organization show_statistics attribute is false" do
+          let(:organization) { create(:organization, show_statistics: false) }
+
+          it "does not show the statistics block" do
+            expect(page).to have_no_content("Participation in figures")
+          end
+        end
+
+        context "when organization show_statistics attribute is true" do
+          let(:organization) { create(:organization, show_statistics: true) }
+          let(:metrics) do
+            Decidim.metrics_registry.all.each do |metric_registry|
+              create(:metric, metric_type: metric_registry.metric_name, day: Time.zone.today, organization: organization, cumulative: 5, quantity: 2)
+            end
+          end
+
+          context "and have metric records" do
+            before do
+              metrics
+              visit current_path
+            end
+
+            it "shows the metrics block" do
+              within "#metrics" do
+                expect(page).to have_content("Metrics")
+                Decidim.metrics_registry.filtered(highlight: true, scope: "home").each do |metric_registry|
+                  expect(page).to have_css(%(##{metric_registry.metric_name}_chart), visible: false)
+                end
+                Decidim.metrics_registry.filtered(highlight: false, scope: "home").each do |metric_registry|
+                  expect(page).to have_css(%(##{metric_registry.metric_name}_chart), visible: false)
+                end
               end
-              Decidim.metrics_registry.not_highlighted.each do |metric_registry|
-                expect(page).to have_no_css("##{metric_registry.metric_name}_chart")
+            end
+          end
+
+          context "and does not have metric records" do
+            before do
+              visit current_path
+            end
+
+            it "shows the metrics block empty" do
+              within "#metrics" do
+                expect(page).to have_content("Metrics")
+                Decidim.metrics_registry.highlighted.each do |metric_registry|
+                  expect(page).to have_no_css("##{metric_registry.metric_name}_chart")
+                end
+                Decidim.metrics_registry.not_highlighted.each do |metric_registry|
+                  expect(page).to have_no_css("##{metric_registry.metric_name}_chart")
+                end
               end
             end
           end
         end
       end
-    end
 
-    describe "social links" do
-      before do
-        organization.update(
-          twitter_handler: "twitter_handler",
-          facebook_handler: "facebook_handler",
-          youtube_handler: "youtube_handler",
-          github_handler: "github_handler"
-        )
+      describe "social links" do
+        before do
+          organization.update(
+            twitter_handler: "twitter_handler",
+            facebook_handler: "facebook_handler",
+            youtube_handler: "youtube_handler",
+            github_handler: "github_handler"
+          )
 
-        visit current_path
+          visit current_path
+        end
+
+        it "includes the links to social networks" do
+          expect(page).to have_xpath("//a[@href = 'https://twitter.com/twitter_handler']")
+          expect(page).to have_xpath("//a[@href = 'https://www.facebook.com/facebook_handler']")
+          expect(page).to have_xpath("//a[@href = 'https://www.youtube.com/youtube_handler']")
+          expect(page).to have_xpath("//a[@href = 'https://www.github.com/github_handler']")
+        end
       end
 
-      it "includes the links to social networks" do
-        expect(page).to have_xpath("//a[@href = 'https://twitter.com/twitter_handler']")
-        expect(page).to have_xpath("//a[@href = 'https://www.facebook.com/facebook_handler']")
-        expect(page).to have_xpath("//a[@href = 'https://www.youtube.com/youtube_handler']")
-        expect(page).to have_xpath("//a[@href = 'https://www.github.com/github_handler']")
-      end
-    end
+      context "and has highlighted content banner enabled" do
+        let(:organization) do
+          create(:organization,
+                 official_url: official_url,
+                 highlighted_content_banner_enabled: true,
+                 highlighted_content_banner_title: Decidim::Faker::Localized.sentence(2),
+                 highlighted_content_banner_short_description: Decidim::Faker::Localized.sentence(2),
+                 highlighted_content_banner_action_title: Decidim::Faker::Localized.sentence(2),
+                 highlighted_content_banner_action_subtitle: Decidim::Faker::Localized.sentence(2),
+                 highlighted_content_banner_action_url: ::Faker::Internet.url,
+                 highlighted_content_banner_image: Decidim::Dev.test_file("city.jpeg", "image/jpeg"))
+        end
 
-    context "and has highlighted content banner enabled" do
-      let(:organization) do
-        create(:organization,
-               official_url: official_url,
-               highlighted_content_banner_enabled: true,
-               highlighted_content_banner_title: Decidim::Faker::Localized.sentence(2),
-               highlighted_content_banner_short_description: Decidim::Faker::Localized.sentence(2),
-               highlighted_content_banner_action_title: Decidim::Faker::Localized.sentence(2),
-               highlighted_content_banner_action_subtitle: Decidim::Faker::Localized.sentence(2),
-               highlighted_content_banner_action_url: ::Faker::Internet.url,
-               highlighted_content_banner_image: Decidim::Dev.test_file("city.jpeg", "image/jpeg"))
-      end
+        before do
+          switch_to_host(organization.host)
+          visit decidim.root_path
+        end
 
-      before do
-        switch_to_host(organization.host)
-        visit decidim.root_path
-      end
+        it "shows the banner's title" do
+          expect(page).to have_i18n_content(organization.highlighted_content_banner_title)
+        end
 
-      it "shows the banner's title" do
-        expect(page).to have_i18n_content(organization.highlighted_content_banner_title)
-      end
+        it "shows the banner's description" do
+          expect(page).to have_i18n_content(organization.highlighted_content_banner_short_description)
+        end
 
-      it "shows the banner's description" do
-        expect(page).to have_i18n_content(organization.highlighted_content_banner_short_description)
-      end
+        it "shows the banner's action title" do
+          expect(page).to have_i18n_content(organization.highlighted_content_banner_action_title, upcase: true)
+        end
 
-      it "shows the banner's action title" do
-        expect(page).to have_i18n_content(organization.highlighted_content_banner_action_title, upcase: true)
+        it "shows the banner's action subtitle" do
+          expect(page).to have_i18n_content(organization.highlighted_content_banner_action_subtitle)
+        end
       end
 
-      it "shows the banner's action subtitle" do
-        expect(page).to have_i18n_content(organization.highlighted_content_banner_action_subtitle)
-      end
-    end
+      context "when downloading open data", download: true do
+        before do
+          Decidim::OpenDataJob.perform_now(organization)
+          switch_to_host(organization.host)
+          visit decidim.root_path
+        end
 
-    context "when downloading open data", download: true do
-      before do
-        Decidim::OpenDataJob.perform_now(organization)
-        switch_to_host(organization.host)
-        visit decidim.root_path
-      end
-
-      it "lets the users download open data files" do
-        click_link "Download Open Data files"
-        expect(File.basename(download_path)).to include("open-data.zip")
-        Zip::File.open(download_path) do |zipfile|
-          expect(zipfile.glob("*open-data-proposals.csv").length).to eq(1)
-          expect(zipfile.glob("*open-data-results.csv").length).to eq(1)
-          expect(zipfile.glob("*open-data-meetings.csv").length).to eq(1)
+        it "lets the users download open data files" do
+          click_link "Download Open Data files"
+          expect(File.basename(download_path)).to include("open-data.zip")
+          Zip::File.open(download_path) do |zipfile|
+            expect(zipfile.glob("*open-data-proposals.csv").length).to eq(1)
+            expect(zipfile.glob("*open-data-results.csv").length).to eq(1)
+            expect(zipfile.glob("*open-data-meetings.csv").length).to eq(1)
+          end
         end
       end
     end

--- a/decidim-initiatives/spec/system/initiative_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_spec.rb
@@ -22,30 +22,34 @@ describe "Initiative", type: :system do
     let!(:initiative) { base_initiative }
     let(:attached_to) { initiative }
 
-    before do
-      visit decidim_initiatives.initiative_path(initiative)
+    it_behaves_like "editable content for admins" do
+      let(:target_path) { decidim_initiatives.initiative_path(initiative) }
     end
 
-    it_behaves_like "editable content for admins"
-
-    it "shows the details of the given initiative" do
-      within "main" do
-        expect(page).to have_content(translated(initiative.title, locale: :en))
-        expect(page).to have_content(ActionView::Base.full_sanitizer.sanitize(translated(initiative.description, locale: :en), tags: []))
-        expect(page).to have_content(translated(initiative.type.title, locale: :en))
-        expect(page).to have_content(translated(initiative.scope.name, locale: :en))
-        expect(page).to have_content(initiative.author_name)
-        expect(page).to have_content(initiative.hashtag)
-        expect(page).to have_content(initiative.reference)
+    context "when requesting the initiative path" do
+      before do
+        visit decidim_initiatives.initiative_path(initiative)
       end
-    end
 
-    it "shows the author name once in the authors list" do
-      within ".initiative-authors" do
-        expect(page).to have_content(initiative.author_name, count: 1)
+      it "shows the details of the given initiative" do
+        within "main" do
+          expect(page).to have_content(translated(initiative.title, locale: :en))
+          expect(page).to have_content(ActionView::Base.full_sanitizer.sanitize(translated(initiative.description, locale: :en), tags: []))
+          expect(page).to have_content(translated(initiative.type.title, locale: :en))
+          expect(page).to have_content(translated(initiative.scope.name, locale: :en))
+          expect(page).to have_content(initiative.author_name)
+          expect(page).to have_content(initiative.hashtag)
+          expect(page).to have_content(initiative.reference)
+        end
       end
-    end
 
-    it_behaves_like "has attachments"
+      it "shows the author name once in the authors list" do
+        within ".initiative-authors" do
+          expect(page).to have_content(initiative.author_name, count: 1)
+        end
+      end
+
+      it_behaves_like "has attachments"
+    end
   end
 end

--- a/decidim-initiatives/spec/system/initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/initiatives_spec.rb
@@ -19,59 +19,63 @@ describe "Initiatives", type: :system do
       create(:initiative, :created, organization: organization)
     end
 
-    before do
-      visit decidim_initiatives.initiatives_path
-    end
-
     it_behaves_like "shows contextual help" do
       let(:index_path) { decidim_initiatives.initiatives_path }
       let(:manifest_name) { :initiatives }
     end
 
-    it_behaves_like "editable content for admins"
+    it_behaves_like "editable content for admins" do
+      let(:target_path) { decidim_initiatives.initiatives_path }
+    end
 
-    context "when accessing from the homepage" do
-      it "the menu link is shown" do
-        visit decidim.root_path
+    context "when requesting the initiatives path" do
+      before do
+        visit decidim_initiatives.initiatives_path
+      end
 
-        within ".main-nav" do
-          expect(page).to have_content("Initiatives")
-          click_link "Initiatives"
+      context "when accessing from the homepage" do
+        it "the menu link is shown" do
+          visit decidim.root_path
+
+          within ".main-nav" do
+            expect(page).to have_content("Initiatives")
+            click_link "Initiatives"
+          end
+
+          expect(page).to have_current_path(decidim_initiatives.initiatives_path)
+        end
+      end
+
+      it "lists all the initiatives" do
+        within "#initiatives-count" do
+          expect(page).to have_content("1")
         end
 
-        expect(page).to have_current_path(decidim_initiatives.initiatives_path)
-      end
-    end
-
-    it "lists all the initiatives" do
-      within "#initiatives-count" do
-        expect(page).to have_content("1")
+        within "#initiatives" do
+          expect(page).to have_content(translated(initiative.title, locale: :en))
+          expect(page).to have_content(initiative.author_name, count: 1)
+          expect(page).not_to have_content(translated(unpublished_initiative.title, locale: :en))
+        end
       end
 
-      within "#initiatives" do
-        expect(page).to have_content(translated(initiative.title, locale: :en))
-        expect(page).to have_content(initiative.author_name, count: 1)
-        expect(page).not_to have_content(translated(unpublished_initiative.title, locale: :en))
+      it "links to the individual initiative page" do
+        click_link(translated(initiative.title, locale: :en))
+        expect(page).to have_current_path(decidim_initiatives.initiative_path(initiative))
       end
-    end
 
-    it "links to the individual initiative page" do
-      click_link(translated(initiative.title, locale: :en))
-      expect(page).to have_current_path(decidim_initiatives.initiative_path(initiative))
-    end
-
-    it "displays the filter initiative type filter" do
-      within ".new_filter[action='/initiatives']" do
-        expect(page).to have_content(/Type/i)
-      end
-    end
-
-    context "when there is a unique initiative type" do
-      let!(:unpublished_initiative) { nil }
-
-      it "doesn't display the initiative type filter" do
+      it "displays the filter initiative type filter" do
         within ".new_filter[action='/initiatives']" do
-          expect(page).not_to have_content(/Type/i)
+          expect(page).to have_content(/Type/i)
+        end
+      end
+
+      context "when there is a unique initiative type" do
+        let!(:unpublished_initiative) { nil }
+
+        it "doesn't display the initiative type filter" do
+          within ".new_filter[action='/initiatives']" do
+            expect(page).not_to have_content(/Type/i)
+          end
         end
       end
     end

--- a/decidim-pages/spec/system/page_show_spec.rb
+++ b/decidim-pages/spec/system/page_show_spec.rb
@@ -17,14 +17,18 @@ describe "Show a page", type: :system do
   let!(:page_component) { create(:page, component: component, body: body) }
 
   describe "page show" do
-    before do
-      visit_component
+    it_behaves_like "editable content for admins" do
+      let(:target_path) { main_component_path(component) }
     end
 
-    it_behaves_like "editable content for admins"
+    context "when requesting the page path" do
+      before do
+        visit_component
+      end
 
-    it "renders the content of the page" do
-      expect(page).to have_content("Content")
+      it "renders the content of the page" do
+        expect(page).to have_content("Content")
+      end
     end
   end
 end

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -78,76 +78,80 @@ describe "Participatory Processes", type: :system do
     let!(:grouped_process) { create :participatory_process, organization: organization }
     let!(:group) { create :participatory_process_group, participatory_processes: [grouped_process], organization: organization }
 
-    before do
-      visit decidim_participatory_processes.participatory_processes_path
-    end
-
     it_behaves_like "shows contextual help" do
       let(:index_path) { decidim_participatory_processes.participatory_processes_path }
       let(:manifest_name) { :participatory_processes }
     end
 
-    it_behaves_like "editable content for admins"
-
-    context "and accessing from the homepage" do
-      it "the menu link is not shown" do
-        visit decidim.root_path
-
-        within ".main-nav" do
-          expect(page).to have_content("Processes")
-          click_link "Processes"
-        end
-
-        expect(page).to have_current_path decidim_participatory_processes.participatory_processes_path
-      end
+    it_behaves_like "editable content for admins" do
+      let(:target_path) { decidim_participatory_processes.participatory_processes_path }
     end
 
-    it "lists all the highlighted processes" do
-      within "#highlighted-processes" do
-        expect(page).to have_content(translated(promoted_process.title, locale: :en))
-        expect(page).to have_selector("article.card--full", count: 1)
-      end
-    end
-
-    it "lists the active processes" do
-      within "#processes-grid" do
-        within "#processes-grid h3" do
-          expect(page).to have_content("3 ACTIVE PROCESSES")
-        end
-
-        expect(page).to have_content(translated(participatory_process.title, locale: :en))
-        expect(page).to have_content(translated(promoted_process.title, locale: :en))
-        expect(page).to have_content(translated(group.name, locale: :en))
-        expect(page).to have_selector("article.card", count: 3)
-
-        expect(page).to have_no_content(translated(unpublished_process.title, locale: :en))
-        expect(page).to have_no_content(translated(past_process.title, locale: :en))
-        expect(page).to have_no_content(translated(upcoming_process.title, locale: :en))
-        expect(page).to have_no_content(translated(grouped_process.title, locale: :en))
-      end
-    end
-
-    it "links to the individual process page" do
-      click_link(translated(participatory_process.title, locale: :en))
-
-      expect(page).to have_current_path decidim_participatory_processes.participatory_process_path(participatory_process)
-    end
-
-    context "with active steps" do
-      let!(:step) { create(:participatory_process_step, participatory_process: participatory_process) }
-      let!(:active_step) do
-        create(:participatory_process_step,
-               :active,
-               participatory_process: participatory_process,
-               title: { en: "Active step", ca: "Fase activa", es: "Fase activa" })
-      end
-
-      it "links to the active step" do
+    context "when requesting the processes path" do
+      before do
         visit decidim_participatory_processes.participatory_processes_path
+      end
 
-        within find("#processes-grid .column", text: translated(participatory_process.title)) do
-          within ".card__footer" do
-            expect(page).to have_content("CURRENT PHASE:\nActive step")
+      context "and accessing from the homepage" do
+        it "the menu link is not shown" do
+          visit decidim.root_path
+
+          within ".main-nav" do
+            expect(page).to have_content("Processes")
+            click_link "Processes"
+          end
+
+          expect(page).to have_current_path decidim_participatory_processes.participatory_processes_path
+        end
+      end
+
+      it "lists all the highlighted processes" do
+        within "#highlighted-processes" do
+          expect(page).to have_content(translated(promoted_process.title, locale: :en))
+          expect(page).to have_selector("article.card--full", count: 1)
+        end
+      end
+
+      it "lists the active processes" do
+        within "#processes-grid" do
+          within "#processes-grid h3" do
+            expect(page).to have_content("3 ACTIVE PROCESSES")
+          end
+
+          expect(page).to have_content(translated(participatory_process.title, locale: :en))
+          expect(page).to have_content(translated(promoted_process.title, locale: :en))
+          expect(page).to have_content(translated(group.name, locale: :en))
+          expect(page).to have_selector("article.card", count: 3)
+
+          expect(page).to have_no_content(translated(unpublished_process.title, locale: :en))
+          expect(page).to have_no_content(translated(past_process.title, locale: :en))
+          expect(page).to have_no_content(translated(upcoming_process.title, locale: :en))
+          expect(page).to have_no_content(translated(grouped_process.title, locale: :en))
+        end
+      end
+
+      it "links to the individual process page" do
+        click_link(translated(participatory_process.title, locale: :en))
+
+        expect(page).to have_current_path decidim_participatory_processes.participatory_process_path(participatory_process)
+      end
+
+      context "with active steps" do
+        let!(:step) { create(:participatory_process_step, participatory_process: participatory_process) }
+        let!(:active_step) do
+          create(:participatory_process_step,
+                 :active,
+                 participatory_process: participatory_process,
+                 title: { en: "Active step", ca: "Fase activa", es: "Fase activa" })
+        end
+
+        it "links to the active step" do
+          visit decidim_participatory_processes.participatory_processes_path
+
+          within find("#processes-grid .column", text: translated(participatory_process.title)) do
+            within ".card__footer" do
+              expect(page).to have_content("CURRENT PHASE:\nActive step")
+            end
           end
         end
       end
@@ -166,158 +170,162 @@ describe "Participatory Processes", type: :system do
       visit decidim_participatory_processes.participatory_process_path(participatory_process)
     end
 
-    it_behaves_like "editable content for admins"
-
-    it "shows the details of the given process" do
-      within "main" do
-        expect(page).to have_content(translated(participatory_process.title, locale: :en))
-        expect(page).to have_content(translated(participatory_process.subtitle, locale: :en))
-        expect(page).to have_content(translated(participatory_process.description, locale: :en))
-        expect(page).to have_content(translated(participatory_process.short_description, locale: :en))
-        expect(page).to have_content(translated(participatory_process.meta_scope, locale: :en))
-        expect(page).to have_content(translated(participatory_process.developer_group, locale: :en))
-        expect(page).to have_content(translated(participatory_process.local_area, locale: :en))
-        expect(page).to have_content(translated(participatory_process.target, locale: :en))
-        expect(page).to have_content(translated(participatory_process.participatory_scope, locale: :en))
-        expect(page).to have_content(translated(participatory_process.participatory_structure, locale: :en))
-        expect(page).to have_content(I18n.l(participatory_process.end_date, format: :long))
-        expect(page).to have_content(participatory_process.hashtag)
-      end
+    it_behaves_like "editable content for admins" do
+      let(:target_path) { decidim_participatory_processes.participatory_process_path(participatory_process) }
     end
 
-    it_behaves_like "has attachments" do
-      let(:attached_to) { participatory_process }
-    end
-
-    it_behaves_like "has attachment collections" do
-      let(:attached_to) { participatory_process }
-      let(:collection_for) { participatory_process }
-    end
-
-    context "when it has some linked processes" do
-      let(:published_process) { create :participatory_process, :published, organization: organization }
-      let(:unpublished_process) { create :participatory_process, :unpublished, organization: organization }
-
-      it "only shows the published linked processes" do
-        participatory_process
-          .link_participatory_space_resources(
-            [published_process, unpublished_process],
-            "related_processes"
-          )
-        visit decidim_participatory_processes.participatory_process_path(participatory_process)
-        expect(page).to have_content(translated(published_process.title))
-        expect(page).to have_no_content(translated(unpublished_process.title))
-      end
-    end
-
-    context "and the process has some components" do
-      it "shows the components" do
-        within ".process-nav" do
-          expect(page).to have_content(translated(proposals_component.name, locale: :en).upcase)
-          expect(page).to have_no_content(translated(meetings_component.name, locale: :en).upcase)
+    context "when requesting the process path" do
+      it "shows the details of the given process" do
+        within "main" do
+          expect(page).to have_content(translated(participatory_process.title, locale: :en))
+          expect(page).to have_content(translated(participatory_process.subtitle, locale: :en))
+          expect(page).to have_content(translated(participatory_process.description, locale: :en))
+          expect(page).to have_content(translated(participatory_process.short_description, locale: :en))
+          expect(page).to have_content(translated(participatory_process.meta_scope, locale: :en))
+          expect(page).to have_content(translated(participatory_process.developer_group, locale: :en))
+          expect(page).to have_content(translated(participatory_process.local_area, locale: :en))
+          expect(page).to have_content(translated(participatory_process.target, locale: :en))
+          expect(page).to have_content(translated(participatory_process.participatory_scope, locale: :en))
+          expect(page).to have_content(translated(participatory_process.participatory_structure, locale: :en))
+          expect(page).to have_content(I18n.l(participatory_process.end_date, format: :long))
+          expect(page).to have_content(participatory_process.hashtag)
         end
       end
 
-      context "and the process metrics are enabled" do
-        let(:organization) { create(:organization) }
-        let(:metrics) do
-          Decidim.metrics_registry.filtered(highlight: true, scope: "participatory_process").each do |metric_registry|
-            create(:metric, metric_type: metric_registry.metric_name, day: Time.zone.today - 1.week, organization: organization, participatory_space_type: Decidim::ParticipatoryProcess.name, participatory_space_id: participatory_process.id, cumulative: 5, quantity: 2)
+      it_behaves_like "has attachments" do
+        let(:attached_to) { participatory_process }
+      end
+
+      it_behaves_like "has attachment collections" do
+        let(:attached_to) { participatory_process }
+        let(:collection_for) { participatory_process }
+      end
+
+      context "when it has some linked processes" do
+        let(:published_process) { create :participatory_process, :published, organization: organization }
+        let(:unpublished_process) { create :participatory_process, :unpublished, organization: organization }
+
+        it "only shows the published linked processes" do
+          participatory_process
+            .link_participatory_space_resources(
+              [published_process, unpublished_process],
+              "related_processes"
+            )
+          visit decidim_participatory_processes.participatory_process_path(participatory_process)
+          expect(page).to have_content(translated(published_process.title))
+          expect(page).to have_no_content(translated(unpublished_process.title))
+        end
+      end
+
+      context "and the process has some components" do
+        it "shows the components" do
+          within ".process-nav" do
+            expect(page).to have_content(translated(proposals_component.name, locale: :en).upcase)
+            expect(page).to have_no_content(translated(meetings_component.name, locale: :en).upcase)
           end
         end
 
-        before do
-          metrics
-          visit current_path
+        context "and the process metrics are enabled" do
+          let(:organization) { create(:organization) }
+          let(:metrics) do
+            Decidim.metrics_registry.filtered(highlight: true, scope: "participatory_process").each do |metric_registry|
+              create(:metric, metric_type: metric_registry.metric_name, day: Time.zone.today - 1.week, organization: organization, participatory_space_type: Decidim::ParticipatoryProcess.name, participatory_space_id: participatory_process.id, cumulative: 5, quantity: 2)
+            end
+          end
+
+          before do
+            metrics
+            visit current_path
+          end
+
+          it "shows the metrics charts" do
+            expect(page).to have_css("h3.section-heading", text: "METRICS")
+
+            within "#metrics" do
+              Decidim.metrics_registry.filtered(highlight: true, scope: "participatory_process").each do |metric_registry|
+                expect(page).to have_css(%(##{metric_registry.metric_name}_chart))
+              end
+            end
+          end
+
+          it "renders a link to all metrics" do
+            within "#metrics" do
+              expect(page).to have_link("Show all metrics")
+            end
+          end
+
+          it "click link" do
+            click_link("Show all metrics")
+            have_current_path(decidim_participatory_processes.all_metrics_participatory_process_path(participatory_process))
+          end
         end
 
-        it "shows the metrics charts" do
-          expect(page).to have_css("h3.section-heading", text: "METRICS")
+        context "and the process statistics are enabled" do
+          let(:show_statistics) { true }
 
-          within "#metrics" do
-            Decidim.metrics_registry.filtered(highlight: true, scope: "participatory_process").each do |metric_registry|
-              expect(page).to have_css(%(##{metric_registry.metric_name}_chart))
+          it "the stats for those components are visible" do
+            within "#participatory_process-statistics" do
+              expect(page).to have_css("h4.section-heading", text: "STATISTICS")
+              expect(page).to have_css(".process-stats__title", text: "PROPOSALS")
+              expect(page).to have_css(".process-stats__number", text: "3")
+              expect(page).to have_no_css(".process-stats__title", text: "MEETINGS")
+              expect(page).to have_no_css(".process-stats__number", text: "0")
             end
           end
         end
 
-        it "renders a link to all metrics" do
-          within "#metrics" do
-            expect(page).to have_link("Show all metrics")
+        context "and the process statistics are not enabled" do
+          let(:show_statistics) { false }
+
+          it "the stats for those components are not visible" do
+            expect(page).to have_no_css("h4.section-heading", text: "STATISTICS")
+            expect(page).to have_no_css(".process-stats__title", text: "PROPOSALS")
+            expect(page).to have_no_css(".process-stats__number", text: "3")
           end
         end
 
-        it "click link" do
-          click_link("Show all metrics")
-          have_current_path(decidim_participatory_processes.all_metrics_participatory_process_path(participatory_process))
+        context "and the process metrics are not enabled" do
+          let(:show_metrics) { false }
+
+          it "the metrics for the participatory processes are not rendered" do
+            expect(page).to have_no_css("h4.section-heading", text: "METRICS")
+          end
+
+          it "has no link to all metrics" do
+            expect(page).to have_no_link("Show all metrics")
+          end
         end
-      end
 
-      context "and the process statistics are enabled" do
-        let(:show_statistics) { true }
+        context "and the process doesn't have hashtag" do
+          let(:hashtag) { false }
 
-        it "the stats for those components are visible" do
-          within "#participatory_process-statistics" do
-            expect(page).to have_css("h4.section-heading", text: "STATISTICS")
-            expect(page).to have_css(".process-stats__title", text: "PROPOSALS")
-            expect(page).to have_css(".process-stats__number", text: "3")
-            expect(page).to have_no_css(".process-stats__title", text: "MEETINGS")
-            expect(page).to have_no_css(".process-stats__number", text: "0")
+          it "the hashtags for those components are not visible" do
+            expect(page).to have_no_content("#")
           end
         end
       end
 
-      context "and the process statistics are not enabled" do
-        let(:show_statistics) { false }
+      context "when assemblies are linked to participatory process" do
+        let!(:published_assembly) { create(:assembly, :published, organization: organization) }
+        let!(:unpublished_assembly) { create(:assembly, :unpublished, organization: organization) }
+        let!(:private_assembly) { create(:assembly, :published, :private, :opaque, organization: organization) }
+        let!(:transparent_assembly) { create(:assembly, :published, :private, :transparent, organization: organization) }
 
-        it "the stats for those components are not visible" do
-          expect(page).to have_no_css("h4.section-heading", text: "STATISTICS")
-          expect(page).to have_no_css(".process-stats__title", text: "PROPOSALS")
-          expect(page).to have_no_css(".process-stats__number", text: "3")
-        end
-      end
-
-      context "and the process metrics are not enabled" do
-        let(:show_metrics) { false }
-
-        it "the metrics for the participatory processes are not rendered" do
-          expect(page).to have_no_css("h4.section-heading", text: "METRICS")
+        before do
+          published_assembly.link_participatory_space_resources(participatory_process, "included_participatory_processes")
+          unpublished_assembly.link_participatory_space_resources(participatory_process, "included_participatory_processes")
+          private_assembly.link_participatory_space_resources(participatory_process, "included_participatory_processes")
+          transparent_assembly.link_participatory_space_resources(participatory_process, "included_participatory_processes")
+          visit decidim_participatory_processes.participatory_process_path(participatory_process)
         end
 
-        it "has no link to all metrics" do
-          expect(page).to have_no_link("Show all metrics")
+        it "display related assemblies" do
+          expect(page).to have_content("RELATED ASSEMBLIES")
+          expect(page).to have_content(translated(published_assembly.title))
+          expect(page).to have_content(translated(transparent_assembly.title))
+          expect(page).to have_no_content(translated(unpublished_assembly.title))
+          expect(page).to have_no_content(translated(private_assembly.title))
         end
-      end
-
-      context "and the process doesn't have hashtag" do
-        let(:hashtag) { false }
-
-        it "the hashtags for those components are not visible" do
-          expect(page).to have_no_content("#")
-        end
-      end
-    end
-
-    context "when assemblies are linked to participatory process" do
-      let!(:published_assembly) { create(:assembly, :published, organization: organization) }
-      let!(:unpublished_assembly) { create(:assembly, :unpublished, organization: organization) }
-      let!(:private_assembly) { create(:assembly, :published, :private, :opaque, organization: organization) }
-      let!(:transparent_assembly) { create(:assembly, :published, :private, :transparent, organization: organization) }
-
-      before do
-        published_assembly.link_participatory_space_resources(participatory_process, "included_participatory_processes")
-        unpublished_assembly.link_participatory_space_resources(participatory_process, "included_participatory_processes")
-        private_assembly.link_participatory_space_resources(participatory_process, "included_participatory_processes")
-        transparent_assembly.link_participatory_space_resources(participatory_process, "included_participatory_processes")
-        visit decidim_participatory_processes.participatory_process_path(participatory_process)
-      end
-
-      it "display related assemblies" do
-        expect(page).to have_content("RELATED ASSEMBLIES")
-        expect(page).to have_content(translated(published_assembly.title))
-        expect(page).to have_content(translated(transparent_assembly.title))
-        expect(page).to have_no_content(translated(unpublished_assembly.title))
-        expect(page).to have_no_content(translated(private_assembly.title))
       end
     end
   end

--- a/decidim-proposals/spec/system/proposal_show_spec.rb
+++ b/decidim-proposals/spec/system/proposal_show_spec.rb
@@ -12,34 +12,38 @@ describe "Show a Proposal", type: :system do
   end
 
   describe "proposal show" do
-    before do
-      visit_proposal
+    it_behaves_like "editable content for admins" do
+      let(:target_path) { resource_locator(proposal).path }
     end
 
-    it_behaves_like "editable content for admins"
-
-    describe "extra admin link" do
+    context "when requesting the proposal path" do
       before do
-        login_as user, scope: :user
-        visit current_path
+        visit_proposal
       end
 
-      context "when I'm an admin user" do
-        let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+      describe "extra admin link" do
+        before do
+          login_as user, scope: :user
+          visit current_path
+        end
 
-        it "has a link to answer to the proposal at the admin" do
-          within ".topbar" do
-            expect(page).to have_link("Answer", href: /.*admin.*proposal-answer.*/)
+        context "when I'm an admin user" do
+          let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+
+          it "has a link to answer to the proposal at the admin" do
+            within ".topbar" do
+              expect(page).to have_link("Answer", href: /.*admin.*proposal-answer.*/)
+            end
           end
         end
-      end
 
-      context "when I'm a regular user" do
-        let(:user) { create(:user, :confirmed, organization: organization) }
+        context "when I'm a regular user" do
+          let(:user) { create(:user, :confirmed, organization: organization) }
 
-        it "does not have a link to answer the proposal at the admin" do
-          within ".topbar" do
-            expect(page).not_to have_link("Answer")
+          it "does not have a link to answer the proposal at the admin" do
+            within ".topbar" do
+              expect(page).not_to have_link("Answer")
+            end
           end
         end
       end

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -365,11 +365,9 @@ describe "Proposals", type: :system do
     end
 
     describe "editable content" do
-      before do
-        visit_component
+      it_behaves_like "editable content for admins" do
+        let(:target_path) { main_component_path(component) }
       end
-
-      it_behaves_like "editable content for admins"
     end
 
     context "when comments have been moderated" do


### PR DESCRIPTION
#### :tophat: What? Why?

The tests at `decidim/decidim-core/lib/decidim/core/test/shared_examples/edit_link_shared_examples.rb` seemed to fail randomly at different runs of the exactly same test. Even when the test was re-run with the exactly same random seed, it seemed to fail randomly. In particular this was happening with the `decidim-assemblies/spec/system/assemblies_spec.rb`.

An example result of a test run where this happened:
https://github.com/decidim/decidim/pull/6124/checks?check_run_id=745277393

The failure looked something like this (depending on which test actually failed):

```
  1) Assemblies when there are some published assemblies behaves like editable content for admins edit link when I'm an admin user has a link to edit the content at the admin
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
       expected to find link "Edit" with href matching /admin/ within #<Capybara::Node::Element tag="div" path="/HTML/BODY[1]/DIV[2]/DIV[1]/DIV[3]/DIV[1]/DIV[1]/DIV[1]"> but there were no matches

     Shared Example Group: "editable content for admins" called from ./spec/system/assemblies_spec.rb:79
     # /home/runner/work/decidim/decidim/decidim-core/lib/decidim/core/test/shared_examples/edit_link_shared_examples.rb:15:in `block (5 levels) in <top (required)>'
     # /home/runner/work/decidim/decidim/decidim-core/lib/decidim/core/test/shared_examples/edit_link_shared_examples.rb:14:in `block (4 levels) in <top (required)>'
```

After debugging this, the reason was that when the "editable content for admins" shared example is used, there should be no prior requests still working in the background. It should be therefore completely isolated from prior requests.

In particular, this is what caused the particular example test to run:

- The `assemblies_spec.rb` was doing an initial request for the assemblies page at https://github.com/decidim/decidim/blob/418e9b9bc35856c559364edcae1bc0ad20cdc909/decidim-assemblies/spec/system/assemblies_spec.rb#L76
- The initial request was finished and the page was rendered
- The "editable content for admins" shared spec started its own request for the current page at https://github.com/decidim/decidim/blob/418e9b9bc35856c559364edcae1bc0ad20cdc909/decidim-core/lib/decidim/core/test/shared_examples/edit_link_shared_examples.rb#L7
- The headless browser was still working on the dynamic functionality of the initial request which caused another request from the organization chart rendering at https://github.com/decidim/decidim/blob/418e9b9bc35856c559364edcae1bc0ad20cdc909/decidim-assemblies/app/assets/javascripts/decidim/assemblies/orgchart.js.es6#L664
- The dynamic request was "consuming" the logged in state of Warden making all further requests have a logged out state
- The actual request from "editable content for admins" finishes with a logged out state causing the tests to fail

A take from this is that when using the "editable content for admins" shared examples, do not do any prior requests causing more dynamic requests before those tests are run.

#### :pushpin: Related Issues
- Related to #6124

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add/modify seeds
