### PR TITLE
Fix sorted questions status when submiting a questionnaire with errors

### DIFF
--- a/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
@@ -569,6 +569,39 @@ shared_examples_for "has questionnaire" do
 
         expect(page).to have_content("are not complete")
       end
+
+      it "displays maintains sorting order if errors" do
+        visit questionnaire_public_path
+
+        check "No"
+        check "por"
+        check "idiotas"
+
+        accept_confirm { click_button "Submit" }
+
+        within ".alert.flash" do
+          expect(page).to have_content("problem")
+        end
+
+        # Check the next round to ensure a re-submission conserves status
+        expect(page).to have_content("are not complete")
+        expect(page).to have_content("1. No\n2. por\n3. idiotas\ntrates\nnos")
+
+        checkboxes = page.all("input[type=checkbox]")
+
+        checkboxes[0].uncheck
+        check "No"
+        check "nos"
+
+        accept_confirm { click_button "Submit" }
+
+        within ".alert.flash" do
+          expect(page).to have_content("problem")
+        end
+
+        expect(page).to have_content("are not complete")
+        expect(page).to have_content("1. por\n2. idiotas\n3. No\n4. nos\ntrates")
+      end
     end
 
     context "when question type is matrix_single" do


### PR DESCRIPTION
#### :tophat: What? Why?

When using sorted questions in questionnaires, there is a bug that appears when there's an error anywhere in the questionnaire and the controller renders again the page. Previous selected order disappears, and some element may appear duplicated as a result of some DOM manipulations with JQuery. As these kind of questions requires that all the options are selected in order to be submitted is quite likely that the user won't will be able to submit the questionnaire at the first attempt.

This PR refactors the JavaScript code and introduces tests to check that this problem won't happen again and status of previously selected items maintain order and coherence.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [x] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
After submission (prior to fix):
![imatge](https://user-images.githubusercontent.com/1401520/86130547-98f93480-bae4-11ea-8044-33435a3197a5.png)

After submission (fixed):
![imatge](https://user-images.githubusercontent.com/1401520/86130471-7cf59300-bae4-11ea-93bb-d5369885da63.png)

