### PR TITLE
Remove validation rule that detects long words

### DIFF
--- a/decidim-core/app/validators/etiquette_validator.rb
+++ b/decidim-core/app/validators/etiquette_validator.rb
@@ -27,8 +27,9 @@ class EtiquetteValidator < ActiveModel::EachValidator
     record.errors.add(attribute, options[:message] || :too_many_marks)
   end
 
+  # ensure no long words but prevent links to be checked
   def validate_long_words(record, attribute, value)
-    return if value.scan(/[A-z]{35,}/).empty?
+    return if value.gsub(%r{https?://\S+}, "").scan(/\S{35,}/).empty?
 
     record.errors.add(attribute, options[:message] || :long_words)
   end

--- a/decidim-core/app/validators/etiquette_validator.rb
+++ b/decidim-core/app/validators/etiquette_validator.rb
@@ -8,7 +8,6 @@ class EtiquetteValidator < ActiveModel::EachValidator
 
     validate_caps(record, attribute, value)
     validate_marks(record, attribute, value)
-    validate_long_words(record, attribute, value)
     validate_caps_first(record, attribute, value)
     validate_length(record, attribute, value)
   end
@@ -25,13 +24,6 @@ class EtiquetteValidator < ActiveModel::EachValidator
     return if value.scan(/[!?¡¿]{2,}/).empty?
 
     record.errors.add(attribute, options[:message] || :too_many_marks)
-  end
-
-  # ensure no long words but prevent links to be checked
-  def validate_long_words(record, attribute, value)
-    return if value.gsub(%r{https?://\S+}, "").scan(/\S{35,}/).empty?
-
-    record.errors.add(attribute, options[:message] || :long_words)
   end
 
   def validate_caps_first(record, attribute, value)

--- a/decidim-core/spec/validators/etiquette_validator_spec.rb
+++ b/decidim-core/spec/validators/etiquette_validator_spec.rb
@@ -49,9 +49,23 @@ describe EtiquetteValidator do
   end
 
   context "when the text has very long words" do
-    let(:body) { "This word is veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery long." }
+    context "and contains ascii chars" do
+      let(:body) { "This word is veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery long." }
 
-    it { is_expected.to be_invalid }
+      it { is_expected.to be_invalid }
+    end
+
+    context "and contains extended chars" do
+      let(:body) { "This word is veeeeeeeeeeeeeeéeeeeeeeeeeeeeeeeeeeeery long." }
+
+      it { is_expected.to be_invalid }
+    end
+
+    context "and long words are links" do
+      let(:body) { "This word is http://veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery.com https://veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery.com long." }
+
+      it { is_expected.to be_valid }
+    end
   end
 
   context "when the text is written starting in downcase" do

--- a/decidim-core/spec/validators/etiquette_validator_spec.rb
+++ b/decidim-core/spec/validators/etiquette_validator_spec.rb
@@ -52,13 +52,13 @@ describe EtiquetteValidator do
     context "and contains ascii chars" do
       let(:body) { "This word is veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery long." }
 
-      it { is_expected.to be_invalid }
+      it { is_expected.to be_valid }
     end
 
     context "and contains extended chars" do
       let(:body) { "This word is veeeeeeeeeeeeeeéeeeeeeeeeeeeeeeeeeeeery long." }
 
-      it { is_expected.to be_invalid }
+      it { is_expected.to be_valid }
     end
 
     context "and long words are links" do


### PR DESCRIPTION
#### :tophat: What? Why?

User content generated text (ie proposal) uses a regex validator to ensure that no words longer than 35 characters are written.
However, this has 2 problems:
1. Links should be ignored, there are links longer than 35 characters.
2. The current implementation does not check for words with non-ascii chars in it, for instance the word `supercalifragilisticoóspialidosoisalongword` passes the test just fine and it should be detected.

This PR should solve both problems.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Add tests

### :camera: Screenshots (optional)
![longlink](https://user-images.githubusercontent.com/1401520/86476521-fdb3c980-bd46-11ea-9562-cacb80bb0fa3.png)
