### PR TITLE
Ignore builds on Crowdin PRs in v0.22

### DIFF
--- a/.github/workflows/ci_accountability.yml
+++ b/.github/workflows/ci_accountability.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -20,7 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_admin.yml
+++ b/.github/workflows/ci_admin.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -20,7 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -20,7 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_assemblies.yml
+++ b/.github/workflows/ci_assemblies.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -20,7 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_blogs.yml
+++ b/.github/workflows/ci_blogs.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -20,7 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_budgets.yml
+++ b/.github/workflows/ci_budgets.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -20,7 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_comments.yml
+++ b/.github/workflows/ci_comments.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -21,7 +21,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_conferences.yml
+++ b/.github/workflows/ci_conferences.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -20,7 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_consultations.yml
+++ b/.github/workflows/ci_consultations.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -20,7 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_core.yml
+++ b/.github/workflows/ci_core.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -20,7 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_debates.yml
+++ b/.github/workflows/ci_debates.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -20,7 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_elections.yml
+++ b/.github/workflows/ci_elections.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -20,7 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_forms.yml
+++ b/.github/workflows/ci_forms.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -20,7 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -20,7 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_initiatives.yml
+++ b/.github/workflows/ci_initiatives.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -20,7 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_meetings.yml
+++ b/.github/workflows/ci_meetings.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -20,7 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_pages.yml
+++ b/.github/workflows/ci_pages.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -20,7 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_participatory_processes.yml
+++ b/.github/workflows/ci_participatory_processes.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -20,7 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_proposals_system_admin.yml
+++ b/.github/workflows/ci_proposals_system_admin.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -20,7 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_proposals_system_public.yml
+++ b/.github/workflows/ci_proposals_system_public.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -20,7 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_proposals_unit_tests.yml
+++ b/.github/workflows/ci_proposals_unit_tests.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -20,7 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_sortitions.yml
+++ b/.github/workflows/ci_sortitions.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -20,7 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_surveys.yml
+++ b/.github/workflows/ci_surveys.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -20,7 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_system.yml
+++ b/.github/workflows/ci_system.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -20,7 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci_verifications.yml
+++ b/.github/workflows/ci_verifications.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -20,7 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -8,7 +8,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "l10n_*"
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -20,7 +20,7 @@ jobs:
   lint:
     name: Lint code
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'l10n_')"
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
         if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"


### PR DESCRIPTION
#### :tophat: What? Why?
In Crowdin PRs only execute `main` workflow.
This PR is required because of the recent renaming of branches. Workflows were updated at `develop` but backport to release v0.22 was pending.

#### :pushpin: Related Issues
- Related to #6222 #6037 #6076
