### PR TITLE
Fix Question for Consultation can not be rendered without image

### DIFF
--- a/decidim-consultations/app/views/decidim/consultations/questions/show.html.erb
+++ b/decidim-consultations/app/views/decidim/consultations/questions/show.html.erb
@@ -36,7 +36,7 @@
 <%= content_for :question_header_details do %>
   <div id="question-header-details" class="row consultations-home-intro">
     <div class="columns medium-5">
-      <%= image_tag current_question.hero_image&.url, alt: t("question.hero_image", scope: "activemodel.attributes") %>
+      <%= image_tag current_question.hero_image&.url, alt: t("question.hero_image", scope: "activemodel.attributes") unless current_question.hero_image %>
     </div>
 
     <div class="columns medium-5">


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes question resulting in an error if there is no hero_image set.
This fix should be backported to branch release/0.22-stable since it's the version that introduced this bug.

#### :pushpin: Related Issues
- Fixes #6504 

