### PR TITLE
Add a task to fix locale issues

### DIFF
--- a/decidim-core/lib/tasks/decidim_locales_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_locales_tasks.rake
@@ -16,7 +16,7 @@ namespace :decidim do
     desc "Rebuild the search index"
     task rebuild_search: :environment do
       Decidim::SearchableResource.destroy_all
-      Decidim::Searchable.searchable_resources.pluck(0).each do |resource|
+      Decidim::Searchable.searchable_resources.keys.each do |resource|
         resource.constantize.all.each(&:try_update_index_for_search_resource)
       end
     end

--- a/decidim-core/lib/tasks/decidim_locales_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_locales_tasks.rake
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+namespace :decidim do
+  namespace :locales do
+    desc "Ensures locales in organizations are in sync with Decidim initializer"
+    task sync_all: :environment do
+      Decidim::Organization.all.each do |organization|
+        organization.available_locales = Decidim.available_locales.filter do |lang|
+          organization.available_locales.include?(lang.to_s)
+        end
+        organization.default_locale = organization.available_locales.first unless organization.available_locales.include? organization.default_locale
+        organization.save!
+      end
+    end
+
+    desc "Rebuild the search index"
+    task rebuild_search: :environment do
+      Decidim::SearchableResource.destroy_all
+      Decidim::Searchable.searchable_resources.pluck(0).each do |resource|
+        resource.constantize.all.each(&:try_update_index_for_search_resource)
+      end
+    end
+  end
+end

--- a/decidim-core/lib/tasks/decidim_locales_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_locales_tasks.rake
@@ -4,20 +4,31 @@ namespace :decidim do
   namespace :locales do
     desc "Ensures locales in organizations are in sync with Decidim initializer"
     task sync_all: :environment do
-      Decidim::Organization.all.each do |organization|
-        organization.available_locales = Decidim.available_locales.filter do |lang|
-          organization.available_locales.include?(lang.to_s)
+      allowed_locales = Decidim.available_locales.map(&:to_s)
+      Decidim::Organization.find_each do |organization|
+        print "#{organization.name} uses #{organization.available_locales} with [#{organization.default_locale}] as default"
+
+        orphan = (organization.available_locales - allowed_locales)
+        organization.available_locales = organization.available_locales - orphan
+        default = organization.default_locale
+        organization.default_locale = organization.available_locales.first unless organization.available_locales.include? default
+        if default != organization.default_locale || orphan.present?
+          organization.save!
+          puts " [FIXED]"
+        else
+          puts " [OK]"
         end
-        organization.default_locale = organization.available_locales.first unless organization.available_locales.include? organization.default_locale
-        organization.save!
       end
     end
 
     desc "Rebuild the search index"
     task rebuild_search: :environment do
       Decidim::SearchableResource.destroy_all
-      Decidim::Searchable.searchable_resources.keys.each do |resource|
-        resource.constantize.all.each(&:try_update_index_for_search_resource)
+      total = Decidim::Searchable.searchable_resources.count
+      Decidim::Searchable.searchable_resources.values.each.with_index(1) do |klass, index|
+        print "Indexing #{index}/#{total} #{klass}"
+        klass.find_each(&:try_update_index_for_search_resource)
+        puts " [DONE]"
       end
     end
   end

--- a/docs/advanced/fixing_locales.md
+++ b/docs/advanced/fixing_locales.md
@@ -8,7 +8,7 @@ However, this may be delicate, specially if you need to remove them.
 
 When you create an organization, you choose the available languages for it (through the `/system/` url). However, when trying to edit it, the language selector is not available anymore. Here is a way to update that locales manually:
 
-First, be sure that your initializer file has all the locales you want:
+First, make sure that your initializer file has all the locales you want:
 
 Edit the file `config/initializers/decidim.rb` and be sure to include all the necessary locales:
 
