### PR TITLE
Move CTA from Appearence to 'Hero' Content Block

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/update_organization_appearance.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization_appearance.rb
@@ -57,8 +57,6 @@ module Decidim
 
       def appearance_attributes
         {
-          cta_button_path: form.cta_button_path,
-          cta_button_text: form.cta_button_text,
           description: form.description,
           logo: form.logo,
           remove_logo: form.remove_logo,

--- a/decidim-admin/app/forms/decidim/admin/organization_appearance_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_appearance_form.rb
@@ -22,7 +22,6 @@ module Decidim
       attribute :official_url
       attribute :show_statistics, Boolean
       attribute :header_snippets, String
-      attribute :cta_button_path, String
       attribute :highlighted_content_banner_enabled, Boolean, default: false
       attribute :highlighted_content_banner_action_url, String
       attribute :highlighted_content_banner_image
@@ -38,7 +37,6 @@ module Decidim
       attribute :highlight_color, String, default: "#be6400"
       attribute :highlight_alternative_color, String, default: "#ff5731"
 
-      translatable_attribute :cta_button_text, String
       translatable_attribute :description, String
       translatable_attribute :highlighted_content_banner_title, String
       translatable_attribute :highlighted_content_banner_short_description, String
@@ -47,7 +45,6 @@ module Decidim
       translatable_attribute :omnipresent_banner_title, String
       translatable_attribute :omnipresent_banner_short_description, String
 
-      validates :cta_button_path, format: { with: %r{\A[a-zA-Z]+[a-zA-Z0-9\-\_/]+\z} }, allow_blank: true
       validates :official_img_header,
                 :official_img_footer,
                 :logo,

--- a/decidim-admin/app/views/decidim/admin/organization_appearance/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization_appearance/_form.html.erb
@@ -12,18 +12,6 @@
     <div class="row column">
       <%= form.translated :editor, :description %>
     </div>
-
-    <div class="row">
-      <div class="columns xlarge-6 slug">
-        <%= form.text_field :cta_button_path %>
-        <p class="help-text"><%== t(".cta_button_path_help", url: decidim_form_slug_url("", form.object.cta_button_path)) %></p>
-      </div>
-
-      <div class="columns xlarge-6">
-        <%= form.translated :text_field, :cta_button_text %>
-        <p class="help-text"><%= t(".cta_button_text_help") %></p>
-      </div>
-    </div>
   </div>
 </div>
 

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -35,8 +35,6 @@ en:
         alert_color: Alert
         badges_enabled: Enable badges
         comments_max_length: Comments max length (Leave 0 for default value)
-        cta_button_path: Call To Action button path
-        cta_button_text: Call To Action button text
         customize_welcome_notification: Customize welcome notification
         default_locale: Default locale
         description: Description
@@ -599,8 +597,6 @@ en:
           colors:
             colors_title: Organization colors
             header_snippets_help: Use this field to add things to the HTML head. The most common use is to integrate third-party services that require some extra JavaScript or CSS. Also, you can use it to add extra meta tags to the HTML. Note that this will only be rendered in public pages, not in the admin section.
-          cta_button_path_help: 'You can overwrite where the Call To Action button in the homepage links to. Use partial paths, not full URLs here. Accepts letters, numbers, dashes and slashes, and must start with a letter. The Call To Action button is shown in the homepage between the welcome text and the description. Example: %{url}'
-          cta_button_text_help: You can overwrite the Call To Action button text in the homepage for each available language in your organization. If not set, the default value will be used. The Call To Action button is shown in the homepage between the welcome text and the description.
           homepage_appearance_title: Edit homepage appearance
           homepage_highlighted_content_banner_title: Highligted content banner
           images:

--- a/decidim-admin/spec/forms/organization_appearance_form_spec.rb
+++ b/decidim-admin/spec/forms/organization_appearance_form_spec.rb
@@ -20,7 +20,6 @@ module Decidim
         }
       end
       let(:organization) { create(:organization) }
-      let(:cta_button_path) { nil }
       let(:highlighted_content_banner_enabled) { false }
       let(:empty_translatable) { { en: "", es: "", ca: "" } }
       let(:highlighted_content_banner_title) { empty_translatable }
@@ -43,7 +42,6 @@ module Decidim
             "description_es" => description[:es],
             "description_ca" => description[:ca],
             "show_statics" => false,
-            "cta_button_path" => cta_button_path,
             "header_snippets" => header_snippets,
             "highlighted_content_banner_enabled" => highlighted_content_banner_enabled,
             "highlighted_content_banner_title_en" => highlighted_content_banner_title[:en],
