### PR TITLE
Add more than one attachment to proposals

### DIFF
--- a/decidim-core/app/commands/decidim/gallery_methods.rb
+++ b/decidim-core/app/commands/decidim/gallery_methods.rb
@@ -26,7 +26,7 @@ module Decidim
     end
 
     def gallery_invalid?
-      gallery.each do |photo|
+      @gallery.each do |photo|
         if photo.invalid? && photo.errors.has_key?(:file)
           @form.errors.add(:add_photos, photo.errors[:file])
           return true

--- a/decidim-core/app/commands/decidim/multiple_attachments_methods.rb
+++ b/decidim-core/app/commands/decidim/multiple_attachments_methods.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Decidim
+  module MultipleAttachmentsMethods
+    private
+
+    def build_attachments
+      @files = []
+      @form.add_files.each do |file|
+        @files << Attachment.new(
+          title: file.original_filename,
+          file: file,
+          attached_to: @attached_to
+        )
+      end
+    end
+
+    def attachments_invalid?
+      @files.each do |file|
+        if file.invalid? && file.errors.has_key?(:file)
+          @form.errors.add(:add_files, file.errors[:file])
+          return true
+        end
+      end
+      false
+    end
+
+    def create_attachments
+      @files.map! do |file|
+        file.attached_to = @attached_to
+        file.save!
+        @form.files << file.id.to_s
+      end
+    end
+
+    def file_cleanup!
+      @attached_to.documents.each do |file|
+        file.destroy! if @form.files.exclude? file.id.to_s
+      end
+
+      @attached_to.reload
+      @attached_to.instance_variable_set(:@files, nil)
+    end
+
+    def process_attachments?
+      @form.add_files.any?
+    end
+  end
+end

--- a/decidim-core/app/commands/decidim/multiple_attachments_methods.rb
+++ b/decidim-core/app/commands/decidim/multiple_attachments_methods.rb
@@ -5,20 +5,20 @@ module Decidim
     private
 
     def build_attachments
