### PR TITLE
Fix pending authorization list

### DIFF
--- a/decidim-verifications/app/views/decidim/verifications/id_documents/admin/pending_authorizations/index.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/id_documents/admin/pending_authorizations/index.html.erb
@@ -15,8 +15,8 @@
         </tr>
       </thead>
       <tbody>
-        <tr>
-          <% @pending_online_authorizations.each do |authorization| %>
+        <% @pending_online_authorizations.each do |authorization| %>
+          <tr>
             <td>
               <%= link_to t(".verification_number", n: authorization.id),
                           new_pending_authorization_confirmation_path(authorization.id) %>
@@ -26,8 +26,8 @@
                 <%= image_tag authorization.verification_attachment.url(:thumbnail), class: "thumbnail-list" %>
               <% end %>
             </td>
-          <% end %>
-        </tr>
+          </tr>
+        <% end %>
       </tbody>
     </table>
   </div>


### PR DESCRIPTION
#### :tophat: What? Why?
Currently the list of pending verifications is displayed in a single row, which makes it impossible to see the entire list with the width of the screen.
These changes show each pending verification in a different row.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing

1. Login as admin
2. Enter the Admin dashboard
3. Enter the section Participants -> Verifications -> Identity documents
4. Here you can see the list in one row and the documents in each different column, which truncates the list

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
**Before**
![pending_authorization_list-00](https://user-images.githubusercontent.com/346040/96047879-5fea9300-0e3b-11eb-991f-dba97a5a4687.png)
**After**
![pending_authorization_list-01](https://user-images.githubusercontent.com/346040/96047887-64af4700-0e3b-11eb-9778-b1111f3a2cb8.png)

:hearts: Thank you!
