### PR TITLE
Add scope to proposals import

### DIFF
--- a/decidim-budgets/app/commands/decidim/budgets/admin/import_proposals_to_budgets.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/admin/import_proposals_to_budgets.rb
@@ -60,9 +60,9 @@ module Decidim
         end
 
         def proposals
-          return all_proposals if form.decidim_scope_id.blank?
+          return all_proposals if form.scope_id.blank?
 
-          all_proposals.where(decidim_scope_id: form.decidim_scope_id)
+          all_proposals.where(decidim_scope_id: form.scope_id)
         end
 
         def all_proposals

--- a/decidim-budgets/app/commands/decidim/budgets/admin/import_proposals_to_budgets.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/admin/import_proposals_to_budgets.rb
@@ -60,9 +60,9 @@ module Decidim
         end
 
         def proposals
-          return all_proposals if form.scope_id.blank?
+          return all_proposals if form.decidim_scope_id.blank?
 
-          all_proposals.where(decidim_scope_id: form.scope_id)
+          all_proposals.where(decidim_scope_id: form.decidim_scope_id)
         end
 
         def all_proposals

--- a/decidim-budgets/app/commands/decidim/budgets/admin/import_proposals_to_budgets.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/admin/import_proposals_to_budgets.rb
@@ -67,7 +67,7 @@ module Decidim
 
         def all_proposals
           Decidim::Proposals::Proposal.where(component: origin_component)
-                                      .where(state: "accepted")
+                                      .where(state: :accepted)
         end
 
         def origin_component

--- a/decidim-budgets/app/commands/decidim/budgets/admin/import_proposals_to_budgets.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/admin/import_proposals_to_budgets.rb
@@ -60,7 +60,14 @@ module Decidim
         end
 
         def proposals
-          Decidim::Proposals::Proposal.where(component: origin_component).where(state: "accepted")
+          return all_proposals if form.scope_id.blank?
+
+          all_proposals.where(decidim_scope_id: form.scope_id)
+        end
+
+        def all_proposals
+          Decidim::Proposals::Proposal.where(component: origin_component)
+                                      .where(state: "accepted")
         end
 
         def origin_component

--- a/decidim-budgets/app/forms/decidim/budgets/admin/project_import_proposals_form.rb
+++ b/decidim-budgets/app/forms/decidim/budgets/admin/project_import_proposals_form.rb
@@ -17,7 +17,7 @@ module Decidim
         validates :import_all_accepted_proposals, allow_nil: false, acceptance: true
         validates :default_budget, presence: true, numericality: { greater_than: 0 }
         validates :scope, presence: true, if: ->(form) { form.decidim_scope_id.present? }
-        validates :decidim_scope_id, scope_belongs_to_component: true, if: ->(form) { form.decidim_scope_id.present? }
+        validates :scope_id, scope_belongs_to_component: true, if: ->(form) { form.scope_id.present? }
 
         def origin_component
           @origin_component ||= origin_components.find_by(id: origin_component_id)
@@ -34,11 +34,11 @@ module Decidim
         end
 
         def scope
-          @scope ||= @decidim_scope_id ? current_component.scopes.find_by(id: @decidim_scope_id) : current_component.scope
+          @scope ||= @scope_id ? current_component.scopes.find_by(id: @decidim_scope_id) : current_component.scope
         end
 
-        def decidim_scope_id
-          @decidim_scope_id || scope&.id
+        def scope_id
+          @scope_id || scope&.id
         end
 
         def budget

--- a/decidim-budgets/app/forms/decidim/budgets/admin/project_import_proposals_form.rb
+++ b/decidim-budgets/app/forms/decidim/budgets/admin/project_import_proposals_form.rb
@@ -9,14 +9,14 @@ module Decidim
         mimic :proposals_import
 
         attribute :origin_component_id, Integer
-        attribute :decidim_scope_id, Integer
+        attribute :scope_id, Integer
         attribute :default_budget, Integer
         attribute :import_all_accepted_proposals, Boolean
 
         validates :origin_component_id, :origin_component, :current_component, presence: true
         validates :import_all_accepted_proposals, allow_nil: false, acceptance: true
         validates :default_budget, presence: true, numericality: { greater_than: 0 }
-        validates :scope, presence: true, if: ->(form) { form.decidim_scope_id.present? }
+        validates :scope, presence: true, if: ->(form) { form.scope_id.present? }
         validates :scope_id, scope_belongs_to_component: true, if: ->(form) { form.scope_id.present? }
 
         def origin_component
@@ -34,7 +34,7 @@ module Decidim
         end
 
         def scope
-          @scope ||= @scope_id ? current_component.scopes.find_by(id: @decidim_scope_id) : current_component.scope
+          @scope ||= @scope_id ? current_component.scopes.find_by(id: @scope_id) : current_component.scope
         end
 
         def scope_id

