### PR TITLE
Take the first image attachment when rendering a proposal card

### DIFF
--- a/decidim-core/app/models/decidim/attachment.rb
+++ b/decidim-core/app/models/decidim/attachment.rb
@@ -15,7 +15,7 @@ module Decidim
     validates_upload :file
     mount_uploader :file, Decidim::AttachmentUploader
 
-    default_scope { order(arel_table[:weight].asc) }
+    default_scope { order(arel_table[:weight].asc, arel_table[:id].asc) }
 
     # Returns the organization related to this attachment in case the
     # attached_to model belongs to an organization. Otherwise will return nil.

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
@@ -116,11 +116,11 @@ module Decidim
       end
 
       def has_image?
-        model.attachments.first.present? && model.attachments.first.file.content_type.start_with?("image") && model.component.settings.allow_card_image
+        @has_image ||= model.component.settings.allow_card_image && model.attachments.find_by("content_type like '%image%'").present?
       end
 
       def resource_image_path
-        model.attachments.first.url if has_image?
+        @resource_image_path ||= has_image? ? model.attachments.find_by("content_type like '%image%'").url : nil
       end
     end
   end

--- a/decidim-proposals/spec/cells/decidim/proposals/proposal_m_cell_spec.rb
+++ b/decidim-proposals/spec/cells/decidim/proposals/proposal_m_cell_spec.rb
@@ -12,7 +12,8 @@ module Decidim::Proposals
     let(:cell_html) { my_cell.call }
     let(:created_at) { Time.current - 1.month }
     let(:published_at) { Time.current }
-    let!(:proposal) { create(:proposal, created_at: created_at, published_at: published_at) }
+    let(:component) { create(:proposal_component, :with_attachments_allowed, :with_card_image_allowed) }
+    let!(:proposal) { create(:proposal, component: component, created_at: created_at, published_at: published_at) }
     let(:model) { proposal }
     let(:user) { create :user, organization: proposal.participatory_space.organization }
     let!(:emendation) { create(:proposal) }
@@ -68,6 +69,18 @@ module Decidim::Proposals
           expect(subject).to have_css(".card__header")
           expect(subject).to have_css(".card__text")
           expect(subject).to have_no_css(".card-data__item")
+        end
+      end
+
+      context "and has an image attachment" do
+        let!(:attachment_1_pdf) { create(:attachment, :with_pdf, attached_to: proposal) }
+        let!(:attachment_2_img) { create(:attachment, :with_image, attached_to: proposal) }
+        let!(:attachment_3_pdf) { create(:attachment, :with_pdf, attached_to: proposal) }
+        let!(:attachment_4_img) { create(:attachment, :with_image, attached_to: proposal) }
+
+        it "renders the first image in the card whatever the order between attachments" do
+          expect(subject).to have_css(".card__image")
+          expect(subject).to have_css("img[src=\"#{attachment_2_img.url}\"]")
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
We've found that depending on the versions of the PostgreSql database the ordering in which the attachments are returned by the `Attachment` default scope may vary. This scope is:

```ruby
default_scope { order(arel_table[:weight].asc) }
```

for this scope, when all results have the same `weight`, PostgreSql versions prior to v12 return results finally ordered by `id DESC`. For PostgreSql versions after v12, results having the same `weight` are finally also ordered by `id` but this time `ASC`.

When the card of a Proposal was checking if the first attachment is an image, it was behaving differently depending on the PostgreSql version.

This PR slightly changes how Proposal cards decide if an image in the attachments should be rendered or not.
Before this PR, the first attachment ought to be an image in order to be rendered in the card. If the first attachment was a PDF, and the image was the second attachment, then the image was not rendered.
After this PR is merged, the first attachment with mime type image is rendered if there's one.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to decidim-barcelona: https://github.com/AjuntamentdeBarcelona/decidim-barcelona/pull/327

#### Testing
*Describe the best way to test or validate your PR.*

Adding tests to check that the first image is returned whatever the position between attachements of other type.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
