### PR TITLE
Ensure `resource_text` is a string in NotificationMailer

### DIFF
--- a/decidim-core/app/views/decidim/notification_mailer/event_received.html.erb
+++ b/decidim-core/app/views/decidim/notification_mailer/event_received.html.erb
@@ -2,10 +2,10 @@
 
 <p><%= @event_instance.email_intro %></p>
 
-<% if @event_instance.try(:resource_text).present? %>
+<% if @event_instance.try(:safe_resource_text).present? %>
   <blockquote>
     <p>
-      <%= @event_instance.resource_text.html_safe %>
+      <%= @event_instance.safe_resource_text %>
     </p>
   </blockquote>
 <% end %>

--- a/decidim-core/lib/decidim/core/test/shared_examples/simple_event.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/simple_event.rb
@@ -89,6 +89,13 @@ shared_examples_for "a simple event" do |skip_space_checks|
     end
   end
 
+  describe "safe_resource_text" do
+    it "is generated correctly" do
+      expect(subject.safe_resource_text).to be_kind_of(String)
+      expect(subject.safe_resource_text).to be_html_safe
+    end
+  end
+
   describe "notification_title" do
     it "is generated correctly" do
       expect(subject.notification_title).to be_kind_of(String)

--- a/decidim-core/lib/decidim/events/base_event.rb
+++ b/decidim-core/lib/decidim/events/base_event.rb
@@ -69,6 +69,10 @@ module Decidim
 
       def resource_text; end
 
+      def safe_resource_text
+        translated_attribute(resource_text).to_s.html_safe
+      end
+
       def resource_title
         return unless resource
 

--- a/decidim-core/spec/lib/events/base_event_spec.rb
+++ b/decidim-core/spec/lib/events/base_event_spec.rb
@@ -23,6 +23,45 @@ module Decidim
       end
     end
 
+    describe "safe_resource_text" do
+      let(:resource) { build(:dummy_resource) }
+
+      before do
+        allow(subject).to receive(:resource_text).and_return(resource_text)
+      end
+
+      describe "when the resource_text is nil" do
+        let(:resource_text) { nil }
+
+        it "returns a string" do
+          expect(subject.safe_resource_text).to eq ""
+        end
+      end
+
+      describe "when the resource_text is a String" do
+        let(:resource_text) { "foobar" }
+
+        it "returns the string" do
+          expect(subject.safe_resource_text).to eq resource_text
+        end
+      end
+
+      describe "when the resource_text is a translation hash" do
+        let(:resource_text) do
+          {
+            en: "My string",
+            "machine_translations" => {
+              "es" => "Spanish - My string"
+            }
+          }
+        end
+
+        it "returns the current locale string" do
+          expect(subject.safe_resource_text).to eq "My string"
+        end
+      end
+    end
+
     context "when the resource is hashtaggable" do
       let(:resource) { build(:dummy_resource) }
 


### PR DESCRIPTION
#### :tophat: What? Why?
Sometimes the NotificationMailer fails with this error:

```
undefined method `html_safe' for #<Hash:0x000055a91b3be790>
Did you mean?  html_safe?
decidim-25dbc986173a/decidim-core/app/views/decidim/notification_mailer/event_received.html.erb at line 8
<% if @event_instance.try(:resource_text).present? %>
  <blockquote>
    <p>
      <%= @event_instance.resource_text.html_safe %>
    </p>
  </blockquote>
<% end %>
```

This means there's some event that's not properly cleaning the `resource_text` value to make it return a String.

Instead of chasing the event, this PR introduces a new method in the event base class called `safe_resource_text` which makes sure that whatever is set by the `event#resource_text` method is a String and it's HTML-safe.

#### :pushpin: Related Issues
*Link your PR to an issue*
None

#### Testing
Not sure how to find the wrong event, thus I'm not sure how to test it. Since the event is an instantiated class, I don't have the information in my error tracking application (Sentry). But if we chased the culprit, the problem might arise in other events. I think the approach in this PR is safer.

Just in case, I added tests for the new method ensuring it works as expected.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
None

:hearts: Thank you!
