### PR TITLE
Fix some linters errors arising from capybara upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@
 
 ### Fixed
 
-- **decidim-participatory_processes**: Fix some linterns errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
-- **decidim-assemblies**: Fix some linterns errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
-- **decidim-proposals**: Fix some linterns errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
-- **decidim-dev**: Fix some linterns errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
-- **decidim-core**: Fix some linterns errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
-- **decidim-forms**: Fix some linterns errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
+- **decidim-participatory_processes**: Fix some linters errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
+- **decidim-assemblies**: Fix some linters errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
+- **decidim-proposals**: Fix some linters errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
+- **decidim-dev**: Fix some linters errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
+- **decidim-core**: Fix some linters errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
+- **decidim-forms**: Fix some linters errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@
 
 ### Fixed
 
-- **decidim-participatory_processes**: Fix some linterns errors arising from capybara upgrade
-- **decidim-assemblies**: Fix some linterns errors arising from capybara upgrade
-- **decidim-proposals**: Fix some linterns errors arising from capybara upgrade
-- **decidim-dev**: Fix some linterns errors arising from capybara upgrade
-- **decidim-core**: Fix some linterns errors arising from capybara upgrade
-- **decidim-forms**: Fix some linterns errors arising from capybara upgrade
+- **decidim-participatory_processes**: Fix some linterns errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
+- **decidim-assemblies**: Fix some linterns errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
+- **decidim-proposals**: Fix some linterns errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
+- **decidim-dev**: Fix some linterns errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
+- **decidim-core**: Fix some linterns errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
+- **decidim-forms**: Fix some linterns errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@
 
 ### Fixed
 
-- **decidim-participatory_processes**: Fix some linters errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
-- **decidim-assemblies**: Fix some linters errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
-- **decidim-proposals**: Fix some linters errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
-- **decidim-dev**: Fix some linters errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
-- **decidim-core**: Fix some linters errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
-- **decidim-forms**: Fix some linters errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
+- **decidim-participatory_processes**: Fix rubocop errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
+- **decidim-assemblies**: Fix rubocop errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
+- **decidim-proposals**: Fix rubocop errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
+- **decidim-dev**: Fix rubocop errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
+- **decidim-core**: Fix rubocop errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
+- **decidim-forms**: Fix rubocop errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
 
 ### Fixed
 
+- **decidim-participatory_processes**: Fix some linterns errors arising from capybara upgrade
+- **decidim-assemblies**: Fix some linterns errors arising from capybara upgrade
+- **decidim-proposals**: Fix some linterns errors arising from capybara upgrade
+- **decidim-dev**: Fix some linterns errors arising from capybara upgrade
+- **decidim-core**: Fix some linterns errors arising from capybara upgrade
+- **decidim-forms**: Fix some linterns errors arising from capybara upgrade
+
 ### Removed
 
 ## Previous versions

--- a/decidim-assemblies/spec/shared/manage_assemblies_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assemblies_examples.rb
@@ -152,7 +152,7 @@ shared_examples "manage assemblies" do
       uncheck :assembly_scopes_enabled
 
       expect(page).to have_selector("#assembly_scope_id.disabled")
-      expect(page).to have_selector("#assembly_scope_id .picker-values div input[disabled]", visible: :visible)
+      expect(page).to have_selector("#assembly_scope_id .picker-values div input[disabled]", visible: :all)
 
       within ".edit_assembly" do
         find("*[type=submit]").click

--- a/decidim-assemblies/spec/shared/manage_assemblies_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assemblies_examples.rb
@@ -152,7 +152,7 @@ shared_examples "manage assemblies" do
       uncheck :assembly_scopes_enabled
 
       expect(page).to have_selector("#assembly_scope_id.disabled")
-      expect(page).to have_selector("#assembly_scope_id .picker-values div input[disabled]", visible: false)
+      expect(page).to have_selector("#assembly_scope_id .picker-values div input[disabled]", visible: :visible)
 
       within ".edit_assembly" do
         find("*[type=submit]").click

--- a/decidim-conferences/spec/shared/manage_conferences_examples.rb
+++ b/decidim-conferences/spec/shared/manage_conferences_examples.rb
@@ -202,7 +202,7 @@ shared_examples "manage conferences" do
       uncheck :conference_scopes_enabled
 
       expect(page).to have_selector("#conference_scope_id.disabled")
