### PR TITLE
Fix crash when proposals meeting author is deleted

### DIFF
--- a/decidim-core/app/helpers/decidim/application_helper.rb
+++ b/decidim-core/app/helpers/decidim/application_helper.rb
@@ -28,12 +28,18 @@ module Decidim
     end
 
     def present(object, presenter_class: nil)
-      presenter_class ||= "#{object.class.name}Presenter".constantize
+      presenter_class ||= resolve_presenter_class(object, presenter_class: presenter_class)
       presenter = presenter_class.new(object)
 
       yield(presenter) if block_given?
 
       presenter
+    end
+
+    def resolve_presenter_class(object, presenter_class: nil)
+      presenter_class || "#{object.class.name}Presenter".constantize
+    rescue StandardError
+      ::Decidim::NilPresenter
     end
 
     # Generates a link to be added to the global Edit link so admins

--- a/decidim-core/app/presenters/decidim/nil_presenter.rb
+++ b/decidim-core/app/presenters/decidim/nil_presenter.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Decidim
+  # A default presenter for the cases when the presented object is nil.
+  # For example, when there are data inconsistencies like when a Meeting which is the creator of a proposal is removed.
+  # This presenter will also be useful if the presenter for the presented object can not be resolved.
+  #
+  # It behaves as a presenter for deleted resources.
+  # Returns an empty string for most of the method calls.
+  class NilPresenter < Rectify::Presenter
+    def deleted?
+      true
+    end
+
+    def avatar_url
+      Decidim::AvatarUploader.new.default_url
+    end
+
+    def respond_to_missing?
+      true
+    end
+
+    # rubocop:disable Style/MethodMissingSuper
+    def method_missing(_method, *_args)
+      ""
+    end
+    # rubocop:enable Style/MethodMissingSuper
+  end
+end

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -465,6 +465,27 @@ FactoryBot.define do
     end
   end
 
+  factory :coauthorable_dummy_resource, class: "Decidim::DummyResources::CoauthorableDummyResource" do
+    title { generate(:name) }
+    component { create(:component, manifest_name: "dummy") }
+
+    trait :with_coautors do
+      transient do
+        coauthors { [create { :user }] }
+      end
+
+      after :build do |resource, evaluator|
+        evaluator.coauthors.each do |coauthor|
+          resource.coauthorships << if coauthor.is_a?(::Decidim::UserGroup)
+                                      build(:coauthorship, author: coauthor.users.first, user_group: coauthor, coauthorable: resource)
+                                    else
+                                      build(:coauthorship, author: coauthor, coauthorable: resource)
+                                    end
+        end
+      end
+    end
+  end
+
   factory :resource_link, class: "Decidim::ResourceLink" do
     name { generate(:slug) }
     to { build(:dummy_resource) }

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -469,19 +469,17 @@ FactoryBot.define do
     title { generate(:name) }
     component { create(:component, manifest_name: "dummy") }
 
-    trait :with_coautors do
-      transient do
-        coauthors { [create { :user }] }
-      end
+    transient do
+      authors_list { [create(:user, organization: component.organization)] }
+    end
 
-      after :build do |resource, evaluator|
-        evaluator.coauthors.each do |coauthor|
-          resource.coauthorships << if coauthor.is_a?(::Decidim::UserGroup)
-                                      build(:coauthorship, author: coauthor.users.first, user_group: coauthor, coauthorable: resource)
-                                    else
-                                      build(:coauthorship, author: coauthor, coauthorable: resource)
-                                    end
-        end
+    after :build do |resource, evaluator|
+      evaluator.authors_list.each do |coauthor|
+        resource.coauthorships << if coauthor.is_a?(::Decidim::UserGroup)
+                                    build(:coauthorship, author: coauthor.users.first, user_group: coauthor, coauthorable: resource, organization: evaluator.component.organization)
+                                  else
+                                    build(:coauthorship, author: coauthor, coauthorable: resource, organization: evaluator.component.organization)
+                                  end
       end
     end
   end

