### PR TITLE
Remove unneeded Rubocop cop

### DIFF
--- a/decidim-meetings/spec/lib/decidim/meetings/registrations/code_generator_spec.rb
+++ b/decidim-meetings/spec/lib/decidim/meetings/registrations/code_generator_spec.rb
@@ -20,13 +20,11 @@ module Decidim
           before do
             create :registration, meeting: meeting, code: existing_code
 
-            # rubocop:disable RSpec/SubjectStub
             expect(subject)
               .to receive(:choose)
               .with(length)
               .twice
               .and_return(existing_code, valid_code)
-            # rubocop:enable RSpec/SubjectStub
           end
 
           it "returns an unique code" do


### PR DESCRIPTION
#### :tophat: What? Why?
Remove unneeded Rubocop cop after upgrading `rubocop-rspec` to 1.41.0 while Bumping to 0.22.0.rc2.
