### PR TITLE
Add line feeds at the end of paragraphs and lists

### DIFF
--- a/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
@@ -94,7 +94,7 @@ module Decidim
       private
 
       def sanitize_unordered_lists(text)
-        text.gsub(%r{(?=.*<\/ul>)(?!.*?<li>.*?<\/ol>.*?<\/ul>)<li>}) { |li| li + '• ' }
+        text.gsub(%r{(?=.*<\/ul>)(?!.*?<li>.*?<\/ol>.*?<\/ul>)<li>}) { |li| li + "• " }
       end
 
       def sanitize_ordered_lists(text)

--- a/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
@@ -52,10 +52,7 @@ module Decidim
       def body(links: false, extras: true, strip_tags: false)
         text = proposal.body
 
-        if strip_tags
-          text = text.gsub(%r{<\/p>}, "\n\n")
-          text = strip_tags(text)
-        end
+        text = strip_tags(sanitize_text(text)) if strip_tags
 
         renderer = Decidim::ContentRenderers::HashtagRenderer.new(text)
         text = renderer.render(links: links, extras: extras).html_safe
@@ -92,6 +89,45 @@ module Decidim
 
       def resource_manifest
         proposal.class.resource_manifest
+      end
+
+      private
+
+      def sanitize_unordered_lists(text)
+        text.gsub(%r{(?=.*<\/ul>)(?!.*?<li>.*?<\/ol>.*?<\/ul>)<li>}) { |li| li + '• ' }
+      end
+
+      def sanitize_ordered_lists(text)
+        i = 0
+
+        text.gsub(%r{(?=.*<\/ol>)(?!.*?<li>.*?<\/ul>.*?<\/ol>)<li>}) do |li|
+          i += 1
+
+          li + "#{i}. "
+        end
+      end
+
+      def add_line_feeds_to_paragraphs(text)
+        text.gsub("</p>") { |p| p + "\n\n" }
+      end
+
+      def add_line_feeds_to_list_items(text)
+        text.gsub("</li>") { |li| li + "\n" }
+      end
+
+      # Adds line feeds after the paragraph and list item closing tags.
+      #
+      # Returns a String.
+      def add_line_feeds(text)
+        add_line_feeds_to_paragraphs(add_line_feeds_to_list_items(text))
+      end
+
+      # Maintains the paragraphs and lists separations with their bullet points and
+      # list numberings where appropriate.
+      #
+      # Returns a String.
+      def sanitize_text(text)
+        add_line_feeds(sanitize_ordered_lists(sanitize_unordered_lists(text)))
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What?
The participatory text was showing itself without newlines when it should.

#### :tophat: Why?
It was fixed for paragraphs, but then also the same problem was discovered for the lists created in a participatory text.

Now it also detects whether if a list is ordered or unordered, and adds numberings or bullet points respectively.

#### :pushpin: Related Issues
- Related to #6158
- Fixes Jira DECIDIM-140

### :camera: Screenshots (optional)

#### Before
![imagen](https://user-images.githubusercontent.com/61017625/84668528-0b361a80-af24-11ea-964b-e828544d3ebf.png)


#### After paragraph fix
![imagen](https://user-images.githubusercontent.com/61017625/84668295-c27e6180-af23-11ea-9ab8-f2185d018816.png)

#### After list fix and numbering feature
![imagen](https://user-images.githubusercontent.com/61017625/84668359-d7f38b80-af23-11ea-9a4c-4b40280b1ff1.png)
