### PR TITLE
Better initiative button

### DIFF
--- a/decidim-core/app/views/decidim/shared/_login_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_login_modal.html.erb
@@ -9,7 +9,14 @@
   <% if current_organization.sign_in_enabled? %>
     <div class="row">
       <div class="columns medium-8 medium-centered">
-          <%= decidim_form_for(Decidim::User.new, namespace: "login", as: :user, url: session_path(:user), html: { class: "register-form new_user" }) do |f| %>
+          <%
+            path = if content_for(:redirect_after_login)
+                     session_path(:user, redirect_url: content_for(:redirect_after_login))
+                   else
+                     session_path(:user)
+                   end
+          %>
+          <%= decidim_form_for(Decidim::User.new, namespace: "login", as: :user, url: path, html: { class: "register-form new_user" }) do |f| %>
             <div>
               <div class="field">
                 <%= f.email_field :email %>

--- a/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
@@ -19,7 +19,6 @@ module Decidim
       helper PaginateHelper
       helper InitiativeHelper
       include InitiativeSlug
-
       include FilterResource
       include Paginable
       include Decidim::Initiatives::Orderable

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_index_header.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_index_header.html.erb
@@ -2,10 +2,44 @@
   <h1 id="initiatives-count" class="title-action__title section-heading">
     <%= render partial: "count" %>
   </h1>
-  <% if allowed_to? :create, :initiative %>
-    <%= link_to create_initiative_path(:select_initiative_type), class: "title-action__action button small" do %>
+  <% if Decidim::Initiatives.creation_enabled %>
+    <% if current_user && allowed_to?(:create, :initiative) %>
+      <%= link_to create_initiative_path(:select_initiative_type), class: "title-action__action button small" do %>
         <%= t(".new_initiative") %>
         <%= icon "plus", role: "img", "aria-hidden": true %>
+      <% end %>
+    <% elsif current_user %>
+      <button type="button" class="title-action__action button small" data-open="not-authorized-modal" aria-controls="not-authorized-modal" aria-haspopup="true" tabindex="0">
+        <%= t(".new_initiative") %>
+        <%= icon "plus", role: "img", "aria-hidden": true %>
+      </button>
+    <% else %>
+      <% content_for(:redirect_after_login) { create_initiative_url(:select_initiative_type) } %>
+      <button type="button" class="title-action__action button small" data-open="loginModal" aria-controls="loginModal" aria-haspopup="true" tabindex="0">
+        <%= t(".new_initiative") %>
+        <%= icon "plus", role: "img", "aria-hidden": true %>
+      </button>
     <% end %>
   <% end %>
+</div>
+
+<div class="reveal not-authorized-reveal" id="not-authorized-modal" aria-hidden="true" role="dialog" aria-labelledby="not-authorized-modal-title" data-reveal data-multiple-opened="true">
+  <div class="reveal__header">
+    <h2 class="reveal__title" id="not-authorized-modal-title"><%= t(".not_authorized.title") %></h2>
+    <button class="close-button" data-close aria-label="<%= t(".not_authorized.close") %>"
+      type="button">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+  <div class="not-authhorized-content">
+    <div class="not-authorized-modal-content">
+      <p>
+        <%= t(".not_authorized.explanation") %>
+      </p>
+    </div>
+  </div>
+  <div class="not-authorized-modal-footer reveal__footer">
+    <%= link_to t(".not_authorized.authorizations_page"), decidim_verifications.authorizations_path(redirect_url: create_initiative_url(:select_initiative_type)), class: "button expanded" %>
+  </div>
+  </div>
 </div>

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -419,6 +419,11 @@ en:
           unfold: Unfold
         index_header:
           new_initiative: New initiative
+          not_authorized:
+            authorizations_page: View authorizations
+            close: Close
+            explanation: You need to be verified in order to create a new initiative.
+            title: Authorization required
         interactions:
           comments_count:
             count:

--- a/decidim-verifications/app/views/decidim/verifications/authorizations/index.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/authorizations/index.html.erb
@@ -1,5 +1,6 @@
 <% add_decidim_page_title(t("authorizations", scope: "layouts.decidim.user_profile")) %>
 <% content_for(:subtitle) { t("authorizations", scope: "layouts.decidim.user_profile") } %>
+<% url_params = (redirect_url.present? ? { redirect_url: redirect_url } : {}) %>
 
 <div class="row column authorizations-list">
   <section class="section">
@@ -7,7 +8,7 @@
       <div class="card card--list">
         <% @granted_authorizations.each do |authorization| %>
           <% if authorization.expired? %>
-            <%= link_to authorization_method(authorization).root_path, title: t(".expired_verification"), class: "card--list__item" do %>
+            <%= link_to authorization_method(authorization).root_path(url_params), title: t(".expired_verification"), class: "card--list__item" do %>
               <% render partial: "granted_authorization", locals: { authorization: authorization } %>
             <% end %>
           <% elsif authorization.renewable? %>
@@ -28,7 +29,7 @@
     <% if @pending_authorizations.any? %>
       <div class="card card--list">
         <% @pending_authorizations.each do |authorization| %>
-          <%= link_to authorization_method(authorization).resume_authorization_path do %>
+          <%= link_to authorization_method(authorization).resume_authorization_path(url_params) do %>
             <div class="card--list__item">
               <div class="card--list__text">
                 <%= icon "reload", class: "card--list__icon", aria_label: t(".pending_verification"), role: "img" %>
@@ -55,7 +56,7 @@
     <% if unauthorized_methods.any? %>
       <div class="card card--list">
         <% unauthorized_methods.each do |unauthorized_method| %>
-          <%= link_to unauthorized_method.root_path do %>
+          <%= link_to unauthorized_method.root_path(url_params) do %>
             <div class="card--list__item">
               <div class="card--list__text">
                 <%= icon "lock-unlocked", class: "card--list__icon", aria_label: t(".unauthorized_verification"), role: "img" %>


### PR DESCRIPTION
#### :tophat: What? Why?

Enable always showing the new initiative button even if users aren't logged in. The only case when it's not shown is when creating initiatives is disabled.

Since initiatives are participatory space instead of components, I couldn't use the regular authorization modal. Whenever possible, users are redirected to the initiative form after login and after verification.

#### :pushpin: Related Issues
- Related to #5737  

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [x] Add tests
- [ ] Another subtask

### :camera: Screenshots
![Screenshot 2020-07-31 at 13 11 47](https://user-images.githubusercontent.com/5254/89030115-1906fa00-d330-11ea-8e37-b85f1c4680b4.png)
![Screenshot 2020-07-31 at 13 12 02](https://user-images.githubusercontent.com/5254/89030116-199f9080-d330-11ea-8580-d51ad0617fae.png)
![Screenshot 2020-07-31 at 13 13 21](https://user-images.githubusercontent.com/5254/89030121-1a382700-d330-11ea-9548-1164f95c4f77.png)
![Screenshot 2020-07-31 at 13 13 55](https://user-images.githubusercontent.com/5254/89030122-1a382700-d330-11ea-96b6-c247e3fe8af6.png)

