### PR TITLE
Fix meeting and debate presenters with machine translations

### DIFF
--- a/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
+++ b/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
@@ -50,11 +50,11 @@ module Decidim
       def handle_locales(content, all_locales, &block)
         if all_locales
           content.each_with_object({}) do |(key, value), parsed_content|
-            if key == "machine_translations"
-              parsed_content[key] = handle_locales(value, all_locales, &block)
-            else
-              parsed_content[key] = block.call(value)
-            end
+            parsed_content[key] = if key == "machine_translations"
+                                    handle_locales(value, all_locales, &block)
+                                  else
+                                    block.call(value)
+                                  end
           end
         else
           yield(translated_attribute(content))

--- a/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
+++ b/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
@@ -47,10 +47,14 @@ module Decidim
         end
       end
 
-      def handle_locales(content, all_locales)
+      def handle_locales(content, all_locales, &block)
         if all_locales
-          content.each_with_object({}) do |(locale, string), parsed_content|
-            parsed_content[locale] = yield(string)
+          content.each_with_object({}) do |(key, value), parsed_content|
+            if key == "machine_translations"
+              parsed_content[key] = handle_locales(value, all_locales, &block)
+            else
+              parsed_content[key] = block.call(value)
+            end
           end
         else
           yield(translated_attribute(content))

--- a/decidim-debates/spec/presenters/decidim/debates/debate_presenter_spec.rb
+++ b/decidim-debates/spec/presenters/decidim/debates/debate_presenter_spec.rb
@@ -44,4 +44,3 @@ module Decidim::Debates
     end
   end
 end
-

--- a/decidim-debates/spec/presenters/decidim/debates/debate_presenter_spec.rb
+++ b/decidim-debates/spec/presenters/decidim/debates/debate_presenter_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Debates
+  describe DebatePresenter, type: :helper do
+    let(:debate) { create :debate, component: debate_component }
+    let(:user) { create :user, :admin, organization: organization }
+
+    let(:organization) { create(:organization) }
+    let(:participatory_process) { create :participatory_process, organization: organization }
+    let(:debates_component) { create(:debates_component, participatory_space: participatory_process) }
+
+    let(:presented_debate) { described_class.new(debate) }
+
+    describe "description" do
+      let(:description1) do
+        Decidim::ContentProcessor.parse_with_processor(:hashtag, "Description #description", current_organization: organization).rewrite
+      end
+      let(:description2) do
+        Decidim::ContentProcessor.parse_with_processor(:hashtag, "Description in Spanish #description", current_organization: organization).rewrite
+      end
+      let(:debate) do
+        create(
+          :debate,
+          component: debates_component,
+          description: {
+            en: description1,
+            machine_translations: {
+              es: description2
+            }
+          }
+        )
+      end
+
+      it "parses hashtags in machine translations" do
+        expect(debate.description["en"]).to match(/gid:/)
+        expect(debate.description["machine_translations"]["es"]).to match(/gid:/)
+
+        presented_description = presented_debate.description(all_locales: true)
+        expect(presented_description["en"]).to eq("Description #description")
+        expect(presented_description["machine_translations"]["es"]).to eq("Description in Spanish #description")
+      end
+    end
+  end
+end
+

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -82,11 +82,11 @@ module Decidim
       def handle_locales(content, all_locales, &block)
         if all_locales
           content.each_with_object({}) do |(key, value), parsed_content|
-            if key == "machine_translations"
-              parsed_content[key] = handle_locales(value, all_locales, &block)
-            else
-              parsed_content[key] = block.call(value)
-            end
+            parsed_content[key] = if key == "machine_translations"
+                                    handle_locales(value, all_locales, &block)
+                                  else
+                                    block.call(value)
+                                  end
           end
         else
           yield(translated_attribute(content))

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -79,10 +79,14 @@ module Decidim
 
       private
 
-      def handle_locales(content, all_locales)
+      def handle_locales(content, all_locales, &block)
         if all_locales
-          content.each_with_object({}) do |(locale, string), parsed_content|
-            parsed_content[locale] = yield(string)
+          content.each_with_object({}) do |(key, value), parsed_content|
+            if key == "machine_translations"
+              parsed_content[key] = handle_locales(value, all_locales, &block)
+            else
+              parsed_content[key] = block.call(value)
+            end
           end
         else
           yield(translated_attribute(content))

--- a/decidim-meetings/spec/presenters/decidim/meetings/meeting_presenter_spec.rb
+++ b/decidim-meetings/spec/presenters/decidim/meetings/meeting_presenter_spec.rb
@@ -49,5 +49,35 @@ module Decidim::Meetings
         end
       end
     end
+
+    describe "description" do
+      let(:description1) do
+        Decidim::ContentProcessor.parse_with_processor(:hashtag, "Description #description", current_organization: organization).rewrite
+      end
+      let(:description2) do
+        Decidim::ContentProcessor.parse_with_processor(:hashtag, "Description in Spanish #description", current_organization: organization).rewrite
+      end
+      let(:meeting) do
+        create(
+          :meeting,
+          component: meeting_component,
+          description: {
+            en: description1,
+            machine_translations: {
+              es: description2
+            }
+          }
+        )
+      end
+
+      it "parses hashtags in machine translations" do
+        expect(meeting.description["en"]).to match(/gid:/)
+        expect(meeting.description["machine_translations"]["es"]).to match(/gid:/)
+
+        presented_description = presented_meeting.description(all_locales: true)
+        expect(presented_description["en"]).to eq("Description #description")
+        expect(presented_description["machine_translations"]["es"]).to eq("Description in Spanish #description")
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
These presenters are broken after adding machine translations. It only affects installations using machine translations.

#### :pushpin: Related Issues
None

#### Testing
Have a meeeting or a debate with machine translations. They fail when presented without this PR.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
None

:hearts: Thank you!
