### PR TITLE
Missing i18n on closed debate notification

### DIFF
--- a/decidim-debates/config/locales/en.yml
+++ b/decidim-debates/config/locales/en.yml
@@ -201,10 +201,16 @@ en:
           email_subject: Debates now available in %{participatory_space_title}
           notification_title: You can now start <a href="%{resource_path}">new debates</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
         debate_closed:
-          email_intro: 'The "%{resource_title}" debate was closed. You can read the conclusions from its page:'
-          email_outro: You have received this notification because you are following the "%{resource_title}" debate. You can unfollow it from the previous link.
-          email_subject: The "%{resource_title}" debate was closed
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a> debate was closed.
+          affected_user:
+            email_intro: 'The "%{resource_title}" debate was closed. You can read the conclusions from its page:'
+            email_outro: You have received this notification because you are following the "%{resource_title}" debate. You can unfollow it from the previous link.
+            email_subject: The "%{resource_title}" debate was closed
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a> debate was closed.
+          follower:
+            email_intro: 'The "%{resource_title}" debate was closed. You can read the conclusions from its page:'
+            email_outro: You have received this notification because you are following the "%{resource_title}" debate. You can unfollow it from the previous link.
+            email_subject: The "%{resource_title}" debate was closed
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a> debate was closed.
     gamification:
       badges:
         commented_debates:


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes locales structure so `debate_closed` contain both `follower` and `affected_user`.

#### :pushpin: Related Issues
- Related to #6702 

#### Testing
1. As a user, follow a debate
2. As an admin, close the debate
3. As a user, receive the notification.


#### :clipboard: Checklist
- [x] Update `en.yml` structure


### :camera: Screenshots
<img width="1224" alt="Screenshot 2020-10-26 at 13 14 34" src="https://user-images.githubusercontent.com/12495882/97171189-52af9b80-178d-11eb-8cb8-13f427927f3c.png">

