### PR TITLE
Fix proposal creation

### DIFF
--- a/decidim-core/lib/decidim/hashtaggable.rb
+++ b/decidim-core/lib/decidim/hashtaggable.rb
@@ -8,11 +8,6 @@ module Decidim
     included do
       def search_title
         field = title
-        field = if field.is_a?(String)
-                  field
-                elsif field.is_a?(Hash)
-                  field.values.first
-                end
         search_value_for(field)
       end
 
@@ -20,11 +15,6 @@ module Decidim
 
       def search_body
         field = try(:body) || try(:description) || title
-        field = if field.is_a?(String)
-                  field
-                elsif field.is_a?(Hash)
-                  field.values.first
-                end
         search_value_for(field)
       end
 

--- a/decidim-core/lib/decidim/hashtaggable.rb
+++ b/decidim-core/lib/decidim/hashtaggable.rb
@@ -7,14 +7,25 @@ module Decidim
 
     included do
       def search_title
-        search_value_for(title)
+        field = title
+        field = if field.is_a?(String)
+                  field
+                elsif field.is_a?(Hash)
+                  field.values.first
+                end
+        search_value_for(field)
       end
 
       alias_method :formatted_title, :search_title
 
       def search_body
-        value = try(:body) || try(:description) || title
-        search_value_for(value)
+        field = try(:body) || try(:description) || title
+        field = if field.is_a?(String)
+                  field
+                elsif field.is_a?(Hash)
+                  field.values.first
+                end
+        search_value_for(field)
       end
 
       alias_method :formatted_body, :search_body

--- a/decidim-proposals/app/commands/decidim/proposals/admin/create_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/create_proposal.rb
@@ -60,9 +60,11 @@ module Decidim
         end
 
         def attributes
+          parsed_title = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.title, current_organization: form.current_organization).rewrite
+          parsed_body = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.body, current_organization: form.current_organization).rewrite
           {
-            title: title_with_hashtags,
-            body: body_with_hashtags,
+            title: parsed_title,
+            body: parsed_body,
             category: form.category,
             scope: form.scope,
             component: form.component,

--- a/decidim-proposals/app/commands/decidim/proposals/admin/publish_participatory_text.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/publish_participatory_text.rb
@@ -65,7 +65,10 @@ module Decidim
           body = proposal.body
 
           PaperTrail.request(enabled: false) do
-            proposal.update_columns(title: "", body: "") # rubocop:disable Rails/SkipsModelValidations
+            proposal.update_columns(
+              title: { I18n.locale => ""},
+              body: { I18n.locale => ""}
+            ) # rubocop:disable Rails/SkipsModelValidations
           end
 
           [title, body]

--- a/decidim-proposals/app/commands/decidim/proposals/admin/publish_participatory_text.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/publish_participatory_text.rb
@@ -65,10 +65,12 @@ module Decidim
           body = proposal.body
 
           PaperTrail.request(enabled: false) do
+            # rubocop:disable Rails/SkipsModelValidations
             proposal.update_columns(
-              title: { I18n.locale => ""},
-              body: { I18n.locale => ""}
-            ) # rubocop:disable Rails/SkipsModelValidations
+              title: { I18n.locale => "" },
+              body: { I18n.locale => "" }
+            )
+            # rubocop:enable Rails/SkipsModelValidations
           end
 
           [title, body]

--- a/decidim-proposals/app/commands/decidim/proposals/admin/update_participatory_text.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/update_participatory_text.rb
@@ -5,6 +5,8 @@ module Decidim
     module Admin
       # A command with all the business logic when an admin updates participatory text proposals.
       class UpdateParticipatoryText < Rectify::Command
+        include Decidim::TranslatableAttributes
+
         # Public: Initializes the command.
         #
         # form - A PreviewParticipatoryTextForm form object with the params.
@@ -40,10 +42,12 @@ module Decidim
         def update_contents_and_resort_proposals(form)
           PaperTrail.request(enabled: false) do
             form.proposals.each do |prop_form|
+              add_failure(prop_form) if prop_form.invalid?
+
               proposal = Proposal.where(component: form.current_component).find(prop_form.id)
               proposal.set_list_position(prop_form.position) if proposal.position != prop_form.position
-              proposal.title =  { I18n.locale => prop_form.title }
-              proposal.body = { I18n.locale => prop_form.body } if proposal.participatory_text_level == ParticipatoryTextSection::LEVELS[:article]
+              proposal.title = { I18n.locale => translated_attribute(prop_form.title) }
+              proposal.body = { I18n.locale => translated_attribute(prop_form.body) } if proposal.participatory_text_level == ParticipatoryTextSection::LEVELS[:article]
 
               add_failure(proposal) unless proposal.save
             end

--- a/decidim-proposals/app/commands/decidim/proposals/admin/update_participatory_text.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/update_participatory_text.rb
@@ -42,8 +42,8 @@ module Decidim
             form.proposals.each do |prop_form|
               proposal = Proposal.where(component: form.current_component).find(prop_form.id)
               proposal.set_list_position(prop_form.position) if proposal.position != prop_form.position
-              proposal.title = prop_form.title
-              proposal.body = prop_form.body if proposal.participatory_text_level == ParticipatoryTextSection::LEVELS[:article]
+              proposal.title =  { I18n.locale => prop_form.title }
+              proposal.body = { I18n.locale => prop_form.body } if proposal.participatory_text_level == ParticipatoryTextSection::LEVELS[:article]
 
               add_failure(proposal) unless proposal.save
             end

--- a/decidim-proposals/app/commands/decidim/proposals/admin/update_participatory_text.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/update_participatory_text.rb
@@ -47,7 +47,11 @@ module Decidim
               proposal = Proposal.where(component: form.current_component).find(prop_form.id)
               proposal.set_list_position(prop_form.position) if proposal.position != prop_form.position
               proposal.title = { I18n.locale => translated_attribute(prop_form.title) }
-              proposal.body = { I18n.locale => translated_attribute(prop_form.body) } if proposal.participatory_text_level == ParticipatoryTextSection::LEVELS[:article]
+              if proposal.participatory_text_level == ParticipatoryTextSection::LEVELS[:article]
+                proposal.body = { I18n.locale => translated_attribute(prop_form.body) }
+              else
+                proposal.body = { I18n.locale => "" }
+              end
 
               add_failure(proposal) unless proposal.save
             end

