### PR TITLE
Make comments handle i18n

### DIFF
--- a/decidim-accountability/spec/system/explore_results_spec.rb
+++ b/decidim-accountability/spec/system/explore_results_spec.rb
@@ -171,7 +171,7 @@ describe "Explore results", versioning: true, type: :system do
 
       it "shows the comments" do
         comments.each do |comment|
-          expect(page).to have_content(comment.body)
+          expect(page).to have_content(comment.body.values.first)
         end
       end
     end

--- a/decidim-comments/app/commands/decidim/comments/create_comment.rb
+++ b/decidim-comments/app/commands/decidim/comments/create_comment.rb
@@ -37,7 +37,7 @@ module Decidim
           author: @author,
           commentable: form.commentable,
           root_commentable: root_commentable(form.commentable),
-          body: parsed.rewrite,
+          body: { I18n.locale => parsed.rewrite },
           alignment: form.alignment,
           decidim_user_group_id: form.user_group_id
         }

--- a/decidim-comments/app/models/decidim/comments/comment.rb
+++ b/decidim-comments/app/models/decidim/comments/comment.rb
@@ -158,7 +158,7 @@ module Decidim
       # Private: Returns the comment body sanitized, sanitizing HTML tags
       def sanitized_body
         Rails::Html::WhiteListSanitizer.new.sanitize(
-          render_markdown(body),
+          render_markdown(body.values.first),
           scrubber: Decidim::Comments::UserInputScrubber.new
         ).try(:html_safe)
       end

--- a/decidim-comments/app/models/decidim/comments/comment.rb
+++ b/decidim-comments/app/models/decidim/comments/comment.rb
@@ -14,6 +14,8 @@ module Decidim
       include Decidim::Traceable
       include Decidim::Loggable
 
+      include Decidim::TranslatableAttributes
+
       # Limit the max depth of a comment tree. If C is a comment and R is a reply:
       # C          (depth 0)
       # |--R       (depth 1)
@@ -124,6 +126,10 @@ module Decidim
         root_commentable.can_participate?(user)
       end
 
+      def translated_body
+        translated_attribute(body)
+      end
+
       private
 
       def body_length
@@ -158,7 +164,7 @@ module Decidim
       # Private: Returns the comment body sanitized, sanitizing HTML tags
       def sanitized_body
         Rails::Html::WhiteListSanitizer.new.sanitize(
-          render_markdown(body.values.first),
+          render_markdown(translated_body),
           scrubber: Decidim::Comments::UserInputScrubber.new
         ).try(:html_safe)
       end

--- a/decidim-comments/app/models/decidim/comments/seed.rb
+++ b/decidim-comments/app/models/decidim/comments/seed.rb
@@ -25,7 +25,7 @@ module Decidim
           params = {
             commentable: resource,
             root_commentable: resource,
-            body: ::Faker::Lorem.sentence(50),
+            body: { en: ::Faker::Lorem.sentence(50) },
             author: author,
             user_group: user_group
           }

--- a/decidim-comments/db/migrate/20200706123136_make_comments_handle_i18n.rb
+++ b/decidim-comments/db/migrate/20200706123136_make_comments_handle_i18n.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class MakeCommentsHandleI18n < ActiveRecord::Migration[5.2]
+  class User < ApplicationRecord
+    self.table_name = :decidim_users
+  end
+
+  class Comment < ApplicationRecord
+    self.table_name = :decidim_comments_comments
+  end
+
+  class Organization < ApplicationRecord
+    self.table_name = :decidim_organizations
+  end
+
+  def change
+    add_column :decidim_comments_comments, :new_body, :jsonb
+
+    User.reset_column_information
+    Comment.reset_column_information
+    Organization.reset_column_information
+
+    Comment.find_each do |comment|
+      locale, org_id = User.where(id: comment.decidim_author_id).pluck(:locale, :decidim_organization_id).first
+      locale = locale.presence ||
+        Organization.find(org_id).default_locale
+
+      comment.new_body = {
+        locale => comment.body
+      }
+
+      comment.save!
+    end
+
+    remove_column :decidim_comments_comments, :body
+    rename_column :decidim_comments_comments, :new_body, :body
+
+    User.reset_column_information
+    Comment.reset_column_information
+    Organization.reset_column_information
+  end
+end

--- a/decidim-comments/db/migrate/20200706123136_make_comments_handle_i18n.rb
+++ b/decidim-comments/db/migrate/20200706123136_make_comments_handle_i18n.rb
@@ -22,8 +22,7 @@ class MakeCommentsHandleI18n < ActiveRecord::Migration[5.2]
 
     Comment.find_each do |comment|
       locale, org_id = User.where(id: comment.decidim_author_id).pluck(:locale, :decidim_organization_id).first
