### PR TITLE
Improve newsletter real time counters performance when using segmentation 

### DIFF
--- a/decidim-admin/app/assets/javascripts/decidim/admin/newsletters.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/newsletters.js.es6
@@ -70,7 +70,7 @@ $(() => {
     $form.on("change", function() {
       let $data = $form.serializeJSON().newsletter;
       let $url = $form.data("recipients-count-newsletter-path");
-      const $modal = $("#recipients_count_modal");
+      const $modal = $("#recipients_count_spinner");
       $modal.removeClass("hide");
       $.get($url, {data: $data}, function(recipientsCount) {
         $("#recipients_count").text(recipientsCount);

--- a/decidim-admin/app/assets/javascripts/decidim/admin/newsletters.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/newsletters.js.es6
@@ -74,7 +74,7 @@ $(() => {
       $modal.removeClass("hide");
       $.get($url, {data: $data}, function(recipientsCount) {
         $("#recipients_count").text(recipientsCount);
-      }).always(function(){
+      }).always(function() {
         $modal.addClass("hide");
       });
     })

--- a/decidim-admin/app/assets/javascripts/decidim/admin/newsletters.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/newsletters.js.es6
@@ -70,12 +70,11 @@ $(() => {
     $form.on("change", function() {
       let $data = $form.serializeJSON().newsletter;
       let $url = $form.data("recipients-count-newsletter-path");
-      const $modal = $(`#recipients_count_modal`);
+      const $modal = $("#recipients_count_modal");
       $modal.removeClass("hide");
       $.get($url, {data: $data}, function(recipientsCount) {
         $("#recipients_count").text(recipientsCount);
-      })
-      .always(function(){
+      }).always(function(){
         $modal.addClass("hide");
       });
     })

--- a/decidim-admin/app/assets/javascripts/decidim/admin/newsletters.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/newsletters.js.es6
@@ -70,8 +70,13 @@ $(() => {
     $form.on("change", function() {
       let $data = $form.serializeJSON().newsletter;
       let $url = $form.data("recipients-count-newsletter-path");
+      const $modal = $(`#recipients_count_modal`);
+      $modal.removeClass("hide");
       $.get($url, {data: $data}, function(recipientsCount) {
         $("#recipients_count").text(recipientsCount);
+      })
+      .always(function(){
+        $modal.addClass("hide");
       });
     })
   }

--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_loading-spinner.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_loading-spinner.scss
@@ -8,4 +8,14 @@
     content: "";
     vertical-align: middle;
   }
+  
+  &.full-box-spinner{
+    width: 100%;
+    height: 100%;
+    background-color: rgba(256,256,256,0.6);
+    cursor: wait;
+    &::before{
+      top: 50%;
+    }
+  }
 }

--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_loading-spinner.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_loading-spinner.scss
@@ -8,15 +8,12 @@
     content: "";
     vertical-align: middle;
   }
+}
 
-  &.full-box-spinner{
-    width: 100%;
-    height: 100%;
-    background-color: rgba(256, 256, 256, .6);
-    cursor: wait;
+span.loading-spinner{
+  height: 15px;
 
-    &::before{
-      top: 50%;
-    }
+  &::before{
+    @include spinner(15px, $medium-gray, var(--primary), 800ms);
   }
 }

--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_loading-spinner.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_loading-spinner.scss
@@ -8,12 +8,13 @@
     content: "";
     vertical-align: middle;
   }
-  
+
   &.full-box-spinner{
     width: 100%;
     height: 100%;
-    background-color: rgba(256,256,256,0.6);
+    background-color: rgba(256, 256, 256, .6);
     cursor: wait;
+
     &::before{
       top: 50%;
     }

--- a/decidim-admin/app/helpers/decidim/admin/newsletters_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/newsletters_helper.rb
@@ -141,9 +141,11 @@ module Decidim
       end
 
       def newsletter_recipients_count_callout_args
+        spinner = %Q{<span id="recipients_count_spinner" class="loading-spinner hide"></span>}
+        body = "#{t("recipients_count", scope: "decidim.admin.newsletters.select_recipients_to_deliver", count: recipients_count_query)} #{spinner}"
         {
           announcement: {
-            body: t("recipients_count", scope: "decidim.admin.newsletters.select_recipients_to_deliver", count: recipients_count_query)
+            body: body
           },
           callout_class: "warning"
         }

--- a/decidim-admin/app/queries/decidim/admin/newsletter_recipients.rb
+++ b/decidim-admin/app/queries/decidim/admin/newsletter_recipients.rb
@@ -46,7 +46,7 @@ module Decidim
       def spaces
         return if @form.participatory_space_types.blank?
 
-        @form.participatory_space_types.map do |type|
+        @spaces||= @form.participatory_space_types.map do |type|
           next if type.ids.blank?
 
           object_class = "Decidim::#{type.manifest_name.classify}"
@@ -79,17 +79,19 @@ module Decidim
           Decidim::Component.where(id: space.component_ids, manifest_name: available_components).published.each do |component|
             Decidim.find_component_manifest(component.manifest_name).try(&:newsletter_participant_entities).flatten.each do |object|
               klass = Object.const_get(object)
-              participant_ids << klass.newsletter_participant_ids(component)
+              participant_ids |= klass.newsletter_participant_ids(component)
             end
           end
-          next unless defined?(Decidim::Comments)
+        end
 
-          Decidim::Comments.newsletter_participant_entities.flatten.each do |object|
+        if defined?(Decidim::Comments)
+          Decidim::Comments.newsletter_participant_entities.each do |object|
             klass = Object.const_get(object)
-            participant_ids << klass.newsletter_participant_ids(space)
+            participant_ids |= klass.newsletter_participant_ids(spaces.first)
           end
         end
-        participant_ids.flatten.compact.uniq
+
+        participant_ids.compact.uniq
       end
     end
   end

--- a/decidim-admin/app/queries/decidim/admin/newsletter_recipients.rb
+++ b/decidim-admin/app/queries/decidim/admin/newsletter_recipients.rb
@@ -93,7 +93,7 @@ module Decidim
           end
         end
 
-        participant_ids.compact.uniq
+        participant_ids.flatten.compact.uniq
       end
     end
   end

--- a/decidim-admin/app/queries/decidim/admin/newsletter_recipients.rb
+++ b/decidim-admin/app/queries/decidim/admin/newsletter_recipients.rb
@@ -46,7 +46,7 @@ module Decidim
       def spaces
         return if @form.participatory_space_types.blank?
 
-        @spaces||= @form.participatory_space_types.map do |type|
+        @spaces ||= @form.participatory_space_types.map do |type|
           next if type.ids.blank?
 
           object_class = "Decidim::#{type.manifest_name.classify}"

--- a/decidim-admin/app/queries/decidim/admin/newsletter_recipients.rb
+++ b/decidim-admin/app/queries/decidim/admin/newsletter_recipients.rb
@@ -75,11 +75,13 @@ module Decidim
 
         participant_ids = []
         spaces.each do |space|
-          available_components = Decidim.component_manifests.map { |m| m.name.to_s if m.newsletter_participant_entities.present? }.compact
-          Decidim::Component.where(id: space.component_ids, manifest_name: available_components).published.each do |component|
-            Decidim.find_component_manifest(component.manifest_name).try(&:newsletter_participant_entities).flatten.each do |object|
-              klass = Object.const_get(object)
-              participant_ids |= klass.newsletter_participant_ids(component)
+          if defined? space.component_ids
+            available_components = Decidim.component_manifests.map { |m| m.name.to_s if m.newsletter_participant_entities.present? }.compact
+            Decidim::Component.where(id: space.component_ids, manifest_name: available_components).published.each do |component|
+              Decidim.find_component_manifest(component.manifest_name).try(&:newsletter_participant_entities).flatten.each do |object|
+                klass = Object.const_get(object)
+                participant_ids |= klass.newsletter_participant_ids(component)
+              end
             end
           end
         end

--- a/decidim-admin/app/queries/decidim/admin/newsletter_recipients.rb
+++ b/decidim-admin/app/queries/decidim/admin/newsletter_recipients.rb
@@ -75,13 +75,13 @@ module Decidim
 
         participant_ids = []
         spaces.each do |space|
-          if defined? space.component_ids
-            available_components = Decidim.component_manifests.map { |m| m.name.to_s if m.newsletter_participant_entities.present? }.compact
-            Decidim::Component.where(id: space.component_ids, manifest_name: available_components).published.each do |component|
-              Decidim.find_component_manifest(component.manifest_name).try(&:newsletter_participant_entities).flatten.each do |object|
-                klass = Object.const_get(object)
-                participant_ids |= klass.newsletter_participant_ids(component)
-              end
+          next unless defined? space.component_ids
+
+          available_components = Decidim.component_manifests.map { |m| m.name.to_s if m.newsletter_participant_entities.present? }.compact
+          Decidim::Component.where(id: space.component_ids, manifest_name: available_components).published.each do |component|
+            Decidim.find_component_manifest(component.manifest_name).try(&:newsletter_participant_entities).flatten.each do |object|
+              klass = Object.const_get(object)
+              participant_ids |= klass.newsletter_participant_ids(component)
             end
           end
         end

--- a/decidim-admin/app/views/decidim/admin/newsletters/select_recipients_to_deliver.html.erb
+++ b/decidim-admin/app/views/decidim/admin/newsletters/select_recipients_to_deliver.html.erb
@@ -1,4 +1,4 @@
-<%= decidim_form_for(@form, url: deliver_newsletter_path(@newsletter), method: :post, html: { class: "form newsletter_deliver" }, data: { "recipients-count-newsletter-path": recipients_count_newsletter_path(@newsletter) }) do |f| %>
+<%= decidim_form_for(@form, url: deliver_newsletter_path(@newsletter), method: :post, html: { class: "form newsletter_deliver absolutes" }, data: { "recipients-count-newsletter-path": recipients_count_newsletter_path(@newsletter) }) do |f| %>
   <div class="card">
 
     <div class="card-divider">
@@ -73,6 +73,7 @@
       </div>
     </div>
   </div>
+  <div id="recipients_count_modal" class="loading-spinner full-box-spinner hide left top"></div>
 <% end %>
 
 <%= javascript_include_tag "decidim/admin/newsletters" %>

--- a/decidim-admin/app/views/decidim/admin/newsletters/select_recipients_to_deliver.html.erb
+++ b/decidim-admin/app/views/decidim/admin/newsletters/select_recipients_to_deliver.html.erb
@@ -1,4 +1,4 @@
-<%= decidim_form_for(@form, url: deliver_newsletter_path(@newsletter), method: :post, html: { class: "form newsletter_deliver absolutes" }, data: { "recipients-count-newsletter-path": recipients_count_newsletter_path(@newsletter) }) do |f| %>
+<%= decidim_form_for(@form, url: deliver_newsletter_path(@newsletter), method: :post, html: { class: "form newsletter_deliver" }, data: { "recipients-count-newsletter-path": recipients_count_newsletter_path(@newsletter) }) do |f| %>
   <div class="card">
 
     <div class="card-divider">
@@ -73,7 +73,6 @@
       </div>
     </div>
   </div>
-  <div id="recipients_count_modal" class="loading-spinner full-box-spinner hide left top"></div>
 <% end %>
 
 <%= javascript_include_tag "decidim/admin/newsletters" %>

--- a/decidim-comments/app/models/decidim/comments/comment.rb
+++ b/decidim-comments/app/models/decidim/comments/comment.rb
@@ -116,8 +116,8 @@ module Decidim
         #                           .where("decidim_comments_comments.decidim_author_id" => Decidim::User.where(organization: space.organization))
         #                           .where("decidim_comments_comments.decidim_author_type" => "Decidim::UserBaseEntity")
         #                           .map(&:author).pluck(:id).flatten.compact.uniq
-        authors_sql= Decidim::Comments::Comment.select("DISTINCT decidim_comments_comments.decidim_author_id").not_hidden
-                                  .where("decidim_comments_comments.decidim_author_type" => "Decidim::UserBaseEntity").to_sql
+        authors_sql = Decidim::Comments::Comment.select("DISTINCT decidim_comments_comments.decidim_author_id").not_hidden
+                                                .where("decidim_comments_comments.decidim_author_type" => "Decidim::UserBaseEntity").to_sql
 
         Decidim::User.where(organization: space.organization).where("id IN (#{authors_sql})").pluck(:id)
       end

--- a/decidim-comments/app/models/decidim/comments/comment.rb
+++ b/decidim-comments/app/models/decidim/comments/comment.rb
@@ -112,10 +112,14 @@ module Decidim
       end
 
       def self.newsletter_participant_ids(space)
-        Decidim::Comments::Comment.includes(:root_commentable).not_hidden
-                                  .where("decidim_comments_comments.decidim_author_id IN (?)", Decidim::User.where(organization: space.organization).pluck(:id))
-                                  .where("decidim_comments_comments.decidim_author_type IN (?)", "Decidim::UserBaseEntity")
-                                  .map(&:author).pluck(:id).flatten.compact.uniq
+        # Decidim::Comments::Comment.includes(:root_commentable).not_hidden
+        #                           .where("decidim_comments_comments.decidim_author_id" => Decidim::User.where(organization: space.organization))
+        #                           .where("decidim_comments_comments.decidim_author_type" => "Decidim::UserBaseEntity")
+        #                           .map(&:author).pluck(:id).flatten.compact.uniq
+        authors_sql= Decidim::Comments::Comment.select("DISTINCT decidim_comments_comments.decidim_author_id").not_hidden
+                                  .where("decidim_comments_comments.decidim_author_type" => "Decidim::UserBaseEntity").to_sql
+
+        Decidim::User.where(organization: space.organization).where("id IN (#{authors_sql})").pluck(:id)
       end
 
       def can_participate?(user)


### PR DESCRIPTION
#### :tophat: What? Why?
This PR works the performance on newsletter real time counters when using segmentation (by scopes, etc).
Comments is the most unperformant module of the retrieval of participant ids and this is the starting point for this improvements.

Another improvement to be done is the lack of feedback to the admin when the ajax request is waiting for server's response.

#### :pushpin: Related Issues
- Related to #5555 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
