### PR TITLE
Add scope to debates (resource)

### DIFF
--- a/decidim-debates/app/commands/decidim/debates/admin/create_debate.rb
+++ b/decidim-debates/app/commands/decidim/debates/admin/create_debate.rb
@@ -38,6 +38,7 @@ module Decidim
             instructions: form.instructions,
             end_time: form.end_time,
             start_time: form.start_time,
+            scope: form.scope,
             component: form.current_component,
             author: form.current_organization
           }

--- a/decidim-debates/app/commands/decidim/debates/admin/update_debate.rb
+++ b/decidim-debates/app/commands/decidim/debates/admin/update_debate.rb
@@ -42,7 +42,8 @@ module Decidim
             information_updates: form.information_updates,
             instructions: form.instructions,
             end_time: form.end_time,
-            start_time: form.start_time
+            start_time: form.start_time,
+            scope: form.scope
           )
         end
       end

--- a/decidim-debates/app/commands/decidim/debates/create_debate.rb
+++ b/decidim-debates/app/commands/decidim/debates/create_debate.rb
@@ -42,6 +42,7 @@ module Decidim
           description: {
             I18n.locale => parsed_description
           },
+          scope: form.scope,
           component: form.current_component
         }
 

--- a/decidim-debates/app/commands/decidim/debates/update_debate.rb
+++ b/decidim-debates/app/commands/decidim/debates/update_debate.rb
@@ -48,7 +48,8 @@ module Decidim
           },
           description: {
             I18n.locale => parsed_description
-          }
+          },
+          scope: form.scope
         }
       end
     end

--- a/decidim-debates/app/forms/decidim/debates/admin/debate_form.rb
+++ b/decidim-debates/app/forms/decidim/debates/admin/debate_form.rb
@@ -14,6 +14,7 @@ module Decidim
         attribute :start_time, Decidim::Attributes::TimeWithZone
         attribute :end_time, Decidim::Attributes::TimeWithZone
         attribute :decidim_category_id, Integer
+        attribute :scope_id, Integer
 
         validates :title, translatable_presence: true
         validates :description, translatable_presence: true
@@ -22,6 +23,8 @@ module Decidim
         validates :end_time, presence: { if: ->(object) { object.start_time.present? } }, date: { after: :start_time, allow_blank: true }
 
         validates :category, presence: true, if: ->(form) { form.decidim_category_id.present? }
+        validates :scope, presence: true, if: ->(form) { form.scope_id.present? }
+        validates :scope_id, scope_belongs_to_component: true, if: ->(form) { form.scope_id.present? }
 
         def map_model(model)
           self.decidim_category_id = model.categorization.decidim_category_id if model.categorization
@@ -35,6 +38,20 @@ module Decidim
           return unless current_component
 
           @category ||= current_component.categories.find_by(id: decidim_category_id)
+        end
+
+        # Finds the Scope from the given decidim_scope_id, uses the compoenent scope if missing.
+        #
+        # Returns a Decidim::Scope
+        def scope
+          @scope ||= @scope_id ? current_component.scopes.find_by(id: @scope_id) : current_component.scope
+        end
+
+        # Scope identifier
+        #
+        # Returns the scope identifier related to the meeting
+        def scope_id
+          @scope_id || scope&.id
         end
       end
     end

--- a/decidim-debates/app/forms/decidim/debates/debate_form.rb
+++ b/decidim-debates/app/forms/decidim/debates/debate_form.rb
@@ -9,6 +9,7 @@ module Decidim
       attribute :title, String
       attribute :description, String
       attribute :category_id, Integer
+      attribute :scope_id, Integer
       attribute :user_group_id, Integer
       attribute :debate, Debate
 
@@ -36,6 +37,20 @@ module Decidim
 
       def category
         @category ||= current_component.categories.find_by(id: category_id)
