### PR TITLE
Memoizes and caches provider settings to improve performance

### DIFF
--- a/decidim-core/app/models/decidim/organization.rb
+++ b/decidim-core/app/models/decidim/organization.rb
@@ -133,18 +133,19 @@ module Decidim
     end
 
     def omniauth_provider_settings(provider)
-      provider_settings = {}
+      @omniauth_provider_settings ||= Hash.new do |hash, provider_key|
+        hash[provider_key] = begin
+          omniauth_settings.each_with_object({}) do |(key, value), provider_settings|
+            next unless key.to_s.include?(provider_key.to_s)
 
-      omniauth_settings.each do |key, value|
-        next unless key.to_s.include?(provider.to_s)
+            value = Decidim::AttributeEncryptor.decrypt(value) if Decidim::OmniauthProvider.value_defined?(value)
+            setting_key = Decidim::OmniauthProvider.extract_setting_key(key, provider_key)
 
-        value = Decidim::AttributeEncryptor.decrypt(value) if Decidim::OmniauthProvider.value_defined?(value)
-        setting_key = Decidim::OmniauthProvider.extract_setting_key(key, provider)
-
-        provider_settings[setting_key] = value
+            provider_settings[setting_key] = value
+          end
+        end
       end
-
-      provider_settings
+      @omniauth_provider_settings[provider]
     end
   end
 end

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -19,7 +19,9 @@
     </div>
   </div>
 
-  <%= render "decidim/devise/shared/omniauth_buttons" %>
+  <% cache current_organization do %>
+    <%= render "decidim/devise/shared/omniauth_buttons" %>
+  <% end %>
 
   <div class="row">
     <div class="columns large-6 medium-10 medium-centered">

--- a/decidim-core/app/views/decidim/devise/sessions/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/sessions/new.html.erb
@@ -21,7 +21,9 @@
         <% end %>
       </div>
     </div>
-    <%= render "decidim/devise/shared/omniauth_buttons" %>
+    <% cache current_organization do %>
+      <%= render "decidim/devise/shared/omniauth_buttons" %>
+    <% end %>
 
     <% if current_organization.sign_in_enabled? %>
       <div class="row">

--- a/decidim-core/app/views/decidim/shared/_login_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_login_modal.html.erb
@@ -32,7 +32,9 @@
           </p>
       </div>
     </div>
-    <%= render "decidim/devise/shared/omniauth_buttons_mini" %>
+    <% cache current_organization do %>
+      <%= render "decidim/devise/shared/omniauth_buttons_mini" %>
+    <% end %>
   <% else %>
     <div class="row">
       <div class="columns medium-8 medium-centered">
@@ -41,6 +43,8 @@
         </p>
       </div>
     </div>
-    <%= render "decidim/devise/shared/omniauth_buttons" %>
+    <% cache current_organization do %>
+      <%= render "decidim/devise/shared/omniauth_buttons" %>
+    <% end %>
   <% end %>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?
Improves performance of pages including omniauth links by memoizing their configuration and caching the related partials.

Main issue here is that the method `omniauth_provider_settings`, which does the parsing and decrypting of the omniauth provider settings, is called 5 times for each provider in a single request.

Quick debug log before the optimization, having 3 omniauth providers enabled, taking almost 1 second to render the partial:

```
  Rendered /decidim/decidim-core/app/views/layouts/decidim/_wrapper.html.erb (693.0ms)
In the omniauth_provider_settings method for twitter
In the omniauth_provider_settings method for facebook
In the omniauth_provider_settings method for google_oauth2
In the omniauth_provider_settings method for twitter
In the omniauth_provider_settings method for facebook
In the omniauth_provider_settings method for google_oauth2
In the omniauth_provider_settings method for twitter
In the omniauth_provider_settings method for facebook
In the omniauth_provider_settings method for google_oauth2
In the omniauth_provider_settings method for twitter
In the omniauth_provider_settings method for facebook
In the omniauth_provider_settings method for google_oauth2
In the omniauth_provider_settings method for twitter
In the omniauth_provider_settings method for facebook
In the omniauth_provider_settings method for google_oauth2
  Rendered /decidim/decidim-core/app/views/decidim/devise/shared/_omniauth_buttons_mini.html.erb (943.9ms)
```

Just by memoizing the result, the process is run once from each provider and the rendering time for the partial is reduced to rougly 200ms:

```
  Rendered /decidim/decidim-core/app/views/layouts/decidim/_wrapper.html.erb (651.0ms)
In the omniauth_provider_settings method for twitter
In the omniauth_provider_settings method for facebook
In the omniauth_provider_settings method for google_oauth2
  Rendered /decidim/decidim-core/app/views/decidim/devise/shared/_omniauth_buttons_mini.html.erb (195.8ms)
```
 
#### :pushpin: Related Issues
- Related to #6141 

