### PR TITLE
Move meeting services to their own model

### DIFF
--- a/decidim-meetings/app/commands/decidim/meetings/admin/copy_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/copy_meeting.rb
@@ -26,61 +26,71 @@ module Decidim
 
           transaction do
             copy_meeting!
+            copy_services!
             schedule_upcoming_meeting_notification
             send_notification
           end
 
-          broadcast(:ok, @copied_meeting)
+          broadcast(:ok, copied_meeting)
         end
 
         private
 
-        attr_reader :form, :meeting
+        attr_reader :form, :meeting, :copied_meeting
 
         def copy_meeting!
-          parsed_title = Decidim::ContentProcessor.parse_with_processor(:hashtag, @form.title, current_organization: @meeting.organization).rewrite
-          parsed_description = Decidim::ContentProcessor.parse_with_processor(:hashtag, @form.description, current_organization: @meeting.organization).rewrite
+          parsed_title = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.title, current_organization: meeting.organization).rewrite
+          parsed_description = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.description, current_organization: meeting.organization).rewrite
 
           @copied_meeting = Decidim.traceability.create!(
             Meeting,
-            @form.current_user,
-            scope: @meeting.scope,
-            category: @meeting.category,
+            form.current_user,
+            scope: meeting.scope,
+            category: meeting.category,
             title: parsed_title,
             description: parsed_description,
-            end_time: @form.end_time,
-            start_time: @form.start_time,
-            address: @form.address,
-            latitude: @form.latitude,
-            longitude: @form.longitude,
-            location: @form.location,
-            location_hints: @form.location_hints,
-            services: @form.services_to_persist.map { |service| { "title" => service.title, "description" => service.description } },
-            component: @meeting.component,
-            private_meeting: @form.private_meeting,
-            transparent: @form.transparent,
-            author: @form.current_organization,
-            questionnaire: @form.questionnaire,
-            registrations_enabled: @meeting.registrations_enabled,
-            available_slots: @meeting.available_slots,
-            registration_terms: @meeting.registration_terms
+            end_time: form.end_time,
+            start_time: form.start_time,
+            address: form.address,
+            latitude: form.latitude,
+            longitude: form.longitude,
+            location: form.location,
+            location_hints: form.location_hints,
+            component: meeting.component,
+            private_meeting: form.private_meeting,
+            transparent: form.transparent,
+            author: form.current_organization,
+            questionnaire: form.questionnaire,
+            registrations_enabled: meeting.registrations_enabled,
+            available_slots: meeting.available_slots,
+            registration_terms: meeting.registration_terms
           )
         end
 
+        def copy_services!
+          form.services_to_persist.map do |service|
+            Decidim::Meetings::Service.create!(
+              meeting: copied_meeting,
+              "title" => service.title,
+              "description" => service.description
+            )
+          end
+        end
+
         def schedule_upcoming_meeting_notification
-          checksum = Decidim::Meetings::UpcomingMeetingNotificationJob.generate_checksum(@copied_meeting)
+          checksum = Decidim::Meetings::UpcomingMeetingNotificationJob.generate_checksum(copied_meeting)
 
           Decidim::Meetings::UpcomingMeetingNotificationJob
-            .set(wait_until: @copied_meeting.start_time - 2.days)
-            .perform_later(@copied_meeting.id, checksum)
+            .set(wait_until: copied_meeting.start_time - 2.days)
+            .perform_later(copied_meeting.id, checksum)
         end
 
         def send_notification
           Decidim::EventsManager.publish(
             event: "decidim.events.meetings.meeting_created",
             event_class: Decidim::Meetings::CreateMeetingEvent,
-            resource: @copied_meeting,
-            followers: @copied_meeting.participatory_space.followers
+            resource: copied_meeting,
+            followers: copied_meeting.participatory_space.followers
           )
         end
       end

--- a/decidim-meetings/app/commands/decidim/meetings/admin/update_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/update_meeting.rb
@@ -25,6 +25,7 @@ module Decidim
             update_meeting!
             send_notification if should_notify_followers?
             schedule_upcoming_meeting_notification if start_time_changed?
+            update_services!
           end
 
           broadcast(:ok, meeting)
@@ -45,7 +46,6 @@ module Decidim
             category: form.category,
             title: parsed_title,
             description: parsed_description,
-            services: form.services_to_persist.map { |service| { "title" => service.title, "description" => service.description } },
             end_time: form.end_time,
             start_time: form.start_time,
             address: form.address,