+      end
+
+      # Finds the Scope from the given scope_id, uses component scope if missing.
+      #
+      # Returns a Decidim::Scope
+      def scope
+        @scope ||= @scope_id ? current_component.scopes.find_by(id: @scope_id) : current_component.scope
+      end
+
+      # Scope identifier
+      #
+      # Returns the scope identifier related to the debate
+      def scope_id
+        @scope_id || scope&.id
       end
 
       private

--- a/decidim-debates/app/forms/decidim/debates/debate_form.rb
+++ b/decidim-debates/app/forms/decidim/debates/debate_form.rb
@@ -18,6 +18,8 @@ module Decidim
       validates :category, presence: true, if: ->(form) { form.category_id.present? }
       validate :editable_by_user
 
+      validates :scope_id, scope_belongs_to_component: true, if: ->(form) { form.scope_id.present? }
+
       def map_model(debate)
         super
         self.debate = debate

--- a/decidim-debates/app/types/decidim/debates/debate_type.rb
+++ b/decidim-debates/app/types/decidim/debates/debate_type.rb
@@ -6,7 +6,8 @@ module Decidim
       interfaces [
         -> { Decidim::Core::CategorizableInterface },
         -> { Decidim::Comments::CommentableInterface },
-        -> { Decidim::Core::AuthorableInterface }
+        -> { Decidim::Core::AuthorableInterface },
+        -> { Decidim::Core::ScopableInterface }
       ]
 
       name "Debate"

--- a/decidim-debates/app/views/decidim/debates/admin/debates/_form.html.erb
+++ b/decidim-debates/app/views/decidim/debates/admin/debates/_form.html.erb
@@ -29,6 +29,12 @@
       </div>
     </div>
 
+    <% if current_component.has_subscopes? %>
+      <div class="row column">
+        <%= scopes_picker_field form, :scope_id, root: current_component.scope %>
+      </div>
+    <% end %>
+
     <div class="row column">
       <%= form.categories_select :decidim_category_id, current_participatory_space.categories, include_blank: "", disable_parents: false %>
     </div>

--- a/decidim-debates/app/views/decidim/debates/debates/_filters.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/_filters.html.erb
@@ -16,7 +16,7 @@
 
   <%= form.check_boxes_tree :state, filter_debates_state_values, legend_title: t(".state"), "aria-controls": "debates" %>
 
-  <% if current_participatory_space.has_subscopes? %>
+  <% if current_component.has_subscopes? %>
     <%= form.check_boxes_tree :scope_id, filter_scopes_values, legend_title: t(".scope"), "aria-controls": "debates" %>
   <% end %>
 

--- a/decidim-debates/app/views/decidim/debates/debates/_form.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/_form.html.erb
@@ -6,6 +6,12 @@
   <%= text_editor_for_debate_description(form) %>
 </div>
 
+<% if current_component.has_subscopes? %>
+  <div class="row column">
+    <%= scopes_picker_field form, :scope_id, root: current_component.scope %>
+  </div>
+<% end %>
+
 <% if current_participatory_space.categories&.any? %>
   <div class="field">
     <%= form.categories_select :category_id, current_participatory_space.categories, include_blank: t(".select_a_category"), disable_parents: false %>

