### PR TITLE
Fix and improve amendments diff visualizations

### DIFF
--- a/decidim-core/app/assets/javascripts/decidim/diff_mode_dropdown.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/diff_mode_dropdown.js.es6
@@ -3,9 +3,14 @@ $(() => {
 
   $(document).on("click", ".diff-view-by a.diff-view-mode", (event) => {
     event.preventDefault();
-    const $target = $(event.target);
-    $target.parents(".is-dropdown-submenu-parent").find("#diff-view-selected").text($target.text());
+    const $target = $(event.target)
     let type = "escaped";
+    const $selected = $target.parents(".is-dropdown-submenu-parent").find("#diff-view-selected");
+    if ($selected.text().trim() === $target.text().trim()) {
+      return;
+    }
+
+    $selected.text($target.text());
 
     if ($target.attr("id") === "diff-view-unified") {
       if ($(".row#diff_view_split_escaped").hasClass("hide")) {

--- a/decidim-core/app/assets/javascripts/decidim/diff_mode_dropdown.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/diff_mode_dropdown.js.es6
@@ -5,14 +5,23 @@ $(() => {
     event.preventDefault();
     const $target = $(event.target);
     $target.parents(".is-dropdown-submenu-parent").find("#diff-view-selected").text($target.text());
+    let type = "escaped";
 
     if ($target.attr("id") === "diff-view-unified") {
+      if ($(".row#diff_view_split_escaped").hasClass("hide")) {
+        type = "unescaped";
+      }
+
       $allDiffViews.addClass("hide");
-      $(".row#diff_view_unified_escaped").removeClass("hide");
+      $(`.row#diff_view_unified_${type}`).removeClass("hide");
     }
     if ($target.attr("id") === "diff-view-split") {
+      if ($(".row#diff_view_unified_escaped").hasClass("hide")) {
+        type = "unescaped";
+      }
+
       $allDiffViews.addClass("hide");
-      $(".row#diff_view_split_escaped").removeClass("hide");
+      $(`.row#diff_view_split_${type}`).removeClass("hide");
     }
   })
 
@@ -32,6 +41,4 @@ $(() => {
       $visibleDiffViews.filter("[id$=_unescaped]").removeClass("hide");
     }
   })
-
-
 });

--- a/decidim-core/app/cells/decidim/diff/attribute.erb
+++ b/decidim-core/app/cells/decidim/diff/attribute.erb
@@ -5,23 +5,23 @@
     </h3>
   </div>
 
-  <div class="row" id="diff_view_unified_escaped">
-    <%= diff_unified(data, :html) %>
-  </div>
-
-  <div class="row hide" id="diff_view_unified_unescaped">
+  <div class="row<%= " hide" unless show_html_view_dropdown? %>" id="diff_view_unified_unescaped">
     <%= diff_unified(data, :unescaped_html) %>
   </div>
 
-  <div class="row hide" id="diff_view_split_escaped">
-    <%= diff_split(data, "left", :html) %>
-
-    <%= diff_split(data, "right", :html) %>
+  <div class="row<%= " hide" if show_html_view_dropdown? %>" id="diff_view_unified_escaped">
+    <%= diff_unified(data, :html) %>
   </div>
 
   <div class="row hide" id="diff_view_split_unescaped">
     <%= diff_split(data, "left", :unescaped_html) %>
 
     <%= diff_split(data, "right", :unescaped_html) %>
+  </div>
+
+  <div class="row hide" id="diff_view_split_escaped">
+    <%= diff_split(data, "left", :html) %>
+
+    <%= diff_split(data, "right", :html) %>
   </div>
 </div>

--- a/decidim-core/app/cells/decidim/diff/diff_mode_html.erb
+++ b/decidim-core/app/cells/decidim/diff/diff_mode_html.erb
@@ -8,19 +8,19 @@
       <ul class="dropdown menu" data-dropdown-menu>
         <li class="is-dropdown-submenu-parent">
           <a id="diff-view-selected">
-            <%= t("versions.dropdown.option_escaped") %>
+            <%= t("versions.dropdown.option_unescaped") %>
           </a>
 
           <ul class="menu">
             <li>
-              <%= link_to "#escaped-html", class: "diff-view-html", id:"escaped-html" do %>
-                <%= t("versions.dropdown.option_escaped") %>
+              <%= link_to "#unescaped-html", class: "diff-view-html", id:"unescaped-html" do %>
+                <%= t("versions.dropdown.option_unescaped") %>
               <% end %>
             </li>
 
             <li>
-              <%= link_to "#unescaped-html", class: "diff-view-html", id:"unescaped-html" do %>
-                <%= t("versions.dropdown.option_unescaped") %>
+              <%= link_to "#escaped-html", class: "diff-view-html", id:"escaped-html" do %>
+                <%= t("versions.dropdown.option_escaped") %>
               <% end %>
             </li>
           </ul>

--- a/decidim-core/lib/decidim/diffy_extension.rb
+++ b/decidim-core/lib/decidim/diffy_extension.rb
@@ -22,5 +22,26 @@ module Decidim
         UnescapedHtmlFormatter.new(self, options).to_s
       end
     end
+
+    # The private "split" method SplitDiff needs to be overriden to take into
+    # account the new :unescaped_html format, and the fact that the tags
+    # <ins> <del> are not there anymore
+    Diffy::SplitDiff.module_eval do
+      private
+
+      def split
+        return [split_left, split_right] unless @format == :unescaped_html
+
+        [unescaped_split_left, unescaped_split_right]
+      end
+
+      def unescaped_split_left
+        @diff.gsub(%r{<li class="ins">([\s\S]*?)<\/li>}, "")
+      end
+
+      def unescaped_split_right
+        @diff.gsub(%r{<li class="del">([\s\S]*?)<\/li>}, "")
+      end
+    end
   end
 end

--- a/decidim-core/spec/cells/decidim/diff_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/diff_cell_spec.rb
@@ -88,5 +88,38 @@ describe Decidim::DiffCell, versioning: true, type: :cell do
         expect(html).to have_content("alert('SCRIPT')")
       end
     end
+
+    context "with diff_view_split_unescaped" do
+      let(:html) { subject.find(".diff-for-body #diff_view_split_unescaped") }
+
+      it "renders potentially safe HTML tags unescaped" do
+        expect(html).to have_selector("em", text: "em")
+        expect(html).to have_selector("u", text: "u")
+        expect(html).to have_selector("strong", text: "strong")
+      end
+
+      it "sanitizes potentially malicious HTML tags" do
+        expect(html).not_to have_selector("script", visible: :all)
+        expect(html).to have_content("alert('SCRIPT')")
+      end
+    end
+
+    context "with diff_view_split_escaped" do
+      let(:html) { subject.find(".diff-for-body #diff_view_split_escaped") }
+
+      it "sanitizes potentially safe HTML tags" do
+        expect(html).not_to have_selector("em")
+        expect(html).to have_content("em")
+        expect(html).not_to have_selector("u")
+        expect(html).to have_content("u")
+        expect(html).not_to have_selector("strong")
+        expect(html).to have_content("strong")
+      end
+
+      it "sanitizes potentially malicious HTML tags" do
+        expect(html).not_to have_selector("script", visible: :all)
+        expect(html).to have_content("alert('SCRIPT')")
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

The DIFF visualization of the amendments does not work properly on side-by-side views when using unescaped html. This PR fixes that.
Also, it changes the default visualization to show the **unescaped html** by default if the rich text editor is enabled in the organization. This is because most admins find that viewing diffs with its raw HTML is very confusing and not really useful for most purposes. If the rich text editor is not enabled, it works the same way as before.

#### :clipboard: Subtasks
- [x] Add tests

### :camera: Screenshots (optional)
![diff gif](https://user-images.githubusercontent.com/1401520/86247181-63b81980-bbac-11ea-8a78-2681f044eb95.gif)

