### PR TITLE
Add official documentation in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Test suite
 
 # What do you need to do?
 
-* [Getting started with Decidim](#getting-started-with-decidim)
 * [Official Documentation](https://docs.decidim.org/init/en/)
+* [Getting started with Decidim](#getting-started-with-decidim)
 * [Contribute to the project](#how-to-contribute)
 * [Modules](#modules)
 * [Create & browse development app](#browse-decidim)

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Test suite
 # What do you need to do?
 
 * [Getting started with Decidim](#getting-started-with-decidim)
+* [Official Documentation](https://docs.decidim.org/init/en/)
 * [Contribute to the project](#how-to-contribute)
 * [Modules](#modules)
 * [Create & browse development app](#browse-decidim)


### PR DESCRIPTION
#### :tophat: What? Why?

I add a link to the decidim documentation, because there is no link to the documentation in the README 🤷.

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [x] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
