### PR TITLE
Fix linter on recipient counter text for newsletter helper

### DIFF
--- a/decidim-admin/app/helpers/decidim/admin/newsletters_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/newsletters_helper.rb
@@ -141,7 +141,7 @@ module Decidim
       end
 
       def newsletter_recipients_count_callout_args
-        spinner = %Q{<span id="recipients_count_spinner" class="loading-spinner hide"></span>}
+        spinner = "<span id='recipients_count_spinner' class='loading-spinner hide'></span>"
         body = "#{t("recipients_count", scope: "decidim.admin.newsletters.select_recipients_to_deliver", count: recipients_count_query)} #{spinner}"
         {
           announcement: {


### PR DESCRIPTION
#### :tophat: What? Why?
After merging #6258 a linter error on recipient counter label has raised in `develop` due to different rubocop versions.
This PR fixes this.

#### :pushpin: Related Issues
- Fixes #6258 

