### PR TITLE
Backport "Fix InvitePresenter when invitation does not exist anymore" to v0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The use case that originated this change is the persistence of the user's gender
 
 ### Fixed
 
+- **decidim-meetings**: Fix InvitePresenter when invitation does not exist anymore. [\#6470](https://github.com/decidim/decidim/pull/6470)
 - **decidim-meeting**: Backport "Avoid deleting a meeting when it has at least one proposal originated in it". [\#6250](https://github.com/decidim/decidim/pull/6250)
 - **decidim-core**: Backport "Fix crash when proposals meeting author is deleted". [\#6243](https://github.com/decidim/decidim/pull/6243)
 - **decidim-proposals**: Fix participatory text newline absence. [\#6159](https://github.com/decidim/decidim/pull/6159)

--- a/decidim-admin/spec/system/admin_manages_newsletters_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_newsletters_spec.rb
@@ -199,7 +199,7 @@ describe "Admin manages newsletters", type: :system do
         end
       end
 
-      it "sends to participants" do
+      it "sends to participants", :slow do
         visit decidim_admin.select_recipients_to_deliver_newsletter_path(newsletter)
         perform_enqueued_jobs do
           within(".newsletter_deliver") do

--- a/decidim-core/app/presenters/decidim/log/base_presenter.rb
+++ b/decidim-core/app/presenters/decidim/log/base_presenter.rb
@@ -190,7 +190,7 @@ module Decidim
       def i18n_params
         {
           user_name: user_presenter.present,
-          resource_name: resource_presenter.present,
+          resource_name: resource_presenter.try(:present),
           space_name: space_presenter.present
         }
       end

--- a/decidim-meetings/app/commands/decidim/meetings/admin/invite_user_to_join_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/invite_user_to_join_meeting.rb
@@ -50,7 +50,8 @@ module Decidim
             },
             participatory_space: {
               title: meeting.participatory_space.title
-            }
+            },
+            attendee_name: user.name
           }
 
           @invite = Decidim.traceability.create!(

--- a/decidim-meetings/app/presenters/decidim/meetings/admin_log/invite_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/admin_log/invite_presenter.rb
@@ -24,9 +24,13 @@ module Decidim
           end
         end
 
+        # Tries to use the attendee name from the invitation (resource).
+        # If invitation does not exist anymore use the one in extras.
         def i18n_params
+          attendee_name = action_log.resource ? action_log.resource.user.name : action_log.extra["attendee_name"]
           super.merge(
-            attendee_name: action_log.resource.user.name
+            # before Decidim v0.23.0 attendee_name was not being copied into the extras so it may be nil
+            attendee_name: attendee_name || "????"
           )
         end
       end

--- a/decidim-meetings/spec/commands/admin/invite_user_to_join_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/admin/invite_user_to_join_meeting_spec.rb
@@ -51,7 +51,7 @@ module Decidim::Meetings
         it "traces the action", versioning: true do
           expect(Decidim.traceability)
             .to receive(:create!)
-            .with(Decidim::Meetings::Invite, current_user, kind_of(Hash), hash_including(resource: hash_including(:title), participatory_space: hash_including(:title)))
+            .with(Decidim::Meetings::Invite, current_user, kind_of(Hash), hash_including(resource: hash_including(:title), participatory_space: hash_including(:title), attendee_name: attendee_name))
             .and_call_original
 
           expect { subject.call }.to change(Decidim::ActionLog, :count)
@@ -66,6 +66,7 @@ module Decidim::Meetings
 
       context "when the form provides an existing user" do
         let!(:user) { create(:user, :confirmed, organization: organization) }
+        let(:attendee_name) { user.name }
         let(:existing_user) { true }
         let(:user_id) { user.id }
 
@@ -87,6 +88,7 @@ module Decidim::Meetings
 
       context "when a user already exists" do
         let!(:user) { create(:user, :confirmed, email: form.email, organization: organization) }
+        let(:attendee_name) { user.name }
 
         it "does not create another user" do
           expect do
@@ -105,6 +107,8 @@ module Decidim::Meetings
       end
 
       context "when a user does not exist for the given email" do
+        let(:attendee_name) { "name" }
+
         it "creates it" do
           expect do
             subject.call

--- a/decidim-meetings/spec/presenters/decidim/meetings/admin_log/invite_presenter_spec.rb
+++ b/decidim-meetings/spec/presenters/decidim/meetings/admin_log/invite_presenter_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Meetings::AdminLog
+  describe InvitePresenter, type: :helper do
+    subject { described_class.new(action_log, helper).present }
+
+    let(:participatory_space) { create :participatory_process }
+    let(:component) { create :component, participatory_space: participatory_space }
+    let(:invite) { create(:invite, sent_at: nil) }
+    let(:action_log) { create(:action_log, participatory_space: participatory_space, component: component, resource: invite, action: "create") }
+
+    before do
+      helper.class.include Decidim::TranslatableAttributes
+    end
+
+    describe "#present" do
+      context "when invite still exists" do
+        it "renders the invite information" do
+          user = action_log.user
+          inviter = "<a class=\"logs__log__author\" title=\"@#{user.nickname}\" data-tooltip=\"true\" data-disable-hover=\"false\" href=\"/profiles/#{user.nickname}\">#{user.name}</a>"
+          space = "<a class=\"logs__log__space\" href=\"/processes/#{participatory_space.slug}?participatory_process_slug=#{participatory_space.slug}\">#{translated(participatory_space.title)}</a>"
+          action_string = "#{inviter} invited #{invite.user.name} to join <span class=\"logs__log__resource\"></span> meeting on the #{space} space"
+          expect(subject).to include action_string
+        end
+      end
+
+      context "when invite doesn't exist anymore" do
+        before do
+          invite.destroy
+          action_log.reload
+        end
+
+        it "renders the attendee name as ????" do
+          expect(subject).to include "invited ???? to join"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Backport the fix that solves the NilClass exception when rendering action logs corresponding to a meeting invitation that has already been destroyed.

#### :pushpin: Related Issues
- Related to #6468, #6469 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
