### PR TITLE
Update Faker quotes in design module in order to match the current gem syntax

### DIFF
--- a/decidim_app-design/app/views/admin/component-meetings-edit-errors.html.erb
+++ b/decidim_app-design/app/views/admin/component-meetings-edit-errors.html.erb
@@ -89,7 +89,7 @@
             <div class="cell">
               <ul>
                 <% 2.times do %>
-                <li><u><%= Faker::Zelda.character %>.<%= Faker::File.extension %></u>&nbsp;<a href="" class="text-alert"><u>remove</u></a></li>
+                <li><u><%= Faker::Games::Zelda.character %>.<%= Faker::File.extension %></u>&nbsp;<a href="" class="text-alert"><u>remove</u></a></li>
                 <% end %>
               </ul>
             </div>
@@ -169,7 +169,7 @@
             <div class="cell">
               <ul>
                 <% 2.times do %>
-                <li><u><%= Faker::Zelda.character %>.<%= Faker::File.extension %></u>&nbsp;<a href="" class="text-alert"><u>remove</u></a></li>
+                <li><u><%= Faker::Games::Zelda.character %>.<%= Faker::File.extension %></u>&nbsp;<a href="" class="text-alert"><u>remove</u></a></li>
                 <% end %>
               </ul>
             </div>
@@ -190,7 +190,7 @@
                     <div class="grid-x grid-padding-x pt-s pb-s">
                       <div class="cell shrink text-center"><%= icon "move" %></div>
                       <div class="cell small-3"><%= Faker::Time.forward(7, :morning).strftime("%R") %>-<%= Faker::Time.forward(7, :evening).strftime("%R") %>&nbsp;<small>(<%= Faker::Number.between(10, 180) %> min)</small></div>
-                      <div class="cell auto"><strong><%= Faker::StarWars.quote[0..50] %></strong>&nbsp;<small><%= Faker::StarWars.quote %></small></div>
+                      <div class="cell auto"><strong><%= Faker::Movies::StarWars.quote[0..50] %></strong>&nbsp;<small><%= Faker::Movies::StarWars.quote %></small></div>
                       <div class="cell shrink text-center"><%= icon "circle-x" %></div>
                     </div>
                   <% end %>

--- a/decidim_app-design/app/views/admin/component-meetings-edit-item.html.erb
+++ b/decidim_app-design/app/views/admin/component-meetings-edit-item.html.erb
@@ -66,7 +66,7 @@
             <div class="cell">
               <ul>
                 <% 2.times do %>
-                <li><u><%= Faker::Zelda.character %>.<%= Faker::File.extension %></u>&nbsp;<a href="" class="text-alert"><u>remove</u></a></li>
+                <li><u><%= Faker::Games::Zelda.character %>.<%= Faker::File.extension %></u>&nbsp;<a href="" class="text-alert"><u>remove</u></a></li>
                 <% end %>
               </ul>
             </div>

--- a/decidim_app-design/app/views/admin/component-meetings-initial.html.erb
+++ b/decidim_app-design/app/views/admin/component-meetings-initial.html.erb
@@ -82,9 +82,9 @@
             <div class="cell medium-6">
               <label>Category</label>
               <select>
-                <option selected="selected" value="en"><%= Faker::GameOfThrones.house %></option>
+                <option selected="selected" value="en"><%= Faker::TvShows::GameOfThrones.house %></option>
                 <%= 3.times do %>
-                  <option value="ca"><%= Faker::GameOfThrones.house %></option>
+                  <option value="ca"><%= Faker::TvShows::GameOfThrones.house %></option>
                 <% end %>
               </select>
             </div>

--- a/decidim_app-design/app/views/admin/component-meetings-items.html.erb
+++ b/decidim_app-design/app/views/admin/component-meetings-items.html.erb
@@ -85,7 +85,7 @@
             <div class="cell">
               <ul>
                 <% 3.times do %>
-                <li><u><%= Faker::Zelda.character %>.<%= Faker::File.extension %></u>&nbsp;<a href="" class="text-alert"><u>remove</u></a></li>
+                <li><u><%= Faker::Games::Zelda.character %>.<%= Faker::File.extension %></u>&nbsp;<a href="" class="text-alert"><u>remove</u></a></li>
                 <% end %>
               </ul>
             </div>
@@ -164,7 +164,7 @@
             <div class="cell">
               <ul>
                 <% 3.times do %>
-                <li><u><%= Faker::Zelda.character %>.<%= Faker::File.extension %></u>&nbsp;<a href="" class="text-alert"><u>remove</u></a></li>
+                <li><u><%= Faker::Games::Zelda.character %>.<%= Faker::File.extension %></u>&nbsp;<a href="" class="text-alert"><u>remove</u></a></li>
                 <% end %>
               </ul>
             </div>
@@ -185,7 +185,7 @@
                     <div class="grid-x grid-padding-x pt-s pb-s">
                       <div class="cell shrink text-center"><%= icon "move" %></div>
                       <div class="cell small-3"><%= Faker::Time.forward(7, :morning).strftime("%R") %>-<%= Faker::Time.forward(7, :evening).strftime("%R") %>&nbsp;<small>(<%= Faker::Number.between(10, 180) %> min)</small></div>
-                      <div class="cell auto"><strong><%= Faker::StarWars.quote[0..50] %></strong>&nbsp;<small><%= Faker::StarWars.quote %></small></div>
+                      <div class="cell auto"><strong><%= Faker::Movies::StarWars.quote[0..50] %></strong>&nbsp;<small><%= Faker::Movies::StarWars.quote %></small></div>
                       <div class="cell shrink text-center"><%= icon "circle-x" %></div>
                     </div>
                   <% end %>

--- a/decidim_app-design/app/views/admin/component-meetings-minutes.html.erb
+++ b/decidim_app-design/app/views/admin/component-meetings-minutes.html.erb
@@ -41,7 +41,7 @@
               <% 5.times do %>
                 <tr>
                   <td><input type="checkbox"></td>
-                  <td><%= Faker::FamilyGuy.quote %></td>
+                  <td><%= Faker::TvShows::FamilyGuy.quote %></td>
                   <td><%= Faker::Date.forward(1).strftime("%d/%m/%y") %>&nbsp;&#8212;&nbsp;<%= Faker::Time.forward(1).strftime("%R") %>&nbsp;-&nbsp;<%= Faker::Time.forward(1).strftime("%R") %></td>
                   <td><u>Gestionar</u></td>
                   <td><%= Faker::Boolean.boolean(0.5) ? raw("<u>Gestionar</u>") : raw("&#8212;") %></td>
@@ -86,7 +86,7 @@
               <% 5.times do %>
                 <tr>
                   <td><input type="checkbox"></td>
-                  <td><%= Faker::FamilyGuy.quote %></td>
+                  <td><%= Faker::TvShows::FamilyGuy.quote %></td>
                   <td><%= Faker::Date.forward(1).strftime("%d/%m/%y") %>&nbsp;&#8212;&nbsp;<%= Faker::Time.forward(1).strftime("%R") %>&nbsp;-&nbsp;<%= Faker::Time.forward(1).strftime("%R") %></td>
                   <td><u>Ver</u></td>
                   <td><%= Faker::Boolean.boolean(0.25) ? raw("<u>Ver</u>") : raw("&#8212;") %></td>

