### PR TITLE
Elections authorizations

### DIFF
--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -62,3 +62,5 @@ jobs:
       - run: bundle exec rake
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+      - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
+        name: Upload coverage

--- a/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
@@ -5,6 +5,8 @@ module Decidim
     # This class contains helpers needed in order for component settings to
     # properly render.
     module SettingsHelper
+      include Decidim::ScopesHelper
+
       TYPES = {
         boolean: :check_box,
         integer: :number_field,

--- a/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
@@ -10,6 +10,7 @@ module Decidim
         integer: :number_field,
         string: :text_field,
         text: :text_area,
+        scope: :scope_field,
         enum: :collection_radio_buttons
       }.freeze
 
@@ -45,6 +46,8 @@ module Decidim
             form.send(:translated, form_method, name, options)
           elsif form_method == :collection_radio_buttons
             render_enum_form_field(form, attribute, name, i18n_scope, options)
+          elsif form_method == :scope_field
+            scopes_picker_field(form, name)
           else
             form.send(form_method, name, options)
           end

--- a/decidim-admin/lib/decidim/admin/test/manage_component_permissions_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_component_permissions_examples.rb
@@ -31,7 +31,7 @@ shared_examples "Managing component permissions" do
       within "form.new_component_permissions" do
         within ".foo-permission" do
           check "Example authorization (Direct)"
-          fill_in "Postal code", with: "08002"
+          fill_in "Allowed postal codes", with: "08002"
         end
         find("*[type=submit]").click
       end
@@ -42,7 +42,7 @@ shared_examples "Managing component permissions" do
         include(
           "authorization_handlers" => {
             "dummy_authorization_handler" => {
-              "options" => { "postal_code" => "08002" }
+              "options" => { "allowed_postal_codes" => "08002" }
             }
           }
         )
@@ -61,7 +61,7 @@ shared_examples "Managing component permissions" do
       within "form.new_component_permissions" do
         within ".foo-permission" do
           check "Example authorization (Direct)"
-          fill_in "Postal code", with: "08002"
+          fill_in "Allowed postal codes", with: "08002"
         end
         find("*[type=submit]").click
       end
@@ -79,7 +79,7 @@ shared_examples "Managing component permissions" do
           "foo" => {
             "authorization_handlers" => {
               "dummy_authorization_handler" => {
-                "options" => { "postal_code" => "08002" }
+                "options" => { "allowed_postal_codes" => "08002" }
               }
             }
           }
@@ -114,7 +114,7 @@ shared_examples "Managing component permissions" do
           "foo" => {
             "authorization_handlers" => {
               "dummy_authorization_handler" => {
-                "options" => { "postal_code" => "08002" }
+                "options" => { "allowed_postal_codes" => "08002" }
               }
             }
           }