-      expect(page).to have_selector("#conference_scope_id .picker-values div input[disabled]", visible: false)
+      expect(page).to have_selector("#conference_scope_id .picker-values div input[disabled]", visible: :visible)
 
       within ".edit_conference" do
         find("*[type=submit]").click

--- a/decidim-conferences/spec/shared/manage_conferences_examples.rb
+++ b/decidim-conferences/spec/shared/manage_conferences_examples.rb
@@ -202,7 +202,7 @@ shared_examples "manage conferences" do
       uncheck :conference_scopes_enabled
 
       expect(page).to have_selector("#conference_scope_id.disabled")
-      expect(page).to have_selector("#conference_scope_id .picker-values div input[disabled]", visible: :visible)
+      expect(page).to have_selector("#conference_scope_id .picker-values div input[disabled]", visible: :all)
 
       within ".edit_conference" do
         find("*[type=submit]").click

--- a/decidim-core/lib/decidim/core/test/shared_examples/rich_text_editor_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/rich_text_editor_examples.rb
@@ -3,7 +3,7 @@
 shared_examples "having a rich text editor" do |css, toolbar|
   it "has a form with a rich text editor" do
     within "form.#{css}" do
-      expect(page).to have_selector("input[toolbar='#{toolbar}']", visible: false)
+      expect(page).to have_selector("input[toolbar='#{toolbar}']", visible: :visible)
     end
   end
 end
@@ -30,7 +30,7 @@ shared_examples "rendering safe content" do |css|
 
   it "sanitizes potentially malicious HTML tags" do
     within css do
-      expect(page).not_to have_selector("script", visible: false)
+      expect(page).not_to have_selector("script", visible: :visible)
       expect(page).to have_content("alert('SCRIPT')")
     end
   end
@@ -52,7 +52,7 @@ shared_examples "rendering unsafe content" do |css|
 
   it "strips potentially malicious HTML tags" do
     within css do
-      expect(page).not_to have_selector("script", visible: false)
+      expect(page).not_to have_selector("script", visible: :visible)
       expect(page).not_to have_content("alert('SCRIPT')")
     end
   end

--- a/decidim-core/lib/decidim/core/test/shared_examples/rich_text_editor_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/rich_text_editor_examples.rb
@@ -3,7 +3,7 @@
 shared_examples "having a rich text editor" do |css, toolbar|
   it "has a form with a rich text editor" do
     within "form.#{css}" do
-      expect(page).to have_selector("input[toolbar='#{toolbar}']", visible: :visible)
+      expect(page).to have_selector("input[toolbar='#{toolbar}']", visible: :all)
     end
   end
 end
@@ -30,7 +30,7 @@ shared_examples "rendering safe content" do |css|
 
   it "sanitizes potentially malicious HTML tags" do
     within css do
-      expect(page).not_to have_selector("script", visible: :visible)
+      expect(page).not_to have_selector("script", visible: :all)
       expect(page).to have_content("alert('SCRIPT')")
     end
   end
@@ -52,7 +52,7 @@ shared_examples "rendering unsafe content" do |css|
 
   it "strips potentially malicious HTML tags" do
     within css do
-      expect(page).not_to have_selector("script", visible: :visible)
+      expect(page).not_to have_selector("script", visible: :all)
       expect(page).not_to have_content("alert('SCRIPT')")
     end
   end

--- a/decidim-core/spec/cells/decidim/diff_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/diff_cell_spec.rb
@@ -66,7 +66,7 @@ describe Decidim::DiffCell, versioning: true, type: :cell do
       end
 
       it "sanitizes potentially malicious HTML tags" do
-        expect(html).not_to have_selector("script", visible: :visible)
+        expect(html).not_to have_selector("script", visible: :all)
         expect(html).to have_content("alert('SCRIPT')")
       end
     end
@@ -84,7 +84,7 @@ describe Decidim::DiffCell, versioning: true, type: :cell do
       end
 
       it "sanitizes potentially malicious HTML tags" do
-        expect(html).not_to have_selector("script", visible: :visible)
+        expect(html).not_to have_selector("script", visible: :all)
         expect(html).to have_content("alert('SCRIPT')")
       end
     end

