### PR TITLE
Fix install profiling gems in development_app rake task

### DIFF
--- a/decidim-generators/lib/decidim/generators/install_generator.rb
+++ b/decidim-generators/lib/decidim/generators/install_generator.rb
@@ -146,6 +146,8 @@ module Decidim
 
         copy_file "bullet_initializer.rb", "config/initializers/bullet.rb"
         copy_file "rack_profiler_initializer.rb", "config/initializers/rack_profiler.rb"
+
+        run "bundle install"
       end
 
       private

--- a/decidim-generators/lib/decidim/generators/install_generator.rb
+++ b/decidim-generators/lib/decidim/generators/install_generator.rb
@@ -106,25 +106,6 @@ module Decidim
         end
       end
 
-      def profiling_gems
-        return unless options[:profiling]
-
-        append_file "Gemfile", <<~RUBY
-
-          group :development do
-            # Profiling gems
-            gem "bullet"
-            gem "flamegraph"
-            gem "memory_profiler"
-            gem "rack-mini-profiler", require: false
-            gem "stackprof"
-          end
-        RUBY
-
-        copy_file "bullet_initializer.rb", "config/initializers/bullet.rb"
-        copy_file "rack_profiler_initializer.rb", "config/initializers/rack_profiler.rb"
-      end
-
       def copy_migrations
         rails "decidim:upgrade"
         recreate_db if options[:recreate_db]
@@ -146,6 +127,25 @@ module Decidim
             |  config.action_mailer.default_url_options = { port: 3000 }
           RUBY
         end
+      end
+
+      def profiling_gems
+        return unless options[:profiling]
+
+        append_file "Gemfile", <<~RUBY
+
+          group :development do
+            # Profiling gems
+            gem "bullet"
+            gem "flamegraph"
+            gem "memory_profiler"
+            gem "rack-mini-profiler", require: false
+            gem "stackprof"
+          end
+        RUBY
+
+        copy_file "bullet_initializer.rb", "config/initializers/bullet.rb"
+        copy_file "rack_profiler_initializer.rb", "config/initializers/rack_profiler.rb"
       end
 
       private


### PR DESCRIPTION
#### :tophat: What? Why?

Adding the profiling gems to the Gemfile midway through the install generator breaks the next steps because they are still missing. That's because we don't run `bundle install` in the generator. Moving this to the end makes it work.

The issue wasn't noticed because I had those gems installed already. It only happens when you don't.
    
This got broken in https://github.com/decidim/decidim/pull/6281. Thanks to @microstudi for the heads-up!

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
