### PR TITLE
Escape conferences user input

### DIFF
--- a/decidim-conferences/app/cells/decidim/conferences/media_link/show.erb
+++ b/decidim-conferences/app/cells/decidim/conferences/media_link/show.erb
@@ -2,7 +2,7 @@
   <%= icon "external-link", role: "img", "aria-hidden": true %>
   <div>
     <%= link_to model.link, target: "_blank" do %>
-      <strong><%= translated_attribute(model.title) %> </strong>
+      <strong><%= decidim_html_escape  translated_attribute(model.title) %> </strong>
     <% end %>
     <div class="text-small"><%= l(model.date, format: :decidim_short_with_month_name_short) %> · <%= model.link %></div>
   </div>

--- a/decidim-conferences/app/cells/decidim/conferences/media_link_cell.rb
+++ b/decidim-conferences/app/cells/decidim/conferences/media_link_cell.rb
@@ -5,6 +5,7 @@ module Decidim
     # This cell renders the media link card for an instance of a MediaLink
     class MediaLinkCell < Decidim::ViewModel
       include Decidim::LayoutHelper
+      include Decidim::SanitizeHelper
 
       def show
         render

--- a/decidim-core/app/cells/decidim/activity_cell.rb
+++ b/decidim-core/app/cells/decidim/activity_cell.rb
@@ -66,7 +66,7 @@ module Decidim
 
     # The text to show as the link to the resource.
     def resource_link_text
-      translated_attribute(resource.title)
+      decidim_html_escape(translated_attribute(resource.title))
     end
 
     def created_at
@@ -120,7 +120,7 @@ module Decidim
 
     def participatory_space_link
       link_to(
-        translated_attribute(participatory_space.title),
+        decidim_html_escape(translated_attribute(participatory_space.title)),
         resource_locator(participatory_space).path
       )
     end


### PR DESCRIPTION
#### :tophat: What? Why?
This escapes some user input fields on the `conferences` module that weren't properly escaped.

**Note**: As it turns out, `cells` are [not escaped by default](https://github.com/trailblazer/cells#html-escaping). Maybe we should consider adding the `Escaped` module sometime.

#### :pushpin: Related Issues
*None*

#### Testing
Add `"><h1><font color=red>XSS_Conference_title</font></h1><img src=x onerror=alert(1)>` as an user input on a conference, and check out a related activity on your profile. You should see the title escaped.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*None*