### PR TITLE
[WIP] Fixes and improvements for questionnaire exports

### DIFF
--- a/decidim-core/app/jobs/decidim/export_job.rb
+++ b/decidim-core/app/jobs/decidim/export_job.rb
@@ -11,10 +11,11 @@ module Decidim
 
       collection = export_manifest.collection.call(component, user)
       serializer = export_manifest.serializer
+      options    = export_manifest.options
 
       export_data = Decidim::Exporters.find_exporter(format).new(collection, serializer).export
 
-      ExportMailer.export(user, name, export_data).deliver_now
+      ExportMailer.export(user, name, export_data, options).deliver_now
     end
   end
 end

--- a/decidim-core/app/jobs/decidim/export_job.rb
+++ b/decidim-core/app/jobs/decidim/export_job.rb
@@ -11,7 +11,7 @@ module Decidim
 
       collection = export_manifest.collection.call(component, user)
       serializer = export_manifest.serializer
-      options    = export_manifest.options
+      options = export_manifest.options
 
       export_data = Decidim::Exporters.find_exporter(format).new(collection, serializer).export
 

--- a/decidim-core/app/mailers/decidim/export_mailer.rb
+++ b/decidim-core/app/mailers/decidim/export_mailer.rb
@@ -10,16 +10,21 @@ module Decidim
     # user        - The user to be notified.
     # export_name - The name of the export.
     # export_data - The data containing the result of the export.
+    # options     - Options regarding the export (zip: whether to send the attachment compressed in a .zip file).
     #
     # Returns nothing.
-    def export(user, export_name, export_data)
+    def export(user, export_name, export_data, options = { zip: true })
       @user = user
       @organization = user.organization
 
       filename = export_data.filename(export_name)
       filename_without_extension = export_data.filename(export_name, extension: false)
 
-      attachments["#{filename_without_extension}.zip"] = FileZipper.new(filename, export_data.read).zip
+      if options[:zip]
+        attachments["#{filename_without_extension}.zip"] = FileZipper.new(filename, export_data.read).zip
+      else
+        attachments[filename] = export_data.read
+      end
 
       with_user(user) do
         mail(to: "#{user.name} <#{user.email}>", subject: I18n.t("decidim.export_mailer.subject", name: filename))

--- a/decidim-core/lib/decidim/exporters/export_manifest.rb
+++ b/decidim-core/lib/decidim/exporters/export_manifest.rb
@@ -91,13 +91,15 @@ module Decidim
         @formats ||= formats || DEFAULT_FORMATS
       end
 
+      DEFAULT_OPTIONS = { zip: true }.freeze
+
       # Public: Defines options for the export.
       #
       # options - The hash containing the options.
       #
       # Returns the stored options if previously stored, or
       # the default empty hash.
-      def options(options = {})
+      def options(options = DEFAULT_OPTIONS)
         @options ||= options
       end
 

--- a/decidim-core/lib/decidim/exporters/export_manifest.rb
+++ b/decidim-core/lib/decidim/exporters/export_manifest.rb
@@ -91,6 +91,16 @@ module Decidim
         @formats ||= formats || DEFAULT_FORMATS
       end
 
+      # Public: Defines options for the export.
+      #
+      # options - The hash containing the options.
+      #
+      # Returns the stored options if previously stored, or
+      # the default empty hash.
+      def options(options = {})
+        @options ||= options
+      end
+
       private
 
       # Private: Loads the given exporters when formats argument is provided.

--- a/decidim-core/spec/lib/exporters/export_manifest_spec.rb
+++ b/decidim-core/spec/lib/exporters/export_manifest_spec.rb
@@ -69,5 +69,23 @@ module Decidim
         end
       end
     end
+
+    describe "#options" do
+      context "when no options are specified" do
+        it "returns an empty hash" do
+          expect(subject.options).to eq({})
+        end
+      end
+
+      context "when some options are specified" do
+        before do
+          subject.options option: "value"
+        end
+
+        it "returns the options hash" do
+          expect(subject.options).to eq(option: "value")
+        end
+      end
+    end
   end
 end

--- a/decidim-core/spec/lib/exporters/export_manifest_spec.rb
+++ b/decidim-core/spec/lib/exporters/export_manifest_spec.rb
@@ -73,7 +73,7 @@ module Decidim
     describe "#options" do
       context "when no options are specified" do
         it "returns an empty hash" do
