### PR TITLE
Add comments metadata to debates

### DIFF
--- a/decidim-core/app/models/decidim/organization.rb
+++ b/decidim-core/app/models/decidim/organization.rb
@@ -9,6 +9,7 @@ module Decidim
     include Decidim::Traceable
     include Decidim::Loggable
     include Decidim::TranslatableResource
+    include Decidim::ActsAsAuthor
 
     SOCIAL_HANDLERS = [:twitter, :facebook, :instagram, :youtube, :github].freeze
     AVAILABLE_MACHINE_TRANSLATION_DISPLAY_PRIORITIES = %w(original translation).freeze
@@ -123,6 +124,12 @@ module Decidim
 
     def machine_translation_prioritizes_translation?
       machine_translation_display_priority == "translation"
+    end
+
+    # Returns the presenter for this author, to be used in the views.
+    # Required by ActsAsAuthor.
+    def presenter
+      Decidim::Debates::OfficialAuthorPresenter.new
     end
 
     private

--- a/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
+++ b/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
@@ -33,6 +33,39 @@ module Decidim
         content = strip_tags(content) if strip_tags
         content
       end
+
+      def last_comment_by
+        return unless comments_authors.any?
+
+        comment_author = comments.order("created_at DESC").first.normalized_author
+        return unless comment_author
+
+        if comment_author.is_a?(Decidim::User)
+          Decidim::UserPresenter.new(comment_author)
+        elsif comment_author.is_a?(Decidim::UserGroup)
+          Decidim::UserGroupPresenter.new(comment_author)
+        elsif comment_author.is_a?(Decidim::Organization)
+          Decidim::Debates::OfficialAuthorPresenter.new
+        end
+      end
+
+      def participants_count
+        comments_authors.count do |author|
+          author.is_a?(Decidim::User)
+        end
+      end
+
+      def groups_count
+        comments_authors.count do |author|
+          author.is_a?(Decidim::UserGroup)
+        end
+      end
+
+      private
+
+      def comments_authors
+        @comments_authors ||= debate.comments.includes(:author, :user_group).map(&:normalized_author).uniq
+      end
     end
   end
 end

--- a/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
+++ b/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
@@ -37,16 +37,7 @@ module Decidim
       def last_comment_by
         return unless comments_authors.any?
 
-        comment_author = comments.order("created_at DESC").first.normalized_author
-        return unless comment_author
-
-        if comment_author.is_a?(Decidim::User)
-          Decidim::UserPresenter.new(comment_author)
-        elsif comment_author.is_a?(Decidim::UserGroup)
-          Decidim::UserGroupPresenter.new(comment_author)
-        elsif comment_author.is_a?(Decidim::Organization)
-          Decidim::Debates::OfficialAuthorPresenter.new
-        end
+        comments.order("created_at DESC").first.normalized_author&.presenter
       end
 
       def participants_count

--- a/decidim-debates/app/views/decidim/debates/debates/show.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/show.html.erb
@@ -56,6 +56,36 @@ edit_link(
         <%= render partial: "decidim/shared/follow_button", locals: { followable: debate, large: false } %>
       </div>
     </div>
+    <div class="card extra">
+      <div class="definition-data">
+        <div class="definition-data__item definition-data__item">
+          <span class="definition-data__title">
+            <%= t ".last_comment_by" %>
+          </span>
+          <span class="definition-data__text">
+            <% if debate_presenter.last_comment_by %>
+              <%= cell "decidim/author", debate_presenter.last_comment_by, context: { extra_classes: ["author-data--small"] } %>
+            <% else %>
+              <%= t ".no_comments_yet" %>
+            <% end %>
+          </span>
+        </div>
+
+        <div class="definition-data__item definition-data__item--double">
+          <span class="definition-data__title">
+            <%= t ".participants_count" %>
+          </span>
+          <span class="definition-data__number"><%= debate_presenter.participants_count %></span>
+        </div>
+
+        <div class="definition-data__item definition-data__item--double">
+          <span class="definition-data__title">
+            <%= t ".groups_count" %>
+          </span>
+          <span class="definition-data__number"><%= debate_presenter.groups_count %></span>
+        </div>
+      </div>
+    </div>
     <%= resource_reference(debate) %>
     <%= resource_version(debate_presenter, versions_path: debate_versions_path(debate)) %>
     <%= render partial: "decidim/shared/share_modal" %>

--- a/decidim-debates/config/locales/en.yml
+++ b/decidim-debates/config/locales/en.yml
@@ -128,6 +128,10 @@ en:
           debate_conclusions_are: 'The debate was closed on %{date} with these conclusions:'
           edit_conclusions: Edit conclusions
           edit_debate: Edit debate
+          groups_count: Groups
+          last_comment_by: Last comment by
+          no_comments_yet: No comments yet
+          participants_count: Participants
         update:
           invalid: There was a problem updating the debate.
           success: Debate successfully updated.

--- a/decidim-debates/spec/system/show_spec.rb
+++ b/decidim-debates/spec/system/show_spec.rb
@@ -20,4 +20,39 @@ describe "show", type: :system do
 
     it_behaves_like "going back to list button"
   end
+
+  describe "comments metadata" do
+    context "when there are no comments" do
+      it "shows default values" do
+        within ".definition-data" do
+          expect(page).to have_content("No comments yet")
+        end
+      end
+    end
+
+    context "when there are some comments" do
+      let(:last_comment) { Decidim::Comments::Comment.last }
+
+      before do
+        group = create(:user_group, organization: debate.organization)
+        create(:comment, commentable: debate, author: group)
+        create(:comment, commentable: debate)
+
+        visit current_url
+      end
+
+      it "shows the last comment author" do
+        within ".definition-data" do
+          expect(page).to have_content(last_comment.author.name)
+        end
+      end
+
+      it "shows the number of participants" do
+        within ".definition-data" do
+          expect(page).to have_content("PARTICIPANTS\n1")
+          expect(page).to have_content("GROUPS\n1")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Adds metadata about comments in debates.

#### :pushpin: Related Issues
- Related to #6004

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [x] Add tests
- [ ] Another subtask

### :camera: Screenshots

<img width="1237" alt="Screenshot 2020-08-24 at 12 09 46" src="https://user-images.githubusercontent.com/5254/91034501-67dd4200-e605-11ea-9e01-6f1999b17b9f.png">
<img width="576" alt="Screenshot 2020-08-24 at 12 09 58" src="https://user-images.githubusercontent.com/5254/91034512-6b70c900-e605-11ea-9189-ce3ac5d81d20.png">
<img width="439" alt="Screenshot 2020-08-24 at 12 10 25" src="https://user-images.githubusercontent.com/5254/91034516-6c095f80-e605-11ea-9367-9c2355bb92b5.png">


