### PR TITLE
Improve moderation panel

### DIFF
--- a/decidim-admin/app/assets/javascripts/decidim/admin/application.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/application.js.es6
@@ -19,6 +19,7 @@
 // = require ./draggable-list
 // = require ./sortable
 // = require ./gallery
+// = require ./moderations
 // = require decidim/input_tags
 // = require decidim/input_hashtags
 // = require decidim/input_mentions

--- a/decidim-admin/app/assets/javascripts/decidim/admin/moderations.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/moderations.js.es6
@@ -1,0 +1,24 @@
+((exports) => {
+  const $ = exports.$;
+
+  $(() => {
+    const $moderationDetails = $('.moderation-details');
+    const $toggleContentButton = $moderationDetails.find('.toggle-content');
+    const $reportedContent = $moderationDetails.find('.reported-content');
+    const $currentContent = $reportedContent.find('.current');
+    const $originalContent = $reportedContent.find('.original');
+
+    $originalContent.hide();
+
+    $toggleContentButton.on('click', () => {
+      $currentContent.toggle();
+      $originalContent.toggle();
+
+      if ($currentContent.is(":hidden")) {
+        $toggleContentButton.html($toggleContentButton.data('see-current-button-label'));
+      } else {
+        $toggleContentButton.html($toggleContentButton.data('see-original-button-label'));
+      }
+    })
+  })
+})(window)