@@ -79,18 +77,6 @@ module Decidim
       end
 
       context "when everything is OK" do
-        it { is_expected.to be_valid }
-      end
-
-      context "when cta_button_path is a full URL" do
-        let(:cta_button_path) { "http://example.org" }
-
-        it { is_expected.not_to be_valid }
-      end
-
-      context "when cta_button_path is a valid path" do
-        let(:cta_button_path) { "processes/my-process/" }
-
         it { is_expected.to be_valid }
       end
 
@@ -141,12 +127,6 @@ module Decidim
             it { is_expected.to be_valid }
           end
         end
-      end
-
-      context "when cta_button_path is a valid path with underscore" do
-        let(:cta_button_path) { "processes/my_process/" }
-
-        it { is_expected.to be_valid }
       end
 
       context "when enable_omnipresent_banner is true" do

--- a/decidim-core/app/cells/decidim/content_blocks/hero_settings_form/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/hero_settings_form/show.erb
@@ -1,5 +1,18 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
   <%= settings_fields.translated :text_field, :welcome_text, label: t(".welcome_text") %>
+
+  <div class="row">
+    <div class="columns xlarge-6 slug">
+      <%= settings_fields.translated :text_field, :cta_button_path, label: t(".cta_button_path") %>
+      <p class="help-text"><%== t(".cta_button_path_help", url: decidim_form_slug_url("", translated_attribute(form.object.settings.cta_button_path))) %></p>
+    </div>
+
+    <div class="columns xlarge-6">
+      <%= settings_fields.translated :text_field, :cta_button_text, label: t(".cta_button_text") %>
+      <p class="help-text"><%= t(".cta_button_text_help") %></p>
+    </div>
+  </div>
+
 <% end %>
 
 <% form.fields_for :images, form.object.images do |images_fields| %>

--- a/decidim-core/app/helpers/decidim/cta_button_helper.rb
+++ b/decidim-core/app/helpers/decidim/cta_button_helper.rb
@@ -6,15 +6,15 @@ module Decidim
     # Renders the Call To Action button. Link and text can be configured
     # per organization.
     def cta_button
-      button_text = translated_attribute(current_organization.cta_button_text).presence || t("decidim.pages.home.hero.participate")
+      button_text = translated_attribute(content_block.settings.cta_button_text).presence || t("decidim.pages.home.hero.participate")
 
       link_to button_text, cta_button_path, class: "hero-cta button expanded large button--sc", title: t("decidim.pages.home.hero.participate_title")
     end
 
     # Finds the CTA button path to reuse it in other places.
     def cta_button_path
-      if current_organization.cta_button_path.present?
-        current_organization.cta_button_path
+      if content_block.settings.cta_button_path.present?
+        translated_attribute(content_block.settings.cta_button_path)
       elsif Decidim::ParticipatoryProcess.where(organization: current_organization).published.any?
         decidim_participatory_processes.participatory_processes_path
       elsif current_user
@@ -24,6 +24,13 @@ module Decidim
       else
         decidim.new_user_session_path
       end
+    end
+
+    private
+
+    # Finds the Hero ContentBlock
+    def content_block
+      Decidim::ContentBlock.find_by(organization: current_organization, scope_name: :homepage, manifest_name: :hero)
     end
   end
 end

--- a/decidim-core/app/models/decidim/organization.rb
+++ b/decidim-core/app/models/decidim/organization.rb
@@ -15,7 +15,7 @@ module Decidim
     SOCIAL_HANDLERS = [:twitter, :facebook, :instagram, :youtube, :github].freeze
     AVAILABLE_MACHINE_TRANSLATION_DISPLAY_PRIORITIES = %w(original translation).freeze
 
-    translatable_fields :description, :cta_button_text, :omnipresent_banner_title, :omnipresent_banner_short_description,
+    translatable_fields :description, :omnipresent_banner_title, :omnipresent_banner_short_description,
                         :highlighted_content_banner_title, :highlighted_content_banner_short_description, :highlighted_content_banner_action_title,
                         :highlighted_content_banner_action_subtitle, :welcome_notification_subject, :welcome_notification_body, :id_documents_explanation_text,
                         :admin_terms_of_use_body

