### PR TITLE
Backport "Fix in space highlighted meetings show only visible meetings" to 0.22

### DIFF
--- a/decidim-meetings/app/cells/decidim/meetings/highlighted_meetings_for_component_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/highlighted_meetings_for_component_cell.rb
@@ -18,7 +18,7 @@ module Decidim
       private
 
       def meetings
-        @meetings ||= Decidim::Meetings::Meeting.where(component: model)
+        @meetings ||= Decidim::Meetings::Meeting.where(component: model).visible_meeting_for(current_user)
       end
 
       def past_meetings


### PR DESCRIPTION
#### :tophat: What? Why?
Backport of fix that show only highlighted meetings for current for release 0.22

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #6707 

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

