### PR TITLE
Fix import proposals to election answers i18n bug

### DIFF
--- a/decidim-budgets/app/commands/decidim/budgets/admin/import_proposals_to_budgets.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/admin/import_proposals_to_budgets.rb
@@ -65,12 +65,6 @@ module Decidim
             proposal.component == target_component
           end
         end
-
-        def project_localized(text)
-          Decidim.available_locales.inject({}) do |result, locale|
-            result.update(locale => text)
-          end.with_indifferent_access
-        end
       end
     end
   end

--- a/decidim-elections/app/commands/decidim/elections/admin/import_proposals_to_elections.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/import_proposals_to_elections.rb
@@ -47,8 +47,8 @@ module Decidim
         def create_answer_from_proposal(original_proposal)
           params = {
             question: form.question,
-            title: answer_localized(original_proposal.title),
-            description: answer_localized(original_proposal.body),
+            title: original_proposal.title,
+            description: original_proposal.body,
             weight: form.weight
           }
 
@@ -80,12 +80,6 @@ module Decidim
           original_proposal.linked_resources(:answers, "related_proposals").any? do |answer|
             answer.question == target_question
           end
-        end
-
-        def answer_localized(text)
-          Decidim.available_locales.inject({}) do |result, locale|
-            result.update(locale => text)
-          end.with_indifferent_access
         end
       end
     end

--- a/decidim-elections/spec/commands/decidim/elections/admin/import_proposals_to_elections_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/admin/import_proposals_to_elections_spec.rb
@@ -78,8 +78,8 @@ module Decidim
                 answers = Decidim::Elections::Answer.where(question: question)
                 first_answer = answers.first
                 last_answer = answers.last
-                expect(translated(first_answer.title)).to eq(proposal.title)
-                expect(translated(last_answer.title)).to eq(proposal.title)
+                expect(first_answer.title).to eq(proposal.title)
+                expect(last_answer.title).to eq(proposal.title)
               end
             end
 
@@ -96,8 +96,8 @@ module Decidim
               command.call
 
               new_answer = Decidim::Elections::Answer.where(question: question).last
-              expect(translated(new_answer.title)).to eq(proposal.title)
-              expect(translated(new_answer.description)).to eq(proposal.body)
+              expect(new_answer.title).to eq(proposal.title)
+              expect(new_answer.description).to eq(proposal.body)
             end
 
             it "traces the action", versioning: true do


### PR DESCRIPTION
#### :tophat: What? Why?
#6384 fixed this bug for `budgets`. We imported proposals to election answers as well. This PR fixes the bug for the `election` module.  

#### :pushpin: Related Issues
- Related to #6384 

#### :clipboard: Subtasks
