### PR TITLE
Backport "Add migration to update Proposal endorsement Notifications" to v0.22

### DIFF
--- a/decidim-proposals/db/migrate/20200730131631_move_proposal_endorsed_event_notifications_to_resource_endorsed_event.rb
+++ b/decidim-proposals/db/migrate/20200730131631_move_proposal_endorsed_event_notifications_to_resource_endorsed_event.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class MoveProposalEndorsedEventNotificationsToResourceEndorsedEvent < ActiveRecord::Migration[5.2]
+  def up
+    Decidim::Notification.where(event_name: "decidim.events.proposals.proposal_endorsed", event_class: "Decidim::Proposals::ProposalEndorsedEvent").find_each do |notification|
+      notification.update(event_name: "decidim.events.resource_endorsed", event_class: "Decidim::ResourceEndorsedEvent")
+    end
+  end
+
+  def down
+    Decidim::Notification.where(
+      event_name: "decidim.events.resource_endorsed",
+      event_class: "Decidim::ResourceEndorsedEvent",
+      decidim_resource_type: "Decidim::Proposals::Proposal"
+    )
+                         .find_each do |notification|
+      notification.update(event_name: "decidim.events.proposals.proposal_endorsed", event_class: "Decidim::Proposals::ProposalEndorsedEvent")
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Backports the fix in #6367 to release/0.22-stable branch.

#### :pushpin: Related Issues
- Related to #6367
