### PR TITLE
Link is lost when user logs in

### DIFF
--- a/decidim-core/app/controllers/concerns/decidim/force_authentication.rb
+++ b/decidim-core/app/controllers/concerns/decidim/force_authentication.rb
@@ -22,7 +22,7 @@ module Decidim
       # Next stop: Let's check whether auth is ok
       unless user_signed_in?
         flash[:warning] = t("actions.login_before_access", scope: "decidim.core")
-        session[:previous_path_before_login] = request.path
+        store_location_for(:user, request.path)
         return redirect_to decidim.new_user_session_path
       end
     end

--- a/decidim-core/app/controllers/concerns/decidim/force_authentication.rb
+++ b/decidim-core/app/controllers/concerns/decidim/force_authentication.rb
@@ -22,7 +22,7 @@ module Decidim
       # Next stop: Let's check whether auth is ok
       unless user_signed_in?
         flash[:warning] = t("actions.login_before_access", scope: "decidim.core")
-        store_location_for(:user, request.path)
+        store_current_location
         return redirect_to decidim.new_user_session_path
       end
     end

--- a/decidim-core/app/controllers/concerns/decidim/force_authentication.rb
+++ b/decidim-core/app/controllers/concerns/decidim/force_authentication.rb
@@ -22,6 +22,7 @@ module Decidim
       # Next stop: Let's check whether auth is ok
       unless user_signed_in?
         flash[:warning] = t("actions.login_before_access", scope: "decidim.core")
+        session[:previous_path_before_login] = request.path
         return redirect_to decidim.new_user_session_path
       end
     end

--- a/decidim-core/app/controllers/concerns/decidim/force_authentication.rb
+++ b/decidim-core/app/controllers/concerns/decidim/force_authentication.rb
@@ -22,7 +22,7 @@ module Decidim
       # Next stop: Let's check whether auth is ok
       unless user_signed_in?
         flash[:warning] = t("actions.login_before_access", scope: "decidim.core")
-        store_current_location
+        store_location_for(:user, request.path)
         return redirect_to decidim.new_user_session_path
       end
     end

--- a/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
@@ -6,7 +6,7 @@ module Decidim
     class SessionsController < ::Devise::SessionsController
       include Decidim::DeviseControllers
 
-      before_action :check_sign_in_enabled, only: :create
+      before_action :check_sign_in_enabled, :redirect_to_previous_link, only: :create
 
       def create
         super
@@ -45,6 +45,11 @@ module Decidim
 
       def check_sign_in_enabled
         redirect_to new_user_session_path unless current_organization.sign_in_enabled?
+      end
+
+      def redirect_to_previous_link
+        redirect_to(session[:previous_path_before_login] || root_path)
+        session[:previous_path_before_login] = nil
       end
     end
   end

--- a/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
@@ -20,8 +20,6 @@ module Decidim
       def after_sign_in_path_for(user)
         if first_login_and_not_authorized?(user) && !user.admin? && !pending_redirect?(user)
           decidim_verifications.first_login_authorizations_path
-        elsif session[:previous_path_before_login].present?
-          previous_path_before_login
         else
           super
         end
@@ -47,12 +45,6 @@ module Decidim
 
       def check_sign_in_enabled
         redirect_to new_user_session_path unless current_organization.sign_in_enabled?
-      end
-
-      def previous_path_before_login
-        previous_path = session[:previous_path_before_login]
-        session[:previous_path_before_login] = nil
-        previous_path
       end
     end
   end

--- a/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
@@ -6,7 +6,7 @@ module Decidim
     class SessionsController < ::Devise::SessionsController
       include Decidim::DeviseControllers
 
-      before_action :check_sign_in_enabled, :redirect_to_previous_link, only: :create
+      before_action :check_sign_in_enabled, only: :create
 
       def create
         super
@@ -21,7 +21,7 @@ module Decidim
         if first_login_and_not_authorized?(user) && !user.admin? && !pending_redirect?(user)
           decidim_verifications.first_login_authorizations_path
         elsif session[:previous_path_before_login].present?
-          redirect_to_previous_link
+          previous_path_before_login
         else
           super
         end
@@ -49,7 +49,7 @@ module Decidim
         redirect_to new_user_session_path unless current_organization.sign_in_enabled?
       end
 
-      def redirect_to_previous_link
+      def previous_path_before_login
         previous_path = session[:previous_path_before_login]
         session[:previous_path_before_login] = nil
         previous_path

--- a/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
@@ -20,6 +20,8 @@ module Decidim
       def after_sign_in_path_for(user)
         if first_login_and_not_authorized?(user) && !user.admin? && !pending_redirect?(user)
           decidim_verifications.first_login_authorizations_path
+        elsif session[:previous_path_before_login].present?
+          redirect_to_previous_link
         else
           super
         end
@@ -48,8 +50,9 @@ module Decidim
       end
 
       def redirect_to_previous_link
-        redirect_to(session[:previous_path_before_login] || root_path)
+        previous_path = session[:previous_path_before_login]
         session[:previous_path_before_login] = nil
+        previous_path
       end
     end
   end

--- a/decidim-core/spec/system/user_redirect_spec.rb
+++ b/decidim-core/spec/system/user_redirect_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "UserRedirect", type: :system do
+  before do
+    switch_to_host(organization.host)
+  end
+
+  context "when organization has forced login" do
+    let(:organization) { create :organization, force_users_to_authenticate_before_access_organization: true }
+
+    let(:user) { create(:user, :confirmed, organization: organization) }
+
+    context "when logging for the first time" do
+      before do
+        visit decidim.pages_path
+
+        within "form.new_user" do
+          fill_in :session_user_email, with: user.email
+          fill_in :session_user_password, with: "password1234"
+          find("*[type=submit]").click
+        end
+      end
+
+      it "redirects the user to the page attempted to access before login" do
+        expect(page).to have_css("h1.heading1.page-title", text: "Help")
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
When a member recives a link, and does not have the session opened, the link takes him directly to the login screen. When the user is already logged, the user loses the link to which is supposed to go and redirects to the homepage, instead of going to the initial link.

#### :pushpin: Related Issues
- Fixes #6183

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] Add tests

### :camera: Screenshots (optional)