--- a/decidim-admin/app/assets/javascripts/decidim/admin/moderations.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/moderations.js.es6
@@ -1,23 +1,23 @@
 ((exports) => {
-  const $ = exports.$;
+  const $ = exports.$; // eslint-disable-line
 
   $(() => {
-    const $moderationDetails = $('.moderation-details');
-    const $toggleContentButton = $moderationDetails.find('.toggle-content');
-    const $reportedContent = $moderationDetails.find('.reported-content');
-    const $currentContent = $reportedContent.find('.current');
-    const $originalContent = $reportedContent.find('.original');
+    const $moderationDetails = $(".moderation-details");
+    const $toggleContentButton = $moderationDetails.find(".toggle-content");
+    const $reportedContent = $moderationDetails.find(".reported-content");
+    const $currentContent = $reportedContent.find(".current");
+    const $originalContent = $reportedContent.find(".original");
 
     $originalContent.hide();
 
-    $toggleContentButton.on('click', () => {
+    $toggleContentButton.on("click", () => {
       $currentContent.toggle();
       $originalContent.toggle();
 
       if ($currentContent.is(":hidden")) {
-        $toggleContentButton.html($toggleContentButton.data('see-current-button-label'));
+        $toggleContentButton.html($toggleContentButton.data("see-current-button-label"));
       } else {
-        $toggleContentButton.html($toggleContentButton.data('see-original-button-label'));
+        $toggleContentButton.html($toggleContentButton.data("see-original-button-label"));
       }
     })
   })

--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_moderations.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_moderations.scss
@@ -1,21 +1,24 @@
-.moderation-details {
-  .toggle-content {
+.moderation-details{
+  .toggle-content{
     cursor: pointer;
-    margin-left: 0.5rem;
-    font-size: 0.9rem;
+    margin-left: .5rem;
+    font-size: .9rem;
   }
-  .callout {
-    &-text {
-      margin-left: 0.5rem;
-      .icon {
-        width: 0.6rem;
-        margin: 0 0.2rem;
+
+  .callout{
+    &-text{
+      margin-left: .5rem;
+
+      .icon{
+        width: .6rem;
+        margin: 0 .2rem;
       }
     }
   }
-  dd {
+
+  dd{
     padding: $global-padding;
     background-color: $light-gray;
-    margin-bottom: 0.5rem;
+    margin-bottom: .5rem;
   }
 }

--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_moderations.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_moderations.scss
@@ -5,10 +5,15 @@
     font-size: .9rem;
   }
 
+  .reported-content{
+    .original{
+      display: none
+    }
+  }
+
   .callout{
     &-text{
       margin-left: .5rem;
-
       .icon{
         width: .6rem;
         margin: 0 .2rem;
@@ -20,5 +25,13 @@
     padding: $global-padding;
     background-color: $light-gray;
     margin-bottom: .5rem;
+  }
+
+  .reportable-authors{
+    list-style: none;
+    margin: 0;
+    .icon{
+      margin-left: .5rem;
+    }
   }
 }

--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_moderations.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_moderations.scss
@@ -7,13 +7,14 @@
 
   .reported-content{
     .original{
-      display: none
+      display: none;
     }
   }
 
   .callout{
     &-text{
       margin-left: .5rem;
+
       .icon{
         width: .6rem;
         margin: 0 .2rem;
@@ -30,6 +31,7 @@
   .reportable-authors{
     list-style: none;
     margin: 0;
+
     .icon{
       margin-left: .5rem;
     }

--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_moderations.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_moderations.scss
@@ -1,0 +1,21 @@
+.moderation-details {
+  .toggle-content {
+    cursor: pointer;
+    margin-left: 0.5rem;
+    font-size: 0.9rem;
+  }
+  .callout {
+    &-text {
+      margin-left: 0.5rem;
+      .icon {
+        width: 0.6rem;
+        margin: 0 0.2rem;
+      }
+    }
+  }
+  dd {
+    padding: $global-padding;
+    background-color: $light-gray;
+    margin-bottom: 0.5rem;
+  }
+}

--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_modules.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_modules.scss
@@ -39,3 +39,4 @@
 
 //Admin dashboard
 @import "users_statistics";
+@import "moderations";

--- a/decidim-admin/app/controllers/concerns/decidim/moderations/admin/filterable.rb
+++ b/decidim-admin/app/controllers/concerns/decidim/moderations/admin/filterable.rb
@@ -16,6 +16,34 @@ module Decidim
           def base_query
             collection
           end
+
+          def filters
+            [
+              :reportable_type_string_eq
+            ]
+          end
+
+          def filters_with_values
+            {
+              reportable_type_string_eq: reportable_types
+            }
+          end
+
+          def dynamically_translated_filters
+            [:reportable_type_string_eq]
+          end
+
+          def translated_reportable_type_string_eq(value)
+            value.constantize.name.demodulize
+          end
+
+          def search_field_predicate
+            :reportable_id_string_cont
+          end
+
+          def reportable_types
+            collection.pluck(:decidim_reportable_type).uniq.sort
+          end
         end
       end
     end

--- a/decidim-admin/app/controllers/concerns/decidim/moderations/admin/filterable.rb
+++ b/decidim-admin/app/controllers/concerns/decidim/moderations/admin/filterable.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  module Moderations
+    module Admin
+      module Filterable
+        extend ActiveSupport::Concern
+
+        included do
+          include Decidim::Admin::Filterable
+
+          private
+
+          def base_query
+            collection
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/app/controllers/concerns/decidim/moderations/admin/filterable.rb
+++ b/decidim-admin/app/controllers/concerns/decidim/moderations/admin/filterable.rb
@@ -37,8 +37,11 @@ module Decidim
             value.constantize.name.demodulize
           end
 
+          # Private: the predicate used by `Ransack` to perform a search. We used `reported` instead
+          #          of `reportable` because otherwise `Ransack` try to traverse the polymorphic
+          #          association automatically and it fails.
           def search_field_predicate
-            :reportable_id_string_cont
+            :reported_id_string_or_reported_content_cont
           end
 
           def reportable_types

--- a/decidim-admin/app/controllers/decidim/admin/moderations/reports_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/moderations/reports_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    module Moderations
+      # This controller allows admins to manage reports in a moderation.
+      class ReportsController < Decidim::Admin::ApplicationController
+        helper_method :moderation, :reports
+
+        def index
+          enforce_permission_to :read, :moderation
+        end
+
+        def show
+          enforce_permission_to :read, :moderation
+          @report = reports.find(params[:id])
+        end
+
+        private
+
+        def reports
+          @reports ||= moderation.reports
+        end
+
+        def moderation
+          @moderation ||= participatory_space_moderations.find(params[:moderation_id])
+        end
+
+        def participatory_space_moderations
+          @participatory_space_moderations ||= Decidim::Moderation.where(participatory_space: current_participatory_space)
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/app/controllers/decidim/admin/moderations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/moderations_controller.rb
@@ -4,7 +4,9 @@ module Decidim
   module Admin
     # This controller allows admins to manage moderations in a participatory process.
     class ModerationsController < Decidim::Admin::ApplicationController
-      helper_method :moderations, :allowed_to?
+      include Decidim::Moderations::Admin::Filterable
+
+      helper_method :moderations, :allowed_to?, :query
 
       def index
         enforce_permission_to :read, :moderation
@@ -60,14 +62,23 @@ module Decidim
 
       private
 
-      def moderations
-        @moderations ||= begin
+      # Private: This method is used by the `Filterable` concern as the base query
+      #          without applying filtering and/or sorting options.
+      def collection
+        @collection ||= begin
           if params[:hidden]
             participatory_space_moderations.where.not(hidden_at: nil)
           else
             participatory_space_moderations.where(hidden_at: nil)
           end
         end
+      end
+
+      # Private: Returns a collection of `Moderation` filtered and/or sorted by
+      #          some criteria. The `filtered_collection` is provided by the
+      #          `Filterable` concern.
+      def moderations
+        @moderations ||= filtered_collection
       end
 
       def reportable

--- a/decidim-admin/app/controllers/decidim/admin/moderations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/moderations_controller.rb
@@ -12,6 +12,11 @@ module Decidim
         enforce_permission_to :read, :moderation
       end
 
+      def show
+        enforce_permission_to :read, :moderation
+        @moderation = collection.find(params[:id])
+      end
+
       def unreport
         enforce_permission_to :unreport, :moderation
 

--- a/decidim-admin/app/helpers/decidim/admin/moderations/reports_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/moderations/reports_helper.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    module Moderations
+      # This module includes helpers to show moderation reports in admin
+      module ReportsHelper
+        # Public: Returns the reportable's author names separated by commas.
+        def reportable_author_name(reportable)
+          reportable_authors = reportable.try(:authors) || [reportable.try(:author)]
+          reportable_authors.select(&:present?).map(&:name).join(", ")
+        end
+
+        # Public: Renders a small preview of the content reported.
+        def reported_content_for(reportable, options = {})
+          cell "decidim/reported_content", reportable, options
+        end
+
+        # Public: Renders an extract of the content reported in a text format.
+        def reported_content_excerpt_for(reportable, options = {})
+          I18n.with_locale(options.fetch(:locale, I18n.locale)) do
+            reportable_content = reportable.reported_attributes.map do |attribute_name|
+              attribute_value = reportable.attributes.with_indifferent_access[attribute_name]
+              next translated_attribute(attribute_value) if attribute_value.is_a? Hash
+              attribute_value
+            end
+            reportable_content.filter(&:present?).join(". ").truncate(options.fetch(:limit, 100))
+          end
+        end
+
+        # Public: Whether the resource has some translated attribute or not.
+        def translatable_resource?(reportable)
+          reportable.respond_to?(:content_original_language)
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/app/helpers/decidim/admin/moderations/reports_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/moderations/reports_helper.rb
@@ -22,6 +22,7 @@ module Decidim
             reportable_content = reportable.reported_attributes.map do |attribute_name|
               attribute_value = reportable.attributes.with_indifferent_access[attribute_name]
               next translated_attribute(attribute_value) if attribute_value.is_a? Hash
+
               attribute_value
             end
             reportable_content.filter(&:present?).join(". ").truncate(options.fetch(:limit, 100))

--- a/decidim-admin/app/helpers/decidim/admin/moderations/reports_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/moderations/reports_helper.rb
@@ -5,10 +5,24 @@ module Decidim
     module Moderations
       # This module includes helpers to show moderation reports in admin
       module ReportsHelper
+        include Decidim::Messaging::ConversationHelper
+
         # Public: Returns the reportable's author names separated by commas.
         def reportable_author_name(reportable)
-          reportable_authors = reportable.try(:authors) || [reportable.try(:author)]
-          reportable_authors.select(&:present?).map(&:name).join(", ")
+          reportable_authors = reportable.try(:authors) || [reportable.try(:normalized_author)]
+          content_tag :ul, class: "reportable-authors" do
+            reportable_authors.select(&:present?).map do |author|
+              if author.is_a? User
+                content_tag :li do
+                  link_to current_or_new_conversation_path_with(author), target: "_blank" do
+                    "#{author.name} #{icon "envelope-closed"}".html_safe
+                  end
+                end
+              else
+                content_tag(:li, author.name)
+              end
+            end.join("").html_safe
+          end
         end
 
         # Public: Renders a small preview of the content reported.

--- a/decidim-admin/app/helpers/decidim/admin/moderations/reports_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/moderations/reports_helper.rb
@@ -14,7 +14,7 @@ module Decidim
             reportable_authors.select(&:present?).map do |author|
               if author.is_a? User
                 content_tag :li do
-                  link_to current_or_new_conversation_path_with(author), target: "_blank" do
+                  link_to current_or_new_conversation_path_with(author), target: "_blank", rel: "noopener" do
                     "#{author.name} #{icon "envelope-closed"}".html_safe
                   end
                 end
@@ -28,19 +28,6 @@ module Decidim
         # Public: Renders a small preview of the content reported.
         def reported_content_for(reportable, options = {})
           cell "decidim/reported_content", reportable, options
-        end
-
-        # Public: Renders an extract of the content reported in a text format.
-        def reported_content_excerpt_for(reportable, options = {})
-          I18n.with_locale(options.fetch(:locale, I18n.locale)) do
-            reportable_content = reportable.reported_attributes.map do |attribute_name|
-              attribute_value = reportable.attributes.with_indifferent_access[attribute_name]
-              next translated_attribute(attribute_value) if attribute_value.is_a? Hash
-
-              attribute_value
-            end
-            reportable_content.filter(&:present?).join(". ").truncate(options.fetch(:limit, 100))
-          end
         end
 
         # Public: Whether the resource has some translated attribute or not.

--- a/decidim-admin/app/helpers/decidim/admin/moderations_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/moderations_helper.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # This module includes helpers to show moderation in admin
+    module ModerationsHelper
+      # Public: Renders an extract of the content reported in a text format.
+      def reported_content_excerpt_for(reportable, options = {})
+        I18n.with_locale(options.fetch(:locale, I18n.locale)) do
+          reportable_content = reportable.reported_attributes.map do |attribute_name|
+            attribute_value = reportable.attributes.with_indifferent_access[attribute_name]
+            next translated_attribute(attribute_value) if attribute_value.is_a? Hash
+
+            attribute_value
+          end
+          reportable_content.filter(&:present?).join(". ").truncate(options.fetch(:limit, 100))
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
@@ -83,6 +83,7 @@
           <% end %>
         </tbody>
       </table>
+      <%= paginate moderations, theme: "decidim" %>
     </div>
   </div>
 </div>

--- a/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
@@ -40,7 +40,7 @@
               </td>
               <td>
                 <%=
-                  link_to t("models.moderation.fields.visit_url", scope: "decidim.moderations"), moderation.reportable.reported_content_url
+                  link_to t("models.moderation.fields.visit_url", scope: "decidim.moderations"), moderation.reportable.reported_content_url, data: { tooltip: true }, aria: { haspopup: true }, title: reported_content_excerpt_for(moderation.reportable)
                 %>
               </td>
               <td>

--- a/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
@@ -59,8 +59,7 @@
                 <%= icon_link_to "fullscreen-enter",
                                   moderation_reports_path(moderation_id: moderation),
                                   t("actions.expand", scope: "decidim.moderations"),
-                                  class: "action-icon--expand",
-                                  method: :get %>
+                                  class: "action-icon--expand" %>
                 <% if !moderation.reportable.hidden? && allowed_to?(:unreport, :moderation) %>
                   <%= icon_link_to "action-undo",
                                    unreport_moderation_path(id: moderation),

--- a/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
@@ -56,7 +56,11 @@
                 </td>
               <% end %>
               <td class="actions">
-
+                <%= icon_link_to "fullscreen-enter",
+                                  moderation_reports_path(moderation_id: moderation),
+                                  t("actions.expand", scope: "decidim.moderations"),
+                                  class: "action-icon--expand",
+                                  method: :get %>
                 <% if !moderation.reportable.hidden? && allowed_to?(:unreport, :moderation) %>
                   <%= icon_link_to "action-undo",
                                    unreport_moderation_path(id: moderation),

--- a/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
@@ -18,10 +18,10 @@
           <tr>
             <th><%= t("models.moderation.fields.reportable_id", scope: "decidim.moderations") %></th>
             <th><%= t("models.moderation.fields.reportable_type", scope: "decidim.moderations") %></th>
-            <th><%= t("models.moderation.fields.report_count", scope: "decidim.moderations") %></th>
+            <th><%= sort_link(query, :report_count, t("models.moderation.fields.report_count", scope: "decidim.moderations")) %></th>
             <th><%= t("models.moderation.fields.reported_content_url", scope: "decidim.moderations") %></th>
             <th><%= t("models.moderation.fields.reports", scope: "decidim.moderations") %></th>
-            <th><%= t("models.moderation.fields.created_at", scope: "decidim.moderations") %></th>
+            <th><%= sort_link(query, :created_at, t("models.moderation.fields.created_at", scope: "decidim.moderations")) %></th>
             <% if params[:hidden] %>
               <th><%= t("models.moderation.fields.hidden_at", scope: "decidim.moderations") %></th>
             <% end %>

--- a/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
@@ -16,10 +16,12 @@
       <table class="table-list">
         <thead>
           <tr>
-            <th><%= t("models.moderation.fields.reportable", scope: "decidim.moderations") %></th>
+            <th><%= t("models.moderation.fields.reportable_id", scope: "decidim.moderations") %></th>
+            <th><%= t("models.moderation.fields.reportable_type", scope: "decidim.moderations") %></th>
+            <th><%= t("models.moderation.fields.report_count", scope: "decidim.moderations") %></th>
             <th><%= t("models.moderation.fields.reported_content_url", scope: "decidim.moderations") %></th>
             <th><%= t("models.moderation.fields.reports", scope: "decidim.moderations") %></th>
-            <th><%= t("models.moderation.fields.report_count", scope: "decidim.moderations") %></th>
+            <th><%= t("models.moderation.fields.created_at", scope: "decidim.moderations") %></th>
             <% if params[:hidden] %>
               <th><%= t("models.moderation.fields.hidden_at", scope: "decidim.moderations") %></th>
             <% end %>
@@ -29,8 +31,12 @@
         <tbody>
           <% moderations.each do |moderation| %>
             <tr data-id="<%= moderation.id %>">
+              <td><%= moderation.reportable.id %></td>
               <td>
                 <%= moderation.reportable.class.name.demodulize %>
+              </td>
+              <td>
+                <%= moderation.report_count %>
               </td>
               <td>
                 <%=
@@ -42,7 +48,7 @@
                 <%= safe_join(reports, ",") %>
               </td>
               <td>
-                <%= moderation.report_count %>
+                <%= l(moderation.created_at, format: :long) %>
               </td>
               <% if params[:hidden] %>
                 <td>

--- a/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
@@ -10,7 +10,7 @@
       </div>
     </h2>
   </div>
-
+  <%= admin_filter_selector(:moderations) %>
   <div class="card-section">
     <div class="table-scroll">
       <table class="table-list">

--- a/decidim-admin/app/views/decidim/admin/moderations/reports/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/reports/index.html.erb
@@ -18,19 +18,18 @@
       <dd><%= moderation.reportable.id %></dd>
 
       <% if translatable_resource?(moderation.reportable) %>
-        <dt><%= t('.content_original_language') %></dt>
+        <dt><%= t(".content_original_language") %></dt>
         <dd><%= locale_name moderation.reportable.content_original_language %> </dd>
       <% end %>
 
       <dt>
-        <%= t('.reported_content') %>
+        <%= t(".reported_content") %>
         <% if translatable_resource?(moderation.reportable) %>
           <button
             class="toggle-content"
-            data-see-original-button-label="<%= t('.see_original') %>"
-            data-see-current-button-label="<%= t('.see_current') %>"
-          >
-            <%= t('.see_original') %>
+            data-see-original-button-label="<%= t(".see_original") %>"
+            data-see-current-button-label="<%= t(".see_current") %>">
+            <%= t(".see_original") %>
           </button>
         <% end %>
       </dt>
@@ -45,7 +44,7 @@
         <% end %>
       </dd>
 
-      <dt><%= t('.author') %></dt>
+      <dt><%= t(".author") %></dt>
       <dd>
         <%= reportable_author_name(moderation.reportable) %>
       </dd>
@@ -56,7 +55,7 @@
       <dt><%= t("models.moderation.fields.created_at", scope: "decidim.moderations") %></dt>
       <dd><%= l(moderation.created_at, format: :long) %></dd>
 
-      <dt><%= t('.participatory_space') %></dt>
+      <dt><%= t(".participatory_space") %></dt>
       <dd><%= translated_attribute moderation.participatory_space.title %></dd>
       </div>
     </dl>
@@ -74,7 +73,7 @@
           <% reports.each do |report| %>
             <tr data-id="<%= report.id %>">
               <td><%= t("decidim.admin.moderations.report.reasons.#{report.reason}") %></td>
-              <td><%= report.locale.present? ? locale_name(report.locale) : '' %></td>
+              <td><%= report.locale.present? ? locale_name(report.locale) : "" %></td>
               <td>
                 <%= reported_content_excerpt_for(moderation.reportable) %>
                 <%= icon_link_to "fullscreen-enter",

--- a/decidim-admin/app/views/decidim/admin/moderations/reports/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/reports/index.html.erb
@@ -65,8 +65,8 @@
           <tr>
             <th><%= t("models.report.fields.reason", scope: "decidim.moderations") %></th>
             <th><%= t("models.report.fields.locale", scope: "decidim.moderations") %></th>
-            <th><%= t(".reported_content") %></th>
             <th><%= t("models.report.fields.details", scope: "decidim.moderations") %></th>
+            <th class="actions"><%= t("actions.title", scope: "decidim.moderations") %></th>
           </tr>
         </thead>
         <tbody>
@@ -74,14 +74,13 @@
             <tr data-id="<%= report.id %>">
               <td><%= t("decidim.admin.moderations.report.reasons.#{report.reason}") %></td>
               <td><%= report.locale.present? ? locale_name(report.locale) : "" %></td>
-              <td>
-                <%= reported_content_excerpt_for(moderation.reportable) %>
+              <td><%= report.details %></td>
+              <td class="actions">
                 <%= icon_link_to "fullscreen-enter",
                                   moderation_report_path(moderation_id: moderation, id: report.id),
                                   t("actions.expand", scope: "decidim.moderations"),
                                   class: "action-icon--expand" %>
               </td>
-              <td><%= report.details %></td>
             </tr>
           <% end %>
         </tbody>

--- a/decidim-admin/app/views/decidim/admin/moderations/reports/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/reports/index.html.erb
@@ -1,0 +1,104 @@
+<div class="card">
+  <div class="card-divider">
+    <h2 class="card-title">
+      <%= link_to "#{t("title", scope: "decidim.admin.moderations.index")} > ", moderations_path %>
+      <%= t(".title") %>
+    </h2>
+  </div>
+  <div class="card-section moderation-details">
+    <div class="callout warning">
+      <%= icon "info" %>
+      <span class="callout-text"><%= t(".callout_html", icon: icon("flag")) %></span>
+    </div>
+    <dl>
+      <dt><%= t("models.moderation.fields.reported_content_url", scope: "decidim.moderations") %></dt>
+      <dd><%= link_to moderation.reportable.reported_content_url, moderation.reportable.reported_content_url, target: "_blank" %></dd>
+
+      <dt><%= t("models.moderation.fields.reportable_id", scope: "decidim.moderations") %></dt>
+      <dd><%= moderation.reportable.id %></dd>
+
+      <% if translatable_resource?(moderation.reportable) %>
+        <dt><%= t('.content_original_language') %></dt>
+        <dd><%= locale_name moderation.reportable.content_original_language %> </dd>
+      <% end %>
+
+      <dt>
+        <%= t('.reported_content') %>
+        <% if translatable_resource?(moderation.reportable) %>
+          <button
+            class="toggle-content"
+            data-see-original-button-label="<%= t('.see_original') %>"
+            data-see-current-button-label="<%= t('.see_current') %>"
+          >
+            <%= t('.see_original') %>
+          </button>
+        <% end %>
+      </dt>
+      <dd class="reported-content">
+        <div class="current">
+          <%= reported_content_for moderation.reportable %>
+        </div>
+        <% if translatable_resource?(moderation.reportable) %>
+          <div class="original">
+            <%= reported_content_for moderation.reportable, locale: moderation.reportable.content_original_language %>
+          </div>
+        <% end %>
+      </dd>
+
+      <dt><%= t('.author') %></dt>
+      <dd>
+        <%= reportable_author_name(moderation.reportable) %>
+      </dd>
+
+      <dt><%= t("models.moderation.fields.reportable_type", scope: "decidim.moderations") %></dt>
+      <dd><%= moderation.reportable.class.name.demodulize %></dd>
+
+      <dt><%= t("models.moderation.fields.created_at", scope: "decidim.moderations") %></dt>
+      <dd><%= l(moderation.created_at, format: :long) %></dd>
+
+      <dt><%= t('.participatory_space') %></dt>
+      <dd><%= translated_attribute moderation.participatory_space.title %></dd>
+      </div>
+    </dl>
+    <div class="table-scroll">
+      <table class="table-list">
+        <thead>
+          <tr>
+            <th><%= t("models.report.fields.reason", scope: "decidim.moderations") %></th>
+            <th><%= t("models.report.fields.locale", scope: "decidim.moderations") %></th>
+            <th><%= t(".reported_content") %></th>
+            <th><%= t("models.report.fields.details", scope: "decidim.moderations") %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% reports.each do |report| %>
+            <tr data-id="<%= report.id %>">
+              <td><%= t("decidim.admin.moderations.report.reasons.#{report.reason}") %></td>
+              <td><%= report.locale.present? ? locale_name(report.locale) : '' %></td>
+              <td>
+                <%= icon_link_to "fullscreen-enter",
+                                  moderation_report_path(moderation_id: moderation, id: report.id),
+                                  t("actions.expand", scope: "decidim.moderations"),
+                                  class: "action-icon--expand",
+                                  method: :get %>
+              </td>
+              <td><%= report.details %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+<div class="button--double form-general-submit">
+  <% if !moderation.reportable.hidden? && allowed_to?(:unreport, :moderation) %>
+    <%= link_to t("actions.unreport", scope: "decidim.moderations"), unreport_moderation_path(id: moderation), method: :put, class: "button" %>
+  <% end %>
+  <% if !moderation.reportable.hidden? && allowed_to?(:hide, :moderation) %>
+    <%= link_to t("actions.hide", scope: "decidim.moderations"), hide_moderation_path(id: moderation), method: :put, class: "button alert" %>
+  <% end %>
+  <% if moderation.reportable.hidden? && allowed_to?(:unhide, :moderation) %>
+    <%= link_to t("actions.unhide", scope: "decidim.moderations"), unhide_moderation_path(id: moderation), method: :put, class: "button alert" %>
+  <% end %>
+</div>

--- a/decidim-admin/app/views/decidim/admin/moderations/reports/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/reports/index.html.erb
@@ -76,11 +76,11 @@
               <td><%= t("decidim.admin.moderations.report.reasons.#{report.reason}") %></td>
               <td><%= report.locale.present? ? locale_name(report.locale) : '' %></td>
               <td>
+                <%= reported_content_excerpt_for(moderation.reportable) %>
                 <%= icon_link_to "fullscreen-enter",
                                   moderation_report_path(moderation_id: moderation, id: report.id),
                                   t("actions.expand", scope: "decidim.moderations"),
-                                  class: "action-icon--expand",
-                                  method: :get %>
+                                  class: "action-icon--expand" %>
               </td>
               <td><%= report.details %></td>
             </tr>

--- a/decidim-admin/app/views/decidim/admin/moderations/reports/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/reports/show.html.erb
@@ -13,7 +13,7 @@
       <dd><%= locale_name @report.locale %></dd>
 
       <% if translatable_resource?(moderation.reportable) %>
-        <dt><%= t('content_original_language', scope: "decidim.admin.moderations.reports.index") %></dt>
+        <dt><%= t("content_original_language", scope: "decidim.admin.moderations.reports.index") %></dt>
         <dd><%= locale_name moderation.reportable.content_original_language %> </dd>
       <% end %>
 
@@ -22,10 +22,9 @@
         <% if translatable_resource?(moderation.reportable) %>
           <button
             class="toggle-content"
-            data-see-original-button-label="<%= t('see_original', scope: "decidim.admin.moderations.reports.index") %>"
-            data-see-current-button-label="<%= t('see_current', scope: "decidim.admin.moderations.reports.index") %>"
-          >
-            <%= t('see_original', scope: "decidim.admin.moderations.reports.index") %>
+            data-see-original-button-label="<%= t("see_original", scope: "decidim.admin.moderations.reports.index") %>"
+            data-see-current-button-label="<%= t("see_current", scope: "decidim.admin.moderations.reports.index") %>">
+            <%= t("see_original", scope: "decidim.admin.moderations.reports.index") %>
           </button>
         <% end %>
       </dt>

--- a/decidim-admin/app/views/decidim/admin/moderations/reports/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/reports/show.html.erb
@@ -1,0 +1,51 @@
+<div class="card">
+  <div class="card-divider">
+    <h2 class="card-title">
+      <%= link_to "#{t("title", scope: "decidim.admin.moderations.index")} > ", moderations_path %>
+      <%= link_to "#{t("title", scope: "decidim.admin.moderations.reports.index")} > ", moderation_reports_path %>
+      <%= t(".title") %>
+    </h2>
+  </div>
+
+  <div class="card-section moderation-details">
+    <dl>
+      <dt><%= t(".report_language") %></dt>
+      <dd><%= locale_name @report.locale %></dd>
+
+      <% if translatable_resource?(moderation.reportable) %>
+        <dt><%= t('content_original_language', scope: "decidim.admin.moderations.reports.index") %></dt>
+        <dd><%= locale_name moderation.reportable.content_original_language %> </dd>
+      <% end %>
+
+      <dt>
+        <%= t("reported_content", scope: "decidim.admin.moderations.reports.index") %>
+        <% if translatable_resource?(moderation.reportable) %>
+          <button
+            class="toggle-content"
+            data-see-original-button-label="<%= t('see_original', scope: "decidim.admin.moderations.reports.index") %>"
+            data-see-current-button-label="<%= t('see_current', scope: "decidim.admin.moderations.reports.index") %>"
+          >
+            <%= t('see_original', scope: "decidim.admin.moderations.reports.index") %>
+          </button>
+        <% end %>
+      </dt>
+      <dd class="reported-content">
+        <div class="current">
+          <%= reported_content_for moderation.reportable, locale: @report.locale %>
+        </div>
+        <% if translatable_resource?(moderation.reportable) %>
+          <div class="original">
+            <%= reported_content_for moderation.reportable, locale: moderation.reportable.content_original_language %>
+          </div>
+        <% end %>
+      </dd>
+
+      <dt><%= t(".report_reason") %></dt>
+      <dd><%= t("decidim.admin.moderations.report.reasons.#{@report.reason}") %></dd>
+
+      <dt><%= t(".report_details") %></dt>
+      <dd><%= @report.details %>
+      </div>
+    </dl>
+  </div>
+</div>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -829,9 +829,11 @@ en:
       models:
         moderation:
           fields:
+            created_at: Creation date
             hidden_at: Hidden at
             report_count: Count
-            reportable: Reportable
+            reportable_id: Id
+            reportable_type: Type
             reported_content_url: Reported content URL
             reports: Reports
             visit_url: Visit URL

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -300,6 +300,9 @@ en:
         category_id_eq:
           label: Category
         filter_label: Filter
+        moderations:
+          reportable_type_string_eq:
+            label: Type
         officialized_at_null:
           label: State
           values:
@@ -320,13 +323,10 @@ en:
         search_label: Search
         search_placeholder:
           name_or_nickname_or_email_cont: Search %{collection} by email, name or nickname.
-          title_cont: Search %{collection} by title.
           reported_id_string_or_reported_content_cont: Search %{collection} by reportable id or content.
+          title_cont: Search %{collection} by title.
         state_eq:
           label: State
-        moderations:
-          reportable_type_string_eq:
-            label: "Type"
       help_sections:
         error: There was a problem updating the help sections
         form:

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -478,6 +478,21 @@ en:
             state: State
             users_count: Participants count
       moderations:
+        reports:
+          index:
+            title: "Moderation reports"
+            callout_html: A content appears in the moderation panel when it has been signaled by a user (can be anyone with a registered account) by clicking on the %{icon} flag next to the item.
+            content_original_language: "Content original language"
+            reported_content: "Reported content"
+            author: "Author(s)"
+            participatory_space: "Participatory space"
+            see_original: "See original"
+            see_current: "See current"
+          show:
+            title: Report details
+            report_reason: "Reason"
+            report_details: "Reason details"
+            report_language: "Report language"
         index:
           title: Moderations
         report:
@@ -819,6 +834,7 @@ en:
         title: Actions
         unhide: Unhide
         unreport: Unreport
+        expand: Expand
       admin:
         reportable:
           hide:
@@ -831,6 +847,11 @@ en:
             invalid: There was a problem unreporting the resource.
             success: Resource successfully unreported.
       models:
+        report:
+          fields:
+            reason: "Reason"
+            details: "Reason details"
+            locale: "Language"
         moderation:
           fields:
             created_at: Creation date

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -321,8 +321,12 @@ en:
         search_placeholder:
           name_or_nickname_or_email_cont: Search %{collection} by email, name or nickname.
           title_cont: Search %{collection} by title.
+          reportable_id_string_cont: Search %{collection} by reportable id.
         state_eq:
           label: State
+        moderations:
+          reportable_type_string_eq:
+            label: "Type"
       help_sections:
         error: There was a problem updating the help sections
         form:

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -321,7 +321,7 @@ en:
         search_placeholder:
           name_or_nickname_or_email_cont: Search %{collection} by email, name or nickname.
           title_cont: Search %{collection} by title.
-          reportable_id_string_cont: Search %{collection} by reportable id.
+          reported_id_string_or_reported_content_cont: Search %{collection} by reportable id or content.
         state_eq:
           label: State
         moderations:

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -478,21 +478,6 @@ en:
             state: State
             users_count: Participants count
       moderations:
-        reports:
-          index:
-            title: "Moderation reports"
-            callout_html: A content appears in the moderation panel when it has been signaled by a user (can be anyone with a registered account) by clicking on the %{icon} flag next to the item.
-            content_original_language: "Content original language"
-            reported_content: "Reported content"
-            author: "Author(s)"
-            participatory_space: "Participatory space"
-            see_original: "See original"
-            see_current: "See current"
-          show:
-            title: Report details
-            report_reason: "Reason"
-            report_details: "Reason details"
-            report_language: "Report language"
         index:
           title: Moderations
         report:
@@ -500,6 +485,21 @@ en:
             does_not_belong: Does not belong
             offensive: Offensive
             spam: Spam
+        reports:
+          index:
+            author: Author(s)
+            callout_html: A content appears in the moderation panel when it has been signaled by a user (can be anyone with a registered account) by clicking on the %{icon} flag next to the item.
+            content_original_language: Content original language
+            participatory_space: Participatory space
+            reported_content: Reported content
+            see_current: See current
+            see_original: See original
+            title: Moderation reports
+          show:
+            report_details: Reason details
+            report_language: Report language
+            report_reason: Reason
+            title: Report details
       newsletter_templates:
         index:
           preview_template: Preview
@@ -828,13 +828,13 @@ en:
           reason: You need to provide a reason when managing a non managed participant
     moderations:
       actions:
+        expand: Expand
         hidden: Hidden
         hide: Hide
         not_hidden: Not hidden
         title: Actions
         unhide: Unhide
         unreport: Unreport
-        expand: Expand
       admin:
         reportable:
           hide:
@@ -847,11 +847,6 @@ en:
             invalid: There was a problem unreporting the resource.
             success: Resource successfully unreported.
       models:
-        report:
-          fields:
-            reason: "Reason"
-            details: "Reason details"
-            locale: "Language"
         moderation:
           fields:
             created_at: Creation date
@@ -862,6 +857,11 @@ en:
             reported_content_url: Reported content URL
             reports: Reports
             visit_url: Visit URL
+        report:
+          fields:
+            details: Reason details
+            locale: Language
+            reason: Reason
   errors:
     messages:
       invalid_json: Invalid JSON

--- a/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
@@ -3,7 +3,7 @@
 shared_examples "manage moderations" do
   let!(:moderations) do
     reportables.first(reportables.length - 1).map do |reportable|
-      moderation = create(:moderation, reportable: reportable, report_count: 1, reported_content: reportable.reported_content)
+      moderation = create(:moderation, reportable: reportable, report_count: 1, reported_content: reportable.reported_searchable_content_text)
       create(:report, moderation: moderation)
       moderation
     end
@@ -11,7 +11,7 @@ shared_examples "manage moderations" do
   let!(:moderation) { moderations.first }
   let!(:hidden_moderations) do
     reportables.last(1).map do |reportable|
-      moderation = create(:moderation, reportable: reportable, report_count: 3, reported_content: reportable.reported_content, hidden_at: Time.current)
+      moderation = create(:moderation, reportable: reportable, report_count: 3, reported_content: reportable.reported_searchable_content_text, hidden_at: Time.current)
       create_list(:report, 3, moderation: moderation, reason: :spam)
       moderation
     end

--- a/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
@@ -50,7 +50,7 @@ shared_examples "manage moderations" do
     end
 
     it "user can sort by report count" do
-      moderations.each { |moderation| moderation.update(report_count: rand(1..5)) }
+      moderations.each_with_index { |moderation, index| moderation.update(report_count: index + 1) }
       moderations_ordered_by_report_count_asc = moderations.sort_by(&:report_count)
 
       within "table" do

--- a/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
@@ -3,7 +3,7 @@
 shared_examples "manage moderations" do
   let!(:moderations) do
     reportables.first(reportables.length - 1).map do |reportable|
-      moderation = create(:moderation, reportable: reportable, report_count: 1)
+      moderation = create(:moderation, reportable: reportable, report_count: 1, reported_content: reportable.reported_content)
       create(:report, moderation: moderation)
       moderation
     end
@@ -11,7 +11,7 @@ shared_examples "manage moderations" do
   let!(:moderation) { moderations.first }
   let!(:hidden_moderations) do
     reportables.last(1).map do |reportable|
-      moderation = create(:moderation, reportable: reportable, report_count: 3, hidden_at: Time.current)
+      moderation = create(:moderation, reportable: reportable, report_count: 3, reported_content: reportable.reported_content, hidden_at: Time.current)
       create_list(:report, 3, moderation: moderation, reason: :spam)
       moderation
     end
@@ -71,6 +71,15 @@ shared_examples "manage moderations" do
         click_link reportable_type
       end
       expect(page).to have_selector("tbody tr", count: moderations.length)
+    end
+
+    it "user can filter by reported content" do
+      search = moderation.reportable.id
+      within ".filters__section" do
+        fill_in("Search Moderation by reportable id or content.", with: search)
+        find(:xpath, "//button[@type='submit']").click
+      end
+      expect(page).to have_selector("tbody tr", count: 1)
     end
   end
 

--- a/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
@@ -62,6 +62,16 @@ shared_examples "manage moderations" do
         end
       end
     end
+
+    it "user can filter by reportable type" do
+      reportable_type = moderation.reportable.class.name.demodulize
+      within ".filters__section" do
+        find(:xpath, "//a[contains(text(), 'Filter')]").hover
+        find(:xpath, "//a[contains(text(), 'Type')]").hover
+        click_link reportable_type
+      end
+      expect(page).to have_selector("tbody tr", count: moderations.length)
+    end
   end
 
   context "when listing hidden resources" do

--- a/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
@@ -81,6 +81,15 @@ shared_examples "manage moderations" do
       end
       expect(page).to have_selector("tbody tr", count: 1)
     end
+
+    it "user can see moderation details" do
+      within "tr[data-id=\"#{moderation.id}\"]" do
+        click_link "Expand"
+      end
+
+      reported_content_slice = moderation.reportable.reported_searchable_content_text.split("\n").first
+      expect(page).to have_content(reported_content_slice)
+    end
   end
 
   context "when listing hidden resources" do

--- a/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
@@ -48,6 +48,20 @@ shared_examples "manage moderations" do
       expect(page).to have_admin_callout("Resource successfully hidden")
       expect(page).to have_no_content(moderation.reportable.reported_content_url)
     end
+
+    it "user can sort by report count" do
+      moderations.each { |moderation| moderation.update(report_count: rand(1..5)) }
+      moderations_ordered_by_report_count_asc = moderations.sort_by(&:report_count)
+
+      within "table" do
+        click_link "Count"
+
+        all("tbody tr").each_with_index do |row, index|
+          reportable_id = moderations_ordered_by_report_count_asc[index].reportable.id
+          expect(row.find("td:first-child")).to have_content(reportable_id)
+        end
+      end
+    end
   end
 
   context "when listing hidden resources" do

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/moderations/reports_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/moderations/reports_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Assemblies
+    module Admin
+      module Moderations
+        # This controller allows admins to manage moderation reports in an assembly.
+        class ReportsController < Decidim::Admin::Moderations::ReportsController
+          include Concerns::AssemblyAdmin
+        end
+      end
+    end
+  end
+end

--- a/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
@@ -58,6 +58,7 @@ module Decidim
               put :hide
               put :unhide
             end
+            resources :reports, controller: "moderations/reports", only: [:index, :show]
           end
 
           resources :participatory_space_private_users, controller: "participatory_space_private_users" do

--- a/decidim-comments/app/models/decidim/comments/comment.rb
+++ b/decidim-comments/app/models/decidim/comments/comment.rb
@@ -130,6 +130,14 @@ module Decidim
         end
       end
 
+      # Public: Overrides the `reported_content` Reportable concern method.
+      def reported_content
+        [
+          normalized_author.name,
+          body.values.join("\n")
+        ].join("\n")
+      end
+
       def self.export_serializer
         Decidim::Comments::CommentSerializer
       end

--- a/decidim-comments/app/models/decidim/comments/comment.rb
+++ b/decidim-comments/app/models/decidim/comments/comment.rb
@@ -130,12 +130,14 @@ module Decidim
         end
       end
 
-      # Public: Overrides the `reported_content` Reportable concern method.
-      def reported_content
-        [
-          normalized_author.name,
-          body.values.join("\n")
-        ].join("\n")
+      # Public: Overrides the `reported_attributes` Reportable concern method.
+      def reported_attributes
+        [:body]
+      end
+
+      # Public: Overrides the `reported_searchable_content_extras` Reportable concern method.
+      def reported_searchable_content_extras
+        [normalized_author.name]
       end
 
       def self.export_serializer

--- a/decidim-conferences/app/controllers/decidim/conferences/admin/moderations/reports_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/admin/moderations/reports_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Conferences
+    module Admin
+      module Moderations
+        # This controller allows admins to manage moderation reports in an conference.
+        class ReportsController < Decidim::Admin::Moderations::ReportsController
+          include Concerns::ConferenceAdmin
+        end
+      end
+    end
+  end
+end

--- a/decidim-conferences/lib/decidim/conferences/admin_engine.rb
+++ b/decidim-conferences/lib/decidim/conferences/admin_engine.rb
@@ -69,6 +69,7 @@ module Decidim
               put :hide
               put :unhide
             end
+            resources :reports, controller: "moderations/reports", only: [:index, :show]
           end
         end
 

--- a/decidim-core/app/cells/decidim/reported_content/show.erb
+++ b/decidim-core/app/cells/decidim/reported_content/show.erb
@@ -1,0 +1,5 @@
+<blockquote>
+  <% model.reported_attributes.each do |attribute_name| %>
+    <p><%= render_value(model.attributes.with_indifferent_access[attribute_name]) %></p>
+  <% end %>
+</blockquote>

--- a/decidim-core/app/cells/decidim/reported_content_cell.rb
+++ b/decidim-core/app/cells/decidim/reported_content_cell.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This cell renders a specific cells for the resource if it was configured
+  # in the component's manifest or a default cell.
+  class ReportedContentCell < Decidim::ViewModel
+    def show
+      if resource_cell?
+        cell(resource_cell, model, options)
+      else
+        render :show
+      end
+    end
+
+    private
+
+    def render_value(value)
+      content = I18n.with_locale(options.fetch(:locale, I18n.locale)) do
+        if value.is_a? Hash
+          translated_attribute(value)
+        else
+          value
+        end
+      end
+      simple_format(content, sanitize: true)
+    end
+
+    def resource_cell?
+      resource_cell.present?
+    end
+
+    def resource_cell
+      @resource_cell ||= resource_reported_content
+    end
+
+    def resource_reported_content
+      resource_manifest&.reported_content.presence
+    end
+
+    def resource_manifest
+      model.try(:resource_manifest) || Decidim.find_resource_manifest(model.class)
+    end
+  end
+end

--- a/decidim-core/app/cells/decidim/reported_content_cell.rb
+++ b/decidim-core/app/cells/decidim/reported_content_cell.rb
@@ -34,7 +34,7 @@ module Decidim
     end
 
     def resource_reported_content
-      resource_manifest&.reported_content.presence
+      resource_manifest&.reported_content_cell.presence
     end
 
     def resource_manifest

--- a/decidim-core/app/commands/decidim/create_report.rb
+++ b/decidim-core/app/commands/decidim/create_report.rb
@@ -25,6 +25,7 @@ module Decidim
 
       transaction do
         find_or_create_moderation!
+        update_reported_content!
         create_report!
         update_report_count!
       end
@@ -45,6 +46,10 @@ module Decidim
 
     def find_or_create_moderation!
       @moderation = Moderation.find_or_create_by!(reportable: @reportable, participatory_space: participatory_space)
+    end
+
+    def update_reported_content!
+      @moderation.update!(reported_content: @reportable.reported_content)
     end
 
     def create_report!

--- a/decidim-core/app/commands/decidim/create_report.rb
+++ b/decidim-core/app/commands/decidim/create_report.rb
@@ -57,7 +57,8 @@ module Decidim
         moderation: @moderation,
         user: @current_user,
         reason: form.reason,
-        details: form.details
+        details: form.details,
+        locale: I18n.locale
       )
     end
 

--- a/decidim-core/app/commands/decidim/create_report.rb
+++ b/decidim-core/app/commands/decidim/create_report.rb
@@ -49,7 +49,7 @@ module Decidim
     end
 
     def update_reported_content!
-      @moderation.update!(reported_content: @reportable.reported_content)
+      @moderation.update!(reported_content: @reportable.reported_searchable_content_text)
     end
 
     def create_report!

--- a/decidim-core/app/models/decidim/moderation.rb
+++ b/decidim-core/app/models/decidim/moderation.rb
@@ -15,5 +15,13 @@ module Decidim
     def self.log_presenter_class_for(_log)
       Decidim::AdminLog::ModerationPresenter
     end
+
+    ransacker :reportable_id_string do
+      Arel.sql(%{cast("decidim_moderations"."decidim_reportable_id" as text)})
+    end
+
+    ransacker :reportable_type_string do
+      Arel.sql(%{cast("decidim_moderations"."decidim_reportable_type" as text)})
+    end
   end
 end

--- a/decidim-core/app/models/decidim/moderation.rb
+++ b/decidim-core/app/models/decidim/moderation.rb
@@ -16,8 +16,12 @@ module Decidim
       Decidim::AdminLog::ModerationPresenter
     end
 
-    ransacker :reportable_id_string do
+    ransacker :reported_id_string do
       Arel.sql(%{cast("decidim_moderations"."decidim_reportable_id" as text)})
+    end
+
+    ransacker :reported_content do
+      Arel.sql(%{cast("decidim_moderations"."reported_content" as text)})
     end
 
     ransacker :reportable_type_string do

--- a/decidim-core/db/migrate/20201013071533_add_reported_content_to_moderations.rb
+++ b/decidim-core/db/migrate/20201013071533_add_reported_content_to_moderations.rb
@@ -1,0 +1,5 @@
+class AddReportedContentToModerations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_moderations, :reported_content, :text
+  end
+end

--- a/decidim-core/db/migrate/20201013071533_add_reported_content_to_moderations.rb
+++ b/decidim-core/db/migrate/20201013071533_add_reported_content_to_moderations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddReportedContentToModerations < ActiveRecord::Migration[5.2]
   def change
     add_column :decidim_moderations, :reported_content, :text

--- a/decidim-core/db/migrate/20201019074554_add_locale_to_moderation_reports.rb
+++ b/decidim-core/db/migrate/20201019074554_add_locale_to_moderation_reports.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLocaleToModerationReports < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_reports, :locale, :string
+  end
+end

--- a/decidim-core/lib/decidim/reportable.rb
+++ b/decidim-core/lib/decidim/reportable.rb
@@ -63,6 +63,7 @@ module Decidim
           reported_attributes.map do |attribute_name|
             attribute_value = attributes.with_indifferent_access[attribute_name]
             next attribute_value.values.join("\n") if attribute_value.is_a? Hash
+
             attribute_value
           end
         ).join("\n")

--- a/decidim-core/lib/decidim/reportable.rb
+++ b/decidim-core/lib/decidim/reportable.rb
@@ -42,6 +42,12 @@ module Decidim
       def reported_content_url
         raise NotImplementedError
       end
+
+      # Public: The reported content in a text format so moderations can
+      #         be filtered by content.
+      def reported_content
+        raise NotImplementedError
+      end
     end
   end
 end

--- a/decidim-core/lib/decidim/reportable.rb
+++ b/decidim-core/lib/decidim/reportable.rb
@@ -43,10 +43,29 @@ module Decidim
         raise NotImplementedError
       end
 
-      # Public: The reported content in a text format so moderations can
-      #         be filtered by content.
-      def reported_content
+      # Public: The collection of attribute names that are considered
+      #         to be reportable.
+      def reported_attributes
         raise NotImplementedError
+      end
+
+      # Public: An `Array` of `String` that will be concatenated to
+      #         the reported searchable content. This content is used
+      #         in the admin dashboard to filter moderations.
+      def reported_searchable_content_extras
+        []
+      end
+
+      # Public: The reported searchable content in a text format so
+      #         moderations can be filtered by content.
+      def reported_searchable_content_text
+        reported_searchable_content_extras.concat(
+          reported_attributes.map do |attribute_name|
+            attribute_value = attributes.with_indifferent_access[attribute_name]
+            next attribute_value.values.join("\n") if attribute_value.is_a? Hash
+            attribute_value
+          end
+        ).join("\n")
       end
     end
   end

--- a/decidim-core/lib/decidim/resource_manifest.rb
+++ b/decidim-core/lib/decidim/resource_manifest.rb
@@ -36,6 +36,9 @@ module Decidim
     # The main card to render an instance of the resource.
     attribute :card, String
 
+    # The reported content to render an instance of the resource.
+    attribute :reported_content, String
+
     # Set this to `true` if you want this resource to be searchable. It requires
     # the model to include the `Decidim::Searchable` concern.
     attribute :searchable, Boolean, default: false

--- a/decidim-core/lib/decidim/resource_manifest.rb
+++ b/decidim-core/lib/decidim/resource_manifest.rb
@@ -37,7 +37,7 @@ module Decidim
     attribute :card, String
 
     # The reported content to render an instance of the resource.
-    attribute :reported_content, String
+    attribute :reported_content_cell, String
 
     # Set this to `true` if you want this resource to be searchable. It requires
     # the model to include the `Decidim::Searchable` concern.

--- a/decidim-core/lib/decidim/translatable_resource.rb
+++ b/decidim-core/lib/decidim/translatable_resource.rb
@@ -73,6 +73,15 @@ module Decidim
           errors.add(field, :invalid)
         end
       end
+
+      # Public: Returns the original language in which the resource was created or
+      #         the organization's default locale.
+      def content_original_language
+        field = self.class.translatable_fields_list.first
+        return field.except("machine_translations").keys.first if field.is_a?(Hash) && field.except("machine_translations").keys.count == 1
+
+        organization.default_locale
+      end
     end
   end
 end

--- a/decidim-core/spec/commands/decidim/create_report_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_report_spec.rb
@@ -59,7 +59,7 @@ module Decidim
           command.call
           last_moderation = Moderation.last
 
-          expect(last_moderation.reported_content).to eq(reportable.reported_content)
+          expect(last_moderation.reported_content).to eq(reportable.reported_searchable_content_text)
         end
 
         it "sends an email to the admin" do

--- a/decidim-core/spec/commands/decidim/create_report_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_report_spec.rb
@@ -62,6 +62,14 @@ module Decidim
           expect(last_moderation.reported_content).to eq(reportable.reported_searchable_content_text)
         end
 
+        it "stores the current locale to the report" do
+          I18n.with_locale :ca do
+            command.call
+            last_report = Report.last
+            expect(last_report.locale).to eq("ca")
+          end
+        end
+
         it "sends an email to the admin" do
           allow(ReportedMailer).to receive(:report).and_call_original
           command.call

--- a/decidim-core/spec/commands/decidim/create_report_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_report_spec.rb
@@ -55,6 +55,13 @@ module Decidim
           expect(last_moderation.reportable).to eq(reportable)
         end
 
+        it "updates the moderation to include the reported content" do
+          command.call
+          last_moderation = Moderation.last
+
+          expect(last_moderation.reported_content).to eq(reportable.reported_content)
+        end
+
         it "sends an email to the admin" do
           allow(ReportedMailer).to receive(:report).and_call_original
           command.call

--- a/decidim-debates/app/cells/decidim/debates/reported_content/show.erb
+++ b/decidim-debates/app/cells/decidim/debates/reported_content/show.erb
@@ -1,0 +1,4 @@
+<blockquote>
+  <h5><%= render_value model.title %></h5>
+  <p><%= render_value model.description %></p>
+</blockquote>

--- a/decidim-debates/app/cells/decidim/debates/reported_content_cell.rb
+++ b/decidim-debates/app/cells/decidim/debates/reported_content_cell.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Debates
+    # This cells renders a small preview of the `Debate` that is
+    # used in the moderations panel.
+    class ReportedContentCell < Decidim::ReportedContentCell
+      def show
+        render :show
+      end
+    end
+  end
+end

--- a/decidim-debates/app/models/decidim/debates/debate.rb
+++ b/decidim-debates/app/models/decidim/debates/debate.rb
@@ -62,14 +62,14 @@ module Decidim
         ResourceLocatorPresenter.new(self).url
       end
 
-      # Public: Overrides the `reported_content` Reportable concern method.
-      def reported_content
-        [
-          normalized_author.name,
-          title.values.join("\n"),
-          description.values.join("\n"),
-          instructions.values.join("\n")
-        ].join("\n")
+      # Public: Overrides the `reported_attributes` Reportable concern method.
+      def reported_attributes
+        [:title, :description]
+      end
+
+      # Public: Overrides the `reported_searchable_content_extras` Reportable concern method.
+      def reported_searchable_content_extras
+        [normalized_author.name]
       end
 
       # Public: Calculates whether the current debate is an AMA-styled one or not.

--- a/decidim-debates/app/models/decidim/debates/debate.rb
+++ b/decidim-debates/app/models/decidim/debates/debate.rb
@@ -62,6 +62,16 @@ module Decidim
         ResourceLocatorPresenter.new(self).url
       end
 
+      # Public: Overrides the `reported_content` Reportable concern method.
+      def reported_content
+        [
+          normalized_author.name,
+          title.values.join("\n"),
+          description.values.join("\n"),
+          instructions.values.join("\n")
+        ].join("\n")
+      end
+
       # Public: Calculates whether the current debate is an AMA-styled one or not.
       # AMA-styled debates are those that have a start and end time set, and comments
       # are only open during that timelapse. AMA stands for Ask Me Anything, a type

--- a/decidim-debates/lib/decidim/debates/component.rb
+++ b/decidim-debates/lib/decidim/debates/component.rb
@@ -50,6 +50,7 @@ Decidim.register_component(:debates) do |component|
   component.register_resource(:debate) do |resource|
     resource.model_class_name = "Decidim::Debates::Debate"
     resource.card = "decidim/debates/debate"
+    resource.reported_content = "decidim/debates/reported_content"
     resource.searchable = true
     resource.actions = %w(create endorse)
   end

--- a/decidim-debates/lib/decidim/debates/component.rb
+++ b/decidim-debates/lib/decidim/debates/component.rb
@@ -50,7 +50,7 @@ Decidim.register_component(:debates) do |component|
   component.register_resource(:debate) do |resource|
     resource.model_class_name = "Decidim::Debates::Debate"
     resource.card = "decidim/debates/debate"
-    resource.reported_content = "decidim/debates/reported_content"
+    resource.reported_content_cell = "decidim/debates/reported_content"
     resource.searchable = true
     resource.actions = %w(create endorse)
   end

--- a/decidim-debates/spec/cells/decidim/debates/reported_content_cell_spec.rb
+++ b/decidim-debates/spec/cells/decidim/debates/reported_content_cell_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Debates
+  describe ReportedContentCell, type: :cell do
+    controller Decidim::Debates::DebatesController
+
+    let!(:debate) { create(:debate, title: { "en" => "the debate's title" }, description: { "en" => "the debate's description" }) }
+
+    context "when rendering" do
+      it "renders the debate's title and description" do
+        html = cell("decidim/reported_content", debate).call
+        expect(html).to have_content("the debate's title")
+        expect(html).to have_content("the debate's description")
+      end
+    end
+  end
+end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
@@ -93,10 +93,12 @@ module Decidim
         ResourceLocatorPresenter.new(self).url
       end
 
-      def reported_content
-        [
-          normalized_author.name
-        ].join("\n")
+      def reported_attributes
+        [:title]
+      end
+
+      def reported_searchable_content_extras
+        [normalized_author.name]
       end
 
       def allow_resource_permissions?

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
@@ -93,6 +93,12 @@ module Decidim
         ResourceLocatorPresenter.new(self).url
       end
 
+      def reported_content
+        [
+          normalized_author.name
+        ].join("\n")
+      end
+
       def allow_resource_permissions?
         component.settings.resources_permissions_enabled
       end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/moderations/reports_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/moderations/reports_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Initiatives
+    module Admin
+      module Moderations
+        # This controller allows admins to manage moderation reports in an conference.
+        class ReportsController < Decidim::Admin::Moderations::ReportsController
+          include InitiativeAdmin
+
+          def permissions_context
+            super.merge(current_participatory_space: current_participatory_space)
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
@@ -64,6 +64,7 @@ module Decidim
               put :hide
               put :unhide
             end
+            resources :reports, controller: "moderations/reports", only: [:index]
           end
         end
 

--- a/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
@@ -64,7 +64,7 @@ module Decidim
               put :hide
               put :unhide
             end
-            resources :reports, controller: "moderations/reports", only: [:index]
+            resources :reports, controller: "moderations/reports", only: [:index, :show]
           end
         end
 

--- a/decidim-meetings/app/cells/decidim/meetings/reported_content/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/reported_content/show.erb
@@ -1,0 +1,3 @@
+<blockquote>
+  <%= render_value model.description %>
+</blockquote>

--- a/decidim-meetings/app/cells/decidim/meetings/reported_content_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/reported_content_cell.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    # This cells renders a small preview of the `Meeting` that is
+    # used in the moderations panel.
+    class ReportedContentCell < Decidim::ReportedContentCell
+      def show
+        render :show
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -194,7 +194,7 @@ module Decidim
           description.values.join("\n"),
           location.values.join("\n"),
           location_hints.values.join("\n"),
-          registration_terms.values.join("\n")
+          registration_terms.present? ? registration_terms.values.join("\n") : ""
         ].join("\n")
       end
 

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -187,6 +187,17 @@ module Decidim
         ResourceLocatorPresenter.new(self).url
       end
 
+      # Public: Overrides the `reported_content` Reportable concern method.
+      def reported_content
+        [
+          normalized_author.name,
+          description.values.join("\n"),
+          location.values.join("\n"),
+          location_hints.values.join("\n"),
+          registration_terms.values.join("\n")
+        ].join("\n")
+      end
+
       def online_meeting?
         type_of_meeting == "online"
       end

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -187,15 +187,14 @@ module Decidim
         ResourceLocatorPresenter.new(self).url
       end
 
-      # Public: Overrides the `reported_content` Reportable concern method.
-      def reported_content
-        [
-          normalized_author.name,
-          description.values.join("\n"),
-          location.values.join("\n"),
-          location_hints.values.join("\n"),
-          registration_terms.present? ? registration_terms.values.join("\n") : ""
-        ].join("\n")
+      # Public: Overrides the `reported_attributes` Reportable concern method.
+      def reported_attributes
+        [:description]
+      end
+
+      # Public: Overrides the `reported_searchable_content_extras` Reportable concern method.
+      def reported_searchable_content_extras
+        [normalized_author.name]
       end
 
       def online_meeting?

--- a/decidim-meetings/lib/decidim/meetings/component.rb
+++ b/decidim-meetings/lib/decidim/meetings/component.rb
@@ -19,7 +19,7 @@ Decidim.register_component(:meetings) do |component|
     resource.model_class_name = "Decidim::Meetings::Meeting"
     resource.template = "decidim/meetings/meetings/linked_meetings"
     resource.card = "decidim/meetings/meeting"
-    resource.reported_content = "decidim/meetings/reported_content"
+    resource.reported_content_cell = "decidim/meetings/reported_content"
     resource.actions = %w(join)
     resource.searchable = true
   end

--- a/decidim-meetings/lib/decidim/meetings/component.rb
+++ b/decidim-meetings/lib/decidim/meetings/component.rb
@@ -19,6 +19,7 @@ Decidim.register_component(:meetings) do |component|
     resource.model_class_name = "Decidim::Meetings::Meeting"
     resource.template = "decidim/meetings/meetings/linked_meetings"
     resource.card = "decidim/meetings/meeting"
+    resource.reported_content = "decidim/meetings/reported_content"
     resource.actions = %w(join)
     resource.searchable = true
   end

--- a/decidim-meetings/spec/cells/decidim/meetings/reported_content_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/reported_content_cell_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Meetings
+  describe ReportedContentCell, type: :cell do
+    controller Decidim::Meetings::MeetingsController
+
+    let!(:meeting) { create(:meeting, description: { "en" => "the meeting's description" }) }
+
+    context "when rendering" do
+      it "renders the meeting's description" do
+        html = cell("decidim/reported_content", meeting).call
+        expect(html).to have_content("the meeting's description")
+      end
+    end
+  end
+end

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/moderations/reports_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/moderations/reports_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ParticipatoryProcesses
+    module Admin
+      module Moderations
+        # This controller allows admins to manage moderation reports in a participatory process.
+        class ReportsController < Decidim::Admin::Moderations::ReportsController
+          include Concerns::ParticipatoryProcessAdmin
+
+          def permissions_context
+            super.merge(current_participatory_space: current_participatory_space)
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
@@ -60,7 +60,9 @@ module Decidim
               put :hide
               put :unhide
             end
+            resources :reports, controller: "moderations/reports", only: [:index, :show]
           end
+
           resources :participatory_space_private_users, controller: "participatory_space_private_users" do
             member do
               post :resend_invitation, to: "participatory_space_private_users#resend_invitation"

--- a/decidim-proposals/app/cells/decidim/proposals/collaborative_drafts/reported_content/show.erb
+++ b/decidim-proposals/app/cells/decidim/proposals/collaborative_drafts/reported_content/show.erb
@@ -1,0 +1,3 @@
+<blockquote>
+  <p><%= render_value model.body %></p>
+</blockquote>

--- a/decidim-proposals/app/cells/decidim/proposals/collaborative_drafts/reported_content_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/collaborative_drafts/reported_content_cell.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    module CollaborativeDrafts
+      # This cells renders a small preview of the `CollaborativeDraft` that is
+      # used in the moderations panel.
+      class ReportedContentCell < Decidim::ReportedContentCell
+        def show
+          render :show
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/cells/decidim/proposals/reported_content/show.erb
+++ b/decidim-proposals/app/cells/decidim/proposals/reported_content/show.erb
@@ -1,0 +1,4 @@
+<blockquote>
+  <h5><%= render_value model.title %></h5>
+  <p><%= render_value model.body %></p>
+</blockquote>

--- a/decidim-proposals/app/cells/decidim/proposals/reported_content_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/reported_content_cell.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    # This cells renders a small preview of the `Proposal` that is
+    # used in the moderations panel.
+    class ReportedContentCell < Decidim::ReportedContentCell
+      def show
+        render :show
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/models/decidim/proposals/collaborative_draft.rb
+++ b/decidim-proposals/app/models/decidim/proposals/collaborative_draft.rb
@@ -58,6 +58,14 @@ module Decidim
       def reported_content_url
         ResourceLocatorPresenter.new(self).url
       end
+
+      # Public: Overrides the `reported_content` Reportable concern method.
+      def reported_content
+        [
+          authors.map(&:name).join("\n"),
+          body
+        ].join("\n")
+      end
     end
   end
 end

--- a/decidim-proposals/app/models/decidim/proposals/collaborative_draft.rb
+++ b/decidim-proposals/app/models/decidim/proposals/collaborative_draft.rb
@@ -59,12 +59,14 @@ module Decidim
         ResourceLocatorPresenter.new(self).url
       end
 
-      # Public: Overrides the `reported_content` Reportable concern method.
-      def reported_content
-        [
-          authors.map(&:name).join("\n"),
-          body
-        ].join("\n")
+      # Public: Overrides the `reported_attributes` Reportable concern method.
+      def reported_attributes
+        [:body]
+      end
+
+      # Public: Overrides the `reported_searchable_content_extras` Reportable concern method.
+      def reported_searchable_content_extras
+        [authors.map(&:name).join("\n")]
       end
     end
   end

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -225,13 +225,14 @@ module Decidim
         ResourceLocatorPresenter.new(self).url
       end
 
-      # Public: Overrides the `reported_content` Reportable concern method.
-      def reported_content
-        [
-          authors.map(&:name).join("\n"),
-          title.values.join("\n"),
-          body.values.join("\n")
-        ].join("\n")
+      # Public: Overrides the `reported_attributes` Reportable concern method.
+      def reported_attributes
+        [:title, :body]
+      end
+
+      # Public: Overrides the `reported_searchable_content_extras` Reportable concern method.
+      def reported_searchable_content_extras
+        [authors.map(&:name).join("\n")]
       end
 
       # Public: Whether the proposal is official or not.

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -225,6 +225,15 @@ module Decidim
         ResourceLocatorPresenter.new(self).url
       end
 
+      # Public: Overrides the `reported_content` Reportable concern method.
+      def reported_content
+        [
+          authors.map(&:name).join("\n"),
+          title.values.join("\n"),
+          body.values.join("\n")
+        ].join("\n")
+      end
+
       # Public: Whether the proposal is official or not.
       def official?
         authors.first.is_a?(Decidim::Organization)

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -80,7 +80,7 @@ Decidim.register_component(:proposals) do |component|
     resource.model_class_name = "Decidim::Proposals::Proposal"
     resource.template = "decidim/proposals/proposals/linked_proposals"
     resource.card = "decidim/proposals/proposal"
-    resource.reported_content = "decidim/proposals/reported_content"
+    resource.reported_content_cell = "decidim/proposals/reported_content"
     resource.actions = %w(endorse vote amend)
     resource.searchable = true
   end
@@ -88,7 +88,7 @@ Decidim.register_component(:proposals) do |component|
   component.register_resource(:collaborative_draft) do |resource|
     resource.model_class_name = "Decidim::Proposals::CollaborativeDraft"
     resource.card = "decidim/proposals/collaborative_draft"
-    resource.reported_content = "decidim/proposals/collaborative_drafts/reported_content"
+    resource.reported_content_cell = "decidim/proposals/collaborative_drafts/reported_content"
   end
 
   component.register_stat :proposals_count, primary: true, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |components, start_at, end_at|

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -80,6 +80,7 @@ Decidim.register_component(:proposals) do |component|
     resource.model_class_name = "Decidim::Proposals::Proposal"
     resource.template = "decidim/proposals/proposals/linked_proposals"
     resource.card = "decidim/proposals/proposal"
+    resource.reported_content = "decidim/proposals/reported_content"
     resource.actions = %w(endorse vote amend)
     resource.searchable = true
   end
@@ -87,6 +88,7 @@ Decidim.register_component(:proposals) do |component|
   component.register_resource(:collaborative_draft) do |resource|
     resource.model_class_name = "Decidim::Proposals::CollaborativeDraft"
     resource.card = "decidim/proposals/collaborative_draft"
+    resource.reported_content = "decidim/proposals/collaborative_drafts/reported_content"
   end
 
   component.register_stat :proposals_count, primary: true, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |components, start_at, end_at|

--- a/decidim-proposals/spec/cells/decidim/proposals/collaborative_drafts/reported_content_cell_spec.rb
+++ b/decidim-proposals/spec/cells/decidim/proposals/collaborative_drafts/reported_content_cell_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Proposals::CollaborativeDrafts
+  describe ReportedContentCell, type: :cell do
+    controller Decidim::Proposals::CollaborativeDraftsController
+
+    let!(:collaborative_draft) { create(:collaborative_draft, body: { "en" => "a nice body" }) }
+
+    context "when rendering" do
+      it "renders the collaborative draft's body" do
+        html = cell("decidim/reported_content", collaborative_draft).call
+        expect(html).to have_content("a nice body")
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/cells/decidim/proposals/reported_content_cell_spec.rb
+++ b/decidim-proposals/spec/cells/decidim/proposals/reported_content_cell_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Proposals
+  describe ReportedContentCell, type: :cell do
+    controller Decidim::Proposals::ProposalsController
+
+    let!(:proposal) { create(:proposal, title: { "en" => "a nice title" }, body: { "en" => "let's do this!" }) }
+
+    context "when rendering" do
+      it "renders the proposal's title and body" do
+        html = cell("decidim/reported_content", proposal).call
+        expect(html).to have_content("a nice title")
+        expect(html).to have_content("let's do this!")
+      end
+    end
+  end
+end

--- a/docs/advanced/reportable.md
+++ b/docs/advanced/reportable.md
@@ -19,8 +19,9 @@ A `Reportable` is expected to implement:
 
 The reccomended way to render the content of a `Reportable` is with a `decidim/reported_content` cell.
 
-To render this button, `decidim-core` offers the `decidim/reported_content` cell. It is strongly recommended to use this cell to make new resources endorsable.
-
 ```ruby
-cell("decidim/endorsement_buttons", resource)
+cell("decidim/reported_content", reportable)
 ```
+
+By default, this will render the generic `Decidim::ReportedContentCell`.
+You can also customize the template for your `Reportable` by extending `Decidim::ReportedContentCell` (see `Decidim::Proposal::ReportedContentCell`)

--- a/docs/advanced/reportable.md
+++ b/docs/advanced/reportable.md
@@ -1,0 +1,60 @@
+# Reportable
+
+## Resources can be reportable
+
+`Reportable` is a feature that allows Decidim resources to be reported by users.
+A resource can be reported by a user as 'spam', 'offensive' or 'does_not_belong'.
+
+When a resource is reported, a `Report` is created. All `Report`s of a resource are grouped in a `Moderation` and can be moderated by the admins.
+
+A `Reportable` is expected to implement:
+ - `reported_content_url`: the URL for the reportable resource;
+ - `reported_attributes`: a list of attributes that can be reported (e.g. `[:title, :body]`) - used to display the report content by the `ReportedContentCell`;
+ - `reported_searchable_content_extras` (optional): a list of attributes other than `reported_attributes` the report can be search by (e.g. `[author.name]`) - used in the reports search bar of the admin panel.
+
+## Public view
+
+### The ReportedContentCell
+
+The reccomended way to render the content of a `Reportable` is with a `decidim/reported_content` cell.
+
+To render this button, `decidim-core` offers the `decidim/reported_content` cell. It is strongly recommended to use this cell to make new resources endorsable.
+
+```ruby
+cell("decidim/endorsement_buttons", resource)
+```
+
+This cell, renders the endorsements counter and the endorsement button by default. But it has the possibility to be invoked to render elements sepparately.
+
+```ruby
+# By default the `show` method is invoked as usual
+# Renders `render_endorsements_count` and `render_endorsements_button` in a block.
+cell("decidim/endorsement_buttons", resource)
+# It is recommended to use the `endorsement_buttons_cell` helper method
+endorsement_buttons_cell(resource)
+
+# Renders the "Endorse" button
+# It takes into account:
+# - if endorsements are enabled
+# - if users are logged in
+# - if users can endorse with many identities (of their user_groups)
+# - if users require verification
+endorsement_buttons_cell(resource).render_endorsements_button
+
+# Renders the counter of endorsements that appears in card.
+endorsement_buttons_cell(resource).render_endorsements_count
+
+# Renders a button to perform the endorse action, but only with the personal identity of the user. It does not take into account if the user belongs to any user group.
+endorsement_buttons_cell(resource).render_user_identity_endorse_button
+```
+
+### The list of endorsers
+
+The `Decidim::EndorsersListCell` renders the list of endorsers of a resource. It is usually rendered in the show of the resource, just upside the comments.
+
+```ruby
+# to render the list of endorsers, the cell requires the endorsable resource, and the current user
+cell "decidim/endorsers_list", resource
+# or using the helper
+endorsers_list_cell(resource)
+```

--- a/docs/advanced/reportable.md
+++ b/docs/advanced/reportable.md
@@ -24,38 +24,3 @@ To render this button, `decidim-core` offers the `decidim/reported_content` cell
 ```ruby
 cell("decidim/endorsement_buttons", resource)
 ```
-
-This cell, renders the endorsements counter and the endorsement button by default. But it has the possibility to be invoked to render elements sepparately.
-
-```ruby
-# By default the `show` method is invoked as usual
-# Renders `render_endorsements_count` and `render_endorsements_button` in a block.
-cell("decidim/endorsement_buttons", resource)
-# It is recommended to use the `endorsement_buttons_cell` helper method
-endorsement_buttons_cell(resource)
-
-# Renders the "Endorse" button
-# It takes into account:
-# - if endorsements are enabled
-# - if users are logged in
-# - if users can endorse with many identities (of their user_groups)
-# - if users require verification
-endorsement_buttons_cell(resource).render_endorsements_button
-
-# Renders the counter of endorsements that appears in card.
-endorsement_buttons_cell(resource).render_endorsements_count
-
-# Renders a button to perform the endorse action, but only with the personal identity of the user. It does not take into account if the user belongs to any user group.
-endorsement_buttons_cell(resource).render_user_identity_endorse_button
-```
-
-### The list of endorsers
-
-The `Decidim::EndorsersListCell` renders the list of endorsers of a resource. It is usually rendered in the show of the resource, just upside the comments.
-
-```ruby
-# to render the list of endorsers, the cell requires the endorsable resource, and the current user
-cell "decidim/endorsers_list", resource
-# or using the helper
-endorsers_list_cell(resource)
-```

--- a/docs/advanced/reportable.md
+++ b/docs/advanced/reportable.md
@@ -8,9 +8,10 @@ A resource can be reported by a user as 'spam', 'offensive' or 'does_not_belong'
 When a resource is reported, a `Report` is created. All `Report`s of a resource are grouped in a `Moderation` and can be moderated by the admins.
 
 A `Reportable` is expected to implement:
- - `reported_content_url`: the URL for the reportable resource;
- - `reported_attributes`: a list of attributes that can be reported (e.g. `[:title, :body]`) - used to display the report content by the `ReportedContentCell`;
- - `reported_searchable_content_extras` (optional): a list of attributes other than `reported_attributes` the report can be search by (e.g. `[author.name]`) - used in the reports search bar of the admin panel.
+
+- `reported_content_url`: the URL for the reportable resource;
+- `reported_attributes`: a list of attributes that can be reported (e.g. `[:title, :body]`) - used to display the report content by the `ReportedContentCell`;
+- `reported_searchable_content_extras` (optional): a list of attributes other than `reported_attributes` the report can be search by (e.g. `[author.name]`) - used in the reports search bar of the admin panel.
 
 ## Public view
 


### PR DESCRIPTION
#### :tophat: What? Why?

This add a few improvements in the moderations panel:

- Added new columns (`id`, `created_at`) and reorganise them. 
- Sort table by some columns (`report_count` and `created_at`)
- Add filter component with search bar
- Paginate moderations: side effect of using the `Filterable` concern.

**Updated (21/10/2020)**

This also adds two new views to the moderation panel:

- In the moderations list you can click the "Expand" button to see more details about the moderation (see screenshot below). In this new page you can see a table with all the reports that belongs to that moderation.
- In the reports table there is an excerpt of the reported content in the language that the user was using at the moment. You can also click the "Expand" button to see the whole content.

Both views includes a "preview" of the reported content. Since we don't want to display the whole content I created a new cell called reported_content_cell that can be configured for each resource. This cell will be used to preview this content in the email sent to the moderators.


#### Related issues/prs
- Related to https://meta.decidim.org/processes/roadmap/f/122/proposals/15627 Implements the "In the moderation panel" section from the proposal exceept the part of the modal.

#### Testing

1. First report a few resources (i.e. proposals, meetings, ...)
1. Navigate to the admin dashboard and go to the moderations panel
1. Try to sort the table by report count or creation date
1. Filter moderations by reportable type
1. Search moderations by reportable id or reported content.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

**Before:**

![image](https://user-images.githubusercontent.com/106021/96098973-033ab700-0ed3-11eb-8861-e8f687995d6d.png)

**After:**

![image](https://user-images.githubusercontent.com/106021/96730099-27f0cc00-13b6-11eb-9db1-9271c64b03f9.png)

_(when hovering over "Visit URL" link)_

![image](https://user-images.githubusercontent.com/106021/96859944-6ba10f80-1462-11eb-90a2-fc52d6f66b1a.png)

![image](https://user-images.githubusercontent.com/106021/96860019-896e7480-1462-11eb-9efd-0c818780faf6.png)

_(previous screenshot when scrolling down a bit...)_

![image](https://user-images.githubusercontent.com/106021/96860006-82dffd00-1462-11eb-9baa-60cb801fbb48.png)

![image](https://user-images.githubusercontent.com/106021/96730136-30e19d80-13b6-11eb-96fd-3c7354f291ff.png)

