### PR TITLE
Remove decidim-surveys legacy tables after migrating to decidim-forms

### DIFF
--- a/decidim-surveys/db/migrate/20200610090533_remove_survey_answer_choices.rb
+++ b/decidim-surveys/db/migrate/20200610090533_remove_survey_answer_choices.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveSurveyAnswerChoices < ActiveRecord::Migration[5.2]
+  def change
+    drop_table :decidim_surveys_survey_answer_choices, if_exists: true
+  end
+end

--- a/decidim-surveys/db/migrate/20200610090650_remove_survey_answer_options.rb
+++ b/decidim-surveys/db/migrate/20200610090650_remove_survey_answer_options.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveSurveyAnswerOptions < ActiveRecord::Migration[5.2]
+  def change
+    drop_table :decidim_surveys_survey_answer_options, if_exists: true
+  end
+end

--- a/decidim-surveys/db/migrate/20200610090725_remove_survey_answers.rb
+++ b/decidim-surveys/db/migrate/20200610090725_remove_survey_answers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveSurveyAnswers < ActiveRecord::Migration[5.2]
+  def change
+    drop_table :decidim_surveys_survey_answers, if_exists: true
+  end
+end

--- a/decidim-surveys/db/migrate/20200610090845_remove_survey_questions.rb
+++ b/decidim-surveys/db/migrate/20200610090845_remove_survey_questions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveSurveyQuestions < ActiveRecord::Migration[5.2]
+  def change
+    drop_table :decidim_surveys_survey_questions, if_exists: true
+  end
+end

--- a/decidim-surveys/db/migrate/20200610105927_remove_survey_columns.rb
+++ b/decidim-surveys/db/migrate/20200610105927_remove_survey_columns.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class RemoveSurveyColumns < ActiveRecord::Migration[5.2]
+  def change
+    if ActiveRecord::Base.connection.column_exists?(:decidim_surveys_surveys, :title)
+      remove_column :decidim_surveys_surveys, :title
+    end
+    if ActiveRecord::Base.connection.column_exists?(:decidim_surveys_surveys, :description)
+      remove_column :decidim_surveys_surveys, :description
+    end
+    if ActiveRecord::Base.connection.column_exists?(:decidim_surveys_surveys, :tos)
+      remove_column :decidim_surveys_surveys, :tos
+    end
+    if ActiveRecord::Base.connection.column_exists?(:decidim_surveys_surveys, :published_at)
+      remove_column :decidim_surveys_surveys, :published_at
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Remove legacy tables and also legacy columns in `decidim_surveys_surveys`. Those tables and columns were moved into `decidim-forms` in version `0.16.0`.

#### :pushpin: Related Issues
- Related to #6162 and #5443

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
