### PR TITLE
Backport "Fix random indent style on notifications" to v0.22

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_modules.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_modules.scss
@@ -51,6 +51,7 @@
 @import "decidim/modules/floating-helper";
 @import "decidim/modules/versions";
 @import "decidim/modules/sticky";
+@import "decidim/modules/notification";
 
 //Process elements
 @import "decidim/modules/process-header";

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_notification.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_notification.scss
@@ -1,0 +1,5 @@
+#notifications{
+  .card-data__item--expand{
+    align-items: stretch;
+  }
+}


### PR DESCRIPTION
#### :tophat: What? Why?
This PR backports the fix for random indent on notifications cards in #6415.

#### :pushpin: Related Issues
- Related to #6415
- Fixes #6378
