### PR TITLE
Require the necessary "zip" gem in the open data exporter

### DIFF
--- a/decidim-core/app/services/decidim/open_data_exporter.rb
+++ b/decidim-core/app/services/decidim/open_data_exporter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "zip"
+
 module Decidim
   # Public: It generates a ZIP file with Open Data CSV files ready
   # to be uploaded somewhere so users can download an organization


### PR DESCRIPTION
#### :tophat: What? Why?

Without this, the exporter would not work in environments where the "zip" gem is not explicitly loaded through the Gemfile, as in most Decidim instances.

Why I think it works with the rspec tests is that it loads all the Decidim's dependency gems through the dummy app's Gemfile (which is the Gemfile at the root of this project). However, this is not the case in many production environments.