-          expect(subject.options).to eq({})
+          expect(subject.options).to eq(described_class::DEFAULT_OPTIONS)
         end
       end
 

--- a/decidim-forms/app/assets/stylesheets/decidim/forms/questionnaire-answers-pdf.scss
+++ b/decidim-forms/app/assets/stylesheets/decidim/forms/questionnaire-answers-pdf.scss
@@ -6,6 +6,8 @@ $white: white;
 $border-radius-top: 4px 4px 0 0;
 $border-radius-bottom: 0 0 4px 4px;
 
+$border: 1px solid $foreground;
+
 $small-padding: 10px;
 $padding: 25px;
 
@@ -13,6 +15,11 @@ $padding: 25px;
   font-family: 'Source Sans Pro', Helvetica, Roboto, Arial, sans-serif;
   
   .header{
+    .logo {
+      height: 1rem;
+      width: auto;
+    }
+
     .title, .subtitle, .description{
       margin: 0;
       padding: $small-padding $padding;
@@ -29,16 +36,22 @@ $padding: 25px;
       border-radius: 0;
       padding-top: $padding;
     }
-    
-    .subtitle, .description{
+
+    .subtitle, .description, .answers-count{
       background: $background-alt;
       color: $foreground;
+    }
+
+    .answers-count{
+      margin: -1px 0px;
+      padding: $padding;
     }
 
     .description{
       border-radius: $border-radius-bottom;
     }
   }
+
 
   .answer{
     margin-top: $padding;
@@ -61,34 +74,34 @@ $padding: 25px;
       text-align: center;
       background: $background-alt;
       color: $foreground;
-      border-bottom: 1px solid $foreground;
+      border-bottom: $border;
       page-break-inside: avoid;
 
-      th:first-child{
-        text-align: left;
-      }
-
-      td:first-child{
-        text-align: left;
-      }
-
-      th:last-child{
-        text-align: right;
-      }
-
-      td:last-child{
-        text-align: right;
+      td, th {
+        &:first-child{
+          text-align: left;
+        }
+        &:last-child{ 
+          text-align: right;
+        }
       }
     }
 
     .answers{
       padding: 25px;
+      
+      .response {
+        ol, ul, dl {
+          color: red;
+        }
+      }
 
       .question{
         page-break-inside: avoid;
         font-size: inherit;
         color: $foreground;
       }
+
     }
   }
 }

