### PR TITLE
Backport "Avoid deleting a meeting when it has at least one proposal originated in it" to v0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The use case that originated this change is the persistence of the user's gender
 
 ### Fixed
 
+- **decidim-meeting**: Backport "Avoid deleting a meeting when it has at least one proposal originated in it". [\#6250](https://github.com/decidim/decidim/pull/6250)
 - **decidim-core**: Backport "Fix crash when proposals meeting author is deleted". [\#6243](https://github.com/decidim/decidim/pull/6243)
 - **decidim-proposals**: Fix participatory text newline absence. [\#6159](https://github.com/decidim/decidim/pull/6159)
 - **decidim-core**: Fix broken puma version in generator's Gemfile. [\#6060](https://github.com/decidim/decidim/pull/6060)

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -208,6 +208,7 @@ ignore_unused:
   - layouts.decidim.assembly_widgets.*
   - layouts.decidim.conference_widgets.*
   - layouts.decidim.participatory_process_widgets.*
+  - decidim.meetings.actions.invalid_destroy.proposals_count.*
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -96,6 +96,7 @@ ignore_missing:
   - notification_title
   - decidim.wizard_step_form_cell.*
   - decidim.proposals.application_helper.activity_filter_values.*
+  - actions.invalid_destroy.proposals_count
 
 # Consider these keys used:
 ignore_unused:

--- a/decidim-meetings/app/assets/config/decidim_meetings_manifest.js
+++ b/decidim-meetings/app/assets/config/decidim_meetings_manifest.js
@@ -3,4 +3,5 @@
 //= link decidim/meetings/admin/registrations_invite_form.js
 //= link decidim/meetings/admin/meetings_form.js
 //= link decidim/meetings/admin/agendas.js
+//= link decidim/meetings/admin/destroy_meeting_alert.js
 //= link_tree ../images/decidim

--- a/decidim-meetings/app/assets/javascripts/decidim/meetings/admin/destroy_meeting_alert.js.es6
+++ b/decidim-meetings/app/assets/javascripts/decidim/meetings/admin/destroy_meeting_alert.js.es6
@@ -1,0 +1,21 @@
+$(() => {
+  const $confirmButton = $(".destroy-meeting-alert");
+
+  if ($confirmButton.length > 0) {
+    console.log($confirmButton.data("proposal-titles"));
+
+    $confirmButton.on("click", () => {
+      console.log($confirmButton.data("invalid-destroy-message"));
+
+      let alertText = $confirmButton.data("invalid-destroy-message") + "\n\n";
+
+      alertText += $confirmButton.data("proposal-titles");
+
+      // $confirmButton.data("proposal-titles").forEach((title, index) => {
+      //   alertText += `${index + 1}) ${title}\n`
+      // });
+
+      alert(alertText);
+    });
+  }
+});

--- a/decidim-meetings/app/assets/javascripts/decidim/meetings/admin/destroy_meeting_alert.js.es6
+++ b/decidim-meetings/app/assets/javascripts/decidim/meetings/admin/destroy_meeting_alert.js.es6
@@ -2,18 +2,9 @@ $(() => {
   const $confirmButton = $(".destroy-meeting-alert");
 
   if ($confirmButton.length > 0) {
-    console.log($confirmButton.data("proposal-titles"));
-
     $confirmButton.on("click", () => {
-      console.log($confirmButton.data("invalid-destroy-message"));
-
       let alertText = $confirmButton.data("invalid-destroy-message") + "\n\n";
-
       alertText += $confirmButton.data("proposal-titles");
-
-      // $confirmButton.data("proposal-titles").forEach((title, index) => {
-      //   alertText += `${index + 1}) ${title}\n`
-      // });
 
       alert(alertText);
     });

--- a/decidim-meetings/app/assets/javascripts/decidim/meetings/admin/destroy_meeting_alert.js.es6
+++ b/decidim-meetings/app/assets/javascripts/decidim/meetings/admin/destroy_meeting_alert.js.es6
@@ -4,9 +4,13 @@ $(() => {
   if ($confirmButton.length > 0) {
     $confirmButton.on("click", () => {
       let alertText = $confirmButton.data("invalid-destroy-message") + "\n\n";
-      alertText += $confirmButton.data("proposal-titles");
+      alertText += removeNewlineAdjacentSpaces($confirmButton.data("proposal-titles"));
 
       alert(alertText);
     });
   }
 });
+
+const removeNewlineAdjacentSpaces = (text) => {
+  return text.replace(/\n\s/g, "\n");
+}

--- a/decidim-meetings/app/assets/javascripts/decidim/meetings/admin/destroy_meeting_alert.js.es6
+++ b/decidim-meetings/app/assets/javascripts/decidim/meetings/admin/destroy_meeting_alert.js.es6
@@ -1,16 +1,16 @@
+const removeNewlineAdjacentSpaces = (text) => {
+  return text.replace(/\n\s/g, "\n");
+}
+
 $(() => {
   const $confirmButton = $(".destroy-meeting-alert");
 
   if ($confirmButton.length > 0) {
     $confirmButton.on("click", () => {
-      let alertText = $confirmButton.data("invalid-destroy-message") + "\n\n";
+      let alertText = `${$confirmButton.data("invalid-destroy-message")} \n\n`;
       alertText += removeNewlineAdjacentSpaces($confirmButton.data("proposal-titles"));
 
-      alert(alertText);
+      alert(alertText); // eslint-disable-line no-alert
     });
   }
 });
-
-const removeNewlineAdjacentSpaces = (text) => {
-  return text.replace(/\n\s/g, "\n");
-}

--- a/decidim-meetings/app/commands/decidim/meetings/admin/destroy_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/destroy_meeting.rb
@@ -19,12 +19,10 @@ module Decidim
         #
         # Broadcasts :ok if successful, :invalid otherwise.
         def call
-          if proposals.any?
-            broadcast(:invalid, proposals.count)
-          else
-            destroy_meeting
-            broadcast(:ok)
-          end
+          return broadcast(:invalid, proposals.count) if proposals.any?
+
+          destroy_meeting
+          broadcast(:ok)
         end
 
         private

--- a/decidim-meetings/app/commands/decidim/meetings/admin/destroy_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/destroy_meeting.rb
@@ -42,12 +42,7 @@ module Decidim
         end
 
         def proposals
-          @proposals ||= Decidim::Proposals::Proposal
-                         .joins(:coauthorships)
-                         .where(decidim_coauthorships: {
-                           decidim_author_type: "Decidim::Meetings::Meeting",
-                           decidim_author_id: meeting.id
-                         })
+          @proposals ||= meeting.proposals
         end
       end
     end

--- a/decidim-meetings/app/commands/decidim/meetings/admin/destroy_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/destroy_meeting.rb
@@ -19,7 +19,7 @@ module Decidim
         #
         # Broadcasts :ok if successful, :invalid otherwise.
         def call
-          return broadcast(:invalid, proposals.count) if proposals.any?
+          return broadcast(:invalid, proposals.size) if proposals.any?
 
           destroy_meeting
           broadcast(:ok)

--- a/decidim-meetings/app/commands/decidim/meetings/admin/destroy_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/destroy_meeting.rb
@@ -40,7 +40,7 @@ module Decidim
         end
 
         def proposals
-          @proposals ||= meeting.proposals
+          @proposals ||= meeting.authored_proposals.load
         end
       end
     end

--- a/decidim-meetings/app/commands/decidim/meetings/admin/destroy_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/destroy_meeting.rb
@@ -19,9 +19,12 @@ module Decidim
         #
         # Broadcasts :ok if successful, :invalid otherwise.
         def call
-          destroy_meeting
-
-          broadcast(:ok)
+          if proposals.any?
+            broadcast(:invalid, proposals.count)
+          else
+            destroy_meeting
+            broadcast(:ok)
+          end
         end
 
         private
@@ -36,6 +39,15 @@ module Decidim
           ) do
             meeting.destroy!
           end
+        end
+
+        def proposals
+          @proposals ||= Decidim::Proposals::Proposal
+                         .joins(:coauthorships)
+                         .where(decidim_coauthorships: {
+                           decidim_author_type: "Decidim::Meetings::Meeting",
+                           decidim_author_id: meeting.id
+                         })
         end
       end
     end

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_controller.rb
@@ -67,9 +67,9 @@ module Decidim
 
             on(:invalid) do |proposals_count|
               flash.now[:alert] = I18n.t(
-                "meetings.destroy.invalid.proposals_count.#{proposals_count == 1 ? 'one' : 'other'}",
-                scope: "decidim.meetings.admin",
-                proposals_count: proposals_count
+                "meetings.destroy.invalid.proposals_count",
+                count: proposals_count,
+                scope: "decidim.meetings.admin"
               )
 
               render action: "index"

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_controller.rb
@@ -64,6 +64,20 @@ module Decidim
 
               redirect_to meetings_path
             end
+
+            on(:invalid) do |proposals_count|
+              if proposals_count == 1
+                flash.now[:alert] = I18n.t("meetings.destroy.invalid.proposals_count.one",
+                                           scope: "decidim.meetings.admin",
+                                           proposals_count: proposals_count)
+              else
+                flash.now[:alert] = I18n.t("meetings.destroy.invalid.proposals_count.other",
+                                           scope: "decidim.meetings.admin",
+                                           proposals_count: proposals_count)
+              end
+
+              render action: "index"
+            end
           end
         end
 

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_controller.rb
@@ -66,15 +66,11 @@ module Decidim
             end
 
             on(:invalid) do |proposals_count|
-              if proposals_count == 1
-                flash.now[:alert] = I18n.t("meetings.destroy.invalid.proposals_count.one",
-                                           scope: "decidim.meetings.admin",
-                                           proposals_count: proposals_count)
-              else
-                flash.now[:alert] = I18n.t("meetings.destroy.invalid.proposals_count.other",
-                                           scope: "decidim.meetings.admin",
-                                           proposals_count: proposals_count)
-              end
+              flash.now[:alert] = I18n.t(
+                "meetings.destroy.invalid.proposals_count.#{proposals_count == 1 ? 'one' : 'other'}",
+                scope: "decidim.meetings.admin",
+                proposals_count: proposals_count
+              )
 
               render action: "index"
             end

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -173,6 +173,17 @@ module Decidim
         (Time.current - end_time) < 72.hours
       end
 
+      def proposals
+        Decidim::Proposals::Proposal
+          .joins(:coauthorships)
+          .where(
+            decidim_coauthorships: {
+              decidim_author_type: "Decidim::Meetings::Meeting",
+              decidim_author_id: self.id
+            }
+          )
+      end
+
       private
 
       def can_participate_in_meeting?(user)

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -173,7 +173,7 @@ module Decidim
         (Time.current - end_time) < 72.hours
       end
 
-      def proposals
+      def authored_proposals
         Decidim::Proposals::Proposal
           .joins(:coauthorships)
           .where(

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -179,7 +179,7 @@ module Decidim
           .where(
             decidim_coauthorships: {
               decidim_author_type: "Decidim::Meetings::Meeting",
-              decidim_author_id: self.id
+              decidim_author_id: id
             }
           )
       end

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -66,6 +66,18 @@ module Decidim
         false
       end
 
+      def proposals
+        return unless meeting
+
+        @proposals ||= meeting.proposals
+      end
+
+      def proposals_titles_sanitized
+        return unless meeting
+
+        proposals.map.with_index { |proposal, index| "#{index + 1}) #{proposal.title}\n" }
+      end
+
       private
 
       def handle_locales(content, all_locales)

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -69,7 +69,7 @@ module Decidim
       def proposals
         return unless meeting
 
-        @proposals ||= meeting.proposals
+        @proposals ||= meeting.authored_proposals.load
       end
 
       def formatted_proposals_titles

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -72,7 +72,7 @@ module Decidim
         @proposals ||= meeting.proposals
       end
 
-      def proposals_titles_sanitized
+      def formatted_proposals_titles
         return unless meeting
 
         proposals.map.with_index { |proposal, index| "#{index + 1}) #{proposal.title}\n" }

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
@@ -83,8 +83,8 @@
                     <%=
                       content_tag(:button,
                                   class: ["action-icon", "action-icon--remove", "destroy-meeting-alert"],
-                                  "data-invalid-destroy-message" => t("actions.invalid_destroy.proposals_count.#{present(meeting).proposals.count == 1 ? 'one' : 'other'}", scope: "decidim.meetings", proposals_count: present(meeting).proposals.count),
-                                  "data-proposal-titles" => present(meeting).proposals_titles_sanitized) do
+                                  "data-invalid-destroy-message" => t("actions.invalid_destroy.proposals_count.#{present(meeting).proposals.count == 1 ? "one" : "other"}", scope: "decidim.meetings", proposals_count: present(meeting).proposals.count),
+                                  "data-proposal-titles" => present(meeting).formatted_proposals_titles) do
                         content_tag(:span,
                                     data: { tooltip: true, disable_hover: false, click_open: false },
                                     title: t("actions.destroy", scope: "decidim.meetings")) do

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
@@ -77,13 +77,13 @@
                 <%= resource_permissions_link(meeting) %>
 
                 <% if allowed_to? :destroy, :meeting, meeting: meeting %>
-                  <% if present(meeting).proposals.empty? %>
+                  <% if present(meeting).authored_proposals.empty? %>
                     <%= icon_link_to "circle-x", meeting_path(meeting), t("actions.destroy", scope: "decidim.meetings"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.meetings") } %>
                   <% else %>
                     <%=
                       content_tag(:button,
                                   class: ["action-icon", "action-icon--remove", "destroy-meeting-alert"],
-                                  "data-invalid-destroy-message" => t("actions.invalid_destroy.proposals_count", count: present(meeting).proposals.size, scope: "decidim.meetings"),
+                                  "data-invalid-destroy-message" => t("actions.invalid_destroy.proposals_count", count: present(meeting).authored_proposals.size, scope: "decidim.meetings"),
                                   "data-proposal-titles" => present(meeting).formatted_proposals_titles) do
                         content_tag(:span,
                                     data: { tooltip: true, disable_hover: false, click_open: false },

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
@@ -83,7 +83,7 @@
                     <%=
                       content_tag(:button,
                                   class: ["action-icon", "action-icon--remove", "destroy-meeting-alert"],
-                                  "data-invalid-destroy-message" => t("actions.invalid_destroy.proposals_count", count: present(meeting).proposals.count, scope: "decidim.meetings"),
+                                  "data-invalid-destroy-message" => t("actions.invalid_destroy.proposals_count", count: present(meeting).proposals.size, scope: "decidim.meetings"),
                                   "data-proposal-titles" => present(meeting).formatted_proposals_titles) do
                         content_tag(:span,
                                     data: { tooltip: true, disable_hover: false, click_open: false },

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
@@ -77,7 +77,22 @@
                 <%= resource_permissions_link(meeting) %>
 
                 <% if allowed_to? :destroy, :meeting, meeting: meeting %>
-                  <%= icon_link_to "circle-x", meeting_path(meeting), t("actions.destroy", scope: "decidim.meetings"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.meetings") } %>
+                  <% if present(meeting).proposals.empty? %>
+                    <%= icon_link_to "circle-x", meeting_path(meeting), t("actions.destroy", scope: "decidim.meetings"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.meetings") } %>
+                  <% else %>
+                    <%=
+                      content_tag(:button,
+                                  class: ["action-icon", "action-icon--remove", "destroy-meeting-alert"],
+                                  "data-invalid-destroy-message" => t("actions.invalid_destroy.proposals_count.#{present(meeting).proposals.count == 1 ? 'one' : 'other'}", scope: "decidim.meetings", proposals_count: present(meeting).proposals.count),
+                                  "data-proposal-titles" => present(meeting).proposals_titles_sanitized) do
+                        content_tag(:span,
+                                    data: { tooltip: true, disable_hover: false, click_open: false },
+                                    title: t("actions.destroy", scope: "decidim.meetings")) do
+                          icon("circle-x")
+                        end
+                      end
+                    %>
+                  <% end %>
                 <% end %>
               </td>
             </tr>
@@ -88,3 +103,5 @@
     </div>
   </div>
 </div>
+
+<%= javascript_include_tag "decidim/meetings/admin/destroy_meeting_alert" %>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
@@ -83,7 +83,7 @@
                     <%=
                       content_tag(:button,
                                   class: ["action-icon", "action-icon--remove", "destroy-meeting-alert"],
-                                  "data-invalid-destroy-message" => t("actions.invalid_destroy.proposals_count.#{present(meeting).proposals.count == 1 ? "one" : "other"}", scope: "decidim.meetings", proposals_count: present(meeting).proposals.count),
+                                  "data-invalid-destroy-message" => t("actions.invalid_destroy.proposals_count", count: present(meeting).proposals.count, scope: "decidim.meetings"),
                                   "data-proposal-titles" => present(meeting).formatted_proposals_titles) do
                         content_tag(:span,
                                     data: { tooltip: true, disable_hover: false, click_open: false },

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -156,8 +156,8 @@ en:
         edit: Edit
         invalid_destroy:
           proposals_count:
-            one: "The meeting cannot be destroyed because it has %{proposals_count} proposal associated to it:"
-            other: "The meeting cannot be destroyed because it has %{proposals_count} proposals associated to it:"
+            one: 'The meeting cannot be destroyed because it has %{proposals_count} proposal associated to it:'
+            other: 'The meeting cannot be destroyed because it has %{proposals_count} proposals associated to it:'
         minutes: Minutes
         new: New meeting
         preview: Preview

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -154,6 +154,10 @@ en:
         confirm_destroy: Are you sure you want to delete this meeting?
         destroy: Delete
         edit: Edit
+        invalid_destroy:
+          proposals_count:
+            one: "The meeting cannot be destroyed because it has %{proposals_count} proposal associated to it:"
+            other: "The meeting cannot be destroyed because it has %{proposals_count} proposals associated to it:"
         minutes: Minutes
         new: New meeting
         preview: Preview

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -235,6 +235,10 @@ en:
             invalid: There was a problem creating this meeting
             success: Meeting successfully created
           destroy:
+            invalid:
+              proposals_count:
+                one: "The meeting cannot be destroyed because it has %{proposals_count} proposal associated to it"
+                other: "The meeting cannot be destroyed because it has %{proposals_count} proposals associated to it"
             success: Meeting successfully deleted
           edit:
             update: Update

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -156,8 +156,8 @@ en:
         edit: Edit
         invalid_destroy:
           proposals_count:
-            one: 'The meeting cannot be destroyed because it has %{proposals_count} proposal associated to it:'
-            other: 'The meeting cannot be destroyed because it has %{proposals_count} proposals associated to it:'
+            one: 'The meeting cannot be destroyed because it has %{count} proposal associated to it:'
+            other: 'The meeting cannot be destroyed because it has %{count} proposals associated to it:'
         minutes: Minutes
         new: New meeting
         preview: Preview
@@ -241,8 +241,8 @@ en:
           destroy:
             invalid:
               proposals_count:
-                one: The meeting cannot be destroyed because it has %{proposals_count} proposal associated to it
-                other: The meeting cannot be destroyed because it has %{proposals_count} proposals associated to it
+                one: The meeting cannot be destroyed because it has %{count} proposal associated to it
+                other: The meeting cannot be destroyed because it has %{count} proposals associated to it
             success: Meeting successfully deleted
           edit:
             update: Update

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -237,8 +237,8 @@ en:
           destroy:
             invalid:
               proposals_count:
-                one: "The meeting cannot be destroyed because it has %{proposals_count} proposal associated to it"
-                other: "The meeting cannot be destroyed because it has %{proposals_count} proposals associated to it"
+                one: The meeting cannot be destroyed because it has %{proposals_count} proposal associated to it
+                other: The meeting cannot be destroyed because it has %{proposals_count} proposals associated to it
             success: Meeting successfully deleted
           edit:
             update: Update

--- a/decidim-meetings/spec/commands/admin/destroy_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/admin/destroy_meeting_spec.rb
@@ -50,7 +50,7 @@ module Decidim::Meetings
       it "cannot destroy the meeting" do
         subject.call
 
-        expect { meeting.reload }.not_to raise_error(ActiveRecord::RecordNotFound)
+        expect { meeting.reload }.not_to raise_error
       end
     end
   end

--- a/decidim-meetings/spec/commands/admin/destroy_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/admin/destroy_meeting_spec.rb
@@ -14,7 +14,7 @@ module Decidim::Meetings
     let(:meeting_component) { create(:meeting_component, participatory_space: participatory_process) }
     let(:proposal_component) { create(:proposal_component, participatory_space: participatory_process) }
     let(:proposal) { create(:proposal, component: proposal_component) }
-    let(:meeting_proposals) { meeting.proposals }
+    let(:meeting_proposals) { meeting.authored_proposals }
 
     context "when everything is ok" do
       it "destroys the meeting" do

--- a/decidim-meetings/spec/commands/admin/destroy_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/admin/destroy_meeting_spec.rb
@@ -44,7 +44,7 @@ module Decidim::Meetings
       it "broadcasts invalid and proposals count" do
         expect do
           subject.call
-        end.to broadcast(:invalid, meeting_proposals.count)
+        end.to broadcast(:invalid, meeting_proposals.size)
       end
 
       it "cannot destroy the meeting" do

--- a/decidim-meetings/spec/commands/admin/destroy_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/admin/destroy_meeting_spec.rb
@@ -6,8 +6,15 @@ module Decidim::Meetings
   describe Admin::DestroyMeeting do
     subject { described_class.new(meeting, user) }
 
-    let(:meeting) { create :meeting }
-    let(:user) { create :user, :admin }
+    let(:meeting) { create :meeting, component: meeting_component, organizer: user }
+    let(:user) { create :user, :admin, organization: organization }
+
+    let(:organization) { create(:organization) }
+    let(:participatory_process) { create :participatory_process, organization: organization }
+    let(:meeting_component) { create(:meeting_component, participatory_space: participatory_process) }
+    let(:proposal_component) { create(:proposal_component, participatory_space: participatory_process) }
+    let(:proposal) { create(:proposal, component: proposal_component) }
+    let(:meeting_proposals) { meeting.proposals }
 
     context "when everything is ok" do
       it "destroys the meeting" do
@@ -25,6 +32,25 @@ module Decidim::Meetings
         expect { subject.call }.to change(Decidim::ActionLog, :count)
         action_log = Decidim::ActionLog.last
         expect(action_log.version).to be_present
+      end
+    end
+
+    context "when the meeting has at least one proposal associated to it" do
+      before do
+        proposal.coauthorships.clear
+        proposal.add_coauthor(meeting)
+      end
+
+      it "broadcasts invalid and proposals count" do
+        expect do
+          subject.call
+        end.to broadcast(:invalid, meeting_proposals.count)
+      end
+
+      it "cannot destroy the meeting" do
+        subject.call
+
+        expect { meeting.reload }.not_to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Backport #6242 to v0.21 (latest stable release).

#### :pushpin: Related Issues
- Related to #6242

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` upgrade notes, if required
- [x] Add tests