### PR TITLE
Fixes meeting card date and address alignment

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_cards.scss
@@ -961,6 +961,7 @@ a .card__title{
       font-size: $global-font-size;
       text-transform: none;
       justify-content: left;
+      flex-direction: row;
 
       strong{
         text-transform: uppercase;

--- a/decidim-elections/app/assets/stylesheets/decidim/elections/elections.scss
+++ b/decidim-elections/app/assets/stylesheets/decidim/elections/elections.scss
@@ -1,9 +1,5 @@
 @import "focus/*";
 
-li.card-data__item{
-  flex-direction: inherit;
-}
-
 .card__icondata ul li:not(:first-child) strong,
 .card__block ul li:not(:first-child) strong{
   font-size: 100%;


### PR DESCRIPTION
#### :tophat: What? Why?
This fixes issue #6547 about alignment of date and address for the card meetings.

#### :pushpin: Related Issues
- Related to #6547 

#### Testing
N/A

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
v22
![image](https://user-images.githubusercontent.com/8941178/96324694-ad583300-0fe8-11eb-98a1-26809b0b6325.png)

v23 but fix in the wrong place (discussed in #6547 ) and this fix
![image](https://user-images.githubusercontent.com/8941178/96324675-9285be80-0fe8-11eb-97ab-7cce1a593cf4.png)


:hearts: Thank you!
