### PR TITLE
Document when contributors should contribute to changelog

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 - Fixes #?
 
 #### :clipboard: Subtasks
-- [x] Add `CHANGELOG` upgrade notes, if required
+- [ ] Add `CHANGELOG` upgrade notes, if required
 - [ ] If there's a new public field, add it to GraphQL API
 - [ ] Add documentation regarding the feature 
 - [ ] Add/modify seeds

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 - Fixes #?
 
 #### :clipboard: Subtasks
-- [x] Add `CHANGELOG` entry
+- [x] Add `CHANGELOG` upgrade notes, if required
 - [ ] If there's a new public field, add it to GraphQL API
 - [ ] Add documentation regarding the feature 
 - [ ] Add/modify seeds

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,11 +12,13 @@ If you haven't already, come find us in [Gitter](https://gitter.im/decidim/decid
 
 * If you're unable to find an open issue addressing the problem, [open a new one on Metadecidim](https://meta.decidim.org/processes/bug-report/f/210/proposals/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
 
-## Did you write a patch that fixes a bug or contributes features to the project?
+## Did you write a patch that fixes a bug or contributes features?
 
 * Open a new GitHub pull request with the patch.
 
 * Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
+
+* Check our [development_guide](https://github.com/decidim/decidim/blob/develop/docs/development_guide.md)
 
 * When the PR includes a breaking change or includes something that requires manual intervention when deploying, it's necesary to add it on the changelog upgrade notes. See [the discussion](https://github.com/decidim/decidim/issues/5908) regarding changelog simplification for further context.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,11 +12,13 @@ If you haven't already, come find us in [Gitter](https://gitter.im/decidim/decid
 
 * If you're unable to find an open issue addressing the problem, [open a new one on Metadecidim](https://meta.decidim.org/processes/bug-report/f/210/proposals/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
 
-## Did you write a patch that fixes a bug?
+## Did you write a patch that fixes a bug or contributes features to the project?
 
 * Open a new GitHub pull request with the patch.
 
 * Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
+
+* When the PR includes a breaking change or includes something that requires manual intervention when deploying, it's necesary to add it on the changelog upgrade notes. See [the discussion](https://github.com/decidim/decidim/issues/5908) regarding changelog simplification for further context.
 
 ## Do you intend to add a new feature or change an existing one?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ If you haven't already, come find us in [Gitter](https://gitter.im/decidim/decid
 
 * Check our [development_guide](https://github.com/decidim/decidim/blob/develop/docs/development_guide.md)
 
-* When the PR includes a breaking change or includes something that requires manual intervention when deploying, it's necesary to add it on the changelog upgrade notes. See [the discussion](https://github.com/decidim/decidim/issues/5908) regarding changelog simplification for further context.
+* When the PR includes a breaking change or includes something that requires manual intervention when deploying, it's necessary to add it on the changelog upgrade notes. See [the discussion](https://github.com/decidim/decidim/issues/5908) regarding changelog simplification for further context.
 
 ## Do you intend to add a new feature or change an existing one?
 


### PR DESCRIPTION
#### :tophat: What? Why?
Starting with the development of Decidim `v0.23` and due to what's been agreed on [the discussion on automated chagelog generation](https://github.com/decidim/decidim/issues/5908) we're not requiring contributors to add a changelog entry on every PR anymore.

This PR simplifies our previous request to contributors to add a changelog entry for every PR by updating the `CONTRIBUTING.md` and the PR template.

#### :pushpin: Related Issues
- Related to #5908 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [x] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
