### PR TITLE
Do not migrate surveys that were already migrated in the past

### DIFF
--- a/decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb
+++ b/decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb
@@ -42,6 +42,10 @@ class CheckLegacyTables < ActiveRecord::Migration[5.2]
     ActiveRecord::Base.transaction do
       Decidim::Surveys::Survey.find_each do |survey|
         puts "Migrating survey #{survey.id}..."
+        if survey.questionnaire.present?
+          puts("already migrated at questionnaire #{survey.questionnaire.id}")
+          next
+        end
 
         questionnaire = ::Decidim::Forms::Questionnaire.create!(
           questionnaire_for: survey,


### PR DESCRIPTION
#### :tophat: What? Why?
In #6299 I forgot to modify the code in the rake task to check if a survey was already migrated. In these cases another (empty) `Questionnaire` is associated to the survey. Then this empty `Questionnaire` uses to be the one resolved by `survey.questionnaire` and it renders empty in the backoffice and in the public views.

This PR adds a check before migrating each survey and if `survey.questionnaire.present?` the survey is not migrated.

#### :pushpin: Related Issues
- Related to  #6275
- Fixes #6299

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