--- a/decidim_app-design/app/views/admin/component-meetings-with-content.html.erb
+++ b/decidim_app-design/app/views/admin/component-meetings-with-content.html.erb
@@ -82,9 +82,9 @@
             <div class="cell medium-6">
               <label>Category</label>
               <select>
-                <option selected="selected" value="en"><%= Faker::GameOfThrones.house %></option>
+                <option selected="selected" value="en"><%= Faker::TvShows::GameOfThrones.house %></option>
                 <%= 3.times do %>
-                  <option value="ca"><%= Faker::GameOfThrones.house %></option>
+                  <option value="ca"><%= Faker::TvShows::GameOfThrones.house %></option>
                 <% end %>
               </select>
             </div>

--- a/decidim_app-design/app/views/admin/component-meetings-with-content.html.erb
+++ b/decidim_app-design/app/views/admin/component-meetings-with-content.html.erb
@@ -107,7 +107,7 @@
             <div class="grid-x grid-padding-x pt-s pb-s">
               <div class="cell shrink text-center"><%= icon "move" %></div>
               <div class="cell small-2"><%= Faker::Time.forward(7, :morning).strftime("%R") %>-<%= Faker::Time.forward(7, :evening).strftime("%R") %>&nbsp;<small>(<%= Faker::Number.between(10, 180) %> min)</small></div>
-              <div class="cell auto"><strong><%= Faker::StarWars.quote[0..50] %></strong>&nbsp;<small><%= Faker::StarWars.quote %></small></div>
+              <div class="cell auto"><strong><%= Faker::Movies::StarWars.quote[0..50] %></strong>&nbsp;<small><%= Faker::Movies::StarWars.quote %></small></div>
               <div class="cell shrink text-center"><%= icon "circle-x" %></div>
             </div>
           <% end %>

--- a/decidim_app-design/app/views/admin/component-proposals-actions.html.erb
+++ b/decidim_app-design/app/views/admin/component-proposals-actions.html.erb
@@ -54,7 +54,7 @@
                   <td><%= Faker::Number.digit %></td>
                   <td><%= Faker::TvShows::FamilyGuy.quote %></td>
                   <td><%= Faker::Food.dish %></td>
-                  <td><%= Faker::Cat.name %></td>
+                  <td><%= Faker::Creature::Cat.name %></td>
                   <td class="warning">not answered</td>
                   <td><%= Faker::Number.between(1, 10) %></td>
                   <td class="muted"><%= icon "comment-square", class: "icon--small" %></td>

--- a/decidim_app-design/app/views/admin/component-proposals-actions.html.erb
+++ b/decidim_app-design/app/views/admin/component-proposals-actions.html.erb
@@ -52,7 +52,7 @@
                 <tr class="selected">
                   <td><input type="checkbox" checked></td>
                   <td><%= Faker::Number.digit %></td>
-                  <td><%= Faker::FamilyGuy.quote %></td>
+                  <td><%= Faker::TvShows::FamilyGuy.quote %></td>
                   <td><%= Faker::Food.dish %></td>
                   <td><%= Faker::Cat.name %></td>
                   <td class="warning">not answered</td>

--- a/decidim_app-design/app/views/admin/component-proposals-apply-action.html.erb
+++ b/decidim_app-design/app/views/admin/component-proposals-apply-action.html.erb
@@ -50,7 +50,7 @@
                   <td><%= Faker::Number.digit %></td>
                   <td><%= Faker::TvShows::FamilyGuy.quote %></td>
                   <td><%= Faker::Food.dish %></td>
-                  <td><%= Faker::Cat.name %></td>
+                  <td><%= Faker::Creature::Cat.name %></td>
                   <td class="warning">not answered</td>
                   <td><%= Faker::Number.between(1, 10) %></td>
                   <td class="muted"><%= icon "comment-square", class: "icon--small" %></td>

--- a/decidim_app-design/app/views/admin/component-proposals-apply-action.html.erb
+++ b/decidim_app-design/app/views/admin/component-proposals-apply-action.html.erb
@@ -48,7 +48,7 @@
                 <tr class="selected">
                   <td><input type="checkbox" checked></td>
                   <td><%= Faker::Number.digit %></td>
-                  <td><%= Faker::FamilyGuy.quote %></td>
+                  <td><%= Faker::TvShows::FamilyGuy.quote %></td>
                   <td><%= Faker::Food.dish %></td>
                   <td><%= Faker::Cat.name %></td>
                   <td class="warning">not answered</td>

--- a/decidim_app-design/app/views/admin/component-proposals-none.html.erb
+++ b/decidim_app-design/app/views/admin/component-proposals-none.html.erb
@@ -47,7 +47,7 @@
                   <td><%= Faker::Number.digit %></td>
                   <td><%= Faker::TvShows::FamilyGuy.quote %></td>
                   <td><%= Faker::Food.dish %></td>
-                  <td><%= Faker::Cat.name %></td>
+                  <td><%= Faker::Creature::Cat.name %></td>
                   <td class="warning">not answered</td>
                   <td><%= Faker::Number.between(1, 10) %></td>
                   <td class="muted"><%= icon "comment-square", class: "icon--small" %></td>

--- a/decidim_app-design/app/views/admin/component-proposals-none.html.erb
+++ b/decidim_app-design/app/views/admin/component-proposals-none.html.erb
@@ -45,7 +45,7 @@
                 <tr>
                   <td><input type="checkbox"></td>
                   <td><%= Faker::Number.digit %></td>
-                  <td><%= Faker::FamilyGuy.quote %></td>
+                  <td><%= Faker::TvShows::FamilyGuy.quote %></td>
                   <td><%= Faker::Food.dish %></td>
                   <td><%= Faker::Cat.name %></td>
                   <td class="warning">not answered</td>

--- a/decidim_app-design/app/views/admin/component-proposals-search.html.erb
+++ b/decidim_app-design/app/views/admin/component-proposals-search.html.erb
@@ -46,7 +46,7 @@
                   <td><%= Faker::Number.digit %></td>
                   <td><%= Faker::TvShows::FamilyGuy.quote %></td>
                   <td><%= Faker::Food.dish %></td>
-                  <td><%= Faker::Cat.name %></td>
+                  <td><%= Faker::Creature::Cat.name %></td>
                   <td class="warning">not answered</td>
                   <td><%= Faker::Number.between(1, 10) %></td>
                   <td class="muted"><%= icon "comment-square", class: "icon--small" %></td>

--- a/decidim_app-design/app/views/admin/component-proposals-search.html.erb
+++ b/decidim_app-design/app/views/admin/component-proposals-search.html.erb
@@ -44,7 +44,7 @@
                 <tr>
                   <td><input type="checkbox"></td>
                   <td><%= Faker::Number.digit %></td>
-                  <td><%= Faker::FamilyGuy.quote %></td>
+                  <td><%= Faker::TvShows::FamilyGuy.quote %></td>
                   <td><%= Faker::Food.dish %></td>
                   <td><%= Faker::Cat.name %></td>
                   <td class="warning">not answered</td>

