### PR TITLE
Edit debates

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -226,6 +226,8 @@ ignore_unused:
   - decidim.initiatives.versions.shared.back_to_resource
   - decidim.meetings.actions.invalid_destroy.proposals_count.*
   - decidim.meetings.versions.back_to_resource
+  - decidim.debates.debates.versions.*
+  - decidim.debates.debates.versions_list.*
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/decidim-debates/app/commands/decidim/debates/create_debate.rb
+++ b/decidim-debates/app/commands/decidim/debates/create_debate.rb
@@ -20,6 +20,8 @@ module Decidim
           send_notification_to_author_followers
           send_notification_to_space_followers
         end
+
+        follow_debate
         broadcast(:ok, debate)
       end
 
@@ -71,6 +73,13 @@ module Decidim
             type: "participatory_space"
           }
         )
+      end
+
+      def follow_debate
+        follow_form = Decidim::FollowForm
+                      .from_params(followable_gid: debate.to_signed_global_id.to_s)
+                      .with_context(current_user: debate.author)
+        Decidim::CreateFollow.call(follow_form, debate.author)
       end
     end
   end

--- a/decidim-debates/app/commands/decidim/debates/create_debate.rb
+++ b/decidim-debates/app/commands/decidim/debates/create_debate.rb
@@ -27,23 +27,17 @@ module Decidim
 
       attr_reader :debate, :form
 
-      def organization
-        @organization = form.current_component.organization
-      end
-
-      def i18n_field(field)
-        organization.available_locales.inject({}) do |i18n, locale|
-          i18n.update(locale => field)
-        end
-      end
-
       def create_debate
         params = {
           author: form.current_user,
           decidim_user_group_id: form.user_group_id,
           category: form.category,
-          title: i18n_field(form.title),
-          description: i18n_field(form.description),
+          title: {
+            I18n.locale => form.title
+          },
+          description: {
+            I18n.locale => form.description
+          },
           component: form.current_component
         }
 

--- a/decidim-debates/app/commands/decidim/debates/update_debate.rb
+++ b/decidim-debates/app/commands/decidim/debates/update_debate.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Debates
+    # A command with all the business logic when a user updates a debate.
+    class UpdateDebate < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # form         - A form object with the params.
+      def initialize(form)
+        @form = form
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid, together with the debate.
+      # - :invalid if the form wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        return broadcast(:invalid) if form.invalid?
+        return broadcast(:invalid) unless form.debate.editable_by?(form.current_user)
+
+        update_debate
+        broadcast(:ok, @debate)
+      end
+
+      private
+
+      attr_reader :form
+
+      def update_debate
+        @debate = Decidim.traceability.update!(
+          @form.debate,
+          @form.current_user,
+          attributes,
+          visibility: "public-only"
+        )
+      end
+
+      def attributes
+        {
+          category: form.category,
+          title: {
+            I18n.locale => form.title
+          },
+          description: {
+            I18n.locale => form.description
+          }
+        }
+      end
+    end
+  end
+end

--- a/decidim-debates/app/controllers/decidim/debates/versions_controller.rb
+++ b/decidim-debates/app/controllers/decidim/debates/versions_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Debates
+    # Exposes Debates versions so users can see how a Debate has been updated
+    # through time.
+    class VersionsController < Decidim::Proposals::ApplicationController
+      include Decidim::ApplicationHelper
+      include Decidim::ResourceVersionsConcern
+
+      def versioned_resource
+        @versioned_resource ||= present(Debate.where(component: current_component).find(params[:debate_id]))
+      end
+    end
+  end
+end

--- a/decidim-debates/app/forms/decidim/debates/debate_form.rb
+++ b/decidim-debates/app/forms/decidim/debates/debate_form.rb
@@ -23,7 +23,7 @@ module Decidim
 
         # Debates can be translated in different languages from the admin but
         # the public form doesn't allow it. When a user creates a debate the
