### PR TITLE
Fix crash at newsletter preview

### DIFF
--- a/decidim-core/app/views/layouts/decidim/_mailer_logo.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_mailer_logo.html.erb
@@ -6,7 +6,7 @@
   <% end %>
   <%= link_to url do %>
     <% if organization.logo.present? %>
-      <%= image_tag organization.logo.medium.url, style: "max-height: 50px", alt: "#{@organization.name}" %>
+      <%= image_tag organization.logo.medium.url, style: "max-height: 50px", alt: "#{organization.name}" %>
     <% else %>
       <span><%= organization.name %></span>
     <% end %>

--- a/decidim-core/spec/cells/decidim/newsletter_templates/basic_only_text_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/newsletter_templates/basic_only_text_cell_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::NewsletterTemplates::BasicOnlyTextCell, type: :cell do
+  subject do
+    cell(content_block.cell, content_block, organization: organization,
+                                            newsletter: newsletter,
+                                            recipient_user: user,
+                                            context: {
+                                              controller: controller
+                                            }).call
+  end
+
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, organization: organization) }
+  let(:content_block) { create :content_block, organization: organization, manifest_name: :basic_only_text, scope_name: :newsletter_template, settings: settings }
+  let(:newsletter) { create :newsletter, organization: organization }
+  let(:body) { ::Faker::Lorem.sentences.join("\n") }
+  let(:settings) { { body_en: body } }
+
+  controller Decidim::PagesController
+
+  context "when the organization has no logo setted" do
+    it "shows the custom body" do
+      expect(subject).to have_text(body)
+    end
+  end
+
+  context "when the organization has a logo setted" do
+    let(:logo) do
+      Rack::Test::UploadedFile.new(
+        Decidim::Dev.test_file("city.jpeg", "image/jpeg"),
+        "image/jpg"
+      )
+    end
+
+    before do
+      organization.logo = logo
+      organization.save!
+    end
+
+    it "renders the organization logo" do
+      expect(subject.to_s).to include(organization.logo.medium.url)
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Since #5888 the `decidim-core/app/views/layouts/decidim/_mailer_logo.html.erb` partial was using `@organization` to access the organization object. It worked fine in the context of the `NewsletterMailer` but now this partial is also invoked from `decidim-core/app/cells/decidim/newsletter_templates/image_text_cta/show.erb` without a global `@organization` attribute. This use case happens when rendering the preview of newsletter templates from the administration panel.

This PR uses `organization` local variable instead of  `@organization`.

#### :pushpin: Related Issues
- Fixes #5888

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
