### PR TITLE
Fix accept invitation to private meetings

### DIFF
--- a/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
@@ -30,7 +30,7 @@ module Decidim
       end
 
       def create
-        enforce_permission_to :join, :meeting, meeting: meeting
+        enforce_permission_to :register, :meeting, meeting: meeting
 
         @form = JoinMeetingForm.from_params(params)
 

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -84,8 +84,9 @@ module Decidim
         !closed? && registrations_enabled? && can_participate?(user)
       end
 
-      def can_register_invitation_meeting_for?(user)
-        !closed? && registrations_enabled? && can_register_invitation?(user)
+      def can_register_invitation?(user)
+        !closed? && registrations_enabled? &&
+          can_participate_in_space?(user) && user_has_invitation_for_meeting?(user)
       end
 
       def closed?
@@ -143,10 +144,6 @@ module Decidim
 
       def can_participate?(user)
         can_participate_in_space?(user) && can_participate_in_meeting?(user)
-      end
-
-      def can_register_invitation?(user)
-        can_participate_in_space?(user) && user_has_invitation_for_meeting?(user)
       end
 
       def current_user_can_visit_meeting?(current_user)

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -84,6 +84,10 @@ module Decidim
         !closed? && registrations_enabled? && can_participate?(user)
       end
 
+      def can_register_invitation_meeting_for?(user)
+        !closed? && registrations_enabled? && can_register_invitation?(user)
+      end
+
       def closed?
         closed_at.present?
       end
@@ -139,6 +143,10 @@ module Decidim
 
       def can_participate?(user)
         can_participate_in_space?(user) && can_participate_in_meeting?(user)
+      end
+
+      def can_register_invitation?(user)
+        can_participate_in_space?(user) && user_has_invitation_for_meeting?(user)
       end
 
       def current_user_can_visit_meeting?(current_user)
@@ -198,6 +206,13 @@ module Decidim
         return false unless user
 
         registrations.exists?(decidim_user_id: user.id)
+      end
+
+      def user_has_invitation_for_meeting?(user)
+        return true unless private_meeting?
+        return false unless user
+
+        invites.exists?(decidim_user_id: user.id)
       end
     end
   end

--- a/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
+++ b/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
@@ -60,7 +60,7 @@ module Decidim
       end
 
       def can_register_invitation_meeting?
-        meeting.can_register_invitation_meeting_for?(user) &&
+        meeting.can_register_invitation?(user) &&
           authorized?(:register, resource: meeting)
       end
     end

--- a/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
+++ b/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
@@ -23,6 +23,8 @@ module Decidim
           toggle_allow(can_create_meetings?)
         when :update
           toggle_allow(can_update_meeting?)
+        when :register
+          toggle_allow(can_register_invitation_meeting?)
         end
 
         permission_action
@@ -55,6 +57,11 @@ module Decidim
       def can_update_meeting?
         component_settings&.creation_enabled_for_participants? &&
           meeting.authored_by?(user)
+      end
+
+      def can_register_invitation_meeting?
+        meeting.can_register_invitation_meeting_for?(user) &&
+          authorized?(:register, resource: meeting)
       end
     end
   end

--- a/decidim-meetings/spec/models/meeting_spec.rb
+++ b/decidim-meetings/spec/models/meeting_spec.rb
@@ -99,6 +99,40 @@ module Decidim::Meetings
       end
     end
 
+    describe "#can_register_invitation_meeting_for?" do
+      subject { meeting.can_register_invitation_meeting_for?(user) }
+
+      let(:user) { build :user, organization: meeting.component.organization }
+
+      context "when registrations are disabled" do
+        let(:meeting) { build :meeting, registrations_enabled: false }
+
+        it { is_expected.to eq false }
+      end
+
+      context "when meeting is closed" do
+        let(:meeting) { build :meeting, :closed }
+
+        it { is_expected.to eq false }
+      end
+
+      context "when the user cannot participate to the meeting" do
+        let(:meeting) { build :meeting, :closed }
+
+        before do
+          allow(meeting).to receive(:can_register_invitation?).and_return(false)
+        end
+
+        it { is_expected.to eq false }
+      end
+
+      context "when everything is OK" do
+        let(:meeting) { build :meeting, registrations_enabled: true }
+
+        it { is_expected.to eq true }
+      end
+    end
+
     describe "#meeting_duration" do
       let(:start_time) { 1.day.from_now }
       let!(:meeting) { build(:meeting, start_time: start_time, end_time: start_time.advance(hours: 2)) }

