### PR TITLE
Truncate debate cell text & do not sanitize instructions

### DIFF
--- a/decidim-debates/app/cells/decidim/debates/debate_m_cell.rb
+++ b/decidim-debates/app/cells/decidim/debates/debate_m_cell.rb
@@ -14,11 +14,12 @@ module Decidim
       private
 
       def title
-        present(model).title
+        decidim_html_escape(present(model).title)
       end
 
       def description
-        present(model).description(strip_tags: true)
+        body = decidim_sanitize(present(model).description)
+        body.truncate(200, separator: /\s/)
       end
 
       def resource_icon

--- a/decidim-debates/app/cells/decidim/debates/debate_m_cell.rb
+++ b/decidim-debates/app/cells/decidim/debates/debate_m_cell.rb
@@ -17,9 +17,12 @@ module Decidim
         decidim_html_escape(present(model).title)
       end
 
+      def body
+        decidim_sanitize(present(model).description)
+      end
+
       def description
-        body = decidim_sanitize(present(model).description)
-        body.truncate(200, separator: /\s/)
+        strip_tags(body).truncate(200, separator: /\s/)
       end
 
       def resource_icon

--- a/decidim-debates/app/cells/decidim/debates/debate_m_cell.rb
+++ b/decidim-debates/app/cells/decidim/debates/debate_m_cell.rb
@@ -14,7 +14,7 @@ module Decidim
       private
 
       def title
-        decidim_html_escape(present(model).title)
+        present(model).title
       end
 
       def body

--- a/decidim-debates/app/views/decidim/debates/debates/show.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/show.html.erb
@@ -56,7 +56,7 @@ edit_link(
       <% end %>
       <% if translated_attribute(debate.information_updates).present? %>
         <div class="callout success">
-          <%= simple_format(translated_attribute(debate.information_updates), {}, sanitize: false) %>
+          <%= decidim_sanitize(simple_format(translated_attribute(debate.information_updates), {}, sanitize: false)) %>
         </div>
       <% end %>
       <% if debate.category %>

--- a/decidim-debates/app/views/decidim/debates/debates/show.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/show.html.erb
@@ -51,12 +51,12 @@ edit_link(
       <%= render_debate_description(debate) %>
       <% if translated_attribute(debate.instructions).present? %>
         <div class="callout secondary">
-          <%= decidim_sanitize(simple_format(translated_attribute(debate.instructions))) %>
+          <%= decidim_sanitize(simple_format(translated_attribute(debate.instructions), {}, sanitize: false)) %>
         </div>
       <% end %>
       <% if translated_attribute(debate.information_updates).present? %>
         <div class="callout success">
-          <%= simple_format(translated_attribute(debate.information_updates)) %>
+          <%= simple_format(translated_attribute(debate.information_updates), {}, sanitize: false) %>
         </div>
       <% end %>
       <% if debate.category %>


### PR DESCRIPTION
#### :tophat: What? Why?

The debates components shows the full text in each debate `card_m`. It should be truncated as proposals for instance.

Also, the instructions and updates applies too much sanitation to the html so links that should open in a new window (externa links) open in the same. This is not the standard behavior in other callouts.

#### :pushpin: Related Issues

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
Before:
![imatge](https://user-images.githubusercontent.com/1401520/85156082-db578180-b259-11ea-9300-11f0e69341ca.png)

After:
![imatge](https://user-images.githubusercontent.com/1401520/85155920-a8ad8900-b259-11ea-8a98-0f567b3c1d8d.png)