-      @files = []
-      @form.add_files.each do |file|
-        @files << Attachment.new(
+      @documents = []
+      @form.add_documents.each do |file|
+        @documents << Attachment.new(
           title: file.original_filename,
-          attached_to: @attached_to || files_attached_to,
+          attached_to: @attached_to || documents_attached_to,
           file: file
         )
       end
     end
 
     def attachments_invalid?
-      @files.each do |file|
+      @documents.each do |file|
         if file.invalid? && file.errors.has_key?(:file)
-          @form.errors.add(:add_files, file.errors[:file])
+          @form.errors.add(:add_documents, file.errors[:file])
           return true
         end
       end
@@ -26,27 +26,27 @@ module Decidim
     end
 
     def create_attachments
-      @files.map! do |file|
-        file.attached_to = files_attached_to
+      @documents.map! do |file|
+        file.attached_to = documents_attached_to
         file.save!
-        @form.files << file.id.to_s
+        @form.documents << file.id.to_s
       end
     end
 
-    def file_cleanup!
-      files_attached_to.documents.each do |file|
-        file.destroy! if @form.files.exclude? file.id.to_s
+    def document_cleanup!
+      documents_attached_to.documents.each do |file|
+        file.destroy! if @form.documents.exclude? file.id.to_s
       end
 
-      files_attached_to.reload
-      files_attached_to.instance_variable_set(:@files, nil)
+      documents_attached_to.reload
+      documents_attached_to.instance_variable_set(:@documents, nil)
     end
 
     def process_attachments?
-      @form.add_files.any?
+      @form.add_documents.any?
     end
 
-    def files_attached_to
+    def documents_attached_to
       return @attached_to if @attached_to.present?
       return form.current_organization if form.respond_to?(:current_organization)
 

--- a/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal.rb
@@ -46,6 +46,7 @@ module Decidim
             create_attachment if process_attachments?
             create_gallery if process_gallery?
             photo_cleanup!
+            file_cleanup!
           end
 
           broadcast(:ok, proposal)

--- a/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal.rb
@@ -46,7 +46,6 @@ module Decidim
             create_attachment if process_attachments?
             create_gallery if process_gallery?
             photo_cleanup!
-            file_cleanup!
           end
 
           broadcast(:ok, proposal)

--- a/decidim-proposals/app/commands/decidim/proposals/update_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/update_proposal.rb
@@ -49,6 +49,9 @@ module Decidim
           end
           create_gallery if process_gallery?
           create_attachments if process_attachments?
+
+          photo_cleanup!
+          document_cleanup!
         end
 
         broadcast(:ok, proposal)

--- a/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
@@ -18,8 +18,8 @@ module Decidim
       attribute :suggested_hashtags, Array[String]
       attribute :photos, Array[String]
       attribute :add_photos, Array
-      attribute :files, Array[String]
-      attribute :add_files, Array
+      attribute :documents, Array[String]
+      attribute :add_documents, Array
 
       validates :address, geocoding: true, if: ->(form) { form.has_address? && !form.geocoded? }
       validates :address, presence: true, if: ->(form) { form.has_address? }

--- a/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
@@ -16,6 +16,10 @@ module Decidim
       attribute :has_address, Boolean
       attribute :attachment, AttachmentForm
       attribute :suggested_hashtags, Array[String]
+      attribute :photos, Array[String]
+      attribute :add_photos, Array
+      attribute :files, Array[String]
+      attribute :add_files, Array
 
       validates :address, geocoding: true, if: ->(form) { form.has_address? && !form.geocoded? }
       validates :address, presence: true, if: ->(form) { form.has_address? }

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
@@ -62,22 +62,34 @@
 
 <% if component_settings.attachments_allowed? && @proposal %>
   <fieldset>
-    <legend><%= t("attachment_legend", scope: "decidim.proposals.proposals.edit") %></legend>
-    <%= form.fields_for :attachment, @form.attachment do |nested_form| %>
-      <div class="field">
-        <%= nested_form.text_field :title %>
-      </div>
+    <legend><%= t("gallery_legend", scope: "decidim.proposals.proposals.edit") %></legend>
 
-      <div class="field">
-        <%= nested_form.upload :file, optional: false %>
-        <% if @form.errors[:attachment].present? %>
-          <% @form.errors[:attachment].each do |message| %>
-            <small class="form-error is-visible">
-              <%= message %>
-            </small>
-          <% end %>
-        <% end %>
-      </div>
+    <% if @form.photos.any? %>
+      <% @form.photos.each do |photo| %>
+        <div class="callout gallery__item" data-closable>
+          <%= image_tag photo.thumbnail_url, class: "thumbnail", alt: photo.file.file.filename %>
+          <%= form.hidden_field :photos, multiple: true, value: photo.id, id: "photo-#{photo.id}" %>
+          <button class="close-button"
+                  aria-label="<%= t("delete_image", scope: "decidim.proposals.proposals.edit") %>"
+                  title="<%= t("delete_image", scope: "decidim.proposals.proposals.edit") %>"
+                  type="button"
+                  data-close>
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+      <% end %>
     <% end %>
+
+    <div class="row column">
+      <%= form.file_field :add_photos, multiple: false, label: t("add_images", scope: "decidim.proposals.proposals.edit") %>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend><%= t("attachment_legend", scope: "decidim.proposals.proposals.edit") %></legend>
+
+    <div class="row column">
+      <%= form.file_field :add_files, multiple: true, label: t("add_images", scope: "decidim.proposals.proposals.edit") %>
+    </div>
   </fieldset>
 <% end %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
@@ -88,8 +88,24 @@
   <fieldset>
     <legend><%= t("attachment_legend", scope: "decidim.proposals.proposals.edit") %></legend>
 
+    <% if @form.documents.any? %>
+      <% @form.documents.each do |document| %>
+        <div class="callout" data-closable>
+          <%= link_to translated_attribute(document.title), document.url %>
+          <small><%= document.file_type %> <%= number_to_human_size(document.file_size) %></small>
+          <%= form.hidden_field :documents, multiple: true, value: document.id, id: "document-#{document.id}" %>
+          <button class="close-button"
+                  aria-label="<%= t("delete_document", scope: "decidim.proposals.proposals.edit") %>"
+                  title="<%= t("delete_document", scope: "decidim.proposals.proposals.edit") %>"
+                  type="button" data-close>
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+      <% end %>
+    <% end %>
+
     <div class="row column">
-      <%= form.file_field :add_files, multiple: true, label: t("add_images", scope: "decidim.proposals.proposals.edit") %>
+      <%= form.file_field :add_documents, multiple: true, label: t("add_documents", scope: "decidim.proposals.proposals.edit") %>
     </div>
   </fieldset>
 <% end %>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -723,8 +723,11 @@ en:
             one: "%{count} proposal"
             other: "%{count} proposals"
         edit:
+          add_images: File
           attachment_legend: "(Optional) Add an attachment"
           back: Back
+          delete_image: Delete Image
+          gallery_legend: "(Optional) Add an image to the proposal card"
           select_a_category: Please select a category
           send: Send
           title: Edit proposal

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -723,9 +723,11 @@ en:
             one: "%{count} proposal"
             other: "%{count} proposals"
         edit:
+          add_documents: Documents
           add_images: File
           attachment_legend: "(Optional) Add an attachment"
           back: Back
+          delete_document: Delete Document
           delete_image: Delete Image
           gallery_legend: "(Optional) Add an image to the proposal card"
           select_a_category: Please select a category

--- a/decidim-proposals/spec/commands/decidim/proposals/update_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/update_proposal_spec.rb
@@ -31,6 +31,12 @@ module Decidim
       let(:latitude) { 40.1234 }
       let(:longitude) { 2.1234 }
       let(:suggested_hashtags) { [] }
+      let(:attachment_params) { nil }
+      let(:uploaded_photos) { [] }
+      let(:current_photos) { [] }
+      let(:current_files) { [] }
+      let(:uploaded_files) { [] }
+      let(:errors) { double.as_null_object }
 
       describe "call" do
         let(:form_params) do
@@ -40,7 +46,13 @@ module Decidim
             address: address,
             has_address: has_address,
             user_group_id: user_group.try(:id),
-            suggested_hashtags: suggested_hashtags
+            suggested_hashtags: suggested_hashtags,
+            attachment: attachment_params,
+            photos: current_photos,
+            add_photos: uploaded_photos,
+            files: current_files,
+            add_files: uploaded_files,
+            errors: errors
           }
         end
 
