### PR TITLE
Fix order for elections

### DIFF
--- a/decidim-elections/app/controllers/concerns/decidim/elections/orderable.rb
+++ b/decidim-elections/app/controllers/concerns/decidim/elections/orderable.rb
@@ -25,9 +25,9 @@ module Decidim
         def reorder(elections)
           case order
           when "recent"
-            elections.order(start_time: :asc)
-          else
             elections.order(start_time: :desc)
+          else
+            elections.order(start_time: :asc)
           end
         end
       end

--- a/decidim-elections/spec/system/sorting_elections_spec.rb
+++ b/decidim-elections/spec/system/sorting_elections_spec.rb
@@ -8,8 +8,8 @@ describe "Sorting elections", type: :system do
 
   let(:organization) { create :organization }
   let!(:user) { create :user, :confirmed, organization: organization }
-  let(:election1) { create :election, :complete, :published, :ongoing, component: component, start_time: 1.day.ago }
-  let(:election2) { create :election, :complete, :published, :ongoing, component: component, start_time: 2.days.ago }
+  let!(:election1) { create :election, :complete, :published, :ongoing, component: component, start_time: 1.day.ago }
+  let!(:election2) { create :election, :complete, :published, :ongoing, component: component, start_time: 2.days.ago }
 
   before do
     switch_to_host(organization.host)
@@ -17,19 +17,19 @@ describe "Sorting elections", type: :system do
   end
 
   context "when ordering by recent" do
-    it "lists the elections in asc start_time order" do
+    it "lists the elections in desc start_time order" do
       visit_component
       within ".order-by" do
         expect(page).to have_selector("ul[data-dropdown-menu$=dropdown-menu]", text: "Recent")
       end
 
-      expect(page).to have_selector("#elections .card-grid .column:first-child", text: election1.title[:en])
-      expect(page).to have_selector("#elections .card-grid .column:last-child", text: election2.title[:en])
+      expect(page).to have_selector("#elections .card-grid .column:first-child .card__title", text: translated(election1.title))
+      expect(page).to have_selector("#elections .card-grid .column:last-child .card__title", text: translated(election2.title))
     end
   end
 
   context "when ordering by older" do
-    it "lists the elections in desc start_time order" do
+    it "lists the elections in asc start_time order" do
       visit_component
       within ".order-by" do
         expect(page).to have_selector("ul[data-dropdown-menu$=dropdown-menu]", text: "Recent")
@@ -37,8 +37,8 @@ describe "Sorting elections", type: :system do
         click_link "Older"
       end
 
-      expect(page).to have_selector("#elections .card-grid .column:first-child", text: election2.title[:en])
-      expect(page).to have_selector("#elections .card-grid .column:last-child", text: election1.title[:en])
+      expect(page).to have_selector("#elections .card-grid .column:first-child", text: translated(election2.title))
+      expect(page).to have_selector("#elections .card-grid .column:last-child", text: translated(election1.title))
     end
   end
 end

--- a/decidim-elections/spec/system/sorting_elections_spec.rb
+++ b/decidim-elections/spec/system/sorting_elections_spec.rb
@@ -23,8 +23,8 @@ describe "Sorting elections", type: :system do
         expect(page).to have_selector("ul[data-dropdown-menu$=dropdown-menu]", text: "Recent")
       end
 
-      expect(page).to have_selector("#elections .card-grid .column:first-child .card__title", text: translated(election1.title))
-      expect(page).to have_selector("#elections .card-grid .column:last-child .card__title", text: translated(election2.title))
+      expect(page).to have_selector("#elections .card-grid .column:first-child", text: translated(election1.title))
+      expect(page).to have_selector("#elections .card-grid .column:last-child", text: translated(election2.title))
     end
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?
The `elections` filter for *recent*  and *older*  elections were twisted. This PR fixes it, so that *recent* will order `desc` from an elections' `start_time`. 

#### :pushpin: Related Issues
- Related to #6266 

#### Testing
I updated the `system` test but you can also go to the `elections` component and change the order between *recent*  and *older*.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*

:hearts: Thank you!
