### PR TITLE
Backport "Apply migration of data in surveys legacy tables automatically" to v0.22

### DIFF
--- a/decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb
+++ b/decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb
@@ -21,7 +21,7 @@ class CheckLegacyTables < ActiveRecord::Migration[5.2]
   end
 
   def up
-    return if Rails.env.test? || ENV["CI"] == "true"
+    return if Rails.env.development? || Rails.env.test? || ENV["CI"] == "true"
 
     if tables_exists.any?
       puts "If you already migrated the data, the following raise statement can be safely removed and migrations can continue to be run again."

--- a/decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb
+++ b/decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb
@@ -21,7 +21,8 @@ class CheckLegacyTables < ActiveRecord::Migration[5.2]
   end
 
   def up
-    return if Rails.env.development? || Rails.env.test? || ENV["CI"] == "true"
+    byebug
+    return if development_app? || Rails.env.test? || ENV["CI"] == "true"
 
     if tables_exists.any?
       puts "If you already migrated the data, the following raise statement can be safely removed and migrations can continue to be run again."
@@ -111,6 +112,10 @@ class CheckLegacyTables < ActiveRecord::Migration[5.2]
         end
       end
     end
+  end
+
+  def development_app?
+    Rails.root.to_s.ends_with? 'development_app'
   end
 end
 # rubocop:enable Lint/UnreachableCode

--- a/decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb
+++ b/decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb
@@ -21,7 +21,6 @@ class CheckLegacyTables < ActiveRecord::Migration[5.2]
   end
 
   def up
-    byebug
     return if development_app? || Rails.env.test? || ENV["CI"] == "true"
 
     if tables_exists.any?
@@ -115,7 +114,7 @@ class CheckLegacyTables < ActiveRecord::Migration[5.2]
   end
 
   def development_app?
-    Rails.root.to_s.ends_with? 'development_app'
+    Rails.root.to_s.ends_with? "development_app"
   end
 end
 # rubocop:enable Lint/UnreachableCode

--- a/decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb
+++ b/decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb
@@ -2,7 +2,6 @@
 
 # rubocop:disable Rails/Output
 # rubocop:disable Style/GuardClause
-# rubocop:disable Lint/UnreachableCode
 class CheckLegacyTables < ActiveRecord::Migration[5.2]
   class Answer < ApplicationRecord
     self.table_name = :decidim_surveys_survey_answers
@@ -21,18 +20,11 @@ class CheckLegacyTables < ActiveRecord::Migration[5.2]
   end
 
   def up
-    return if development_app? || Rails.env.test? || ENV["CI"] == "true"
-
     if tables_exists.any?
-      puts "If you already migrated the data, the following raise statement can be safely removed and migrations can continue to be run again."
-      puts "But beware, they will remove some surveys' legacy tables!"
-      puts "Otherwise check this migration in order to keep your data safe. Legacy tables will be removed by the following migrations."
-      raise "ERROR: there's the risk to loose legacy information from old surveys!"
-
       if tables_exists.all?
         migrate_legacy_data if Question.any?
       else
-        puts "Some legacy surveys tables exist but not all. Have you already migrated the data?"
+        puts "Some legacy surveys tables exist but not all. Have you migrated all the data?"
         puts "Migrate or backup your data and then remove the following raise statement to continue with the migrations (that will remove surveys legacy tables)"
         puts "For migrating your data you can do that with the command:"
         puts "bundle exec rake decidim_surveys:migrate_data_to_decidim_forms"
@@ -117,6 +109,6 @@ class CheckLegacyTables < ActiveRecord::Migration[5.2]
     Rails.root.to_s.ends_with? "development_app"
   end
 end
-# rubocop:enable Lint/UnreachableCode
+
 # rubocop:enable Style/GuardClause
 # rubocop:enable Rails/Output

--- a/decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb
+++ b/decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb
@@ -104,11 +104,6 @@ class CheckLegacyTables < ActiveRecord::Migration[5.2]
       end
     end
   end
-
-  def development_app?
-    Rails.root.to_s.ends_with? "development_app"
-  end
 end
-
 # rubocop:enable Style/GuardClause
 # rubocop:enable Rails/Output


### PR DESCRIPTION
#### :tophat: What? Why?
As the original PR, this one fixes the migration of surveys' legacy tables to:
> execute surveys' "legacy tables check" migration of data automatically if there is data in these tables otherwise keep on with the migrations.

#### :pushpin: Related Issues
- Related to #6275 and PR #6308 