### PR TITLE
Amendments validations enhancement for participatory texts

### DIFF
--- a/decidim-core/app/forms/decidim/amendable/create_form.rb
+++ b/decidim-core/app/forms/decidim/amendable/create_form.rb
@@ -11,8 +11,8 @@ module Decidim
       attribute :emendation_params, Hash
 
       validates :amendable_gid, presence: true
-      validate :emendation_must_change_amendable
       validate :amendable_form_must_be_valid
+      validate :emendation_must_change_amendable
 
       def amendable
         @amendable ||= GlobalID::Locator.locate_signed(amendable_gid)

--- a/decidim-core/app/forms/decidim/amendable/form.rb
+++ b/decidim-core/app/forms/decidim/amendable/form.rb
@@ -57,11 +57,9 @@ module Decidim
       end
 
       # Compare the amendable_form errors and original_form errors
-      # amendable_form errors are duplicated in argument and erased.
-      # Then it compares the difference between the original_form and amendable_form. If amendable_form add more errors than original, error is store in amendable_form errors.
+      # If amendable_form add more errors than original, error is stored in amendable_form errors.
       #
       # Params: amendable_form_errors => Duplicated @amendable_form.errors
-      # Returns nil
       def compare_amendable_form_errors(amendable_form_errors)
         @amendable_form.errors.clear
         @original_form.errors.details.keys.each do |key|

--- a/decidim-core/app/forms/decidim/amendable/form.rb
+++ b/decidim-core/app/forms/decidim/amendable/form.rb
@@ -51,7 +51,7 @@ module Decidim
         original_form.validate unless defined?(@amendable_form) # Preserves previously added errors.
         amendable_form.validate unless defined?(@amendable_form) # Preserves previously added errors.
 
-        compare_amendable_form_errors(@amendable_form.errors.dup) if @original_form.errors.details.count.positive?
+        compare_amendable_form_errors(@amendable_form.errors.dup) if @original_form.present? && @original_form.errors.details.count.positive?
 
         @errors = @amendable_form.errors
       end

--- a/decidim-core/app/forms/decidim/amendable/form.rb
+++ b/decidim-core/app/forms/decidim/amendable/form.rb
@@ -47,8 +47,8 @@ module Decidim
       # Validates the emendation using the amendable form.
       def amendable_form_must_be_valid
         parse_hashtaggable_params
+        original_form.validate unless defined?(@original_form) # Preserves previously added errors.
 
-        original_form.validate unless defined?(@amendable_form) # Preserves previously added errors.
         amendable_form.validate unless defined?(@amendable_form) # Preserves previously added errors.
 
         compare_amendable_form_errors(@amendable_form.errors.dup) if @original_form.present? && @original_form.errors.details.count.positive?
@@ -88,13 +88,20 @@ module Decidim
       end
 
       def original_form
-        @original_form ||= amendable
+        @original_form ||= i18n_amendable
                            .amendable_form
-                           .from_model(amendable)
+                           .from_model(@i18n_amendable)
                            .with_context(
-                             current_component: amendable.component,
-                             current_participatory_space: amendable.participatory_space
+                             current_component: @i18n_amendable.component,
+                             current_participatory_space: @i18n_amendable.participatory_space
                            )
+      end
+
+      def i18n_amendable
+        @i18n_amendable ||= amendable
+        @i18n_amendable.title = translated_attribute(amendable.title)
+        @i18n_amendable.body = normalized_body(amendable)
+        @i18n_amendable
       end
 
       # Returns the amendable fields keys as String.

--- a/decidim-proposals/spec/forms/decidim/proposals/amendable/create_amendment_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/amendable/create_amendment_form_spec.rb
@@ -37,6 +37,37 @@ module Decidim
 
         it { is_expected.to be_invalid }
       end
+
+      context "when amendable title is not etiquette-compliant" do
+        let(:amendable) { create(:proposal, title: "A") }
+        let(:emendation_params) { { title: amendable.title, body: "A new body which is long enough" } }
+
+        it { is_expected.to be_valid }
+      end
+
+      context "when amendable body is not etiquette-compliant" do
+        let(:amendable) { create(:proposal, body: "A") }
+        let(:emendation_params) { { title: "A title which is long enough", body: amendable.body } }
+
+        it { is_expected.to be_valid }
+      end
+
+      context "when emendation adds more errors than original" do
+        let(:amendable) { create(:proposal, title: "AAAAAAAAAAAAAAAAAAAAAAAAAA") }
+        let(:emendation_params) { { title: "AA", body: amendable.body } }
+
+        it "is invalid" do
+          expect(form).to be_invalid
+          expect(form.errors[:title]).to eq(["is too short (under 15 characters)"])
+        end
+      end
+
+      context "when emendation adds less errors than original" do
+        let(:amendable) { create(:proposal, title: "1 A!!#?", body: "#$^^ABC") }
+        let(:emendation_params) { { title: "A title which is long enough", body: "A new body which is long enough" } }
+
+        it { is_expected.to be_valid }
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

As a registered user, when amending a proposal, I can't keep the same title as the original one if it contains an error (i.e: "Title is too short (under 15 characters)"). This is particularly a problem in the case of participatory texts, as proposals titles are not submitted to field validations. 

#### :pushpin: Related Issues
- Fixes #6343

#### :clipboard: Subtasks
- [x] Ensure amendments cannot add more errors than original proposal
- [x] Add tests