@@ -56,6 +56,13 @@ module Decidim
             private_meeting: form.private_meeting,
             transparent: form.transparent
           )
+        end
+
+        def update_services!
+          meeting.services = form.services_to_persist.map do |service|
+            Decidim::Meetings::Service.new("title" => service.title, "description" => service.description)
+          end
+          meeting.save!
         end
 
         def send_notification

--- a/decidim-meetings/app/forms/decidim/meetings/admin/meeting_copy_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/meeting_copy_form.rb
@@ -37,7 +37,7 @@ module Decidim
 
         def map_model(model)
           self.services = model.services.map do |service|
-            MeetingServiceForm.new(service)
+            MeetingServiceForm.new(service.attributes)
           end
         end
 

--- a/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
@@ -42,7 +42,7 @@ module Decidim
 
         def map_model(model)
           self.services = model.services.map do |service|
-            MeetingServiceForm.new(service)
+            MeetingServiceForm.from_model(service)
           end
 
           self.decidim_category_id = model.categorization.decidim_category_id if model.categorization

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -26,6 +26,7 @@ module Decidim
 
       has_many :registrations, class_name: "Decidim::Meetings::Registration", foreign_key: "decidim_meeting_id", dependent: :destroy
       has_many :invites, class_name: "Decidim::Meetings::Invite", foreign_key: "decidim_meeting_id", dependent: :destroy
+      has_many :services, class_name: "Decidim::Meetings::Service", foreign_key: "decidim_meeting_id", dependent: :destroy
       has_one :minutes, class_name: "Decidim::Meetings::Minutes", foreign_key: "decidim_meeting_id", dependent: :destroy
       has_one :agenda, class_name: "Decidim::Meetings::Agenda", foreign_key: "decidim_meeting_id", dependent: :destroy
 

--- a/decidim-meetings/app/models/decidim/meetings/service.rb
+++ b/decidim-meetings/app/models/decidim/meetings/service.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    class Service < Meetings::ApplicationRecord
+      include Decidim::Traceable
+
+      belongs_to :meeting, foreign_key: "decidim_meeting_id", class_name: "Decidim::Meetings::Meeting"
+    end
+  end
+end

--- a/decidim-meetings/db/migrate/20200702123209_create_meeting_services_table.rb
+++ b/decidim-meetings/db/migrate/20200702123209_create_meeting_services_table.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateMeetingServicesTable < ActiveRecord::Migration[5.2]
+  def change
+    create_table :decidim_meetings_services do |t|
+      t.jsonb :title
+      t.jsonb :description
+      t.bigint :decidim_meeting_id, null: false, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/decidim-meetings/db/migrate/20200702123210_move_meeting_services_to_own_model.rb
+++ b/decidim-meetings/db/migrate/20200702123210_move_meeting_services_to_own_model.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class MoveMeetingServicesToOwnModel < ActiveRecord::Migration[5.2]
+  class Meeting < ApplicationRecord
+    self.table_name = :decidim_meetings_meetings
+  end
+
+  class Service < ApplicationRecord
+    self.table_name = :decidim_meetings_services
+  end
+
+  def change
+    create_table :decidim_meetings_services do |t|
+      t.jsonb :title
+      t.jsonb :description
+      t.bigint :decidim_meeting_id, null: false, index: true
+
+      t.timestamps
+    end
+
+    Meeting.find_each do |meeting|
+      meeting["services"].each do |service|
+        Service.create!(
+          decidim_meeting_id: meeting.id,
+          title: service["title"],
+          description: service["description"]
+        )
+      end
+    end
+
+    remove_column :decidim_meetings_meetings, :services
+  end
+end

--- a/decidim-meetings/db/migrate/20200702123210_move_meeting_services_to_own_model.rb
+++ b/decidim-meetings/db/migrate/20200702123210_move_meeting_services_to_own_model.rb
@@ -10,13 +10,8 @@ class MoveMeetingServicesToOwnModel < ActiveRecord::Migration[5.2]
   end
 
   def change
-    create_table :decidim_meetings_services do |t|
-      t.jsonb :title
-      t.jsonb :description
-      t.bigint :decidim_meeting_id, null: false, index: true
-
-      t.timestamps
-    end
+    Meeting.reset_column_information
+    Service.reset_column_information
 
     Meeting.find_each do |meeting|
       meeting["services"].each do |service|