--- a/decidim_app-design/app/views/admin/component-proposals-selected.html.erb
+++ b/decidim_app-design/app/views/admin/component-proposals-selected.html.erb
@@ -47,7 +47,7 @@
                   <td><%= Faker::Number.digit %></td>
                   <td><%= Faker::TvShows::FamilyGuy.quote %></td>
                   <td><%= Faker::Food.dish %></td>
-                  <td><%= Faker::Cat.name %></td>
+                  <td><%= Faker::Creature::Cat.name %></td>
                   <td class="warning">not answered</td>
                   <td><%= Faker::Number.between(1, 10) %></td>
                   <td class="muted"><%= icon "comment-square", class: "icon--small" %></td>
@@ -58,7 +58,7 @@
                 <td><%= Faker::Number.digit %></td>
                 <td><%= Faker::TvShows::FamilyGuy.quote %></td>
                 <td><%= Faker::Food.dish %></td>
-                <td><%= Faker::Cat.name %></td>
+                <td><%= Faker::Creature::Cat.name %></td>
                 <td class="warning">not answered</td>
                 <td><%= Faker::Number.between(1, 10) %></td>
                 <td class="muted"><%= icon "comment-square", class: "icon--small" %></td>
@@ -69,7 +69,7 @@
                   <td><%= Faker::Number.digit %></td>
                   <td><%= Faker::TvShows::FamilyGuy.quote %></td>
                   <td><%= Faker::Food.dish %></td>
-                  <td><%= Faker::Cat.name %></td>
+                  <td><%= Faker::Creature::Cat.name %></td>
                   <td class="warning">not answered</td>
                   <td><%= Faker::Number.between(1, 10) %></td>
                   <td class="muted"><%= icon "comment-square", class: "icon--small" %></td>

--- a/decidim_app-design/app/views/admin/component-proposals-selected.html.erb
+++ b/decidim_app-design/app/views/admin/component-proposals-selected.html.erb
@@ -45,7 +45,7 @@
                 <tr>
                   <td><input type="checkbox"></td>
                   <td><%= Faker::Number.digit %></td>
-                  <td><%= Faker::FamilyGuy.quote %></td>
+                  <td><%= Faker::TvShows::FamilyGuy.quote %></td>
                   <td><%= Faker::Food.dish %></td>
                   <td><%= Faker::Cat.name %></td>
                   <td class="warning">not answered</td>
@@ -56,7 +56,7 @@
               <tr class="selected"><!-- selected class in row -->
                 <td><input type="checkbox" checked></td>
                 <td><%= Faker::Number.digit %></td>
-                <td><%= Faker::FamilyGuy.quote %></td>
+                <td><%= Faker::TvShows::FamilyGuy.quote %></td>
                 <td><%= Faker::Food.dish %></td>
                 <td><%= Faker::Cat.name %></td>
                 <td class="warning">not answered</td>
@@ -67,7 +67,7 @@
                 <tr>
                   <td><input type="checkbox"></td>
                   <td><%= Faker::Number.digit %></td>
-                  <td><%= Faker::FamilyGuy.quote %></td>
+                  <td><%= Faker::TvShows::FamilyGuy.quote %></td>
                   <td><%= Faker::Food.dish %></td>
                   <td><%= Faker::Cat.name %></td>
                   <td class="warning">not answered</td>

--- a/decidim_app-design/app/views/public/amendments/proposal-view-with-amendment-rejected.html.erb
+++ b/decidim_app-design/app/views/public/amendments/proposal-view-with-amendment-rejected.html.erb
@@ -76,7 +76,7 @@
                     <div class="card__header">
                       <%= link_to page_path("proposal-view"), class: "card__link" do %>
                       <h5 class="card__title">
-                        <%= Faker::StarWars.quote[0..75] %>
+                        <%= Faker::Movies::StarWars.quote[0..75] %>
                       </h5>
                       <% end %>
                       <div class="card__author">

--- a/decidim_app-design/app/views/public/amendments/proposal-view-with-amendments.html.erb
+++ b/decidim_app-design/app/views/public/amendments/proposal-view-with-amendments.html.erb
@@ -79,7 +79,7 @@
                     <div class="card__header">
                       <%= link_to page_path("proposal-view"), class: "card__link" do %>
                       <h5 class="card__title">
-                        <%= Faker::StarWars.quote[0..75] %>
+                        <%= Faker::Movies::StarWars.quote[0..75] %>
                       </h5>
                       <% end %>
                       <div class="card__author">

--- a/decidim_app-design/app/views/public/assemblies/assemblies.html.erb
+++ b/decidim_app-design/app/views/public/assemblies/assemblies.html.erb
@@ -60,7 +60,7 @@
             <div class="card__header">
               <%= link_to page_path("assemblies/assembly-view"), class: "card__link" do %>
               <h5 class="card__title">
-                <%= Faker::StarWars.quote[0..75] %>
+                <%= Faker::Movies::StarWars.quote[0..75] %>
               </h5>
               <% end %>
             </div>
@@ -134,7 +134,7 @@
             <div class="card__header">
               <%= link_to page_path("assemblies/assembly-view"), class: "card__link" do %>
               <h5 class="card__title">
-                <%= Faker::StarWars.quote[0..75] %>
+                <%= Faker::Movies::StarWars.quote[0..75] %>
               </h5>
               <% end %>
             </div>
@@ -195,7 +195,7 @@
             <div class="card__header">
               <%= link_to page_path("assemblies/assembly-view"), class: "card__link" do %>
               <h5 class="card__title">
-                <%= Faker::StarWars.quote[0..75] %>
+                <%= Faker::Movies::StarWars.quote[0..75] %>
               </h5>
               <% end %>
             </div>

--- a/decidim_app-design/app/views/public/assemblies/assembly-view.html.erb
+++ b/decidim_app-design/app/views/public/assemblies/assembly-view.html.erb
@@ -99,11 +99,11 @@
         </div>
         <div class="section">
           <h2 class="section-heading">Grups de treball intern</h2>
-          <p><%= Faker::Lovecraft.paragraph %></p>
+          <p><%= Faker::Books::Lovecraft.paragraph %></p>
         </div>
         <div class="section">
           <h2 class="section-heading">Composició</h2>
-          <p><%= Faker::Lovecraft.paragraph %></p>
+          <p><%= Faker::Books::Lovecraft.paragraph %></p>
           <article id="orgchart-<%= SecureRandom.hex(5) %>" class="card orgchart js-orgchart absolutes">
             <button class="medium-1 m-s top left button small hollow invisible js-reset-orgchart">Inicio</button>
             <select class="medium-2 m-s top right">
@@ -129,7 +129,7 @@
                     </div>
                     <div class="card__text card--picture-offset">
                       <div><small><strong><%= Faker::Company.profession.capitalize %></strong></small></div>
-                      <div><small><%= Faker::StarWars.vehicle %></small></div>
+                      <div><small><%= Faker::Movies::StarWars.vehicle %></small></div>
                       <div class="text-small">Designated on <strong><%= Faker::Date.backward(365).strftime("%D") %></strong></div>
                       <div class="text-small mt-s"><%= Faker::Demographic.sex %> / <%= Faker::Number.number(2) %> / <%= Faker::Address.city %></div>
                     </div>

