### PR TITLE
Polymorphic route support for ResourceLocatorPresenter

### DIFF
--- a/decidim-core/app/presenters/decidim/resource_locator_presenter.rb
+++ b/decidim-core/app/presenters/decidim/resource_locator_presenter.rb
@@ -2,6 +2,7 @@
 
 module Decidim
   # A presenter to get the url or path from a resource.
+  # resource - a record or array of nested records.
   class ResourceLocatorPresenter
     def initialize(resource)
       @resource = resource
@@ -26,7 +27,7 @@ module Decidim
     #
     # Returns a String.
     def url(options = {})
-      member_route("url", options.merge(host: resource.organization.host))
+      member_route("url", options.merge(host: target.organization.host))
     end
 
     # Builds the index path to the associated collection of resources.
@@ -53,7 +54,9 @@ module Decidim
     #
     # Returns a String.
     def show(options = {})
-      admin_route_proxy.send("#{member_route_name}_path", resource, options)
+      options.merge!(options_for_polymorphic)
+
+      admin_route_proxy.send("#{member_route_name}_path", target, options)
     end
 
     # Builds the admin edit path to the resource.
@@ -62,53 +65,93 @@ module Decidim
     #
     # Returns a String.
     def edit(options = {})
-      admin_route_proxy.send("edit_#{member_route_name}_path", resource, options)
+      options.merge!(options_for_polymorphic)
+
+      admin_route_proxy.send("edit_#{member_route_name}_path", target, options)
     end
 
     private
+
+    def polymorphic?
+      resource.is_a? Array
+    end
+
+    def target
+      if polymorphic?
+        resource.last
+      else
+        resource
+      end
+    end
 
     # Private: Build the route to the resource.
     #
     # Returns a String.
     def member_route(route_type, options)
-      route_proxy.send("#{member_route_name}_#{route_type}", resource, options)
+      options.merge!(options_for_polymorphic)
+
+      route_proxy.send("#{member_route_name}_#{route_type}", target, options)
     end
 
     # Private: Build the route to the associated collection of resources.
     #
     # Returns a String.
     def collection_route(route_type, options)
+      options.merge!(options_for_polymorphic)
+
       route_proxy.send("#{collection_route_name}_#{route_type}", options)
     end
 
     def admin_collection_route(route_type, options)
+      options.merge!(options_for_polymorphic)
+
       admin_route_proxy.send("#{collection_route_name}_#{route_type}", options)
     end
 
     def manifest
-      resource.try(:resource_manifest) ||
-        resource.class.try(:resource_manifest) ||
-        resource.class.try(:participatory_space_manifest)
+      target.try(:resource_manifest) ||
+        target.class.try(:resource_manifest) ||
+        target.class.try(:participatory_space_manifest)
     end
 
     def component
-      resource.component if resource.respond_to?(:component)
+      target.component if target.respond_to?(:component)
     end
 
     def member_route_name
-      manifest.route_name
+      if polymorphic?
+        polymorphic_member_route_name
+      else
+        manifest.route_name
+      end
+    end
+
+    def polymorphic_member_route_name
+      return unless polymorphic?
+
+      resource.map { |record| record.model_name.param_key }.join("_")
     end
 
     def collection_route_name
       member_route_name.pluralize
     end
 
+    def options_for_polymorphic
+      return {} unless polymorphic?
+
+      parent_resources = {}
+      (resource - [target]).each do |parent|
+        parent_resources["#{parent.model_name.param_key}_id"] = parent.id
+      end
+      parent_resources
+    end
+
     def route_proxy
-      @route_proxy ||= EngineRouter.main_proxy(component || resource)
+      @route_proxy ||= EngineRouter.main_proxy(component || target)
     end
 
     def admin_route_proxy
-      @admin_route_proxy ||= EngineRouter.admin_proxy(component || resource)
+      @admin_route_proxy ||= EngineRouter.admin_proxy(component || target)
     end
   end
 end

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -465,6 +465,11 @@ FactoryBot.define do
     end
   end
 
+  factory :nested_dummy_resource, class: "Decidim::DummyResources::NestedDummyResource" do
+    title { generate(:name) }
+    dummy_resource { create(:dummy_resource) }
+  end
+
   factory :coauthorable_dummy_resource, class: "Decidim::DummyResources::CoauthorableDummyResource" do
     title { generate(:name) }
     component { create(:component, manifest_name: "dummy") }

--- a/decidim-core/spec/presenters/decidim/resource_locator_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/resource_locator_presenter_spec.rb
@@ -54,6 +54,58 @@ module Decidim
       end
     end
 
