### PR TITLE
Fix dependencies for decidim-templates within decidim-forms

### DIFF
--- a/decidim-forms/app/controllers/decidim/forms/admin/concerns/has_questionnaire.rb
+++ b/decidim-forms/app/controllers/decidim/forms/admin/concerns/has_questionnaire.rb
@@ -18,9 +18,9 @@ module Decidim
             helper_method :questionnaire_for, :questionnaire, :blank_question, :blank_answer_option, :blank_matrix_row,
                           :blank_display_condition, :question_types, :display_condition_types, :update_url, :public_url, :answer_options_url
 
-            if defined? Decidim::Templates
+            if defined? Decidim::Templates::Admin
               include Decidim::Templates::Admin::Concerns::Templatable
-              helper Decidim::Templates::Admin::TemplatesHelper if defined? Decidim::Templates
+              helper Decidim::Templates::Admin::TemplatesHelper
 
               def templatable_type
                 "Decidim::Forms::Questionnaire"

--- a/decidim-forms/app/helpers/decidim/forms/admin/application_helper.rb
+++ b/decidim-forms/app/helpers/decidim/forms/admin/application_helper.rb
@@ -33,6 +33,12 @@ module Decidim
             truncate translated_attribute(title), length: options[:max_length], omission: options[:omission]
           end
         end
+
+        def template?(questionnaire_for)
+          return unless defined? Decidim::Templates::Template
+
+          questionnaire_for.is_a? Decidim::Templates::Template
+        end
       end
     end
   end

--- a/decidim-forms/app/helpers/decidim/forms/admin/application_helper.rb
+++ b/decidim-forms/app/helpers/decidim/forms/admin/application_helper.rb
@@ -40,12 +40,13 @@ module Decidim
           questionnaire_for.is_a? Decidim::Templates::Template
         end
 
-        def title_for_questionnaire(templates_defined)
-          if templates_defined
-            t("form.title", scope: "decidim.templates.admin.questionnaire_templates")
-          else
-            t(".title")
-          end
+        def templates_defined?
+          defined? Decidim::Templates::Admin::Concerns::Templatable
+        end
+
+        def title_for_questionnaire
+          scope = templates_defined? ? "decidim.templates.admin.questionnaire_templates" : "decidim.forms.admin.questionnaires"
+          t("form.title", scope: scope)
         end
       end
     end

--- a/decidim-forms/app/helpers/decidim/forms/admin/application_helper.rb
+++ b/decidim-forms/app/helpers/decidim/forms/admin/application_helper.rb
@@ -39,6 +39,14 @@ module Decidim
 
           questionnaire_for.is_a? Decidim::Templates::Template
         end
+
+        def title_for_questionnaire(templates_defined)
+          if templates_defined
+            t("form.title", scope: "decidim.templates.admin.questionnaire_templates")
+          else
+            t(".title")
+          end
+        end
       end
     end
   end

--- a/decidim-forms/app/helpers/decidim/forms/admin/application_helper.rb
+++ b/decidim-forms/app/helpers/decidim/forms/admin/application_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# i18n-tasks-use t('decidim.templates.admin.questionnaire_templates.form.title')
+
 module Decidim
   module Forms
     module Admin

--- a/decidim-forms/app/models/decidim/forms/questionnaire.rb
+++ b/decidim-forms/app/models/decidim/forms/questionnaire.rb
@@ -4,7 +4,7 @@ module Decidim
   module Forms
     # The data store for a Questionnaire in the Decidim::Forms component.
     class Questionnaire < Forms::ApplicationRecord
-      include Decidim::Templates::Templatable if defined? Decidim::Templates
+      include Decidim::Templates::Templatable if defined? Decidim::Templates::Templatable
       include Decidim::Publicable
       include Decidim::TranslatableResource
 

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/_form.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/_form.html.erb
@@ -2,7 +2,7 @@
   <div class="card-divider">
     <h2 class="card-title">
       <%= t(".title") %>
-      <% unless questionnaire.questionnaire_for.class == Decidim::Templates::Template %>
+      <% unless template? questionnaire.questionnaire_for %>
         <% if allowed_to? :preview, :questionnaire %>
           <div class="button--title">
             <%= link_to t(".preview"), public_url, class: "button tiny button--simple", target: :_blank %>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/edit.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/edit.html.erb
@@ -8,8 +8,7 @@
                object: form,
                locals: {
                  title: templates_defined ? t("form.title", scope: "decidim.templates.admin.questionnaire_templates") : t(".title")
-               }
-    %>
+    } %>
 
     <div class="button--double form-general-submit">
       <%= form.submit t(".save"), class: "button" %>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/edit.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/edit.html.erb