--- a/decidim_app-design/app/views/public/cards/m/_assembly.html.erb
+++ b/decidim_app-design/app/views/public/cards/m/_assembly.html.erb
@@ -6,7 +6,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>
@@ -69,7 +69,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>

--- a/decidim_app-design/app/views/public/cards/m/_blog.html.erb
+++ b/decidim_app-design/app/views/public/cards/m/_blog.html.erb
@@ -6,7 +6,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
           <div class="card__author">

--- a/decidim_app-design/app/views/public/cards/m/_consultation.html.erb
+++ b/decidim_app-design/app/views/public/cards/m/_consultation.html.erb
@@ -9,7 +9,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>
@@ -93,7 +93,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>
@@ -179,7 +179,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>
@@ -242,7 +242,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>
@@ -305,7 +305,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>

--- a/decidim_app-design/app/views/public/cards/m/_debate.html.erb
+++ b/decidim_app-design/app/views/public/cards/m/_debate.html.erb
@@ -6,7 +6,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
           <div class="card__author">
@@ -59,7 +59,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
           <div class="card__author">

--- a/decidim_app-design/app/views/public/cards/m/_identifier.html.erb
+++ b/decidim_app-design/app/views/public/cards/m/_identifier.html.erb
@@ -7,7 +7,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
           <div class="card__author">
@@ -73,7 +73,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
           <div class="card__author">
@@ -139,7 +139,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
           <h5 class="card__title">
-            <%= Faker::StarWars.quote[0..75] %>
+            <%= Faker::Movies::StarWars.quote[0..75] %>
           </h5>
           <% end %>
           <div class="card__author">
@@ -203,7 +203,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
           <h5 class="card__title">
-            <%= Faker::StarWars.quote[0..75] %>
+            <%= Faker::Movies::StarWars.quote[0..75] %>
           </h5>
           <% end %>
           <div class="card__author">

--- a/decidim_app-design/app/views/public/cards/m/_initiative.html.erb
+++ b/decidim_app-design/app/views/public/cards/m/_initiative.html.erb
@@ -6,7 +6,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
           <div class="card__author">

--- a/decidim_app-design/app/views/public/cards/m/_meeting.html.erb
+++ b/decidim_app-design/app/views/public/cards/m/_meeting.html.erb
@@ -6,7 +6,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>
@@ -85,7 +85,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>
@@ -166,7 +166,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>
@@ -244,7 +244,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>
@@ -308,7 +308,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>
@@ -382,7 +382,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>

--- a/decidim_app-design/app/views/public/cards/m/_member.html.erb
+++ b/decidim_app-design/app/views/public/cards/m/_member.html.erb
@@ -8,7 +8,7 @@
         </div>
         <div class="card__text card--picture-offset">
           <div><small><strong><%= Faker::Company.profession.capitalize %></strong></small></div>
-          <div><small><%= Faker::StarWars.vehicle %></small></div>
+          <div><small><%= Faker::Movies::StarWars.vehicle %></small></div>
           <div class="text-small">Designated on <strong><%= Faker::Date.backward(365).strftime("%D") %></strong></div>
           <div class="text-small mt-s"><%= Faker::Demographic.sex %> / <%= Faker::Number.number(2) %> / <%= Faker::Address.city %></div>
         </div>

--- a/decidim_app-design/app/views/public/cards/m/_process.html.erb
+++ b/decidim_app-design/app/views/public/cards/m/_process.html.erb
@@ -6,7 +6,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>
@@ -84,7 +84,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>
@@ -161,7 +161,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>
@@ -237,7 +237,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>
@@ -320,7 +320,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>

--- a/decidim_app-design/app/views/public/cards/m/_project.html.erb
+++ b/decidim_app-design/app/views/public/cards/m/_project.html.erb
@@ -6,7 +6,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>
@@ -76,7 +76,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>

--- a/decidim_app-design/app/views/public/cards/m/_proposal.html.erb
+++ b/decidim_app-design/app/views/public/cards/m/_proposal.html.erb
@@ -11,7 +11,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
           <div class="card__author">
@@ -81,7 +81,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
           <div class="card__author">
@@ -153,7 +153,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
           <div class="card__author">
@@ -226,7 +226,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
           <div class="card__author">

--- a/decidim_app-design/app/views/public/cards/m/_result.html.erb
+++ b/decidim_app-design/app/views/public/cards/m/_result.html.erb
@@ -6,7 +6,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>
@@ -67,7 +67,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>
@@ -147,7 +147,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>
@@ -208,7 +208,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>

--- a/decidim_app-design/app/views/public/cards/m/_search-results.html.erb
+++ b/decidim_app-design/app/views/public/cards/m/_search-results.html.erb
@@ -7,7 +7,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
           <div class="card__author">

--- a/decidim_app-design/app/views/public/cards/m/_sortition.html.erb
+++ b/decidim_app-design/app/views/public/cards/m/_sortition.html.erb
@@ -6,7 +6,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
           <div class="card__author">
@@ -68,7 +68,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
           <div class="card__author">
@@ -132,7 +132,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
           <div class="card__author">

--- a/decidim_app-design/app/views/public/cards/m/_stack.html.erb
+++ b/decidim_app-design/app/views/public/cards/m/_stack.html.erb
@@ -6,7 +6,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>

--- a/decidim_app-design/app/views/public/cards/m/_status.html.erb
+++ b/decidim_app-design/app/views/public/cards/m/_status.html.erb
@@ -6,7 +6,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
           <div class="card__author">
@@ -71,7 +71,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
           <div class="card__author">
@@ -138,7 +138,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
           <div class="card__author">
@@ -210,7 +210,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
           <div class="card__author">

--- a/decidim_app-design/app/views/public/cards/m/_survey.html.erb
+++ b/decidim_app-design/app/views/public/cards/m/_survey.html.erb
@@ -6,7 +6,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>
@@ -55,7 +55,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>
@@ -105,7 +105,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>
@@ -153,7 +153,7 @@
         <div class="card__header">
           <%= link_to page_path("proposal-view"), class: "card__link" do %>
             <h5 class="card__title">
-              <%= Faker::StarWars.quote[0..75] %>
+              <%= Faker::Movies::StarWars.quote[0..75] %>
             </h5>
           <% end %>
         </div>

--- a/decidim_app-design/app/views/public/debates.html.erb
+++ b/decidim_app-design/app/views/public/debates.html.erb
@@ -25,7 +25,7 @@
             <div class="card__header">
               <%= link_to page_path("proposal-view"), class: "card__link" do %>
               <h5 class="card__title">
-                <%= Faker::StarWars.quote[0..75] %>
+                <%= Faker::Movies::StarWars.quote[0..75] %>
               </h5>
               <% end %>
               <div class="card__author">
@@ -77,7 +77,7 @@
             <div class="card__header">
               <%= link_to page_path("proposal-view"), class: "card__link" do %>
               <h5 class="card__title">
