### PR TITLE
Add CSV/Excel exporter sanitizer

### DIFF
--- a/decidim-core/app/helpers/decidim/sanitize_helper.rb
+++ b/decidim-core/app/helpers/decidim/sanitize_helper.rb
@@ -32,7 +32,8 @@ module Decidim
 
     # Security fix - Avoid CSV injection - https://owasp.org/www-community/attacks/CSV_Injection
     def csv_sanitize(value)
-      return value unless value.instance_of? String and invalid_first_chars.include? value.first
+      return value unless value.instance_of?(String) && invalid_first_chars.include?(value.first)
+
       value.prepend("'")
     end
 

--- a/decidim-core/app/helpers/decidim/sanitize_helper.rb
+++ b/decidim-core/app/helpers/decidim/sanitize_helper.rb
@@ -30,7 +30,6 @@ module Decidim
       decidim_html_escape(text).sub(/^javascript:/, "")
     end
 
-    # Security fix - Avoid CSV injection - https://owasp.org/www-community/attacks/CSV_Injection
     def csv_sanitize(value)
       return value unless value.instance_of?(String) && invalid_first_chars.include?(value.first)
 

--- a/decidim-core/app/helpers/decidim/sanitize_helper.rb
+++ b/decidim-core/app/helpers/decidim/sanitize_helper.rb
@@ -35,7 +35,7 @@ module Decidim
       return value unless value.instance_of?(String) and invalid_first_chars.include?(value.first)
 
       # rubocop:enable Style/AndOr
-      value.prepend("'")
+      value.dup.prepend("'")
     end
 
     def invalid_first_chars

--- a/decidim-core/app/helpers/decidim/sanitize_helper.rb
+++ b/decidim-core/app/helpers/decidim/sanitize_helper.rb
@@ -29,17 +29,5 @@ module Decidim
     def decidim_url_escape(text)
       decidim_html_escape(text).sub(/^javascript:/, "")
     end
-
-    def csv_sanitize(value)
-      # rubocop:disable Style/AndOr
-      return value unless value.instance_of?(String) and invalid_first_chars.include?(value.first)
-
-      # rubocop:enable Style/AndOr
-      value.dup.prepend("'")
-    end
-
-    def invalid_first_chars
-      %w(= + - @)
-    end
   end
 end

--- a/decidim-core/app/helpers/decidim/sanitize_helper.rb
+++ b/decidim-core/app/helpers/decidim/sanitize_helper.rb
@@ -29,5 +29,15 @@ module Decidim
     def decidim_url_escape(text)
       decidim_html_escape(text).sub(/^javascript:/, "")
     end
+
+    # Security fix - Avoid CSV injection - https://owasp.org/www-community/attacks/CSV_Injection
+    def csv_sanitize(value)
+      return value unless value.instance_of? String and invalid_first_chars.include? value.first
+      value.prepend("'")
+    end
+
+    def invalid_first_chars
+      %w(= + - @)
+    end
   end
 end

--- a/decidim-core/app/helpers/decidim/sanitize_helper.rb
+++ b/decidim-core/app/helpers/decidim/sanitize_helper.rb
@@ -31,8 +31,10 @@ module Decidim
     end
 
     def csv_sanitize(value)
-      return value unless value.instance_of?(String) && invalid_first_chars.include?(value.first)
+      # rubocop:disable Style/AndOr
+      return value unless value.instance_of?(String) and invalid_first_chars.include?(value.first)
 
+      # rubocop:enable Style/AndOr
       value.prepend("'")
     end
 

--- a/decidim-core/lib/decidim/exporters/csv.rb
+++ b/decidim-core/lib/decidim/exporters/csv.rb
@@ -11,8 +11,6 @@ module Decidim
     # For example, `{ name: { ca: "Hola", en: "Hello" } }` would result into
     # the columns: `name/ca` and `name/es`.
     class CSV < Exporter
-      include Decidim::SanitizeHelper
-
       # Public: Exports a CSV serialized version of the collection using the
       # provided serializer and following the previously described strategy.
       #
@@ -20,10 +18,24 @@ module Decidim
       def export(col_sep = Decidim.default_csv_col_sep)
         data = ::CSV.generate(headers: headers, write_headers: true, col_sep: col_sep) do |csv|
           processed_collection.each do |resource|
-            csv << headers.map { |header| csv_sanitize(resource[header]) }
+            csv << headers.map { |header| custom_sanitize(resource[header]) }
           end
         end
         ExportData.new(data, "csv")
