### PR TITLE
Add validation for max selections on election questions

### DIFF
--- a/decidim-elections/app/controllers/decidim/elections/admin/answers_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/admin/answers_controller.rb
@@ -10,9 +10,7 @@ module Decidim
         helper_method :election, :question, :answers, :answers, :missing_answers
 
         def index
-          if question.max_selections > answers.count
-            flash.now[:alert] = I18n.t("answers.index.invalid_max_selections", scope: "decidim.elections.admin", missing_answers: missing_answers)
-          end
+          flash.now[:alert] = I18n.t("answers.index.invalid_max_selections", scope: "decidim.elections.admin", missing_answers: missing_answers) if missing_answers.present?
         end
 
         def new

--- a/decidim-elections/app/controllers/decidim/elections/admin/answers_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/admin/answers_controller.rb
@@ -10,7 +10,7 @@ module Decidim
         helper_method :election, :question, :answers, :answers, :missing_answers
 
         def index
-          flash.now[:alert] = I18n.t("answers.index.invalid_max_selections", scope: "decidim.elections.admin", missing_answers: missing_answers) if missing_answers.present?
+          flash.now[:alert] = I18n.t("answers.index.invalid_max_selections", scope: "decidim.elections.admin", missing_answers: missing_answers) if missing_answers.positive?
         end
 
         def new

--- a/decidim-elections/app/controllers/decidim/elections/admin/answers_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/admin/answers_controller.rb
@@ -7,7 +7,13 @@ module Decidim
       class AnswersController < Admin::ApplicationController
         include Decidim::Proposals::Admin::Picker
         helper Decidim::ApplicationHelper
-        helper_method :election, :question, :answers, :answers
+        helper_method :election, :question, :answers, :answers, :missing_answers
+
+        def index
+          if question.max_selections > answers.count
+            flash.now[:alert] = I18n.t("answers.index.invalid_max_selections", scope: "decidim.elections.admin", missing_answers: missing_answers)
+          end
+        end
 
         def new
           enforce_permission_to :update, :answer, election: election, question: question
@@ -85,6 +91,10 @@ module Decidim
 
         def answer
           answers.find(params[:id])
+        end
+
+        def missing_answers
+          question.max_selections - answers.count
         end
       end
     end

--- a/decidim-elections/app/models/decidim/elections/election.rb
+++ b/decidim-elections/app/models/decidim/elections/election.rb
@@ -60,6 +60,15 @@ module Decidim
         started? && !finished?
       end
 
+      # Public: Checks if the election questions are valid
+      #
+      # Returns a boolean.
+      def valid_questions?
+        questions.each do |question|
+          return false unless question.valid_max_selection?
+        end
+      end
+
       # Public: Gets the voting period status of the election
       #
       # Returns one of these symbols: upcoming, ongoing or finished

--- a/decidim-elections/app/models/decidim/elections/question.rb
+++ b/decidim-elections/app/models/decidim/elections/question.rb
@@ -26,6 +26,13 @@ module Decidim
           0
         end
       end
+
+      # Public: Checks if enough answers are given for max_selections attribute
+      #
+      # Returns a boolean.
+      def valid_max_selection?
+        max_selections <= answers.count
+      end
     end
   end
 end

--- a/decidim-elections/app/permissions/decidim/elections/admin/permissions.rb
+++ b/decidim-elections/app/permissions/decidim/elections/admin/permissions.rb
@@ -19,8 +19,10 @@ module Decidim
             case permission_action.action
             when :create, :read
               allow!
-            when :delete, :update, :publish, :unpublish
+            when :delete, :update, :unpublish
               allow_if_not_started
+            when :publish
+              allow_if_valid_and_not_started
             end
           end
 
@@ -33,8 +35,16 @@ module Decidim
           @election ||= context.fetch(:election, nil)
         end
 
+        def question
+          @question ||= context.fetch(:question, nil)
+        end
+
         def allow_if_not_started
           toggle_allow(election && !election.started?)
+        end
+
+        def allow_if_valid_and_not_started
+          toggle_allow(election && !election.started? && election.valid_questions?)
         end
       end
     end

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -73,6 +73,7 @@ en:
             title: Edit answer
             update: Update answer
           index:
+            invalid_max_selections: You need %{missing_answers} more answer/s to match max selections
             title: Answers
           new:
             create: Create answer

--- a/decidim-elections/spec/permissions/decidim/elections/admin/permissions_spec.rb
+++ b/decidim-elections/spec/permissions/decidim/elections/admin/permissions_spec.rb
@@ -28,6 +28,14 @@ describe Decidim::Elections::Admin::Permissions do
     end
   end
 
+  shared_examples "not allowed when election has invalid questions" do
+    context "when election has invalid questions" do
+      let(:question) { create :question, :candidates, max_selections: 11, election: election }
+
+      it { is_expected.to eq false }
+    end
+  end
+
   context "when scope is not admin" do
     let(:action) do
       { scope: :foo, action: :bar, subject: :election }
@@ -79,6 +87,7 @@ describe Decidim::Elections::Admin::Permissions do
     it { is_expected.to eq true }
 
     it_behaves_like "not allowed when election has started"
+    it_behaves_like "not allowed when election has invalid questions"
   end
 
   describe "election delete" do

--- a/decidim-elections/spec/system/admin_manages_answers_spec.rb
+++ b/decidim-elections/spec/system/admin_manages_answers_spec.rb
@@ -89,6 +89,14 @@ describe "Admin manages answers", type: :system do
     end
   end
 
+  context "when max selections is higher than answers count" do
+    let(:question) { create :question, election: election, max_selections: 5 }
+
+    it "shows alert" do
+      expect(page).to have_content("You need 4 more answer/s")
+    end
+  end
+
   describe "updating an answer" do
     it "updates an answer" do
       within find("tr", text: translated(answer.title)) do

--- a/decidim-elections/spec/system/admin_manages_elections_spec.rb
+++ b/decidim-elections/spec/system/admin_manages_elections_spec.rb
@@ -104,7 +104,7 @@ describe "Admin manages elections", type: :system do
 
   describe "publishing an election" do
     context "when the election is unpublished" do
-      let!(:election) { create(:election, :upcoming, component: current_component) }
+      let!(:election) { create(:election, :upcoming, :complete, component: current_component) }
 
       it "publishes the election" do
         within find("tr", text: translated(election.title)) do


### PR DESCRIPTION
#### :tophat: What? Why?
Until now, it was possible to set "max selections" to a higher value than answers are given. This PR adds an alert in case the max selections value isn't reached when creating answers. Also, a validation was added so an election with invalid questions can't get published.

#### :pushpin: Related Issues
- Fixes #6355

#### :clipboard: Subtasks
- [x] Add tests
- [x] Add alert
- [x] Add validation

### :camera: Screenshots (optional)
The 2nd `election` has `questions` where the `max_selections` value is too high, so it can't get published.

<img width="1416" alt="Screenshot 2020-09-09 at 09 54 55" src="https://user-images.githubusercontent.com/19774772/92571244-2abeb400-f283-11ea-85b4-8cd9c324f657.png">

When creating `answers`, an alert appears if the `max_selections` value isn't reached.
<img width="1417" alt="Screenshot 2020-09-09 at 09 54 38" src="https://user-images.githubusercontent.com/19774772/92571378-55a90800-f283-11ea-90fc-652781f4e2d7.png">
