### PR TITLE
Backport dependencies for decidim-templates within decidim-forms

### DIFF
--- a/decidim-forms/app/controllers/decidim/forms/admin/concerns/has_questionnaire.rb
+++ b/decidim-forms/app/controllers/decidim/forms/admin/concerns/has_questionnaire.rb
@@ -18,9 +18,9 @@ module Decidim
             helper_method :questionnaire_for, :questionnaire, :blank_question, :blank_answer_option, :blank_matrix_row,
                           :blank_display_condition, :question_types, :display_condition_types, :update_url, :public_url, :answer_options_url
 
-            if defined? Decidim::Templates
+            if defined? Decidim::Templates::Admin
               include Decidim::Templates::Admin::Concerns::Templatable
-              helper Decidim::Templates::Admin::TemplatesHelper if defined? Decidim::Templates
+              helper Decidim::Templates::Admin::TemplatesHelper
 
               def templatable_type
                 "Decidim::Forms::Questionnaire"

--- a/decidim-forms/app/helpers/decidim/forms/admin/application_helper.rb
+++ b/decidim-forms/app/helpers/decidim/forms/admin/application_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# i18n-tasks-use t('decidim.templates.admin.questionnaire_templates.form.title')
+
 module Decidim
   module Forms
     module Admin
@@ -32,6 +34,21 @@ module Decidim
           content_tag :span, class: options[:class], data: data do
             truncate translated_attribute(title), length: options[:max_length], omission: options[:omission]
           end
+        end
+
+        def template?(questionnaire_for)
+          return unless defined? Decidim::Templates::Template
+
+          questionnaire_for.is_a? Decidim::Templates::Template
+        end
+
+        def templates_defined?
+          defined? Decidim::Templates::Admin::Concerns::Templatable
+        end
+
+        def title_for_questionnaire
+          scope = templates_defined? ? "decidim.templates.admin.questionnaire_templates" : "decidim.forms.admin.questionnaires"
+          t("form.title", scope: scope)
         end
       end
     end

--- a/decidim-forms/app/models/decidim/forms/questionnaire.rb
+++ b/decidim-forms/app/models/decidim/forms/questionnaire.rb
@@ -4,7 +4,7 @@ module Decidim
   module Forms
     # The data store for a Questionnaire in the Decidim::Forms component.
     class Questionnaire < Forms::ApplicationRecord
-      include Decidim::Templates::Templatable if defined? Decidim::Templates
+      include Decidim::Templates::Templatable if defined? Decidim::Templates::Templatable
       include Decidim::Publicable
       include Decidim::TranslatableResource
 

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/_form.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/_form.html.erb
@@ -2,7 +2,7 @@
   <div class="card-divider">
     <h2 class="card-title">
       <%= t(".title") %>
-      <% unless questionnaire.questionnaire_for.class == Decidim::Templates::Template %>
+      <% unless template? questionnaire.questionnaire_for %>
         <% if allowed_to? :preview, :questionnaire %>
           <div class="button--title">
             <%= link_to t(".preview"), public_url, class: "button tiny button--simple", target: :_blank %>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/edit.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/edit.html.erb
@@ -1,8 +1,8 @@
-<% if (defined? Decidim::Templates) && choose_template? %>
+<% if templates_defined? && choose_template? %>
   <%= render partial: "decidim/templates/admin/questionnaire_templates/choose", locals: { target: questionnaire, form_title: t("decidim.forms.admin.questionnaires.edit.title") } %>
 <% else %>
   <%= decidim_form_for(@form, url: update_url, method: :put, html: { class: "form edit_questionnaire" }) do |form| %>
-    <%= render partial: "decidim/forms/admin/questionnaires/form", object: form, locals: { title: t("form.title", scope: "decidim.templates.admin.questionnaire_templates") } %>
+    <%= render partial: "decidim/forms/admin/questionnaires/form", object: form, locals: { title: title_for_questionnaire } %>
 
     <div class="button--double form-general-submit">
       <%= form.submit t(".save"), class: "button" %>


### PR DESCRIPTION
#### :tophat: What? Why?

Backport to truly separate decidim-templates from decidim-forms and other modules https://github.com/decidim/decidim/pull/6652

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #6652 #6697

