### PR TITLE
Fix expanding new questions when questionnaire has errors

### DIFF
--- a/decidim-forms/app/assets/javascripts/decidim/forms/admin/forms.js.es6
+++ b/decidim-forms/app/assets/javascripts/decidim/forms/admin/forms.js.es6
@@ -123,6 +123,15 @@
     });
   }
 
+  const createCollapsibleQuestion = ($target) => {
+    const $collapsible = $target.find(".collapsible");
+    if ($collapsible.length > 0) {
+      const collapsibleId = $collapsible.attr("id").replace("-question-card", "");
+      const toggleAttr = `${collapsibleId}-question-card button--collapse-question-${collapsibleId} button--expand-question-${collapsibleId}`;
+      $target.find(".question--collapse").data("toggle", toggleAttr);
+    }
+  };
+
   const createDynamicFieldsForAnswerOptions = (fieldId) => {
     const autoButtons = createAutoButtonsByMinItemsForAnswerOptions(fieldId);
     const autoSelectOptions = createAutoMaxChoicesByNumberOfAnswerOptions(fieldId);
@@ -281,6 +290,7 @@
     const fieldId = $target.attr("id");
     const $fieldQuestionTypeSelect = $target.find(questionTypeSelector);
 
+    createCollapsibleQuestion($target);
     createDynamicQuestionTitle(fieldId);
 
     createFieldDependentInputs({
@@ -367,13 +377,6 @@
     moveUpFieldButtonSelector: ".move-up-question",
     moveDownFieldButtonSelector: ".move-down-question",
     onAddField: ($field) => {
-      const $collapsible = $field.find(".collapsible");
-      if ($collapsible.length > 0) {
-        const collapsibleId = $collapsible.attr("id").replace("-question-card", "");
-        const toggleAttr = `${collapsibleId}-question-card button--collapse-question-${collapsibleId} button--expand-question-${collapsibleId}`;
-        $field.find(".question--collapse").data("toggle", toggleAttr);
-      }
-
       setupInitialQuestionAttributes($field);
       createSortableList();
 

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/_question.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/_question.html.erb
@@ -1,4 +1,5 @@
 <% question = form.object %>
+<% is_expanded = question.errors.any? %>
 
 <div class="card questionnaire-question" id="<%= id %>-field">
   <div class="card-divider question-divider">
@@ -11,11 +12,11 @@
     </span>
 
     <button type="button" class="button small secondary button--title question--collapse" data-toggle="<%= id %>-question-card button--collapse-question-<%= id %> button--expand-question-<%= id %>">
-      <span id="button--collapse-question-<%= id %>" data-toggler=".hide" class="icon-collapse hide">
+      <span id="button--collapse-question-<%= id %>" data-toggler=".hide" class="icon-collapse <%= "hide" unless is_expanded %>">
         <%== icon("caret-top", aria_label: t(".collapse"), role: "img") %>
       </span>
 
-      <span id="button--expand-question-<%= id %>" data-toggler=".hide" class="icon-expand">
+      <span id="button--expand-question-<%= id %>" data-toggler=".hide" class="icon-expand <%= "hide" if is_expanded %>">
         <%== icon("caret-bottom", aria_label: t(".expand"), role: "img") %>
       </span>
     </button>
@@ -36,7 +37,7 @@
     </h2>
   </div>
 
-  <div class="card-section collapsible hide" data-toggler=".hide" id="<%= id %>-question-card">
+  <div class="card-section collapsible <%= "hide" unless is_expanded %>" data-toggler=".hide" id="<%= id %>-question-card">
     <div class="row column">
       <%=
         form.translated(

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/update_questions.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/update_questions.rb
@@ -362,6 +362,29 @@ shared_examples_for "update questions" do
 
         it_behaves_like "collapsing a question"
       end
+
+      context "when submitting a new question with an error" do
+        before do
+          click_button "Add question"
+          click_button "Save"
+          
+          within ".questionnaire-question:last-of-type" do
+            page.find(".question--collapse").click
+          end
+        end
+
+        it_behaves_like "collapsing a question"
+        
+        it "can be expanded" do
+          within ".questionnaire-question:last-of-type" do
+            page.find(".question--collapse").click
+          end
+
+          within ".questionnaire-question:last-of-type" do
+            expect(page).to have_selector(".icon-collapse")
+          end
+        end
+      end
     end
 
     it "properly decides which button to show after adding/removing questions" do

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/update_questions.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/update_questions.rb
@@ -367,14 +367,14 @@ shared_examples_for "update questions" do
         before do
           click_button "Add question"
           click_button "Save"
-          
+
           within ".questionnaire-question:last-of-type" do
             page.find(".question--collapse").click
           end
         end
 
         it_behaves_like "collapsing a question"
-        
+
         it "can be expanded" do
           within ".questionnaire-question:last-of-type" do
             page.find(".question--collapse").click


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes a bug where new questions with errors could not be expanded when editing a questionnaire.
It also adds the behaviour for questions with errors to be expanded when page loads.

#### Testing
- Test suite: `decidim-surveys/spec/system/admin_manages_surveys_spec.rb:18`
- GUI:
  - Visit `/admin/participatory_processes`
  - Click on a participatory process with a _survey_ component
  - Edit the _survey_ (click on the component name in the column at the left of the page, under components) 
  - Add a new question leaving the `Statement` field blank

### :camera: Screenshots
![Expand and collapse a question with error](https://user-images.githubusercontent.com/8806781/94712954-75938f00-034a-11eb-8f10-fc00d6bd32f2.gif)

![Expanded question with error](https://user-images.githubusercontent.com/8806781/94712701-20577d80-034a-11eb-9e8b-0f2d7ace2e82.png)
