### PR TITLE
Fix issue when the file upload settings is not a hash

### DIFF
--- a/decidim-system/app/forms/decidim/system/file_upload_settings_form.rb
+++ b/decidim-system/app/forms/decidim/system/file_upload_settings_form.rb
@@ -15,7 +15,13 @@ module Decidim
       attribute :maximum_file_size, Hash[Symbol => Float]
 
       def map_model(settings_hash)
-        settings_hash = default_settings.deep_merge(settings_hash.deep_stringify_keys)
+        settings_hash = begin
+          if settings_hash.is_a?(Hash)
+            default_settings.deep_merge(settings_hash.deep_stringify_keys)
+          else
+            default_settings
+          end
+        end
 
         attribute_set.each do |attr|
           key = attr.name.to_s

--- a/decidim-system/spec/forms/decidim/system/file_upload_settings_form_spec.rb
+++ b/decidim-system/spec/forms/decidim/system/file_upload_settings_form_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::System
+  describe FileUploadSettingsForm do
+    subject do
+      described_class.from_model(model)
+    end
+
+    let(:defaults) { Decidim::OrganizationSettings.default(:upload) }
+
+    describe "#map_model" do
+      context "when the model is not a hash" do
+        let(:model) { double }
+
+        it "sets the default settings for the view" do
+          expect(subject.allowed_file_extensions).to eq(
+            defaults["allowed_file_extensions"].map { |k, v| [k.to_sym, v.join(",")] }.to_h
+          )
+          expect(subject.allowed_content_types).to eq(
+            defaults["allowed_content_types"].map { |k, v| [k.to_sym, v.join(",")] }.to_h
+          )
+          expect(subject.maximum_file_size).to eq(
+            defaults["maximum_file_size"].map { |k, v| [k.to_sym, v.to_f] }.to_h
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
When the organization file upload settings is `nil`, the default values are not mapped correctly in the system organization management view.

This fixes it by using the default settings in case a hash is not given.

#### :pushpin: Related Issues

- #6377

#### Testing
- Update the organization file upload settings to `nil` through the console.
- Go to the system management panel and open the editing view of the organization.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.