+    context "with a polymorphic resource" do
+      let(:nested_resource) do
+        create(:nested_dummy_resource, id: 1, dummy_resource: resource)
+      end
+
+      describe "#url" do
+        subject { described_class.new([resource, nested_resource]).url }
+
+        it { is_expected.to eq("http://1.lvh.me/processes/my-process/f/1/dummy_resources/1/nested_dummy_resources/1") }
+
+        context "when specific port configured" do
+          before do
+            allow(ActionMailer::Base)
+              .to receive(:default_url_options)
+              .and_return(port: 3000)
+          end
+
+          it { is_expected.to eq("http://1.lvh.me:3000/processes/my-process/f/1/dummy_resources/1/nested_dummy_resources/1") }
+        end
+      end
+
+      describe "#path" do
+        subject { described_class.new([resource, nested_resource]).path }
+
+        it { is_expected.to eq("/processes/my-process/f/1/dummy_resources/1/nested_dummy_resources/1") }
+      end
+
+      describe "#index" do
+        subject { described_class.new([resource, nested_resource]).index }
+
+        it { is_expected.to eq("/processes/my-process/f/1/dummy_resources/1/nested_dummy_resources") }
+      end
+
+      describe "#admin_index" do
+        subject { described_class.new([resource, nested_resource]).admin_index }
+
+        it { is_expected.to start_with("/admin/participatory_processes/my-process/components/1/manage/dummy_resources/1/nested_dummy_resources") }
+      end
+
+      describe "#show" do
+        subject { described_class.new([resource, nested_resource]).show }
+
+        it { is_expected.to start_with("/admin/participatory_processes/my-process/components/1/manage/dummy_resources/1/nested_dummy_resources/1") }
+      end
+
+      describe "#edit" do
+        subject { described_class.new([resource, nested_resource]).edit }
+
+        it { is_expected.to start_with("/admin/participatory_processes/my-process/components/1/manage/dummy_resources/1/nested_dummy_resources/1/edit") }
+      end
+    end
+
     context "with a participatory_space" do
       describe "#url" do
         subject { described_class.new(participatory_process).url }

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
@@ -114,8 +114,6 @@ module Decidim
     class NestedDummyResource < ApplicationRecord
       include Decidim::Resourceable
       belongs_to :dummy_resource
-      has_one :component, through: :dummy_resource, foreign_key: "decidim_component_id", class_name: "Decidim::Component"
-      delegate :organization, :participatory_space, to: :component
     end
 
     class CoauthorableDummyResource < ApplicationRecord

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
@@ -29,6 +29,7 @@ module Decidim
         root to: proc { [200, {}, ["DUMMY ENGINE"]] }
 
         resources :dummy_resources do
+          resources :nested_dummy_resources
           get :foo, on: :member
         end
       end
@@ -38,6 +39,10 @@ module Decidim
       engine_name "dummy_admin"
 
       routes do
+        resources :dummy_resources do
+          resources :nested_dummy_resources
+        end
+
         root to: proc { [200, {}, ["DUMMY ADMIN ENGINE"]] }
       end
     end
@@ -104,6 +109,13 @@ module Decidim
                                               .where.not(author: nil)
                                               .pluck(:decidim_author_id).flatten.compact.uniq
       end
+    end
+
+    class NestedDummyResource < ApplicationRecord
+      include Decidim::Resourceable
+      belongs_to :dummy_resource
+      has_one :component, through: :dummy_resource, foreign_key: "decidim_component_id", class_name: "Decidim::Component"
+      delegate :organization, :participatory_space, to: :component
     end
 
     class CoauthorableDummyResource < ApplicationRecord
@@ -195,6 +207,11 @@ Decidim.register_component(:dummy) do |component|
     resource.searchable = true
   end
 
+  component.register_resource(:nested_dummy_resource) do |resource|
+    resource.name = :nested_dummy
+    resource.model_class_name = "Decidim::DummyResources::NestedDummyResource"
+  end
+
   component.register_resource(:coauthorable_dummy_resource) do |resource|
     resource.name = :coauthorable_dummy
     resource.model_class_name = "Decidim::DummyResources::CoauthorableDummyResource"
@@ -243,6 +260,15 @@ RSpec.configure do |config|
           t.references :decidim_scope, index: false
           t.string :reference
 
+          t.timestamps
+        end
+      end
+      unless ActiveRecord::Base.connection.data_source_exists?("decidim_dummy_resources_nested_dummy_resources")
+        ActiveRecord::Migration.create_table :decidim_dummy_resources_nested_dummy_resources do |t|
+          t.jsonb :translatable_text
+          t.string :title
+
+          t.references :dummy_resource, index: false
           t.timestamps
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

While developing the "Budget component with many budgets" the Budget component has `:budget` registered as a resource and `:projects` as its nested resource, when needed to link to a `:project` from another engine (cell) the `ResourceLocatorPresenter` was not able to generate the appropriate path name.

So with this PR, it will be possible to generate a link for nested resources when passing an array of resources as an argument:

```rb
# return a route for a resource
resource_locator(budget).path
# => "/processes/ad-sunt/f/4/budgets/1"

# return a route for a nested resource
resource_locator([project.budget, project]).path
# => "/processes/ad-sunt/f/4/budgets/1/projects/1"
```

#### :pushpin: Related Issues
- Related to #6223

#### :clipboard: Subtasks
- [x] Add tests

### :camera: Screenshots (optional)
![Description](URL)