--- a/decidim-core/spec/cells/decidim/diff_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/diff_cell_spec.rb
@@ -66,7 +66,7 @@ describe Decidim::DiffCell, versioning: true, type: :cell do
       end
 
       it "sanitizes potentially malicious HTML tags" do
-        expect(html).not_to have_selector("script", visible: false)
+        expect(html).not_to have_selector("script", visible: :visible)
         expect(html).to have_content("alert('SCRIPT')")
       end
     end
@@ -84,7 +84,7 @@ describe Decidim::DiffCell, versioning: true, type: :cell do
       end
 
       it "sanitizes potentially malicious HTML tags" do
-        expect(html).not_to have_selector("script", visible: false)
+        expect(html).not_to have_selector("script", visible: :visible)
         expect(html).to have_content("alert('SCRIPT')")
       end
     end

--- a/decidim-core/spec/system/homepage_spec.rb
+++ b/decidim-core/spec/system/homepage_spec.rb
@@ -125,7 +125,7 @@ describe "Homepage", type: :system do
         let(:organization) { create(:organization, official_url: official_url, header_snippets: snippet) }
 
         it "does not include the header snippets" do
-          expect(page).not_to have_selector("meta[data-hello]", visible: false)
+          expect(page).not_to have_selector("meta[data-hello]", visible: :visible)
         end
 
         context "when header snippets are enabled" do
@@ -135,7 +135,7 @@ describe "Homepage", type: :system do
           end
 
           it "includes the header snippets" do
-            expect(page).to have_selector("meta[data-hello]", visible: false)
+            expect(page).to have_selector("meta[data-hello]", visible: :visible)
           end
         end
       end

--- a/decidim-core/spec/system/homepage_spec.rb
+++ b/decidim-core/spec/system/homepage_spec.rb
@@ -125,7 +125,7 @@ describe "Homepage", type: :system do
         let(:organization) { create(:organization, official_url: official_url, header_snippets: snippet) }
 
         it "does not include the header snippets" do
-          expect(page).not_to have_selector("meta[data-hello]", visible: :visible)
+          expect(page).not_to have_selector("meta[data-hello]", visible: :all)
         end
 
         context "when header snippets are enabled" do
@@ -135,7 +135,7 @@ describe "Homepage", type: :system do
           end
 
           it "includes the header snippets" do
-            expect(page).to have_selector("meta[data-hello]", visible: :visible)
+            expect(page).to have_selector("meta[data-hello]", visible: :all)
           end
         end
       end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara_scopes_picker.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara_scopes_picker.rb
@@ -10,7 +10,7 @@ module Capybara
       match do |scope_picker|
         data_picker = scope_picker.data_picker
         scope_name = expected ? translated(expected.name) : t("decidim.scopes.global")
-        expect(data_picker).to have_selector(".picker-values div input[value='#{expected&.id || scope_picker.global_value}']", visible: false)
+        expect(data_picker).to have_selector(".picker-values div input[value='#{expected&.id || scope_picker.global_value}']", visible: :visible)
         expect(data_picker).to have_selector(:xpath, "//div[contains(@class,'picker-values')]/div/a[text()[contains(.,'#{scope_name}')]]")
       end
     end
@@ -19,7 +19,7 @@ module Capybara
       match do |scope_picker|
         data_picker = scope_picker.data_picker
         scope_name = expected ? translated(expected.name) : t("decidim.scopes.global")
-        expect(data_picker).not_to have_selector(".picker-values div input[value='#{expected&.id || scope_picker.global_value}']", visible: false)
+        expect(data_picker).not_to have_selector(".picker-values div input[value='#{expected&.id || scope_picker.global_value}']", visible: :visible)
         expect(data_picker).not_to have_selector(:xpath, "//div[contains(@class,'picker-values')]/div/a[text()[contains(.,'#{scope_name}')]]")
       end
     end
@@ -27,7 +27,7 @@ module Capybara
     def scope_pick(scope_picker, scope)
       data_picker = scope_picker.data_picker
       # use scope_repick to change single scope picker selected scope
