### PR TITLE
Fix page's slug help not generating the right URL

### DIFF
--- a/decidim-admin/app/views/decidim/admin/static_pages/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_pages/_form.html.erb
@@ -6,7 +6,7 @@
   <%= javascript_include_tag "decidim/slug_form" %>
   <div class="row column slug">
     <%= form.text_field :slug %>
-    <p class="help-text"><%== t(".slug_help", url: decidim_form_slug_url("", form.object.slug)) %></p>
+    <p class="help-text"><%== t(".slug_help", url: decidim_form_slug_url("pages", form.object.slug)) %></p>
   </div>
 <% end %>
 


### PR DESCRIPTION
#### :tophat: What? Why?
*Please describe your pull request.*

Fix a mini bug with the generation of the slug in the pages. 

It was missing a prefix so it was not generating the good final URL. 

#### Testing
*Describe the best way to test or validate your PR.*

1. Go to edit a page
2. See that the slug from the help is correct

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*

#### Before

![bad slug](https://user-images.githubusercontent.com/717367/94928835-8b2cc400-04c4-11eb-81f7-ebe37fabaf46.png)

#### After

![good slug](https://user-images.githubusercontent.com/717367/94928812-81a35c00-04c4-11eb-9681-c3a758a84501.png)

:hearts: Thank you!
