### PR TITLE
Change locale checker's default branch

### DIFF
--- a/decidim-dev/lib/tasks/locale_checker.rake
+++ b/decidim-dev/lib/tasks/locale_checker.rake
@@ -5,7 +5,7 @@ namespace :decidim do
   task check_locales: :environment do
     FileUtils.remove_dir("tmp/decidim_repo", true)
 
-    branch = ENV["TARGET_BRANCH"] || "master"
+    branch = ENV["TARGET_BRANCH"] || "develop"
     status = system("git clone --depth=1 --single-branch --branch #{branch} https://github.com/decidim/decidim tmp/decidim_repo")
     return unless status
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -167,8 +167,10 @@ You can also make sure new translations are complete for all languages in your
 application with:
 
 ```console
-bin/rails decidim:check_locales
+TARGET_BRANCH=release/0.22-stable bin/rails decidim:check_locales
 ```
+
+Here the `TARGET_BRANCH` must be the same as the `decidim` dependency in your `Gemfile`.
 
 Be aware that this task might not be able to detect everything, so make sure you
 also manually check your application before upgrading.


### PR DESCRIPTION
#### :tophat: What? Why?
This PR comes from the discussion in #6307 .
The `check_locale` task was using `master` as its default branch, but we changed Decidim repository default branch to `develop`. This PR updates `check_locale` to use `develop` instead of `master` by default.

It must be taken in to account that Decidim installations rarely depend upon Decidim `develop` so I've also updated the documentation in how to use the same `TARGET_BRANCH` as the one in the application's `Gemfile`.

#### :pushpin: Related Issues
- Related to #6307

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [x] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests