### PR TITLE
Avoid rendering values on the secrets.yml when creating a new app

### DIFF
--- a/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb
+++ b/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb
@@ -34,9 +34,9 @@ default: &default
     api_version: "1.2.1"
   bulletin_board:
     identification_private_key: |
-<%= ENV["BULLETIN_BOARD_IDENTIFICATION_PRIVATE_KEY"]&.indent(6) %>
-    server: <%= ENV["BULLETIN_BOARD_SERVER"] %>
-    api_key: <%= ENV["BULLETIN_BOARD_API_KEY"] %>
+<%%= ENV["BULLETIN_BOARD_IDENTIFICATION_PRIVATE_KEY"]&.indent(6) %>
+    server: <%%= ENV["BULLETIN_BOARD_SERVER"] %>
+    api_key: <%%= ENV["BULLETIN_BOARD_API_KEY"] %>
 
 development:
   <<: *default


### PR DESCRIPTION
#### :tophat: What? Why?
The template should mantain the <%= %> block to access the environment variables on the execution of the application.

#### :pushpin: Related Issues
- Related to #6420

#### Testing
- Create a new dev application using the rake task.
- Open the secrets.yml file and check that `bulletin_board.identification_private_key` is not empty.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots


:hearts: Thank you!