-      expect(data_picker).to have_selector(".picker-values:empty", visible: false) if data_picker.has_css?(".picker-single")
+      expect(data_picker).to have_selector(".picker-values:empty", visible: :visible) if data_picker.has_css?(".picker-single")
 
       expect(data_picker).to have_selector(".picker-prompt")
       data_picker.find(".picker-prompt").click
@@ -41,7 +41,7 @@ module Capybara
     def scope_repick(scope_picker, old_scope, new_scope)
       data_picker = scope_picker.data_picker
 
-      expect(data_picker).to have_selector(".picker-values div input[value='#{old_scope&.id || scope_picker.global_value}']", visible: false)
+      expect(data_picker).to have_selector(".picker-values div input[value='#{old_scope&.id || scope_picker.global_value}']", visible: :visible)
       data_picker.find(:xpath, "//div[contains(@class,'picker-values')]/div/input[@value='#{old_scope&.id || scope_picker.global_value}']/../a").click
 
       # browse to lowest common parent between old and new scope
@@ -57,7 +57,7 @@ module Capybara
     def scope_unpick(scope_picker, scope)
       data_picker = scope_picker.data_picker
 
-      expect(data_picker).to have_selector(".picker-values div input[value='#{scope&.id || scope_picker.global_value}']", visible: false)
+      expect(data_picker).to have_selector(".picker-values div input[value='#{scope&.id || scope_picker.global_value}']", visible: :visible)
       data_picker.find(".picker-values div input[value='#{scope&.id || scope_picker.global_value}']").click
 
       expect(scope_picker).to have_scope_not_picked(scope)

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara_scopes_picker.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara_scopes_picker.rb
@@ -10,7 +10,7 @@ module Capybara
       match do |scope_picker|
         data_picker = scope_picker.data_picker
         scope_name = expected ? translated(expected.name) : t("decidim.scopes.global")
-        expect(data_picker).to have_selector(".picker-values div input[value='#{expected&.id || scope_picker.global_value}']", visible: :visible)
+        expect(data_picker).to have_selector(".picker-values div input[value='#{expected&.id || scope_picker.global_value}']", visible: :all)
         expect(data_picker).to have_selector(:xpath, "//div[contains(@class,'picker-values')]/div/a[text()[contains(.,'#{scope_name}')]]")
       end
     end
@@ -19,7 +19,7 @@ module Capybara
       match do |scope_picker|
         data_picker = scope_picker.data_picker
         scope_name = expected ? translated(expected.name) : t("decidim.scopes.global")
-        expect(data_picker).not_to have_selector(".picker-values div input[value='#{expected&.id || scope_picker.global_value}']", visible: :visible)
+        expect(data_picker).not_to have_selector(".picker-values div input[value='#{expected&.id || scope_picker.global_value}']", visible: :all)
         expect(data_picker).not_to have_selector(:xpath, "//div[contains(@class,'picker-values')]/div/a[text()[contains(.,'#{scope_name}')]]")
       end
     end
@@ -27,7 +27,7 @@ module Capybara
     def scope_pick(scope_picker, scope)
       data_picker = scope_picker.data_picker
       # use scope_repick to change single scope picker selected scope
-      expect(data_picker).to have_selector(".picker-values:empty", visible: :visible) if data_picker.has_css?(".picker-single")
+      expect(data_picker).to have_selector(".picker-values:empty", visible: :all) if data_picker.has_css?(".picker-single")
 
       expect(data_picker).to have_selector(".picker-prompt")
       data_picker.find(".picker-prompt").click
@@ -41,7 +41,7 @@ module Capybara
     def scope_repick(scope_picker, old_scope, new_scope)
       data_picker = scope_picker.data_picker
 
-      expect(data_picker).to have_selector(".picker-values div input[value='#{old_scope&.id || scope_picker.global_value}']", visible: :visible)
+      expect(data_picker).to have_selector(".picker-values div input[value='#{old_scope&.id || scope_picker.global_value}']", visible: :all)
       data_picker.find(:xpath, "//div[contains(@class,'picker-values')]/div/input[@value='#{old_scope&.id || scope_picker.global_value}']/../a").click
 
       # browse to lowest common parent between old and new scope
@@ -57,7 +57,7 @@ module Capybara
     def scope_unpick(scope_picker, scope)
       data_picker = scope_picker.data_picker
 