--- a/decidim-debates/app/views/decidim/debates/debates/show.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/show.html.erb
@@ -123,11 +123,8 @@ edit_link(
           <%= decidim_sanitize(simple_format(translated_attribute(debate.information_updates), {}, sanitize: false)) %>
         </div>
       <% end %>
-      <% if debate.category %>
-        <ul class="tags tags--debate">
-          <li><%= link_to translated_attribute(debate.category.name), debates_path(filter: { category_id: debate.category.id }) %></li>
-        </ul>
-      <% end %>
+
+      <%= render partial: "decidim/shared/tags", locals: { resource: debate, tags_class_extra: "tags--debate" } %>
 
       <%= cell "decidim/endorsers_list", debate %>
     </div>

--- a/decidim-debates/db/migrate/20200930145546_add_scope_to_debates_debate.rb
+++ b/decidim-debates/db/migrate/20200930145546_add_scope_to_debates_debate.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddScopeToDebatesDebate < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :decidim_debates_debates, :decidim_scope, foreign_key: true, index: true
+  end
+end

--- a/decidim-debates/spec/commands/decidim/debates/admin/create_debate_spec.rb
+++ b/decidim-debates/spec/commands/decidim/debates/admin/create_debate_spec.rb
@@ -8,6 +8,7 @@ describe Decidim::Debates::Admin::CreateDebate do
   let(:organization) { create :organization, available_locales: [:en, :ca, :es], default_locale: :en }
   let(:participatory_process) { create :participatory_process, organization: organization }
   let(:current_component) { create :component, participatory_space: participatory_process, manifest_name: "debates" }
+  let(:scope) { create :scope, organization: organization }
   let(:category) { create :category, participatory_space: participatory_process }
   let(:user) { create :user, :admin, :confirmed, organization: organization }
   let(:form) do
@@ -19,6 +20,7 @@ describe Decidim::Debates::Admin::CreateDebate do
       instructions: { en: "instructions" },
       start_time: 1.day.from_now,
       end_time: 1.day.from_now + 1.hour,
+      scope: scope,
       category: category,
       current_user: user,
       current_component: current_component,
@@ -40,6 +42,11 @@ describe Decidim::Debates::Admin::CreateDebate do
 
     it "creates the debate" do
       expect { subject.call }.to change { Decidim::Debates::Debate.count }.by(1)
+    end
+
+    it "sets the scope" do
+      subject.call
+      expect(debate.scope).to eq scope
     end
 
     it "sets the category" do

--- a/decidim-debates/spec/commands/decidim/debates/admin/update_debate_spec.rb
+++ b/decidim-debates/spec/commands/decidim/debates/admin/update_debate_spec.rb
@@ -7,6 +7,7 @@ describe Decidim::Debates::Admin::UpdateDebate do
 
   let(:debate) { create :debate }
   let(:organization) { debate.component.organization }
+  let(:scope) { create :scope, organization: organization }
   let(:category) { create :category, participatory_space: debate.component.participatory_space }
   let(:user) { create :user, :admin, :confirmed, organization: organization }
   let(:form) do
@@ -19,6 +20,7 @@ describe Decidim::Debates::Admin::UpdateDebate do
       instructions: { en: "instructions" },
       start_time: 1.day.from_now,
       end_time: 1.day.from_now + 1.hour,
+      scope: scope,
       category: category,
       current_organization: organization
     )
@@ -40,6 +42,11 @@ describe Decidim::Debates::Admin::UpdateDebate do
       expect(translated(debate.description)).to eq "description"
       expect(translated(debate.information_updates)).to eq "information_updates"
       expect(translated(debate.instructions)).to eq "instructions"
+    end
+
+    it "sets the scope" do
+      subject.call
+      expect(debate.scope).to eq scope
     end
 
     it "sets the category" do

--- a/decidim-debates/spec/commands/decidim/debates/create_debate_spec.rb
+++ b/decidim-debates/spec/commands/decidim/debates/create_debate_spec.rb
@@ -8,6 +8,7 @@ describe Decidim::Debates::CreateDebate do
   let(:organization) { create :organization, available_locales: [:en, :ca, :es], default_locale: :en }
   let(:participatory_process) { create :participatory_process, organization: organization }
   let(:current_component) { create :component, participatory_space: participatory_process, manifest_name: "debates" }
+  let(:scope) { create :scope, organization: organization }
   let(:category) { create :category, participatory_space: participatory_process }
   let(:user) { create :user, organization: organization }
   let(:form) do
@@ -16,6 +17,7 @@ describe Decidim::Debates::CreateDebate do
       title: "title",
       description: "description",
       user_group_id: nil,
+      scope: scope,
       category: category,
       current_user: user,
       current_component: current_component,