--- a/decidim-budgets/app/forms/decidim/budgets/admin/project_import_proposals_form.rb
+++ b/decidim-budgets/app/forms/decidim/budgets/admin/project_import_proposals_form.rb
@@ -9,6 +9,7 @@ module Decidim
         mimic :proposals_import
 
         attribute :origin_component_id, Integer
+        attribute :scope_id, Integer
         attribute :default_budget, Integer
         attribute :import_all_accepted_proposals, Boolean
 
@@ -27,6 +28,12 @@ module Decidim
         def origin_components_collection
           origin_components.map do |component|
             [component.name[I18n.locale.to_s], component.id]
+          end
+        end
+
+        def scopes_collection
+          Decidim::Scope.all.map do |scope|
+            [scope.name[I18n.locale.to_s], scope.id]
           end
         end
 

--- a/decidim-budgets/app/views/decidim/budgets/admin/proposals_imports/new.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/proposals_imports/new.html.erb
@@ -11,7 +11,7 @@
         </div>
         <% if current_component.scopes_enabled? %>
           <div class="row column">
-            <%= scopes_picker_field f, :decidim_scope_id, root: budget.scope %>
+            <%= scopes_picker_field f, :scope_id, root: budget.scope %>
           </div>
         <% end %>
         <div class="row column">

--- a/decidim-budgets/app/views/decidim/budgets/admin/proposals_imports/new.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/proposals_imports/new.html.erb
@@ -9,9 +9,11 @@
         <div class="row column">
           <%= f.select :origin_component_id, @form.origin_components_collection, prompt: t(".select_component") %>
         </div>
-        <div class="row column">
-          <%= scopes_picker_field f, :decidim_scope_id, root: budget.scope %>
-        </div>
+        <% if current_component.scopes_enabled? %>
+          <div class="row column">
+            <%= scopes_picker_field f, :decidim_scope_id, root: budget.scope %>
+          </div>
+        <% end %>
         <div class="row column">
           <%= f.number_field :default_budget %>
         </div>

--- a/decidim-budgets/app/views/decidim/budgets/admin/proposals_imports/new.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/proposals_imports/new.html.erb
@@ -10,6 +10,9 @@
           <%= f.select :origin_component_id, @form.origin_components_collection, prompt: t(".select_component") %>
         </div>
         <div class="row column">
+          <%= f.select :scope_id, @form.scopes_collection, prompt: t(".select_scope") %>
+        </div>
+        <div class="row column">
           <%= f.number_field :default_budget %>
         </div>
         <div class="row column">

--- a/decidim-budgets/app/views/decidim/budgets/admin/proposals_imports/new.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/proposals_imports/new.html.erb
@@ -10,7 +10,7 @@
           <%= f.select :origin_component_id, @form.origin_components_collection, prompt: t(".select_component") %>
         </div>
         <div class="row column">
-          <%= f.select :scope_id, @form.scopes_collection, prompt: t(".select_scope") %>
+          <%= scopes_picker_field f, :decidim_scope_id, root: budget.scope %>
         </div>
         <div class="row column">
           <%= f.number_field :default_budget %>

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -85,7 +85,6 @@ en:
             create: Import proposals to projects
             no_components: There are no other proposal components in this participatory space to import the proposals into projects.
             select_component: Please select a component
-            select_scope: Any scope
       admin_log:
         budget:
           create: "%{user_name} created the %{resource_name} budget in the %{space_name} space"

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -85,6 +85,7 @@ en:
             create: Import proposals to projects
             no_components: There are no other proposal components in this participatory space to import the proposals into projects.
             select_component: Please select a component
+            select_scope: Any scope
       admin_log:
         budget:
           create: "%{user_name} created the %{resource_name} budget in the %{space_name} space"

--- a/decidim-budgets/spec/commands/decidim/budgets/admin/import_proposals_to_budgets_spec.rb
+++ b/decidim-budgets/spec/commands/decidim/budgets/admin/import_proposals_to_budgets_spec.rb
@@ -28,7 +28,7 @@ module Decidim
               current_user: current_user,
               default_budget: default_budget,
               import_all_accepted_proposals: import_all_accepted_proposals,
-              decidim_scope_id: "",
+              scope_id: "",
               budget: budget,
               valid?: valid
             )

--- a/decidim-budgets/spec/commands/decidim/budgets/admin/import_proposals_to_budgets_spec.rb
+++ b/decidim-budgets/spec/commands/decidim/budgets/admin/import_proposals_to_budgets_spec.rb
@@ -19,7 +19,7 @@ module Decidim
           let(:budget) { create :budget, component: current_component }
           let!(:current_user) { create(:user, :admin, organization: current_component.participatory_space.organization) }
           let!(:organization) { current_component.participatory_space.organization }
