### PR TITLE
Change default initializer settings

### DIFF
--- a/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
@@ -190,6 +190,9 @@ Decidim.configure do |config|
 
   # Machine Translation Configuration
   #
+  # Enable machine translations
+  config.enable_machine_translations = false
+  #
   # If you want to enable machine translation you can create your own service
   # to interact with third party service to translate the user content.
   #

--- a/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
@@ -14,18 +14,15 @@ Decidim.configure do |config|
   # of languages will be equal or a subset of the list in this file.
   config.available_locales = [:en, :ca, :es]
 
-  # Enable machine translations
-  config.enable_machine_translations = false
+  # Sets the default locale for new organizations. When creating a new
+  # organization from the System area, system admins will be able to overwrite
+  # this value for that specific organization.
+  config.default_locale = :en
 
   # Restrict access to the system part with an authorized ip list.
   # You can use a single ip like ("1.2.3.4"), or an ip subnet like ("1.2.3.4/24")
   # You may specify multiple ip in an array ["1.2.3.4", "1.2.3.4/24"]
   # config.system_accesslist_ips = ["127.0.0.1"]
-
-  # Sets the default locale for new organizations. When creating a new
-  # organization from the System area, system admins will be able to overwrite
-  # this value for that specific organization.
-  config.default_locale = :en
 
   # Defines a list of custom content processors. They are used to parse and
   # render specific tags inside some user-provided content. Check the docs for

--- a/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
@@ -5,7 +5,7 @@ Decidim.configure do |config|
   config.application_name = "My Application Name"
 
   # The email that will be used as sender in all emails from Decidim
-  config.mailer_sender = "change-me@domain.org"
+  config.mailer_sender = "change-me@example.org"
 
   # Sets the list of available locales for the whole application.
   #

--- a/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
@@ -84,13 +84,6 @@ Decidim.configure do |config|
   # Time window were users can access the website even if their email is not confirmed.
   # config.unconfirmed_access_for = 2.days
 
-  # Etherpad configuration. Check the docs for more info.
-  # config.etherpad = {
-  #   server: <your url>,
-  #   api_key: <your key>,
-  #   api_version: <your version>
-  # }
-
   # A base path for the uploads. If set, make sure it ends in a slash.
   # Uploads will be set to `<base_path>/uploads/`. This can be useful if you
   # want to use the same uploads place for both staging and production

--- a/decidim-system/config/locales/en.yml
+++ b/decidim-system/config/locales/en.yml
@@ -155,9 +155,9 @@ en:
             api_secret: API secret
         smtp_settings:
           instructions:
-            from_label: 'Email sender will be: "your-organization-name <your-organization@your-provider.org>". Leave blank to use the ''from_email'' as label'
+            from_label: 'Email sender will be: "your-organization-name <your-organization@example.org>". Leave blank to use the ''from_email'' as label'
           placeholder:
-            from_email: your-organization@your-provider.org
+            from_email: your-organization@example.org
             from_label: your-organization-name
         update:
           error: There was a problem updating this organization.


### PR DESCRIPTION
#### :tophat: What? Why?

As I was working in upgrading docs, I found some issues in the default config initializer: 

1) Using other domains for documentation: this Changes domain.org and your-provider.org to example.org: 

    """
    As described in RFC 2606 and RFC 6761, a number of domains
    such as example.com and example.org are maintained for
    documentation purposes. These domains may be used as
    illustrative examples in documents without prior coordination
    with us. They are not available for registration or transfer.
    """
    
    See https://www.iana.org/domains/reserved

2) Move locales settings near in default Initializer:

Between `config.available_locales` and `config.default_locale` there were a couple of unrelated settings. That's weird.

3) Remove Etherpad duplicated config in default Initializer: we had it two times. That didn't make much sense.

4) Move 'machine translations' settings near in default Initializer: there were two Machine Translations related settings, one at the beginning and the other at the end. That's weird. 

#### Testing

Generate a new app, see that the default settings in the initializer had changed. 

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
