### PR TITLE
Improve proposal selection

### DIFF
--- a/decidim-budgets/app/controllers/decidim/budgets/admin/projects_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/admin/projects_controller.rb
@@ -5,7 +5,10 @@ module Decidim
     module Admin
       # This controller allows an admin to manage projects from a Participatory Process
       class ProjectsController < Admin::ApplicationController
-        helper_method :projects, :finished_orders, :pending_orders
+        include Decidim::ApplicationHelper
+        include Decidim::Proposals::Admin::Picker
+
+        helper_method :projects, :finished_orders, :pending_orders, :present
 
         def new
           enforce_permission_to :create, :project

--- a/decidim-budgets/app/forms/decidim/budgets/admin/project_form.rb
+++ b/decidim-budgets/app/forms/decidim/budgets/admin/project_form.rb
@@ -44,8 +44,8 @@ module Decidim
         def proposals
           @proposals ||= Decidim.find_resource_manifest(:proposals).try(:resource_scope, current_component)
                          &.published
+                         &.where(id: proposal_ids)
                          &.order(title: :asc)
-                         &.map { |proposal| [present(proposal).title, proposal.id] }
         end
 
         # Finds the Category from the decidim_category_id.

--- a/decidim-budgets/app/forms/decidim/budgets/admin/project_form.rb
+++ b/decidim-budgets/app/forms/decidim/budgets/admin/project_form.rb
@@ -43,7 +43,6 @@ module Decidim
 
         def proposals
           @proposals ||= Decidim.find_resource_manifest(:proposals).try(:resource_scope, current_component)
-                         &.published
                          &.where(id: proposal_ids)
                          &.order(title: :asc)
         end

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/_form.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/_form.html.erb
@@ -27,12 +27,7 @@
     </div>
 
     <div class="row column">
-      <% if @form.proposals %>
-        <%= form.select :proposal_ids,
-                        @form.proposals,
-                        {},
-                        { multiple: true, class: "chosen-select" } %>
-      <% end %>
+      <%= proposals_picker(form, :proposals, proposals_picker_projects_path) %>
     </div>
 
     <%= render partial: "decidim/admin/shared/gallery", locals: { form: form } %>

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/proposals_picker.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/proposals_picker.html.erb
@@ -1,0 +1,1 @@
+<%= cell "decidim/proposals/proposals_picker", current_component %>

--- a/decidim-budgets/lib/decidim/budgets/admin_engine.rb
+++ b/decidim-budgets/lib/decidim/budgets/admin_engine.rb
@@ -13,6 +13,8 @@ module Decidim
 
       routes do
         resources :projects do
+          get :proposals_picker, on: :collection
+
           resources :attachment_collections
           resources :attachments
           collection do

--- a/decidim-budgets/spec/forms/project_form_spec.rb
+++ b/decidim-budgets/spec/forms/project_form_spec.rb
@@ -110,8 +110,7 @@ module Decidim::Budgets
         it "does not return the draft proposals" do
           create_list(:proposal, 10, :draft, component: proposals_component)
 
-          expect(subject.proposals)
-            .to eq([proposal])
+          expect(subject.proposals).to eq([proposal])
         end
       end
 

--- a/decidim-budgets/spec/forms/project_form_spec.rb
+++ b/decidim-budgets/spec/forms/project_form_spec.rb
@@ -84,34 +84,39 @@ module Decidim::Budgets
     end
 
     context "with proposals" do
+      subject { described_class.from_model(project).with_context(context) }
+
       let(:proposals_component) { create :component, manifest_name: :proposals, participatory_space: participatory_process }
       let!(:proposal) { create :proposal, component: proposals_component }
 
+      let(:project) do
+        create(
+          :project,
+          component: current_component,
+          scope: scope,
+          category: category
+        )
+      end
+
       describe "#proposals" do
+        before do
+          project.link_resources([proposal], "included_proposals")
+        end
+
         it "returns the available proposals in a way suitable for the form" do
-          expect(subject.proposals)
-            .to eq([[proposal.title, proposal.id]])
+          expect(subject.proposals).to eq([proposal])
         end
 
         it "does not return the draft proposals" do
           create_list(:proposal, 10, :draft, component: proposals_component)
 
           expect(subject.proposals)
-            .to eq([[proposal.title, proposal.id]])
+            .to eq([proposal])
         end
       end
 
       describe "#map_model" do
         subject { described_class.from_model(project).with_context(context) }
-
-        let(:project) do
-          create(
-            :project,
-            component: current_component,
-            scope: scope,
-            category: category
-          )
-        end
 
         it "sets the proposal_ids correctly" do
           project.link_resources([proposal], "included_proposals")

--- a/decidim-budgets/spec/forms/project_form_spec.rb
+++ b/decidim-budgets/spec/forms/project_form_spec.rb
@@ -106,12 +106,6 @@ module Decidim::Budgets
         it "returns the available proposals in a way suitable for the form" do
           expect(subject.proposals).to eq([proposal])
         end
-
-        it "does not return the draft proposals" do
-          create_list(:proposal, 10, :draft, component: proposals_component)
-
-          expect(subject.proposals).to eq([proposal])
-        end
       end
 
       describe "#map_model" do

--- a/decidim-budgets/spec/system/admin_manages_projects_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_projects_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "decidim/proposals/test/capybara_proposals_picker"
 
 describe "Admin manages projects", type: :system do
   let(:manifest_name) { "budgets" }

--- a/decidim-proposals/app/cells/decidim/proposals/proposals_picker_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposals_picker_cell.rb
@@ -59,7 +59,9 @@ module Decidim
       end
 
       def proposals
-        @proposals ||= Decidim.find_resource_manifest(:proposals).try(:resource_scope, component)&.order(id: :asc)
+        @proposals ||= Decidim.find_resource_manifest(:proposals).try(:resource_scope, component)
+                       &.published
+                       &.order(id: :asc)
       end
 
       def proposals_collection_name


### PR DESCRIPTION
#### :tophat: What? Why?
A constant complaint we've heard over the years is that it is extremely difficult to link proposals to the budgeting projects when there is a high number of proposals.

Why not use the same proposal picker component as we use for accountability results? This will fix the following (which addresses the complaints):

- Easier to find the proposals by name
- Possibility to find the proposals based on their ID

In addition, this fixes an issue with the proposals picker that it showed the unpublished proposals as well.

#### :clipboard: Subtasks
- [x] Add/modify seeds
- [x] Add tests