### PR TITLE
Custom validator that checks string fields

### DIFF
--- a/decidim-core/app/validators/sanitize_validator.rb
+++ b/decidim-core/app/validators/sanitize_validator.rb
@@ -12,7 +12,7 @@ class SanitizeValidator < ActiveModel::EachValidator
   private
 
   def validate_first_char(record, attribute, value)
-    return unless invalid_first_chars.include? value[0]
+    return unless invalid_first_chars.include? value.first
 
     record.errors.add(attribute, options[:message] || :invalid_first_char)
   end

--- a/decidim-core/app/validators/sanitize_validator.rb
+++ b/decidim-core/app/validators/sanitize_validator.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# This validator takes care of ensuring the validated content is
+# respectful, doesn't use invalid first character.
+class SanitizeValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    validate_first_char(record, attribute, value)
+  end
+
+  private
+
+  def validate_first_char(record, attribute, value)
+    return unless invalid_first_chars.include? value[0]
+
+    record.errors.add(attribute, options[:message] || :invalid_first_char)
+  end
+
+  def invalid_first_chars
+    %w(= + - @)
+  end
+end

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1400,6 +1400,7 @@ en:
       cycle_detected: a scope's parent can't be one of its descendants
       expired: has expired, please request a new one
       file_size_is_less_than_or_equal_to: file size must be less than or equal to %{count}
+      invalid_first_char: invalid first character
       invalid_time_zone: is not a valid time zone
       long_words: contains words that are too long (over 35 characters)
       must_start_with_caps: must start with a capital letter

--- a/decidim-core/spec/validators/sanitize_validator_spec.rb
+++ b/decidim-core/spec/validators/sanitize_validator_spec.rb
@@ -20,7 +20,7 @@ describe SanitizeValidator do
 
   let(:subject) { validatable.new(body: body) }
 
-  context "when the body is reasonable" do
+  context "when body is reasonable" do
     [
       %(I am a very reasonable body, ain't I? I have the right length, the right style, the right words. Yup.),
       %("Validate bodies", they said. "It's gonna be fun!", they said.),
@@ -36,7 +36,7 @@ describe SanitizeValidator do
     end
   end
 
-  context "when the text begins by invalid char" do
+  context "when text begins by invalid char" do
     %w(= + - @).each do |char|
       let(:body) { char + Faker::Lorem.sentence }
 

--- a/decidim-core/spec/validators/sanitize_validator_spec.rb
+++ b/decidim-core/spec/validators/sanitize_validator_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe SanitizeValidator do
+  let(:validatable) do
+    Class.new do
+      def self.model_name
+        ActiveModel::Name.new(self, nil, "Validatable")
+      end
+
+      include Virtus.model
+      include ActiveModel::Validations
+
+      attribute :body
+
+      validates :body, sanitize: true
+    end
+  end
+
+  let(:subject) { validatable.new(body: body) }
+
+  context "when the body is reasonable" do
+    [
+      %(I am a very reasonable body, ain't I? I have the right length, the right style, the right words. Yup.),
+      %("Validate bodies", they said. "It's gonna be fun!", they said.),
+      %(I contain special characters because I'm à la mode.)
+    ].each do |a_body|
+      describe "like \"#{a_body}\"" do
+        let(:body) { a_body }
+
+        it "validates first character" do
+          expect(subject).to be_valid
+        end
+      end
+    end
+  end
+
+  context "when the text begins by invalid char" do
+    %w(= + - @).each do |char|
+      let(:body) { char + Faker::Lorem.sentence }
+
+      it "like '#{char}' char" do
+        expect(subject).to be_invalid
+      end
+    end
+  end
+end

--- a/decidim-initiatives/app/forms/decidim/initiatives/initiative_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/initiative_form.rb
@@ -19,7 +19,7 @@ module Decidim
       attribute :state, String
       attribute :attachment, AttachmentForm
 
-      validates :title, :description, presence: true
+      validates :title, :description, presence: true, sanitize: true
       validates :title, length: { maximum: 150 }
       validates :signature_type, presence: true
       validates :type_id, presence: true

--- a/decidim-initiatives/spec/forms/initiative_form_spec.rb
+++ b/decidim-initiatives/spec/forms/initiative_form_spec.rb
@@ -46,6 +46,12 @@ module Decidim
         it { is_expected.to be_invalid }
       end
 
+      context "when title begins by invalid first char" do
+        let(:title) { "=Fake title" }
+
+        it { is_expected.to be_invalid }
+      end
+
       context "when initiative type enables custom signature end date" do
         let(:initiatives_type) { create(:initiatives_type, :custom_signature_end_date_enabled, organization: organization) }
 

--- a/decidim-proposals/app/forms/decidim/proposals/proposal_wizard_create_step_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/proposal_wizard_create_step_form.rb
@@ -11,7 +11,7 @@ module Decidim
       attribute :body_template, String
       attribute :user_group_id, Integer
 
-      validates :title, :body, presence: true, etiquette: true
+      validates :title, :body, presence: true, etiquette: true, sanitize: true
       validates :title, length: { maximum: 150 }
 
       validate :proposal_length

--- a/decidim-proposals/spec/forms/decidim/proposals/proposal_wizard_create_step_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/proposal_wizard_create_step_form_spec.rb
@@ -48,6 +48,18 @@ module Decidim
         end
       end
 
+      context "when title begins by invalid first char" do
+        let(:title) { "=Fake title" }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "when body begins by invalid first char" do
+        let(:body) { "+Fake body" }
+
+        it { is_expected.to be_invalid }
+      end
+
       context "when there's no body" do
         let(:body) { nil }
 


### PR DESCRIPTION
#### :tophat: What? Why?

Custom validator that checks the first character of a string field. 
Allows to prevent invalids chars insertion.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Create custom validator
- [x] Used in initiatives form
- [x] Used in proposals form
- [x] Add tests
