### PR TITLE
Show draft initiatives

### DIFF
--- a/decidim-initiatives/app/helpers/decidim/initiatives/application_helper.rb
+++ b/decidim-initiatives/app/helpers/decidim/initiatives/application_helper.rb
@@ -11,6 +11,7 @@ module Decidim
         TreeNode.new(
           TreePoint.new("", t("decidim.initiatives.application_helper.filter_state_values.all")),
           [
+            TreePoint.new("created", t("decidim.initiatives.application_helper.filter_state_values.draft")),
             TreePoint.new("open", t("decidim.initiatives.application_helper.filter_state_values.open")),
             TreeNode.new(
               TreePoint.new("closed", t("decidim.initiatives.application_helper.filter_state_values.closed")),

--- a/decidim-initiatives/app/services/decidim/initiatives/initiative_search.rb
+++ b/decidim-initiatives/app/services/decidim/initiatives/initiative_search.rb
@@ -18,7 +18,6 @@ module Decidim
           .includes(scoped_type: [:scope])
           .joins("JOIN decidim_users ON decidim_users.id = decidim_initiatives.decidim_author_id")
           .where(organization: options[:organization])
-          .published
       end
 
       # Handle the search_text filter
@@ -50,6 +49,7 @@ module Decidim
         answered = state.member?("answered") ? query.answered : nil
         open = state.member?("open") ? query.open : nil
         closed = state.member?("closed") ? query.closed : nil
+        draft = state.member?("created") ? query.created : nil
 
         query
           .where(id: accepted)
@@ -57,6 +57,7 @@ module Decidim
           .or(query.where(id: answered))
           .or(query.where(id: open))
           .or(query.where(id: closed))
+          .or(query.where(id: draft).where(published_at: nil))
       end
 
       def search_type_id

--- a/decidim-initiatives/app/services/decidim/initiatives/initiative_search.rb
+++ b/decidim-initiatives/app/services/decidim/initiatives/initiative_search.rb
@@ -51,13 +51,8 @@ module Decidim
         closed = state.member?("closed") ? query.closed : nil
         draft = state.member?("created") ? query.created : nil
 
-        query
-          .where(id: accepted)
-          .or(query.where(id: rejected))
-          .or(query.where(id: answered))
-          .or(query.where(id: open))
-          .or(query.where(id: closed))
-          .or(query.where(id: draft).where(published_at: nil))
+        query.where(id: [accepted, rejected, answered, open, closed])
+             .or(query.where(id: draft, published_at: nil))
       end
 
       def search_type_id

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -295,6 +295,7 @@ en:
           all: All
           answered: Answered
           closed: Closed
+          draft: Draft
           open: Open
           rejected: Not enough signatures
         filter_type_values:

--- a/decidim-initiatives/spec/services/decidim/initiatives/initiative_search_spec.rb
+++ b/decidim-initiatives/spec/services/decidim/initiatives/initiative_search_spec.rb
@@ -66,6 +66,18 @@ module Decidim
         end
 
         context "when the filter includes state" do
+          context "and filtering draft initiatives" do
+            let(:state) { ["created"] }
+
+            it "returns only draft initiatives" do
+              draft_initiatives = create_list(:initiative, 3, organization: organization, state: "created", published_at: nil)
+              create_list(:initiative, 3, :acceptable, organization: organization)
+              
+              expect(subject.size).to eq(3)
+              expect(subject).to match_array(draft_initiatives)
+            end
+          end
+          
           context "and filtering open initiatives" do
             let(:state) { ["open"] }
 

--- a/decidim-initiatives/spec/services/decidim/initiatives/initiative_search_spec.rb
+++ b/decidim-initiatives/spec/services/decidim/initiatives/initiative_search_spec.rb
@@ -72,12 +72,12 @@ module Decidim
             it "returns only draft initiatives" do
               draft_initiatives = create_list(:initiative, 3, organization: organization, state: "created", published_at: nil)
               create_list(:initiative, 3, :acceptable, organization: organization)
-              
+
               expect(subject.size).to eq(3)
               expect(subject).to match_array(draft_initiatives)
             end
           end
-          
+
           context "and filtering open initiatives" do
             let(:state) { ["open"] }
 

--- a/decidim-initiatives/spec/system/filter_initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/filter_initiatives_spec.rb
@@ -76,6 +76,7 @@ describe "Filter Initiatives", :slow, type: :system do
       create_list(:initiative, 4, organization: organization)
       create_list(:initiative, 3, :accepted, organization: organization)
       create_list(:initiative, 2, :rejected, organization: organization)
+      create_list(:initiative, 1, :created, organization: organization)
       create(:initiative, :acceptable, organization: organization)
       create(:initiative, organization: organization, answered_at: Time.current)
 
@@ -95,8 +96,20 @@ describe "Filter Initiatives", :slow, type: :system do
           check "All"
         end
 
-        expect(page).to have_css(".card--initiative", count: 11)
-        expect(page).to have_content("11 INITIATIVES")
+        expect(page).to have_css(".card--initiative", count: 12)
+        expect(page).to have_content("12 INITIATIVES")
+      end
+    end
+
+    context "when selecting the draft state" do
+      it "lists the draft initiatives" do
+        within ".filters .state_check_boxes_tree_filter" do
+          uncheck "All"
+          check "Draft"
+        end
+
+        expect(page).to have_css(".card--initiative", count: 1)
+        expect(page).to have_content("1 INITIATIVE")
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
As a promoter of an Initiative, I can see my drafted Initiatives.

#### :pushpin: Related Issues
- Related to #5736 

#### Testing
The functionality can be tested in this [review app](https://decidim-staging-pr-187.herokuapp.com/). 
1. Go to [Initiatives](https://decidim-staging-pr-187.herokuapp.com/initiatives)
2. Try filtering by `Draft`

#### :clipboard: Checklist
- [x] Adds tests
- [x] Filters by draft
- [x] Shows draft initiatives


### :camera: Screenshots
<img width="281" alt="Screenshot 2020-10-02 at 09 46 56" src="https://user-images.githubusercontent.com/12495882/94899964-82bc9500-0494-11eb-87d5-c40bc83b5b29.png">
<img width="275" alt="Screenshot 2020-10-02 at 09 48 01" src="https://user-images.githubusercontent.com/12495882/94899971-851eef00-0494-11eb-8ad0-d99699211242.png">
<img width="779" alt="Screenshot 2020-10-02 at 09 48 13" src="https://user-images.githubusercontent.com/12495882/94899979-88b27600-0494-11eb-8cf8-002392dfbdd9.png">


