### PR TITLE
Backport "Upgrade to bundler 2 to be able to run `rake release`" to v0.22

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -808,4 +808,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -800,4 +800,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/decidim.gemspec
+++ b/decidim.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
   s.add_dependency "decidim-system", Decidim.version
   s.add_dependency "decidim-verifications", Decidim.version
 
-  s.add_development_dependency "bundler", "~> 1.12"
+  s.add_development_dependency "bundler", "~> 2.1.2"
   s.add_development_dependency "rake", "~> 12.0"
   s.add_development_dependency "rspec", "~> 3.0"
 end

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -810,4 +810,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.17.3
+   2.1.4


### PR DESCRIPTION
#### :tophat: What? Why?
While releasing Decidim v0.22.0 we've found [that bug](https://github.com/rubygems/bundler/issues/6854) in `bundler` v1.7.
This PR backports the required `bundler` upgrade to `release/0.22-stable`.

#### :pushpin: Related Issues
- Related to #6452

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