@@ -29,5 +24,8 @@ class MoveMeetingServicesToOwnModel < ActiveRecord::Migration[5.2]
     end
 
     remove_column :decidim_meetings_meetings, :services
+
+    Meeting.reset_column_information
+    Service.reset_column_information
   end
 end

--- a/decidim-meetings/lib/decidim/api/services_interface.rb
+++ b/decidim-meetings/lib/decidim/api/services_interface.rb
@@ -7,13 +7,7 @@ module Decidim
       name "ServicesInterface"
       description "An interface that can be used with services."
 
-      field :services, !types[ServiceType], "The object's services" do
-        resolve ->(meeting, _args, _ctx) {
-          return [] unless meeting.services.respond_to? :map
-
-          meeting.services.map { |service| OpenStruct.new(service) }
-        }
-      end
+      field :services, !types[ServiceType], "The object's services"
     end
   end
 end

--- a/decidim-meetings/lib/decidim/meetings/component.rb
+++ b/decidim-meetings/lib/decidim/meetings/component.rb
@@ -114,11 +114,7 @@ Decidim.register_component(:meetings) do |component|
         author: participatory_space.organization,
         registration_terms: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
           Decidim::Faker::Localized.paragraph(3)
-        end,
-        services: [
-          { title: Decidim::Faker::Localized.sentence(2), description: Decidim::Faker::Localized.sentence(5) },
-          { title: Decidim::Faker::Localized.sentence(2), description: Decidim::Faker::Localized.sentence(5) }
-        ]
+        end
       }
 
       meeting = Decidim.traceability.create!(
@@ -127,6 +123,14 @@ Decidim.register_component(:meetings) do |component|
         params,
         visibility: "all"
       )
