### PR TITLE
Fix test texts after merging Spanish translations

### DIFF
--- a/decidim-core/spec/system/translations_spec.rb
+++ b/decidim-core/spec/system/translations_spec.rb
@@ -81,7 +81,7 @@ describe "Translations", type: :system do
       end
 
       it "shows a button to show translated text" do
-        expect(page).to have_content("Show automatically-translated text")
+        expect(page).to have_content("Mostrar el texto traducido automáticamente")
       end
 
       it "shows the original English text" do
@@ -100,7 +100,7 @@ describe "Translations", type: :system do
 
       context "when toggling translations" do
         before do
-          click_link "Show automatically-translated text"
+          click_link "Mostrar el texto traducido automáticamente"
         end
 
         it "shows the translated title" do
@@ -127,7 +127,7 @@ describe "Translations", type: :system do
       end
 
       it "shows a button to show original text" do
-        expect(page).to have_content("Show original text")
+        expect(page).to have_content("Mostrar el texto original")
       end
 
       it "shows the Spanish texts" do
@@ -146,7 +146,7 @@ describe "Translations", type: :system do
 
       context "when toggling translations" do
         before do
-          click_link "Show original text"
+          click_link "Mostrar el texto original"
         end
 
         it "shows the original values" do


### PR DESCRIPTION
#### :tophat: What? Why?
After merging https://github.com/decidim/decidim/pull/6127 translations to Spanish were still not set and tests which rely on them were using English for some UI labels when it should be Spanish. As translations defaulted to English tests succeeded but when Spanish translations have been merged into `develop` these tests start to fail.

This PR, resolves this situation.

#### :pushpin: Related Issues
- Fixes #6127

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