-                <%= Faker::StarWars.quote[0..75] %>
+                <%= Faker::Movies::StarWars.quote[0..75] %>
               </h5>
               <% end %>
               <div class="card__author">
@@ -141,7 +141,7 @@
             <div class="card__header">
               <%= link_to page_path("proposal-view"), class: "card__link" do %>
               <h5 class="card__title">
-                <%= Faker::StarWars.quote[0..75] %>
+                <%= Faker::Movies::StarWars.quote[0..75] %>
               </h5>
               <% end %>
               <div class="card__author">

--- a/decidim_app-design/app/views/public/evote-poll-list.html.erb
+++ b/decidim_app-design/app/views/public/evote-poll-list.html.erb
@@ -22,7 +22,7 @@
                 <div class="card__header">
                   <%= link_to page_path("proposal-view"), class: "card__link" do %>
                     <h5 class="card__title">
-                      <%= Faker::StarWars.quote[0..75] %>
+                      <%= Faker::Movies::StarWars.quote[0..75] %>
                     </h5>
                   <% end %>
                 </div>

--- a/decidim_app-design/app/views/public/initiatives/initiatives.html.erb
+++ b/decidim_app-design/app/views/public/initiatives/initiatives.html.erb
@@ -30,7 +30,7 @@
                 <div class="card__header">
                   <%= link_to page_path("proposal-view"), class: "card__link" do %>
                   <h5 class="card__title">
-                    <%= Faker::StarWars.quote[0..75] %>
+                    <%= Faker::Movies::StarWars.quote[0..75] %>
                   </h5>
                   <% end %>
                   <div class="card__author">

--- a/decidim_app-design/app/views/public/meetings/meeting-view-closed.html.erb
+++ b/decidim_app-design/app/views/public/meetings/meeting-view-closed.html.erb
@@ -62,21 +62,21 @@
             <div class="card__content scroll">
               <h5 class="heading5"><strong class="text-uppercase">WILLKOMMEN</strong>&nbsp;<span class="text-small">[<%= Faker::Time.forward(365, :evening).strftime("%R") %> - <%= Faker::Time.forward(365, :evening).strftime("%R") %>]</span></h5>
               <hr class="reset m-none mb-s">
-              <p><%= Faker::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
               <h5 class="heading5"><strong class="text-uppercase">Hauptdiskussionen</strong>&nbsp;<span class="text-small">[<%= Faker::Time.forward(365, :evening).strftime("%R") %> - <%= Faker::Time.forward(365, :evening).strftime("%R") %>]</span></h5>
               <hr class="reset m-none mb-s">
-              <p><%= Faker::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
               <h6 class="heading6"><strong class="text-uppercase">Überprüfung der Ziele</strong>&nbsp;<span class="text-small">[<%= Faker::Time.forward(365, :evening).strftime("%R") %> - <%= Faker::Time.forward(365, :evening).strftime("%R") %>]</span></h6>
-              <p><%= Faker::Lovecraft.paragraph %></p>
-              <p><%= Faker::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
               <h5 class="heading5"><strong class="text-uppercase">Hauptdiskussionen: Zweiter Teil</strong>&nbsp;<span class="text-small">[<%= Faker::Time.forward(365, :evening).strftime("%R") %> - <%= Faker::Time.forward(365, :evening).strftime("%R") %>]</span></h5>
               <hr class="reset m-none mb-s">
-              <p><%= Faker::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
               <h6 class="heading6"><strong class="text-uppercase">Überprüfung der Ziele: Zweiter Teil</strong>&nbsp;<span class="text-small">[<%= Faker::Time.forward(365, :evening).strftime("%R") %> - <%= Faker::Time.forward(365, :evening).strftime("%R") %>]</span></h6>
-              <p><%= Faker::Lovecraft.paragraph %></p>
-              <p><%= Faker::Lovecraft.paragraph %></p>
-              <p><%= Faker::Lovecraft.paragraph %></p>
-              <p><%= Faker::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
             </div>
           </div>
         </div>

--- a/decidim_app-design/app/views/public/meetings/meeting-view-custom-status.html.erb
+++ b/decidim_app-design/app/views/public/meetings/meeting-view-custom-status.html.erb
@@ -49,7 +49,7 @@
       <div class="columns mediumlarge-8 mediumlarge-pull-4">
         <div class="row column">
           <div class="callout warning mb-sm">
-            <p><%= Faker::StarWars.quote %></p>
+            <p><%= Faker::Movies::StarWars.quote %></p>
           </div>
         </div>
         <div class="section">
@@ -66,21 +66,21 @@
             <div class="card__content scroll">
               <h5 class="heading5"><strong class="text-uppercase">WILLKOMMEN</strong>&nbsp;<span class="text-small">[<%= Faker::Time.forward(365, :evening).strftime("%R") %> - <%= Faker::Time.forward(365, :evening).strftime("%R") %>]</span></h5>
               <hr class="reset m-none mb-s">
-              <p><%= Faker::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
               <h5 class="heading5"><strong class="text-uppercase">Hauptdiskussionen</strong>&nbsp;<span class="text-small">[<%= Faker::Time.forward(365, :evening).strftime("%R") %> - <%= Faker::Time.forward(365, :evening).strftime("%R") %>]</span></h5>
               <hr class="reset m-none mb-s">
-              <p><%= Faker::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
               <h6 class="heading6"><strong class="text-uppercase">Überprüfung der Ziele</strong>&nbsp;<span class="text-small">[<%= Faker::Time.forward(365, :evening).strftime("%R") %> - <%= Faker::Time.forward(365, :evening).strftime("%R") %>]</span></h6>
-              <p><%= Faker::Lovecraft.paragraph %></p>
-              <p><%= Faker::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
               <h5 class="heading5"><strong class="text-uppercase">Hauptdiskussionen: Zweiter Teil</strong>&nbsp;<span class="text-small">[<%= Faker::Time.forward(365, :evening).strftime("%R") %> - <%= Faker::Time.forward(365, :evening).strftime("%R") %>]</span></h5>
               <hr class="reset m-none mb-s">
-              <p><%= Faker::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
               <h6 class="heading6"><strong class="text-uppercase">Überprüfung der Ziele: Zweiter Teil</strong>&nbsp;<span class="text-small">[<%= Faker::Time.forward(365, :evening).strftime("%R") %> - <%= Faker::Time.forward(365, :evening).strftime("%R") %>]</span></h6>
-              <p><%= Faker::Lovecraft.paragraph %></p>
-              <p><%= Faker::Lovecraft.paragraph %></p>
-              <p><%= Faker::Lovecraft.paragraph %></p>
-              <p><%= Faker::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
             </div>
           </div>
         </div>

--- a/decidim_app-design/app/views/public/meetings/meeting-view-longer.html.erb
+++ b/decidim_app-design/app/views/public/meetings/meeting-view-longer.html.erb
@@ -69,21 +69,21 @@
             <div class="card__content scroll">
               <h5 class="heading5"><strong class="text-uppercase">WILLKOMMEN</strong>&nbsp;<span class="text-small">[<%= Faker::Time.forward(365, :evening).strftime("%R") %> - <%= Faker::Time.forward(365, :evening).strftime("%R") %>]</span></h5>
               <hr class="reset m-none mb-s">
