### PR TITLE
Filter created initiatives only by author

### DIFF
--- a/decidim-initiatives/app/helpers/decidim/initiatives/application_helper.rb
+++ b/decidim-initiatives/app/helpers/decidim/initiatives/application_helper.rb
@@ -11,7 +11,6 @@ module Decidim
         TreeNode.new(
           TreePoint.new("", t("decidim.initiatives.application_helper.filter_state_values.all")),
           [
-            TreePoint.new("created", t("decidim.initiatives.application_helper.filter_state_values.draft")),
             TreePoint.new("open", t("decidim.initiatives.application_helper.filter_state_values.open")),
             TreeNode.new(
               TreePoint.new("closed", t("decidim.initiatives.application_helper.filter_state_values.closed")),

--- a/decidim-initiatives/app/services/decidim/initiatives/initiative_search.rb
+++ b/decidim-initiatives/app/services/decidim/initiatives/initiative_search.rb
@@ -64,7 +64,8 @@ module Decidim
 
       def search_author
         if author == "myself" && options[:current_user]
-          query.where(decidim_author_id: options[:current_user], decidim_author_type: Decidim::UserBaseEntity.name).unscope(where: :published_at)
+          query.where(decidim_author_id: options[:current_user], decidim_author_type: Decidim::UserBaseEntity.name)
+               .unscope(where: :published_at)
         else
           query
         end

--- a/decidim-initiatives/app/services/decidim/initiatives/initiative_search.rb
+++ b/decidim-initiatives/app/services/decidim/initiatives/initiative_search.rb
@@ -64,7 +64,7 @@ module Decidim
 
       def search_author
         if author == "myself" && options[:current_user]
-          Decidim::Initiative.where(decidim_author_id: options[:current_user],  decidim_author_type: Decidim::UserBaseEntity.name)
+          Decidim::Initiative.where(decidim_author_id: options[:current_user], decidim_author_type: Decidim::UserBaseEntity.name)
         else
           query
         end

--- a/decidim-initiatives/app/services/decidim/initiatives/initiative_search.rb
+++ b/decidim-initiatives/app/services/decidim/initiatives/initiative_search.rb
@@ -18,6 +18,7 @@ module Decidim
           .includes(scoped_type: [:scope])
           .joins("JOIN decidim_users ON decidim_users.id = decidim_initiatives.decidim_author_id")
           .where(organization: options[:organization])
+          .published
       end
 
       # Handle the search_text filter
@@ -49,10 +50,8 @@ module Decidim
         answered = state.member?("answered") ? query.answered : nil
         open = state.member?("open") ? query.open : nil
         closed = state.member?("closed") ? query.closed : nil
-        draft = state.member?("created") ? query.created : nil
 
         query.where(id: [accepted, rejected, answered, open, closed])
-             .or(query.where(id: draft, published_at: nil))
       end
 
       def search_type_id
@@ -65,7 +64,7 @@ module Decidim
 
       def search_author
         if author == "myself" && options[:current_user]
-          query.where(decidim_author_id: options[:current_user].id)
+          Decidim::Initiative.where(decidim_author_id: options[:current_user].id)
         else
           query
         end

--- a/decidim-initiatives/app/services/decidim/initiatives/initiative_search.rb
+++ b/decidim-initiatives/app/services/decidim/initiatives/initiative_search.rb
@@ -64,7 +64,7 @@ module Decidim
 
       def search_author
         if author == "myself" && options[:current_user]
-          Decidim::Initiative.where(decidim_author_id: options[:current_user], decidim_author_type: Decidim::UserBaseEntity.name)
+          query.where(decidim_author_id: options[:current_user], decidim_author_type: Decidim::UserBaseEntity.name).unscope(where: :published_at)
         else
           query
         end

--- a/decidim-initiatives/app/services/decidim/initiatives/initiative_search.rb
+++ b/decidim-initiatives/app/services/decidim/initiatives/initiative_search.rb
@@ -64,7 +64,7 @@ module Decidim
 
       def search_author
         if author == "myself" && options[:current_user]
-          Decidim::Initiative.where(decidim_author_id: options[:current_user].id)
+          Decidim::Initiative.where(decidim_author_id: options[:current_user],  decidim_author_type: Decidim::UserBaseEntity.name)
         else
           query
         end

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -303,7 +303,6 @@ en:
           all: All
           answered: Answered
           closed: Closed
-          draft: Draft
           open: Open
           rejected: Not enough signatures
         filter_type_values:

--- a/decidim-initiatives/spec/services/decidim/initiatives/initiative_search_spec.rb
+++ b/decidim-initiatives/spec/services/decidim/initiatives/initiative_search_spec.rb
@@ -66,18 +66,6 @@ module Decidim
         end
 
         context "when the filter includes state" do
-          context "and filtering draft initiatives" do
-            let(:state) { ["created"] }
-
-            it "returns only draft initiatives" do
-              draft_initiatives = create_list(:initiative, 3, organization: organization, state: "created", published_at: nil)
-              create_list(:initiative, 3, :acceptable, organization: organization)
-
-              expect(subject.size).to eq(3)
-              expect(subject).to match_array(draft_initiatives)
-            end
-          end
-
           context "and filtering open initiatives" do
             let(:state) { ["open"] }
 
@@ -163,6 +151,7 @@ module Decidim
         context "when the filter includes author" do
           let!(:initiative) { create(:initiative, organization: organization) }
           let!(:initiative2) { create(:initiative, organization: organization, author: user1) }
+          let!(:created_initiative) { create(:initiative, :created, organization: organization, author: user1) }
 
           context "and any author" do
             it "contains all initiatives" do
@@ -174,7 +163,7 @@ module Decidim
             let(:author) { "myself" }
 
             it "contains only initiatives of the author" do
-              expect(subject).to match_array [initiative2]
+              expect(subject).to match_array [initiative2, created_initiative]
             end
           end
         end

--- a/decidim-initiatives/spec/system/filter_initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/filter_initiatives_spec.rb
@@ -76,7 +76,6 @@ describe "Filter Initiatives", :slow, type: :system do
       create_list(:initiative, 4, organization: organization)
       create_list(:initiative, 3, :accepted, organization: organization)
       create_list(:initiative, 2, :rejected, organization: organization)
-      create_list(:initiative, 1, :created, organization: organization)
       create(:initiative, :acceptable, organization: organization)
       create(:initiative, organization: organization, answered_at: Time.current)
 
@@ -96,20 +95,8 @@ describe "Filter Initiatives", :slow, type: :system do
           check "All"
         end
 
-        expect(page).to have_css(".card--initiative", count: 12)
-        expect(page).to have_content("12 INITIATIVES")
-      end
-    end
-
-    context "when selecting the draft state" do
-      it "lists the draft initiatives" do
-        within ".filters .state_check_boxes_tree_filter" do
-          uncheck "All"
-          check "Draft"
-        end
-
-        expect(page).to have_css(".card--initiative", count: 1)
-        expect(page).to have_content("1 INITIATIVE")
+        expect(page).to have_css(".card--initiative", count: 11)
+        expect(page).to have_content("11 INITIATIVES")
       end
     end
 
@@ -319,6 +306,7 @@ describe "Filter Initiatives", :slow, type: :system do
 
       before do
         create_list(:initiative, 2, organization: organization, author: user)
+        create_list(:initiative, 1, :created, organization: organization, author: user)
         create(:initiative, organization: organization)
 
         login_as user, scope: :user
@@ -349,8 +337,8 @@ describe "Filter Initiatives", :slow, type: :system do
             choose "My initiatives"
           end
 
-          expect(page).to have_css(".card--initiative", count: 2)
-          expect(page).to have_content("2 INITIATIVES")
+          expect(page).to have_css(".card--initiative", count: 3)
+          expect(page).to have_content("3 INITIATIVES")
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Removes `draft` state filter and shows all initiatives (published and not published) when filtering by `my initiatives`.

This PR updates the changes added in #6584 after a redefinition of the feature.

#### :pushpin: Related Issues
- Related to #5736 

#### 🟢  Testing
The functionality can be tested in this [review app](https://decidim-staging-pr-198.herokuapp.com/initiatives).

#### :clipboard: Checklist
- [x] Remove `draft` state filter
- [x] Update `search_author` query
- [x] Show initiatives with any `state` when filtering by **My initiatives**
- [x] Update tests

### :camera: Screenshots
![Screenshot 2020-10-12 at 12 26 35](https://user-images.githubusercontent.com/12495882/95736195-30465a00-0c86-11eb-8cd6-e0aad096987b.png)
