### PR TITLE
Require confirmation on exiting election voting process

### DIFF
--- a/decidim-elections/app/assets/javascripts/decidim/elections/vote.js.es6
+++ b/decidim-elections/app/assets/javascripts/decidim/elections/vote.js.es6
@@ -104,6 +104,25 @@ $(() => {
     }, 3000)
   })
 
+  // exit message before confirming
+  const $form = $(".evote__options");
+  if ($form.length > 0) {
+    $(document).on("click", "a.confirm", (event) => {
+      window.confirmed = true;
+    });
+
+    window.onbeforeunload = () => {
+      const confirmed = window.confirmed;
+      window.confirmed = null;
+
+      if (confirmed) {
+        return null;
+      }
+
+      return "";
+    }
+  }
+
   $(document).on("on.zf.toggler", (event) => {
     // continue and back btn
     initStep()

--- a/decidim-elections/app/assets/javascripts/decidim/elections/vote.js.es6
+++ b/decidim-elections/app/assets/javascripts/decidim/elections/vote.js.es6
@@ -93,29 +93,33 @@ $(() => {
     return indexedArray;
   }
 
-  // log form Data
+  // confirm vote
   $(".button.confirm").on("click", (event) => {
     const boothMode = $(event.currentTarget).data("booth-mode");
+    const formData = getFormData($formData);
+    castVote(boothMode, formData)
+  });
 
-    console.log(`Your vote got encrypted successfully. The booth mode is ${boothMode}. Your vote content is:`, getFormData($formData)) // eslint-disable-line no-console
+  // cast vote
+  function castVote(boothMode, formData) {
+    // log form Data
+    console.log(`Your vote got encrypted successfully. The booth mode is ${boothMode}. Your vote content is:`, formData) // eslint-disable-line no-console
+
     window.setTimeout(function() {
       $($vote).find("#encrypting").addClass("hide")
       $($vote).find("#confirmed_page").removeClass("hide")
+      window.confirmed = true;
     }, 3000)
-  })
+  }
 
   // exit message before confirming
   const $form = $(".evote__options");
   if ($form.length > 0) {
-    $(document).on("click", "a.confirm", (event) => {
-      window.confirmed = true;
-    });
 
     window.onbeforeunload = () => {
-      const confirmed = window.confirmed;
-      window.confirmed = null;
+      const voteCast = window.confirmed;
 
-      if (confirmed) {
+      if (voteCast) {
         return null;
       }
 

--- a/decidim-elections/spec/shared/vote_examples.rb
+++ b/decidim-elections/spec/shared/vote_examples.rb
@@ -52,6 +52,8 @@ shared_examples "allows to preview booth" do
 end
 
 shared_examples "uses the voting booth" do
+  include_context "with elections router"
+
   it "uses the voting booth" do
     selected_answers = []
     non_selected_answers = []
@@ -125,6 +127,11 @@ shared_examples "uses the voting booth" do
       expect(page).to have_content("Vote confirmed")
       expect(page).to have_content("Your vote has already been cast!")
     end
+
+    # close voting booth without alert
+    page.find("a.focus__exit").click
+
+    expect(page).to have_current_path router.election_path(id: election.id)
   end
 
   def question_step(number)

--- a/decidim-elections/spec/system/vote_spec.rb
+++ b/decidim-elections/spec/system/vote_spec.rb
@@ -93,4 +93,30 @@ describe "Vote in an election", type: :system do
 
     it_behaves_like "allow admins to preview the voting booth"
   end
+
+  context "when the voting is confirmed" do
+    before do
+      visit_component
+
+      click_link translated(election.title)
+      click_link "Vote"
+    end
+
+    it_behaves_like "uses the voting booth"
+  end
+
+  context "when the voting is not confirmed" do
+    it "is alerted when trying to leave the component before completing" do
+      visit_component
+
+      click_link translated(election.title)
+      click_link "Vote"
+
+      dismiss_prompt do
+        page.find("a.focus__exit").click
+      end
+
+      expect(page).to have_content("Next")
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
If a participant tries to leave the voting process before submitting, an alert appears. As soon as the vote process is submitted, he/she can quit the process without alert. 

#### :pushpin: Related Issues
- Fixes #6347 

#### :clipboard: Subtasks
- [x] Add tests