+      end
+
+      protected
+
+      def custom_sanitize(value)
+        # rubocop:disable Style/AndOr
+        return value unless value.instance_of?(String) and invalid_first_chars.include?(value.first)
+
+        # rubocop:enable Style/AndOr
+        value.dup.prepend("'")
+      end
+
+      def invalid_first_chars
+        %w(= + - @)
       end
 
       private

--- a/decidim-core/lib/decidim/exporters/csv.rb
+++ b/decidim-core/lib/decidim/exporters/csv.rb
@@ -11,6 +11,8 @@ module Decidim
     # For example, `{ name: { ca: "Hola", en: "Hello" } }` would result into
     # the columns: `name/ca` and `name/es`.
     class CSV < Exporter
+      include Decidim::SanitizeHelper
+
       # Public: Exports a CSV serialized version of the collection using the
       # provided serializer and following the previously described strategy.
       #
@@ -18,7 +20,7 @@ module Decidim
       def export(col_sep = Decidim.default_csv_col_sep)
         data = ::CSV.generate(headers: headers, write_headers: true, col_sep: col_sep) do |csv|
           processed_collection.each do |resource|
-            csv << headers.map { |header| resource[header] }
+            csv << headers.map { |header| csv_sanitize(resource[header]) }
           end
         end
         ExportData.new(data, "csv")

--- a/decidim-core/lib/decidim/exporters/excel.rb
+++ b/decidim-core/lib/decidim/exporters/excel.rb
@@ -36,7 +36,7 @@ module Decidim
         end
 
         processed_collection.each_with_index do |resource, index|
-          sheet.row(index + 1).replace(headers.map { |header| csv_sanitize(resource[header]) })
+          sheet.row(index + 1).replace(headers.map { |header| custom_sanitize(resource[header]) })
         end
 
         output = StringIO.new

--- a/decidim-core/lib/decidim/exporters/excel.rb
+++ b/decidim-core/lib/decidim/exporters/excel.rb
@@ -36,7 +36,7 @@ module Decidim
         end
 
         processed_collection.each_with_index do |resource, index|
-          sheet.row(index + 1).replace(headers.map { |header| resource[header] })
+          sheet.row(index + 1).replace(headers.map { |header| csv_sanitize(resource[header]) })
         end
 
         output = StringIO.new

--- a/decidim-core/spec/lib/exporters/csv_spec.rb
+++ b/decidim-core/spec/lib/exporters/csv_spec.rb
@@ -26,7 +26,11 @@ module Decidim
     let(:collection) do
       [
         OpenStruct.new(id: 1, name: { ca: "foocat", es: "fooes" }, ids: [1, 2, 3]),
-        OpenStruct.new(id: 2, name: { ca: "barcat", es: "bares" }, ids: [1, 2, 3])
+        OpenStruct.new(id: 2, name: { ca: "barcat", es: "bares" }, ids: [1, 2, 3]),
+        OpenStruct.new(id: 3, name: { ca: "@atcat", es: "@ates" }, ids: [1, 2, 3]),
+        OpenStruct.new(id: 4, name: { ca: "=equalcat", es: "=equales" }, ids: [1, 2, 3]),
+        OpenStruct.new(id: 5, name: { ca: "+pluscat", es: "+pluses" }, ids: [1, 2, 3]),
+        OpenStruct.new(id: 6, name: { ca: "-minuscat", es: "-minuses" }, ids: [1, 2, 3])
       ]
     end
 
@@ -35,6 +39,23 @@ module Decidim
         exported = subject.export.read
         data = CSV.parse(exported, headers: true, col_sep: ";").map(&:to_h)
         expect(data[0]["serialized_name/ca"]).to eq("foocat")
+      end
+    end
+
+    describe "export sanitizer" do
+      it "exports the collection sanitizing invalid first chars correctly" do
+        exported = subject.export.read
+        data = CSV.parse(exported, headers: true, col_sep: ";").map(&:to_h)
+        expect(data[0]["serialized_name/ca"]).to eq("foocat")
+        expect(data[1]["serialized_name/ca"]).to eq("barcat")
+        expect(data[2]["serialized_name/ca"]).to eq("'@atcat")
+        expect(data[2]["serialized_name/es"]).to eq("'@ates")
+        expect(data[3]["serialized_name/ca"]).to eq("'=equalcat")
+        expect(data[3]["serialized_name/es"]).to eq("'=equales")
+        expect(data[4]["serialized_name/ca"]).to eq("'+pluscat")
+        expect(data[4]["serialized_name/es"]).to eq("'+pluses")
+        expect(data[5]["serialized_name/ca"]).to eq("'-minuscat")
+        expect(data[5]["serialized_name/es"]).to eq("'-minuses")
       end
     end
   end