-      locale = locale.presence ||
-        Organization.find(org_id).default_locale
+      locale = locale.presence || Organization.find(org_id).default_locale
 
       comment.new_body = {
         locale => comment.body

--- a/decidim-comments/lib/decidim/comments/api/comment_type.rb
+++ b/decidim-comments/lib/decidim/comments/api/comment_type.rb
@@ -25,7 +25,11 @@ module Decidim
         }
       end
 
-      field :body, !types.String, "The comment message"
+      field :body, !types.String, "The comment message" do
+        resolve lambda { |obj, _args, _ctx|
+          obj.body.values.first
+        }
+      end
 
       field :formattedBody, !types.String, "The comment message ready to display (it is expected to include HTML)", property: :formatted_body
 

--- a/decidim-comments/lib/decidim/comments/api/comment_type.rb
+++ b/decidim-comments/lib/decidim/comments/api/comment_type.rb
@@ -27,7 +27,7 @@ module Decidim
 
       field :body, !types.String, "The comment message" do
         resolve lambda { |obj, _args, _ctx|
-          obj.body.values.first
+          obj.translated_body
         }
       end
 

--- a/decidim-comments/lib/decidim/comments/comment_serializer.rb
+++ b/decidim-comments/lib/decidim/comments/comment_serializer.rb
@@ -11,7 +11,8 @@ module Decidim
         {
           id: resource.id,
           created_at: resource.created_at,
-          body: resource.body,
+          body: resource.body.values.first,
+          locale: resource.body.keys.first,
           author: {
             id: resource.author.id,
             name: resource.author.name

--- a/decidim-comments/lib/decidim/comments/test/factories.rb
+++ b/decidim-comments/lib/decidim/comments/test/factories.rb
@@ -9,6 +9,14 @@ FactoryBot.define do
     root_commentable { commentable }
     body { Faker::Lorem.paragraph }
 
+    after(:build) do |comment, evaluator|
+      comment.body = if evaluator.body.is_a?(String)
+                       { comment.root_commentable.organization.default_locale || "en" => evaluator.body }
+                     else
+                       evaluator.body
+                     end
+    end
+
     trait :comment_on_comment do
       author { build(:user, organization: root_commentable.organization) }
       commentable do

--- a/decidim-comments/spec/cells/decidim/comments/comment_activity_cell_spec.rb
+++ b/decidim-comments/spec/cells/decidim/comments/comment_activity_cell_spec.rb
@@ -22,14 +22,14 @@ module Decidim::Comments
         html = cell("decidim/comments/comment_activity", action_log).call
         expect(html).to have_css(".card__content")
         expect(html).to have_content("New comment at #{comment.root_commentable.title}")
-        expect(html).to have_content(comment.body)
+        expect(html).to have_content(comment.body.values.first)
       end
 
       context "when the comment has mentions" do
         before do
           body = "Comment mentioning some user, @#{comment.author.nickname}"
           parsed_body = Decidim::ContentProcessor.parse(body, current_organization: comment.organization)
-          comment.body = parsed_body.rewrite
+          comment.body = { en: parsed_body.rewrite }
           comment.save
         end
 
@@ -57,7 +57,7 @@ module Decidim::Comments
           html = cell("decidim/comments/comment_activity", action_log).call
           expect(html).to have_css(".card__content")
           expect(html).to have_content("New comment at #{comment.root_commentable.title}")
-          expect(html).to have_content(comment.body)
+          expect(html).to have_content(comment.body.values.first)
         end
       end
     end

--- a/decidim-comments/spec/commands/create_comment_spec.rb
+++ b/decidim-comments/spec/commands/create_comment_spec.rb
@@ -52,7 +52,7 @@ module Decidim
               author: author,
               commentable: commentable,
               root_commentable: commentable,
-              body: body,
+              body: { en: body },
               alignment: alignment,
               decidim_user_group_id: user_group_id
             ).and_call_original
@@ -117,7 +117,7 @@ module Decidim
                 author: author,
                 commentable: commentable,
                 root_commentable: commentable,
-                body: Decidim::ContentProcessor.parse(body, parser_context).rewrite,
+                body: { en: Decidim::ContentProcessor.parse(body, parser_context).rewrite },
                 alignment: alignment,
                 decidim_user_group_id: user_group_id
               ).and_call_original
@@ -152,7 +152,7 @@ module Decidim
                 author: author,
                 commentable: commentable,
                 root_commentable: commentable,
