### PR TITLE
Setup profiling tooling

### DIFF
--- a/decidim-dev/lib/tasks/generators.rake
+++ b/decidim-dev/lib/tasks/generators.rake
@@ -44,7 +44,8 @@ namespace :decidim do
         "..",
         "--recreate_db",
         "--seed_db",
-        "--demo"
+        "--demo",
+        "--profiling"
       )
     end
   end

--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -61,6 +61,10 @@ module Decidim
                           default: false,
                           desc: "Generate demo authorization handlers"
 
+      class_option :profiling, type: :boolean,
+                               default: false,
+                               desc: "Add the necessary gems to profile the app"
+
       def database_yml
         template "database.yml.erb", "config/database.yml", force: true
       end
@@ -192,7 +196,8 @@ module Decidim
             "--recreate_db=#{options[:recreate_db]}",
             "--seed_db=#{options[:seed_db]}",
             "--skip_gemfile=#{options[:skip_gemfile]}",
-            "--app_name=#{app_name}"
+            "--app_name=#{app_name}",
+            "--profiling=#{options[:profiling]}"
           ]
         )
       end

--- a/decidim-generators/lib/decidim/generators/app_templates/bullet_initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/bullet_initializer.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+if defined?(Bullet)
+  Rails.application.config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.rails_logger = true
+    Bullet.stacktrace_includes = %w(
+      decidim-accountability
+      decidim-admin
+      decidim-api
+      decidim-assemblies
+      decidim-blogs
+      decidim-budgets
+      decidim-comments
+      decidim-conferences
+      decidim-consultations
+      decidim-core
+      decidim-debates
+      decidim-dev
+      decidim-elections
+      decidim-forms
+      decidim-generators
+      decidim-initiatives
+      decidim-meetings
+      decidim-pages
+      decidim-participatory_processes
+      decidim-proposals
+      decidim-sortitions
+      decidim-surveys
+      decidim-system
+      decidim-verifications
+    )
+  end
+end

--- a/decidim-generators/lib/decidim/generators/app_templates/bullet_initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/bullet_initializer.rb
@@ -5,31 +5,6 @@ if defined?(Bullet)
     Bullet.enable = true
     Bullet.bullet_logger = true
     Bullet.rails_logger = true
-    Bullet.stacktrace_includes = %w(
-      decidim-accountability
-      decidim-admin
-      decidim-api
-      decidim-assemblies
-      decidim-blogs
-      decidim-budgets
-      decidim-comments
-      decidim-conferences
-      decidim-consultations
-      decidim-core
-      decidim-debates
-      decidim-dev
-      decidim-elections
-      decidim-forms
-      decidim-generators
-      decidim-initiatives
-      decidim-meetings
-      decidim-pages
-      decidim-participatory_processes
-      decidim-proposals
-      decidim-sortitions
-      decidim-surveys
-      decidim-system
-      decidim-verifications
-    )
+    Bullet.stacktrace_includes = %w(decidim-)
   end
 end

--- a/decidim-generators/lib/decidim/generators/app_templates/rack_profiler_initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/rack_profiler_initializer.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+if Rails.env.development?
+  require "rack-mini-profiler"
+
+  # initialization is skipped so trigger it
+  Rack::MiniProfilerRails.initialize!(Rails.application)
+end

--- a/decidim-generators/lib/decidim/generators/install_generator.rb
+++ b/decidim-generators/lib/decidim/generators/install_generator.rb
@@ -30,6 +30,10 @@ module Decidim
                                   default: false,
                                   desc: "Don't generate a Gemfile for the application"
 
+      class_option :profiling, type: :boolean,
+                               default: false,
+                               desc: "Add the necessary gems to profile the app"
+
       def install
         route "mount Decidim::Core::Engine => '/'"
       end
@@ -100,6 +104,25 @@ module Decidim
             |  }
           RUBY
         end