--- a/decidim-core/app/presenters/decidim/admin_log/organization_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/organization_presenter.rb
@@ -59,8 +59,6 @@ module Decidim
 
       def appearance_attributes_mapping
         {
-          cta_button_path: :string,
-          cta_button_text: :i18n,
           description: :i18n,
           logo: :string,
           header_snippets: :string,

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -376,6 +376,10 @@ en:
       hero_settings_form:
         background_image: Background image
         welcome_text: Welcome text
+        cta_button_text: Call To Action button text
+        cta_button_text_help: You can overwrite the Call To Action button text in the homepage for each available language in your organization. If not set, the default value will be used. The Call To Action button is shown in the homepage between the welcome text and the description.
+        cta_button_path: Call To Action button URL
+        cta_button_path_help: 'You can overwrite where the Call To Action button in the homepage links to. Use partial paths, not full URLs here. Accepts letters, numbers, dashes and slashes, and must start with a letter. The Call To Action button is shown in the homepage between the welcome text and the description. Example: %{url}'
       highlighted_content_banner:
         name: Highlighted content banner
       how_to_participate:

--- a/decidim-core/db/migrate/20200930125538_move_cta_to_hero_content_block.rb
+++ b/decidim-core/db/migrate/20200930125538_move_cta_to_hero_content_block.rb
@@ -15,7 +15,7 @@ class MoveCtaToHeroContentBlock < ActiveRecord::Migration[5.2]
 
       unless organization.cta_button_path.empty?
         # Adds i18n support to cta_button_path for every defined lang in cta_button_text
-        settings = cta_button_text.inject(settings) { |acc, (k, v)| acc.update("cta_button_path_#{k}" => organization.cta_button_path) }
+        settings = cta_button_text.inject(settings) { |acc, (k, _v)| acc.update("cta_button_path_#{k}" => organization.cta_button_path) }
       end
 
       content_block.settings = settings

--- a/decidim-core/db/migrate/20200930125538_move_cta_to_hero_content_block.rb
+++ b/decidim-core/db/migrate/20200930125538_move_cta_to_hero_content_block.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class MoveCtaToHeroContentBlock < ActiveRecord::Migration[5.2]
+  class Organization < ApplicationRecord
+    self.table_name = :decidim_organizations
+  end
+
+  def change
+    Decidim::ContentBlock.reset_column_information
+    Organization.find_each do |organization|
+      content_block = Decidim::ContentBlock.find_by(organization: organization, scope_name: :homepage, manifest_name: :hero)
+      settings = {}
+      cta_button_text = organization.cta_button_text || {}
+      settings = cta_button_text.inject(settings) { |acc, (k, v)| acc.update("cta_button_text_#{k}" => v) }
+
+      unless organization.cta_button_path.empty?
+        # Adds i18n support to cta_button_path for every defined lang in cta_button_text
+        settings = cta_button_text.inject(settings) { |acc, (k, v)| acc.update("cta_button_path_#{k}" => organization.cta_button_path) }
+      end
+
+      content_block.settings = settings
+      content_block.settings_will_change!
+      content_block.save!
+    end
+
+    remove_column :decidim_organizations, :cta_button_text
+    remove_column :decidim_organizations, :cta_button_path
+  end
+end

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -333,6 +333,8 @@ module Decidim
 
           content_block.settings do |settings|
             settings.attribute :welcome_text, type: :text, translated: true
+            settings.attribute :cta_button_path, type: :string, translated: true
+            settings.attribute :cta_button_text, type: :string, translated: true
           end
 
           content_block.default!

--- a/decidim-core/spec/cells/decidim/content_blocks/hero_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/content_blocks/hero_cell_spec.rb
@@ -61,7 +61,7 @@ describe Decidim::ContentBlocks::HeroCell, type: :cell do
       }
     end
 
-    it "it is a valid path" do
+    it "is a valid path" do
       expect(subject).to have_link(href: "processes/my_process/")
     end
   end
@@ -73,8 +73,8 @@ describe Decidim::ContentBlocks::HeroCell, type: :cell do
       }
     end
 
-    it "it isn't a valid path" do
-      expect(subject).to_not have_link(href: "http://example.org")
+    it "isn't a valid path" do
+      expect(subject).not_to have_link(href: "http://example.org")
     end
   end
 

--- a/decidim-core/spec/cells/decidim/content_blocks/hero_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/content_blocks/hero_cell_spec.rb
@@ -15,6 +15,14 @@ describe Decidim::ContentBlocks::HeroCell, type: :cell do
     it "shows the default welcome text" do
       expect(subject).to have_text("Welcome to #{organization.name}")
     end
