### PR TITLE
Backport Latvian language on release/0.21-stable

### DIFF
--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -19,6 +19,7 @@ files:
         hu: hu
         id-ID: id
         it: it
+        lv: lv
         nl: nl
         no: no
         pl: pl

--- a/decidim-core/config/locales/lv-LV.yml
+++ b/decidim-core/config/locales/lv-LV.yml
@@ -1256,7 +1256,7 @@ lv:
       widget:
         see_more: Skatīt vairāk
   locale:
-    name: Angliski
+    name: Latvian
   password_validator:
     domain_included_in_password: ir pārāk līdzīga šī domēna vārdam
     email_included_in_password: ir pārāk līdzīga jūsu e-pasta adresei

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -133,7 +133,7 @@ module Decidim
 
   # Exposes a configuration option: The application available locales.
   config_accessor :available_locales do
-    %w(en ar ca de el es es-MX es-PY eu fi-pl fi fr gl hu id it nl no pl pt pt-BR ro ru sk sv tr uk)
+    %w(en ar ca de el es es-MX es-PY eu fi-pl fi fr gl hu id it lv nl no pl pt pt-BR ro ru sk sv tr uk)
   end
 
   # Exposes a configuration option: The application default locale.

--- a/decidim-core/spec/lib/available_locales_spec.rb
+++ b/decidim-core/spec/lib/available_locales_spec.rb
@@ -12,7 +12,7 @@ end
 
 describe "available locales", type: :system do
   let(:languages) do
-    %w(en ar ca de el es es-MX es-PY eu fi-pl fi fr gl hu id it nl no pl pt pt-BR ro ru sk sv tr uk)
+    %w(en ar ca de el es es-MX es-PY eu fi-pl fi fr gl hu id it lv nl no pl pt pt-BR ro ru sk sv tr uk)
   end
   let(:datepicker_file) do
     lambda { |lang|

--- a/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.lv.js
+++ b/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.lv.js
@@ -1,0 +1,15 @@
+/**
+ * Latvian translation for foundation-datepicker
+ */
+;(function($){
+	$.fn.fdatepicker.dates['lv'] = {
+		days: ["Svētdiena", "Pirmdiena", "Otrdiena", "Trešdiena", "Ceturtdiena", "Piektdiena", "Sestdiena", "Svētdiena"],
+		daysShort: ["Svētd", "Pirmd", "Otrd", "Trešd", "Ceturtd", "Piektd", "Sestd", "Svētd"],
+		daysMin: ["S", "P", "O", "T", "C", "P", "S", "S"],
+		months: ["Janvāris", "Februāris", "Marts", "Aprīlis", "Maijs", "Jūnijs", "Jūlijs", "Augusts", "Septembris", "Oktobris", "Novembris", "Décembris"],
+		monthsShort: ["Janv", "Febr", "Marts", "Apr", "Maijs", "Jūn", "Jūl", "Aug", "Sept", "Okt", "Nov", "Dec"],
+		today: "Šodien",
+		clear: "Izdzēst",
+		weekStart: 1
+	};
+}(jQuery));

--- a/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.lv.js
+++ b/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.lv.js
@@ -3,9 +3,9 @@
  */
 ;(function($){
 	$.fn.fdatepicker.dates['lv'] = {
-		days: ["Svētdiena", "Pirmdiena", "Otrdiena", "Trešdiena", "Ceturtdiena", "Piektdiena", "Sestdiena", "Svētdiena"],
-		daysShort: ["Svētd", "Pirmd", "Otrd", "Trešd", "Ceturtd", "Piektd", "Sestd", "Svētd"],
-		daysMin: ["S", "P", "O", "T", "C", "P", "S", "S"],
+		days: ["Svētdiena", "Pirmdiena", "Otrdiena", "Trešdiena", "Ceturtdiena", "Piektdiena", "Sestdiena"],
+		daysShort: ["Svētd", "Pirmd", "Otrd", "Trešd", "Ceturtd", "Piektd", "Sestd"],
+		daysMin: ["S", "P", "O", "T", "C", "P", "S"],
 		months: ["Janvāris", "Februāris", "Marts", "Aprīlis", "Maijs", "Jūnijs", "Jūlijs", "Augusts", "Septembris", "Oktobris", "Novembris", "Décembris"],
 		monthsShort: ["Janv", "Febr", "Marts", "Apr", "Maijs", "Jūn", "Jūl", "Aug", "Sept", "Okt", "Nov", "Dec"],
 		today: "Šodien",


### PR DESCRIPTION
#### :tophat: What? Why?

Latvian has been previously added to Crowdin, this PR aims to implement Latvian support on `0.21-stable` 

#### :clipboard: Subtasks
- [x] Add Latvian to available locales
- [x] Add tests
- [ ] Backport on `release/0.22-stable`