### PR TITLE
Point simplecov to master to fix a coverage on monorepos

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,11 @@ gem "faker", "~> 1.9"
 group :development, :test do
   gem "byebug", "~> 11.0", platform: :mri
 
+  # Use latest simplecov from master until next version of simplecov is
+  # released (greather than 0.18.5)
+  # See https://github.com/decidim/decidim/issues/6230
+  gem "simplecov", git: "https://github.com/colszowka/simplecov"
+
   gem "decidim-dev", path: "."
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/colszowka/simplecov
+  revision: 9056bd3852d0daca2221c9b0a964b8abada1c48c
+  specs:
+    simplecov (0.18.5)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+
 PATH
   remote: .
   specs:
@@ -691,9 +699,6 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     seven_zip_ruby (1.2.5)
-    simplecov (0.18.5)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
     simplecov-cobertura (1.3.1)
       simplecov (~> 0.8)
     simplecov-html (0.12.2)
@@ -788,6 +793,7 @@ DEPENDENCIES
   letter_opener_web (~> 1.3)
   listen (~> 3.1)
   puma (>= 4.3.5)
+  simplecov!
   spring (~> 2.0)
   spring-watcher-listen (~> 2.0)
   uglifier (~> 4.1)

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/colszowka/simplecov
+  revision: 9056bd3852d0daca2221c9b0a964b8abada1c48c
+  specs:
+    simplecov (0.18.5)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+
 PATH
   remote: ..
   specs:
@@ -691,9 +699,6 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     seven_zip_ruby (1.2.5)
-    simplecov (0.18.5)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
     simplecov-cobertura (1.3.1)
       simplecov (~> 0.8)
     simplecov-html (0.12.2)
@@ -788,6 +793,7 @@ DEPENDENCIES
   letter_opener_web (~> 1.3)
   listen (~> 3.1)
   puma (>= 4.3.5)
+  simplecov!
   spring (~> 2.0)
   spring-watcher-listen (~> 2.0)
   uglifier (~> 4.1)


### PR DESCRIPTION
#### :tophat: What? Why?

This one is 100% from @mrcasals  - I'm only making the final (momentary) fix: 

> When developing #5934, we found a problem: when running tests for the decidim-proposals engine, where we know code from decidim-core is executed, the code in decidim-core was not considered as covered. This reduced the % of covered code in the results. This was reported in colszowka/simplecov#885.

> The Simplecov maintainers have worked on this issue and have released a PR that should fix the problem: colszowka/simplecov#894. We should try this in our repo and see if it actually fixed it.

So, basically, this should fix the coverage issues that we have :pray: :pray: 

As stated on the comment on the Gemfile, on a [next simplecov version](https://rubygems.org/gems/simplecov/versions/0.18.5) (0.18.6 or 0.19.0) this will not be necessary and can be removed. 

#### :pushpin: Related Issues
- Fixes #6230
  