### PR TITLE
Add text editor to proposal's template

### DIFF
--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -44,7 +44,7 @@ Decidim.register_component(:proposals) do |component|
     settings.attribute :amendments_enabled, type: :boolean, default: false
     settings.attribute :amendments_wizard_help_text, type: :text, translated: true, editor: true, required: false
     settings.attribute :announcement, type: :text, translated: true, editor: true
-    settings.attribute :new_proposal_body_template, type: :text, translated: true, editor: false, required: false
+    settings.attribute :new_proposal_body_template, type: :text, translated: true, editor: true, required: false
     settings.attribute :new_proposal_help_text, type: :text, translated: true, editor: true
     settings.attribute :proposal_wizard_step_1_help_text, type: :text, translated: true, editor: true
     settings.attribute :proposal_wizard_step_2_help_text, type: :text, translated: true, editor: true


### PR DESCRIPTION
#### :tophat: What? Why?
Adds a WYSIWYG editor to `new_proposal_body_template` field.

#### :pushpin: Related Issues
- Related to #6007 

### :camera: Screenshots (optional)
<img width="1002" alt="Screenshot 2020-09-14 at 15 36 11" src="https://user-images.githubusercontent.com/12495882/93092725-196d1180-f6a0-11ea-85c7-8c3db5f7af51.png">