-        # text is the same for all languages.
+        # user locale is taken as the text locale.
         self.title = debate.title.values.first
         self.description = debate.description.values.first
         self.user_group_id = debate.decidim_user_group_id

--- a/decidim-debates/app/forms/decidim/debates/debate_form.rb
+++ b/decidim-debates/app/forms/decidim/debates/debate_form.rb
@@ -10,14 +10,40 @@ module Decidim
       attribute :description, String
       attribute :category_id, Integer
       attribute :user_group_id, Integer
+      attribute :debate, Debate
 
       validates :title, presence: true
       validates :description, presence: true
-
       validates :category, presence: true, if: ->(form) { form.category_id.present? }
+      validate :editable_by_user
+
+      def map_model(debate)
+        super
+        self.debate = debate
+
+        # Debates can be translated in different languages from the admin but
+        # the public form doesn't allow it. When a user creates a debate the
+        # text is the same for all languages.
+        self.title = debate.title.values.first
+        self.description = debate.description.values.first
+        self.user_group_id = debate.decidim_user_group_id
+
+        if debate.category.present?
+          self.category_id = debate.category.id
+          @category = debate.category
+        end
+      end
 
       def category
         @category ||= current_component.categories.find_by(id: category_id)
+      end
+
+      private
+
+      def editable_by_user
+        return unless debate.respond_to?(:editable_by?)
+
+        errors.add(:debate, :invalid) unless debate.editable_by?(current_user)
       end
     end
   end

--- a/decidim-debates/app/models/decidim/debates/debate.rb
+++ b/decidim-debates/app/models/decidim/debates/debate.rb
@@ -117,6 +117,13 @@ module Decidim
                                 .pluck(:decidim_author_id).flatten.compact.uniq
       end
 
+      # Checks whether the user can edit the debate.
+      #
+      # user - the user to check for authorship
+      def editable_by?(user)
+        authored_by?(user)
+      end
+
       private
 
       def comments_blocked?

--- a/decidim-debates/app/permissions/decidim/debates/permissions.rb
+++ b/decidim-debates/app/permissions/decidim/debates/permissions.rb
@@ -15,6 +15,8 @@ module Decidim
           toggle_allow(can_create_debate?)
         when :report
           allow!
+        when :edit
+          toggle_allow(can_edit_debate?)
         end
 
         permission_action
@@ -25,6 +27,14 @@ module Decidim
       def can_create_debate?
         authorized?(:create) &&
           current_settings&.creation_enabled? && component.participatory_space.can_participate?(user)
+      end
+
+      def can_edit_debate?
+        allow! if debate&.editable_by?(user)
+      end
+
+      def debate
+        @debate ||= context.fetch(:debate, nil) || context.fetch(:resource, nil)
       end
     end
   end

--- a/decidim-debates/app/services/decidim/debates/diff_renderer.rb
+++ b/decidim-debates/app/services/decidim/debates/diff_renderer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Debates
+    class DiffRenderer < BaseDiffRenderer
+      private
+
+      # Lists which attributes will be diffable and how they should be rendered.
+      def attribute_types
+        {
+          title: :i18n,
+          description: :i18n,
+          information_updates: :i18n,
+          instructions: :i18n,
+          start_time: :string,
+          end_time: :string
+        }
+      end
+
+      def debate
+        @debate ||= Debate.find_by(id: version.item_id)
+      end
+    end
+  end
+end

--- a/decidim-debates/app/views/decidim/debates/debates/_form.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/_form.html.erb
@@ -1,0 +1,19 @@
+<div class="field">
+  <%= form.text_field :title %>
+</div>
+
+<div class="field">
+  <%= text_editor_for_debate_description(form) %>
+</div>
+
+<% if current_participatory_space.categories&.any? %>
+  <div class="field">
+    <%= form.categories_select :category_id, current_participatory_space.categories, prompt: t(".select_a_category"), disable_parents: false %>
+  </div>
+<% end %>
+
+<% if @form.id.blank? && Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.any? %>
+  <div class="field">
+    <%= form.select :user_group_id, Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.map{|g| [g.name, g.id]}, prompt: current_user.name %>
+  </div>
+<% end %>

