### PR TITLE
Fix admin initiative's answer redirection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ After this, `Decidim::Proposals::ProposalEndorsement` and the corresponding coun
 
 ### Fixed
 
+- **decidim-initiatives**: Fix initiative answer redirection in case of invalid form [\#6279](https://github.com/decidim/decidim/pull/6279)
 - **decidim-comments**: Fix comments JS errors and delays [\#6193](https://github.com/decidim/decidim/pull/6193)
 - **decidim-elections**: Improve navigation consistency in the admin zone for elections questions and answers [\#6139](https://github.com/decidim/decidim/pull/6139)
 - **decidim-participatory_processes**: Fix rubocop errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ After this, `Decidim::Proposals::ProposalEndorsement` and the corresponding coun
 
 ### Fixed
 
-- **decidim-initiatives**: Fix initiative answer redirection in case of invalid form [\#6279](https://github.com/decidim/decidim/pull/6279)
 - **decidim-comments**: Fix comments JS errors and delays [\#6193](https://github.com/decidim/decidim/pull/6193)
 - **decidim-elections**: Improve navigation consistency in the admin zone for elections questions and answers [\#6139](https://github.com/decidim/decidim/pull/6139)
 - **decidim-participatory_processes**: Fix rubocop errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/answers_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/answers_controller.rb
@@ -24,7 +24,6 @@ module Decidim
         def update
           enforce_permission_to :answer, :initiative, initiative: current_initiative
 
-          params[:id] = params[:slug]
           @form = form(Decidim::Initiatives::Admin::InitiativeAnswerForm)
                   .from_params(params, initiative: current_initiative)
 
@@ -35,8 +34,8 @@ module Decidim
             end
 
             on(:invalid) do
-              flash.now[:alert] = I18n.t("initiatives.update.error", scope: "decidim.initiatives.admin")
-              render :edit
+              flash[:alert] = I18n.t("initiatives.update.error", scope: "decidim.initiatives.admin")
+              redirect_to edit_initiative_answer_path
             end
           end
         end

--- a/decidim-initiatives/spec/system/admin/answer_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/admin/answer_initiative_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe "User answers the initiative", type: :system do
   include_context "when admins initiative"
 
-  def submit_and_validate(message="successfully")
+  def submit_and_validate(message = "successfully")
     find("*[type=submit]").click
 
     within ".callout-wrapper" do

--- a/decidim-initiatives/spec/system/admin/answer_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/admin/answer_initiative_spec.rb
@@ -5,11 +5,11 @@ require "spec_helper"
 describe "User answers the initiative", type: :system do
   include_context "when admins initiative"
 
-  def submit_and_validate
+  def submit_and_validate(message="successfully")
     find("*[type=submit]").click
 
     within ".callout-wrapper" do
-      expect(page).to have_content("successfully")
+      expect(page).to have_content(message)
     end
   end
 
@@ -58,24 +58,49 @@ describe "User answers the initiative", type: :system do
         initiative.published!
       end
 
-      it "signature dates can be edited in answer" do
-        page.find(".action-icon--answer").click
+      context "and signature dates are editable" do
+        it "can be edited in answer" do
+          page.find(".action-icon--answer").click
 
-        within ".edit_initiative_answer" do
-          fill_in_i18n_editor(
-            :initiative_answer,
-            "#initiative-answer-tabs",
-            en: "An answer",
-            es: "Una respuesta",
-            ca: "Una resposta"
-          )
-          expect(page).to have_css("#initiative_signature_start_date")
-          expect(page).to have_css("#initiative_signature_end_date")
+          within ".edit_initiative_answer" do
+            fill_in_i18n_editor(
+              :initiative_answer,
+              "#initiative-answer-tabs",
+              en: "An answer",
+              es: "Una respuesta",
+              ca: "Una resposta"
+            )
+            expect(page).to have_css("#initiative_signature_start_date")
+            expect(page).to have_css("#initiative_signature_end_date")
 
-          fill_in :initiative_signature_start_date, with: 1.day.ago
+            fill_in :initiative_signature_start_date, with: 1.day.ago
+          end
+
+          submit_and_validate
         end
 
-        submit_and_validate
+        context "when dates are invalid" do
+          it "returns an error message" do
+            page.find(".action-icon--answer").click
+
+            within ".edit_initiative_answer" do
+              fill_in_i18n_editor(
+                :initiative_answer,
+                "#initiative-answer-tabs",
+                en: "An answer",
+                es: "Una respuesta",
+                ca: "Una resposta"
+              )
+              expect(page).to have_css("#initiative_signature_start_date")
+              expect(page).to have_css("#initiative_signature_end_date")
+
+              fill_in :initiative_signature_start_date, with: 1.month.since(initiative.signature_end_date)
+            end
+
+            submit_and_validate("error")
+            expect(page).to have_current_path decidim_admin_initiatives.edit_initiative_answer_path(initiative)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

When an admin answers to an initiative, with an invalid form, he / she is not redirected to the answer edit route. Then if the admin tries to submit again, a 404 error append. 

### Current behaviour
1. Administrator comes on initiative answer route `/admin/initiatives/:id/answer/edit` from `answers_controller#edit`
2. Edit the answer form
3. In case of invalid answer form, he / she is redirected back to the answer form with path `/admin/initiatives/:id/answer` ( I guess `answers_controller#update` )
4. If the administrator update the invalid fields from the form and submit again, then a 404 error occurs "No route matches [POST] "/admin/initiatives/:id/answer""

### Wanted behaviour
1. Administrator comes on initiative answer route `/admin/initiatives/:id/answer/edit` from `answers_controller#edit`
2. In case of invalid answer form, to be redirected to `/admin/initiatives/:id/answer/edit` from `answers_controller#edit`
3. Administrator can update the invalid fields and submit again

### 🔁 Step to reproduce 
1. Go to the initiatives index in backoffice
2. Answer a published initiative
3. Select a `signature_start_date` superior to `signature_end_date` ( Invalid field )
4. Submit
5. The current path should have changed from `/admin/initiatives/:id/answer/edit` to `/admin/initiatives/:id/answer`
6. Choose a valid `signature_start_date`
7. Submit the answer form again

#### :clipboard: Subtasks
- [x] Update answer#update method
- [x] Add tests

#### 📷 Screenshots 
<img width="510" alt="decidim_initiatives_answer_form" src="https://user-images.githubusercontent.com/26109239/86798588-39190580-c071-11ea-8ac4-6be60e8b813b.png">