-              <p><%= Faker::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
               <h5 class="heading5"><strong class="text-uppercase">Hauptdiskussionen</strong>&nbsp;<span class="text-small">[<%= Faker::Time.forward(365, :evening).strftime("%R") %> - <%= Faker::Time.forward(365, :evening).strftime("%R") %>]</span></h5>
               <hr class="reset m-none mb-s">
-              <p><%= Faker::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
               <h6 class="heading6"><strong class="text-uppercase">Überprüfung der Ziele</strong>&nbsp;<span class="text-small">[<%= Faker::Time.forward(365, :evening).strftime("%R") %> - <%= Faker::Time.forward(365, :evening).strftime("%R") %>]</span></h6>
-              <p><%= Faker::Lovecraft.paragraph %></p>
-              <p><%= Faker::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
               <h5 class="heading5"><strong class="text-uppercase">Hauptdiskussionen: Zweiter Teil</strong>&nbsp;<span class="text-small">[<%= Faker::Time.forward(365, :evening).strftime("%R") %> - <%= Faker::Time.forward(365, :evening).strftime("%R") %>]</span></h5>
               <hr class="reset m-none mb-s">
-              <p><%= Faker::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
               <h6 class="heading6"><strong class="text-uppercase">Überprüfung der Ziele: Zweiter Teil</strong>&nbsp;<span class="text-small">[<%= Faker::Time.forward(365, :evening).strftime("%R") %> - <%= Faker::Time.forward(365, :evening).strftime("%R") %>]</span></h6>
-              <p><%= Faker::Lovecraft.paragraph %></p>
-              <p><%= Faker::Lovecraft.paragraph %></p>
-              <p><%= Faker::Lovecraft.paragraph %></p>
-              <p><%= Faker::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
+              <p><%= Faker::Books::Lovecraft.paragraph %></p>
             </div>
           </div>
         </div>

--- a/decidim_app-design/app/views/public/meetings/meetings-callout.html.erb
+++ b/decidim_app-design/app/views/public/meetings/meetings-callout.html.erb
@@ -31,7 +31,7 @@
             <div class="card__header">
               <%= link_to page_path("proposal-view"), class: "card__link" do %>
               <h5 class="card__title">
-                <%= Faker::StarWars.quote[0..75] %>
+                <%= Faker::Movies::StarWars.quote[0..75] %>
               </h5>
               <% end %>
             </div>
@@ -108,7 +108,7 @@
             <div class="card__header">
               <%= link_to page_path("proposal-view"), class: "card__link" do %>
               <h5 class="card__title">
-                <%= Faker::StarWars.quote[0..75] %>
+                <%= Faker::Movies::StarWars.quote[0..75] %>
               </h5>
               <% end %>
             </div>
@@ -181,7 +181,7 @@
             <div class="card__header">
               <%= link_to page_path("proposal-view"), class: "card__link" do %>
               <h5 class="card__title">
-                <%= Faker::StarWars.quote[0..75] %>
+                <%= Faker::Movies::StarWars.quote[0..75] %>
               </h5>
               <% end %>
             </div>

--- a/decidim_app-design/app/views/public/meetings/meetings.html.erb
+++ b/decidim_app-design/app/views/public/meetings/meetings.html.erb
@@ -19,7 +19,7 @@
             <div class="card__header">
               <%= link_to page_path("proposal-view"), class: "card__link" do %>
               <h5 class="card__title">
-                <%= Faker::StarWars.quote[0..75] %>
+                <%= Faker::Movies::StarWars.quote[0..75] %>
               </h5>
               <% end %>
             </div>
@@ -96,7 +96,7 @@
             <div class="card__header">
               <%= link_to page_path("proposal-view"), class: "card__link" do %>
               <h5 class="card__title">
-                <%= Faker::StarWars.quote[0..75] %>
+                <%= Faker::Movies::StarWars.quote[0..75] %>
               </h5>
               <% end %>
             </div>
@@ -174,7 +174,7 @@
             <div class="card__header">
               <%= link_to page_path("proposal-view"), class: "card__link" do %>
               <h5 class="card__title">
-                <%= Faker::StarWars.quote[0..75] %>
+                <%= Faker::Movies::StarWars.quote[0..75] %>
               </h5>
               <% end %>
             </div>

--- a/decidim_app-design/app/views/public/partials/_help-tooltip.html.erb
+++ b/decidim_app-design/app/views/public/partials/_help-tooltip.html.erb
@@ -6,6 +6,6 @@
   tabindex="1"
   data-allow-html="true"
   data-template-classes="light"
-  data-tip-text='<%= render("public/components/help-tooltip-template") { Faker::Lovecraft.sentence } %>'>
+  data-tip-text='<%= render("public/components/help-tooltip-template") { Faker::Books::Lovecraft.sentence } %>'>
   <%= icon "question-mark", class: "icon--small" %>
 </div>

--- a/decidim_app-design/app/views/public/partials/_input_search.html.erb
+++ b/decidim_app-design/app/views/public/partials/_input_search.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="columns mediumlarge-4 large-3">
     <h2 class="section-heading">
-      <%= Faker::Number.between(0, 100) %><span>&nbsp;resultados para:&nbsp;</span>"<%= Faker::StarWars.character %>"
+      <%= Faker::Number.between(0, 100) %><span>&nbsp;resultados para:&nbsp;</span>"<%= Faker::Movies::StarWars.character %>"
     </h2>
   </div>
   <div class="columns mediumlarge-8 large-9">

--- a/decidim_app-design/app/views/public/partials/_last_activity.html.erb
+++ b/decidim_app-design/app/views/public/partials/_last_activity.html.erb
@@ -12,7 +12,7 @@
     <div class="card__header mb-none">
       <%= link_to page_path("proposal-view"), class: "card__link" do %>
       <h5 class="card__title mb-none">
-        <%= Faker::StarWars.quote %>
+        <%= Faker::Movies::StarWars.quote %>
       </h5>
       <% end %>
     </div>
@@ -34,7 +34,7 @@
     <div class="card__header mb-none">
       <%= link_to page_path("proposal-view"), class: "card__link" do %>
       <h5 class="card__title mb-none">
-        <%= Faker::StarWars.quote %>
+        <%= Faker::Movies::StarWars.quote %>
       </h5>
       <% end %>
     </div>

--- a/decidim_app-design/app/views/public/partials/_last_posts.html.erb
+++ b/decidim_app-design/app/views/public/partials/_last_posts.html.erb
@@ -4,7 +4,7 @@
     <div class="card__header">
       <%= link_to page_path("proposal-view"), class: "card__link" do %>
       <h5 class="card__title">
-        <%= Faker::StarWars.quote[0..75] %>
+        <%= Faker::Movies::StarWars.quote[0..75] %>
       </h5>
       <% end %>
       <div class="card__author">

--- a/decidim_app-design/app/views/public/participatory/participatory-texts-draft.html.erb
+++ b/decidim_app-design/app/views/public/participatory/participatory-texts-draft.html.erb
@@ -33,11 +33,11 @@
             </strong>
           </h6>
           <p>