+
+      2.times do
+        Decidim::Meetings::Service.create!(
+          meeting: meeting,
+          title: Decidim::Faker::Localized.sentence(2),
+          description: Decidim::Faker::Localized.sentence(5)
+        )
+      end
 
       Decidim::Forms::Questionnaire.create!(
         title: Decidim::Faker::Localized.paragraph,

--- a/decidim-meetings/lib/decidim/meetings/test/factories.rb
+++ b/decidim-meetings/lib/decidim/meetings/test/factories.rb
@@ -56,11 +56,7 @@ FactoryBot.define do
       end
 
       after(:build) do |meeting, evaluator|
-        meeting.services = evaluator.services ||
-          [
-            build(:service, meeting: meeting),
-            build(:service, meeting: meeting)
-          ]
+        meeting.services = evaluator.services || build_list(:service, 2, meeting: meeting)
       end
     end
 

--- a/decidim-meetings/lib/decidim/meetings/test/factories.rb
+++ b/decidim-meetings/lib/decidim/meetings/test/factories.rb
@@ -49,11 +49,18 @@ FactoryBot.define do
     end
 
     trait :with_services do
-      after(:build) do |meeting|
-        meeting.services = [
-          build(:service, meeting: meeting),
-          build(:service, meeting: meeting)
-        ]
+      transient do
+        services do
+          nil
+        end
+      end
+
+      after(:build) do |meeting, evaluator|
+        meeting.services = evaluator.services ||
+          [
+            build(:service, meeting: meeting),
+            build(:service, meeting: meeting)
+          ]
       end
     end
 

--- a/decidim-meetings/lib/decidim/meetings/test/factories.rb
+++ b/decidim-meetings/lib/decidim/meetings/test/factories.rb
@@ -32,12 +32,6 @@ FactoryBot.define do
     end_time { start_time.advance(hours: 2) }
     private_meeting { false }
     transparent { true }
-    services do
-      [
-        { title: generate_localized_title, description: generate_localized_title },
-        { title: generate_localized_title, description: generate_localized_title }
-      ]
-    end
     questionnaire { build(:questionnaire) }
     registration_form_enabled { true }
     component { build(:component, manifest_name: "meetings") }
@@ -52,6 +46,15 @@ FactoryBot.define do
 
     trait :not_official do
       author { create(:user, organization: component.organization) if component }
+    end
+
+    trait :with_services do
+      after(:build) do |meeting|
+        meeting.services = [
+          build(:service, meeting: meeting),
+          build(:service, meeting: meeting)
+        ]
+      end
     end
 
     trait :with_user_group_author do
@@ -145,5 +148,11 @@ FactoryBot.define do
     trait :rejected do
       rejected_at { Time.current }
     end
+  end
+
+  factory :service, class: "Decidim::Meetings::Service" do
+    meeting
+    title { generate_localized_title }
+    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
   end
 end

--- a/decidim-meetings/spec/commands/admin/copy_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/admin/copy_meeting_spec.rb
@@ -17,13 +17,10 @@ module Decidim::Meetings
     let(:private_meeting) { false }
     let(:transparent) { true }
     let(:services) do
-      [
-        { "title" => { "en" => "First service" }, "description" => { "en" => "First description" } },
-        { "title" => { "en" => "Second service" }, "description" => { "en" => "Second description" } }
-      ]
+      build_list(:service, 2, meeting: meeting)
     end
     let(:services_to_persist) do
-      services.map { |service| Admin::MeetingServiceForm.from_params(service) }
+      services.map { |service| Admin::MeetingServiceForm.from_params(service.attributes) }
     end
 
     let(:form) do
@@ -70,7 +67,11 @@ module Decidim::Meetings
         expect(new_meeting.scope).to eq(old_meeting.scope)
         expect(new_meeting.category).to eq(old_meeting.category)
         expect(new_meeting.component).to eq(old_meeting.component)
-        expect(new_meeting.services).to eq(services)
+
+        new_meeting.services.each_with_index do |service, index|
+          expect(service.title).to eq(services[index]["title"])
+          expect(service.description).to eq(services[index]["description"])
+        end
       end
 
       it "broadcasts ok" do

--- a/decidim-meetings/spec/commands/admin/update_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/admin/update_meeting_spec.rb
@@ -14,17 +14,9 @@ module Decidim::Meetings
     let(:invalid) { false }
     let(:latitude) { 40.1234 }
     let(:longitude) { 2.1234 }
+    let(:service_objects) { build_list(:service, 2) }
     let(:services) do
-      [
-        {
-          "title" => { "en" => "First service" },
-          "description" => { "en" => "First description" }
-        },
-        {
-          "title" => { "en" => "Second service" },
-          "description" => { "en" => "Second description" }
-        }
-      ]
+      service_objects.map(&:attributes)
     end
     let(:services_to_persist) do
       services.map { |service| Admin::MeetingServiceForm.from_params(service) }
@@ -91,7 +83,10 @@ module Decidim::Meetings
 
       it "sets the services" do
         subject.call
-        expect(meeting.services).to eq(services)
+        meeting.services.each_with_index do |service, index|
+          expect(service.title).to eq(service_objects[index].title)
+          expect(service.description).to eq(service_objects[index].description)
+        end
       end
 
       it "traces the action", versioning: true do

--- a/decidim-meetings/spec/forms/admin/meeting_copy_form_spec.rb
+++ b/decidim-meetings/spec/forms/admin/meeting_copy_form_spec.rb
@@ -28,11 +28,11 @@ module Decidim::Meetings
     let(:location_hints) do
       Decidim::Faker::Localized.sentence(3)
     end
+    let(:service_objects) do
+      build_list(:service, 2)
+    end
     let(:services) do
-      [
-        { title: { en: "First service" }, description: { en: "First description" } },
-        { title: { en: "Third service" }, description: { en: "Third description" } }
-      ]
+      service_objects.map(&:attributes)
     end
     let(:address) { "Carrer Pic de Peguera 15, 17003 Girona" }
     let(:latitude) { 40.1234 }
@@ -123,7 +123,7 @@ module Decidim::Meetings
     end
 
     it "properly maps services from model" do
-      meeting = create(:meeting, services: services)
+      meeting = create(:meeting, :with_services, services: service_objects)
 
       services = described_class.from_model(meeting).services
       expect(services).to all be_an(Admin::MeetingServiceForm)

--- a/decidim-meetings/spec/forms/admin/meeting_form_spec.rb
+++ b/decidim-meetings/spec/forms/admin/meeting_form_spec.rb
@@ -32,10 +32,10 @@ module Decidim::Meetings
       Decidim::Faker::Localized.sentence(3)
     end
     let(:services) do
-      [
-        { title: Decidim::Faker::Localized.sentence(2), description: Decidim::Faker::Localized.sentence(5) },
-        { title: Decidim::Faker::Localized.sentence(2), description: Decidim::Faker::Localized.sentence(5) }
-      ]
+      build_list(:service, 2)
+    end
+    let(:services_attributes) do
+      services.map(&:attributes)
     end
     let(:address) { "Carrer Pare Llaurador 113, baixos, 08224 Terrassa" }
     let(:latitude) { 40.1234 }
@@ -62,7 +62,7 @@ module Decidim::Meetings
         end_time: end_time,
         private_meeting: private_meeting,
         transparent: transparent,
-        services: services
+        services: services_attributes
       }
     end
 