+      end
+
+      def profiling_gems
+        return unless options[:profiling]
+
+        append_file "Gemfile", <<~RUBY
+
+          group :development do
+            # Profiling gems
+            gem "bullet"
+            gem "flamegraph"
+            gem "memory_profiler"
+            gem "rack-mini-profiler", require: false
+            gem "stackprof"
+          end
+        RUBY
+
+        copy_file "bullet_initializer.rb", "config/initializers/bullet.rb"
+        copy_file "rack_profiler_initializer.rb", "config/initializers/rack_profiler.rb"
       end
 
       def copy_migrations

--- a/docs/advanced/profiling.md
+++ b/docs/advanced/profiling.md
@@ -1,0 +1,43 @@
+# How to profile a Decidim app
+
+The developmen_app includes a bunch of gems that profile the application. Run the following command in the decidim root's folder:
+
+```bash
+bundle exec rake development_app
+```
+
+and then move into it and boot the server
+
+```bash
+cd developmen_app
+bundle exec rails s
+```
+
+## Bullet
+
+Bullet detects N+1 queries and suggests how to fix them, although it doesn't catch them all. It's currently configured in `config/initializers/bullet.rb` to log in the regular rails log and also in its own `log/bullet.log`. You'll now see entries like the following:
+
+```bash
+user: xxx
+GET /
+USE eager loading detected
+  Decidim::Comments::Comment => [:author]
+  Add to your query: .includes([:author])
+Call stack
+```
+
+It also warns you when there's an unnecessary eager load.
+
+More details: https://github.com/flyerhzm/bullet
+
+## Rack-mini-profiler
+
+This gem can analyze memory, database, and call stack with flamegraphs. It will show up in development on the top left corner and it gives you all sorts of profiling insights about that page. It'll tell you where the response time was spend on in the call stack.
+
+This gem is further enhanced with the `flamegraph`, `stackprof` and `memory_profiler` gems which provide more detailed analysis. Try out by appending `?pp=flamegraph`, `?pp=profile-gc` or `?pp=analyze-memory` to the URL. You can read more about these options at https://github.com/MiniProfiler/rack-mini-profiler#flamegraphs.
+
+More details: https://github.com/MiniProfiler/rack-mini-profiler
+
+## Profiling best practices
+
+You need to take the insights of these gems with a grain of salt though, if you run this in development. Rails' development settings have nothing to do with a production set up where classes are not reloaded and assets are precompiled and served from a web server. Therefore, you should mimic these settings as much as possible if you want your findings to be realistic.


### PR DESCRIPTION
#### :tophat: What? Why?

This adds a bunch of profiling gems that are very useful when debugging performance issues. From now on, the development_app will come with these configured.

This stems from the work we're doing on Future of Europe. From the insights collected by these gems we can then open PRs to tackle individual issues.

[Bullet](https://github.com/flyerhzm/bullet) detects N+1 queries and suggests how to fix them, although it doesn't catch them all. You'll now see entries like the following in your logs

```
    user: pau
    GET /
    USE eager loading detected
      Decidim::Comments::Comment => [:author]
      Add to your query: .includes([:author])
    Call stack
      /home/pau/dev/decidim/decidim-core/lib/decidim/authorable.rb:32:in `normalized_author'
      /home/pau/dev/decidim/decidim-core/app/cells/decidim/activity_cell.rb:77:in `user'
```

On the other hand, [rack-mini-profiler](https://github.com/MiniProfiler/rack-mini-profiler) can analyze memory, database, and call stack with flamegraphs. It will show up in development on the top left corner and it gives you all sorts of insights about that page. See screenshots below.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
~- [ ] Add `CHANGELOG` upgrade notes, if required~
~- [ ] If there's a new public field, add it to GraphQL API~
~- [ ] Add/modify seeds~
~- [ ] Add tests~
- [x] Add documentation regarding the feature 

### :camera: Screenshots (optional)

![Screenshot from 2020-07-07 16-36-22](https://user-images.githubusercontent.com/762088/86797514-0b7f8c80-c070-11ea-86e7-6b51848effcf.png)

![Screenshot from 2020-07-07 16-36-34](https://user-images.githubusercontent.com/762088/86797547-1508f480-c070-11ea-987b-4782edc12da6.png)
