### PR TITLE
Fix the file validator humanizer with static numeric values

### DIFF
--- a/decidim-core/lib/decidim/file_validator_humanizer.rb
+++ b/decidim-core/lib/decidim/file_validator_humanizer.rb
@@ -54,7 +54,8 @@ module Decidim
       end
       if validator
         lte = validator.options[:less_than_or_equal_to]
-        return lte.call(record) if lte && lte.lambda?
+        return lte if lte.is_a?(Numeric)
+        return lte.call(record) if lte.respond_to?(:call)
       end
       return unless passthru_validator
 
@@ -65,7 +66,9 @@ module Decidim
       return unless validator
 
       lte = validator.options[:less_than_or_equal_to]
-      lte.call(passthru_record) if lte && lte.lambda?
+      return lte if lte.is_a?(Numeric)
+
+      lte.call(passthru_record) if lte.respond_to?(:call)
     end
 
     def extension_whitelist

--- a/decidim-core/spec/lib/file_validator_humanizer_spec.rb
+++ b/decidim-core/spec/lib/file_validator_humanizer_spec.rb
@@ -14,8 +14,11 @@ module Decidim
       end
     end
 
+    let(:file_validation_options) { {} }
+
     let(:validatable) do
       mount_class = uploader
+      validation_options = file_validation_options
       Class.new do
         extend CarrierWave::Mount
         include ActiveModel::Model
@@ -26,7 +29,7 @@ module Decidim
         end
 
         attr_accessor :file
-        validates_upload :file
+        validates_upload :file, validation_options
         mount_uploader :file, mount_class
 
         def organization
@@ -55,6 +58,14 @@ module Decidim
     describe "#max_file_size" do
       it "returns the correct max file size" do
         expect(subject.max_file_size).to eq(10.megabytes)
+      end
+
+      context "when the file validator conditions are set as static numbers" do
+        let(:file_validation_options) { { max_size: 1.megabyte } }
+
+        it "returns the correct max file size" do
+          expect(subject.max_file_size).to eq(1.megabyte)
+        end
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
The file validator humanizer is not currently working when given static numeric values. It only works with lambdas as it is being used in the Decidim core. This ensures it works also with numbers.

#### :pushpin: Related Issues
- Related to #6377

#### Testing
There's nothing in the core that is currently broken because of this but this will fix situations where static numbers are used to limit the file sizes.

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.