### PR TITLE
Apply migration of data in surveys legacy tables automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ To keep current Decidim::Proposals::Proposal's endorsement information, endorsem
 
 After this, `Decidim::Proposals::ProposalEndorsement` and the corresponding counter cache column in `decidim_proposals_proposal.proposal_endorsements_count` should be removed. To do so, Decidim provides now the corresponding migration.
 
+- **Removal of Surveys' legacy tables**
+
+This version removes the legacy tables that were left when extracting Questionnaires from `decidim-surveys` into `decidim-forms`.
+These tables were left to give time to Decidim imlementors to migrate the data in them if required.
+It is now time to remove these tables but, as stated in [\#6275](https://github.com/decidim/decidim/issues/6275), the process must avoid data loss.
+
+To avoid data loss migration `decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb` checks if there is still data in `decidim-surveys` legacy tables and migrates this data to the tables in `decidim-forms`.
+
+After 20200609090533 is executed the next 5 migrations will remove the legacy tables and columns.
+
 ### Added
 
 ### Changed
@@ -27,12 +37,7 @@ After this, `Decidim::Proposals::ProposalEndorsement` and the corresponding coun
 
 - **decidim-comments**: Fix comments JS errors and delays [\#6193](https://github.com/decidim/decidim/pull/6193)
 - **decidim-elections**: Improve navigation consistency in the admin zone for elections questions and answers [\#6139](https://github.com/decidim/decidim/pull/6139)
-- **decidim-participatory_processes**: Fix rubocop errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
-- **decidim-assemblies**: Fix rubocop errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
-- **decidim-proposals**: Fix rubocop errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
-- **decidim-dev**: Fix rubocop errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
-- **decidim-core**: Fix rubocop errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
-- **decidim-forms**: Fix rubocop errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
+- **decidim-assemblies**, **decidim-core**, **decidim-dev**, **decidim-forms**, **decidim-participatory_processes**, **decidim-proposals**: Fix rubocop errors arising from capybara upgrade [\#6197](https://github.com/decidim/decidim/pull/6197)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,16 +19,6 @@ To keep current Decidim::Proposals::Proposal's endorsement information, endorsem
 
 After this, `Decidim::Proposals::ProposalEndorsement` and the corresponding counter cache column in `decidim_proposals_proposal.proposal_endorsements_count` should be removed. To do so, Decidim provides now the corresponding migration.
 
-- **Removal of Surveys' legacy tables**
-
-This version removes the legacy tables that were left when extracting Questionnaires from `decidim-surveys` into `decidim-forms`.
-These tables were left to give time to Decidim imlementors to migrate the data in them if required.
-It is now time to remove these tables but, as stated in [\#6275](https://github.com/decidim/decidim/issues/6275), the process must avoid data loss.
-
-To avoid data loss migration `decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb` checks if there is still data in `decidim-surveys` legacy tables and migrates this data to the tables in `decidim-forms`.
-
-After 20200609090533 is executed the next 5 migrations will remove the legacy tables and columns.
-
 ### Added
 
 ### Changed

--- a/decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb
+++ b/decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb
@@ -2,7 +2,6 @@
 
 # rubocop:disable Rails/Output
 # rubocop:disable Style/GuardClause
-# rubocop:disable Lint/UnreachableCode
 class CheckLegacyTables < ActiveRecord::Migration[5.2]
   class Answer < ApplicationRecord
     self.table_name = :decidim_surveys_survey_answers
@@ -21,18 +20,11 @@ class CheckLegacyTables < ActiveRecord::Migration[5.2]
   end
 
   def up
-    return if development_app? || Rails.env.test? || ENV["CI"] == "true"
-
     if tables_exists.any?
-      puts "If you already migrated the data, the following raise statement can be safely removed and migrations can continue to be run again."
-      puts "But beware, they will remove some surveys' legacy tables!"
-      puts "Otherwise check this migration in order to keep your data safe. Legacy tables will be removed by the following migrations."
-      raise "ERROR: there's the risk to loose legacy information from old surveys!"
-
       if tables_exists.all?
         migrate_legacy_data if Question.any?
       else
-        puts "Some legacy surveys tables exist but not all. Have you already migrated the data?"
+        puts "Some legacy surveys tables exist but not all. Have you migrated all the data?"
         puts "Migrate or backup your data and then remove the following raise statement to continue with the migrations (that will remove surveys legacy tables)"
         puts "For migrating your data you can do that with the command:"
         puts "bundle exec rake decidim_surveys:migrate_data_to_decidim_forms"
@@ -111,10 +103,6 @@ class CheckLegacyTables < ActiveRecord::Migration[5.2]
         end
       end
     end
-  end
-
-  def development_app?
-    Rails.root.to_s.ends_with? "development_app"
   end
 end
 # rubocop:enable Lint/UnreachableCode

--- a/decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb
+++ b/decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb
@@ -105,6 +105,6 @@ class CheckLegacyTables < ActiveRecord::Migration[5.2]
     end
   end
 end
-# rubocop:enable Lint/UnreachableCode
+
 # rubocop:enable Style/GuardClause
 # rubocop:enable Rails/Output

--- a/decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb
+++ b/decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb
@@ -21,7 +21,7 @@ class CheckLegacyTables < ActiveRecord::Migration[5.2]
   end
 
   def up
-    return if Rails.env.development? || Rails.env.test? || ENV["CI"] == "true"
+    return if development_app? || Rails.env.test? || ENV["CI"] == "true"
 
     if tables_exists.any?
       puts "If you already migrated the data, the following raise statement can be safely removed and migrations can continue to be run again."
@@ -111,6 +111,10 @@ class CheckLegacyTables < ActiveRecord::Migration[5.2]
         end
       end
     end
+  end
+
+  def development_app?
+    Rails.root.to_s.ends_with? 'development_app'
   end
 end
 # rubocop:enable Lint/UnreachableCode

--- a/decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb
+++ b/decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb
@@ -114,7 +114,7 @@ class CheckLegacyTables < ActiveRecord::Migration[5.2]
   end
 
   def development_app?
-    Rails.root.to_s.ends_with? 'development_app'
+    Rails.root.to_s.ends_with? "development_app"
   end
 end
 # rubocop:enable Lint/UnreachableCode


### PR DESCRIPTION
#### :tophat: What? Why?
Execute surveys' "legacy tables check" migration of data automatically if there is data in these tables otherwise keep on with the migrations.

This PR adds upgrade notes and fixes the #6302 fix which
- always raised an exception if legacy tables exist
- avoided executing the `20200609090533_check_legacy_tables.rb` migration when env was `development`.

The idea is to run all migrations smoothly and perform the migration and deletion of legacy tables in a transparent way for the Decidim implementors.

#### :pushpin: Related Issues
- Related to #6302 and #6299 
- Fixes #6275

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