@@ -166,7 +166,7 @@ shared_examples "Managing component permissions" do
         include(
           "authorization_handlers" => {
             "dummy_authorization_handler" => {
-              "options" => { "postal_code" => "08002" }
+              "options" => { "allowed_postal_codes" => "08002" }
             },
             "another_dummy_authorization_handler" => {
               "options" => { "passport_number" => "AXXXXXXXX" }
@@ -217,7 +217,7 @@ shared_examples "Managing component permissions" do
         within "form.new_component_permissions" do
           within ".foo-permission" do
             check "Example authorization (Direct)"
-            fill_in "Postal code", with: "08002"
+            fill_in "Allowed postal codes", with: "08002"
           end
           find("*[type=submit]").click
         end
@@ -228,7 +228,7 @@ shared_examples "Managing component permissions" do
           include(
             "authorization_handlers" => {
               "dummy_authorization_handler" => {
-                "options" => { "postal_code" => "08002" }
+                "options" => { "allowed_postal_codes" => "08002" }
               }
             }
           )
@@ -244,7 +244,7 @@ shared_examples "Managing component permissions" do
             "foo" => {
               "authorization_handlers" => {
                 "dummy_authorization_handler" => {
-                  "options" => { "postal_code" => "08002" }
+                  "options" => { "allowed_postal_codes" => "08002" }
                 }
               }
             }
@@ -277,7 +277,7 @@ shared_examples "Managing component permissions" do
             "foo" => {
               "authorization_handlers" => {
                 "dummy_authorization_handler" => {
-                  "options" => { "postal_code" => "08002" }
+                  "options" => { "allowed_postal_codes" => "08002" }
                 }
               }
             }
@@ -327,7 +327,7 @@ shared_examples "Managing component permissions" do
           include(
             "authorization_handlers" => {
               "dummy_authorization_handler" => {
-                "options" => { "postal_code" => "08002" }
+                "options" => { "allowed_postal_codes" => "08002" }
               },
               "another_dummy_authorization_handler" => {
                 "options" => { "passport_number" => "AXXXXXXXX" }
@@ -345,7 +345,7 @@ shared_examples "Managing component permissions" do
             "foo" => {
               "authorization_handlers" => {
                 "dummy_authorization_handler" => {
-                  "options" => { "postal_code" => "08002" }
+                  "options" => { "allowed_postal_codes" => "08002" }
                 }
               }
             }
@@ -395,7 +395,7 @@ shared_examples "Managing component permissions" do
           include(
             "authorization_handlers" => {
               "dummy_authorization_handler" => {
-                "options" => { "postal_code" => "08002" }
+                "options" => { "allowed_postal_codes" => "08002" }
               },
               "another_dummy_authorization_handler" => {
                 "options" => { "passport_number" => "AXXXXXXXX" }
@@ -413,7 +413,7 @@ shared_examples "Managing component permissions" do
             "foo" => {
               "authorization_handlers" => {
                 "dummy_authorization_handler" => {
-                  "options" => { "postal_code" => "08002" }
+                  "options" => { "allowed_postal_codes" => "08002" }
                 }
               }
             }

--- a/decidim-admin/spec/helpers/settings_helper_spec.rb
+++ b/decidim-admin/spec/helpers/settings_helper_spec.rb
@@ -115,6 +115,15 @@ module Decidim
           end
         end
       end
+
+      describe "scopes" do
+        let(:type) { :scope }
+
+        it "is supported" do
+          expect(form).to receive(:scopes_picker_field).with(:test)
+          render_input
+        end
+      end
     end
   end
 end

--- a/decidim-admin/spec/helpers/settings_helper_spec.rb
+++ b/decidim-admin/spec/helpers/settings_helper_spec.rb
@@ -22,6 +22,12 @@ module Decidim
         )
       end
 
+      let(:current_participatory_space) { create(:participatory_process) }
+
+      before do
+        allow(view).to receive(:current_participatory_space).and_return(current_participatory_space)
+      end
+
       def render_input
         helper.settings_attribute_input(form, attribute, name, i18n_scope, options)
       end
@@ -120,7 +126,7 @@ module Decidim
         let(:type) { :scope }
 
         it "is supported" do
-          expect(form).to receive(:scopes_picker_field).with(:test)
+          expect(form).to receive(:scopes_picker).with(:test, checkboxes_on_top: true)
           render_input
         end
       end

--- a/decidim-core/app/helpers/decidim/decidim_form_helper.rb
+++ b/decidim-core/app/helpers/decidim/decidim_form_helper.rb
@@ -75,7 +75,7 @@ module Decidim
                          picker_options: picker_options,
                          prompt_params: prompt_params,
                          scopes: scopes,
-                         checkboxes_on_top: true)
+                         values_on_top: true)
       template.html_safe
     end
 

--- a/decidim-core/app/helpers/decidim/scopes_helper.rb
+++ b/decidim-core/app/helpers/decidim/scopes_helper.rb
@@ -35,7 +35,7 @@ module Decidim
     # form - FormBuilder object
     # name - attribute name
     # options       - An optional Hash with options:
-    # - checkboxes_on_top - Show checked picker values on top (default) or below the picker prompt
+    # - checkboxes_on_top - Show checked picker values on top (default) or below the picker prompt (only for multiple pickers)
     #
     # Returns nothing.
     def scopes_picker_field(form, name, root: false, options: { checkboxes_on_top: true })
@@ -64,7 +64,7 @@ module Decidim
     # Renders a scopes picker field in a filter form.
     # form - FilterFormBuilder object
     # name - attribute name
-    # checkboxes_on_top - Show picker values on top (default) or below the picker prompt
+    # checkboxes_on_top - Show picker values on top (default) or below the picker prompt (only for multiple pickers)
     #
     # Returns nothing.
     def scopes_picker_filter(form, name, checkboxes_on_top = true)

--- a/decidim-core/app/views/decidim/authorization_modals/_content.html.erb
+++ b/decidim-core/app/views/decidim/authorization_modals/_content.html.erb
@@ -17,8 +17,8 @@
   <% authorizations.statuses.each do |status| %>
     <% next if status.ok? || authorizations.global_code && status.code != base_code %>
     <p><%= t ".#{status.code}.explanation", authorization: t("#{status.handler_name}.name", scope: "decidim.authorization_handlers") %></p>
-    <% if status.data[:extra_explanation] %>
-      <p><%= t status.data[:extra_explanation][:key], **status.data[:extra_explanation][:params] %></p>
+    <% [status.data[:extra_explanation]].flatten.compact.each do |extra_explanation| %>
+      <p><%= t extra_explanation[:key], **extra_explanation[:params] %></p>
     <% end %>
     <% if status.data[:fields] %>
       <ul>

--- a/decidim-core/app/views/decidim/scopes/_scopes_picker_input.html.erb
+++ b/decidim-core/app/views/decidim/scopes/_scopes_picker_input.html.erb
@@ -1,11 +1,19 @@
-<div id="<%= picker_options[:id] %>" class="data-picker <%= picker_options[:class] %>" data-picker-name="<%= picker_options[:name] %>">
-  <% unless checkboxes_on_top %>
-    <div class="picker-prompt"><a href="<%= prompt_params[:url] %>"><%= prompt_params[:text] %></a></div>
-  <% end %>
-  <div class="picker-values"><% scopes.each do |scope, params| %>
+<%- @scope_picker_prompt = capture do %>
+  <div class="picker-prompt"><a href="<%= prompt_params[:url] %>"><%= prompt_params[:text] %></a></div>
+<% end %>
+
+<%- @scope_picker_values = capture do %>
+  <div class="picker-values"><%- scopes.each do |scope, params| %>
     <div><a href="<%= params[:url] %>" data-picker-value="<%= scope.id %>"><%= params[:text] %></a></div>
   <% end %></div>
-  <% if checkboxes_on_top %>
-    <div class="picker-prompt"><a href="<%= prompt_params[:url] %>"><%= prompt_params[:text] %></a></div>
+<% end %>
+
+<div id="<%= picker_options[:id] %>" class="data-picker <%= picker_options[:class] %>" data-picker-name="<%= picker_options[:name] %>">
+  <% if values_on_top %>
+    <%= @scope_picker_values %>
+    <%= @scope_picker_prompt %>
+  <% else %>
+    <%= @scope_picker_prompt %>
+    <%= @scope_picker_values %>
   <% end %>
 </div>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -260,8 +260,11 @@ en:
       dummy_authorization_handler:
         explanation: Get verified by introducing a document number ending with "X"
         fields:
+          allowed_postal_codes: Allowed postal codes (separated by commas)
+          allowed_scope_id: Allowed scope
           document_number: Document number
           postal_code: Postal code
+          scope_id: Scope
         name: Example authorization
       dummy_authorization_workflow:
         name: Dummy authorization workflow

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -272,7 +272,7 @@ module Decidim
     # options       - An optional Hash with options:
     # - multiple    - Multiple mode, to allow multiple scopes selection.
     # - label       - Show label?
-    # - checkboxes_on_top - Show checked picker values on top (default) or below the picker prompt
+    # - checkboxes_on_top - Show checked picker values on top (default) or below the picker prompt (only for multiple pickers)
     #
     # Also it should receive a block that returns a Hash with :url and :text for each selected scope (and for null scope for prompt)
     #
@@ -294,7 +294,7 @@ module Decidim
                                    picker_options: picker_options,
                                    prompt_params: prompt_params,
                                    scopes: scopes,
-                                   checkboxes_on_top: options[:checkboxes_on_top])
+                                   values_on_top: !options[:multiple] || options[:checkboxes_on_top])
       template += error_and_help_text(attribute, options)
       template.html_safe
     end

--- a/decidim-core/lib/decidim/settings_manifest.rb
+++ b/decidim-core/lib/decidim/settings_manifest.rb
@@ -94,7 +94,8 @@ module Decidim
         string: { klass: String, default: nil },
         text: { klass: String, default: nil },
         array: { klass: Array, default: [] },
-        enum: { klass: String, default: nil }
+        enum: { klass: String, default: nil },
+        scope: { klass: Integer, default: nil }
       }.freeze
 
       attribute :type, Symbol, default: :boolean

--- a/decidim-core/spec/lib/authorization_form_builder_spec.rb
+++ b/decidim-core/spec/lib/authorization_form_builder_spec.rb
@@ -67,7 +67,8 @@ module Decidim
           handler_name: String,
           document_number: String,
           postal_code: String,
-          birthday: Date
+          birthday: Date,
+          scope_id: Integer
         }
       end
 

--- a/decidim-core/spec/lib/settings_manifest_spec.rb
+++ b/decidim-core/spec/lib/settings_manifest_spec.rb
@@ -125,6 +125,12 @@ module Decidim
           expect(attribute.type_class).to eq(String)
           expect(attribute.default_value).to eq(nil)
         end
+
+        it "supports scopes" do
+          attribute = SettingsManifest::Attribute.new(type: :scope)
+          expect(attribute.type_class).to eq(Integer)
+          expect(attribute.default_value).to eq(nil)
+        end
       end
 
       it "only allows valid types" do

--- a/decidim-core/spec/services/decidim/action_authorizer_spec.rb
+++ b/decidim-core/spec/services/decidim/action_authorizer_spec.rb
@@ -182,7 +182,7 @@ module Decidim
           end
 
           context "when custom action authorizer options are present and match the authorization" do
-            let(:options) { { allowed_postal_codes: %w(1234 4567) } }
+            let(:options) { { allowed_postal_codes: "1234 4567" } }
 
             it "returns ok" do
               expect(response).to be_ok
@@ -196,7 +196,7 @@ module Decidim
           end
 
           context "when custom action authorizer options are present and don't match the authorization" do
-            let(:options) { { allowed_postal_codes: %w(2345 4567) } }
+            let(:options) { { allowed_postal_codes: "2345,4567" } }
 
             it "returns an authorization status collection including unauthorized" do
               expect(response.statuses.count).to eq(1)

--- a/decidim-core/spec/services/decidim/action_authorizer_spec.rb
+++ b/decidim-core/spec/services/decidim/action_authorizer_spec.rb
@@ -188,10 +188,10 @@ module Decidim
               expect(response).to be_ok
               expect(response.statuses.count).to eq(1)
               authorizer = response.statuses.first
-              expect(authorizer.data).to include(extra_explanation: { key: "extra_explanation",
-                                                                      params: { scope: "decidim.verifications.dummy_authorization",
-                                                                                count: 2,
-                                                                                postal_codes: "1234, 4567" } })
+              expect(authorizer.data).to include(extra_explanation: [{ key: "extra_explanation.postal_codes",
+                                                                       params: { scope: "decidim.verifications.dummy_authorization",
+                                                                                 count: 2,
+                                                                                 postal_codes: "1234, 4567" } }])
             end
           end
 
@@ -205,10 +205,10 @@ module Decidim
               expect(authorizer.code).to eq(:unauthorized)
               expect(authorizer.handler_name).to eq("dummy_authorization_handler")
               expect(authorizer.data).to include(fields: { "postal_code" => "1234" })
-              expect(authorizer.data).to include(extra_explanation: { key: "extra_explanation",
-                                                                      params: { scope: "decidim.verifications.dummy_authorization",
-                                                                                count: 2,
-                                                                                postal_codes: "2345, 4567" } })
+              expect(authorizer.data).to include(extra_explanation: [{ key: "extra_explanation.postal_codes",
+                                                                       params: { scope: "decidim.verifications.dummy_authorization",
+                                                                                 count: 2,
+                                                                                 postal_codes: "2345, 4567" } }])
             end
           end
 

--- a/decidim-elections/app/controllers/decidim/elections/elections_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/elections_controller.rb
@@ -4,6 +4,21 @@ module Decidim
   module Elections
     # Exposes the elections resources so users can participate on them
     class ElectionsController < Decidim::Elections::ApplicationController
+      helper_method :elections, :election
+
+      def show
+        enforce_permission_to :vote, :election, election: election
+      end
+
+      private
+
+      def elections
+        @elections ||= Election.where(component: current_component)
+      end
+
+      def election
+        @election ||= elections.find(params[:id])
+      end
     end
   end
 end

--- a/decidim-elections/app/models/decidim/elections/election.rb
+++ b/decidim-elections/app/models/decidim/elections/election.rb
@@ -26,6 +26,10 @@ module Decidim
       def finished?
         end_time < Time.current
       end
+
+      def allow_resource_permissions?
+        true
+      end
     end
   end
 end

--- a/decidim-elections/app/permissions/decidim/elections/permissions.rb
+++ b/decidim-elections/app/permissions/decidim/elections/permissions.rb
@@ -9,7 +9,25 @@ module Decidim
         # Delegate the admin permission checks to the admin permissions class
         return Decidim::Elections::Admin::Permissions.new(user, permission_action, context).permissions if permission_action.scope == :admin
 
+        return permission_action if permission_action.scope != :public
+        return permission_action if permission_action.subject != :election
+
+        case permission_action.action
+        when :vote
+          toggle_allow(can_vote?)
+        end
+
         permission_action
+      end
+
+      private
+
+      def can_vote?
+        authorized?(:vote, resource: election)
+      end
+
+      def election
+        @election ||= context[:election]
       end
     end
   end

--- a/decidim-elections/app/views/decidim/elections/admin/elections/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/index.html.erb
@@ -59,6 +59,8 @@
                   <% end %>
                 <% end %>
 
+                <%= resource_permissions_link(election) %>
+
                 <% if allowed_to? :delete, :election, election: election %>
                   <%= icon_link_to "circle-x", election_path(election), t("actions.destroy", scope: "decidim.elections"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.elections") } %>
                 <% else %>

--- a/decidim-elections/app/views/decidim/elections/elections/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/index.html.erb
@@ -1,1 +1,11 @@
 <%= render partial: "decidim/shared/component_announcement" %>
+
+<div class="row column">
+  <ul>
+    <% elections.each do |election| %>
+      <li><%= action_authorized_link_to :vote, election_path(election), resource: election do %>
+        <%= translated_attribute(election.title) %>
+      <% end %></li>
+    <% end %>
+  </ul>
+</div>

--- a/decidim-elections/app/views/decidim/elections/elections/show.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/show.html.erb
@@ -1,0 +1,3 @@
+<div class="row column">
+  <p>Voting in <%= translated_attribute(election.title) %></p>
+</div>

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -41,6 +41,8 @@ en:
         unpublish: "%{user_name} unpublished the %{resource_name} election"
     components:
       elections:
+        actions:
+          vote: Vote
         name: Elections
         settings:
           global:

--- a/decidim-elections/lib/decidim/elections/component.rb
+++ b/decidim-elections/lib/decidim/elections/component.rb
@@ -13,7 +13,7 @@ Decidim.register_component(:elections) do |component|
   # end
 
   # These actions permissions can be configured in the admin panel
-  # component.actions = %w()
+  component.actions = %w(vote)
 
   component.settings(:global) do |settings|
     settings.attribute :announcement, type: :text, translated: true, editor: true
@@ -25,6 +25,7 @@ Decidim.register_component(:elections) do |component|
 
   component.register_resource(:election) do |resource|
     resource.model_class_name = "Decidim::Elections::Election"
+    resource.actions = %w(vote)
   end
 
   component.register_resource(:question) do |resource|

--- a/decidim-elections/spec/permissions/decidim/elections/permissions_spec.rb
+++ b/decidim-elections/spec/permissions/decidim/elections/permissions_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Elections::Permissions do
+  subject { described_class.new(user, permission_action, context).permissions.allowed? }
+
+  let(:user) { create :user, organization: elections_component.organization }
+  let(:context) do
+    {
+      current_component: elections_component,
+      election: election
+    }
+  end
+  let(:elections_component) { create :elections_component }
+  let(:election) { create :election, component: elections_component }
+  let(:permission_action) { Decidim::PermissionAction.new(action) }
+
+  context "when scope is admin" do
+    let(:action) do
+      { scope: :admin, action: :foo, subject: :election }
+    end
+
+    it_behaves_like "delegates permissions to", Decidim::Elections::Admin::Permissions
+  end
+
+  context "when scope is not public" do
+    let(:action) do
+      { scope: :foo, action: :bar, subject: :election }
+    end
+
+    it_behaves_like "permission is not set"
+  end
+
+  context "when subject is not an election" do
+    let(:action) do
+      { scope: :public, action: :bar, subject: :foo }
+    end
+
+    it_behaves_like "permission is not set"
+  end
+
+  context "when action is a random one" do
+    let(:action) do
+      { scope: :public, action: :bar, subject: :election }
+    end
+
+    it_behaves_like "permission is not set"
+  end
+
+  describe "election vote" do
+    let(:action) do
+      { scope: :public, action: :vote, subject: :election }
+    end
+
+    it { is_expected.to eq true }
+  end
+end

--- a/decidim-generators/lib/decidim/generators/app_templates/dummy_authorization_handler.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/dummy_authorization_handler.rb
@@ -26,6 +26,7 @@ class DummyAuthorizationHandler < Decidim::AuthorizationHandler
   attribute :document_number, String
   attribute :postal_code, String
   attribute :birthday, Decidim::Attributes::LocalizedDate
+  attribute :scope_id, Integer
 
   # You can (and should) also define validations on each attribute:
   #
@@ -34,6 +35,7 @@ class DummyAuthorizationHandler < Decidim::AuthorizationHandler
   # You can also define custom validations:
   #
   validate :valid_document_number
+  validate :valid_scope_id
 
   # The only method that needs to be implemented for an authorization handler.
   # Here you can add your business logic to check if the authorization should
@@ -53,6 +55,12 @@ class DummyAuthorizationHandler < Decidim::AuthorizationHandler
     document_number
   end
 
+  # The user scope
+  #
+  def scope
+    Decidim::Scope.find(scope_id) if scope_id
+  end
+
   # If you need to store any of the defined attributes in the authorization you
   # can do it here.
   #
@@ -60,7 +68,7 @@ class DummyAuthorizationHandler < Decidim::AuthorizationHandler
   # it's created, and available though authorization.metadata
   #
   def metadata
-    super.merge(document_number: document_number, postal_code: postal_code)
+    super.merge(document_number: document_number, postal_code: postal_code, scope_id: scope_id)
   end
 
   private
@@ -69,19 +77,27 @@ class DummyAuthorizationHandler < Decidim::AuthorizationHandler
     errors.add(:document_number, :invalid) unless document_number.to_s.end_with?("X")
   end
 
+  def valid_scope_id
+    errors.add(:scope_id, :invalid) if scope_id && !scope
+  end
+
   # If you need custom authorization logic, you can implement your own action
   # authorizer. In this case, it allows to set a list of valid postal codes for
   # an authorization.
   class DummyActionAuthorizer < Decidim::Verifications::DefaultActionAuthorizer
-    attr_reader :allowed_postal_codes
+    attr_reader :allowed_postal_codes, :allowed_scope_id
 
     # Overrides the parent class method, but it still uses it to keep the base behavior
     def authorize
       # Remove the additional setting from the options hash to avoid to be considered missing.
-      @allowed_postal_codes ||= options.delete("allowed_postal_codes")
+      @allowed_postal_codes ||= options.delete("allowed_postal_codes")&.split(/[\W,;]+/)
+      @allowed_scope_id ||= options.delete("allowed_scope_id")&.to_i
 
       status_code, data = *super
 
+      return [status_code, data] unless status_code == :ok
+
+      data[:extra_explanation] = []
       if allowed_postal_codes.present?
         # Does not authorize users with different postal codes
         if status_code == :ok && !allowed_postal_codes.member?(authorization.metadata["postal_code"])
@@ -90,18 +106,45 @@ class DummyAuthorizationHandler < Decidim::AuthorizationHandler
         end
 
         # Adds an extra message for inform the user the additional restriction for this authorization
-        data[:extra_explanation] = { key: "extra_explanation",
-                                     params: { scope: "decidim.verifications.dummy_authorization",
-                                               count: allowed_postal_codes.count,
-                                               postal_codes: allowed_postal_codes.join(", ") } }
+        data[:extra_explanation] << { key: "extra_explanation.postal_codes",
+                                      params: { scope: "decidim.verifications.dummy_authorization",
+                                                count: allowed_postal_codes.count,
+                                                postal_codes: allowed_postal_codes.join(", ") } }
+      end
+
+      if allowed_scope.present?
+        # Does not authorize users with different scope
+        if status_code == :ok && allowed_scope_id != user_scope_id
+          status_code = :unauthorized
+          data[:fields] = { "scope_id" => user_scope.name[I18n.locale.to_s] }
+        end
+
+        # Adds an extra message for inform the user the additional restriction for this authorization
+        data[:extra_explanation] << { key: "extra_explanation.scope",
+                                      params: { scope: "decidim.verifications.dummy_authorization",
+                                                scope_name: allowed_scope.name[I18n.locale.to_s] } }
       end
 
       [status_code, data]
     end
 
-    # Adds the list of allowed postal codes to the redirect URL, to allow forms to inform about it
+    # Adds the list of allowed postal codes and scope to the redirect URL, to allow forms to inform about it
     def redirect_params
-      { "postal_codes" => allowed_postal_codes&.join("-") }
+      { "postal_codes" => allowed_postal_codes&.join(","), "scope" => allowed_scope_id }
+    end
+
+    private
+
+    def allowed_scope
+      @allowed_scope ||= Decidim::Scope.find(allowed_scope_id)
+    end
+
+    def user_scope
+      @user_scope ||= Decidim::Scope.find(user_scope_id)
+    end
+
+    def user_scope_id
+      @user_scope_id ||= authorization.metadata["scope_id"]&.to_i
     end
   end
 end

--- a/decidim-generators/lib/decidim/generators/app_templates/dummy_authorization_handler.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/dummy_authorization_handler.rb
@@ -95,8 +95,6 @@ class DummyAuthorizationHandler < Decidim::AuthorizationHandler
 
       status_code, data = *super
 
-      return [status_code, data] unless status_code == :ok
-
       data[:extra_explanation] = []
       if allowed_postal_codes.present?
         # Does not authorize users with different postal codes
@@ -136,11 +134,11 @@ class DummyAuthorizationHandler < Decidim::AuthorizationHandler
     private
 
     def allowed_scope
-      @allowed_scope ||= Decidim::Scope.find(allowed_scope_id)
+      @allowed_scope ||= Decidim::Scope.find(allowed_scope_id) if allowed_scope_id
     end
 
     def user_scope
-      @user_scope ||= Decidim::Scope.find(user_scope_id)
+      @user_scope ||= Decidim::Scope.find(user_scope_id) if user_scope_id
     end
 
     def user_scope_id

--- a/decidim-generators/lib/decidim/generators/app_templates/dummy_authorization_handler.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/dummy_authorization_handler.rb
@@ -117,7 +117,7 @@ class DummyAuthorizationHandler < Decidim::AuthorizationHandler
           data[:fields] = { "scope_id" => user_scope.name[I18n.locale.to_s] }
         end
 
-        # Adds an extra message for inform the user the additional restriction for this authorization
+        # Adds an extra message to inform the user about additional restrictions for this authorization
         extra_explanations << { key: "extra_explanation.scope",
                                 params: { scope: "decidim.verifications.dummy_authorization",
                                           scope_name: allowed_scope.name[I18n.locale.to_s] } }

--- a/decidim-generators/lib/decidim/generators/app_templates/verifications_initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/verifications_initializer.rb
@@ -8,7 +8,8 @@ Decidim::Verifications.register_workflow(:dummy_authorization_handler) do |workf
   workflow.time_between_renewals = 5.minutes
 
   workflow.options do |options|
-    options.attribute :postal_code, type: :string, default: "08001", required: false
+    options.attribute :allowed_postal_codes, type: :string, default: "08001", required: false
+    options.attribute :allowed_scope_id, type: :scope, required: false
   end
 end
 

--- a/decidim-generators/spec/generators_spec.rb
+++ b/decidim-generators/spec/generators_spec.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
-require "simplecov" if ENV["SIMPLECOV"]
+if ENV["SIMPLECOV"]
+  require "simplecov"
+
+  SimpleCov.add_filter "/lib/decidim/generators/app_templates/"
+  SimpleCov.add_filter "/lib/decidim/generators/component_templates/"
+end
+
 require "spec_helper"
 require "decidim/gem_manager"
 

--- a/decidim-verifications/README.md
+++ b/decidim-verifications/README.md
@@ -97,7 +97,7 @@ Decidim implements two type of authorization methods:
   * `edit_authorization_path`: This is the entry point to resume an existing
     authorization process.
 
-* _Renewable authorizations_.  
+* _Renewable authorizations_.
   By default a participant can't renew its authorization, but this can be enabled when registering the workflow, the time between renewals can be configured (one day by default).
 
   Optionally to change the renew modal content part of the data stored, you can set a new value for the cell used to render the metadata.
@@ -169,8 +169,8 @@ process, and also restrict it to users with postal codes 12345 and 12346. The
 [example authorization handler](https://github.com/decidim/decidim/blob/master/decidim-generators/lib/decidim/generators/app_templates/dummy_authorization_handler.rb)
 included in this module allows to do that. As an admin user, you should visit
 the proposals componenent permissions screen, choose the `Example authorization`
-as the authorization handler name for the `vote` action and type something like
-`{ allowed_postal_codes: ["12345", "12346"] }` in the `Options` field placed below.
+as the authorization handler name for the `vote` action and enter "12345, 12346"
+in the `Allowed postal codes` field placed below.
 
 You can override default behavior implementing a class that inherits form
 `Decidim::Verifications::DefaultActionAuthorizer` and override some methods or that

--- a/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
@@ -13,6 +13,7 @@ module Decidim
       helper Decidim::DecidimFormHelper
       helper Decidim::CtaButtonHelper
       helper Decidim::AuthorizationFormHelper
+      helper Decidim::TranslationsHelper
 
       layout "layouts/decidim/user_profile", only: [:index]
 

--- a/decidim-verifications/app/views/dummy_authorization/_form.html.erb
+++ b/decidim-verifications/app/views/dummy_authorization/_form.html.erb
@@ -1,8 +1,27 @@
-<% if request["postal_codes"]
-  postal_codes = request["postal_codes"].split("-") %>
-  <p><%= t("extra_explanation", scope: "decidim.verifications.dummy_authorization", postal_codes: postal_codes.join(", "), count: postal_codes.count) %></p>
+<% if request["postal_codes"].present?
+  postal_codes = request["postal_codes"].split(",") %>
+  <p><%= t("extra_explanation.postal_codes", scope: "decidim.verifications.dummy_authorization", postal_codes: postal_codes.join(", "), count: postal_codes.count) %></p>
+<% end %>
+
+<% if request["scope"] && (scope = Decidim::Scope.find(request["scope"]&.to_i)) %>
+  <p><%= t("extra_explanation.scope", scope: "decidim.verifications.dummy_authorization", scope_name: translated_attribute(scope.name)) %></p>
 <% end %>
 
 <div class="partial-demo">
-  <%= form.all_fields %>
+  <%= form.hidden_field :handler_name %>
+  <div class="field">
+    <%= form.text_field :document_number %>
+  </div>
+  <div class="field">
+    <%= form.text_field :postal_code %>
+  </div>
+  <div class="field">
+    <%= form.date_field :birthday %>
+  </div>
+  <div class="field">
+    <%= form.scopes_picker :scope_id, {} do |scope|
+        { url: decidim.scopes_picker_path(root: nil, current: form.object.scope_id, field: form.label_for(:scope_id)),
+          text: scope_name_for_picker(form.object.scope, I18n.t("decidim.scopes.global")) }
+      end %>
+  </div>
 </div>

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -142,8 +142,10 @@ en:
             success: Your account has been successfully verified.
       dummy_authorization:
         extra_explanation:
-          one: Participation is restricted to participants with the postal code %{postal_codes}.
-          other: 'Participation is restricted to participants with any of the following postal codes: %{postal_codes}.'
+          postal_codes:
+            one: Participation is restricted to participants with the postal code %{postal_codes}.
+            other: 'Participation is restricted to participants with any of the following postal codes: %{postal_codes}.'
+          scope: Participation is restricted to participants with the scope %{scope_name}.
       id_documents:
         admin:
           config:

--- a/decidim-verifications/spec/services/decidim/dummy_authorization_handler_spec.rb
+++ b/decidim-verifications/spec/services/decidim/dummy_authorization_handler_spec.rb
@@ -5,42 +5,53 @@ require "decidim/dev/test/authorization_shared_examples"
 
 module Decidim
   describe DummyAuthorizationHandler do
-    let(:handler) { described_class.new(params.merge(extra_params)) }
-    let(:params) { { user: create(:user, :confirmed) } }
-    let(:extra_params) { {} }
+    subject(:handler) { described_class.new(params) }
+
+    let(:user) { create(:user, :confirmed) }
+    let(:document_number) { "123456X" }
+    let(:scope) { create :scope, organization: user.organization }
+    let(:scope_id) { scope.id }
+    let(:params) do
+      {
+        user: user,
+        document_number: document_number,
+        postal_code: "123456",
+        scope_id: scope_id
+      }
+    end
 
     it_behaves_like "an authorization handler"
+
+    it { is_expected.to be_valid }
+
+    context "when no document number" do
+      let(:document_number) { nil }
+
+      it { is_expected.to be_invalid }
+    end
+
+    context "when document number is not valid" do
+      let(:document_number) { "123456" }
+
+      it { is_expected.to be_invalid }
+    end
+
+    context "when scope id is invalid" do
+      let(:scope_id) { scope.id + 1 }
+
+      it { is_expected.to be_invalid }
+    end
+
+    context "when scope is from other organization" do
+      let(:scope) { create(:scope) }
+
+      it { is_expected.to be_invalid }
+    end
 
     describe "metadata" do
       subject { handler.metadata }
 
-      let(:extra_params) { { document_number: "123456", postal_code: "123456" } }
-
-      it { is_expected.to eq(document_number: "123456", postal_code: "123456") }
-    end
-
-    describe "valid?" do
-      subject { handler.valid? }
-
-      let(:extra_params) { { document_number: document_number, postal_code: "123456" } }
-
-      context "when no document number" do
-        let(:document_number) { nil }
-
-        it { is_expected.to eq(false) }
-      end
-
-      context "when document number is not valid" do
-        let(:document_number) { "123456" }
-
-        it { is_expected.to eq(false) }
-      end
-
-      context "when document number is valid" do
-        let(:document_number) { "123456X" }
-
-        it { is_expected.to eq(true) }
-      end
+      it { is_expected.to eq(document_number: "123456X", postal_code: "123456", scope_id: scope_id) }
     end
   end
 end

--- a/decidim-verifications/spec/system/action_authorization_spec.rb
+++ b/decidim-verifications/spec/system/action_authorization_spec.rb
@@ -104,7 +104,7 @@ describe "Action Authorization", type: :system do
         let(:other_scope) { create :scope, organization: organization }
         let!(:user_authorization) do
           create(:authorization, name: "dummy_authorization_handler", user: user, granted_at: 1.second.ago,
-                 metadata: { postal_code: "1234", scope_id: other_scope.id } )
+                                 metadata: { postal_code: "1234", scope_id: other_scope.id })
         end
 
         it "prompts user to check her authorization status" do

--- a/decidim-verifications/spec/views/decidim/verifications/authorizations/new.html.erb_spec.rb
+++ b/decidim-verifications/spec/views/decidim/verifications/authorizations/new.html.erb_spec.rb
@@ -13,6 +13,7 @@ module Decidim
       view.extend AuthorizationFormHelper
       view.extend DecidimFormHelper
       view.extend CtaButtonHelper
+      view.extend ScopesHelper
       allow(view).to receive(:current_organization).and_return(organization)
       allow(view).to receive(:handler).and_return(handler)
       allow(view).to receive(:params).and_return(handler: "dummy_authorization_handler")


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds the vote action to the Elections component and to election resources. 

As #5963 states the need for using scopes there, it also adds the ability to use scopes in authorization handlers and adds that feature to a dummy authorization handler.

#### :pushpin: Related Issues
- Fixes #5963

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)
* Resources permissions link
![imagen](https://user-images.githubusercontent.com/453545/84367737-f3356280-abd4-11ea-9c4c-99b2b1148e80.png)
* Allowed scopes added to dummy authorization
![imagen](https://user-images.githubusercontent.com/453545/84368855-655a7700-abd6-11ea-949a-82a4316e468f.png)
* Message to inform users about scope restrictions for participating in this resource
![imagen](https://user-images.githubusercontent.com/453545/84369856-c46cbb80-abd7-11ea-9796-fcd53cd86b71.png)
* Dummy authorization asks users for their scope, but this data can be retrieved from the census.
![imagen](https://user-images.githubusercontent.com/453545/84369894-d3ec0480-abd7-11ea-976f-819b5a5b809d.png)
* Users are not authorized to access the election when the scope doesn't match. When we implement the frontend part, it should allow access to the election information page, but not to cast a vote.
![imagen](https://user-images.githubusercontent.com/453545/84370051-039b0c80-abd8-11ea-892d-a12c4ae0793d.png)