--- a/decidim-core/spec/lib/exporters/excel_spec.rb
+++ b/decidim-core/spec/lib/exporters/excel_spec.rb
@@ -28,7 +28,11 @@ module Decidim
     let(:collection) do
       [
         OpenStruct.new(id: 1, name: { ca: "foocat", es: "fooes" }, ids: [1, 2, 3], float: 1.66, date: Time.zone.local(2017, 10, 1, 5, 0)),
-        OpenStruct.new(id: 2, name: { ca: "barcat", es: "bares" }, ids: [2, 3, 4], float: 0.55, date: Time.zone.local(2017, 9, 20))
+        OpenStruct.new(id: 2, name: { ca: "barcat", es: "bares" }, ids: [2, 3, 4], float: 0.55, date: Time.zone.local(2017, 9, 20)),
+        OpenStruct.new(id: 3, name: { ca: "@atcat", es: "@ates" }, ids: [1, 2, 3], float: 0.35, date: Time.zone.local(2020, 7, 20)),
+        OpenStruct.new(id: 4, name: { ca: "=equalcat", es: "=equales" }, ids: [1, 2, 3], float: 0.45, date: Time.zone.local(2020, 6, 24)),
+        OpenStruct.new(id: 5, name: { ca: "+pluscat", es: "+pluses" }, ids: [1, 2, 3], float: 0.65, date: Time.zone.local(2020, 7, 15)),
+        OpenStruct.new(id: 6, name: { ca: "-minuscat", es: "-minuses" }, ids: [1, 2, 3], float: 0.75, date: Time.zone.local(2020, 6, 27))
       ]
     end
 
@@ -37,7 +41,7 @@ module Decidim
         exported = StringIO.new(subject.export.read)
         book = Spreadsheet.open(exported)
         worksheet = book.worksheet(0)
-        expect(worksheet.rows.length).to eq(3)
+        expect(worksheet.rows.length).to eq(7)
 
         headers = worksheet.rows[0]
         expect(headers).to eq(["id", "serialized_name/ca", "serialized_name/es", "other_ids", "float", "date"])
@@ -46,6 +50,34 @@ module Decidim
 
         expect(worksheet.rows[2][0..4]).to eq([2, "barcat", "bares", "2, 3, 4", 0.55])
         expect(worksheet.rows[2].datetime(5)).to eq(Time.zone.local(2017, 9, 20))
+      end
+    end
+
+    describe "export sanitizer" do
+      it "exports the collection sanitizing invalid first chars correctly" do
+        exported = StringIO.new(subject.export.read)
+        book = Spreadsheet.open(exported)
+        worksheet = book.worksheet(0)
+
+        headers = worksheet.rows[0]
+        expect(headers).to eq(["id", "serialized_name/ca", "serialized_name/es", "other_ids", "float", "date"])
+        expect(worksheet.rows[1][0..4]).to eq([1, "foocat", "fooes", "1, 2, 3", 1.66])
+        expect(worksheet.rows[1].datetime(5)).to eq(Time.zone.local(2017, 10, 1, 5, 0))
+
+        expect(worksheet.rows[2][0..4]).to eq([2, "barcat", "bares", "2, 3, 4", 0.55])
+        expect(worksheet.rows[2].datetime(5)).to eq(Time.zone.local(2017, 9, 20))
+
+        expect(worksheet.rows[3][0..4]).to eq([3, "'@atcat", "'@ates", "1, 2, 3", 0.35])
+        expect(worksheet.rows[3].datetime(5)).to eq(Time.zone.local(2020, 7, 20))
+
+        expect(worksheet.rows[4][0..4]).to eq([4, "'=equalcat", "'=equales", "1, 2, 3", 0.45])
+        expect(worksheet.rows[4].datetime(5)).to eq(Time.zone.local(2020, 6, 24))
+
+        expect(worksheet.rows[5][0..4]).to eq([5, "'+pluscat", "'+pluses", "1, 2, 3", 0.65])
+        expect(worksheet.rows[5].datetime(5)).to eq(Time.zone.local(2020, 7, 15))
+
+        expect(worksheet.rows[6][0..4]).to eq([6, "'-minuscat", "'-minuses", "1, 2, 3", 0.75])
+        expect(worksheet.rows[6].datetime(5)).to eq(Time.zone.local(2020, 6, 27))
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

In order to prevent invalid chars insertion in some csv/excel fields export, this add a new sanitizer that checks the first character of a csv/excel's string field.

#### :pushpin: Related Issues

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [X] Add tests
- [ ] Another subtask

