### PR TITLE
Fix problem showing emails from different participants 

### DIFF
--- a/decidim-admin/spec/system/admin_manages_officializations_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_officializations_spec.rb
@@ -209,7 +209,7 @@ describe "Admin manages officializations", type: :system do
   end
 
   describe "retrieving the user email address" do
-    let!(:user) { create(:user, organization: organization) }
+    let!(:users) { create_list(:user, 3, organization: organization) }
 
     before do
       within ".secondary-nav" do
@@ -217,23 +217,29 @@ describe "Admin manages officializations", type: :system do
       end
     end
 
-    it "shows the user email to admin users and logs the action" do
-      within "tr[data-user-id=\"#{user.id}\"]" do
-        click_link "Show email"
-      end
+    it "shows the users emails to admin users and logs the action" do
+      users.each do |user|
+        within "tr[data-user-id=\"#{user.id}\"]" do
+          click_link "Show email"
+        end
 
-      within "#show-email-modal" do
-        expect(page).to have_content("Show participant email address")
-        expect(page).not_to have_content(user.email)
+        within "#show-email-modal" do
+          expect(page).to have_content("Show participant email address")
+          expect(page).not_to have_content(user.email)
 
-        click_button "Show"
+          click_button "Show"
 
-        expect(page).to have_content(user.email)
+          expect(page).to have_content(user.email)
+
+          find("button[data-close]").click
+        end
       end
 
       visit decidim_admin.root_path
 
-      expect(page).to have_content("#{admin.name} retrieved the email of the participant #{user.name}")
+      users.each do |user|
+        expect(page).to have_content("#{admin.name} retrieved the email of the participant #{user.name}")
+      end
     end
   end
 end

--- a/decidim-core/app/assets/javascripts/decidim/ajax_modals.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/ajax_modals.js.es6
@@ -1,12 +1,12 @@
 $(() => {
   $(document).on("click", "a[data-open-url],button[data-open-url]", (event) => {
     event.preventDefault();
-    const $link = $(event.currentTarget);
-    const $modal = $(`#${$link.data("open")}`);
+    const link = event.currentTarget;
+    const $modal = $(`#${link.dataset.open}`);
     $modal.html("<div class='loading-spinner'></div>");
     $.ajax({
       type: "get",
-      url: $link.data("open-url"),
+      url: link.dataset.openUrl,
       success: (html) => {
         const $html = $(html);
         $modal.html($html);


### PR DESCRIPTION
#### :tophat: What? Why?
When an admin try to view a participant email in the admin zone it works fine. But if the admin tries to see the email of another user without refreshing the page it keeps showing the same email.

This seems to be a jQuery problem. It works well after switching that code to vanilla JS. 

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/5722#issuecomment-688322630

#### :clipboard: Subtasks
- [x] Add tests

### :camera: Screenshots (optional)
![Description](URL)
