### PR TITLE
Add tests for ProposalPresenter#sanitize_text

### DIFF
--- a/decidim-proposals/spec/presenters/decidim/proposals/proposal_presenter_spec.rb
+++ b/decidim-proposals/spec/presenters/decidim/proposals/proposal_presenter_spec.rb
@@ -24,6 +24,113 @@ module Decidim
         end
       end
 
+      describe "when content contains paragraphs" do
+        let(:content) { <<~EOCONTENT }
+          Content with
+
+          <p>some</p><p>paragraphs</p><p>with some interesting</p><p>content</p>on the text.
+        EOCONTENT
+        let(:result) { <<~EORESULT }
+          Content with
+
+          some
+
+          paragraphs
+
+          with some interesting
+
+          content
+
+          on the text.
+        EORESULT
+
+        it "adds line feeds to paragraphs" do
+          expect(subject.body(links: false, strip_tags: true)).to eq(result)
+        end
+      end
+
+      describe "when content contains an ordered list but not unordered" do
+        let(:content) { <<~EOCONTENT }
+          Content with
+
+          <ol><li>a</li><li>random</li><li>ordered</li><li>list</li></ol>
+        EOCONTENT
+        let(:result) { <<~EORESULT }
+          Content with
+
+          1. a
+          2. random
+          3. ordered
+          4. list
+
+        EORESULT
+
+        it "adds numberings to ordered lists" do
+          expect(subject.body(links: false, strip_tags: true)).to eq(result)
+        end
+      end
+
+      describe "when content contains an unordered list but not ordered" do
+        let(:content) { <<~EOCONTENT }
+          Content with
+
+          <ul><li>a</li><li>random</li><li>unordered</li><li>list</li></ul>
+        EOCONTENT
+        let(:result) { <<~EORESULT }
+          Content with
+
+          • a
+          • random
+          • unordered
+          • list
+
+        EORESULT
+
+        it "adds bullet points to unordered lists" do
+          expect(subject.body(links: false, strip_tags: true)).to eq(result)
+        end
+      end
+
+      describe "when content contains paragraphs, ordered and unordered lists" do
+        let(:content) { <<~EOCONTENT }
+          Content with
+
+          <p>some</p><p>paragraphs,</p><ul><li>unordered</li><li>list</li></ul>
+          and a
+
+          <ol><li>random</li><li>ordered</li><li>list</li></ol>
+          and then again another
+
+          <ul><li>unordered</li><li>list</li></ul>
+        EOCONTENT
+        let(:result) { <<~EORESULT }
+          Content with
+
+          some
+
+          paragraphs,
+
+          • unordered
+          • list
+
+          and a
+
+          1. random
+          2. ordered
+          3. list
+
+          and then again another
+
+          • unordered
+          • list
+
+        EORESULT
+
+        it "adds line feeds to paragraphs, bullet points to unordered lists, and numberings to ordered lists" do
+          expect(subject.body(links: false, strip_tags: true)).to eq(result)
+        end
+      end
+
       describe "#versions", versioning: true do
         subject { presenter.versions }
 


### PR DESCRIPTION
#### :tophat: What? Why?
Add tests to proposal presenter.
These tests ensure a correct body rendering when HTML tags are stripped:

- Newlines after paragraphs
- Bullet points on unordered lists
- Numberings on ordered lists

#### :pushpin: Related Issues
- Related to #6200

#### :clipboard: Subtasks
- [x] Add tests