--- a/decidim-debates/app/views/decidim/debates/debates/edit.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/edit.html.erb
@@ -13,7 +13,7 @@
         <%= decidim_form_for(@form) do |form| %>
           <%= render partial: "form", locals: { form: form } %>
           <div class="actions">
-            <%= form.submit t(".create"), class: "button expanded", data: { disable: true } %>
+            <%= form.submit t(".save"), class: "button expanded", data: { disable: true } %>
           </div>
         <% end %>
       </div>

--- a/decidim-debates/app/views/decidim/debates/debates/show.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/show.html.erb
@@ -24,7 +24,9 @@ edit_link(
     <%== present(debate).title %>
   </h2>
 
-  <%= cell "decidim/author", Decidim::Debates::DebatePresenter.new(debate).author, from: debate, context: { extra_classes: ["author-data--small"] } %>
+  <% debate_presenter = Decidim::Debates::DebatePresenter.new(debate) %>
+  <%= cell "decidim/author", debate_presenter.author, from: debate, context: { extra_classes: ["author-data--small"] } %>
+
 </div>
 <div class="row">
   <div class="columns section view-side mediumlarge-4 mediumlarge-push-8 large-3 large-push-9">
@@ -47,6 +49,7 @@ edit_link(
       </div>
     </div>
     <%= resource_reference(debate) %>
+    <%= resource_version(debate_presenter, versions_path: debate_versions_path(debate)) %>
     <%= render partial: "decidim/shared/share_modal" %>
   </div>
   <div class="columns mediumlarge-8 mediumlarge-pull-4">

--- a/decidim-debates/app/views/decidim/debates/debates/show.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/show.html.erb
@@ -27,8 +27,12 @@ edit_link(
   <%= cell "decidim/author", Decidim::Debates::DebatePresenter.new(debate).author, from: debate, context: { extra_classes: ["author-data--small"] } %>
 </div>
 <div class="row">
-  <div class="columns section view-side mediumlarge-4 mediumlarge-push-8
-    large-3 large-push-9">
+  <div class="columns section view-side mediumlarge-4 mediumlarge-push-8 large-3 large-push-9">
+    <% if allowed_to?(:edit, :debate, debate: debate) %>
+      <%= link_to t(".edit_debate"), edit_debate_path(debate), class: "button secondary hollow expanded button-sc button--icon follow-button" %>
+    <% elsif debate.official? && admin_allowed_to?(:update, :debate, debate: debate) %>
+      <%= link_to t(".edit_debate"), resource_locator(debate).edit, class: "button secondary hollow expanded button-sc button--icon follow-button" %>
+    <% end %>
     <div class="card extra">
       <div class="card__content">
         <% if debate.start_time.present? && debate.end_time.present? %>

--- a/decidim-debates/app/views/decidim/debates/versions/index.html.erb
+++ b/decidim-debates/app/views/decidim/debates/versions/index.html.erb
@@ -1,0 +1,8 @@
+<div class="row">
+  <%= cell(
+    "decidim/versions_list",
+    versioned_resource,
+    version_path: proc { |version_index| url_for(action: :show, id: version_index) },
+    i18n_scope: "decidim.debates.debates.versions_list"
+  ) %>
+</div>

--- a/decidim-debates/app/views/decidim/debates/versions/show.html.erb
+++ b/decidim-debates/app/views/decidim/debates/versions/show.html.erb
@@ -1,0 +1,10 @@
+<div class="row">
+  <%= cell(
+    "decidim/version",
+    current_version,
+    index: params[:id],
+    versioned_resource: versioned_resource,
+    versions_path: proc { url_for(action: :index) },
+    i18n_scope: "decidim.debates.debates.versions.#{item_name.to_s.pluralize}"
+  ) %>
+</div>

--- a/decidim-debates/config/locales/en.yml
+++ b/decidim-debates/config/locales/en.yml
@@ -78,6 +78,10 @@ en:
           success: Debate successfully created.
         debate:
           participate: Participate
+        edit:
+          back: Back
+          save: Save changes
+          title: Edit debate
         filters:
           all: All
           category: Category
@@ -91,15 +95,20 @@ en:
           filter: Filter
           filter_by: Filter by
           unfold: Unfold
+        form:
+          select_a_category: Please select a category
         index:
           new_debate: New debate
         new:
           back: Back
           create: Create
-          select_a_category: Please select a category
           title: New debate
         show:
           back: Back to list
+          edit_debate: Edit debate
+        update:
+          invalid: There was a problem updating the debate.
+          success: Debate successfully updated.
       last_activity:
         new_debate_at_html: "<span>New debate at %{link}</span>"
       models:

--- a/decidim-debates/config/locales/en.yml
+++ b/decidim-debates/config/locales/en.yml
@@ -109,6 +109,13 @@ en:
         update:
           invalid: There was a problem updating the debate.
           success: Debate successfully updated.
+        versions:
+          debates:
+            back_to_resource: Go back to debate
+          index:
+            title: Versions
+        versions_list:
+          back_to_resource: Go back to debate
       last_activity:
         new_debate_at_html: "<span>New debate at %{link}</span>"
       models:

--- a/decidim-debates/lib/decidim/debates/engine.rb
+++ b/decidim-debates/lib/decidim/debates/engine.rb
@@ -12,7 +12,9 @@ module Decidim
       isolate_namespace Decidim::Debates
 
       routes do
-        resources :debates, only: [:index, :show, :new, :create, :edit, :update]
+        resources :debates, only: [:index, :show, :new, :create, :edit, :update] do
+          resources :versions, only: [:show, :index]
+        end
         root to: "debates#index"
       end
 

--- a/decidim-debates/lib/decidim/debates/engine.rb
+++ b/decidim-debates/lib/decidim/debates/engine.rb
@@ -12,7 +12,7 @@ module Decidim
       isolate_namespace Decidim::Debates
 
       routes do
-        resources :debates, only: [:index, :show, :new, :create]
+        resources :debates, only: [:index, :show, :new, :create, :edit, :update]
         root to: "debates#index"
       end
 

--- a/decidim-debates/spec/commands/decidim/debates/create_debate_spec.rb
+++ b/decidim-debates/spec/commands/decidim/debates/create_debate_spec.rb
@@ -79,6 +79,11 @@ describe Decidim::Debates::CreateDebate do
       expect(action_log.version).to be_present
       expect(action_log.version.event).to eq "create"
     end
+
+    it "makes the author follow the debate" do
+      subject.call
+      expect(Decidim::Follow.where(user: user, followable: debate).count).to eq(1)
+    end
   end
 
   describe "events" do

--- a/decidim-debates/spec/commands/decidim/debates/create_debate_spec.rb
+++ b/decidim-debates/spec/commands/decidim/debates/create_debate_spec.rb
@@ -56,13 +56,11 @@ describe Decidim::Debates::CreateDebate do
     it "sets the title with i18n" do
       subject.call
       expect(debate.title.values.uniq).to eq ["title"]
-      expect(debate.title.keys).to match_array organization.available_locales
     end
 
     it "sets the description with i18n" do
       subject.call
       expect(debate.description.values.uniq).to eq ["description"]
-      expect(debate.description.keys).to match_array organization.available_locales
     end
 
     it "traces the action", versioning: true do

--- a/decidim-debates/spec/commands/decidim/debates/update_debate_spec.rb
+++ b/decidim-debates/spec/commands/decidim/debates/update_debate_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Debates::UpdateDebate do
+  subject { described_class.new(form) }
+
+  let(:organization) { create :organization, available_locales: [:en, :ca, :es], default_locale: :en }
+  let(:participatory_process) { create :participatory_process, organization: organization }
+  let(:current_component) { create :component, participatory_space: participatory_process, manifest_name: "debates" }
+  let(:category) { create :category, participatory_space: participatory_process }
+  let(:user) { create :user, organization: organization }
+  let!(:debate) { create :debate, author: user, component: current_component }
+  let(:form) do
+    Decidim::Debates::DebateForm.from_params(
+      title: "title",
+      description: "description",
+      category_id: category.id,
+      debate: debate
+    ).with_context(
+      current_organization: organization,
+      current_participatory_space: current_component.participatory_space,
+      current_component: current_component,
+      current_user: user
+    )
+  end
+
+  describe "when the form is not valid" do
+    before do
+      expect(form).to receive(:invalid?).and_return(true)
+    end
+
+    it "broadcasts invalid" do
+      expect { subject.call }.to broadcast(:invalid)
+    end
+
+    it "doesn't update the debate" do
+      expect do
+        subject.call
+      end.not_to change(debate, :title)
+    end
+  end
+
+  describe "when the debate is not editable by the user" do
+    before do
+      expect(debate).to receive(:editable_by?).and_return(false)
+    end
+
+    it "broadcasts invalid" do
+      expect { subject.call }.to broadcast(:invalid)
+    end
+
+    it "doesn't update the debate" do
+      expect do
+        subject.call
+      end.not_to change(debate, :title)
+    end
+  end
+
+  context "when everything is ok" do
+    it "updates the debate" do
+      expect { subject.call }.to change(debate, :title)
+    end
+
+    it "sets the category" do
+      subject.call
+      expect(debate.category).to eq category
+    end
+
+    it "sets the title with i18n" do
+      subject.call
+      expect(debate.title.values.uniq).to eq ["title"]
+    end
+
+    it "sets the description with i18n" do
+      subject.call
+      expect(debate.description.values.uniq).to eq ["description"]
+    end
+
+    it "traces the action", versioning: true do
+      expect(Decidim.traceability)
+        .to receive(:update!)
+        .with(
+          Decidim::Debates::Debate,
+          user,
+          hash_including(:category, :title, :description),
+          visibility: "public-only"
+        )
+        .and_call_original
+
+      expect { subject.call }.to change(Decidim::ActionLog, :count)
+      action_log = Decidim::ActionLog.last
+      expect(action_log.version).to be_present
+      expect(action_log.version.event).to eq "update"
+    end
+  end
+end

--- a/decidim-debates/spec/forms/decidim/debates/debate_form_spec.rb
+++ b/decidim-debates/spec/forms/decidim/debates/debate_form_spec.rb
@@ -13,7 +13,7 @@ describe Decidim::Debates::DebateForm do
     }
   end
   let(:participatory_process) { create :participatory_process, organization: organization }
-  let(:current_component) { create :component, participatory_space: participatory_process }
+  let(:current_component) { create :component, participatory_space: participatory_process, manifest_name: "debates" }
   let(:title) { "My title" }
   let(:description) { "My description" }
   let(:category) { create :category, participatory_space: participatory_process }
@@ -44,5 +44,45 @@ describe Decidim::Debates::DebateForm do
     let(:category_id) { category.id + 10 }
 
     it { is_expected.not_to be_valid }
+  end
+
+  context "when a debate exists" do
+    subject { described_class.from_model(debate).with_context(context.merge(current_user: user)) }
+
+    let(:debate) { create :debate, category: category, component: current_component }
+
+    describe "when the user is the author" do
+      let(:user) { debate.author }
+
+      it { is_expected.to be_valid }
+    end
+
+    describe "when the user is not the author" do
+      let(:user) { create(:user, organization: organization) }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+
+  describe "map_model" do
+    subject { described_class.from_model(debate).with_context(context) }
+
+    let(:debate) { create :debate, category: category, component: current_component }
+
+    it "sets the title" do
+      expect(subject.title).to be_present
+    end
+
+    it "sets the description" do
+      expect(subject.description).to be_present
+    end
+
+    it "sets the category" do
+      expect(subject.category).to be_present
+    end
+
+    it "sets the debate" do
+      expect(subject.debate).to eq(debate)
+    end
   end
 end

--- a/decidim-debates/spec/permissions/decidim/debates/permissions_spec.rb
+++ b/decidim-debates/spec/permissions/decidim/debates/permissions_spec.rb
@@ -69,6 +69,22 @@ describe Decidim::Debates::Permissions do
     end
   end
 
+  context "when editing a debate" do
+    let(:action) do
+      { scope: :public, action: :edit, subject: :debate }
+    end
+
+    context "when the user is the author" do
+      let(:debate) { create :debate, author: user, component: debates_component }
+
+      it { is_expected.to eq true }
+    end
+
+    context "when the user is not the author" do
+      it { is_expected.to eq false }
+    end
+  end
+
   context "when reporting a debate" do
     let(:action) do
       { scope: :public, action: :report, subject: :debate }

--- a/decidim-debates/spec/system/debates_versions_spec.rb
+++ b/decidim-debates/spec/system/debates_versions_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Explore versions", versioning: true, type: :system do
+  include_context "with a component"
+  let(:manifest_name) { "debates" }
+  let!(:debate) { create(:debate, component: component) }
+  let(:debate_path) { Decidim::ResourceLocatorPresenter.new(debate).path }
+
+  context "when visiting a debate details" do
+    before do
+      visit debate_path
+    end
+
+    it "has only one version" do
+      expect(page).to have_content("VERSION 1 (of 1)")
+    end
+
+    it "shows the versions index" do
+      expect(page).to have_link "see other versions"
+    end
+  end
+
+  context "when visiting versions index" do
+    before do
+      update_debate
+      visit debate_path
+      click_link "see other versions"
+    end
+
+    it "lists all versions" do
+      expect(page).to have_link("Version 1")
+      expect(page).to have_link("Version 2")
+    end
+
+    it "shows the versions count" do
+      expect(page).to have_content("VERSIONS\n2")
+    end
+
+    it "allows going back to the debate" do
+      click_link "Go back to debate"
+      expect(page).to have_current_path debate_path
+    end
+
+    it "shows the creation date" do
+      within ".card--list__item:last-child" do
+        expect(page).to have_content(Time.zone.today.strftime("%d/%m/%Y"))
+      end
+    end
+  end
+
+  context "when showing version" do
+    before do
+      visit debate_path
+      update_debate
+      click_link "see other versions"
+
+      within ".card--list__item:last-child" do
+        click_link("Version 2")
+      end
+    end
+
+    it "shows the version number" do
+      expect(page).to have_content("VERSION NUMBER\n2 out of 2")
+    end
+
+    it "allows going back to the debate" do
+      click_link "Go back to debate"
+      expect(page).to have_current_path debate_path
+    end
+
+    it "allows going back to the versions list" do
+      click_link "Show all versions"
+      expect(page).to have_current_path debate_path + "/versions"
+    end
+
+    it "shows the creation date" do
+      within ".card.extra.definition-data" do
+        expect(page).to have_content(Time.zone.today.strftime("%d/%m/%Y"))
+      end
+    end
+
+    it "shows the changed attributes" do
+      expect(page).to have_content("Changes at")
+
+      within ".diff-for-title-english" do
+        expect(page).to have_content("TITLE")
+
+        within ".diff > ul > .ins" do
+          expect(page).to have_content(debate.title["en"])
+        end
+      end
+
+      within ".diff-for-description-english" do
+        expect(page).to have_content("DESCRIPTION")
+
+        within ".diff > ul > .ins" do
+          expect(page).to have_content(debate.description["en"])
+        end
+      end
+    end
+  end
+
+  def update_debate
+    form = Decidim::Debates::Admin::DebateForm.from_params(
+      title: { "en" => "New title" },
+      description: { "en" => "New description" },
+      instructions: { "en" => "New instructions" }
+    ).with_context(
+      current_organization: organization,
+      current_participatory_space: component.participatory_space,
+      current_component: component
+    )
+
+    Decidim::Debates::Admin::UpdateDebate.call(form, debate)
+  end
+end

--- a/decidim-debates/spec/system/user_creates_debate_spec.rb
+++ b/decidim-debates/spec/system/user_creates_debate_spec.rb
@@ -6,20 +6,6 @@ describe "User creates debate", type: :system do
   include_context "with a component"
   let(:manifest_name) { "debates" }
 
-  let(:organization) { create(:organization) }
-  let(:participatory_process) { create(:participatory_process, :with_steps, organization: organization) }
-  let(:current_component) { create :debates_component, participatory_space: participatory_process }
-  let(:debates_count) { 5 }
-  let!(:debates) do
-    create_list(
-      :debate,
-      debates_count,
-      component: current_component,
-      start_time: Time.zone.local(2016, 12, 13, 14, 15),
-      end_time: Time.zone.local(2016, 12, 13, 16, 17)
-    )
-  end
-
   before do
     switch_to_host(organization.host)
   end

--- a/decidim-debates/spec/system/user_edits_debate_spec.rb
+++ b/decidim-debates/spec/system/user_edits_debate_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "User edits a debate", type: :system do
+  include_context "with a component"
+
+  let(:manifest_name) { "debates" }
+  let!(:debate) do
+    create(
+      :debate,
+      author: author,
+      component: component
+    )
+  end
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+  end
+
+  context "when editing my debate" do
+    let(:user) { create :user, :confirmed, organization: organization }
+    let(:author) { user }
+    let!(:category) { create :category, participatory_space: participatory_space }
+
+    it "allows editing my debate", :slow do
+      visit_component
+
+      click_link debate.title.values.first
+      click_link "Edit debate"
+
+      within ".edit_debate" do
+        fill_in :debate_title, with: "Should every organization use Decidim?"
+        fill_in :debate_description, with: "Add your comments on whether Decidim is useful for every organization."
+        select translated(category.name), from: :debate_category_id
+
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_content("successfully")
+      expect(page).to have_content("Should every organization use Decidim?")
+      expect(page).to have_content("Add your comments on whether Decidim is useful for every organization.")
+      expect(page).to have_content(translated(category.name))
+      expect(page).to have_selector(".author-data", text: user.name)
+    end
+
+    context "when editing as a user group" do
+      let(:author) { user }
+      let!(:user_group) { create :user_group, :verified, organization: organization, users: [user] }
+      let!(:debate) do
+        create(
+          :debate,
+          author: author,
+          user_group: user_group,
+          component: component
+        )
+      end
+
+      it "edits their debate", :slow do
+        visit_component
+        click_link debate.title.values.first
+        click_link "Edit debate"
+
+        within ".edit_debate" do
+          fill_in :debate_title, with: "Should every organization use Decidim?"
+          fill_in :debate_description, with: "Add your comment on whether Decidim is useful for every organization."
+          select translated(category.name), from: :debate_category_id
+
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_content("successfully")
+        expect(page).to have_content("Should every organization use Decidim?")
+        expect(page).to have_content("Add your comment on whether Decidim is useful for every organization.")
+        expect(page).to have_content(translated(category.name))
+        expect(page).to have_selector(".author-data", text: user_group.name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Enables regular users to edit their own debates and adds version control to it.

I've also added auto-following your own debates because it doesn't make sense that an author doesn't receive notifications for their debates automatically.

#### :pushpin: Related Issues
- Related to #6185

#### :clipboard: Subtasks
- [x] Add tests

### :camera: Screenshots

![image](https://user-images.githubusercontent.com/5254/86369949-659edd00-bc7f-11ea-92d3-a47a1086d37d.png)
![image](https://user-images.githubusercontent.com/5254/86369996-70f20880-bc7f-11ea-8035-9b1705d5569c.png)
![image](https://user-images.githubusercontent.com/5254/86370023-79e2da00-bc7f-11ea-932c-797c401fb121.png)

