### PR TITLE
Identifying translatable fields in meetings and comments

### DIFF
--- a/decidim-comments/app/models/decidim/comments/comment.rb
+++ b/decidim-comments/app/models/decidim/comments/comment.rb
@@ -13,6 +13,7 @@ module Decidim
       include Decidim::DataPortability
       include Decidim::Traceable
       include Decidim::Loggable
+      include Decidim::TranslatableResource
 
       include Decidim::TranslatableAttributes
 
@@ -24,6 +25,7 @@ module Decidim
       #       |--R (depth 3)
       MAX_DEPTH = 3
 
+      translatable_fields :body
       belongs_to :commentable, foreign_key: "decidim_commentable_id", foreign_type: "decidim_commentable_type", polymorphic: true
       belongs_to :root_commentable, foreign_key: "decidim_root_commentable_id", foreign_type: "decidim_root_commentable_type", polymorphic: true
       has_many :up_votes, -> { where(weight: 1) }, foreign_key: "decidim_comment_id", class_name: "CommentVote", dependent: :destroy

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -25,7 +25,7 @@ module Decidim
       include Decidim::Authorable
       include Decidim::TranslatableResource
 
-      translatable_fields :title, :description, :location, :location_hints, :closing_report, :registration_terms, :services
+      translatable_fields :title, :description, :location, :location_hints, :closing_report, :registration_terms
 
       has_many :registrations, class_name: "Decidim::Meetings::Registration", foreign_key: "decidim_meeting_id", dependent: :destroy
       has_many :invites, class_name: "Decidim::Meetings::Invite", foreign_key: "decidim_meeting_id", dependent: :destroy

--- a/decidim-meetings/app/models/decidim/meetings/service.rb
+++ b/decidim-meetings/app/models/decidim/meetings/service.rb
@@ -4,7 +4,9 @@ module Decidim
   module Meetings
     class Service < Meetings::ApplicationRecord
       include Decidim::Traceable
+      include Decidim::TranslatableResource
 
+      translatable_fields :title, :description
       belongs_to :meeting, foreign_key: "decidim_meeting_id", class_name: "Decidim::Meetings::Meeting"
     end
   end


### PR DESCRIPTION
As part of #6127, 
Applied `TranslatableResource` to meetings and comments.