### PR TITLE
Fallback to closed initiatives when there are no open ones

### DIFF
--- a/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
@@ -31,6 +31,17 @@ module Decidim
       # GET /initiatives
       def index
         enforce_permission_to :list, :initiative
+
+        return unless search.results.blank? && params.dig("filter", "state") != %w(closed)
+
+        @closed_initiatives = search_klass.new(search_params.merge(state: %w(closed)))
+
+        if @closed_initiatives.results.present?
+          params[:filter] ||= {}
+          params[:filter][:date] = %w(closed)
+          @forced_closed_initiatives = true
+          @search = @closed_initiatives
+        end
       end
 
       # GET /initiatives/:id

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_initiatives.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_initiatives.html.erb
@@ -1,3 +1,13 @@
+<% if @forced_closed_initiatives %>
+  <div class="callout warning">
+    <%= t ".closed_initiatives_warning" %>
+  </div>
+<% elsif initiatives.blank? %>
+  <div class="callout warning">
+    <%= t ".no_initiatives_warning" %>
+  </div>
+<% end %>
+
 <div class="collection-sort-controls row small-up-1 medium-up-2 card-grid">
   <div class="column">
     <%= order_selector available_orders, i18n_scope: "decidim.initiatives.initiatives.orders" %>

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -424,6 +424,9 @@ en:
             close: Close
             explanation: You need to be verified in order to create a new initiative.
             title: Authorization required
+        initiatives:
+          closed_initiatives_warning: Currently, there are no open initiatives, but here you can find all the closed initiatives listed.
+          no_initiatives_warning: No initiatives match your search criteria.
         interactions:
           comments_count:
             count:

--- a/decidim-initiatives/spec/system/initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/initiatives_spec.rb
@@ -78,6 +78,27 @@ describe "Initiatives", type: :system do
           end
         end
       end
+
+      context "when there are only closed initiatives" do
+        let!(:closed_initiative) do
+          create(:initiative, :discarded, organization: organization)
+        end
+        let(:base_initiative) {}
+
+        before do
+          visit decidim_initiatives.initiatives_path
+        end
+
+        it "displays a warning" do
+          expect(page).to have_content("Currently, there are no open initiatives, but here you can find all the closed initiatives listed.")
+        end
+
+        it "shows closed initiatives" do
+          within "#initiatives" do
+            expect(page).to have_content(translated(closed_initiative.title, locale: :en))
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

When there are no open initiatives show the user the closed ones if available, just like meetings.

#### :pushpin: Related Issues
- Closes #5738

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [x] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

![Screenshot 2020-07-31 at 16 02 52](https://user-images.githubusercontent.com/5254/89043231-74dd7d00-d348-11ea-98b3-28b731394167.png)