-          let(:scope) { create :scope, organization: organization }
+          let(:scope) { nil }
           let!(:form) do
             instance_double(
               ProjectImportProposalsForm,
@@ -28,7 +28,7 @@ module Decidim
               current_user: current_user,
               default_budget: default_budget,
               import_all_accepted_proposals: import_all_accepted_proposals,
-              scope_id: "",
+              scope_id: scope,
               budget: budget,
               valid?: valid
             )
@@ -67,6 +67,8 @@ module Decidim
             end
 
             context "when there are no proposals in the selected scope" do
+              let(:scope) { create :scope, organization: organization }
+
               it "doesn't create any project" do
                 expect do
                   command.call

--- a/decidim-budgets/spec/commands/decidim/budgets/admin/import_proposals_to_budgets_spec.rb
+++ b/decidim-budgets/spec/commands/decidim/budgets/admin/import_proposals_to_budgets_spec.rb
@@ -27,6 +27,7 @@ module Decidim
               current_user: current_user,
               default_budget: default_budget,
               import_all_accepted_proposals: import_all_accepted_proposals,
+              scope_id: '',
               budget: budget,
               valid?: valid
             )

--- a/decidim-budgets/spec/commands/decidim/budgets/admin/import_proposals_to_budgets_spec.rb
+++ b/decidim-budgets/spec/commands/decidim/budgets/admin/import_proposals_to_budgets_spec.rb
@@ -27,7 +27,7 @@ module Decidim
               current_user: current_user,
               default_budget: default_budget,
               import_all_accepted_proposals: import_all_accepted_proposals,
-              scope_id: "",
+              decidim_scope_id: "",
               budget: budget,
               valid?: valid
             )

--- a/decidim-budgets/spec/commands/decidim/budgets/admin/import_proposals_to_budgets_spec.rb
+++ b/decidim-budgets/spec/commands/decidim/budgets/admin/import_proposals_to_budgets_spec.rb
@@ -19,6 +19,7 @@ module Decidim
           let(:budget) { create :budget, component: current_component }
           let!(:current_user) { create(:user, :admin, organization: current_component.participatory_space.organization) }
           let!(:organization) { current_component.participatory_space.organization }
+          let(:scope) { create :scope, organization: organization }
           let!(:form) do
             instance_double(
               ProjectImportProposalsForm,
@@ -65,6 +66,14 @@ module Decidim
               end.to change { Project.where(budget: budget).count }.by(1)
             end
 
+            context "when there are no proposals in the selected scope" do
+              it "doesn't create any project" do
+                expect do
+                  command.call
+                end.not_to change { Project.where(budget: budget).where(scope: scope).count }
+              end
+            end
+
             context "when a proposal was already imported" do
               let(:second_proposal) { create(:proposal, :accepted, component: proposal.component) }
 
@@ -105,6 +114,7 @@ module Decidim
               expect(new_project.scope).to eq(proposal.scope)
             end
           end
+
         end
       end
     end

--- a/decidim-budgets/spec/commands/decidim/budgets/admin/import_proposals_to_budgets_spec.rb
+++ b/decidim-budgets/spec/commands/decidim/budgets/admin/import_proposals_to_budgets_spec.rb
@@ -27,7 +27,7 @@ module Decidim
               current_user: current_user,
               default_budget: default_budget,
               import_all_accepted_proposals: import_all_accepted_proposals,
-              scope_id: '',
+              scope_id: "",
               budget: budget,
               valid?: valid
             )

--- a/decidim-budgets/spec/commands/decidim/budgets/admin/import_proposals_to_budgets_spec.rb
+++ b/decidim-budgets/spec/commands/decidim/budgets/admin/import_proposals_to_budgets_spec.rb
@@ -70,7 +70,7 @@ module Decidim
               it "doesn't create any project" do
                 expect do
                   command.call
-                end.not_to change { Project.where(budget: budget).where(scope: scope).count }
+                end.not_to(change { Project.where(budget: budget).where(scope: scope).count })
               end
             end
 
@@ -114,7 +114,6 @@ module Decidim
               expect(new_project.scope).to eq(proposal.scope)
             end
           end
-
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Adds a selector to filter accepted proposals by scope in _Import proposals to project_.

#### :pushpin: Related Issues
- Related to #6463 

#### :clipboard: Subtasks
- [x] Add `scope` selector
- [x] Filter `proposals` by scope
- [x] Update tests

### :camera: Screenshots (optional)
<img width="1021" alt="Screenshot 2020-09-17 at 09 24 29" src="https://user-images.githubusercontent.com/12495882/93433839-a0e89980-f8c7-11ea-9284-bbb94bce1217.png">
<img width="712" alt="Screenshot 2020-09-17 at 09 24 21" src="https://user-images.githubusercontent.com/12495882/93433849-a34af380-f8c7-11ea-9cfd-da65b0dfd537.png">

