### PR TITLE
Backport fixing performance degradation while answering surveys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,7 @@ Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now sup
 
 **Fixed**:
 
+- **decidim-forms**: Fixes a performance degradation when displaying forms in surveys. [\#6255](https://github.com/decidim/decidim/pull/6255)
 - **decidim-admin**: Fix: let components without step settings be added [\#6144](https://github.com/decidim/decidim/pull/6144)
 - **decidim-core** Patch various security alerts reported by GitHub. [\#6149](https://github.com/decidim/decidim/pull/6149)
 - **decidim-debates**: Fix a notification failure when the creating a new debate event is fired. [\#6017](https://github.com/decidim/decidim/pull/6017)
@@ -231,7 +232,6 @@ Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now sup
 - **decidim-core**: Fix: use of browse history with filters [#5749](https://github.com/decidim/decidim/pull/5749)
 - **decidim-budgets**: Add a missing fix applied to proposals in [\#5654](https://github.com/decidim/decidim/pull/5654) but not to projects [\#5743](https://github.com/decidim/decidim/pull/5743)
 - **decidim-proposals**: Admin: fix "Answer Proposal" action tooltip [/#5750](https://github.com/decidim/decidim/pull/5750)
-- **decidim-forms**: Fixes a performance degradation when displaying forms in surveys. [\#5819](https://github.com/decidim/decidim/pull/5819)
 - **decidim-proposals**: Fix relative path in mentioned proposal email [\#5852](https://github.com/decidim/decidim/pull/5852)
 
 **Removed**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,7 @@ Thanks to [#5342](https://github.com/decidim/decidim/pull/5342), Decidim now sup
 - **decidim-core**: Fix: use of browse history with filters [#5749](https://github.com/decidim/decidim/pull/5749)
 - **decidim-budgets**: Add a missing fix applied to proposals in [\#5654](https://github.com/decidim/decidim/pull/5654) but not to projects [\#5743](https://github.com/decidim/decidim/pull/5743)
 - **decidim-proposals**: Admin: fix "Answer Proposal" action tooltip [/#5750](https://github.com/decidim/decidim/pull/5750)
+- **decidim-forms**: Fixes a performance degradation when displaying forms in surveys. [\#5819](https://github.com/decidim/decidim/pull/5819)
 - **decidim-proposals**: Fix relative path in mentioned proposal email [\#5852](https://github.com/decidim/decidim/pull/5852)
 
 **Removed**:

--- a/decidim-forms/app/commands/decidim/forms/answer_questionnaire.rb
+++ b/decidim-forms/app/commands/decidim/forms/answer_questionnaire.rb
@@ -30,7 +30,7 @@ module Decidim
 
       def answer_questionnaire
         Answer.transaction do
-          form.answers.each do |form_answer|
+          form.responses.each do |form_answer|
             answer = Answer.new(
               user: @current_user,
               questionnaire: @questionnaire,

--- a/decidim-forms/app/forms/decidim/forms/questionnaire_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/questionnaire_form.rb
@@ -4,7 +4,9 @@ module Decidim
   module Forms
     # This class holds a Form to answer a questionnaire from Decidim's public page.
     class QuestionnaireForm < Decidim::Form
-      attribute :answers, Array[AnswerForm]
+      # as questionnaire uses "answers" for the database relationships is
+      # important not to use the same word here to avoid querying all the entries, resulting in a high performance penalty
+      attribute :responses, Array[AnswerForm]
       attribute :user_group_id, Integer
 
       attribute :tos_agreement, Boolean
@@ -12,11 +14,11 @@ module Decidim
       validates :tos_agreement, allow_nil: false, acceptance: true
       validate :session_token_in_context
 
-      # Private: Create the answers from the questionnaire questions
+      # Private: Create the responses from the questionnaire questions
       #
       # Returns nothing.
       def map_model(model)
-        self.answers = model.questions.map do |question|
+        self.responses = model.questions.map do |question|
           AnswerForm.from_model(Decidim::Forms::Answer.new(question: question))
         end
       end

--- a/decidim-forms/app/views/decidim/forms/questionnaires/_answer.html.erb
+++ b/decidim-forms/app/views/decidim/forms/questionnaires/_answer.html.erb
@@ -21,21 +21,21 @@
 
       <div class="collection-input">
         <%= label_tag "#{choice_id}_body" do %>
-          <%= radio_button_tag "questionnaire[answers][#{answer_idx}][choices][][body]",
+          <%= radio_button_tag "questionnaire[responses][#{answer_idx}][choices][][body]",
                               translated_attribute(answer_option.body),
                               answer_option.id == choice.try(:answer_option_id),
                               id: "#{choice_id}_body", disabled: disabled %>
 
           <%= translated_attribute(answer_option.body) %>
 
-          <%= hidden_field_tag "questionnaire[answers][#{answer_idx}][choices][][answer_option_id]",
+          <%= hidden_field_tag "questionnaire[responses][#{answer_idx}][choices][][answer_option_id]",
                               answer_option.id,
                               id: "#{choice_id}_answer_option",
                               disabled: true %>
         <% end %>
 
         <% if answer_option.free_text %>
-          <%= text_field_tag "questionnaire[answers][#{answer_idx}][choices][][custom_body]",
+          <%= text_field_tag "questionnaire[responses][#{answer_idx}][choices][][custom_body]",
           choice.try(:custom_body),
           id: "#{choice_id}_custom_body",
           disabled: true %>
@@ -50,17 +50,17 @@
 
       <div class="collection-input">
         <%= label_tag do %>
-          <%= check_box_tag "questionnaire[answers][#{answer_idx}][choices][#{idx}][body]",
+          <%= check_box_tag "questionnaire[responses][#{answer_idx}][choices][#{idx}][body]",
                             translated_attribute(answer_option.body),
                             choice.present?, disabled: disabled %>
 
           <%= translated_attribute(answer_option.body) %>
 
-          <%= hidden_field_tag "questionnaire[answers][#{answer_idx}][choices][#{idx}][answer_option_id]", answer_option.id %>
+          <%= hidden_field_tag "questionnaire[responses][#{answer_idx}][choices][#{idx}][answer_option_id]", answer_option.id %>
         <% end %>
 
         <% if answer_option.free_text %>
-          <%= text_field_tag "questionnaire[answers][#{answer_idx}][choices][#{idx}][custom_body]",
+          <%= text_field_tag "questionnaire[responses][#{answer_idx}][choices][#{idx}][custom_body]",
           choice.try(:custom_body),
           disabled: true %>
         <% end %>
@@ -74,7 +74,7 @@
 
       <div class="collection-input">
         <%= label_tag do %>
-          <%= check_box_tag "questionnaire[answers][#{answer_idx}][choices][#{idx}][body]",
+          <%= check_box_tag "questionnaire[responses][#{answer_idx}][choices][#{idx}][body]",
                             translated_attribute(answer_option.body),
                             choice.present?, disabled: disabled %>
 
@@ -82,11 +82,11 @@
 
           <%= translated_attribute(answer_option.body) %>
 
-          <%= hidden_field_tag "questionnaire[answers][#{answer_idx}][choices][#{idx}][position]",
+          <%= hidden_field_tag "questionnaire[responses][#{answer_idx}][choices][#{idx}][position]",
                               choice.try(:position),
                               disabled: true %>
 
-          <%= hidden_field_tag "questionnaire[answers][#{answer_idx}][choices][#{idx}][answer_option_id]", answer_option.id %>
+          <%= hidden_field_tag "questionnaire[responses][#{answer_idx}][choices][#{idx}][answer_option_id]", answer_option.id %>
         <% end %>
       </div>
     <% end %>

--- a/decidim-forms/app/views/decidim/forms/questionnaires/show.html.erb
+++ b/decidim-forms/app/views/decidim/forms/questionnaires/show.html.erb
@@ -40,9 +40,9 @@
 
                 <%= decidim_form_for(@form, url: update_url, method: :post, html: { class: "form answer-questionnaire" }) do |form| %>
                   <%= invisible_captcha %>
-                  <% @form.answers.each_with_index do |answer, answer_idx| %>
+                  <% @form.responses.each_with_index do |answer, answer_idx| %>
                     <div class="row column">
-                      <%= fields_for "questionnaire[answers][#{answer_idx}]", answer do |answer_form| %>
+                      <%= fields_for "questionnaire[responses][#{answer_idx}]", answer do |answer_form| %>
                         <%= render "decidim/forms/questionnaires/answer", answer_form: answer_form, answer: answer, answer_idx: answer_idx, disabled: !current_participatory_space.can_participate?(current_user) %>
                       <% end %>
                     </div>

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
@@ -283,16 +283,16 @@ shared_examples_for "has questionnaire" do
         it "renders them as check boxes with attached text fields disabled by default" do
           expect(page.first(".check-box-collection")).to have_selector("input[type=checkbox]", count: 3)
 
-          expect(page).to have_field("questionnaire_answers_0_choices_2_custom_body", disabled: true, count: 1)
+          expect(page).to have_field("questionnaire_responses_0_choices_2_custom_body", disabled: true, count: 1)
 
           check answer_option_bodies[2]["en"]
 
-          expect(page).to have_field("questionnaire_answers_0_choices_2_custom_body", disabled: false, count: 1)
+          expect(page).to have_field("questionnaire_responses_0_choices_2_custom_body", disabled: false, count: 1)
         end
 
         it "saves the free text in a separate field if submission correct" do
           check answer_option_bodies[2]["en"]
-          fill_in "questionnaire_answers_0_choices_2_custom_body", with: "Cacatua"
+          fill_in "questionnaire_responses_0_choices_2_custom_body", with: "Cacatua"
 
           check "questionnaire_tos_agreement"
           accept_confirm { click_button "Submit" }
@@ -305,12 +305,12 @@ shared_examples_for "has questionnaire" do
         end
 
         it "preserves the previous custom body if submission not correct" do
-          check "questionnaire_answers_1_choices_0_body"
-          check "questionnaire_answers_1_choices_1_body"
-          check "questionnaire_answers_1_choices_2_body"
+          check "questionnaire_responses_1_choices_0_body"
+          check "questionnaire_responses_1_choices_1_body"
+          check "questionnaire_responses_1_choices_2_body"
 
           check answer_option_bodies[2]["en"]
-          fill_in "questionnaire_answers_0_choices_2_custom_body", with: "Cacatua"
+          fill_in "questionnaire_responses_0_choices_2_custom_body", with: "Cacatua"
 
           check "questionnaire_tos_agreement"
           accept_confirm { click_button "Submit" }
@@ -319,7 +319,7 @@ shared_examples_for "has questionnaire" do
             expect(page).to have_content("There was a problem answering")
           end
 
-          expect(page).to have_field("questionnaire_answers_0_choices_2_custom_body", with: "Cacatua")
+          expect(page).to have_field("questionnaire_responses_0_choices_2_custom_body", with: "Cacatua")
         end
       end
     end

--- a/decidim-forms/spec/commands/decidim/forms/answer_questionnaire_spec.rb
+++ b/decidim-forms/spec/commands/decidim/forms/answer_questionnaire_spec.rb
@@ -31,7 +31,7 @@ module Decidim
       let(:answer_option_ids) { answer_options.pluck(:id).map(&:to_s) }
       let(:form_params) do
         {
-          "answers" => [
+          "responses" => [
             {
               "body" => "This is my first answer",
               "question_id" => question_1.id

--- a/decidim-forms/spec/forms/decidim/forms/questionnaire_form_spec.rb
+++ b/decidim-forms/spec/forms/decidim/forms/questionnaire_form_spec.rb
@@ -20,7 +20,7 @@ module Decidim
       end
 
       it "builds empty answers for each question" do
-        expect(subject.answers.length).to eq(1)
+        expect(subject.responses.length).to eq(1)
       end
 
       context "when tos_agreement is not accepted" do

--- a/decidim-meetings/spec/commands/join_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/join_meeting_spec.rb
@@ -217,7 +217,7 @@ module Decidim::Meetings
       context "and everything is ok" do
         before do
           registration_form.tos_agreement = true
-          registration_form.answers.first.body = "My answer response"
+          registration_form.responses.first.body = "My answer response"
         end
 
         it "broadcasts ok" do


### PR DESCRIPTION
#### :tophat: What? Why?

This is a backport for #5819 for the 0.21 release. 
As the 0.22 will be delayed a while, busy sites are suffering from a severe penalty performance without this fixed.

#### :pushpin: Related Issues
- Related to #5819

#### :clipboard: Subtasks
- [x] Add `CHANGELOG`
