### PR TITLE
Add migration to update Proposal endorsement Notifications

### DIFF
--- a/decidim-proposals/db/migrate/20200730131631_move_proposal_endorsed_event_notifications_to_resource_endorsed_event.rb
+++ b/decidim-proposals/db/migrate/20200730131631_move_proposal_endorsed_event_notifications_to_resource_endorsed_event.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class MoveProposalEndorsedEventNotificationsToResourceEndorsedEvent < ActiveRecord::Migration[5.2]
+  def up
+    Decidim::Notification.where(event_name: "decidim.events.proposals.proposal_endorsed", event_class: "Decidim::Proposals::ProposalEndorsedEvent").find_each do |notification|
+      notification.update(event_name: "decidim.events.resource_endorsed", event_class: "Decidim::ResourceEndorsedEvent")
+    end
+  end
+
+  def down
+    Decidim::Notification.where(
+      event_name: "decidim.events.resource_endorsed",
+      event_class: "Decidim::ResourceEndorsedEvent",
+      decidim_resource_type: "Decidim::Proposals::Proposal"
+    )
+                         .find_each do |notification|
+      notification.update(event_name: "decidim.events.proposals.proposal_endorsed", event_class: "Decidim::Proposals::ProposalEndorsedEvent")
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Due to #5542 notifications related with proposal endorsements are generated by a different event than it were before.
Now endorsements are generalized, to be applied to different resources, and so are the corresponding events and notifications. This meant removing the old `decidim.events.proposals.proposal_endorsed` event and introducing a new `decidim.events.resource_endorsed` event. This changes implied also removing the translations for the old event, letting already created notifications with translation missing when being rendered.

This PR solves this situation by updating all `Decidim::Notification` corresponding to Proposal endorsement to the new event_name and event_class.

#### :pushpin: Related Issues
- Fixes #5542 