--- a/decidim-proposals/app/commands/decidim/proposals/admin/update_participatory_text.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/update_participatory_text.rb
@@ -47,11 +47,11 @@ module Decidim
               proposal = Proposal.where(component: form.current_component).find(prop_form.id)
               proposal.set_list_position(prop_form.position) if proposal.position != prop_form.position
               proposal.title = { I18n.locale => translated_attribute(prop_form.title) }
-              if proposal.participatory_text_level == ParticipatoryTextSection::LEVELS[:article]
-                proposal.body = { I18n.locale => translated_attribute(prop_form.body) }
-              else
-                proposal.body = { I18n.locale => "" }
-              end
+              proposal.body = if proposal.participatory_text_level == ParticipatoryTextSection::LEVELS[:article]
+                                { I18n.locale => translated_attribute(prop_form.body) }
+                              else
+                                { I18n.locale => "" }
+                              end
 
               add_failure(proposal) unless proposal.save
             end

--- a/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal.rb
@@ -56,11 +56,13 @@ module Decidim
         attr_reader :form, :proposal, :attachment, :gallery
 
         def update_proposal
+          parsed_title = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.title, current_organization: form.current_organization).rewrite
+          parsed_body = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.body, current_organization: form.current_organization).rewrite
           Decidim.traceability.update!(
             proposal,
             form.current_user,
-            title: title_with_hashtags,
-            body: body_with_hashtags,
+            title: parsed_title,
+            body: parsed_body,
             category: form.category,
             scope: form.scope,
             address: form.address,

--- a/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
@@ -58,7 +58,7 @@ module Decidim
           ) do
             proposal = Proposal.new(
               title: {
-                I18n.locale => title_with_hashtags,
+                I18n.locale => title_with_hashtags
               },
               body: {
                 I18n.locale => body_with_hashtags

--- a/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
@@ -57,8 +57,12 @@ module Decidim
             visibility: "public-only"
           ) do
             proposal = Proposal.new(
-              title: title_with_hashtags,
-              body: body_with_hashtags,
+              title: {
+                I18n.locale => title_with_hashtags,
+              },
+              body: {
+                I18n.locale => body_with_hashtags
+              },
               component: form.component
             )
             proposal.add_coauthor(@current_user, user_group: user_group)

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
@@ -21,14 +21,14 @@ module Decidim
 
         def new
           enforce_permission_to :create, :proposal
-          @form = form(Admin::ProposalForm).from_params(
+          @form = form(Decidim::Proposals::Admin::ProposalForm).from_params(
             attachment: form(AttachmentForm).from_params({})
           )
         end
 
         def create
           enforce_permission_to :create, :proposal
-          @form = form(Admin::ProposalForm).from_params(params)
+          @form = form(Decidim::Proposals::Admin::ProposalForm).from_params(params)
 
           Admin::CreateProposal.call(@form) do
             on(:ok) do

--- a/decidim-proposals/app/forms/decidim/proposals/admin/participatory_text_proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/participatory_text_proposal_form.rb
@@ -6,7 +6,9 @@ module Decidim
       # A form object to be used when admin users want to create a proposal
       # through the participatory texts.
       class ParticipatoryTextProposalForm < Admin::ProposalBaseForm
-        validates :title, length: { maximum: 150 }
+        translatable_attribute :title, String do |field, _locale|
+          validates field, length: { maximum: 150 }, if: Proc.new { |resource| resource.send(field).present? }
+        end
       end
     end
   end

--- a/decidim-proposals/app/forms/decidim/proposals/admin/participatory_text_proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/participatory_text_proposal_form.rb
@@ -6,8 +6,13 @@ module Decidim
       # A form object to be used when admin users want to create a proposal
       # through the participatory texts.
       class ParticipatoryTextProposalForm < Admin::ProposalBaseForm
-        translatable_attribute :title, String do |field, _locale|
-          validates field, length: { maximum: 150 }, if: proc { |resource| resource.send(field).present? }
+        attribute :title, String
+        attribute :body, String
+        validates :title, length: { maximum: 150 }
+
+        def map_model(model)
+          self.title = translated_attribute(model.title)
+          self.body = translated_attribute(model.body)
         end
       end
     end

--- a/decidim-proposals/app/forms/decidim/proposals/admin/participatory_text_proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/participatory_text_proposal_form.rb
@@ -7,7 +7,7 @@ module Decidim
       # through the participatory texts.
       class ParticipatoryTextProposalForm < Admin::ProposalBaseForm
         translatable_attribute :title, String do |field, _locale|
-          validates field, length: { maximum: 150 }, if: Proc.new { |resource| resource.send(field).present? }
+          validates field, length: { maximum: 150 }, if: proc { |resource| resource.send(field).present? }
         end
       end
     end

--- a/decidim-proposals/app/forms/decidim/proposals/admin/participatory_text_proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/participatory_text_proposal_form.rb
@@ -9,7 +9,6 @@ module Decidim
         attribute :title, String
         attribute :body, String
         validates :title, length: { maximum: 150 }, presence: true
-        validates :body, presence: true
 
         def map_model(model)
           self.title = translated_attribute(model.title)

--- a/decidim-proposals/app/forms/decidim/proposals/admin/participatory_text_proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/participatory_text_proposal_form.rb
@@ -8,7 +8,8 @@ module Decidim
       class ParticipatoryTextProposalForm < Admin::ProposalBaseForm
         attribute :title, String
         attribute :body, String
-        validates :title, length: { maximum: 150 }
+        validates :title, length: { maximum: 150 }, presence: true
+        validates :body, presence: true
 
         def map_model(model)
           self.title = translated_attribute(model.title)

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposal_base_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposal_base_form.rb
@@ -23,10 +23,6 @@ module Decidim
         attribute :photos, Array[String]
         attribute :add_photos, Array
 
-        translatable_attribute :title, String
-        translatable_attribute :body, String
-
-        validates :title, :body, translatable_presence: true
         validates :address, geocoding: true, if: -> { current_component.settings.geocoding_enabled? }
         validates :category, presence: true, if: ->(form) { form.category_id.present? }
         validates :scope, presence: true, if: ->(form) { form.scope_id.present? }

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposal_base_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposal_base_form.rb
@@ -5,13 +5,11 @@ module Decidim
     module Admin
       # A form object to be used when admin users want to create a proposal.
       class ProposalBaseForm < Decidim::Form
-        include Decidim::ApplicationHelper
         include Decidim::TranslatableAttributes
+        include Decidim::ApplicationHelper
 
         mimic :proposal
 
-        attribute :title, String
-        attribute :body, String
         attribute :address, String
         attribute :latitude, Float
         attribute :longitude, Float
@@ -25,7 +23,10 @@ module Decidim
         attribute :photos, Array[String]
         attribute :add_photos, Array
 
-        validates :title, :body, presence: true
+        translatable_attribute :title, String
+        translatable_attribute :body, String
+
+        validates :title, :body, translatable_presence: true
         validates :address, geocoding: true, if: -> { current_component.settings.geocoding_enabled? }
         validates :category, presence: true, if: ->(form) { form.category_id.present? }
         validates :scope, presence: true, if: ->(form) { form.scope_id.present? }

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
@@ -6,7 +6,7 @@ module Decidim
       # A form object to be used when admin users want to create a proposal.
       class ProposalForm < Decidim::Proposals::Admin::ProposalBaseForm
         translatable_attribute :title, String do |field, _locale|
-          validates field, length: { in: 15..150 }, if: Proc.new { |resource| resource.send(field).present? }
+          validates field, length: { in: 15..150 }, if: proc { |resource| resource.send(field).present? }
         end
       end
     end

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
@@ -4,8 +4,7 @@ module Decidim
   module Proposals
     module Admin
       # A form object to be used when admin users want to create a proposal.
-      class ProposalForm < Admin::ProposalBaseForm
-        validates :title, length: { in: 15..150 }
+      class ProposalForm < Decidim::Proposals::Admin::ProposalBaseForm
       end
     end
   end

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
@@ -8,6 +8,9 @@ module Decidim
         translatable_attribute :title, String do |field, _locale|
           validates field, length: { in: 15..150 }, if: proc { |resource| resource.send(field).present? }
         end
+        translatable_attribute :body, String
+
+        validates :title, :body, translatable_presence: true
       end
     end
   end

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
@@ -5,6 +5,9 @@ module Decidim
     module Admin
       # A form object to be used when admin users want to create a proposal.
       class ProposalForm < Decidim::Proposals::Admin::ProposalBaseForm
+        translatable_attribute :title, String do |field, _locale|
+          validates field, length: { in: 15..150 }, if: Proc.new { |resource| resource.send(field).present? }
+        end
       end
     end
   end

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
@@ -11,6 +11,8 @@ module Decidim
         translatable_attribute :body, String
 
         validates :title, :body, translatable_presence: true
+
+        validate :notify_missing_attachment_if_errored
       end
     end
   end

--- a/decidim-proposals/app/queries/decidim/proposals/similar_proposals.rb
+++ b/decidim-proposals/app/queries/decidim/proposals/similar_proposals.rb
@@ -30,8 +30,8 @@ module Decidim
           .published
           .where(
             "GREATEST(#{title_similarity}, #{body_similarity}) >= ?",
-            @proposal.title,
-            @proposal.body,
+            translated_attribute(@proposal.title),
+            translated_attribute(@proposal.body),
             Decidim::Proposals.similarity_threshold
           )
           .limit(Decidim::Proposals.similarity_limit)

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
@@ -5,11 +5,11 @@
 
   <div class="card-section">
     <div class="row column hashtags__container">
-      <%= form.text_field :title, class: "js-hashtags", value: form_presenter.title(extras: false).strip %>
+      <%= form.translated :text_field, :title, class: "js-hashtags", value: form_presenter.title(extras: false).strip, hashtaggable: true %>
     </div>
 
     <div class="row column hashtags__container">
-      <%= form.editor :body, hashtaggable: true, value: form_presenter.body(extras: false).strip %>
+      <%= form.translated :editor, :body, hashtaggable: true, value: form_presenter.body(extras: false).strip %>
     </div>
 
     <% if @form.component_automatic_hashtags.any? %>

--- a/decidim-proposals/db/migrate/20200915151348_fix_proposals_data_to_ensure_title_and_body_are_hashes.rb
+++ b/decidim-proposals/db/migrate/20200915151348_fix_proposals_data_to_ensure_title_and_body_are_hashes.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class FixProposalsDataToEnsureTitleAndBodyAreHashes < ActiveRecord::Migration[5.2]
+  def up
+    reset_column_information
+
+    PaperTrail.request(enabled: false) do
+      Decidim::Proposals::Proposal.find_each do |proposal|
+        next if proposal.title.is_a?(Hash) && proposal.body.is_a?(Hash)
+
+        author = proposal.coauthorships.first.author
+
+        locale = author.try(:locale).presence || author.try(:default_locale).presence || author.try(:organization).try(:default_locale).presence
+
+        proposal.title = {
+          locale => proposal.title
+        }
+        proposal.body = {
+          locale => proposal.body
+        }
+
+        proposal.save!
+      end
+    end
+
+    reset_column_information
+  end
+
+  def down; end
+
+  def reset_column_information
+    Decidim::User.reset_column_information
+    Decidim::Coauthorship.reset_column_information
+    Decidim::Proposals::Proposal.reset_column_information
+    Decidim::Organization.reset_column_information
+  end
+end

--- a/decidim-proposals/lib/decidim/proposals/markdown_to_proposals.rb
+++ b/decidim-proposals/lib/decidim/proposals/markdown_to_proposals.rb
@@ -131,8 +131,8 @@ module Decidim
       def create_proposal(title, body, participatory_text_level)
         attributes = {
           component: @component,
-          title: title,
-          body: body,
+          title: { I18n.locale => title },
+          body: { I18n.locale => body },
           participatory_text_level: participatory_text_level
         }
 

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/create_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/create_proposal_spec.rb
@@ -35,8 +35,8 @@ module Decidim
         describe "call" do
           let(:form_params) do
             {
-              title: "A reasonable proposal title",
-              body: "A reasonable proposal body",
+              title: {en: "A reasonable proposal title" },
+              body: { en: "A reasonable proposal body" },
               address: address,
               has_address: has_address,
               attachment: attachment_params,

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/create_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/create_proposal_spec.rb
@@ -35,7 +35,7 @@ module Decidim
         describe "call" do
           let(:form_params) do
             {
-              title: {en: "A reasonable proposal title" },
+              title:{ en: "A reasonable proposal title" },
               body: { en: "A reasonable proposal body" },
               address: address,
               has_address: has_address,

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/create_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/create_proposal_spec.rb
@@ -35,7 +35,7 @@ module Decidim
         describe "call" do
           let(:form_params) do
             {
-              title:{ en: "A reasonable proposal title" },
+              title: { en: "A reasonable proposal title" },
               body: { en: "A reasonable proposal body" },
               address: address,
               has_address: has_address,

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/update_participatory_text_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/update_participatory_text_spec.rb
@@ -26,11 +26,14 @@ module Decidim
             modifs = []
             new_positions = [3, 1, 2]
             proposals.each do |proposal|
-              modifs << Decidim::Proposals::Admin::ProposalForm.new(
+              modifs << Decidim::Proposals::Admin::ParticipatoryTextProposalForm.new(
                 id: proposal.id,
                 position: new_positions.shift,
                 title: ::Faker::Books::Lovecraft.fhtagn,
-                body: ::Faker::Books::Lovecraft.fhtagn(5)
+                body: { en: ::Faker::Books::Lovecraft.fhtagn(5) }
+              ).with_context(
+                current_participatory_space: current_component.participatory_space,
+                current_component: current_component
               )
             end
             modifs
@@ -58,15 +61,12 @@ module Decidim
                 expect { command.call }.to broadcast(:ok)
                 proposals.zip(proposal_modifications).each do |proposal, proposal_form|
                   proposal.reload
-                  actual = {}
-                  expected = {}
-                  %w(position title body).each do |attr|
-                    next if (attr == "body") && (proposal.participatory_text_level != Decidim::Proposals::ParticipatoryTextSection::LEVELS[:article])
 
-                    expected[attr] = proposal_form.send attr.to_sym
-                    actual[attr] = proposal.attributes[attr]
+                  expect(translated(proposal_form.title)).to eq translated(proposal.title)
+                  if proposal.participatory_text_level == Decidim::Proposals::ParticipatoryTextSection::LEVELS[:article]
+                    expect(translated(proposal_form.body.stringify_keys)).to eq translated(proposal.body)
                   end
-                  expect(actual).to eq(expected)
+                  expect(proposal_form.position).to eq proposal.position
                 end
               end
             end

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/update_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/update_proposal_spec.rb
@@ -32,8 +32,8 @@ describe Decidim::Proposals::Admin::UpdateProposal do
   describe "call" do
     let(:form_params) do
       {
-        title: "A reasonable proposal title",
-        body: "A reasonable proposal body",
+        title: {en: "A reasonable proposal title" },
+        body: { en: "A reasonable proposal body" },
         address: address,
         has_address: has_address,
         attachment: attachment_params,

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/update_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/update_proposal_spec.rb
@@ -32,7 +32,7 @@ describe Decidim::Proposals::Admin::UpdateProposal do
   describe "call" do
     let(:form_params) do
       {
-        title: {en: "A reasonable proposal title" },
+        title: { en: "A reasonable proposal title" },
         body: { en: "A reasonable proposal body" },
         address: address,
         has_address: has_address,

--- a/decidim-proposals/spec/commands/decidim/proposals/create_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/create_proposal_spec.rb
@@ -66,6 +66,16 @@ module Decidim
             end.to change(Decidim::Proposals::Proposal, :count).by(1)
           end
 
+          it "sets the body and title as i18n" do
+            command.call
+            proposal = Decidim::Proposals::Proposal.last
+
+            expect(proposal.title).to be_kind_of(Hash)
+            expect(proposal.title[I18n.locale.to_s]).to eq form_params[:title]
+            expect(proposal.body).to be_kind_of(Hash)
+            expect(proposal.body[I18n.locale.to_s]).to eq form_params[:body]
+          end
+
           it "traces the action", versioning: true do
             expect(Decidim.traceability)
               .to receive(:perform_action!)

--- a/decidim-proposals/spec/forms/decidim/proposals/admin/admin_proposal_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/admin/admin_proposal_form_spec.rb
@@ -6,8 +6,8 @@ module Decidim
   module Proposals
     module Admin
       describe ProposalForm do
-        it_behaves_like "a proposal form", skip_etiquette_validation: true
-        it_behaves_like "a proposal form with meeting as author", skip_etiquette_validation: true
+        it_behaves_like "a proposal form", skip_etiquette_validation: true, i18n: true
+        it_behaves_like "a proposal form with meeting as author", skip_etiquette_validation: true, i18n: true
       end
     end
   end

--- a/decidim-proposals/spec/forms/decidim/proposals/proposal_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/proposal_form_spec.rb
@@ -11,7 +11,7 @@ module Decidim
         )
       end
 
-      it_behaves_like "a proposal form", user_group_check: true
+      it_behaves_like "a proposal form", user_group_check: true, i18n: false
     end
   end
 end

--- a/decidim-proposals/spec/lib/decidim/proposals/markdown_to_proposals_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/markdown_to_proposals_spec.rb
@@ -19,8 +19,8 @@ module Decidim
       def proposal_should_conform(section_level, title, body)
         proposal = Decidim::Proposals::Proposal.where(component: component).last
         expect(proposal.participatory_text_level).to eq(Decidim::Proposals::ParticipatoryTextSection::LEVELS[section_level])
-        expect(translated proposal.title).to eq(title)
-        expect(translated proposal.body).to eq(body)
+        expect(translated(proposal.title)).to eq(title)
+        expect(translated(proposal.body)).to eq(body)
       end
 
       let!(:component) { create(:proposal_component) }
@@ -42,8 +42,8 @@ module Decidim
             should_parse_and_produce_proposals(1)
 
             proposal = Proposal.last
-            expect(translated proposal.title).to eq(title)
-            expect(translated proposal.body).to eq(title)
+            expect(translated(proposal.title)).to eq(title)
+            expect(translated(proposal.body)).to eq(title)
             expect(proposal.position).to eq(1)
             expect(proposal.participatory_text_level).to eq(ParticipatoryTextSection::LEVELS[:section])
             should_have_expected_states(proposal)
@@ -63,8 +63,8 @@ module Decidim
             proposals = should_parse_and_produce_proposals(5)
 
             proposals.order(:position).each_with_index do |proposal, idx|
-              expect(translated proposal.title).to eq(titles[idx])
-              expect(translated proposal.body).to eq(titles[idx])
+              expect(translated(proposal.title)).to eq(titles[idx])
+              expect(translated(proposal.body)).to eq(titles[idx])
               expect(proposal.position).to eq(expected_pos)
               expected_pos += 1
               expect(proposal.participatory_text_level).to eq("sub-section")
@@ -86,8 +86,8 @@ module Decidim
 
           proposal = Proposal.last
           # proposal titled with its numbering (position)
-          expect(translated proposal.title).to eq("1")
-          expect(translated proposal.body).to eq(paragraph)
+          expect(translated(proposal.title)).to eq("1")
+          expect(translated(proposal.body)).to eq(paragraph)
           expect(proposal.position).to eq(1)
           expect(proposal.participatory_text_level).to eq(ParticipatoryTextSection::LEVELS[:article])
           should_have_expected_states(proposal)
@@ -107,9 +107,9 @@ module Decidim
           proposal = Proposal.last
           # proposal titled with its numbering (position)
           # the paragraph and proposal's body
-          expect(translated proposal.title).to eq("1")
+          expect(translated(proposal.title)).to eq("1")
           paragraph = %q(This text links to <a href="https://meta.decidim.org" title="Community's meeting point">Meta Decidim</a>.)
-          expect(translated proposal.body).to eq(paragraph)
+          expect(translated(proposal.body)).to eq(paragraph)
           expect(proposal.position).to eq(1)
           expect(proposal.participatory_text_level).to eq(ParticipatoryTextSection::LEVELS[:article])
           should_have_expected_states(proposal)
@@ -127,9 +127,9 @@ module Decidim
           should_parse_and_produce_proposals(1)
 
           proposal = Proposal.last
-          expect(translated proposal.title).to eq("1")
+          expect(translated(proposal.title)).to eq("1")
           paragraph = 'Text with <img src="https://meta.decidim.org/assets/decidim/decidim-logo-1f39092fb3e41d23936dc8aeadd054e2119807dccf3c395de88637e4187f0a3f.svg" alt="Important image for Decidim" title="Img title"/>.'
-          expect(translated proposal.body).to eq(paragraph)
+          expect(translated(proposal.body)).to eq(paragraph)
           expect(proposal.position).to eq(1)
           expect(proposal.participatory_text_level).to eq(ParticipatoryTextSection::LEVELS[:article])
           should_have_expected_states(proposal)
@@ -163,7 +163,7 @@ module Decidim
           should_parse_and_produce_proposals(1)
 
           proposal = Proposal.last
-          expect(translated proposal.title).to eq("1")
+          expect(translated(proposal.title)).to eq("1")
           paragraph = <<~EOEXPECTED
             <strong>bold text</strong> is supported, <em>italics text</em> is supported, <strong>underlined text</strong> is supported.
             As explained <a href="https://daringfireball.net/projects/markdown/syntax#em">here</a> Markdown treats asterisks
@@ -179,7 +179,7 @@ module Decidim
             - &lt;strong>double asterisks&lt;/strong>
             - &lt;strong>double underscores&lt;/strong>
           EOEXPECTED
-          expect(translated proposal.body).to eq(paragraph.strip)
+          expect(translated(proposal.body)).to eq(paragraph.strip)
           expect(proposal.position).to eq(1)
           expect(proposal.participatory_text_level).to eq(ParticipatoryTextSection::LEVELS[:article])
           should_have_expected_states(proposal)

--- a/decidim-proposals/spec/lib/decidim/proposals/markdown_to_proposals_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/markdown_to_proposals_spec.rb
@@ -19,8 +19,8 @@ module Decidim
       def proposal_should_conform(section_level, title, body)
         proposal = Decidim::Proposals::Proposal.where(component: component).last
         expect(proposal.participatory_text_level).to eq(Decidim::Proposals::ParticipatoryTextSection::LEVELS[section_level])
-        expect(proposal.title).to eq(title)
-        expect(proposal.body).to eq(body)
+        expect(translated proposal.title).to eq(title)
+        expect(translated proposal.body).to eq(body)
       end
 
       let!(:component) { create(:proposal_component) }
@@ -42,8 +42,8 @@ module Decidim
             should_parse_and_produce_proposals(1)
 
             proposal = Proposal.last
-            expect(proposal.title).to eq(title)
-            expect(proposal.body).to eq(title)
+            expect(translated proposal.title).to eq(title)
+            expect(translated proposal.body).to eq(title)
             expect(proposal.position).to eq(1)
             expect(proposal.participatory_text_level).to eq(ParticipatoryTextSection::LEVELS[:section])
             should_have_expected_states(proposal)
@@ -63,8 +63,8 @@ module Decidim
             proposals = should_parse_and_produce_proposals(5)
 
             proposals.order(:position).each_with_index do |proposal, idx|
-              expect(proposal.title).to eq(titles[idx])
-              expect(proposal.body).to eq(titles[idx])
+              expect(translated proposal.title).to eq(titles[idx])
+              expect(translated proposal.body).to eq(titles[idx])
               expect(proposal.position).to eq(expected_pos)
               expected_pos += 1
               expect(proposal.participatory_text_level).to eq("sub-section")
@@ -86,8 +86,8 @@ module Decidim
 
           proposal = Proposal.last
           # proposal titled with its numbering (position)
-          expect(proposal.title).to eq("1")
-          expect(proposal.body).to eq(paragraph)
+          expect(translated proposal.title).to eq("1")
+          expect(translated proposal.body).to eq(paragraph)
           expect(proposal.position).to eq(1)
           expect(proposal.participatory_text_level).to eq(ParticipatoryTextSection::LEVELS[:article])
           should_have_expected_states(proposal)
@@ -107,9 +107,9 @@ module Decidim
           proposal = Proposal.last
           # proposal titled with its numbering (position)
           # the paragraph and proposal's body
-          expect(proposal.title).to eq("1")
+          expect(translated proposal.title).to eq("1")
           paragraph = %q(This text links to <a href="https://meta.decidim.org" title="Community's meeting point">Meta Decidim</a>.)
-          expect(proposal.body).to eq(paragraph)
+          expect(translated proposal.body).to eq(paragraph)
           expect(proposal.position).to eq(1)
           expect(proposal.participatory_text_level).to eq(ParticipatoryTextSection::LEVELS[:article])
           should_have_expected_states(proposal)
@@ -127,9 +127,9 @@ module Decidim
           should_parse_and_produce_proposals(1)
 
           proposal = Proposal.last
-          expect(proposal.title).to eq("1")
+          expect(translated proposal.title).to eq("1")
           paragraph = 'Text with <img src="https://meta.decidim.org/assets/decidim/decidim-logo-1f39092fb3e41d23936dc8aeadd054e2119807dccf3c395de88637e4187f0a3f.svg" alt="Important image for Decidim" title="Img title"/>.'
-          expect(proposal.body).to eq(paragraph)
+          expect(translated proposal.body).to eq(paragraph)
           expect(proposal.position).to eq(1)
           expect(proposal.participatory_text_level).to eq(ParticipatoryTextSection::LEVELS[:article])
           should_have_expected_states(proposal)
@@ -163,7 +163,7 @@ module Decidim
           should_parse_and_produce_proposals(1)
 
           proposal = Proposal.last
-          expect(proposal.title).to eq("1")
+          expect(translated proposal.title).to eq("1")
           paragraph = <<~EOEXPECTED
             <strong>bold text</strong> is supported, <em>italics text</em> is supported, <strong>underlined text</strong> is supported.
             As explained <a href="https://daringfireball.net/projects/markdown/syntax#em">here</a> Markdown treats asterisks
@@ -179,7 +179,7 @@ module Decidim
             - &lt;strong>double asterisks&lt;/strong>
             - &lt;strong>double underscores&lt;/strong>
           EOEXPECTED
-          expect(proposal.body).to eq(paragraph.strip)
+          expect(translated proposal.body).to eq(paragraph.strip)
           expect(proposal.position).to eq(1)
           expect(proposal.participatory_text_level).to eq(ParticipatoryTextSection::LEVELS[:article])
           should_have_expected_states(proposal)

--- a/decidim-proposals/spec/services/decidim/proposals/searchable_proposal_resource_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/searchable_proposal_resource_spec.rb
@@ -161,10 +161,10 @@ module Decidim
 
     def expected_searchable_resource_attrs(proposal, locale)
       {
-        "content_a" => I18n.transliterate(proposal.search_title[locale]),
+        "content_a" => I18n.transliterate(proposal.title[locale]),
         "content_b" => "",
         "content_c" => "",
-        "content_d" => I18n.transliterate(proposal.search_body[locale]),
+        "content_d" => I18n.transliterate(proposal.body[locale]),
         "locale" => locale,
         "decidim_organization_id" => proposal.component.organization.id,
         "decidim_participatory_space_id" => current_component.participatory_space_id,

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -65,8 +65,8 @@ shared_examples "manage proposals" do
             click_link "New proposal"
 
             within ".new_proposal" do
-              fill_in :proposal_title, with: "Make decidim great again"
-              fill_in_editor :proposal_body, with: "Decidim is great but it can be better"
+              fill_in_i18n :proposal_title, "#proposal-title-tabs", en: "Make decidim great again"
+              fill_in_i18n_editor :proposal_body, "#proposal-body-tabs", en: "Decidim is great but it can be better"
               select translated(category.name), from: :proposal_category_id
               scope_pick select_data_picker(:proposal_scope_id), scope
               find("*[type=submit]").click
@@ -100,8 +100,8 @@ shared_examples "manage proposals" do
             click_link "New proposal"
 
             within ".new_proposal" do
-              fill_in :proposal_title, with: "Make decidim great again"
-              fill_in_editor :proposal_body, with: "Decidim is great but it can be better"
+              fill_in_i18n :proposal_title, "#proposal-title-tabs", en: "Make decidim great again"
+              fill_in_i18n_editor :proposal_body, "#proposal-body-tabs", en: "Decidim is great but it can be better"
               select category.name["en"], from: :proposal_category_id
               find("*[type=submit]").click
             end
@@ -133,8 +133,8 @@ shared_examples "manage proposals" do
               click_link "New proposal"
 
               within ".new_proposal" do
-                fill_in :proposal_title, with: "Make decidim great again"
-                fill_in_editor :proposal_body, with: "Decidim is great but it can be better"
+                fill_in_i18n :proposal_title, "#proposal-title-tabs", en: "Make decidim great again"
+                fill_in_i18n_editor :proposal_body, "#proposal-body-tabs", en: "Decidim is great but it can be better"
                 select category.name["en"], from: :proposal_category_id
                 scope_repick select_data_picker(:proposal_scope_id), scope, child_scope
                 find("*[type=submit]").click
@@ -162,8 +162,8 @@ shared_examples "manage proposals" do
               click_link "New proposal"
 
               within ".new_proposal" do
-                fill_in :proposal_title, with: "Make decidim great again"
-                fill_in_editor :proposal_body, with: "Decidim is great but it can be better"
+                fill_in_i18n :proposal_title, "#proposal-title-tabs", en: "Make decidim great again"
+                fill_in_i18n_editor :proposal_body, "#proposal-body-tabs", en: "Decidim is great but it can be better"
                 fill_in :proposal_address, with: address
                 select category.name["en"], from: :proposal_category_id
                 find("*[type=submit]").click
@@ -192,8 +192,8 @@ shared_examples "manage proposals" do
             click_link "New proposal"
 
             within ".new_proposal" do
-              fill_in :proposal_title, with: "Proposal with attachments"
-              fill_in_editor :proposal_body, with: "This is my proposal and I want to upload attachments."
+              fill_in_i18n :proposal_title, "#proposal-title-tabs", en: "Proposal with attachments"
+              fill_in_i18n_editor :proposal_body, "#proposal-body-tabs", en: "This is my proposal and I want to upload attachments."
               fill_in :proposal_attachment_title, with: "My attachment"
               attach_file :proposal_attachment_file, Decidim::Dev.asset("city.jpeg")
               find("*[type=submit]").click
@@ -214,8 +214,8 @@ shared_examples "manage proposals" do
             click_link "New proposal"
 
             within ".new_proposal" do
-              fill_in :proposal_title, with: "Proposal with meeting as author"
-              fill_in_editor :proposal_body, with: "Proposal body of meeting as author"
+              fill_in_i18n :proposal_title, "#proposal-title-tabs", en: "Proposal with meeting as author"
+              fill_in_i18n_editor :proposal_body, "#proposal-body-tabs", en: "Proposal body of meeting as author"
               execute_script("$('#proposal_created_in_meeting').change()")
               find(:css, "#proposal_created_in_meeting").set(true)
               select translated(meetings.first.title), from: :proposal_meeting_id

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -78,7 +78,7 @@ shared_examples "manage proposals" do
               proposal = Decidim::Proposals::Proposal.last
 
               expect(page).to have_content("Make decidim great again")
-              expect(proposal.body).to eq("<p>Decidim is great but it can be better</p>")
+              expect(translated proposal.body).to eq("<p>Decidim is great but it can be better</p>")
               expect(proposal.category).to eq(category)
               expect(proposal.scope).to eq(scope)
             end
@@ -112,7 +112,7 @@ shared_examples "manage proposals" do
               proposal = Decidim::Proposals::Proposal.last
 
               expect(page).to have_content("Make decidim great again")
-              expect(proposal.body).to eq("<p>Decidim is great but it can be better</p>")
+              expect(translated proposal.body).to eq("<p>Decidim is great but it can be better</p>")
               expect(proposal.category).to eq(category)
               expect(proposal.scope).to eq(scope)
             end
@@ -146,7 +146,7 @@ shared_examples "manage proposals" do
                 proposal = Decidim::Proposals::Proposal.last
 
                 expect(page).to have_content("Make decidim great again")
-                expect(proposal.body).to eq("<p>Decidim is great but it can be better</p>")
+                expect(translated proposal.body).to eq("<p>Decidim is great but it can be better</p>")
                 expect(proposal.category).to eq(category)
                 expect(proposal.scope).to eq(child_scope)
               end
@@ -175,7 +175,7 @@ shared_examples "manage proposals" do
                 proposal = Decidim::Proposals::Proposal.last
 
                 expect(page).to have_content("Make decidim great again")
-                expect(proposal.body).to eq("<p>Decidim is great but it can be better</p>")
+                expect(translated proposal.body).to eq("<p>Decidim is great but it can be better</p>")
                 expect(proposal.category).to eq(category)
                 expect(proposal.scope).to eq(scope)
               end
@@ -229,7 +229,7 @@ shared_examples "manage proposals" do
               proposal = Decidim::Proposals::Proposal.last
 
               expect(page).to have_content("Proposal with meeting as author")
-              expect(proposal.body).to eq("<p>Proposal body of meeting as author</p>")
+              expect(translated proposal.body).to eq("<p>Proposal body of meeting as author</p>")
               expect(proposal.category).to eq(category)
             end
           end

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -78,7 +78,7 @@ shared_examples "manage proposals" do
               proposal = Decidim::Proposals::Proposal.last
 
               expect(page).to have_content("Make decidim great again")
-              expect(translated proposal.body).to eq("<p>Decidim is great but it can be better</p>")
+              expect(translated(proposal.body)).to eq("<p>Decidim is great but it can be better</p>")
               expect(proposal.category).to eq(category)
               expect(proposal.scope).to eq(scope)
             end
@@ -112,7 +112,7 @@ shared_examples "manage proposals" do
               proposal = Decidim::Proposals::Proposal.last
 
               expect(page).to have_content("Make decidim great again")
-              expect(translated proposal.body).to eq("<p>Decidim is great but it can be better</p>")
+              expect(translated(proposal.body)).to eq("<p>Decidim is great but it can be better</p>")
               expect(proposal.category).to eq(category)
               expect(proposal.scope).to eq(scope)
             end
@@ -146,7 +146,7 @@ shared_examples "manage proposals" do
                 proposal = Decidim::Proposals::Proposal.last
 
                 expect(page).to have_content("Make decidim great again")
-                expect(translated proposal.body).to eq("<p>Decidim is great but it can be better</p>")
+                expect(translated(proposal.body)).to eq("<p>Decidim is great but it can be better</p>")
                 expect(proposal.category).to eq(category)
                 expect(proposal.scope).to eq(child_scope)
               end
@@ -175,7 +175,7 @@ shared_examples "manage proposals" do
                 proposal = Decidim::Proposals::Proposal.last
 
                 expect(page).to have_content("Make decidim great again")
-                expect(translated proposal.body).to eq("<p>Decidim is great but it can be better</p>")
+                expect(translated(proposal.body)).to eq("<p>Decidim is great but it can be better</p>")
                 expect(proposal.category).to eq(category)
                 expect(proposal.scope).to eq(scope)
               end
@@ -229,7 +229,7 @@ shared_examples "manage proposals" do
               proposal = Decidim::Proposals::Proposal.last
 
               expect(page).to have_content("Proposal with meeting as author")
-              expect(translated proposal.body).to eq("<p>Proposal body of meeting as author</p>")
+              expect(translated(proposal.body)).to eq("<p>Proposal body of meeting as author</p>")
               expect(proposal.category).to eq(category)
             end
           end

--- a/decidim-proposals/spec/shared/proposal_form_examples.rb
+++ b/decidim-proposals/spec/shared/proposal_form_examples.rb
@@ -24,8 +24,8 @@ shared_examples "a proposal form" do |options|
   let(:meeting_as_author) { false }
   let(:params) do
     {
-      title: title,
-      body: body,
+      title: { en: title },
+      body: { en: body },
       author: author,
       category_id: category_id,
       scope_id: scope_id,
@@ -56,7 +56,7 @@ shared_examples "a proposal form" do |options|
 
     it "only adds errors to this field" do
       subject.valid?
-      expect(subject.errors.keys).to eq [:title]
+      expect(subject.errors.keys).to eq [:title_en]
     end
   end
 
@@ -219,8 +219,8 @@ shared_examples "a proposal form" do |options|
 
       it "adds an error to the `:attachment` field" do
         expect(subject).not_to be_valid
-        expect(subject.errors.full_messages).to match_array(["Title can't be blank", "Title is too short (under 15 characters)", "Attachment Needs to be reattached"])
-        expect(subject.errors.keys).to match_array([:title, :attachment])
+        expect(subject.errors.full_messages).to match_array(["Title en can't be blank", "Attachment Needs to be reattached"])
+        expect(subject.errors.keys).to match_array([:title_en, :attachment])
       end
     end
   end
@@ -287,8 +287,8 @@ shared_examples "a proposal form with meeting as author" do |options|
 
   let(:params) do
     {
-      title: title,
-      body: body,
+      title: { en: title },
+      body: { en: body },
       created_in_meeting: created_in_meeting,
       author: meeting_as_author,
       meeting_id: author.id

--- a/decidim-proposals/spec/shared/proposal_form_examples.rb
+++ b/decidim-proposals/spec/shared/proposal_form_examples.rb
@@ -6,8 +6,20 @@ shared_examples "a proposal form" do |options|
   let(:organization) { create(:organization, available_locales: [:en]) }
   let(:participatory_space) { create(:participatory_process, :with_steps, organization: organization) }
   let(:component) { create(:proposal_component, participatory_space: participatory_space) }
-  let(:title) { "More sidewalks and less roads!" }
-  let(:body) { "Everything would be better" }
+  let(:title) do
+    if options[:i18n] == false
+      "More sidewalks and less roads!"
+    else
+      { en: "More sidewalks and less roads!" }
+    end
+  end
+  let(:body) do
+    if options[:i18n] == false
+      "Everything would be better"
+    else
+      { en: "Everything would be better" }
+    end
+  end
   let(:author) { create(:user, organization: organization) }
   let(:user_group) { create(:user_group, :verified, users: [author], organization: organization) }
   let(:user_group_id) { user_group.id }
@@ -24,8 +36,8 @@ shared_examples "a proposal form" do |options|
   let(:meeting_as_author) { false }
   let(:params) do
     {
-      title: { en: title },
-      body: { en: body },
+      title: title,
+      body: body,
       author: author,
       category_id: category_id,
       scope_id: scope_id,
@@ -56,19 +68,35 @@ shared_examples "a proposal form" do |options|
 
     it "only adds errors to this field" do
       subject.valid?
-      expect(subject.errors.keys).to eq [:title_en]
+      if options[:i18n]
+        expect(subject.errors.keys).to eq [:title_en]
+      else
+        expect(subject.errors.keys).to eq [:title]
+      end
     end
   end
 
   context "when the title is too long" do
-    let(:title) { "A" * 200 }
+    let(:title) do
+      if options[:i18n] == false
+        "A" * 200
+      else
+        { en: "A" * 200 }
+      end
+    end
 
     it { is_expected.to be_invalid }
   end
 
   unless options[:skip_etiquette_validation]
     context "when the body is not etiquette-compliant" do
-      let(:body) { "A" }
+      let(:body) do
+        if options[:i18n] == false
+          "A"
+        else
+          { en: "A" }
+        end
+      end
 
       it { is_expected.to be_invalid }
     end
@@ -219,8 +247,14 @@ shared_examples "a proposal form" do |options|
 
       it "adds an error to the `:attachment` field" do
         expect(subject).not_to be_valid
-        expect(subject.errors.full_messages).to match_array(["Title en can't be blank", "Attachment Needs to be reattached"])
-        expect(subject.errors.keys).to match_array([:title_en, :attachment])
+
+        if options[:i18n]
+          expect(subject.errors.full_messages).to match_array(["Title en can't be blank", "Attachment Needs to be reattached"])
+          expect(subject.errors.keys).to match_array([:title_en, :attachment])
+        else
+          expect(subject.errors.full_messages).to match_array(["Title can't be blank", "Title is too short (under 15 characters)", "Attachment Needs to be reattached"])
+          expect(subject.errors.keys).to match_array([:title, :attachment])
+        end
       end
     end
   end
@@ -278,8 +312,8 @@ shared_examples "a proposal form with meeting as author" do |options|
   let(:organization) { create(:organization, available_locales: [:en]) }
   let(:participatory_space) { create(:participatory_process, :with_steps, organization: organization) }
   let(:component) { create(:proposal_component, participatory_space: participatory_space) }
-  let(:title) { "More sidewalks and less roads!" }
-  let(:body) { "Everything would be better" }
+  let(:title) { { en: "More sidewalks and less roads!" } }
+  let(:body) { { en: "Everything would be better" } }
   let(:created_in_meeting) { true }
   let(:meeting_component) { create(:meeting_component, participatory_space: participatory_space) }
   let(:author) { create(:meeting, component: meeting_component) }
@@ -287,8 +321,8 @@ shared_examples "a proposal form with meeting as author" do |options|
 
   let(:params) do
     {
-      title: { en: title },
-      body: { en: body },
+      title: title,
+      body: body,
       created_in_meeting: created_in_meeting,
       author: meeting_as_author,
       meeting_id: author.id
@@ -314,14 +348,26 @@ shared_examples "a proposal form with meeting as author" do |options|
   end
 
   context "when the title is too long" do
-    let(:title) { "A" * 200 }
+    let(:title) do
+      if options[:i18n] == false
+        "A" * 200
+      else
+        { en: "A" * 200 }
+      end
+    end
 
     it { is_expected.to be_invalid }
   end
 
   unless options[:skip_etiquette_validation]
     context "when the body is not etiquette-compliant" do
-      let(:body) { "A" }
+      let(:body) do
+        if options[:i18n] == false
+          "A"
+        else
+          { en: "A" }
+        end
+      end
 
       it { is_expected.to be_invalid }
     end

--- a/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
@@ -31,8 +31,8 @@ describe "Admin edits proposals", type: :system do
       find("a.action-icon--edit-proposal").click
       expect(page).to have_content "Update proposal"
 
-      fill_in "Title", with: new_title
-      fill_in_editor :proposal_body, with: new_body
+      fill_in_i18n :proposal_title, "#proposal-title-tabs", en: new_title
+      fill_in_i18n_editor :proposal_body, "#proposal-body-tabs", en: new_body
       click_button "Update"
 
       preview_window = window_opened_by { find("a.action-icon--preview").click }

--- a/decidim-proposals/spec/system/admin/admin_manages_participatory_texts_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_manages_participatory_texts_spec.rb
@@ -44,6 +44,7 @@ describe "Admin manages participatory texts", type: :system do
     click_button "Upload document"
     expect(page).to have_content "The following sections have been converted to proposals. Now you can review and adjust them before publishing."
     expect(page).to have_content "Preview participatory text"
+    validate_proposals
   end
 
   def validate_occurrences(sections: nil, subsections: nil, articles: nil)
@@ -78,7 +79,15 @@ describe "Admin manages participatory texts", type: :system do
     ]
     expect(proposals.count).to eq(titles.size)
     expect(proposals.published.count).to eq(titles.size)
-    expect(proposals.published.order(:position).pluck(:title)).to eq(titles)
+    expect(proposals.published.order(:position).pluck(:title).map(&:values).map(&:first)).to eq(titles)
+  end
+
+  def validate_proposals
+    proposals = Decidim::Proposals::Proposal.where(component: current_component)
+    proposals.each do |proposal|
+      expect(proposal.title).to be_kind_of(Hash)
+      expect(proposal.body).to be_kind_of(Hash)
+    end
   end
 
   def edit_participatory_text_body(index, new_body)
@@ -144,7 +153,7 @@ describe "Admin manages participatory texts", type: :system do
       save_participatory_text_drafts
       validate_occurrences(sections: 0, subsections: 0, articles: 1)
       proposal.reload
-      expect(proposal.body.delete("\r")).to eq(new_body)
+      expect(translated(proposal.body).delete("\r")).to eq(new_body)
     end
   end
 
@@ -159,7 +168,7 @@ describe "Admin manages participatory texts", type: :system do
       save_participatory_text_drafts
       validate_occurrences(sections: 0, subsections: 0, articles: 1)
       proposal.reload
-      expect(proposal.body.delete("\r")).to eq(new_body)
+      expect(translated(proposal.body).delete("\r")).to eq(new_body)
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
After #6285 and #6384, some bugs were still found:

- In some cases, proposal title and body were persisted as simple strings, instead of JSONB content in the DB.
- Proposals couldn't be created as i18n from the admin side.

This PR solves both issues.

#### :pushpin: Related Issues
- Related to #6285, #6384


#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None
