### PR TITLE
Backport "Fix rubocop errors arising from capybara upgrade" to v0.22

### DIFF
--- a/decidim-assemblies/spec/lib/query_extensions_spec.rb
+++ b/decidim-assemblies/spec/lib/query_extensions_spec.rb
@@ -9,16 +9,16 @@ module Decidim
       include_context "with a graphql type"
 
       describe "assembliesTypes" do
-        let!(:assembliesType1) { create(:assemblies_type, organization: current_organization) }
-        let!(:assembliesType2) { create(:assemblies_type, organization: current_organization) }
-        let!(:assembliesType3) { create(:assemblies_type) }
+        let!(:assemblies_type1) { create(:assemblies_type, organization: current_organization) }
+        let!(:assemblies_type2) { create(:assemblies_type, organization: current_organization) }
+        let!(:assemblies_type3) { create(:assemblies_type) }
 
         let(:query) { %({ assembliesTypes { id }}) }
 
         it "returns all the assembliesType" do
-          expect(response["assembliesTypes"]).to include("id" => assembliesType1.id.to_s)
-          expect(response["assembliesTypes"]).to include("id" => assembliesType2.id.to_s)
-          expect(response["assembliesTypes"]).not_to include("id" => assembliesType3.id.to_s)
+          expect(response["assembliesTypes"]).to include("id" => assemblies_type1.id.to_s)
+          expect(response["assembliesTypes"]).to include("id" => assemblies_type2.id.to_s)
+          expect(response["assembliesTypes"]).not_to include("id" => assemblies_type3.id.to_s)
         end
       end
 
