### PR TITLE
Allow customization of the upload help messages

### DIFF
--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -450,20 +450,28 @@ module Decidim
     # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/PerceivedComplexity
 
-    def upload_help(attribute, _options = {})
+    def upload_help(attribute, options = {})
       humanizer = FileValidatorHumanizer.new(object, attribute)
 
       help_scope = begin
-        if humanizer.uploader.is_a?(Decidim::ImageUploader)
+        if options[:help_i18n_scope].present?
+          options[:help_i18n_scope]
+        elsif humanizer.uploader.is_a?(Decidim::ImageUploader)
           "decidim.forms.file_help.image"
         else
           "decidim.forms.file_help.file"
         end
       end
 
-      content_tag(:div, class: "help-text") do
-        help_messages = %w(message_1 message_2)
+      help_messages = begin
+        if options[:help_i18n_messages].present?
+          Array(options[:help_i18n_messages])
+        else
+          %w(message_1 message_2)
+        end
+      end
 
+      content_tag(:div, class: "help-text") do
         inner = "<p>#{I18n.t("explanation", scope: help_scope)}</p>".html_safe
         inner + content_tag(:ul) do
           messages = help_messages.each.map { |msg| I18n.t(msg, scope: help_scope) }

--- a/decidim-core/spec/lib/form_builder_spec.rb
+++ b/decidim-core/spec/lib/form_builder_spec.rb
@@ -632,6 +632,52 @@ module Decidim
           expect(parsed.css("p.help-text")).not_to be_empty
         end
       end
+
+      context "when :help_i18n_scope is passed as option" do
+        let(:attributes) { { help_i18n_scope: "custom.scope" } }
+        let(:output) { builder.upload :image, attributes }
+
+        it "renders calls I18n.t() with the correct scope" do
+          # Upload messages
+          expect(I18n).to receive(:t).with("default_image", scope: "decidim.forms")
+          # Upload help messages
+          expect(I18n).to receive(:t).with("explanation", scope: "custom.scope")
+          expect(I18n).to receive(:t).with("message_1", scope: "custom.scope")
+          expect(I18n).to receive(:t).with("message_2", scope: "custom.scope")
+          output
+        end
+      end
+
+      context "when :help_i18n_messages is passed as option" do
+        let(:attributes) { { help_i18n_messages: %w(message_1 message_2 message_3) } }
+        let(:output) { builder.upload :image, attributes }
+
+        it "renders calls I18n.t() with the correct messages" do
+          # Upload messages
+          expect(I18n).to receive(:t).with("default_image", scope: "decidim.forms")
+          # Upload help messages
+          expect(I18n).to receive(:t).with("explanation", scope: "decidim.forms.file_help.file")
+          expect(I18n).to receive(:t).with("message_1", scope: "decidim.forms.file_help.file")
+          expect(I18n).to receive(:t).with("message_2", scope: "decidim.forms.file_help.file")
+          expect(I18n).to receive(:t).with("message_3", scope: "decidim.forms.file_help.file")
+          output
+        end
+
+        context "with only one message" do
+          let(:attributes) { { help_i18n_messages: "message_1" } }
+          let(:output) { builder.upload :image, attributes }
+
+          it "renders calls I18n.t() with the correct messages" do
+            # Upload messages
+            expect(I18n).to receive(:t).with("default_image", scope: "decidim.forms")
+            # Upload help messages
+            expect(I18n).to receive(:t).with("explanation", scope: "decidim.forms.file_help.file")
+            expect(I18n).to receive(:t).with("message_1", scope: "decidim.forms.file_help.file")
+            expect(I18n).not_to receive(:t).with("message_2", scope: "decidim.forms.file_help.file")
+            output
+          end
+        end
+      end
     end
 
     describe "#data_picker" do


### PR DESCRIPTION
#### :tophat: What? Why?
Sometimes we want to use different upload help messages than the defaults. This makes it possible.

#### Testing
You can create the upload field with the form builder e.g. as follows:

```ruby
form.upload :file, help_i18n_messages: "custom_message", help_i18n_scope: "custom.scope"
```

This will make the upload help messages appear based on the translation for `custom_message.custom.scope`.

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.