--- a/decidim-core/spec/cells/decidim/coauthorships_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/coauthorships_cell_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::CoauthorshipsCell, type: :cell do
+  subject { my_cell.call }
+
+  controller Decidim::PagesController
+
+  let(:my_cell) { cell("decidim/coauthorships", coauthorable) }
+  let!(:organization) { create(:organization) }
+  let!(:component) { create(:component, manifest_name: "dummy", organization: organization) }
+  let(:coauthorable) { create(:coauthorable_dummy_resource, :with_coautors, component: component, coauthors: coauthors) }
+  let(:user) { create(:user, :confirmed, organization: organization) }
+
+  context "with User coauthorships" do
+    let(:coauthors) { [user] }
+
+    it "renders the User author" do
+      expect(subject).to have_content(user.name)
+    end
+  end
+
+  context "with UserGroup coauthorships" do
+    let(:user_group) { create(:user_group, :verified, users: [user]) }
+    let(:coauthors) { [user_group] }
+
+    it "renders the User author" do
+      expect(subject).to have_content(user_group.name)
+    end
+  end
+
+  context "with Official coauthorships" do
+    let(:coauthors) { [organization] }
+
+    it "renders the Official author" do
+      expect(subject).to have_content(Decidim::DummyResources::OfficialAuthorPresenter.new.name)
+    end
+  end
+
+  context "with unresolveable coauthorships" do
+    let(:coauthors) { [user] }
+
+    before do
+      coauthorable.present?
+      user.destroy
+      coauthorable.reload
+    end
+
+    it "renders with the NilPresenter" do
+      expect(subject).to have_css(".author-data")
+    end
+  end
+end

--- a/decidim-core/spec/cells/decidim/coauthorships_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/coauthorships_cell_spec.rb
@@ -10,7 +10,7 @@ describe Decidim::CoauthorshipsCell, type: :cell do
   let(:my_cell) { cell("decidim/coauthorships", coauthorable) }
   let!(:organization) { create(:organization) }
   let!(:component) { create(:component, manifest_name: "dummy", organization: organization) }
-  let(:coauthorable) { create(:coauthorable_dummy_resource, :with_coautors, component: component, coauthors: coauthors) }
+  let(:coauthorable) { create(:coauthorable_dummy_resource, component: component, authors_list: coauthors) }
   let(:user) { create(:user, :confirmed, organization: organization) }
 
   context "with User coauthorships" do

--- a/decidim-core/spec/helpers/decidim/application_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/application_helper_spec.rb
@@ -5,14 +5,14 @@ require_relative "../../../app/helpers/decidim/application_helper"
 
 module Decidim
   describe ApplicationHelper do
+    let(:helper) do
+      Class.new.tap do |v|
+        v.extend(Decidim::ApplicationHelper)
+      end
+    end
+
     describe "#html_truncate" do
       subject { helper.html_truncate(text, length: length) }
-
-      let(:helper) do
-        Class.new.tap do |v|
-          v.extend(Decidim::ApplicationHelper)
-        end
-      end
 
       describe "truncating HTML text" do
         let(:text) { "<p>Hello, this is dog</p>" }
@@ -35,6 +35,22 @@ module Decidim
         let(:length) { 5 }
 
         it { is_expected.to eq("Hello ...read more") }
+      end
+    end
+
+    describe "#present" do
+      subject { helper.present(presentable).class }
+
+      context "when presentable's presenter follows naming convention" do
+        let(:presentable) { create(:user) }
+
+        it { is_expected.to eq(Decidim::UserPresenter) }
+      end
+
+      context "when presentable is nil" do
+        let(:presentable) { nil }
+
+        it { is_expected.to eq(Decidim::NilPresenter) }
       end
     end
   end

--- a/decidim-core/spec/presenters/decidim/nil_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/nil_presenter_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe NilPresenter do
+    subject { ::Decidim::NilPresenter.new.send(method) }
+
+    describe "#deleted?" do
+      let(:method) { :deleted? }
+
+      it { is_expected.to be true }
+    end
+
+    describe "#avatar_url" do
+      let(:method) { :avatar_url }
+
+      it "returns the default avatar url" do
+        expect(subject.starts_with?("/assets/decidim/default-avatar-")).to be true
+        expect(subject.ends_with?(".svg")).to be true
+      end
+    end
+
+    describe "#render" do
+      let(:method) { :render }
+
+      it { is_expected.to eq("") }
+    end
+
+    describe "#translated_name" do
+      let(:method) { :translated_name }
+
+      it { is_expected.to eq("") }
+    end
+
+    describe "#url" do
+      let(:method) { :url }
+
+      it { is_expected.to eq("") }
+    end
+
+    describe "#path" do
+      let(:method) { :path }
+
+      it { is_expected.to eq("") }
+    end
+
+    describe "with user related methods" do
+      [:nickname, :badge, :profile_path, :display_mention].each do |method|
+        let(:method) { method }
+
+        it { is_expected.to eq("") }
+      end
+    end
+
+    describe "with resource_locator related methods" do
+      [:resource, :path, :url, :index, :admin_index, :show, :edit].each do |method|
+        subject { ::Decidim::NilPresenter.new.send(method, {}) }
+
+        let(:method) { method }
+
+        it { is_expected.to eq("") }
+      end
+    end
+
+    describe "with metrics related methods" do
+      [:highlighted, :not_highlighted, :highlighted_metrics, :not_highlighted_metrics].each do |method|
+        let(:method) { method }
+
+        it { is_expected.to eq("") }
+      end
+    end
+
+    describe "with metrics related methods" do
+      [:highlighted, :not_highlighted, :highlighted_metrics, :not_highlighted_metrics].each do |method|
+        let(:method) { method }
+
+        it { is_expected.to eq("") }
+      end
+    end
+
+    describe "with hashtag related methods" do
+      [:name, :hashtag_path, :display_hashtag, :display_hashtag_name].each do |method|
+        let(:method) { method }
+
+        it { is_expected.to eq("") }
+      end
+    end
+  end
+end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
@@ -105,6 +105,39 @@ module Decidim
                                               .pluck(:decidim_author_id).flatten.compact.uniq
       end
     end
