### PR TITLE
Upgrade to bundler 2 to be able to run `rake release`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -817,4 +817,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -802,4 +802,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/decidim.gemspec
+++ b/decidim.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
   s.add_dependency "decidim-system", Decidim.version
   s.add_dependency "decidim-verifications", Decidim.version
 
-  s.add_development_dependency "bundler", "~> 1.12"
+  s.add_development_dependency "bundler", "~> 2.1.2"
   s.add_development_dependency "rake", "~> 12.0"
   s.add_development_dependency "rspec", "~> 3.0"
 end

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -817,4 +817,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   1.17.3
+   2.1.4


### PR DESCRIPTION
#### :tophat: What? Why?
Due to the enablig of MFA in rubygems we're facing the problem that `rake release` hangs not asking for the OTP code. This is a [known bug](https://github.com/rubygems/bundler/issues/6854) that has been already solved in [this PR](https://github.com/rubygems/bundler/pull/7199).
It requires to upgrade the gem system to v3 (`gem update --system`) and bundler to v2 (`bundle update --bundler`) to be able to use `rake release`.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