+
+    it "shows the default cta text" do
+      expect(subject).to have_selector("a.hero-cta", text: "Participate")
+    end
+
+    it "shows the default cta path" do
+      expect(subject).to have_link(href: "/users/sign_up")
+    end
   end
 
   context "when the content block has customized the welcome text setting value" do
@@ -26,6 +34,47 @@ describe Decidim::ContentBlocks::HeroCell, type: :cell do
 
     it "shows the custom welcome text" do
       expect(subject).to have_text("This is my welcome text")
+    end
+  end
+
+  context "when the content block has customized call to action values" do
+    let(:settings) do
+      {
+        "cta_button_path_en" => "/some-path",
+        "cta_button_text_en" => "Go!"
+      }
+    end
+
+    it "shows the cta_button_text" do
+      expect(subject).to have_text("Go!")
+    end
+
+    it "shows the cta_button_path" do
+      expect(subject).to have_link(href: "/some-path")
+    end
+  end
+
+  context "when cta_button_path is a valid path with underscore" do
+    let(:settings) do
+      {
+        "cta_button_path_en" => "processes/my_process/"
+      }
+    end
+
+    it "it is a valid path" do
+      expect(subject).to have_link(href: "processes/my_process/")
+    end
+  end
+
+  context "when cta_button_path is a full URL" do
+    let(:settings) do
+      {
+        "cta_button_path_en" => "http://example.org"
+      }
+    end
+
+    it "it isn't a valid path" do
+      expect(subject).to_not have_link(href: "http://example.org")
     end
   end
 

--- a/decidim-core/spec/system/homepage_spec.rb
+++ b/decidim-core/spec/system/homepage_spec.rb
@@ -68,58 +68,6 @@ describe "Homepage", type: :system do
         end
       end
 
-      describe "call to action" do
-        let!(:participatory_process) { create :participatory_process, :published }
-        let!(:organization) { participatory_process.organization }
-
-        before do
-          switch_to_host(organization.host)
-          visit decidim.root_path
-        end
-
-        context "when the organization has the CTA button text customized" do
-          let(:cta_button_text) { { en: "Sign up", es: "Regístrate", ca: "Registra't" } }
-          let(:organization) { create(:organization, cta_button_text: cta_button_text) }
-
-          it "uses the custom values for the CTA button text" do
-            within ".hero" do
-              expect(page).to have_selector("a.hero-cta", text: "SIGN UP")
-              click_link "Sign up"
-            end
-
-            expect(page).to have_current_path decidim.new_user_registration_path
-          end
-        end
-
-        context "when the organization has the CTA button link customized" do
-          let(:organization) { create(:organization, cta_button_path: "users/sign_in") }
-
-          it "uses the custom values for the CTA button" do
-            within ".hero" do
-              expect(page).to have_selector("a.hero-cta", text: "PARTICIPATE")
-              click_link "Participate"
-            end
-
-            expect(page).to have_current_path decidim.new_user_session_path
-            expect(page).to have_content("Sign in")
-            expect(page).to have_content("New to the platform?")
-          end
-        end
-
-        context "when the organization does not have it customized" do
-          it "uses the default values for the CTA button" do
-            visit decidim.root_path
-
-            within ".hero" do
-              expect(page).to have_selector("a.hero-cta", text: "PARTICIPATE")
-              click_link "Participate"
-            end
-
-            expect(page).to have_current_path decidim_participatory_processes.participatory_processes_path
-          end
-        end
-      end
-
       context "with header snippets" do
         let(:snippet) { "<meta data-hello=\"This is the organization header_snippet field\">" }
         let(:organization) { create(:organization, official_url: official_url, header_snippets: snippet) }


### PR DESCRIPTION
#### :tophat: What? Why?

I was writing some docs and I've seen that we've never moved the CTA button text and path from Appearance to ContentBlocks.

This is a legacy setting, introduced in #552 that doesn't make sense after the ContentBlocks introduction of the homepage (see #3839). 

This PR moves these settings to their place. It also adds support to i18n in the CTA button path, as that was easier to implement (AFAIK there's no way to have non-translatable content blocks fields, or I didn't find a way of doing that). 

#### :pushpin: Related Issues
- Related to #3839 
- Related to [Move homepage settings to Homepage section](https://meta.decidim.org/processes/roadmap/f/122/proposals/15693) in Meta

#### Testing
*Describe the best way to test or validate your PR.*

1. On an already created app, configure the CTA button and text.
1. Then apply these changes, there's a migration to Content Block 

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*


![imatge](https://user-images.githubusercontent.com/717367/94712922-6b719080-034a-11eb-91dc-07fd60bdb84f.png)