+
+    class CoauthorableDummyResource < ApplicationRecord
+      include ::Decidim::Coauthorable
+      include HasComponent
+    end
+
+    class OfficialAuthorPresenter
+      def name
+        self.class.name
+      end
+
+      def nickname
+        UserBaseEntity.nicknamize(name)
+      end
+
+      def deleted?
+        false
+      end
+
+      def respond_to_missing?
+        true
+      end
+
+      def method_missing(method, *args)
+        if method.to_s.ends_with?("?")
+          false
+        elsif [:avatar_url, :profile_path, :badge, :followers_count].include?(method)
+          ""
+        else
+          super
+        end
+      end
+    end
   end
 end
 
@@ -162,6 +195,14 @@ Decidim.register_component(:dummy) do |component|
     resource.searchable = true
   end
 
+  component.register_resource(:coauthorable_dummy_resource) do |resource|
+    resource.name = :coauthorable_dummy
+    resource.model_class_name = "Decidim::DummyResources::CoauthorableDummyResource"
+    resource.template = "decidim/coauthorabledummy_resource/linked_dummys"
+    resource.actions = %w(foo-coauthorable)
+    resource.searchable = true
+  end
+
   component.register_stat :dummies_count_high, primary: true, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |components, _start_at, _end_at|
     components.count * 10
   end
@@ -198,6 +239,26 @@ RSpec.configure do |config|
           t.integer :decidim_author_id, index: false
           t.string :decidim_author_type, index: false
           t.integer :decidim_user_group_id, index: false
+          t.references :decidim_category, index: false
+          t.references :decidim_scope, index: false
+          t.string :reference
+
+          t.timestamps
+        end
+      end
+      unless ActiveRecord::Base.connection.data_source_exists?("decidim_dummy_resources_coauthorable_dummy_resources")
+        ActiveRecord::Migration.create_table :decidim_dummy_resources_coauthorable_dummy_resources do |t|
+          t.jsonb :translatable_text
+          t.string :title
+          t.string :body
+          t.text :address
+          t.float :latitude
+          t.float :longitude
+          t.datetime :published_at
+          t.integer :coauthorships_count, null: false, default: 0
+          t.integer :endorsements_count, null: false, default: 0
+
+          t.references :decidim_component, index: false
           t.references :decidim_category, index: false
           t.references :decidim_scope, index: false
           t.string :reference

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
@@ -200,7 +200,7 @@ Decidim.register_component(:dummy) do |component|
     resource.model_class_name = "Decidim::DummyResources::CoauthorableDummyResource"
     resource.template = "decidim/coauthorabledummy_resource/linked_dummys"
     resource.actions = %w(foo-coauthorable)
-    resource.searchable = true
+    resource.searchable = false
   end
 
   component.register_stat :dummies_count_high, primary: true, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |components, _start_at, _end_at|


### PR DESCRIPTION
#### :tophat: What? Why?
Do not crash when proposals meeting author is deleted. Right now, it is possible to leave Proposals without any author, in this case Decidim crashes when listing the proposals in the public view (see related issues).
This PR introduces a `NilPresenter` that is used when the `ApplicationHelper#presenter` factory method is not able to resolve the presenter for a resource.
The `NilPresenter` behaves like a deleted resource.

#### :pushpin: Related Issues
- Fixes #5900 
- Related to #6151 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [x] Add tests
- [x] Another subtask

### :camera: Screenshots (optional)
**Voluptatem aut** proposal card with the Meeting that created it deleted:
![imatge](https://user-images.githubusercontent.com/199462/85374080-899e4800-b534-11ea-97b6-a2a4304a794c.png)

Show proposal without coauthors
![imatge](https://user-images.githubusercontent.com/199462/85374268-c9fdc600-b534-11ea-8f02-7013c24ea4c8.png)

