### PR TITLE
Identifying translatable fields for proposals

### DIFF
--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -27,10 +27,9 @@ module Decidim
       include Decidim::Endorsable
       include Decidim::Proposals::Valuatable
       include Decidim::TranslatableResource
-
-      translatable_fields :title, :body, :state, :answer, :address
-
       include Decidim::TranslatableAttributes
+
+      translatable_fields :title, :body
 
       POSSIBLE_STATES = %w(not_answered evaluating accepted rejected withdrawn).freeze
 


### PR DESCRIPTION
As part of #6127,
Applied TranslatableResource to proposals now that #6285 is merged to `develop`