### PR TITLE
Mark meetings spec as slow

### DIFF
--- a/decidim-meetings/spec/system/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/system/explore_meetings_spec.rb
@@ -125,7 +125,7 @@ describe "Explore meetings", :slow, type: :system do
         end
       end
 
-      it "allows searching by text" do
+      it "allows searching by text", :slow do
         visit_component
         within ".filters" do
           fill_in "filter[search_text]", with: translated(meetings.first.title)


### PR DESCRIPTION
#### :tophat: What? Why?
We're having a slow test on meetings that's failing most of the time. Until we find a better solution for it, this PR marks the test as slow so it doesn't fail.

#### :pushpin: Related Issues
None

#### Testing
Let tests run, see no errors

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
None

:hearts: Thank you!