@@ -2,7 +2,7 @@
   <%= render partial: "decidim/templates/admin/questionnaire_templates/choose", locals: { target: questionnaire, form_title: t("decidim.forms.admin.questionnaires.edit.title") } %>
 <% else %>
   <%= decidim_form_for(@form, url: update_url, method: :put, html: { class: "form edit_questionnaire" }) do |form| %>
-    <%= render partial: "decidim/forms/admin/questionnaires/form", object: form, locals: { title: title_for_questionnaire(scope: I18n.current_scope) } %>
+    <%= render partial: "decidim/forms/admin/questionnaires/form", object: form, locals: { title: title_for_questionnaire } %>
 
     <div class="button--double form-general-submit">
       <%= form.submit t(".save"), class: "button" %>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/edit.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/edit.html.erb
@@ -1,10 +1,8 @@
-<% templates_defined = (defined? Decidim::Templates::Admin::Concerns::Templatable) %>
-
-<% if templates_defined && choose_template? %>
+<% if templates_defined? && choose_template? %>
   <%= render partial: "decidim/templates/admin/questionnaire_templates/choose", locals: { target: questionnaire, form_title: t("decidim.forms.admin.questionnaires.edit.title") } %>
 <% else %>
   <%= decidim_form_for(@form, url: update_url, method: :put, html: { class: "form edit_questionnaire" }) do |form| %>
-    <%= render partial: "decidim/forms/admin/questionnaires/form", object: form, locals: { title: title_for_questionnaire(templates_defined) } %>
+    <%= render partial: "decidim/forms/admin/questionnaires/form", object: form, locals: { title: title_for_questionnaire(scope: I18n.current_scope) } %>
 
     <div class="button--double form-general-submit">
       <%= form.submit t(".save"), class: "button" %>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/edit.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/edit.html.erb
@@ -1,8 +1,15 @@
-<% if (defined? Decidim::Templates) && choose_template? %>
+<% templates_defined = (defined? Decidim::Templates::Admin::Concerns::Templatable) %>
+
+<% if templates_defined && choose_template? %>
   <%= render partial: "decidim/templates/admin/questionnaire_templates/choose", locals: { target: questionnaire, form_title: t("decidim.forms.admin.questionnaires.edit.title") } %>
 <% else %>
   <%= decidim_form_for(@form, url: update_url, method: :put, html: { class: "form edit_questionnaire" }) do |form| %>
-    <%= render partial: "decidim/forms/admin/questionnaires/form", object: form, locals: { title: t("form.title", scope: "decidim.templates.admin.questionnaire_templates") } %>
+    <%= render partial: "decidim/forms/admin/questionnaires/form",
+               object: form,
+               locals: {
+                 title: templates_defined ? t("form.title", scope: "decidim.templates.admin.questionnaire_templates") : t(".title")
+               }
+    %>
 
     <div class="button--double form-general-submit">
       <%= form.submit t(".save"), class: "button" %>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/edit.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/edit.html.erb
@@ -4,11 +4,7 @@
   <%= render partial: "decidim/templates/admin/questionnaire_templates/choose", locals: { target: questionnaire, form_title: t("decidim.forms.admin.questionnaires.edit.title") } %>
 <% else %>
   <%= decidim_form_for(@form, url: update_url, method: :put, html: { class: "form edit_questionnaire" }) do |form| %>
-    <%= render partial: "decidim/forms/admin/questionnaires/form",
-               object: form,
-               locals: {
-                 title: templates_defined ? t("form.title", scope: "decidim.templates.admin.questionnaire_templates") : t(".title")
-    } %>
+    <%= render partial: "decidim/forms/admin/questionnaires/form", object: form, locals: { title: title_for_questionnaire(templates_defined) } %>
 
     <div class="button--double form-general-submit">
       <%= form.submit t(".save"), class: "button" %>


### PR DESCRIPTION
#### :tophat: What? Why?
The `decidim-templates` module is intended to be optional, but there were still some files in `decidim-forms` dependant on this module. This PR removes this dependencies to isolate `decidim-templates` so no modules depend on it. 

#### :pushpin: Related Issues
- Related to [Templates Module (\#6247)](https://github.com/decidim/decidim/pull/6247)
- Fixes [codegram/decidim-staging#190](https://github.com/codegram/decidim-staging/pull/190)

#### Testing
```sh
rspec decidim-surveys/spec/system/admin_manages_surveys_spec.rb # (for example)
```
(Or editing a survey component's questionnaire, without requiring `decidim-templates` in the application `Gemfile`)
