### PR TITLE
Fix non-XHR requests for comments (e.g. for search engines)

### DIFF
--- a/decidim-comments/app/controllers/decidim/comments/comments_controller.rb
+++ b/decidim-comments/app/controllers/decidim/comments/comments_controller.rb
@@ -5,6 +5,8 @@ module Decidim
     # Controller that manages the comments for a commentable object.
     #
     class CommentsController < Decidim::Comments::ApplicationController
+      include Decidim::ResourceHelper
+
       before_action :authenticate_user!, only: [:create]
       before_action :set_commentable
       before_action :ensure_commentable!
@@ -21,7 +23,18 @@ module Decidim
         )
         @comments_count = commentable.comments.count
 
-        render :reload if reload?
+        respond_to do |format|
+          format.js do
+            if reload?
+              render :reload
+            else
+              render :index
+            end
+          end
+
+          # This makes sure bots are not causing unnecessary log entries.
+          format.html { redirect_to resource_locator(commentable).path }
+        end
       end
 
       def create
@@ -36,12 +49,16 @@ module Decidim
         Decidim::Comments::CreateComment.call(form, current_user) do
           on(:ok) do |comment|
             handle_success(comment)
-            render :create
+            respond_to do |format|
+              format.js { render :create }
+            end
           end
 
           on(:invalid) do
             @error = t("create.error", scope: "decidim.comments.comments")
-            render :error
+            respond_to do |format|
+              format.js { render :error }
+            end
           end
         end
       end

--- a/decidim-comments/app/controllers/decidim/comments/votes_controller.rb
+++ b/decidim-comments/app/controllers/decidim/comments/votes_controller.rb
@@ -17,10 +17,14 @@ module Decidim
 
         Decidim::Comments::VoteComment.call(comment, current_user, weight: params[:weight].to_i) do
           on(:ok) do
-            render :create
+            respond_to do |format|
+              format.js { render :create }
+            end
           end
           on(:invalid) do
-            render :error
+            respond_to do |format|
+              format.js { render :error }
+            end
           end
         end
       end

--- a/decidim-comments/spec/controllers/decidim/comments/comments_controller_spec.rb
+++ b/decidim-comments/spec/controllers/decidim/comments/comments_controller_spec.rb
@@ -22,6 +22,15 @@ module Decidim
           expect(subject).to render_template(:index)
         end
 
+        context "when requested without an XHR request" do
+          it "redirects to the commentable" do
+            get :index, params: { commentable_gid: commentable.to_signed_global_id.to_s }
+            expect(subject).to redirect_to(
+              Decidim::ResourceLocatorPresenter.new(commentable).path
+            )
+          end
+        end
+
         context "when the reload parameter is given" do
           it "renders the reload template" do
             get :index, xhr: true, params: { commentable_gid: commentable.to_signed_global_id.to_s, reload: 1 }
@@ -71,6 +80,14 @@ module Decidim
             expect(comment.body.values.first).to eq("This is a new comment")
             expect(comment.alignment).to eq(comment_alignment)
             expect(subject).to render_template(:create)
+          end
+
+          context "when requested without an XHR request" do
+            it "throws an unknown format exception" do
+              expect do
+                post :create, params: { comment: comment_params }
+              end.to raise_error(ActionController::UnknownFormat)
+            end
           end
 
           context "when comments are disabled for the component" do
@@ -130,6 +147,14 @@ module Decidim
             it "renders the error template" do
               post :create, xhr: true, params: { comment: comment_params }
               expect(subject).to render_template(:error)
+            end
+
+            context "when requested without an XHR request" do
+              it "throws an unknown format exception" do
+                expect do
+                  post :create, params: { comment: comment_params }
+                end.to raise_error(ActionController::UnknownFormat)
+              end
             end
           end
 

--- a/decidim-comments/spec/controllers/decidim/comments/votes_controller_spec.rb
+++ b/decidim-comments/spec/controllers/decidim/comments/votes_controller_spec.rb
@@ -47,6 +47,14 @@ module Decidim
               expect(comment.up_votes.count).to eq(1)
               expect(subject).to render_template(:create)
             end
+
+            context "when requested without an XHR request" do
+              it "throws an unknown format exception" do
+                expect do
+                  post :create, params: { comment_id: comment.id, weight: 1 }
+                end.to raise_error(ActionController::UnknownFormat)
+              end
+            end
           end
 
           context "when vote weight is negative" do


### PR DESCRIPTION
#### :tophat: What? Why?
After the comments refactor, there are now many long exceptions traced in the application logs. E.g. search engines can directly request those comments URLs that are available e.g. in the sorting links.

This happens because only JS templates are defined for the comments and Rails cannot find the HTML template being requested.

This cleans those long exceptions out of the application logs.

#### :pushpin: Related Issues
- Related to #6498

#### Testing
- Go to any view with comments enabled
- Click one of the comments sorting links with the right mouse button
- Open the link in a new tab
- See an exception

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.