### PR TITLE
Reorganize `before` sentences to avoid flaky tests

### DIFF
--- a/decidim-assemblies/spec/system/private_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/private_assemblies_spec.rb
@@ -84,29 +84,29 @@ describe "Private Assemblies", type: :system do
       context "when user is loged in and is not a assembly private user" do
         before do
           switch_to_host(organization.host)
-          login_as user, scope: :user
+          login_as logged_in_user, scope: :user
           visit decidim_assemblies.assemblies_path
         end
 
-        it "lists only the not private assembly" do
-          within "#parent-assemblies" do
-            within "#parent-assemblies h3" do
-              expect(page).to have_content("1")
+        context "when the user is admin" do
+          let(:logged_in_user) { user }
+
+          it "lists only the not private assembly" do
+            within "#parent-assemblies" do
+              within "#parent-assemblies h3" do
+                expect(page).to have_content("1")
+              end
+
+              expect(page).to have_content(translated(assembly.title, locale: :en))
+              expect(page).to have_selector(".card--assembly", count: 1)
+
+              expect(page).to have_no_content(translated(private_assembly.title, locale: :en))
             end
-
-            expect(page).to have_content(translated(assembly.title, locale: :en))
-            expect(page).to have_selector(".card--assembly", count: 1)
-
-            expect(page).to have_no_content(translated(private_assembly.title, locale: :en))
           end
         end
 
         context "when the user is admin" do
-          before do
-            switch_to_host(organization.host)
-            login_as admin, scope: :user
-            visit decidim_assemblies.assemblies_path
-          end
+          let(:logged_in_user) { admin }
 
           it "lists private assemblies" do
             within "#parent-assemblies" do


### PR DESCRIPTION
#### :tophat: What? Why?
We're having many flaky failures from `decidim-assemblies`. The flaky comes from `spec/system/private_assemblies_spec.rb:114`.
After analyzing the code the assertions starting in line [111](https://github.com/decidim/decidim/blob/c93316f8d72b5f65c483021a1a5fb64bb28db2b7/decidim-assemblies/spec/system/private_assemblies_spec.rb#L111) will execute two `before` blocks, the one in line [85](https://github.com/decidim/decidim/blob/c93316f8d72b5f65c483021a1a5fb64bb28db2b7/decidim-assemblies/spec/system/private_assemblies_spec.rb#L85) and the one in line [105](https://github.com/decidim/decidim/blob/c93316f8d72b5f65c483021a1a5fb64bb28db2b7/decidim-assemblies/spec/system/private_assemblies_spec.rb#L105). If the first finishes after the second, the assertion in line [114](https://github.com/decidim/decidim/blob/c93316f8d72b5f65c483021a1a5fb64bb28db2b7/decidim-assemblies/spec/system/private_assemblies_spec.rb#L114) will fail.

This PR tries to solve this flaky by avoiding the execution of the `before` block in line 85 which is unnecessary for the current specs in 111.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*
It is difficult to validate flaky tests but I guess that ensuring it succeeds at first attempt will mean something.
I'll try to re-run `decidim-assemblies` test three times at least (I'm not sure if it's possible if the test succeeds) .

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
