### PR TITLE
Make cors more strict

### DIFF
--- a/decidim-api/lib/decidim/api/engine.rb
+++ b/decidim-api/lib/decidim/api/engine.rb
@@ -19,7 +19,7 @@ module Decidim
         app.config.middleware.insert_before 0, Rack::Cors do
           allow do
             origins "*"
-            resource "*", headers: :any, methods: [:get, :post, :options]
+            resource "/api", headers: :any, methods: [:post, :options]
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
Right now, because of the `api` module, an entire decidim installation will have a very lax CORS policy. This restricts it to the `/api` resource.

#### :pushpin: Related Issues
*None*

#### Testing
Use a site like https://www.test-cors.org/ to check against an installation with this patch to see it only has CORS enabled on the `/api` route.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*None*