### PR TITLE
fix maltese translation for foundation datepicker

### DIFF
--- a/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.mt.js
+++ b/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.mt.js
@@ -3,9 +3,9 @@
  */
 ; (function ($) {
 	$.fn.fdatepicker.dates['mt'] = {
-		days: ["Ħadd", "It-Tnejn", "It-Tlieta", "L-Erbgħa", "Il-Ħamis", "Nhar il-Ġimgħa", "Is-Sibt],
-		daysShort: ["Ħadd", "It-Tnejn", "dimatri", "L-Erbgħa", "Il-Ħamis", "Nhar il-Ġimgħa", "Is-Sibt],
-		daysMin: ["Ħadd", "It-Tnejn", "dimatri", "L-Erbgħa", "Il-Ħamis", "Nhar il-Ġimgħa", "Is-Sibt],
+		days: ["Ħadd", "It-Tnejn", "It-Tlieta", "L-Erbgħa", "Il-Ħamis", "Nhar il-Ġimgħa", "Is-Sibt"],
+		daysShort: ["Ħadd", "It-Tnejn", "dimatri", "L-Erbgħa", "Il-Ħamis", "Nhar il-Ġimgħa", "Is-Sibt"],
+		daysMin: ["Ħadd", "It-Tnejn", "dimatri", "L-Erbgħa", "Il-Ħamis", "Nhar il-Ġimgħa", "Is-Sibt"],
 		months: ["Ġeneru", "Frar", "Marzu", "April", "Mejju", "Ġunju", "Lulju", "Awissu", "Settembru", "Ottubru", "Novembru", "Diċembru"],
 		monthsShort: ["Ġeneru", "Frar", "Marzu", "April", "Mejju", "Ġunju", "Lulju", "Awissu", "Settembru", "Ottubru", "Novembru", "Diċembru"],
 		today: "illum",


### PR DESCRIPTION
#### :tophat: What? Why?
The `foundation-datepicker` with Maltese translations had missing quotation marks. This PR adds them. 

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