@@ -154,6 +166,49 @@ module Decidim
                   expect(proposal.longitude).to eq(longitude)
                 end
               end
+            end
+          end
+
+          context "when attachments are allowed", processing_uploads_for: Decidim::AttachmentUploader do
+            let(:component) { create(:proposal_component, :with_attachments_allowed) }
+            let(:uploaded_files) do
+              [
+                Decidim::Dev.test_file("city.jpeg", "image/jpeg"),
+                Decidim::Dev.test_file("Exampledocument.pdf", "application/pdf")
+              ]
+            end
+
+            it "creates multiple atachments for the proposal" do
+              expect { command.call }.to change(Decidim::Attachment, :count).by(2)
+              last_proposal = Decidim::Proposals::Proposal.last
+              last_attachment = Decidim::Attachment.last
+              expect(last_attachment.attached_to).to eq(last_proposal)
+            end
+          end
+
+          context "when attachments are allowed and file is invalid", processing_uploads_for: Decidim::AttachmentUploader do
+            let(:component) { create(:proposal_component, :with_attachments_allowed) }
+            let(:uploaded_files) do
+              [
+                Decidim::Dev.test_file("city.jpeg", ""),
+                Decidim::Dev.test_file("Exampledocument.pdf", "application/pdf")
+              ]
+            end
+
+            it "does not create atachments for the proposal" do
+              expect { command.call }.to change(Decidim::Attachment, :count).by(0)
+            end
+          end
+
+          context "when gallery are allowed", processing_uploads_for: Decidim::AttachmentUploader do
+            let(:component) { create(:proposal_component, :with_attachments_allowed) }
+            let(:uploaded_photos) { [Decidim::Dev.test_file("city.jpeg", "image/jpeg")] }
+
+            it "creates an image attachment for the proposal" do
+              expect { command.call }.to change(Decidim::Attachment, :count).by(1)
+              last_proposal = Decidim::Proposals::Proposal.last
+              last_attachment = Decidim::Attachment.last
+              expect(last_attachment.attached_to).to eq(last_proposal)
             end
           end
         end