-            <%= Faker::Lovecraft.paragraph(Faker::Number.between(8, 15)) %>
+            <%= Faker::Books::Lovecraft.paragraph(Faker::Number.between(8, 15)) %>
           </p>
           <% if Faker::Boolean.boolean %>
           <p>
-            <%= Faker::Lovecraft.paragraph(Faker::Number.between(3, 8)) %>
+            <%= Faker::Books::Lovecraft.paragraph(Faker::Number.between(3, 8)) %>
           </p>
           <% end %>
           <% end %>

--- a/decidim_app-design/app/views/public/processes/processes.html.erb
+++ b/decidim_app-design/app/views/public/processes/processes.html.erb
@@ -106,7 +106,7 @@
             <div class="card__header">
               <%= link_to page_path("proposal-view"), class: "card__link" do %>
                 <h5 class="card__title">
-                  <%= Faker::StarWars.quote[0..75] %>
+                  <%= Faker::Movies::StarWars.quote[0..75] %>
                 </h5>
               <% end %>
             </div>

--- a/decidim_app-design/app/views/public/profile/_badge.html.erb
+++ b/decidim_app-design/app/views/public/profile/_badge.html.erb
@@ -1,7 +1,7 @@
 <% level ||= SecureRandom.random_number(5) %>
 <article class="card card--badge absolutes">
   <div class="right badge-tip">
-    <div data-tooltip data-position="top" title="<%= Faker::Lebowski.quote %>">
+    <div data-tooltip data-position="top" title="<%= Faker::Movies::Lebowski.quote %>">
       <%= icon "info", class: "icon--small" %>
     </div>
   </div>

--- a/decidim_app-design/app/views/public/profile/_conversations.html.erb
+++ b/decidim_app-design/app/views/public/profile/_conversations.html.erb
@@ -29,7 +29,7 @@
             Con: <strong><%= Faker::Name.name %><span class="muted">&nbsp;@<%= Faker::Twitter.screen_name %></span></strong>
           <% end %>
           <br>
-          <span class="muted"><%= Faker::FamilyGuy.quote %></span>
+          <span class="muted"><%= Faker::TvShows::FamilyGuy.quote %></span>
           <br>
           <span class="text-small">Último mensaje: <strong>hace <%= Faker::Number.between(1, 59) %> minutos</strong></span>
         </div>

--- a/decidim_app-design/app/views/public/profile/_timeline.html.erb
+++ b/decidim_app-design/app/views/public/profile/_timeline.html.erb
@@ -15,7 +15,7 @@
             <strong><%= Faker::ChuckNorris.fact %></strong>
           </h5>
           <% end %>
-          <span><%= Faker::Lovecraft.paragraph %></span>
+          <span><%= Faker::Books::Lovecraft.paragraph %></span>
         </div>
       </li>
     </ul>
@@ -36,7 +36,7 @@
             <strong><%= Faker::ChuckNorris.fact %></strong>
           </h5>
           <% end %>
-          <span><%= Faker::Lovecraft.paragraph %></span>
+          <span><%= Faker::Books::Lovecraft.paragraph %></span>
         </div>
       </li>
     </ul>
@@ -57,7 +57,7 @@
             <strong><%= Faker::ChuckNorris.fact %></strong>
           </h5>
           <% end %>
-          <span><%= Faker::Lovecraft.paragraph %></span>
+          <span><%= Faker::Books::Lovecraft.paragraph %></span>
         </div>
       </li>
     </ul>
@@ -78,7 +78,7 @@
             <strong><%= Faker::ChuckNorris.fact %></strong>
           </h5>
           <% end %>
-          <span><%= Faker::Lovecraft.paragraph %></span>
+          <span><%= Faker::Books::Lovecraft.paragraph %></span>
         </div>
       </li>
     </ul>

--- a/decidim_app-design/app/views/public/profile/_user-card.html.erb
+++ b/decidim_app-design/app/views/public/profile/_user-card.html.erb
@@ -56,7 +56,7 @@
       <div class="row column mb-s">
         <strong class="muted">Badges</strong>
         <div class="badge-tip badge-tip--inline">
-          <div data-tooltip data-position="top" title="<%= Faker::Lebowski.quote %>">
+          <div data-tooltip data-position="top" title="<%= Faker::Movies::Lebowski.quote %>">
             <%= icon "info", class: "icon--small" %>
           </div>
         </div>

--- a/decidim_app-design/app/views/public/proposals/proposal-stats.html.erb
+++ b/decidim_app-design/app/views/public/proposals/proposal-stats.html.erb
@@ -13,19 +13,19 @@
       <h2 class="section-heading">Esta propuesta en números</h2>
     </div>
     <div class="row columns">
-      <%= partial "rowchart", metric: "rowchart-" + SecureRandom.random_number(2).to_s, percent: true, title: Faker::GameOfThrones.character, subtitle: Faker::Lorem.sentence %>
+      <%= partial "rowchart", metric: "rowchart-" + SecureRandom.random_number(2).to_s, percent: true, title: Faker::TvShows::GameOfThrones.character, subtitle: Faker::Lorem.sentence %>
       <p class="pull-right"><a href="#"><small class="text-small"><u>Descargar datos (csv)</u></small></a></p>
     </div>
     <div class="row columns">
-      <%= partial "rowchart", metric: "rowchart-" + SecureRandom.random_number(2).to_s, percent: true, title: Faker::GameOfThrones.character, subtitle: Faker::Lorem.sentence %>
+      <%= partial "rowchart", metric: "rowchart-" + SecureRandom.random_number(2).to_s, percent: true, title: Faker::TvShows::GameOfThrones.character, subtitle: Faker::Lorem.sentence %>
       <p class="pull-right"><a href="#"><small class="text-small"><u>Descargar datos (csv)</u></small></a></p>
     </div>
     <div class="row columns">
-      <%= partial "rowchart", metric: "rowchart-" + SecureRandom.random_number(2).to_s, title: Faker::GameOfThrones.character, subtitle: Faker::Lorem.sentence %>
+      <%= partial "rowchart", metric: "rowchart-" + SecureRandom.random_number(2).to_s, title: Faker::TvShows::GameOfThrones.character, subtitle: Faker::Lorem.sentence %>
       <p class="pull-right"><a href="#"><small class="text-small"><u>Descargar datos (csv)</u></small></a></p>
     </div>
     <div class="row columns">
-      <%= partial "linechart", ratio: "16:9", metric: "linechart-0", title: Faker::GameOfThrones.character, subtitle: Faker::Lorem.sentence %>
+      <%= partial "linechart", ratio: "16:9", metric: "linechart-0", title: Faker::TvShows::GameOfThrones.character, subtitle: Faker::Lorem.sentence %>
       <p class="pull-right"><a href="#"><small class="text-small"><u>Descargar datos (csv)</u></small></a></p>
   </div>
   </div>

--- a/decidim_app-design/app/views/public/proposals/proposals-collaboratives.html.erb
+++ b/decidim_app-design/app/views/public/proposals/proposals-collaboratives.html.erb
@@ -41,7 +41,7 @@
                 <div class="card__header">
                   <%= link_to page_path("proposals/proposal-view"), class: "card__link" do %>
                   <h5 class="card__title">
