### PR TITLE
Fix meetings creation

### DIFF
--- a/decidim-meetings/app/commands/decidim/meetings/create_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/create_meeting.rb
@@ -45,7 +45,7 @@ module Decidim
           location_hints: { I18n.locale => form.location_hints },
           author: form.current_user,
           decidim_user_group_id: form.user_group_id,
-          registration_terms: { I18n.locale => form.current_component.settings.default_registration_terms },
+          registration_terms: form.current_component.settings.default_registration_terms,
           online_meeting_url: form.online_meeting_url,
           type_of_meeting: form.clean_type_of_meeting,
           component: form.current_component

--- a/decidim-meetings/db/migrate/20201016065302_fix_meetings_registration_terms.rb
+++ b/decidim-meetings/db/migrate/20201016065302_fix_meetings_registration_terms.rb
@@ -7,7 +7,12 @@ class FixMeetingsRegistrationTerms < ActiveRecord::Migration[5.2]
     PaperTrail.request(enabled: false) do
       Decidim::Meetings::Meeting.find_each do |meeting|
         next if meeting.component.nil?
+        # Only user-created meetings have this problem
+        next if meeting.official?
 
+        # Since user-created meetings have no way to override the `registration_terms` field
+        # and it's supposed to use the component defaults,
+        # we can safely override this.
         meeting.registration_terms = meeting.component.settings.default_registration_terms
         meeting.save!
       end

--- a/decidim-meetings/db/migrate/20201016065302_fix_meetings_registration_terms.rb
+++ b/decidim-meetings/db/migrate/20201016065302_fix_meetings_registration_terms.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class FixMeetingsRegistrationTerms < ActiveRecord::Migration[5.2]
+  def up
+    reset_column_information
+
+    PaperTrail.request(enabled: false) do
+      Decidim::Meetings::Meeting.find_each do |meeting|
+        next if meeting.component.nil?
+
+        meeting.registration_terms = meeting.component.settings.default_registration_terms
+        meeting.save!
+      end
+    end
+    reset_column_information
+  end
+
+  def down; end
+
+  def reset_column_information
+    Decidim::Meetings::Meeting.reset_column_information
+    Decidim::Component.reset_column_information
+  end
+end

--- a/decidim-meetings/spec/commands/create_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/create_meeting_spec.rb
@@ -68,6 +68,11 @@ module Decidim::Meetings
         expect(meeting.category).to eq category
       end
 
+      it "sets the registration_terms" do
+        subject.call
+        expect(meeting.registration_terms).to eq meeting.component.settings.default_registration_terms.stringify_keys
+      end
+
       it "sets the component" do
         subject.call
         expect(meeting.component).to eq current_component


### PR DESCRIPTION
#### :tophat: What? Why?
Meetings created from the public side have a mis-saved i18n field. This PR fixes the error and adds a migration to fix the data.

#### Testing
Check the `meeting.registration_terms` before this PR for a meeting created from the public side. It will have a bad shape of the field.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.


:hearts: Thank you!