-      expect(data_picker).to have_selector(".picker-values div input[value='#{scope&.id || scope_picker.global_value}']", visible: :visible)
+      expect(data_picker).to have_selector(".picker-values div input[value='#{scope&.id || scope_picker.global_value}']", visible: :all)
       data_picker.find(".picker-values div input[value='#{scope&.id || scope_picker.global_value}']").click
 
       expect(scope_picker).to have_scope_not_picked(scope)

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires.rb
@@ -794,7 +794,7 @@ shared_examples_for "manage questionnaires" do
         context "when clicking on Expand all button" do
           it "expands all questions" do
             click_button "Expand all questions"
-            expect(page).to have_selector(".collapsible", visible: true)
+            expect(page).to have_selector(".collapsible", visible: :visible)
             expect(page).to have_selector(".question--collapse .icon-collapse", count: questionnaire.questions.count)
           end
         end
@@ -802,7 +802,7 @@ shared_examples_for "manage questionnaires" do
         context "when clicking on Collapse all button" do
           it "collapses all questions" do
             click_button "Collapse all questions"
-            expect(page).not_to have_selector(".collapsible", visible: true)
+            expect(page).not_to have_selector(".collapsible", visible: :visible)
             expect(page).to have_selector(".question--collapse .icon-expand", count: questionnaire.questions.count)
           end
         end
@@ -816,7 +816,7 @@ shared_examples_for "manage questionnaires" do
 
           it "hides the question card section" do
             within ".questionnaire-question:last-of-type" do
-              expect(page).not_to have_selector(".collapsible", visible: true)
+              expect(page).not_to have_selector(".collapsible", visible: :visible)
             end
           end
         end
@@ -829,7 +829,7 @@ shared_examples_for "manage questionnaires" do
           end
 
           it "shows the question card section" do
-            expect(page).to have_selector(".collapsible", visible: true)
+            expect(page).to have_selector(".collapsible", visible: :visible)
           end
         end
 

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires.rb
@@ -802,7 +802,7 @@ shared_examples_for "manage questionnaires" do
         context "when clicking on Collapse all button" do
           it "collapses all questions" do
             click_button "Collapse all questions"
-            expect(page).not_to have_selector(".collapsible", visible: :all)
+            expect(page).not_to have_selector(".collapsible", visible: :visible)
             expect(page).to have_selector(".question--collapse .icon-expand", count: questionnaire.questions.count)
           end
         end
@@ -816,7 +816,7 @@ shared_examples_for "manage questionnaires" do
 
           it "hides the question card section" do
             within ".questionnaire-question:last-of-type" do
-              expect(page).not_to have_selector(".collapsible", visible: :all)
+              expect(page).not_to have_selector(".collapsible", visible: :visible)
             end
           end
         end
@@ -829,7 +829,7 @@ shared_examples_for "manage questionnaires" do
           end
 
           it "shows the question card section" do
-            expect(page).to have_selector(".collapsible", visible: :all)
+            expect(page).to have_selector(".collapsible", visible: :visible)
           end
         end
 

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires.rb
@@ -794,7 +794,7 @@ shared_examples_for "manage questionnaires" do
         context "when clicking on Expand all button" do
           it "expands all questions" do
             click_button "Expand all questions"
-            expect(page).to have_selector(".collapsible", visible: :visible)
+            expect(page).to have_selector(".collapsible", visible: :all)
             expect(page).to have_selector(".question--collapse .icon-collapse", count: questionnaire.questions.count)
           end
         end
@@ -802,7 +802,7 @@ shared_examples_for "manage questionnaires" do
         context "when clicking on Collapse all button" do
           it "collapses all questions" do
             click_button "Collapse all questions"
-            expect(page).not_to have_selector(".collapsible", visible: :visible)
+            expect(page).not_to have_selector(".collapsible", visible: :all)
             expect(page).to have_selector(".question--collapse .icon-expand", count: questionnaire.questions.count)
           end
         end
@@ -816,7 +816,7 @@ shared_examples_for "manage questionnaires" do
 
           it "hides the question card section" do
             within ".questionnaire-question:last-of-type" do
-              expect(page).not_to have_selector(".collapsible", visible: :visible)
+              expect(page).not_to have_selector(".collapsible", visible: :all)
             end
           end
         end