-                    <%= Faker::StarWars.quote[0..75] %>
+                    <%= Faker::Movies::StarWars.quote[0..75] %>
                   </h5>
                   <% end %>
                   <div class="card__author">

--- a/decidim_app-design/app/views/public/proposals/proposals-no-vote.html.erb
+++ b/decidim_app-design/app/views/public/proposals/proposals-no-vote.html.erb
@@ -37,7 +37,7 @@
                 <div class="card__header">
                   <%= link_to page_path("proposals/proposal-view"), class: "card__link" do %>
                   <h5 class="card__title">
-                    <%= Faker::StarWars.quote[0..75] %>
+                    <%= Faker::Movies::StarWars.quote[0..75] %>
                   </h5>
                 <% end %>
                 <div class="card__author">

--- a/decidim_app-design/app/views/public/proposals/proposals-with-filters.html.erb
+++ b/decidim_app-design/app/views/public/proposals/proposals-with-filters.html.erb
@@ -30,7 +30,7 @@
                 <div class="card__header">
                   <%= link_to page_path("proposals/proposal-view"), class: "card__link" do %>
                   <h5 class="card__title">
-                    <%= Faker::StarWars.quote[0..75] %>
+                    <%= Faker::Movies::StarWars.quote[0..75] %>
                   </h5>
                   <% end %>
                   <div class="card__author">
@@ -99,7 +99,7 @@
                 <div class="card__header">
                   <%= link_to page_path("proposals/proposal-view"), class: "card__link" do %>
                   <h5 class="card__title">
-                    <%= Faker::StarWars.quote[0..75] %>
+                    <%= Faker::Movies::StarWars.quote[0..75] %>
                   </h5>
                   <% end %>
                   <div class="card__author">

--- a/decidim_app-design/app/views/public/proposals/proposals.html.erb
+++ b/decidim_app-design/app/views/public/proposals/proposals.html.erb
@@ -30,7 +30,7 @@
                 <div class="card__header">
                   <%= link_to page_path("proposals/proposal-view"), class: "card__link" do %>
                   <h5 class="card__title">
-                    <%= Faker::StarWars.quote[0..75] %>
+                    <%= Faker::Movies::StarWars.quote[0..75] %>
                   </h5>
                   <% end %>
                   <div class="card__author">

--- a/decidim_app-design/app/views/public/proposals/proposals_2.html.erb
+++ b/decidim_app-design/app/views/public/proposals/proposals_2.html.erb
@@ -51,7 +51,7 @@
                 <div class="card__header">
                   <%= link_to page_path("proposals/proposal-view"), class: "card__link" do %>
                   <h5 class="card__title">
-                    <%= Faker::StarWars.quote[0..75] %>
+                    <%= Faker::Movies::StarWars.quote[0..75] %>
                   </h5>
                   <% end %>
                   <div class="card__author">

--- a/decidim_app-design/app/views/public/results.html.erb
+++ b/decidim_app-design/app/views/public/results.html.erb
@@ -20,7 +20,7 @@
             <div class="card__header">
               <%= link_to page_path("proposal-view"), class: "card__link" do %>
               <h5 class="card__title">
-                <%= Faker::StarWars.quote[0..75] %>
+                <%= Faker::Movies::StarWars.quote[0..75] %>
               </h5>
               <% end %>
             </div>
@@ -97,7 +97,7 @@
             <div class="card__header">
               <%= link_to page_path("proposal-view"), class: "card__link" do %>
               <h5 class="card__title">
-                <%= Faker::StarWars.quote[0..75] %>
+                <%= Faker::Movies::StarWars.quote[0..75] %>
               </h5>
               <% end %>
             </div>

--- a/decidim_app-design/app/views/public/search.html.erb
+++ b/decidim_app-design/app/views/public/search.html.erb
@@ -21,7 +21,7 @@
                 <div class="card__header">
                   <%= link_to page_path("proposal-view"), class: "card__link" do %>
                   <h5 class="card__title">
-                    <%= Faker::StarWars.quote[0..75] %>
+                    <%= Faker::Movies::StarWars.quote[0..75] %>
                   </h5>
                   <% end %>
                   <div class="card__author">
@@ -107,7 +107,7 @@
                 <div class="card__header">
                   <%= link_to page_path("proposal-view"), class: "card__link" do %>
                     <h5 class="card__title">
-                      <%= Faker::StarWars.quote[0..75] %>
+                      <%= Faker::Movies::StarWars.quote[0..75] %>
                     </h5>
                   <% end %>
                   <div class="card__author">
@@ -180,7 +180,7 @@
                 </div>
                 <div class="card__text card--picture-offset">
                   <div><small><strong><%= Faker::Company.profession.capitalize %></strong></small></div>
-                  <div><small><%= Faker::StarWars.vehicle %></small></div>
+                  <div><small><%= Faker::Movies::StarWars.vehicle %></small></div>
                   <div class="text-small">Designated on <strong><%= Faker::Date.backward(365).strftime("%D") %></strong></div>
                   <div class="text-small mt-s"><%= Faker::Demographic.sex %> / <%= Faker::Number.number(2) %> / <%= Faker::Address.city %></div>
                 </div>

--- a/decidim_app-design/app/views/public/vizzs/_linecharts.html.erb
+++ b/decidim_app-design/app/views/public/vizzs/_linecharts.html.erb
@@ -23,7 +23,7 @@
   <code>partial "linechart", metric: "metrica", title: "Lorem", subtitle: "Ipsum"</code>
 </div>
 <div class="row column mt-s">
-  <%= partial "linechart", metric: "linechart-" + SecureRandom.random_number(2).to_s, title: Faker::GameOfThrones.character, subtitle: Faker::Lorem.sentence %>
+  <%= partial "linechart", metric: "linechart-" + SecureRandom.random_number(2).to_s, title: Faker::TvShows::GameOfThrones.character, subtitle: Faker::Lorem.sentence %>
 </div>
 <br>
 <div class="row column">

--- a/decidim_app-design/app/views/public/vizzs/_rowcharts.html.erb
+++ b/decidim_app-design/app/views/public/vizzs/_rowcharts.html.erb
@@ -22,7 +22,7 @@
   <code>partial "rowchart", metric: "metrica", title: "Lorem", subtitle: "Ipsum"</code>
 </div>
 <div class="row column mt-s">
-  <%= partial "rowchart", metric: "rowchart-" + SecureRandom.random_number(2).to_s, title: Faker::GameOfThrones.character, subtitle: Faker::Lorem.sentence %>
+  <%= partial "rowchart", metric: "rowchart-" + SecureRandom.random_number(2).to_s, title: Faker::TvShows::GameOfThrones.character, subtitle: Faker::Lorem.sentence %>
 </div>
 <br>
 <div class="row column">


### PR DESCRIPTION
#### :tophat: What? Why?
Updated Faker gem had some issues with the current Faker syntax in the design module. This fixes all the quotes use in order to match the new syntax.

i.e:

instead of `Faker::FamilyGuy.quote` use `Faker::TvShows::FamilyGuy.quote` 
