### PR TITLE
Only load SimpleCov if the env variable is set

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,26 +1,28 @@
 # frozen_string_literal: true
 
-SimpleCov.start do
-  # `ENGINE_ROOT` holds the name of the engine we're testing.
-  # This brings us to the main Decidim folder.
-  root File.expand_path("..", ENV["ENGINE_ROOT"])
+if ENV["SIMPLECOV"]
+  SimpleCov.start do
+    # `ENGINE_ROOT` holds the name of the engine we're testing.
+    # This brings us to the main Decidim folder.
+    root File.expand_path("..", ENV["ENGINE_ROOT"])
 
-  # We make sure we track all Ruby files, to avoid skipping unrequired files
-  # We need to include the `../` section, otherwise it only tracks files from the
-  # `ENGINE_ROOT` folder for some reason.
-  track_files "../**/*.rb"
+    # We make sure we track all Ruby files, to avoid skipping unrequired files
+    # We need to include the `../` section, otherwise it only tracks files from the
+    # `ENGINE_ROOT` folder for some reason.
+    track_files "../**/*.rb"
 
-  # We ignore some of the files because they are never tested
-  add_filter "/config/"
-  add_filter "/db/"
-  add_filter "/vendor/"
-  add_filter "/spec/"
-  add_filter "/test/"
-end
+    # We ignore some of the files because they are never tested
+    add_filter "/config/"
+    add_filter "/db/"
+    add_filter "/vendor/"
+    add_filter "/spec/"
+    add_filter "/test/"
+  end
 
-SimpleCov.merge_timeout 1800
+  SimpleCov.merge_timeout 1800
 
-if ENV["CI"]
-  require "simplecov-cobertura"
-  SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
+  if ENV["CI"]
+    require "simplecov-cobertura"
+    SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
For a while now, I've been getting this message every time I exited the Rails server or console in the development app, or every time I finished running tests locally:

```
SimpleCov failed to recognize the test framework and/or suite used. Please specify manually using SimpleCov.command_name 'Unit Tests'.
Coverage report generated for Unknown Test Framework to /Users/marc/code/decidim/coverage. 1866 / 73470 LOC (2.54%) covered.
```

This seems to be caused because SimpleCov is being loaded, even though I don't have tthe `SIMPLECOV` env variable set. This PR changes the SimpleCov config so that it only loads if the env variable is set.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None
