### PR TITLE
Remove duplicated locales in debates i18n fields

### DIFF
--- a/decidim-debates/db/migrate/20200708072042_fix_debates_i18n_fields.rb
+++ b/decidim-debates/db/migrate/20200708072042_fix_debates_i18n_fields.rb
@@ -16,9 +16,7 @@ class FixDebatesI18nFields < ActiveRecord::Migration[5.2]
   def change
     reset_column_information
 
-    Debate.find_each do |debate|
-      next if debate.decidim_author_type == "Decidim::Organization"
-
+    debates.find_each do |debate|
       locale, org_id = User.where(id: debate.decidim_author_id).pluck(:locale, :decidim_organization_id).first
       locale = locale.presence || Organization.find(org_id).default_locale
       locale = locale.to_s
@@ -30,10 +28,16 @@ class FixDebatesI18nFields < ActiveRecord::Migration[5.2]
         locale => debate.description[locale]
       }
 
-      debate.save!
+      debate.save!(validate: false)
     end
 
     reset_column_information
+  end
+
+  def debates
+    Debate
+      .where.not(decidim_author_type: "Decidim::Organization")
+      .select(:id, :decidim_author_id, :title, :description)
   end
 
   def reset_column_information

--- a/decidim-debates/db/migrate/20200708072042_fix_debates_i18n_fields.rb
+++ b/decidim-debates/db/migrate/20200708072042_fix_debates_i18n_fields.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class FixDebatesI18nFields < ActiveRecord::Migration[5.2]
+  class User < ApplicationRecord
+    self.table_name = :decidim_users
+  end
+
+  class Debate < ApplicationRecord
+    self.table_name = :decidim_debates_debates
+  end
+
+  class Organization < ApplicationRecord
+    self.table_name = :decidim_organizations
+  end
+
+  def change
+    reset_column_information
+
+    Debate.find_each do |debate|
+      next if debate.decidim_author_type == "Decidim::Organization"
+
+      locale, org_id = User.where(id: debate.decidim_author_id).pluck(:locale, :decidim_organization_id).first
+      locale = locale.presence || Organization.find(org_id).default_locale
+      locale = locale.to_s
+
+      debate.title = {
+        locale => debate.title[locale]
+      }
+      debate.description = {
+        locale => debate.description[locale]
+      }
+
+      debate.save!
+    end
+
+    reset_column_information
+  end
+
+  def reset_column_information
+    User.reset_column_information
+    Debate.reset_column_information
+    Organization.reset_column_information
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
On #6268 we found out that when a user creates a debate from the public area, the same title and description are persisted for all locales. This is useless, because our translation helpers already handle that case, and it creates a problem for #6127. This only affects debates created from the public side. Debates created from the admin area are not affected.

This PR follows the spirit of #6276 in the sense that it's fixing fields so that #6127 will work as expected.

I've tried it locally:

A debate created before applying this PR:

![image](https://user-images.githubusercontent.com/491891/86892266-50eb9a80-c100-11ea-94c1-b85c2814d411.png)

The same debate after applying this PR:

![image](https://user-images.githubusercontent.com/491891/86892298-5e088980-c100-11ea-8177-db04a0997cb6.png)

Note that this PR only affects de debate title and description, which are the only translatable fields that can be set by a user from the public side. Admins can set more fields, but admin-created debates are not affected by the issue.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None