@@ -26,17 +26,17 @@ module Decidim
         let(:query) { %({ assembliesType(id: \"#{id}\") { id }}) }
 
         context "with a assemblies type that belongs to the current organization" do
-          let!(:assembliesType) { create(:assemblies_type, organization: current_organization) }
-          let(:id) { assembliesType.id }
+          let!(:assemblies_type) { create(:assemblies_type, organization: current_organization) }
+          let(:id) { assemblies_type.id }
 
           it "returns the group" do
-            expect(response["assembliesType"]).to eq("id" => assembliesType.id.to_s)
+            expect(response["assembliesType"]).to eq("id" => assemblies_type.id.to_s)
           end
         end
 
         context "with a assembliesType of another organization" do
-          let!(:assembliesType) { create(:assemblies_type) }
-          let(:id) { assembliesType.id }
+          let!(:assemblies_type) { create(:assemblies_type) }
+          let(:id) { assemblies_type.id }
 
           it "returns nil" do
             expect(response["assembliesType"]).to be_nil

--- a/decidim-assemblies/spec/shared/manage_assemblies_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assemblies_examples.rb
@@ -152,7 +152,7 @@ shared_examples "manage assemblies" do
       uncheck :assembly_scopes_enabled
 
       expect(page).to have_selector("#assembly_scope_id.disabled")
-      expect(page).to have_selector("#assembly_scope_id .picker-values div input[disabled]", visible: false)
+      expect(page).to have_selector("#assembly_scope_id .picker-values div input[disabled]", visible: :all)
 
       within ".edit_assembly" do
         find("*[type=submit]").click

--- a/decidim-budgets/spec/system/orders_spec.rb
+++ b/decidim-budgets/spec/system/orders_spec.rb
@@ -27,7 +27,7 @@ describe "Orders", type: :system do
         page.find(".budget-list__action").click
       end
 
-      expect(page).to have_css("#loginModal", visible: true)
+      expect(page).to have_css("#loginModal", visible: :visible)
     end
   end
 
@@ -132,7 +132,7 @@ describe "Orders", type: :system do
             page.find(".budget-list__action").click
           end
 
-          expect(page).to have_css("#budget-excess", visible: true)
+          expect(page).to have_css("#budget-excess", visible: :visible)
         end
       end
 
@@ -152,7 +152,7 @@ describe "Orders", type: :system do
             page.find(".button.small").click
           end
 
-          expect(page).to have_css("#budget-confirm", visible: true)
+          expect(page).to have_css("#budget-confirm", visible: :visible)
 
           within "#budget-confirm" do
             page.find(".button.expanded").click

--- a/decidim-conferences/spec/shared/manage_conferences_examples.rb
+++ b/decidim-conferences/spec/shared/manage_conferences_examples.rb
@@ -202,7 +202,7 @@ shared_examples "manage conferences" do
       uncheck :conference_scopes_enabled
 
       expect(page).to have_selector("#conference_scope_id.disabled")
-      expect(page).to have_selector("#conference_scope_id .picker-values div input[disabled]", visible: false)
+      expect(page).to have_selector("#conference_scope_id .picker-values div input[disabled]", visible: :all)
 
       within ".edit_conference" do
         find("*[type=submit]").click

--- a/decidim-conferences/spec/system/conference_registrations_spec.rb
+++ b/decidim-conferences/spec/system/conference_registrations_spec.rb
@@ -84,7 +84,7 @@ describe "Conference registrations", type: :system do
             first(:button, "Registration").click
           end
 
-          expect(page).to have_css("#loginModal", visible: true)
+          expect(page).to have_css("#loginModal", visible: :visible)
         end
       end
     end

--- a/decidim-consultations/spec/system/vote_spec.rb
+++ b/decidim-consultations/spec/system/vote_spec.rb
@@ -172,7 +172,7 @@ describe "Question vote", type: :system do
         within ".question-vote-cabin", match: :first do
           click_button I18n.t("decidim.questions.vote_button.verification_required")
         end
-        expect(page).to have_css("#authorizationModal", visible: true)
+        expect(page).to have_css("#authorizationModal", visible: :visible)
       end
     end
 

--- a/decidim-core/lib/decidim/core/test/shared_examples/reports_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/reports_examples.rb
@@ -28,7 +28,7 @@ shared_examples "reports" do
           page.find("button").click
         end
 
-        expect(page).to have_css(".flag-modal", visible: true)
+        expect(page).to have_css(".flag-modal", visible: :visible)
 
         within ".flag-modal" do
           click_button "Report"
@@ -53,7 +53,7 @@ shared_examples "reports" do
           page.find("button").click
         end
 
-        expect(page).to have_css(".flag-modal", visible: true)
+        expect(page).to have_css(".flag-modal", visible: :visible)
 
         expect(page).to have_content "already reported"
       end

--- a/decidim-core/lib/decidim/core/test/shared_examples/rich_text_editor_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/rich_text_editor_examples.rb
@@ -3,7 +3,7 @@
 shared_examples "having a rich text editor" do |css, toolbar|
   it "has a form with a rich text editor" do
     within "form.#{css}" do
-      expect(page).to have_selector("input[toolbar='#{toolbar}']", visible: false)
+      expect(page).to have_selector("input[toolbar='#{toolbar}']", visible: :all)
     end
   end
 end
@@ -30,7 +30,7 @@ shared_examples "rendering safe content" do |css|
 
   it "sanitizes potentially malicious HTML tags" do
     within css do
-      expect(page).not_to have_selector("script", visible: false)
+      expect(page).not_to have_selector("script", visible: :all)
       expect(page).to have_content("alert('SCRIPT')")
     end
   end
@@ -52,7 +52,7 @@ shared_examples "rendering unsafe content" do |css|
 
   it "strips potentially malicious HTML tags" do
     within css do
-      expect(page).not_to have_selector("script", visible: false)
+      expect(page).not_to have_selector("script", visible: :all)
       expect(page).not_to have_content("alert('SCRIPT')")
     end
   end

--- a/decidim-core/lib/decidim/core/test/shared_examples/system_endorse_resource_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/system_endorse_resource_examples.rb
@@ -64,7 +64,7 @@ shared_examples "Endorse resource system specs" do
           click_button "Endorse"
         end
 
-        expect(page).to have_css("#loginModal", visible: true)
+        expect(page).to have_css("#loginModal", visible: :visible)
       end
     end
 
@@ -138,7 +138,7 @@ shared_examples "Endorse resource system specs" do
             within ".buttons__row", match: :first do
               click_button "Endorse"
             end
-            expect(page).to have_css("#authorizationModal", visible: true)
+            expect(page).to have_css("#authorizationModal", visible: :visible)
           end
         end
 

--- a/decidim-core/spec/cells/decidim/diff_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/diff_cell_spec.rb
@@ -66,7 +66,7 @@ describe Decidim::DiffCell, versioning: true, type: :cell do
       end
 
       it "sanitizes potentially malicious HTML tags" do
-        expect(html).not_to have_selector("script", visible: false)
+        expect(html).not_to have_selector("script", visible: :all)
         expect(html).to have_content("alert('SCRIPT')")
       end
     end
@@ -84,7 +84,7 @@ describe Decidim::DiffCell, versioning: true, type: :cell do
       end
 
       it "sanitizes potentially malicious HTML tags" do
-        expect(html).not_to have_selector("script", visible: false)
+        expect(html).not_to have_selector("script", visible: :all)
         expect(html).to have_content("alert('SCRIPT')")
       end
     end

--- a/decidim-core/spec/lib/query_extensions_spec.rb
+++ b/decidim-core/spec/lib/query_extensions_spec.rb
@@ -106,9 +106,9 @@ module Decidim
         let!(:user4) { create(:user, :confirmed) }
         let!(:user5) { create(:user, :confirmed, organization: current_organization) }
         let!(:user6) { create(:user, :confirmed, organization: current_organization) }
-        let!(:exclusionIds) { "" }
+        let!(:exclusion_ids) { "" }
 
-        let(:query) { %({ users(filter: { excludeIds: [#{exclusionIds}] }) { id }}) }
+        let(:query) { %({ users(filter: { excludeIds: [#{exclusion_ids}] }) { id }}) }
 
         it "returns all the users without any exclusion" do
           expect(response["users"]).to include("id" => user1.id.to_s)
@@ -127,9 +127,9 @@ module Decidim
         let!(:user4) { create(:user, :confirmed) }
         let!(:user5) { create(:user, :confirmed, organization: current_organization) }
         let!(:user6) { create(:user, :confirmed, organization: current_organization) }
-        let!(:exclusionIds) { user5.id.to_s }
+        let!(:exclusion_ids) { user5.id.to_s }
 
-        let(:query) { %({ users(filter: { excludeIds: [#{exclusionIds}] }) { id }}) }
+        let(:query) { %({ users(filter: { excludeIds: [#{exclusion_ids}] }) { id }}) }
 
         it "returns all the users except excluded one" do
           expect(response["users"]).to include("id" => user1.id.to_s)
@@ -148,9 +148,9 @@ module Decidim
         let!(:user4) { create(:user, :confirmed) }
         let!(:user5) { create(:user, :confirmed, organization: current_organization) }
         let!(:user6) { create(:user, :confirmed, organization: current_organization) }
-        let!(:exclusionIds) { "#{user5.id},#{user6.id}" }
+        let!(:exclusion_ids) { "#{user5.id},#{user6.id}" }
 
-        let(:query) { %({ users(filter: { excludeIds: [#{exclusionIds}] }) { id }}) }
+        let(:query) { %({ users(filter: { excludeIds: [#{exclusion_ids}] }) { id }}) }
 
         it "returns all the users except excluded ones" do
           expect(response["users"]).to include("id" => user1.id.to_s)

--- a/decidim-core/spec/system/homepage_spec.rb
+++ b/decidim-core/spec/system/homepage_spec.rb
@@ -125,7 +125,7 @@ describe "Homepage", type: :system do
         let(:organization) { create(:organization, official_url: official_url, header_snippets: snippet) }
 
         it "does not include the header snippets" do
-          expect(page).not_to have_selector("meta[data-hello]", visible: false)
+          expect(page).not_to have_selector("meta[data-hello]", visible: :all)
         end
 
         context "when header snippets are enabled" do
@@ -135,7 +135,7 @@ describe "Homepage", type: :system do
           end
 
           it "includes the header snippets" do
-            expect(page).to have_selector("meta[data-hello]", visible: false)
+            expect(page).to have_selector("meta[data-hello]", visible: :all)
           end
         end
       end
@@ -252,10 +252,10 @@ describe "Homepage", type: :system do
               within "#metrics" do
                 expect(page).to have_content("Metrics")
                 Decidim.metrics_registry.filtered(highlight: true, scope: "home").each do |metric_registry|
-                  expect(page).to have_css(%(##{metric_registry.metric_name}_chart), visible: false)
+                  expect(page).to have_css(%(##{metric_registry.metric_name}_chart), visible: :all)
                 end
                 Decidim.metrics_registry.filtered(highlight: false, scope: "home").each do |metric_registry|
-                  expect(page).to have_css(%(##{metric_registry.metric_name}_chart), visible: false)
+                  expect(page).to have_css(%(##{metric_registry.metric_name}_chart), visible: :all)
                 end
               end
             end

--- a/decidim-core/spec/system/registration_spec.rb
+++ b/decidim-core/spec/system/registration_spec.rb
@@ -38,7 +38,7 @@ describe "Registration", type: :system do
       within "form.new_user" do
         find("*[type=submit]").click
       end
-      expect(page).to have_css("#sign-up-newsletter-modal", visible: true)
+      expect(page).to have_css("#sign-up-newsletter-modal", visible: :visible)
       expect(page).to have_current_path decidim.new_user_registration_path
     end
 
@@ -48,7 +48,7 @@ describe "Registration", type: :system do
       end
       click_button "Check and continue"
       expect(page).to have_current_path decidim.new_user_registration_path
-      expect(page).to have_css("#sign-up-newsletter-modal", visible: false)
+      expect(page).to have_css("#sign-up-newsletter-modal", visible: :all)
       expect(page).to have_field("user_newsletter", checked: true)
     end
 
@@ -57,7 +57,7 @@ describe "Registration", type: :system do
         find("*[type=submit]").click
       end
       click_button "Keep uncheck"
-      expect(page).to have_css("#sign-up-newsletter-modal", visible: false)
+      expect(page).to have_css("#sign-up-newsletter-modal", visible: :all)
       fill_registration_form
       within "form.new_user" do
         find("*[type=submit]").click

--- a/decidim-core/spec/types/user_entity_input_filter_spec.rb
+++ b/decidim-core/spec/types/user_entity_input_filter_spec.rb
@@ -117,9 +117,9 @@ module Decidim
         end
 
         context "when search a user by wildcard but with empty exclusion list" do
-          let(:query) { %({ users(filter: { wildcard: \"#{term}\", excludeIds: [#{exclusionIds}] }) { name }}) }
+          let(:query) { %({ users(filter: { wildcard: \"#{term}\", excludeIds: [#{exclusion_ids}] }) { name }}) }
           let(:term) { "foo" }
-          let!(:exclusionIds) { "" }
+          let!(:exclusion_ids) { "" }
 
           it "returns matching users without exclusions" do
             expect(response["users"]).to include("name" => user1.name)
@@ -132,9 +132,9 @@ module Decidim
         end
 
         context "when search a user by wildcard but with exclusion list" do
-          let(:query) { %({ users(filter: { wildcard: \"#{term}\", excludeIds: [#{exclusionIds}] }) { name }}) }
+          let(:query) { %({ users(filter: { wildcard: \"#{term}\", excludeIds: [#{exclusion_ids}] }) { name }}) }
           let(:term) { "foo" }
-          let!(:exclusionIds) { user5.id.to_s }
+          let!(:exclusion_ids) { user5.id.to_s }
 
           it "returns matching users without the excluded one" do
             expect(response["users"]).to include("name" => user1.name)
@@ -147,9 +147,9 @@ module Decidim
         end
 
         context "when search a user by wildcard but with multiple exclusion list" do
-          let(:query) { %({ users(filter: { wildcard: \"#{term}\", excludeIds: [#{exclusionIds}] }) { name }}) }
+          let(:query) { %({ users(filter: { wildcard: \"#{term}\", excludeIds: [#{exclusion_ids}] }) { name }}) }
           let(:term) { "foo" }
-          let!(:exclusionIds) { "#{user5.id},#{user6.id}" }
+          let!(:exclusion_ids) { "#{user5.id},#{user6.id}" }
 
           it "returns matching users without the excluded ones" do
             expect(response["users"]).to include("name" => user1.name)

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara_scopes_picker.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara_scopes_picker.rb
@@ -10,7 +10,7 @@ module Capybara
       match do |scope_picker|
         data_picker = scope_picker.data_picker
         scope_name = expected ? translated(expected.name) : t("decidim.scopes.global")
-        expect(data_picker).to have_selector(".picker-values div input[value='#{expected&.id || scope_picker.global_value}']", visible: false)
+        expect(data_picker).to have_selector(".picker-values div input[value='#{expected&.id || scope_picker.global_value}']", visible: :all)
         expect(data_picker).to have_selector(:xpath, "//div[contains(@class,'picker-values')]/div/a[text()[contains(.,'#{scope_name}')]]")
       end
     end
@@ -19,7 +19,7 @@ module Capybara
       match do |scope_picker|
         data_picker = scope_picker.data_picker
         scope_name = expected ? translated(expected.name) : t("decidim.scopes.global")
-        expect(data_picker).not_to have_selector(".picker-values div input[value='#{expected&.id || scope_picker.global_value}']", visible: false)
+        expect(data_picker).not_to have_selector(".picker-values div input[value='#{expected&.id || scope_picker.global_value}']", visible: :all)
         expect(data_picker).not_to have_selector(:xpath, "//div[contains(@class,'picker-values')]/div/a[text()[contains(.,'#{scope_name}')]]")
       end
     end
@@ -27,7 +27,7 @@ module Capybara
     def scope_pick(scope_picker, scope)
       data_picker = scope_picker.data_picker
       # use scope_repick to change single scope picker selected scope
-      expect(data_picker).to have_selector(".picker-values:empty", visible: false) if data_picker.has_css?(".picker-single")
+      expect(data_picker).to have_selector(".picker-values:empty", visible: :all) if data_picker.has_css?(".picker-single")
 
       expect(data_picker).to have_selector(".picker-prompt")
       data_picker.find(".picker-prompt").click
@@ -41,7 +41,7 @@ module Capybara
     def scope_repick(scope_picker, old_scope, new_scope)
       data_picker = scope_picker.data_picker
 
-      expect(data_picker).to have_selector(".picker-values div input[value='#{old_scope&.id || scope_picker.global_value}']", visible: false)
+      expect(data_picker).to have_selector(".picker-values div input[value='#{old_scope&.id || scope_picker.global_value}']", visible: :all)
       data_picker.find(:xpath, "//div[contains(@class,'picker-values')]/div/input[@value='#{old_scope&.id || scope_picker.global_value}']/../a").click
 
       # browse to lowest common parent between old and new scope
@@ -57,7 +57,7 @@ module Capybara
     def scope_unpick(scope_picker, scope)
       data_picker = scope_picker.data_picker
 
-      expect(data_picker).to have_selector(".picker-values div input[value='#{scope&.id || scope_picker.global_value}']", visible: false)
+      expect(data_picker).to have_selector(".picker-values div input[value='#{scope&.id || scope_picker.global_value}']", visible: :all)
       data_picker.find(".picker-values div input[value='#{scope&.id || scope_picker.global_value}']").click
 
       expect(scope_picker).to have_scope_not_picked(scope)

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires.rb
@@ -75,7 +75,7 @@ shared_examples_for "manage questionnaires" do
         within ".questionnaire-question" do
           fill_in find_nested_form_field_locator("body_en"), with: "Body"
 
-          fill_in_editor find_nested_form_field_locator("description_en", visible: false), with: "<b>Superkalifragilistic description</b>"
+          fill_in_editor find_nested_form_field_locator("description_en", visible: :all), with: "<b>Superkalifragilistic description</b>"
         end
 
         click_button "Save"
@@ -794,7 +794,7 @@ shared_examples_for "manage questionnaires" do
         context "when clicking on Expand all button" do
           it "expands all questions" do
             click_button "Expand all questions"
-            expect(page).to have_selector(".collapsible", visible: true)
+            expect(page).to have_selector(".collapsible", visible: :visible)
             expect(page).to have_selector(".question--collapse .icon-collapse", count: questionnaire.questions.count)
           end
         end
@@ -802,7 +802,7 @@ shared_examples_for "manage questionnaires" do
         context "when clicking on Collapse all button" do
           it "collapses all questions" do
             click_button "Collapse all questions"
-            expect(page).not_to have_selector(".collapsible", visible: true)
+            expect(page).not_to have_selector(".collapsible", visible: :visible)
             expect(page).to have_selector(".question--collapse .icon-expand", count: questionnaire.questions.count)
           end
         end
@@ -816,7 +816,7 @@ shared_examples_for "manage questionnaires" do
 
           it "hides the question card section" do
             within ".questionnaire-question:last-of-type" do
-              expect(page).not_to have_selector(".collapsible", visible: true)
+              expect(page).not_to have_selector(".collapsible", visible: :visible)
             end
           end
         end
@@ -829,7 +829,7 @@ shared_examples_for "manage questionnaires" do
           end
 
           it "shows the question card section" do
-            expect(page).to have_selector(".collapsible", visible: true)
+            expect(page).to have_selector(".collapsible", visible: :visible)
           end
         end
 

--- a/decidim-initiatives/spec/lib/tasks/query_extensions_spec.rb
+++ b/decidim-initiatives/spec/lib/tasks/query_extensions_spec.rb
@@ -9,16 +9,16 @@ module Decidim
       include_context "with a graphql type"
 
       describe "initiativesTypes" do
-        let!(:initiativesType1) { create(:initiatives_type, organization: current_organization) }
-        let!(:initiativesType2) { create(:initiatives_type, organization: current_organization) }
-        let!(:initiativesType3) { create(:initiatives_type) }
+        let!(:initiatives_type1) { create(:initiatives_type, organization: current_organization) }
+        let!(:initiatives_type2) { create(:initiatives_type, organization: current_organization) }
+        let!(:initiatives_type3) { create(:initiatives_type) }
 
         let(:query) { %({ initiativesTypes { id }}) }
 
         it "returns all the groups" do
-          expect(response["initiativesTypes"]).to include("id" => initiativesType1.id.to_s)
-          expect(response["initiativesTypes"]).to include("id" => initiativesType2.id.to_s)
-          expect(response["initiativesTypes"]).not_to include("id" => initiativesType3.id.to_s)
+          expect(response["initiativesTypes"]).to include("id" => initiatives_type1.id.to_s)
+          expect(response["initiativesTypes"]).to include("id" => initiatives_type2.id.to_s)
+          expect(response["initiativesTypes"]).not_to include("id" => initiatives_type3.id.to_s)
         end
       end
 

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiatives_spec.rb
@@ -46,7 +46,7 @@ describe "Admin manages initiatives", type: :system do
   let(:area2) { create :area, organization: organization }
 
   STATES.each do |state|
-    let!("#{state}_initiative") { create_initiative_with_trait(state) }
+    let!("#{state}_initiative".to_sym) { create_initiative_with_trait(state) }
   end
 
   before do

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -92,13 +92,13 @@ describe "Initiative", type: :system do
         end
 
         it "Has a hidden field with the selected initiative type" do
-          expect(page).to have_xpath("//input[@id='initiative_type_id']", visible: false)
-          expect(find(:xpath, "//input[@id='initiative_type_id']", visible: false).value).to eq(initiative_type.id.to_s)
+          expect(page).to have_xpath("//input[@id='initiative_type_id']", visible: :all)
+          expect(find(:xpath, "//input[@id='initiative_type_id']", visible: :all).value).to eq(initiative_type.id.to_s)
         end
 
         it "Have fields for title and description" do
           expect(page).to have_xpath("//input[@id='initiative_title']")
-          expect(page).to have_xpath("//input[@id='initiative_description']", visible: false)
+          expect(page).to have_xpath("//input[@id='initiative_description']", visible: :all)
         end
 
         it "Offers contextual help" do
@@ -122,13 +122,13 @@ describe "Initiative", type: :system do
         end
 
         it "Has a hidden field with the selected initiative type" do
-          expect(page).to have_xpath("//input[@id='initiative_type_id']", visible: false)
-          expect(find(:xpath, "//input[@id='initiative_type_id']", visible: false).value).to eq(initiative_type.id.to_s)
+          expect(page).to have_xpath("//input[@id='initiative_type_id']", visible: :all)
+          expect(find(:xpath, "//input[@id='initiative_type_id']", visible: :all).value).to eq(initiative_type.id.to_s)
         end
 
         it "Have fields for title and description" do
           expect(page).to have_xpath("//input[@id='initiative_title']")
-          expect(page).to have_xpath("//input[@id='initiative_description']", visible: false)
+          expect(page).to have_xpath("//input[@id='initiative_description']", visible: :all)
         end
 
         it "Offers contextual help" do
@@ -206,9 +206,9 @@ describe "Initiative", type: :system do
           end
 
           it "Information collected in previous steps is already filled" do
-            expect(find(:xpath, "//input[@id='initiative_type_id']", visible: false).value).to eq(initiative_type.id.to_s)
+            expect(find(:xpath, "//input[@id='initiative_type_id']", visible: :all).value).to eq(initiative_type.id.to_s)
             expect(find(:xpath, "//input[@id='initiative_title']").value).to eq(translated(initiative.title, locale: :en))
-            expect(find(:xpath, "//input[@id='initiative_description']", visible: false).value).to eq(translated(initiative.description, locale: :en))
+            expect(find(:xpath, "//input[@id='initiative_description']", visible: :all).value).to eq(translated(initiative.description, locale: :en))
           end
 
           context "when only one signature collection and scope are available" do
@@ -218,8 +218,8 @@ describe "Initiative", type: :system do
             it "hides and automatically selects the values" do
               expect(page).not_to have_content("Signature collection type")
               expect(page).not_to have_content("Scope")
-              expect(find(:xpath, "//input[@id='initiative_type_id']", visible: false).value).to eq(initiative_type.id.to_s)
-              expect(find(:xpath, "//input[@id='initiative_signature_type']", visible: false).value).to eq("offline")
+              expect(find(:xpath, "//input[@id='initiative_type_id']", visible: :all).value).to eq(initiative_type.id.to_s)
+              expect(find(:xpath, "//input[@id='initiative_signature_type']", visible: :all).value).to eq("offline")
             end
           end
 

--- a/decidim-meetings/spec/shared/manage_meetings_examples.rb
+++ b/decidim-meetings/spec/shared/manage_meetings_examples.rb
@@ -36,34 +36,34 @@ shared_examples "manage meetings" do
         within "#meeting-title-tabs" do
           click_link "English"
         end
-        expect(page).to have_css("input", text: meeting.title[:en], visible: true)
+        expect(page).to have_css("input", text: meeting.title[:en], visible: :visible)
 
         within "#meeting-title-tabs" do
           click_link "Català"
         end
-        expect(page).to have_css("input", text: meeting.title[:ca], visible: true)
+        expect(page).to have_css("input", text: meeting.title[:ca], visible: :visible)
 
         within "#meeting-title-tabs" do
           click_link "Castellano"
         end
-        expect(page).to have_css("input", text: meeting.title[:es], visible: true)
+        expect(page).to have_css("input", text: meeting.title[:es], visible: :visible)
       end
 
       it "shows the description correctly in all available locales" do
         within "#meeting-description-tabs" do
           click_link "English"
         end
-        expect(page).to have_css("input", text: meeting.description[:en], visible: true)
+        expect(page).to have_css("input", text: meeting.description[:en], visible: :visible)
 
         within "#meeting-description-tabs" do
           click_link "Català"
         end
-        expect(page).to have_css("input", text: meeting.description[:ca], visible: true)
+        expect(page).to have_css("input", text: meeting.description[:ca], visible: :visible)
 
         within "#meeting-description-tabs" do
           click_link "Castellano"
         end
-        expect(page).to have_css("input", text: meeting.description[:es], visible: true)
+        expect(page).to have_css("input", text: meeting.description[:es], visible: :visible)
       end
     end
 
@@ -77,12 +77,12 @@ shared_examples "manage meetings" do
 
       it "shows the title correctly" do
         expect(page).not_to have_css("#meeting-title-tabs")
-        expect(page).to have_css("input", text: meeting.title[:en], visible: true)
+        expect(page).to have_css("input", text: meeting.title[:en], visible: :visible)
       end
 
       it "shows the description correctly" do
         expect(page).not_to have_css("#meeting-description-tabs")
-        expect(page).to have_css("input", text: meeting.description[:en], visible: true)
+        expect(page).to have_css("input", text: meeting.description[:en], visible: :visible)
       end
     end
   end
@@ -439,7 +439,7 @@ shared_examples "manage meetings" do
 
     page.all(".meeting-service").each_with_index do |meeting_service, index|
       within meeting_service do
-        fill_in current_scope.find("[id$=title_en]", visible: true)["id"], with: service_titles[index]
+        fill_in current_scope.find("[id$=title_en]", visible: :visible)["id"], with: service_titles[index]
       end
     end
   end

--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -113,7 +113,7 @@ describe "Meeting registrations", type: :system do
             click_button "Join meeting"
           end
 
-          expect(page).to have_css("#loginModal", visible: true)
+          expect(page).to have_css("#loginModal", visible: :visible)
         end
 
         context "and registration form is enabled" do

--- a/decidim-participatory_processes/spec/shared/manage_processes_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_processes_examples.rb
@@ -181,7 +181,7 @@ shared_examples "manage processes examples" do
       uncheck :participatory_process_scopes_enabled
 
       expect(page).to have_selector("#participatory_process_scope_id.disabled")
-      expect(page).to have_selector("#participatory_process_scope_id .picker-values div input[disabled]", visible: false)
+      expect(page).to have_selector("#participatory_process_scope_id .picker-values div input[disabled]", visible: :all)
 
       within ".edit_participatory_process" do
         find("*[type=submit]").click

--- a/decidim-proposals/lib/decidim/proposals/test/capybara_proposals_picker.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/capybara_proposals_picker.rb
@@ -11,7 +11,7 @@ module Capybara
         data_picker = proposals_picker.data_picker
 
         expected.each do |proposal|
-          expect(data_picker).to have_selector(".picker-values div input[value='#{proposal.id}']", visible: false)
+          expect(data_picker).to have_selector(".picker-values div input[value='#{proposal.id}']", visible: :all)
           expect(data_picker).to have_selector(:xpath, "//div[contains(@class,'picker-values')]/div/a[text()[contains(.,\"#{proposal.title}\")]]")
         end
       end
@@ -22,7 +22,7 @@ module Capybara
         data_picker = proposals_picker.data_picker
 
         expected.each do |proposal|
-          expect(data_picker).not_to have_selector(".picker-values div input[value='#{proposal.id}']", visible: false)
+          expect(data_picker).not_to have_selector(".picker-values div input[value='#{proposal.id}']", visible: :all)
           expect(data_picker).not_to have_selector(:xpath, "//div[contains(@class,'picker-values')]/div/a[text()[contains(.,\"#{proposal.title}\")]]")
         end
       end

--- a/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
@@ -194,7 +194,7 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
       it "doesn't show the amendments dependent settings" do
         fields.each do |field|
           expect(page).not_to have_content(field)
-          expect(page).to have_css(".#{field.parameterize.underscore}_container", visible: false)
+          expect(page).to have_css(".#{field.parameterize.underscore}_container", visible: :all)
         end
       end
 
@@ -206,7 +206,7 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
         it "shows the amendments dependent settings" do
           fields.each do |field|
             expect(page).to have_content(field)
-            expect(page).to have_css(".#{field.parameterize.underscore}_container", visible: true)
+            expect(page).to have_css(".#{field.parameterize.underscore}_container", visible: :visible)
           end
         end
       end

--- a/decidim-proposals/spec/system/amendable/amend_proposal_spec.rb
+++ b/decidim-proposals/spec/system/amendable/amend_proposal_spec.rb
@@ -217,7 +217,7 @@ describe "Amend Proposal", versioning: true, type: :system do
           end
 
           it "is shown the login modal" do
-            expect(page).to have_css("#loginModal", visible: true)
+            expect(page).to have_css("#loginModal", visible: :visible)
           end
         end
 
@@ -232,11 +232,11 @@ describe "Amend Proposal", versioning: true, type: :system do
           end
 
           it "is shown the amendment create form" do
-            expect(page).to have_css(".new_amendment", visible: true)
+            expect(page).to have_css(".new_amendment", visible: :visible)
             expect(page).to have_content("Create your amendment")
-            expect(page).to have_css(".field", text: "Title", visible: true)
-            expect(page).to have_css(".field", text: "Body", visible: true)
-            expect(page).to have_css(".field", text: "Amendment author", visible: true)
+            expect(page).to have_css(".field", text: "Title", visible: :visible)
+            expect(page).to have_css(".field", text: "Body", visible: :visible)
+            expect(page).to have_css(".field", text: "Amendment author", visible: :visible)
             expect(page).to have_button("Create")
           end
 

--- a/decidim-proposals/spec/system/vote_proposal_spec.rb
+++ b/decidim-proposals/spec/system/vote_proposal_spec.rb
@@ -71,7 +71,7 @@ describe "Support Proposal", type: :system, slow: true do
           click_button "Support"
         end
 
-        expect(page).to have_css("#loginModal", visible: true)
+        expect(page).to have_css("#loginModal", visible: :visible)
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Backport Rubocop corrections found in #6197, and some more specific to `release/0.22-stable`.

#### :pushpin: Related Issues
- Related to #6197 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
