### PR TITLE
Fix conference speakers js-bio display

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_conference-speaker.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_conference-speaker.scss
@@ -78,9 +78,10 @@
   @include breakpoint(medium){
     position: relative;
 
-    &:nth-of-type(4n + 3) .speaker-bio,
-    &:nth-of-type(4n + 4) .speaker-bio{
-      transform: translateY(-10%) translateX(-50%);
+    &:nth-of-type(4) .speaker-bio,
+    &:nth-of-type(4n + 5) .speaker-bio,
+    &:nth-of-type(5n) .speaker-bio,{
+      transform: translateY(-10%) translateX(-60%);
     }
   }
 }


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes the wrong display of conference speakers js-bio cards. 

<img width="1368" alt="Capture d’écran 2020-10-20 à 19 10 29" src="https://user-images.githubusercontent.com/52420208/96622153-e0146b00-1309-11eb-8b82-ebaafecad1ea.png">

#### :pushpin: Related Issues

- Fixes #6711

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
<img width="1319" alt="Capture d’écran 2020-10-20 à 19 14 29" src="https://user-images.githubusercontent.com/52420208/96622082-c6732380-1309-11eb-9b6a-125c96cd77a5.png">


:hearts: Thank you!