@@ -37,6 +39,11 @@ describe Decidim::Debates::CreateDebate do
 
     it "creates the debate" do
       expect { subject.call }.to change { Decidim::Debates::Debate.count }.by(1)
+    end
+
+    it "sets the scope" do
+      subject.call
+      expect(debate.scope).to eq scope
     end
 
     it "sets the category" do

--- a/decidim-debates/spec/commands/decidim/debates/update_debate_spec.rb
+++ b/decidim-debates/spec/commands/decidim/debates/update_debate_spec.rb
@@ -8,6 +8,7 @@ describe Decidim::Debates::UpdateDebate do
   let(:organization) { create :organization, available_locales: [:en, :ca, :es], default_locale: :en }
   let(:participatory_process) { create :participatory_process, organization: organization }
   let(:current_component) { create :component, participatory_space: participatory_process, manifest_name: "debates" }
+  let(:scope) { create :scope, organization: organization }
   let(:category) { create :category, participatory_space: participatory_process }
   let(:user) { create :user, organization: organization }
   let!(:debate) { create :debate, author: user, component: current_component }
@@ -15,6 +16,7 @@ describe Decidim::Debates::UpdateDebate do
     Decidim::Debates::DebateForm.from_params(
       title: "title",
       description: "description",
+      scope_id: scope.id,
       category_id: category.id,
       debate: debate
     ).with_context(
@@ -60,6 +62,11 @@ describe Decidim::Debates::UpdateDebate do
   context "when everything is ok" do
     it "updates the debate" do
       expect { subject.call }.to change(debate, :title)
+    end
+
+    it "sets the scope" do
+      subject.call
+      expect(debate.scope).to eq scope
     end
 
     it "sets the category" do

--- a/decidim-debates/spec/forms/decidim/debates/admin/debate_form_spec.rb
+++ b/decidim-debates/spec/forms/decidim/debates/admin/debate_form_spec.rb
@@ -3,13 +3,14 @@
 require "spec_helper"
 
 describe Decidim::Debates::Admin::DebateForm do
-  subject { described_class.from_params(attributes).with_context(context) }
+  subject(:form) { described_class.from_params(attributes).with_context(context) }
 
   let(:organization) { create(:organization) }
   let(:context) do
     {
       current_organization: organization,
-      current_component: current_component
+      current_component: current_component,
+      current_participatory_space: participatory_process
     }
   end
   let(:participatory_process) { create :participatory_process, organization: organization }
@@ -27,9 +28,13 @@ describe Decidim::Debates::Admin::DebateForm do
   let(:end_time) { 2.days.from_now + 4.hours }
   let(:category) { create :category, participatory_space: participatory_process }
   let(:category_id) { category.id }
+  let(:parent_scope) { create(:scope, organization: organization) }
+  let(:scope) { create(:subscope, parent: parent_scope) }
+  let(:scope_id) { scope.id }
   let(:attributes) do
     {
       decidim_category_id: category_id,
+      scope_id: scope_id,
       title: title,
       description: description,
       instructions: instructions,
@@ -37,6 +42,8 @@ describe Decidim::Debates::Admin::DebateForm do
       end_time: end_time
     }
   end
+
+  it_behaves_like "a scopable resource"
 
   it { is_expected.to be_valid }
 

--- a/decidim-debates/spec/forms/decidim/debates/debate_form_spec.rb
+++ b/decidim-debates/spec/forms/decidim/debates/debate_form_spec.rb
@@ -3,13 +3,14 @@
 require "spec_helper"
 
 describe Decidim::Debates::DebateForm do
-  subject { described_class.from_params(attributes).with_context(context) }
+  subject(:form) { described_class.from_params(attributes).with_context(context) }
 
   let(:organization) { create(:organization) }
   let(:context) do
     {
       current_organization: organization,
-      current_component: current_component
+      current_component: current_component,
+      current_participatory_space: participatory_process
     }
   end
   let(:participatory_process) { create :participatory_process, organization: organization }
@@ -18,13 +19,19 @@ describe Decidim::Debates::DebateForm do
   let(:description) { "My description" }
   let(:category) { create :category, participatory_space: participatory_process }
   let(:category_id) { category.id }
+  let(:parent_scope) { create(:scope, organization: organization) }
+  let(:scope) { create(:subscope, parent: parent_scope) }
+  let(:scope_id) { scope.id }
   let(:attributes) do
     {
       category_id: category_id,
+      scope_id: scope_id,
       title: title,
       description: description
     }
   end
+
+  it_behaves_like "a scopable resource"
 
   it { is_expected.to be_valid }
 

--- a/decidim-debates/spec/system/explore_debates_spec.rb
+++ b/decidim-debates/spec/system/explore_debates_spec.rb
@@ -8,6 +8,9 @@ describe "Explore debates", type: :system do
 
   before do
     switch_to_host(organization.host)
+    component_scope = create :scope, parent: participatory_process.scope
+    component_settings = component["settings"]["global"].merge!(scopes_enabled: true, scope_id: component_scope.id)
+    component.update!(settings: component_settings)
   end
 
   describe "index" do
@@ -121,6 +124,23 @@ describe "Explore debates", type: :system do
         end
       end
 
+      it "allows filtering by scope" do
+        scope = create(:scope, organization: organization)
+        debate = debates.first
+        debate.scope = scope
+        debate.save
+
+        visit_component
+
+        within ".scope_id_check_boxes_tree_filter" do
+          check "All"
+          uncheck "All"
+          check translated(scope.name)
+        end
+
+        expect(page).to have_css(".card--debate", count: 1)
+      end
+
       context "when filtering by category" do
         let(:category2) { create :category, participatory_space: participatory_space }
         let(:debates) { create_list(:debate, 3, component: component, category: category2) }
@@ -212,7 +232,7 @@ describe "Explore debates", type: :system do
       end
     end
 
-    context "without category" do
+    context "without category or scope" do
       it "does not show any tag" do
         expect(page).not_to have_selector("ul.tags.tags--debate")
       end
@@ -231,6 +251,32 @@ describe "Explore debates", type: :system do
 
         within "ul.tags.tags--debate" do
           expect(page).to have_content(translated(debate.category.name))
+        end
+      end
+    end
+
+    context "with a scope" do
+      let(:debate) do
+        debate = create(:debate, component: component)
+        debate.scope = create(:scope, organization: organization)
+        debate.save
+        debate
+      end
+
+      it "shows tags for scope" do
+        expect(page).to have_selector("ul.tags.tags--debate")
+        within "ul.tags.tags--debate" do
+          expect(page).to have_content(translated(debate.scope.name))
+        end
+      end
+
+      it "links to the filter for this scope" do
+        within "ul.tags.tags--debate" do
+          click_link translated(debate.scope.name)
+        end
+
+        within ".filters" do
+          expect(page).to have_checked_field(translated(debate.scope.name))
         end
       end
     end

--- a/decidim-debates/spec/system/user_edits_debate_spec.rb
+++ b/decidim-debates/spec/system/user_edits_debate_spec.rb
@@ -17,12 +17,17 @@ describe "User edits a debate", type: :system do
   before do
     switch_to_host(organization.host)
     login_as user, scope: :user
+    component_scope = create :scope, parent: component.participatory_space.scope
+    component_settings = component["settings"]["global"].merge!(scopes_enabled: true, scope_id: component_scope.id)
+    component.update!(settings: component_settings)
   end
 
   context "when editing my debate" do
     let(:user) { create :user, :confirmed, organization: organization }
     let(:author) { user }
+    let!(:scope) { create(:scope, organization: organization) }
     let!(:category) { create :category, participatory_space: participatory_space }
+    let(:scope_picker) { select_data_picker(:debate_scope_id) }
 
     it "allows editing my debate", :slow do
       visit_component
@@ -33,6 +38,7 @@ describe "User edits a debate", type: :system do
       within ".edit_debate" do
         fill_in :debate_title, with: "Should every organization use Decidim?"
         fill_in :debate_description, with: "Add your comments on whether Decidim is useful for every organization."
+        scope_pick scope_picker, scope
         select translated(category.name), from: :debate_category_id
 
         find("*[type=submit]").click
@@ -41,6 +47,7 @@ describe "User edits a debate", type: :system do
       expect(page).to have_content("successfully")
       expect(page).to have_content("Should every organization use Decidim?")
       expect(page).to have_content("Add your comments on whether Decidim is useful for every organization.")
+      expect(page).to have_content(translated(scope.name))
       expect(page).to have_content(translated(category.name))
       expect(page).to have_selector(".author-data", text: user.name)
     end
@@ -65,6 +72,7 @@ describe "User edits a debate", type: :system do
         within ".edit_debate" do
           fill_in :debate_title, with: "Should every organization use Decidim?"
           fill_in :debate_description, with: "Add your comment on whether Decidim is useful for every organization."
+          scope_pick scope_picker, scope
           select translated(category.name), from: :debate_category_id
 
           find("*[type=submit]").click
@@ -73,6 +81,7 @@ describe "User edits a debate", type: :system do
         expect(page).to have_content("successfully")
         expect(page).to have_content("Should every organization use Decidim?")
         expect(page).to have_content("Add your comment on whether Decidim is useful for every organization.")
+        expect(page).to have_content(translated(scope.name))
         expect(page).to have_content(translated(category.name))
         expect(page).to have_selector(".author-data", text: user_group.name)
       end

--- a/decidim-debates/spec/types/debate_type_spec.rb
+++ b/decidim-debates/spec/types/debate_type_spec.rb
@@ -5,6 +5,7 @@ require "decidim/api/test/type_context"
 require "decidim/core/test/shared_examples/categorizable_interface_examples"
 require "decidim/core/test/shared_examples/comments_examples"
 require "decidim/core/test/shared_examples/authorable_interface_examples"
+require "decidim/core/test/shared_examples/scopable_interface_examples"
 
 module Decidim
   module Debates
@@ -15,6 +16,7 @@ module Decidim
 
       include_examples "categorizable interface"
       include_examples "authorable interface"
+      include_examples "scopable interface"
 
       describe "id" do
         let(:query) { "{ id }" }


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds the ability to assign a scope to a debate (when the Debates component has scopes enabled).


#### :pushpin: Related Issues
- Related to PR #6309
- Related to issue #5708

#### :clipboard: Subtasks

- [x] If there's a new public field, add it to GraphQL API
- [x] Add tests


### :camera: Screenshots (optional)

- Admin can assign a scope to a debate:  
  <img width="898" alt="Screenshot 2020-12-23 at 19 32 18" src="https://user-images.githubusercontent.com/210216/103028068-4eb6b480-4557-11eb-8e07-a73214e91e28.png">
- Participant can assign a scope to a debate:
  <img width="963" alt="Screenshot 2020-12-23 at 19 35 06" src="https://user-images.githubusercontent.com/210216/103028194-8887bb00-4557-11eb-95ca-edd4bed65d4d.png">
- Participants are able to filter by scope:
  <img width="1131" alt="Screenshot 2020-12-23 at 19 35 49" src="https://user-images.githubusercontent.com/210216/103028254-ace39780-4557-11eb-9240-26ac5825ff97.png">
- Debate details renders scope tag:
  <img width="1131" alt="Screenshot 2020-12-23 at 19 35 49" src="https://user-images.githubusercontent.com/210216/103028288-bff66780-4557-11eb-8956-3004bf406193.png">
  <img width="1149" alt="Screenshot 2020-12-23 at 19 35 26" src="https://user-images.githubusercontent.com/210216/103269451-3232d600-49b6-11eb-823b-21378dd42a0e.png">