@@ -145,7 +145,7 @@ module Decidim::Meetings
     end
 
     it "properly maps services from model" do
-      meeting = create(:meeting, services: services)
+      meeting = create(:meeting, :with_services, services: services)
 
       services = described_class.from_model(meeting).services
       expect(services).to all be_an(Admin::MeetingServiceForm)
@@ -161,7 +161,7 @@ module Decidim::Meetings
     describe "services_to_persist" do
       subject { form.services_to_persist }
 
-      let(:services) do
+      let(:services_attributes) do
         [
           { title: { en: "First service" }, description: { en: "First description" } },
           { title: { en: "Second service" }, description: { en: "Second description" }, deleted: true },

--- a/decidim-meetings/spec/shared/services_interface_examples.rb
+++ b/decidim-meetings/spec/shared/services_interface_examples.rb
@@ -6,33 +6,21 @@ shared_examples_for "services interface" do
   describe "services" do
     let(:query) { '{ services { title { translation(locale:"en") } description { translation(locale:"en") } } }' }
 
-    before do
-      model.update(services: services)
-    end
-
     describe "when services is not present" do
-      let(:services) { nil }
-
       it "does not include the services" do
         expect(response["services"]).to eq([])
       end
     end
 
     describe "with some services" do
-      let(:services) do
-        [{
-          title: {
-            en: "Some title service"
-          },
-          description: {
-            en: "Some description service"
-          }
-        }]
-      end
+      let(:model) { create :meeting, :with_services }
+      let(:services) { model.services }
 
       it "includes the required data" do
-        expect(response["services"].first["title"]["translation"]).to eq(services.first[:title][:en])
-        expect(response["services"].first["description"]["translation"]).to eq(services.first[:description][:en])
+        expect(response["services"].first["title"]["translation"])
+          .to eq(services.first["title"]["en"])
+        expect(response["services"].first["description"]["translation"])
+          .to eq(services.first["description"]["en"])
       end
     end
   end

--- a/decidim-meetings/spec/system/meeting_spec.rb
+++ b/decidim-meetings/spec/system/meeting_spec.rb
@@ -6,14 +6,7 @@ describe "Meeting", type: :system do
   include_context "with a component"
   let(:manifest_name) { "meetings" }
 
-  let(:services) do
-    [
-      { title: Decidim::Faker::Localized.sentence(2), description: Decidim::Faker::Localized.sentence(5) },
-      { title: Decidim::Faker::Localized.sentence(2), description: Decidim::Faker::Localized.sentence(5) }
-    ]
-  end
-
-  let(:meeting) { create :meeting, services: services, component: component }
+  let(:meeting) { create :meeting, :with_services, component: component }
   let!(:user) { create :user, :confirmed, organization: organization }
 
   def visit_meeting
@@ -25,9 +18,9 @@ describe "Meeting", type: :system do
       visit_meeting
 
       within ".view-side .card--list" do
-        expect(page).to have_selector(".card--list__item", count: services.size)
+        expect(page).to have_selector(".card--list__item", count: meeting.services.size)
 
-        services_titles = services.map { |service| service[:title][:en] }
+        services_titles = meeting.services.map { |service| service.title["en"] }
         services_present_in_pages = current_scope.all(".card--list__heading").map(&:text)
         expect(services_titles).to include(*services_present_in_pages)
       end
@@ -35,7 +28,7 @@ describe "Meeting", type: :system do
   end
 
   context "when component is not commentable" do
-    let!(:ressources) { create_list(:meeting, 3, services: services, component: component) }
+    let!(:ressources) { create_list(:meeting, 3, :with_services, component: component) }
 
     it_behaves_like "an uncommentable component"
   end


### PR DESCRIPTION
#### :tophat: What? Why?
As part of #6127, we need to move meeting services to their own table. 

This PR does that.

#### :pushpin: Related Issues
- Related to #6127


#### :clipboard: Subtasks
- [x] Create the model and table
- [x] Migrate data to the new table
- [x] Fix seeds and factories
- [x] Make sure the commands work as expected

### :camera: Screenshots (optional)
None
