### PR TITLE
Sanitize inputs in conferences

### DIFF
--- a/decidim-conferences/app/cells/decidim/conferences/conference_m_cell.rb
+++ b/decidim-conferences/app/cells/decidim/conferences/conference_m_cell.rb
@@ -14,6 +14,10 @@ module Decidim
 
       private
 
+      def title
+        decidim_html_escape(super)
+      end
+
       def has_image?
         true
       end

--- a/decidim-conferences/app/cells/decidim/conferences/registration_type_cell.rb
+++ b/decidim-conferences/app/cells/decidim/conferences/registration_type_cell.rb
@@ -18,11 +18,11 @@ module Decidim
       delegate :current_user, to: :controller, prefix: false
 
       def title
-        translated_attribute model.title
+        decidim_sanitize translated_attribute model.title
       end
 
       def description
-        translated_attribute model.description
+        decidim_sanitize translated_attribute model.description
       end
 
       def price

--- a/decidim-conferences/app/views/decidim/conferences/registration_types/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/registration_types/index.html.erb
@@ -23,7 +23,7 @@ edit_link(
           <%= cell "decidim/conferences/registration_type", registration_type, allowed: allowed_to?(:join, :conference, conference: current_participatory_space) %>
         <% end %>
       <% else %>
-        <%= t("registration_types.index.no_registrations") %>
+        <%= t("registration_types.index.no_registrations", scope: "decidim.conferences") %>
       <% end %>
     </section>
   </div>

--- a/decidim-conferences/app/views/decidim/conferences/registration_types/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/registration_types/index.html.erb
@@ -23,7 +23,7 @@ edit_link(
           <%= cell "decidim/conferences/registration_type", registration_type, allowed: allowed_to?(:join, :conference, conference: current_participatory_space) %>
         <% end %>
       <% else %>
-        No registrations
+        <%= t("registration_types.index.no_registrations") %>
       <% end %>
     </section>
   </div>

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -349,7 +349,6 @@ en:
           form:
             select_conference_meetings: Select conference meetings
           index:
-            no_registrations: No registrations
             title: Registration types
         send_conference_diploma_mailer:
           diploma:
@@ -477,6 +476,7 @@ en:
         index:
           choose_an_option: 'Choose your registration option:'
           login_as: You are logged in as %{name} <%{email}>
+          no_registrations: No registrations
           register: Register
           title: Registration types
       shared:

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -349,6 +349,7 @@ en:
           form:
             select_conference_meetings: Select conference meetings
           index:
+            no_registrations: No registrations
             title: Registration types
         send_conference_diploma_mailer:
           diploma:

--- a/decidim-core/app/scrubbers/decidim/user_input_scrubber.rb
+++ b/decidim-core/app/scrubbers/decidim/user_input_scrubber.rb
@@ -21,7 +21,7 @@ module Decidim
     private
 
     def custom_allowed_attributes
-      Loofah::HTML5::SafeList::ALLOWED_ATTRIBUTES + %w(frameborder allowfullscreen)
+      Loofah::HTML5::SafeList::ALLOWED_ATTRIBUTES + %w(frameborder allowfullscreen) - %w(onerror)
     end
 
     def custom_allowed_tags

--- a/decidim-core/spec/scrubbers/decidim/user_input_scrubber_spec.rb
+++ b/decidim-core/spec/scrubbers/decidim/user_input_scrubber_spec.rb
@@ -44,7 +44,7 @@ describe Decidim::UserInputScrubber do
     expect(html).to be_scrubbed_as("")
   end
 
-  it "does not onerror attributes" do
+  it "does not allow onerror attributes" do
     html = "<img src=x onerror=alert(1)>"
     expect(html).to be_scrubbed_as("<img src=\"x\">")
   end

--- a/decidim-core/spec/scrubbers/decidim/user_input_scrubber_spec.rb
+++ b/decidim-core/spec/scrubbers/decidim/user_input_scrubber_spec.rb
@@ -43,4 +43,9 @@ describe Decidim::UserInputScrubber do
     html = "<script></script>"
     expect(html).to be_scrubbed_as("")
   end
+
+  it "does not onerror attributes" do
+    html = "<img src=x onerror=alert(1)>"
+    expect(html).to be_scrubbed_as("<img src=\"x\">")
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR sanitizes some inputs in the Conferences module. 

It also removes the `onerror` attribute from any sanitized input.

#### :pushpin: Related Issues
None

#### Testing
Add a field like this:

```ruby
resource.title = "\"><h1><font color=red>XSS_Conference_title</font></h1><img src=x onerror=alert(1)><script>alert(\"TITLE\");</script>"
resource.save
```

This should start triggering some JS alerts. With this PR, alerts won't be shown.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
None.