--- a/decidim-forms/app/assets/stylesheets/decidim/forms/questionnaire-answers-pdf.scss
+++ b/decidim-forms/app/assets/stylesheets/decidim/forms/questionnaire-answers-pdf.scss
@@ -1,42 +1,67 @@
+$foreground: #202751;
+$background: #fafafa;
+$background-alt: darken($background, 5%);
+$white: white;
+
+$border-radius-top: 4px 4px 0 0;
+$border-radius-bottom: 0 0 4px 4px;
+
+$small-padding: 10px;
+$padding: 25px;
+
 .questionnaire-answers{
+  font-family: 'Source Sans Pro', Helvetica, Roboto, Arial, sans-serif;
+  
   .header{
-    h1{
+    .title, .subtitle, .description{
       margin: 0;
-      padding: 25px;
-      background: rgb(59, 69, 87);
-      color: white;
-      border-radius: 4px 4px 0 0;
+      padding: $small-padding $padding;
+      background: $foreground;
+      color: $white;
+      border-radius: $border-radius-top;
+    }
+    
+    .title {
+      padding: $padding;
+    }
+    
+    .subtitle {
+      border-radius: 0;
+      padding-top: $padding;
+    }
+    
+    .subtitle, .description{
+      background: $background-alt;
+      color: $foreground;
     }
 
     .description{
-      margin: 0;
-      padding: 25px;
-      background: #f6f6f6;
-      color: #202751;
-      border-radius: 0 0 4px 4px;
+      border-radius: $border-radius-bottom;
     }
   }
 
   .answer{
-    margin-top: 25px;
-    background: #f6f6f6;
-    border-radius: 0 0 4px 4px;
+    margin-top: $padding;
+    background: $background;
+    border-radius: $border-radius-bottom;
 
     .title{
       page-break-inside: avoid;
-      border-radius: 4px 4px 0 0;
-      padding: 10px 25px;
-      background: rgb(59, 69, 87);
-      color: white;
+      border-radius: $border-radius-top;
+      padding: $small-padding $padding;
+      margin: 0;
+      background: $foreground;
+      color: $white;
     }
 
     .participant-info{
       margin-top: 0;
-      padding: 10px 25px;
+      padding: $small-padding $padding;
       width: 100%;
       text-align: center;
-      background: #eee;
-      color: #202751;
+      background: $background-alt;
+      color: $foreground;
+      border-bottom: 1px solid $foreground;
       page-break-inside: avoid;
 
       th:first-child{
@@ -62,7 +87,7 @@
       .question{
         page-break-inside: avoid;
         font-size: inherit;
-        color: #202751;
+        color: $foreground;
       }
     }
   }

--- a/decidim-forms/app/assets/stylesheets/decidim/forms/questionnaire-answers-pdf.scss
+++ b/decidim-forms/app/assets/stylesheets/decidim/forms/questionnaire-answers-pdf.scss
@@ -13,37 +13,41 @@ $padding: 25px;
 
 .questionnaire-answers{
   font-family: 'Source Sans Pro', Helvetica, Roboto, Arial, sans-serif;
-  
+
   .header{
-    .logo {
+    .logo{
       height: 1rem;
       width: auto;
     }
 
-    .title, .subtitle, .description{
+    .title,
+    .subtitle,
+    .description{
       margin: 0;
       padding: $small-padding $padding;
       background: $foreground;
       color: $white;
       border-radius: $border-radius-top;
     }
-    
-    .title {
+
+    .title{
       padding: $padding;
     }
-    
-    .subtitle {
+
+    .subtitle{
       border-radius: 0;
       padding-top: $padding;
     }
 
-    .subtitle, .description, .answers-count{
+    .subtitle,
+    .description,
+    .answers-count{
       background: $background-alt;
       color: $foreground;
     }
 
     .answers-count{
-      margin: -1px 0px;
+      margin: -1px 0;
       padding: $padding;
     }
 
@@ -51,7 +55,6 @@ $padding: 25px;
       border-radius: $border-radius-bottom;
     }
   }
-
 
   .answer{
     margin-top: $padding;
@@ -77,11 +80,13 @@ $padding: 25px;
       border-bottom: $border;
       page-break-inside: avoid;
 
-      td, th {
+      td,
+      th{
         &:first-child{
           text-align: left;
         }
-        &:last-child{ 
+
+        &:last-child{
           text-align: right;
         }
       }
@@ -89,9 +94,11 @@ $padding: 25px;
 
     .answers{
       padding: 25px;
-      
-      .response {
-        ol, ul, dl {
+
+      .response{
+        ol,
+        ul,
+        dl{
           color: red;
         }
       }
@@ -101,7 +108,6 @@ $padding: 25px;
         font-size: inherit;
         color: $foreground;
       }
-
     }
   }
 }

--- a/decidim-forms/app/commands/decidim/forms/answer_questionnaire.rb
+++ b/decidim-forms/app/commands/decidim/forms/answer_questionnaire.rb
@@ -30,7 +30,7 @@ module Decidim
 
       def answer_questionnaire
         Answer.transaction do
-          form.responses_by_step.flatten.select(&:display_conditions_fulfilled?).each do |form_answer|
+          form.responses_by_step.flatten.select(&:display_conditions_fulfilled?).reject(&:separator?).each do |form_answer|
             answer = Answer.new(
               user: @current_user,
               questionnaire: @questionnaire,

--- a/decidim-forms/app/forms/decidim/forms/answer_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/answer_form.rb
@@ -56,9 +56,7 @@ module Decidim
         end
       end
 
-      def separator?
-        question.separator?
-      end
+      delegate :separator?, to: :question
 
       private
 

--- a/decidim-forms/app/forms/decidim/forms/answer_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/answer_form.rb
@@ -56,6 +56,10 @@ module Decidim
         end
       end
 
+      def separator?
+        question.separator?
+      end
+
       private
 
       def mandatory_body?

--- a/decidim-forms/app/jobs/decidim/forms/export_questionnaire_answers_job.rb
+++ b/decidim-forms/app/jobs/decidim/forms/export_questionnaire_answers_job.rb
@@ -12,7 +12,7 @@ module Decidim
         serializer = Decidim::Forms::UserAnswersSerializer
         export_data = Decidim::Exporters::FormPDF.new(answers, serializer).export
 
-        ExportMailer.export(user, title, export_data).deliver_now
+        ExportMailer.export(user, title, export_data, zip: false).deliver_now
       end
     end
   end

--- a/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
+++ b/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
@@ -12,7 +12,7 @@ module Decidim
         attribute :answer, Decidim::Forms::Answer
 
         def question
-          translated_attribute(answer.question.body)
+          translated_attribute(answer.question.body, organization)
         end
 
         def body
@@ -31,6 +31,10 @@ module Decidim
         end
 
         private
+
+        def organization
+          answer.questionnaire.questionnaire_for&.component&.organization
+        end
 
         def choice(choice_body)
           content_tag :li do

--- a/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
+++ b/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
@@ -23,11 +23,11 @@ module Decidim
 
           present_choices
         end
-        
+
         def text?
           %w(short_answer long_answer).include? answer.question.question_type.to_s
         end
-        
+
         private
 
         def organization
@@ -45,9 +45,9 @@ module Decidim
                 answer.choices.map do |c|
                   matrix_row = answer.question.matrix_rows.find_by(id: c.matrix_row.id)
                   safe_join([
-                    content_tag(:dt, translated_attribute(matrix_row.body)),
-                    content_tag(:dd, choice_body(c))
-                  ])
+                              content_tag(:dt, translated_attribute(matrix_row.body)),
+                              content_tag(:dd, choice_body(c))
+                            ])
                 end
               )
             end

--- a/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
+++ b/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
@@ -31,7 +31,7 @@ module Decidim
         private
 
         def organization
-          answer.questionnaire.questionnaire_for&.component&.organization
+          answer.questionnaire.questionnaire_for&.organization
         end
 
         def choice_body(choice)

--- a/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
+++ b/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
@@ -19,15 +19,17 @@ module Decidim
           return answer.body if answer.body.present?
           return "-" if answer.choices.empty?
 
-          choices = answer.choices.map do |choice|
-            choice.try(:custom_body) || choice.try(:body)
-          end
+          return answer.choices.first if answer.question.question_type == "single_option"
 
-          return choices.first if answer.question.question_type == "single_option"
+          present_choices
+        end
 
-          content_tag(:ul) do
-            safe_join(choices.map { |c| choice(c) })
-          end
+        def separator?
+          answer.question.separator?
+        end
+        
+        def matrix?
+          answer.question.matrix?
         end
 
         private
@@ -36,9 +38,31 @@ module Decidim
           answer.questionnaire.questionnaire_for&.component&.organization
         end
 
-        def choice(choice_body)
-          content_tag :li do
-            choice_body
+        def choice_body(choice)
+          choice.try(:custom_body) || choice.try(:body)
+        end
+
+        def present_choices
+          if matrix?
+            content_tag :dl do
+              safe_join(
+                answer.choices.map do |c|
+                  matrix_row = answer.question.matrix_rows.find_by(id: c.matrix_row.id)
+                  safe_join([
+                    content_tag(:dt, translated_attribute(matrix_row.body)),
+                    content_tag(:dd, choice_body(c))
+                  ])
+                end
+              )
+            end
+          else
+            content_tag :ul do
+              safe_join(
+                answer.choices.map do |c|
+                  content_tag(:li, choice_body(c))
+                end
+              )
+            end
           end
         end
       end

--- a/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
+++ b/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
@@ -16,22 +16,18 @@ module Decidim
         end
 
         def body
-          return answer.body if answer.body.present?
+          return simple_format answer.body if answer.body.present?
           return "-" if answer.choices.empty?
 
           return answer.choices.first if answer.question.question_type == "single_option"
 
           present_choices
         end
-
-        def separator?
-          answer.question.separator?
+        
+        def text?
+          %w(short_answer long_answer).include? answer.question.question_type.to_s
         end
         
-        def matrix?
-          answer.question.matrix?
-        end
-
         private
 
         def organization
@@ -43,7 +39,7 @@ module Decidim
         end
 
         def present_choices
-          if matrix?
+          if answer.question.matrix?
             content_tag :dl do
               safe_join(
                 answer.choices.map do |c|
@@ -56,7 +52,7 @@ module Decidim
               )
             end
           else
-            content_tag :ul do
+            content_tag(answer.question.question_type == "sorting" ? :ol : :ul) do
               safe_join(
                 answer.choices.map do |c|
                   content_tag(:li, choice_body(c))

--- a/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
+++ b/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
@@ -19,7 +19,7 @@ module Decidim
           return simple_format answer.body if answer.body.present?
           return "-" if answer.choices.empty?
 
-          return answer.choices.first if answer.question.question_type == "single_option"
+          return answer.choices.first.body if answer.question.question_type == "single_option"
 
           present_choices
         end

--- a/decidim-forms/app/queries/decidim/forms/questionnaire_user_answers.rb
+++ b/decidim-forms/app/queries/decidim/forms/questionnaire_user_answers.rb
@@ -21,7 +21,7 @@ module Decidim
       # Finds and group answers by user for each questionnaire's question.
       def query
         answers = Answer.where(questionnaire: @questionnaire)
-        answers.sort_by { |answer| answer.question.position }.group_by { |a| a.user || a.session_token }.values
+        answers.sort_by { |answer| answer.question.position.to_i }.group_by { |a| a.user || a.session_token }.values
       end
     end
   end

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/export/_answer.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/export/_answer.html.erb
@@ -6,7 +6,6 @@
       <tr>
         <th class='token'><%= t("session_token", scope: "decidim.forms.user_answers_serializer") %></th>
         <th><%= t("user_status",   scope: "decidim.forms.user_answers_serializer") %></th>
-        <th><%= t("ip_hash",       scope: "decidim.forms.user_answers_serializer") %></th>
         <th><%= t("completion",    scope: "decidim.forms.user_answers_serializer") %></th>
         <th><%= t("created_at",    scope: "decidim.forms.user_answers_serializer") %></th>
       </tr>
@@ -15,7 +14,6 @@
       <tr>
         <td><%= participant.session_token %></td>
         <td><%= participant.status %></td>
-        <td><%= participant.ip_hash %></td>
         <td><%= display_percentage(participant.completion) %></td>
         <td><%= l participant.answered_at, format: :short %></td>
       </tr>
@@ -24,12 +22,8 @@
 
   <div class="answers">
     <% participant.answers.each do |answer| %>
-      <% if answer.separator? %>
-        <hr class="separator">
-      <% else %>
-        <h3 class="question"><%= answer.question %></h3>
-        <p><%= simple_format answer.body %></p>
-      <% end %>
+      <h3 class="question"><%= answer.question %></h3>
+      <p class="response"><%= answer.body %></p>
     <% end %>
   </div>
 </div>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/export/_answer.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/export/_answer.html.erb
@@ -24,8 +24,12 @@
 
   <div class="answers">
     <% participant.answers.each do |answer| %>
-      <h3 class="question"><%= answer.question %></h3>
-      <p><%= simple_format answer.body %></p>
+      <% if answer.separator? %>
+        <hr class="separator">
+      <% else %>
+        <h3 class="question"><%= answer.question %></h3>
+        <p><%= simple_format answer.body %></p>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/export/_answer.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/export/_answer.html.erb
@@ -25,7 +25,7 @@
   <div class="answers">
     <% participant.answers.each do |answer| %>
       <h3 class="question"><%= answer.question %></h3>
-      <p><%= answer.body %></p>
+      <p><%= simple_format answer.body %></p>
     <% end %>
   </div>
 </div>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/export/pdf.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/export/pdf.html.erb
@@ -13,18 +13,19 @@
     <h2 class="subtitle">
       <%= translated_attribute(questionnaire.title) %>
     </h2>
+    
+    <% if collection.count > 1 %>
+      <h3 class="answers-count"><%= t("title", scope: "decidim.forms.admin.questionnaires.answers.index", total: collection.count) %></h3>
+    <% end %>
+
     <div class="description">
-      <%== translated_attribute(questionnaire.description).html_safe %>
+      <%= translated_attribute(questionnaire.description).html_safe %>
     </div>
   </div>
   
   <div class="content">
-    <% if collection.count > 1 %>
-      <h3><%= t("title", scope: "decidim.forms.admin.questionnaires.answers.index", total: collection.count) %></h3>
-    <% end %>
+    <%= render partial: "decidim/forms/admin/questionnaires/answers/export/answer", collection: collection, locals: { questionnaire: questionnaire }, as: :participant %>
   </div>
-
-  <%= render partial: "decidim/forms/admin/questionnaires/answers/export/answer", collection: collection, locals: { questionnaire: questionnaire }, as: :participant %>
 
   <footer class="page-footer">
     <%= t("footer", scope: "decidim.forms.admin.questionnaires.answers.index") %>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/export/pdf.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/export/pdf.html.erb
@@ -1,13 +1,32 @@
 <div class="questionnaire-answers">
   <div class="header">
-    <h1><%= translated_attribute(questionnaire.title) %></h1>
+    <% organization = questionnaire.questionnaire_for.organization %>
+
+    <h1 class="title">
+      <% if organization.logo.present? %>
+        <div class="logo">
+          <%= wicked_pdf_image_tag organization.logo.url %>
+        </div>
+      <% end %>
+      <%= organization.name %>
+    </h1>
+    <h2 class="subtitle">
+      <%= translated_attribute(questionnaire.title) %>
+    </h2>
     <div class="description">
       <%== translated_attribute(questionnaire.description).html_safe %>
     </div>
+  </div>
+  
+  <div class="content">
     <% if collection.count > 1 %>
-      <h2><%= t("title", scope: "decidim.forms.admin.questionnaires.answers.index", total: collection.count) %></h2>
+      <h3><%= t("title", scope: "decidim.forms.admin.questionnaires.answers.index", total: collection.count) %></h3>
     <% end %>
   </div>
 
   <%= render partial: "decidim/forms/admin/questionnaires/answers/export/answer", collection: collection, locals: { questionnaire: questionnaire }, as: :participant %>
+
+  <footer class="page-footer">
+    <%= t("footer", scope: "decidim.forms.admin.questionnaires.answers.index") %>
+  </footer>
 </div>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/export/pdf.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/export/pdf.html.erb
@@ -13,7 +13,7 @@
     <h2 class="subtitle">
       <%= translated_attribute(questionnaire.title) %>
     </h2>
-    
+
     <% if collection.count > 1 %>
       <h3 class="answers-count"><%= t("title", scope: "decidim.forms.admin.questionnaires.answers.index", total: collection.count) %></h3>
     <% end %>
@@ -22,7 +22,7 @@
       <%= translated_attribute(questionnaire.description).html_safe %>
     </div>
   </div>
-  
+
   <div class="content">
     <%= render partial: "decidim/forms/admin/questionnaires/answers/export/answer", collection: collection, locals: { questionnaire: questionnaire }, as: :participant %>
   </div>

--- a/decidim-forms/config/locales/en.yml
+++ b/decidim-forms/config/locales/en.yml
@@ -46,8 +46,8 @@ en:
             export_response:
               title: survey_user_answers_%{token}
             index:
-              title: "%{total} total responses"
               footer: Made with Decidim
+              title: "%{total} total responses"
             show:
               title: 'Answer #%{number}'
           display_condition:

--- a/decidim-forms/config/locales/en.yml
+++ b/decidim-forms/config/locales/en.yml
@@ -47,6 +47,7 @@ en:
               title: survey_user_answers_%{token}
             index:
               title: "%{total} total responses"
+              footer: Made with Decidim
             show:
               title: 'Answer #%{number}'
           display_condition:

--- a/decidim-forms/spec/presenters/decidim/admin/questionnaire_answer_presenter_spec.rb
+++ b/decidim-forms/spec/presenters/decidim/admin/questionnaire_answer_presenter_spec.rb
@@ -15,8 +15,8 @@ module Decidim
           answer.body = "abc"
         end
 
-        it "Returns the answer body" do
-          expect(subject.body).to eq(answer.body)
+        it "Returns the formatted answer body" do
+          expect(subject.body).to eq("<p>#{answer.body}</p>")
         end
       end
 
@@ -49,6 +49,35 @@ module Decidim
 
           it "Returns the choice's body as a <li> element inside a <ul>" do
             expect(subject.body).to eq("<ul><li>#{answer_choice.body}</li></ul>")
+          end
+        end
+        
+        context "when it is a matrix_single question" do
+          let!(:question) { create :questionnaire_question, questionnaire: questionnaire, question_type: "matrix_single" }
+          let!(:matrix_row) { create :question_matrix_row, question: question }
+          let!(:answer) { create(:answer, questionnaire: questionnaire, question: question, body: nil) }
+          let!(:answer_option) { create :answer_option, question: question }
+          let!(:answer_choice) { create :answer_choice, answer: answer, answer_option: answer_option, matrix_row: matrix_row, body: translated(answer_option.body, locale: I18n.locale) }
+
+          it "Returns the choice's body as a <dd> element preceded by a <dt> with the matrix row body, both inside a <dl>" do
+            expect(subject.body).to eq("<dl><dt>#{translated matrix_row.body}</dt><dd>#{answer_choice.body}</dd></dl>")
+          end
+        end
+        
+        context "when it is a matrix_multiple question" do
+          let!(:question) { create :questionnaire_question, questionnaire: questionnaire, question_type: "matrix_multiple" }
+          let!(:matrix_rows) { create_list :question_matrix_row, 2, question: question }
+          let!(:answer) { create(:answer, questionnaire: questionnaire, question: question, body: nil) }
+          let!(:answer_options) { create_list :answer_option, 2, question: question }
+          let!(:answer_choice_1) { create :answer_choice, answer: answer, answer_option: answer_options.first, matrix_row: matrix_rows.second }
+          let!(:answer_choice_2) { create :answer_choice, answer: answer, answer_option: answer_options.first, matrix_row: matrix_rows.first }
+          let!(:answer_choice_3) { create :answer_choice, answer: answer, answer_option: answer_options.second, matrix_row: matrix_rows.first }
+
+          it "Returns the choice's body as <dd> elements preceded by a <dt> with the matrix row body, all inside a <dl>" do
+            expect(subject.body).to match "<dl>.*</dl>"
+            expect(subject.body).to include "<dt>#{translated matrix_rows.second.body}</dt><dd>#{answer_choice_1.body}</dd>"
+            expect(subject.body).to include "<dt>#{translated matrix_rows.first.body}</dt><dd>#{answer_choice_2.body}</dd>"
+            expect(subject.body).to include "<dt>#{translated matrix_rows.first.body}</dt><dd>#{answer_choice_3.body}</dd>"
           end
         end
       end

--- a/decidim-forms/spec/presenters/decidim/admin/questionnaire_answer_presenter_spec.rb
+++ b/decidim-forms/spec/presenters/decidim/admin/questionnaire_answer_presenter_spec.rb
@@ -51,7 +51,7 @@ module Decidim
             expect(subject.body).to eq("<ul><li>#{answer_choice.body}</li></ul>")
           end
         end
-        
+
         context "when it is a matrix_single question" do
           let!(:question) { create :questionnaire_question, questionnaire: questionnaire, question_type: "matrix_single" }
           let!(:matrix_row) { create :question_matrix_row, question: question }
@@ -63,7 +63,7 @@ module Decidim
             expect(subject.body).to eq("<dl><dt>#{translated matrix_row.body}</dt><dd>#{answer_choice.body}</dd></dl>")
           end
         end
-        
+
         context "when it is a matrix_multiple question" do
           let!(:question) { create :questionnaire_question, questionnaire: questionnaire, question_type: "matrix_multiple" }
           let!(:matrix_rows) { create_list :question_matrix_row, 2, question: question }

--- a/decidim-surveys/lib/decidim/surveys/component.rb
+++ b/decidim-surveys/lib/decidim/surveys/component.rb
@@ -73,6 +73,8 @@ Decidim.register_component(:surveys) do |component|
     exports.formats %w(CSV JSON Excel FormPDF)
 
     exports.serializer Decidim::Forms::UserAnswersSerializer
+
+    exports.options { { zip: false } }
   end
 
   component.seeds do |participatory_space|


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes some bugs related to exporting questionnaires with new kinds of questions (i.e matrix) and adds some other improvements:

- Exports
  - Adds `options` hash for `export_manifest` to decide whether file should be zipped
  - Makes surveys exports not be zipped by default to improve UX
- Form PDF
  - Render newlines for `short_answer` and `long_answer` answers
  - Render matrix answers correctly
  - Remove `ip_hash` to improve readability of participant information
- Bugfixes
  - Remove bug happening when exporting answers to questions with `position: nil`
  - Fix js logic to decide if matrix questions fulfill `display_conditions`

#### :pushpin: Related issues
- Related to https://github.com/Platoniq/decidim/issues/27


#### :clipboard: Subtasks
- [ ] Add tests