-                body: Decidim::ContentProcessor.parse(body, parser_context).rewrite,
+                body: { en: Decidim::ContentProcessor.parse(body, parser_context).rewrite },
                 alignment: alignment,
                 decidim_user_group_id: user_group_id
               ).and_call_original

--- a/decidim-comments/spec/events/decidim/comments/user_group_mentioned_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/user_group_mentioned_event_spec.rb
@@ -20,7 +20,7 @@ describe Decidim::Comments::UserGroupMentionedEvent do
   before do
     body = "Comment mentioning some user group, @#{group.nickname}"
     parsed_body = Decidim::ContentProcessor.parse(body, current_organization: comment.organization)
-    comment.body = parsed_body.rewrite
+    comment.body = { en: parsed_body.rewrite }
     comment.save
   end
 

--- a/decidim-comments/spec/events/decidim/comments/user_mentioned_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/user_mentioned_event_spec.rb
@@ -10,7 +10,7 @@ describe Decidim::Comments::UserMentionedEvent do
   before do
     body = "Comment mentioning some user, @#{comment.author.nickname}"
     parsed_body = Decidim::ContentProcessor.parse(body, current_organization: comment.organization)
-    comment.body = parsed_body.rewrite
+    comment.body = { en: parsed_body.rewrite }
     comment.save
   end
 

--- a/decidim-comments/spec/lib/decidim/comments/comment_serializer_spec.rb
+++ b/decidim-comments/spec/lib/decidim/comments/comment_serializer_spec.rb
@@ -18,7 +18,11 @@ module Decidim
         end
 
         it "includes the body" do
-          expect(subject.serialize).to include(body: comment.body)
+          expect(subject.serialize).to include(body: comment.body.values.first)
+        end
+
+        it "includes the body locale" do
+          expect(subject.serialize).to include(locale: comment.body.keys.first)
         end
 
         it "includes the author" do

--- a/decidim-comments/spec/models/comment_spec.rb
+++ b/decidim-comments/spec/models/comment_spec.rb
@@ -24,6 +24,18 @@ module Decidim
         expect(comment).to be_valid
       end
 
+      it "is valid with a string as the body" do
+        new_comment = build(:comment, body: "Hey this is a comment")
+        expect(new_comment).to be_valid
+        expect(new_comment.body).to eq("en" => "Hey this is a comment")
+      end
+
+      it "is valid with a string as the body" do
+        new_comment = build(:comment, body: { en:  "Hey this is a comment" })
+        expect(new_comment).to be_valid
+        expect(new_comment.body).to eq("en" => "Hey this is a comment")
+      end
+
       it "has an associated commentable" do
         expect(comment.commentable).to eq(commentable)
       end

--- a/decidim-comments/spec/models/comment_spec.rb
+++ b/decidim-comments/spec/models/comment_spec.rb
@@ -30,8 +30,8 @@ module Decidim
         expect(new_comment.body).to eq("en" => "Hey this is a comment")
       end
 
-      it "is valid with a string as the body" do
-        new_comment = build(:comment, body: { en:  "Hey this is a comment" })
+      it "is valid with a hash as the body" do
+        new_comment = build(:comment, body: { en: "Hey this is a comment" })
         expect(new_comment).to be_valid
         expect(new_comment.body).to eq("en" => "Hey this is a comment")
       end

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -22,7 +22,7 @@ shared_examples "comments" do
     within "#comments" do
       comments.each do |comment|
         expect(page).to have_content comment.author.name
-        expect(page).to have_content comment.body
+        expect(page).to have_content comment.body.values.first
       end
     end
   end

--- a/decidim-proposals/spec/system/collaborative_drafts_spec.rb
+++ b/decidim-proposals/spec/system/collaborative_drafts_spec.rb
@@ -170,7 +170,7 @@ describe "Explore Collaborative Drafts", versioning: true, type: :system do
 
         it "shows the comments" do
           comments.each do |comment|
-            expect(page).to have_content(comment.body)
+            expect(page).to have_content(comment.body.values.first)
           end
         end
       end

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -158,7 +158,7 @@ describe "Proposals", type: :system do
         click_link proposal.title
 
         comments.each do |comment|
-          expect(page).to have_content(comment.body)
+          expect(page).to have_content(comment.body.values.first)
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
In order for #6127 to work, we need to port some resources to our i18n fields system. In this case, I'm porting comments. This PR doesn't change anything for the user, it's an internal refactor so that we can send the comments to the machine translation system.

This PR converts the `body` field into a JSONB. In order to do that, it assumes the text is in the author locale, or the organization's default locale if missing.

#### :pushpin: Related Issues
- Related to #6127

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None
