### PR TITLE
Fix initiative state notification

### DIFF
--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -103,7 +103,7 @@ module Decidim
         .order(Arel.sql("count(decidim_comments_comments.id) desc"))
     }
 
-    after_save :notify_state_change
+    after_commit :notify_state_change
     after_create :notify_creation
 
     searchable_fields({

--- a/decidim-initiatives/spec/mailers/decidim/initiatives/initiatives_mailer_spec.rb
+++ b/decidim-initiatives/spec/mailers/decidim/initiatives/initiatives_mailer_spec.rb
@@ -29,7 +29,7 @@ module Decidim
         end
 
         it "renders the body" do
-          expect(mail.body.encoded).to match(initiative.title["en"])
+          expect(mail.body).to match("The initiative #{initiative.title["en"]} has changed its status to: #{I18n.t(initiative.state, scope: "decidim.initiatives.admin_states")}")
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

When initiative's state changes, the notification sent shows the previous state. 
This behaviour seems to occur because of race condition. In fact, in initiative model, `notify_state_change` method is called with `after_save`. 

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/6330
- Fixes #5552

#### :clipboard: Subtasks
- [x] Light refactor of mailer specs
- [x] Trigger `notify_state_change` with `after_commit` rather than `after_save`
