### PR TITLE
Change popup button from "Keep uncheck" to "Keep unchecked"

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -440,7 +440,7 @@ en:
           buttons:
             check: Check and continue
             close_modal: Close modal
-            uncheck: Keep uncheck
+            uncheck: Keep unchecked
           notice: |-
             <p>Hey, are you sure you don't want to receive a newsletter?<br>
             Please consider again ticking the newsletter checkbox below.<br>

--- a/decidim-core/spec/commands/decidim/create_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_registration_spec.rb
@@ -98,7 +98,7 @@ module Decidim
             expect { command.call }.to change(User, :count).by(1)
           end
 
-          describe "when user keep uncheck newsletter" do
+          describe "when user keeps the newsletter unchecked" do
             let(:newsletter) { "0" }
 
             it "creates a user with no newsletter notifications" do

--- a/decidim-core/spec/system/registration_spec.rb
+++ b/decidim-core/spec/system/registration_spec.rb
@@ -56,7 +56,7 @@ describe "Registration", type: :system do
       within "form.new_user" do
         find("*[type=submit]").click
       end
-      click_button "Keep uncheck"
+      click_button "Keep unchecked"
       expect(page).to have_css("#sign-up-newsletter-modal", visible: :all)
       fill_registration_form
       within "form.new_user" do


### PR DESCRIPTION
### :tophat: What? Why?
The button appears in a popup when a user does _not_ check the "Receive an
occasional newsletter" checkbox while signinup up.  "Keep unchecked" is
a more correct translation.

#### :pushpin: Related Issues
I haven't filed an issue, just because it's a very tiny translation bug and can be explained here.

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![Screenshot of the sign-up screen checkbox that triggers this popup](https://user-images.githubusercontent.com/4812055/92296674-f8f8c680-eeeb-11ea-83a1-26c810b28a7a.png)
![Screenshot of the pop-up with "Keep uncheck"](https://user-images.githubusercontent.com/4812055/92296678-04e48880-eeec-11ea-82de-2bf84dca19ff.png)