### PR TITLE
Make consent cookie name configurable

### DIFF
--- a/decidim-core/app/controllers/decidim/cookie_policy_controller.rb
+++ b/decidim-core/app/controllers/decidim/cookie_policy_controller.rb
@@ -6,9 +6,12 @@ module Decidim
     skip_before_action :store_current_location
 
     def accept
-      response.set_cookie "decidim-cc", value: "true",
-                                        path: "/",
-                                        expires: 1.year.from_now.utc
+      response.set_cookie(
+        Decidim.config.consent_cookie_name,
+        value: "true",
+        path: "/",
+        expires: 1.year.from_now.utc
+      )
 
       respond_to do |format|
         format.js

--- a/decidim-core/app/helpers/decidim/cookies_helper.rb
+++ b/decidim-core/app/helpers/decidim/cookies_helper.rb
@@ -5,7 +5,7 @@ module Decidim
   module CookiesHelper
     # Public: Returns true if the cookie policy has been accepted
     def cookies_accepted?
-      cookies["decidim-cc"].present?
+      cookies[Decidim.config.consent_cookie_name].present?
     end
   end
 end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -343,6 +343,12 @@ module Decidim
     %w(all participants)
   end
 
+  # Defines the name of the cookie used to check if the user allows Decidim to
+  # set cookies.
+  config_accessor :consent_cookie_name do
+    "decidim-cc"
+  end
+
   # Public: Registers a global engine. This method is intended to be used
   # by component engines that also offer unscoped functionality
   #

--- a/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
@@ -226,6 +226,10 @@ Decidim.configure do |config|
   # end
   #
   # config.machine_translation_service = "MyTranslationService"
+
+  # Defines the name of the cookie used to check if the user allows Decidim to
+  # set cookies.
+  # config.consent_cookie_name = "decidim-cc"
 end
 
 Rails.application.config.i18n.available_locales = Decidim.available_locales


### PR DESCRIPTION
#### :tophat: What? Why?
The consent cookie is used to track whether the user allows Decidim to set cookies or not. In some cases, we need to configure the cookie name to match some client needs. This PR adds this configuration.

#### :pushpin: Related Issues
- None

#### :clipboard: Subtasks
None