### PR TITLE
Fix link to previous changelog version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,4 +23,4 @@
 
 ## Previous versions
 
-Please check [0.22-stable](https://github.com/decidim/decidim/blob/0.22-stable/CHANGELOG.md) for previous changes.
+Please check [release/0.22-stable](https://github.com/decidim/decidim/blob/release/0.22-stable/CHANGELOG.md) for previous changes.


### PR DESCRIPTION
#### :tophat: What? Why?
When branching off what is going to be the new v0.22 release branch, the naming for the branch changed to a new nomenclature: `release/0.22-stable`. This broke the link to the previous version in the changelog in `develop`.
This PR fixes the link.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
