### PR TITLE
Fix rubocop lint due to an upgraded ruby 2.7

### DIFF
--- a/decidim-elections/app/commands/decidim/elections/admin/update_trustee_participatory_space.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/update_trustee_participatory_space.rb
@@ -27,6 +27,7 @@ module Decidim
         private
 
         attr_reader :trustee_participatory_space
+
         # Toggle the considered attribute
         def update_trustee_participatory_space!
           trustee_participatory_space.update!(

--- a/decidim-elections/app/models/decidim/elections/trustees_participatory_space.rb
+++ b/decidim-elections/app/models/decidim/elections/trustees_participatory_space.rb
@@ -7,7 +7,7 @@ module Decidim
     # for the trustee.
     class TrusteesParticipatorySpace < ApplicationRecord
       belongs_to :trustee, foreign_key: "decidim_elections_trustee_id", class_name: "Decidim::Elections::Trustee", inverse_of: :trustees_participatory_spaces
-      belongs_to :participatory_space, foreign_key: "participatory_space_id", foreign_type: "participatory_space_type", polymorphic: true
+      belongs_to :participatory_space, foreign_type: "participatory_space_type", polymorphic: true
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
*Please describe your pull request.*

Due to an upgrade to ruby 2.7, this PR fixes a rubocop lint offense in a couple of files

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #6535

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
