### PR TITLE
Keep filter and ordering params

### DIFF
--- a/decidim-budgets/app/cells/decidim/budgets/project_list_item_cell.rb
+++ b/decidim-budgets/app/cells/decidim/budgets/project_list_item_cell.rb
@@ -40,7 +40,7 @@ module Decidim
       private
 
       def resource_path
-        resource_locator(model).path
+        resource_locator(model).path(filter_link_params)
       end
 
       def resource_title

--- a/decidim-budgets/app/services/decidim/budgets/project_search.rb
+++ b/decidim-budgets/app/services/decidim/budgets/project_search.rb
@@ -29,7 +29,7 @@ module Decidim
 
       # Returns the random projects for the current page.
       def results
-        Project.where(id: super.pluck(:id))
+        Project.where(id: super.pluck(:id)).includes([:scope, :component, :attachments, :category])
       end
 
       private

--- a/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
@@ -16,7 +16,7 @@ edit_link(
   <% if current_user.present? && current_settings.votes_enabled? && current_participatory_space.can_participate?(current_user) %>
     <%= render partial: "budget_summary", locals: { include_heading: false } %>
   <% end %>
-  <%= link_to projects_path, class: "muted-link" do %>
+  <%= link_to projects_path(filter_link_params), class: "muted-link" do %>
     <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
     <%= t(".view_all_projects") %>
   <% end %>

--- a/decidim-core/app/cells/decidim/card_m_cell.rb
+++ b/decidim-core/app/cells/decidim/card_m_cell.rb
@@ -19,7 +19,7 @@ module Decidim
     private
 
     def resource_path
-      resource_locator(model).path
+      resource_locator(model).path(filter_link_params)
     end
 
     def resource_image_path

--- a/decidim-core/app/cells/decidim/version_cell.rb
+++ b/decidim-core/app/cells/decidim/version_cell.rb
@@ -77,7 +77,7 @@ module Decidim
     end
 
     def resource_path
-      resource_locator(versioned_resource).path
+      resource_locator(versioned_resource).path(filter_link_params)
     end
   end
 end

--- a/decidim-core/app/cells/decidim/versions_list_cell.rb
+++ b/decidim-core/app/cells/decidim/versions_list_cell.rb
@@ -13,7 +13,7 @@ module Decidim
     end
 
     def resource_path
-      resource_locator(versioned_resource).path
+      resource_locator(versioned_resource).path(filter_link_params)
     end
 
     def i18n_changes_title

--- a/decidim-core/app/controllers/decidim/components/base_controller.rb
+++ b/decidim-core/app/controllers/decidim/components/base_controller.rb
@@ -24,6 +24,7 @@ module Decidim
       helper Decidim::AttachmentsHelper
       helper Decidim::SanitizeHelper
       helper Decidim::PadHelper
+      helper Decidim::FilterParamsHelper
 
       helper_method :current_component,
                     :current_participatory_space,

--- a/decidim-core/app/helpers/decidim/filter_params_helper.rb
+++ b/decidim-core/app/helpers/decidim/filter_params_helper.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Decidim
+  # A helper to allow only Decidim params to be added to a link.
+  # This is useful when we want to preserve the params from a search, ordering
+  # or paginating results. Using this, we can link back to where the user was
+  # at the show page.
+  module FilterParamsHelper
+    # Public: Builds a hash to be added to a _path or _url method with only
+    # allowed params.
+    #
+    # params - An optional Hash with the values of the params. It will try to
+    # get them from the controller if none are present.
+    #
+    # Returns a Hash.
+    def filter_link_params(params = nil)
+      return {} if params.blank? && (!respond_to?(:controller) || !controller.respond_to?(:params))
+
+      params = controller.params.to_unsafe_h if params.blank?
+
+      params.stringify_keys.slice(
+        "order",
+        "filter",
+        "page",
+        "per_page",
+        "locale"
+      )
+    end
+  end
+end

--- a/decidim-core/app/helpers/decidim/orders_helper.rb
+++ b/decidim-core/app/helpers/decidim/orders_helper.rb
@@ -27,7 +27,12 @@ module Decidim
 
       link_to(
         t("#{i18n_scope}.#{order}"),
-        url_for(params.to_unsafe_h.merge(page: nil, order: order)),
+        url_for(params.to_unsafe_h.except(
+          "component_id",
+          "participatory_process_slug",
+          "assembly_slug",
+          "initiative_slug"
+        ).merge(page: nil, order: order)),
         {
           data: { order: order },
           remote: true

--- a/decidim-core/app/helpers/decidim/paginate_helper.rb
+++ b/decidim-core/app/helpers/decidim/paginate_helper.rb
@@ -12,7 +12,9 @@ module Decidim
       # Kaminari uses url_for to generate the url, but this doesn't play nice with our engine system
       # and unless we remove these params they are added again as query string :(
       default_params = {
-        participatory_process_id: nil,
+        participatory_process_slug: nil,
+        assembly_slug: nil,
+        initiative_slug: nil,
         component_id: nil
       }
 

--- a/decidim-core/lib/decidim/view_model.rb
+++ b/decidim-core/lib/decidim/view_model.rb
@@ -14,6 +14,7 @@ module Decidim
     include Decidim::ActionAuthorizationHelper
     include Decidim::ReplaceButtonsHelper
     include Decidim::MarkupHelper
+    include Decidim::FilterParamsHelper
 
     delegate :current_organization, to: :controller
 

--- a/decidim-core/spec/helpers/decidim/filter_params_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/filter_params_helper_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe FilterParamsHelper do
+    describe "filter_link_params" do
+      subject { helper.filter_link_params(params) }
+
+      let(:params) do
+        {
+          "order" => "random",
+          filter: { "search_text" => "hello" },
+          "page" => 2,
+          "per_page" => 10,
+          "locale" => "en",
+          "controller" => "foo",
+          "im_a_hacker" => "🤡"
+        }
+      end
+
+      it { is_expected.to include("filter") }
+      it { is_expected.to include("order") }
+      it { is_expected.to include("page") }
+      it { is_expected.to include("per_page") }
+      it { is_expected.to include("locale") }
+      it { is_expected.not_to include("controller") }
+      it { is_expected.not_to include("im_a_hacker") }
+
+      it "only includes allowed parameters" do
+        expect(subject.keys.length).to eq(5)
+      end
+
+      context "when no params given" do
+        it "gets the params from the controller" do
+          expect(helper.controller).to receive(:params).and_return(double(to_unsafe_h: params))
+          expect(helper.filter_link_params).not_to be_empty
+        end
+      end
+    end
+  end
+end

--- a/decidim-debates/app/views/decidim/debates/debates/show.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/show.html.erb
@@ -14,7 +14,7 @@ edit_link(
 %>
 
 <div class="row column view-header">
-  <%= link_to :debates, class: "small hollow" do %>
+  <%= link_to debates_path(filter_link_params), class: "small hollow" do %>
     <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
     <%= t(".back") %>
   <% end %>

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_list_item_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_list_item_cell.rb
@@ -14,7 +14,7 @@ module Decidim
       private
 
       def resource_path
-        resource_locator(model).path
+        resource_locator(model).path(filter_link_params)
       end
 
       def title

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -16,8 +16,7 @@ edit_link(
 %>
 
 <div class="row column view-header">
-
-  <%= link_to :meetings, class: "small hollow" do %>
+  <%= link_to meetings_path(filter_link_params), class: "small hollow" do %>
     <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
     <%= t(".back") %>
   <% end %>

--- a/decidim-proposals/app/cells/decidim/proposals/collaborative_draft_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/collaborative_draft_cell.rb
@@ -22,7 +22,7 @@ module Decidim
       end
 
       def resource_path
-        resource_locator(model).path
+        resource_locator(model).path(filter_link_params)
       end
 
       def current_participatory_space

--- a/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal_cell.rb
@@ -39,7 +39,7 @@ module Decidim
       end
 
       def resource_path
-        resource_locator(model).path
+        resource_locator(model).path(filter_link_params)
       end
 
       def amend_resource_path

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_cell.rb
@@ -22,7 +22,7 @@ module Decidim
       end
 
       def resource_path
-        resource_locator(model).path
+        resource_locator(model).path(filter_link_params)
       end
 
       def current_participatory_space

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -34,7 +34,7 @@ extra_admin_link(
 <%= emendation_announcement_for @proposal %>
 <div class="row column view-header">
 
-  <%= link_to :proposals, class: "small hollow" do %>
+  <%= link_to proposals_path(filter_link_params), class: "small hollow" do %>
     <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
     <%= t(".back_to_list") %>
   <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

When a user followed a link in a list of filtered or ordered resources the params were lost, this fixed it for debates, projects, proposals and meetings.

#### :pushpin: Related Issues
- Related to #5816

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [x] Add tests
- [ ] Another subtask