@@ -829,7 +829,7 @@ shared_examples_for "manage questionnaires" do
           end
 
           it "shows the question card section" do
-            expect(page).to have_selector(".collapsible", visible: :visible)
+            expect(page).to have_selector(".collapsible", visible: :all)
           end
         end
 

--- a/decidim-participatory_processes/spec/shared/manage_processes_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_processes_examples.rb
@@ -181,7 +181,7 @@ shared_examples "manage processes examples" do
       uncheck :participatory_process_scopes_enabled
 
       expect(page).to have_selector("#participatory_process_scope_id.disabled")
-      expect(page).to have_selector("#participatory_process_scope_id .picker-values div input[disabled]", visible: false)
+      expect(page).to have_selector("#participatory_process_scope_id .picker-values div input[disabled]", visible: :visible)
 
       within ".edit_participatory_process" do
         find("*[type=submit]").click

--- a/decidim-participatory_processes/spec/shared/manage_processes_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_processes_examples.rb
@@ -181,7 +181,7 @@ shared_examples "manage processes examples" do
       uncheck :participatory_process_scopes_enabled
 
       expect(page).to have_selector("#participatory_process_scope_id.disabled")
-      expect(page).to have_selector("#participatory_process_scope_id .picker-values div input[disabled]", visible: :visible)
+      expect(page).to have_selector("#participatory_process_scope_id .picker-values div input[disabled]", visible: :all)
 
       within ".edit_participatory_process" do
         find("*[type=submit]").click

--- a/decidim-proposals/lib/decidim/proposals/test/capybara_proposals_picker.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/capybara_proposals_picker.rb
@@ -11,7 +11,7 @@ module Capybara
         data_picker = proposals_picker.data_picker
 
         expected.each do |proposal|
-          expect(data_picker).to have_selector(".picker-values div input[value='#{proposal.id}']", visible: :visible)
+          expect(data_picker).to have_selector(".picker-values div input[value='#{proposal.id}']", visible: :all)
           expect(data_picker).to have_selector(:xpath, "//div[contains(@class,'picker-values')]/div/a[text()[contains(.,\"#{proposal.title}\")]]")
         end
       end
@@ -22,7 +22,7 @@ module Capybara
         data_picker = proposals_picker.data_picker
 
         expected.each do |proposal|
-          expect(data_picker).not_to have_selector(".picker-values div input[value='#{proposal.id}']", visible: :visible)
+          expect(data_picker).not_to have_selector(".picker-values div input[value='#{proposal.id}']", visible: :all)
           expect(data_picker).not_to have_selector(:xpath, "//div[contains(@class,'picker-values')]/div/a[text()[contains(.,\"#{proposal.title}\")]]")
         end
       end

--- a/decidim-proposals/lib/decidim/proposals/test/capybara_proposals_picker.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/capybara_proposals_picker.rb
@@ -11,7 +11,7 @@ module Capybara
         data_picker = proposals_picker.data_picker
 
         expected.each do |proposal|
-          expect(data_picker).to have_selector(".picker-values div input[value='#{proposal.id}']", visible: false)
+          expect(data_picker).to have_selector(".picker-values div input[value='#{proposal.id}']", visible: :visible)
           expect(data_picker).to have_selector(:xpath, "//div[contains(@class,'picker-values')]/div/a[text()[contains(.,\"#{proposal.title}\")]]")
         end
       end
@@ -22,7 +22,7 @@ module Capybara
         data_picker = proposals_picker.data_picker
 
         expected.each do |proposal|
-          expect(data_picker).not_to have_selector(".picker-values div input[value='#{proposal.id}']", visible: false)
+          expect(data_picker).not_to have_selector(".picker-values div input[value='#{proposal.id}']", visible: :visible)
           expect(data_picker).not_to have_selector(:xpath, "//div[contains(@class,'picker-values')]/div/a[text()[contains(.,\"#{proposal.title}\")]]")
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
Due to the update of the capybara gem, some incidents have occurred in the project.
The following link specifies the change in visibility functionality and how it should be modified in the Decidim project: [here](https://rubocop-rspec.readthedocs.io/en/latest/cops_capybara/#capybaravisibilitymatcher)

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
