### PR TITLE
Improve Decidim Initiative documentation

### DIFF
--- a/decidim-initiatives/README.md
+++ b/decidim-initiatives/README.md
@@ -59,7 +59,7 @@ number of committee members. Once the user has created the initiative and before
 sent for technical validation they need to invite committee members to promote it.
 
 When the user has created the initiative they will be given a link to share with possible
-committee members, which will look something like `/initiatives/i-2/committee_requests/new`
+committee members, which will look something like `/initiatives/.../committee_requests/new`
 
 When a prospective committee member opens the link, they can click a button which allows
 them to request to be part of the committee. The initiative author then needs to approve

--- a/decidim-initiatives/README.md
+++ b/decidim-initiatives/README.md
@@ -10,13 +10,59 @@ Prior to be published an initiative must be technically validated. All the valid
 process and communication between the platform administrators and the sponsorship
 committee is managed via an administration UI.
 
+## Workflow
+
+A user views the Initiatives page at `/initiatives`. If they are authorized (or if
+`Decidim::Initiatives.do_not_require_authorization = true` is set - see below) they see
+a call-to-action button: `New initiative`.
+
+They then choose from the list of initiative types, and go through a number of screens
+to help them refine their initiative. Once created, the initiative is not yet published.
+
+The user must then edit their initiative and click the "Send for technical validation"
+button, which looks greyed out but can be clicked. Then it's sent to the site admins to
+review, and if they're happy they can publish the initiative.
+
+At that point the initiative will display on the site.
+
+### Initiative types
+
+For a user to create an initiative, at least one initiative type needs to be created. An
+initiative type should have one or more scopes, each one is configured with the amount of
+signatures required.
+
+There are a number of ways in which signatures can be collected:
+* online
+* in person
+* mixed
+
+A PDF export of signatures is available.
+
+#### Promotion committee
+
+An initiative type can optionally be supported by a promotion committee, with a minimum
+number of committee members. Once the user has created the initiative and before it can be
+sent for technical validation they need to invite committee members to promote it.
+
+When the user has created the initiative they will be given a link to share with possible
+committee members, which will look something like `/initiatives/i-2/committee_requests/new`
+
+When a prospective committee member opens the link, they can click a button which allows
+them to request to be part of the committee. The initiative author then needs to approve
+each request, by opening the Admin Dashboard link in the user menu, editing their
+initiative, clicking "Committee members" and then approving each member.
+
+Once enough people have joined the promoter committee the initiative author can send it for
+technical validation.
+
 ## Usage
 
 This plugin provides:
 
 * A CRUD engine to manage initiatives.
-
 * Public views for initiatives via a high level section in the main menu.
+* An admin dashboard for the initiative author
+* An admin dashboard for an initiative's promotion committee
 
 ## Installation
 

--- a/decidim-initiatives/README.md
+++ b/decidim-initiatives/README.md
@@ -21,7 +21,7 @@ Once created, the initiative is not yet published.
 
 The user must then edit their initiative and click the "Send for technical validation"
 button, which looks greyed out but can be clicked. Then it's sent to the site admins to
-review, and if they're happy they can publish the initiative.
+review; once reviewed they can publish the initiative.
 
 At that point the initiative will display on the site.
 

--- a/decidim-initiatives/README.md
+++ b/decidim-initiatives/README.md
@@ -15,8 +15,9 @@ committee is managed via an administration UI.
 A user views the Initiatives page at `/initiatives`. If they are allowed to create an
 initiative they see a call-to-action button: `New initiative`.
 
-They then choose from the list of initiative types, and go through a number of screens
-to help them refine their initiative. Once created, the initiative is not yet published.
+If there is more than one type of initiative, they will have to choose one and go through
+several screens, and go through a number of screens to help them refine their initiative.
+Once created, the initiative is not yet published.
 
 The user must then edit their initiative and click the "Send for technical validation"
 button, which looks greyed out but can be clicked. Then it's sent to the site admins to

--- a/decidim-initiatives/README.md
+++ b/decidim-initiatives/README.md
@@ -10,7 +10,7 @@ Prior to be published an initiative must be technically validated. All the valid
 process and communication between the platform administrators and the sponsorship
 committee is managed via an administration UI.
 
-## Workflow
+## Creating an initiative
 
 A user views the Initiatives page at `/initiatives`. If they are authorized (or if
 `Decidim::Initiatives.do_not_require_authorization = true` is set - see below) they see
@@ -24,6 +24,12 @@ button, which looks greyed out but can be clicked. Then it's sent to the site ad
 review, and if they're happy they can publish the initiative.
 
 At that point the initiative will display on the site.
+
+### Components
+
+Once an initiative has been created it gets the Meetings and Page component enabled by
+default. The initiative author has no control over these - an admin will need to manage
+them. All of the other usual components may be added by an admin too.
 
 ### Initiative types
 

--- a/decidim-initiatives/README.md
+++ b/decidim-initiatives/README.md
@@ -12,9 +12,8 @@ committee is managed via an administration UI.
 
 ## Creating an initiative
 
-A user views the Initiatives page at `/initiatives`. If they are authorized (or if
-`Decidim::Initiatives.do_not_require_authorization = true` is set - see below) they see
-a call-to-action button: `New initiative`.
+A user views the Initiatives page at `/initiatives`. If they are allowed to create an
+initiative they see a call-to-action button: `New initiative`.
 
 They then choose from the list of initiative types, and go through a number of screens
 to help them refine their initiative. Once created, the initiative is not yet published.
@@ -24,6 +23,14 @@ button, which looks greyed out but can be clicked. Then it's sent to the site ad
 review, and if they're happy they can publish the initiative.
 
 At that point the initiative will display on the site.
+
+### Determining if a user can create an initiative
+
+A participant can [create an initiative if](https://github.com/decidim/decidim/blob/develop/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb#L76-L79)
+Initiatives creation is enabled, and one of:
+* `Decidim::Initiatives.do_not_require_authorization = true` is set (see below), or
+* they have admin permissions on a group, or
+* they have been individually authorized to do so
 
 ### Components
 


### PR DESCRIPTION
#### :tophat: What? Why?

I found the Decidim Initiatives README vague in terms of what specifically I, as a Decidim admin, needed to know, and wasn't able to properly evaluate what an initiative is or how to explain it to someone else. Playing around with initiatives on https://try.decidim.org/initiatives helped a bit, but didn't assist me enough.

I've added sections to the Decidim Initiatives README which better explain the workflow of adding an initiative:
* what an admin needs to set up (i.e. initiative types)
* how a user can create an initiative and get it published
* the workflow a prospective promotion committee member follows in order to be invited to join the committee