### PR TITLE
Fix notifications page after a removed badge

### DIFF
--- a/decidim-core/db/migrate/20201004160335_remove_notifications_with_continuity_badge.rb
+++ b/decidim-core/db/migrate/20201004160335_remove_notifications_with_continuity_badge.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RemoveNotificationsWithContinuityBadge < ActiveRecord::Migration[5.2]
+  def up
+    Decidim::Notification.where("extra->>'badge_name' =?", "continuity").delete_all
+  end
+
+  def down; end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
After the "continuity" badge was removed, there may still be notifications in the database that are referring to that badge or the event that produced it. This causes the notifications page to break.

This PR fixes the issue.

#### Testing
- Create an instance where the continuity badge still exists.
- Trigger an event that adds the badge to a user and notifies them about it.
- Browse to the notifications page.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.