--- a/decidim-meetings/spec/models/meeting_spec.rb
+++ b/decidim-meetings/spec/models/meeting_spec.rb
@@ -99,8 +99,8 @@ module Decidim::Meetings
       end
     end
 
-    describe "#can_register_invitation_meeting_for?" do
-      subject { meeting.can_register_invitation_meeting_for?(user) }
+    describe "#can_register_invitation?" do
+      subject { meeting.can_register_invitation?(user) }
 
       let(:user) { build :user, organization: meeting.component.organization }
 

--- a/decidim-meetings/spec/models/meeting_spec.rb
+++ b/decidim-meetings/spec/models/meeting_spec.rb
@@ -131,6 +131,29 @@ module Decidim::Meetings
 
         it { is_expected.to eq true }
       end
+
+      context "when no user on register process" do
+        let(:meeting) { build :meeting, registrations_enabled: true, private_meeting: true, transparent: false }
+        let(:user) { nil }
+
+        it { is_expected.to eq false }
+      end
+
+      context "when user has invitation to register" do
+        let(:meeting) { create :meeting, registrations_enabled: true, private_meeting: true, transparent: false }
+        let(:invite) { create(:invite, accepted_at: Time.current, rejected_at: nil, user: user, meeting: meeting) }
+
+        it "allows the user to join the meeting" do
+          meeting.invites << invite
+          expect(subject).to eq true
+        end
+      end
+
+      context "when user has no invitation to register" do
+        let(:meeting) { build :meeting, registrations_enabled: true, private_meeting: true, transparent: false }
+
+        it { is_expected.to eq false }
+      end
     end
 
     describe "#meeting_duration" do

--- a/decidim-meetings/spec/permissions/decidim/meetings/permissions_spec.rb
+++ b/decidim-meetings/spec/permissions/decidim/meetings/permissions_spec.rb
@@ -70,6 +70,31 @@ describe Decidim::Meetings::Permissions do
     end
   end
 
+  context "when registering on a meeting" do
+    let(:action) do
+      { scope: :public, action: :register, subject: :meeting }
+    end
+
+    before do
+      allow(meeting)
+        .to receive(:can_register_invitation_meeting_for?)
+        .with(user)
+        .and_return(can_be_registered)
+    end
+
+    context "when meeting can't be joined" do
+      let(:can_be_registered) { false }
+
+      it { is_expected.to eq false }
+    end
+
+    context "when meeting can be joined" do
+      let(:can_be_registered) { true }
+
+      it { is_expected.to eq true }
+    end
+  end
+
   context "when leaving a meeting" do
     let(:action) do
       { scope: :public, action: :leave, subject: :meeting }

--- a/decidim-meetings/spec/permissions/decidim/meetings/permissions_spec.rb
+++ b/decidim-meetings/spec/permissions/decidim/meetings/permissions_spec.rb
@@ -77,7 +77,7 @@ describe Decidim::Meetings::Permissions do
 
     before do
       allow(meeting)
-        .to receive(:can_register_invitation_meeting_for?)
+        .to receive(:can_register_invitation?)
         .with(user)
         .and_return(can_be_registered)
     end


### PR DESCRIPTION
#### :tophat: What? Why?
When someone invites a user to a private meeting, this user can't access to the meeting from the email link received.
The problem is on the creation process of the registering the user. The permissions system don't allow the user who had received an invitation to join it. 
I've created a new permission conditional to allow invited users to join a meeting by register on it.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
Create a private, non-transparent meeting and invite someone. When the invited user receive the invitation email, click to join it.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*

