### PR TITLE
Backport "Do not migrate surveys that were already migrated in the past" to v0.22

### DIFF
--- a/decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb
+++ b/decidim-surveys/db/migrate/20200609090533_check_legacy_tables.rb
@@ -42,6 +42,10 @@ class CheckLegacyTables < ActiveRecord::Migration[5.2]
     ActiveRecord::Base.transaction do
       Decidim::Surveys::Survey.find_each do |survey|
         puts "Migrating survey #{survey.id}..."
+        if survey.questionnaire.present?
+          puts("already migrated at questionnaire #{survey.questionnaire.id}")
+          next
+        end
 
         questionnaire = ::Decidim::Forms::Questionnaire.create!(
           questionnaire_for: survey,


### PR DESCRIPTION
#### :tophat: What? Why?
Backports avoid migrating a survey when it was already migrated.

#### :pushpin: Related Issues
- Related to #6275 and #6380
- Fixes #6299

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
