### PR TITLE
add information for a correct etherpad integration

### DIFF
--- a/decidim-generators/lib/decidim/generators/app_templates/docker-compose-etherpad.yml
+++ b/decidim-generators/lib/decidim/generators/app_templates/docker-compose-etherpad.yml
@@ -25,7 +25,12 @@ services:
       - ETHERPAD_DB_CHARSET=utf8mb4
       # if file APIKEY.txt is missing, the variable value is used to provision it
       - ETHERPAD_API_KEY=CHANGE_ME_API_KEY
-    image: 'tvelocity/etherpad-lite'
+      # You can skip this if you are not using any proxy to handle SSL certificates.
+      - "TRUST_PROXY=true"
+      # Ensure this etherpad allows cookies while embeded in an Iframe
+      - "COOKIE_SAME_SITE=None"
+    # Official image is etherpad/etherpad but the latest version does not allow yet setting cookies to SameSite=None
+    image: 'platoniq/etherpad:1.8.7'
     deploy:
       replicas: 1
       update_config:

--- a/docs/services/etherpad.md
+++ b/docs/services/etherpad.md
@@ -39,6 +39,33 @@ and then in `config/secrets.yml`:
     api_version: <%= ENV["ETHERPAD_API_VERSION"] %>
 ```
 
+## Issues related to cookies and Iframes
+
+Etherpad requires to set a cookie in order to work.
+
+The way Decidim integrates Etherpad is by creating and Iframe that calls the specific URL for an Etherpad instance. This means that the cookie needs to be created in the context of that Iframe, which is a different one that the Decidim application itself.
+
+Now, recent versions of browsers don't like that and have started to block what's known as "3rd party cookies" (usually used as a tracking mechanism). This is a problem because, usually, Etherpad is installed in a different domain/server and the ability to deal with this situation has been fixed in very [recent versions](https://github.com/ether/etherpad-lite/pull/4384) of Etherpad.
+
+In order to make sure your installation of Etherpad is compatible with Iframe embedding, it is necessary that the cookie generated follows these parameters:
+
+```
+Set-Cookie: session=your_session; SameSite=None; Secure
+```
+
+By default, Etherpad sets the `SameSite` attribute to "Lax", which causes problems, you need to be sure it is set to "None". Remember that your Etherpad instance MUST runt under **https** for this to work.
+
+Also, it is highly recommended that you use some sort of proxy that makes your Etherpad instance a subdomain of your Decidim instance. Although this is not strictly required, if you don't do that, some browsers might make you disable 3rd party cookies (eg: Safari) to be able to use the embedded Etherpad.
+
+The suggested `docker-compose-etherpad.yml` provided by Decidim uses an image of Etherpad that incorporates the changes related to this problem. If you are using your custom instance of Etherpad, make sure that incorporate this [changes](https://github.com/ether/etherpad-lite/pull/4384) and that you set these ENV variables as follows:
+
+```
+TRUST_PROXY=true
+COOKIE_SAME_SITE=None
+```
+
+The `TRUST_PROXY` variable is necessary if you are handling SSL through a external service (ie: Cloudflare), if unsure set it to true.
+
 ## How is Etherpad Lite integrated in Meetings?
 
 To better understand this feature, the final idea is to have the three moments of a meeting covered on Decidim itself by default:


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds information about a recent problem when using Etherpad in Decidim as many browsers block 3rd party cookies by default now.

As Etherpad is embedded in a Iframe, browsers block its cookies if there are not sent with the attributes `SameSite=None; Secure`. However, the current version of Ehterpad in the docker proposed file is outdated and not maintained anymore. Unfortunately, the official versions of Etherpad docker, do not incorporate [this PR](https://github.com/ether/etherpad-lite/pull/4384) that allows to fix this problem (to set the `SameSite=None` basically) yet.

I propose to add documentation about this problem so system admins are aware and can solve it. 
I also propose to change the Etherpad docker version to a new crafted one. Currently, one we've made at Platoniq that incorporates latests changes. This would be temporary until the official [etherpad/etherpad](https://hub.docker.com/r/etherpad/etherpad) image incorporates these changes (I'll make another PR then).

Info about this problem in etherpad:

- https://github.com/ether/etherpad-lite/issues/4332
- https://github.com/ether/etherpad-lite/pull/4384

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
This is the problem when using Etherpad embedded in Iframes and cookies are rejected:
![image](https://user-images.githubusercontent.com/1401520/96454318-f5ab6700-121b-11eb-80dc-4634501dcbba.png)


:hearts: Thank you!
