### PR TITLE
Use followers counter cache when available

### DIFF
--- a/decidim-core/app/cells/decidim/follow_button/show.erb
+++ b/decidim-core/app/cells/decidim/follow_button/show.erb
@@ -4,8 +4,8 @@
       <%= button_to decidim.follow_path, class: button_classes, params: { follow: { followable_gid: model.to_sgid.to_s, inline: inline? } }, data: { disable: true }, method: :delete, remote: true do %>
         <span class="icon-wrap">
           <%= icon "bell", icon_options %>
-          <span aria-hidden="true"><%= model.followers.count %></span>
-          <span class="show-for-sr"><%= t("decidim.followers.followers_count", count: model.followers.count) %></span>
+          <span aria-hidden="true"><%= followers_count %></span>
+          <span class="show-for-sr"><%= t("decidim.followers.followers_count", count: followers_count) %></span>
         </span>
         <span class="text-wrap">
           <%= t("follows.destroy.button", scope: "decidim") %>
@@ -16,8 +16,8 @@
       <%= button_to decidim.follow_path, class: button_classes, params: { follow: { followable_gid: model.to_sgid.to_s, inline: inline? } }, data: { disable: true }, remote: true do %>
         <span class="icon-wrap">
           <%= icon "bell", icon_options %>
-          <span aria-hidden="true"><%= model.followers.count %></span>
-          <span class="show-for-sr"><%= t("decidim.followers.followers_count", count: model.followers.count) %></span>
+          <span aria-hidden="true"><%= followers_count %></span>
+          <span class="show-for-sr"><%= t("decidim.followers.followers_count", count: followers_count) %></span>
         </span>
         <span class="text-wrap">
           <% if current_user.follows?(model.try(:participatory_space)) %>
@@ -42,8 +42,8 @@
       remote: true) do %>
       <span class="icon-wrap">
         <%= icon "bell", icon_options %>
-        <span aria-hidden="true"><%= model.followers.count %></span>
-        <span class="show-for-sr"><%= t("decidim.followers.followers_count", count: model.followers.count) %></span>
+        <span aria-hidden="true"><%= followers_count %></span>
+        <span class="show-for-sr"><%= t("decidim.followers.followers_count", count: followers_count) %></span>
       </span>
       <span class="text-wrap">
         <%= t("follows.create.button", scope: "decidim") %>

--- a/decidim-core/app/cells/decidim/follow_button_cell.rb
+++ b/decidim-core/app/cells/decidim/follow_button_cell.rb
@@ -15,6 +15,14 @@ module Decidim
 
     private
 
+    def followers_count
+      if model.respond_to?(:followers_count)
+        model.followers_count
+      else
+        model.followers.count
+      end
+    end
+
     def button_classes
       return "card__button secondary text-uppercase follow-button mb-none has-tip" if inline?
 


### PR DESCRIPTION
#### :tophat: What? Why?

Investigating proposals' performance together with @mrcasals we found out that a considerable amount of the time is spent rendering coauthorships (all that complexity comes at a cost). Among that, a big issue was an N+1 fetching the authors' followers.

We thought a counter cache had to be added but it turns out it already existed :tada: ! However, `Proposals::Proposal` doesn't implement it and thus, we need to provide a fallback for now. It can be added in a separate PR (I'm not sure I'll get it done before going on holidays)

In my machine, this gets from 

![Screenshot from 2020-08-06 09-18-41](https://user-images.githubusercontent.com/762088/89503413-c95c7e80-d7c6-11ea-8eab-daacd8e1f4b9.png)

to

![Screenshot from 2020-08-06 09-17-08](https://user-images.githubusercontent.com/762088/89503501-eabd6a80-d7c6-11ea-9826-b24fc4af8454.png)

I assume the impact will be noticeable in a production env more than we see here :point_up: 


#### :pushpin: Related Issues
- Related to #? Proposals performance
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
