### PR TITLE
Fix issue with commentable counter cache migration

### DIFF
--- a/decidim-debates/db/migrate/20200827154116_add_commentable_counter_cache_to_debates.rb
+++ b/decidim-debates/db/migrate/20200827154116_add_commentable_counter_cache_to_debates.rb
@@ -4,6 +4,11 @@ class AddCommentableCounterCacheToDebates < ActiveRecord::Migration[5.2]
   def change
     add_column :decidim_debates_debates, :comments_count, :integer, null: false, default: 0, index: true
     Decidim::Debates::Debate.reset_column_information
-    Decidim::Debates::Debate.find_each(&:update_comments_count)
+
+    # rubocop:disable Rails/SkipsModelValidations
+    Decidim::Debates::Debate.includes(:comments).find_each do |debate|
+      debate.update_columns(comments_count: debate.comments.not_hidden.count)
+    end
+    # rubocop:enable Rails/SkipsModelValidations
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
After #6438 got merged, one of the migrations is broken because it tried to update a column which is added in the following migration after this one.

This caused the following exception during the migrations:

```
can't write unknown attribute `last_comment_at`
/.../decidim/decidim-debates/app/models/decidim/debates/debate.rb:170:in `update_comments_count'
/.../decidim/development_app/db/migrate/20200928114308_add_commentable_counter_cache_to_debates.decidim_debates.rb:8:in `change'
bin/rails:4:in `<main>'

Caused by:
ActiveModel::MissingAttributeError: can't write unknown attribute `last_comment_at`
/.../decidim/decidim-debates/app/models/decidim/debates/debate.rb:170:in `update_comments_count'
/.../decidim/development_app/db/migrate/20200928114308_add_commentable_counter_cache_to_debates.decidim_debates.rb:8:in `change'
bin/rails:4:in `<main>'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```

#### :pushpin: Related Issues
- Related to #6438

#### Testing
Run the following on an instance where you have not run the migrations before:

```ruby
$ bundle exec rails decidim:upgrade
$ bundle exec rails db:migrate
```

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.