--- a/decidim-proposals/spec/commands/decidim/proposals/update_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/update_proposal_spec.rb
@@ -190,13 +190,31 @@ module Decidim
             let(:component) { create(:proposal_component, :with_attachments_allowed) }
             let(:uploaded_files) do
               [
-                Decidim::Dev.test_file("city.jpeg", ""),
-                Decidim::Dev.test_file("Exampledocument.pdf", "application/pdf")
+                Decidim::Dev.test_file("city.jpeg", "image/jpeg"),
+                Decidim::Dev.test_file("Exampledocument.pdf", "")
               ]
             end
 
             it "does not create atachments for the proposal" do
               expect { command.call }.to change(Decidim::Attachment, :count).by(0)
+            end
+
+            it "broadcasts invalid" do
+              expect { command.call }.to broadcast(:invalid)
+            end
+          end
+
+          context "when documents and gallery are allowed", processing_uploads_for: Decidim::AttachmentUploader do
+            let(:component) { create(:proposal_component, :with_attachments_allowed) }
+            let(:uploaded_photos) { [Decidim::Dev.test_file("city.jpeg", "image/jpeg")] }
+            let(:uploaded_files) do
+              [
+                Decidim::Dev.test_file("Exampledocument.pdf", "application/pdf")
+              ]
+            end
+
+            it "Create gallery and documents for the proposal" do
+              expect { command.call }.to change(Decidim::Attachment, :count).by(2)
             end
           end
 

--- a/decidim-proposals/spec/commands/decidim/proposals/update_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/update_proposal_spec.rb
@@ -50,8 +50,8 @@ module Decidim
             attachment: attachment_params,
             photos: current_photos,
             add_photos: uploaded_photos,
-            files: current_files,
-            add_files: uploaded_files,
+            documents: current_files,
+            add_documents: uploaded_files,
             errors: errors
           }
         end

--- a/decidim-proposals/spec/system/proposals_fields_spec.rb
+++ b/decidim-proposals/spec/system/proposals_fields_spec.rb
@@ -295,8 +295,7 @@ describe "Proposals", type: :system do
             within ".edit_proposal" do
               fill_in :proposal_title, with: "Proposal with attachments"
               fill_in :proposal_body, with: "This is my proposal and I want to upload attachments."
-              fill_in :proposal_attachment_title, with: "My attachment"
-              attach_file :proposal_attachment_file, Decidim::Dev.asset("city.jpeg")
+              attach_file :proposal_add_photos, Decidim::Dev.asset("city.jpeg")
               find("*[type=submit]").click
             end
 


### PR DESCRIPTION
#### :tophat: What? Why?
When creating a proposal as a participant I can only upload a single attachment. As recently there is an option to allow images on the cards, this PR intends to allow upload the image and multiple attachments if needed.

* Add image galery to the proposals form
* Create a `MultipleAttachmentsmethods` in order to upload multiple files
* Change file upload in the proposals form to have multiple uploads


It's possible to test it on staging https://decidim-staging-pr-180.herokuapp.com

#### :pushpin: Related Issues
- Related to #6126 

#### :clipboard: Subtasks
- [x] Allow upload image to the card and files when `Allow card image` is enabled
- [x] Allow multiple file upload
- [x]  In the detail of a proposal I see both the image and the attached files

### :camera: Screenshots (optional)

#### Upload form
![image](https://user-images.githubusercontent.com/52708/93739847-8a08b680-fbe9-11ea-9e9b-03f65b46c1d4.png)

#### Upload form with two files attached
![image](https://user-images.githubusercontent.com/52708/93739993-e9ff5d00-fbe9-11ea-8f71-7bef60d7a7d5.png)

#### Proposal detail page
![image](https://user-images.githubusercontent.com/52708/93740049-056a6800-fbea-11ea-996f-589f51042a4f.png)

#### Proposals index page
![image](https://user-images.githubusercontent.com/52708/93740106-1dda8280-fbea-11ea-860c-9dbbe90ebae2.png)

