### PR TITLE
Do not check surveys' legacy tables in development env

### DIFF
--- a/decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb
+++ b/decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb
@@ -21,7 +21,7 @@ class CheckLegacyTables < ActiveRecord::Migration[5.2]
   end
 
   def up
-    return if Rails.env.test? || ENV["CI"] == "true"
+    return if Rails.env.development? || Rails.env.test? || ENV["CI"] == "true"
 
     if tables_exists.any?
       puts "If you already migrated the data, the following raise statement can be safely removed and migrations can continue to be run again."


### PR DESCRIPTION
#### :tophat: What? Why?
#6299 raises an exception to warn Decidim implementors about the danger of data loss. This exception should not be raised when in the `development` environment, i.e. when generating the `development_app`.

#### :pushpin: Related Issues
- Related to #6299

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
