### PR TITLE
Memoize current_user

### DIFF
--- a/decidim-core/app/controllers/concerns/decidim/impersonate_users.rb
+++ b/decidim-core/app/controllers/concerns/decidim/impersonate_users.rb
@@ -23,7 +23,7 @@ module Decidim
 
       # Returns a manager user if the real user has an active impersonation
       def current_user
-        managed_user || real_user
+        @current_user ||= managed_user || real_user
       end
 
       # Clear the `@real_user` instance variable because otherwise that would be


### PR DESCRIPTION
## :tophat: What? Why?

This avoids querying the cache to check the managed_user every time `#current_user` is called.

This reduces the count of these cache checks in the default homepage from 229 to 195 in development, which results in a ~100ms shorter response time.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