@@ -64,7 +64,7 @@ In order to solve that you can make use of these rake tasks:
 bundle exec rake decidim:locales:sync_all
 ```
 
-Run this task if you want have changed your `config/initializers/decidim.rb` `available_locales` or `default_locale` and you want to modify all the organizations so they have the same settings.
+Run this task if you have changed `available_locales` or `default_locale` in `config/initializers/decidim.rb` and you want to modify all the organizations so they have the same settings.
 
 **Do not run this task if you have different organizations with different locale configurations**.
 In that case perform it manually through the console method.

--- a/docs/advanced/fixing_locales.md
+++ b/docs/advanced/fixing_locales.md
@@ -1,0 +1,84 @@
+# Fixing locales
+
+Sometimes in production environments you are force to change the locales available for an organization.
+
+However, this may be delicate, specially if you need to remove them.
+
+## Change the available languages of an organization
+
+When you create an organization, you choose the available languages for it (through the `/system/` url). However, when trying to edit it, the language selector is not available anymore. Here is a way to update that locales manually:
+
+First, be sure that your initializer file has all the locales you want:
+
+Edit the file `config/initializers/decidim.rb` and be sure to include all the necessary locales:
+
+```ruby
+...
+# Change these lines to set your preferred locales
+  config.default_locale = :en
+  config.available_locales = [:en, :ca, :es, :fr, :pt]
+..
+```
+
+Then you need to access the rails console and update the organization locales manually.
+
+Access to your rails console and select your organization. If you have only one organization you can just run the command:
+
+```ruby
+o=Decidim::Organization.first
+```
+
+Check your current locales:
+
+```ruby
+o.available_locales
+=> ["en", "ca", "es"]
+```
+
+Then add or remove locales and save the organization.
+
+```ruby
+o.available_locales += ["fr", "pt"]
+=> ["en", "ca", "es", "pt", "fr"]
+o.save!
+```
+
+If you want to change the default locale:
+
+```ruby
+o.default_locale = "fr"
+o.save!
+```
+
+> If you need to remove locales from an organization read the next section!
+
+## Fixing errors in locales
+
+In certain cases (ie. when removing locales from an organization) some operations in Decidim may lead to errors 500 in the browser.
+
+In order to solve that you can make use of these rake tasks:
+
+### Synchronize Locales
+
+```bash
+bundle exec rake decidim:locales:sync_all
+```
+
+Run this task if you want have changed your `config/initializers/decidim.rb` `available_locales` or `default_locale` and you want to modify all the organizations so they have the same settings.
+
+**Do not run this task if you have different organizations with different locale configurations**.
+In that case perform it manually through the console method.
+
+### Repair the search index
+
+In order to provide a global search in Decidim, many content is indexed in a search table, each locale separately.
+This means that, if you remove languages, some content can be orphan as the original resource do not exist anymore.
+This leads to server 500 errors.
+
+To repair the search index you can run the rake task:
+
+```bash
+bundle exec rake decidim:locales:rebuild_search
+```
+
+Be aware that this might take a long time as it will remove and recreate the whole search index for all organizations.

--- a/docs/advanced/fixing_locales.md
+++ b/docs/advanced/fixing_locales.md
@@ -64,10 +64,14 @@ In order to solve that you can make use of these rake tasks:
 bundle exec rake decidim:locales:sync_all
 ```
 
-Run this task if you have changed `available_locales` or `default_locale` in `config/initializers/decidim.rb` and you want to modify all the organizations so they have the same settings.
+Run this task if you have changed `available_locales` or `default_locale` in `config/initializers/decidim.rb` and you think that some organization have values not supported by the Decidim installation.
 
-**Do not run this task if you have different organizations with different locale configurations**.
-In that case perform it manually through the console method.
+Examples:
+
+* `Decidim.available_locales` is set to `[:en, :ca, :fr]` and your organization has `available_locales` to `[:es, :ca]`, running this script will change it to `[:ca]` as `:es` is not supported.
+* `organization.default_locale` is set to `:fr` and your `available_locales` to `[:en, :es]`, running this script will change `organization.default_locale` to `:en`.
+
+It is safe to run this task as it respects organizations with less languages than the supported.
 
 ### Repair the search index
 


### PR DESCRIPTION
#### :tophat: What? Why?

In certain cases is necessary to manipulate locales of an organization through the database. This adds a new task namespace and some commands to solve common issues.
It also provides a new documentation file explaining the usage.

#### :clipboard: Subtasks
- [x] Add documentation regarding the feature 
