### PR TITLE
Add preview of questions to an election

### DIFF
--- a/decidim-elections/app/assets/stylesheets/decidim/elections/focus/_accordion.scss
+++ b/decidim-elections/app/assets/stylesheets/decidim/elections/focus/_accordion.scss
@@ -1,0 +1,36 @@
+.accordion{
+  background: transparent;
+
+  .accordion-title{
+    font-size: $global-font-size;
+    color: inherit;
+    border: 0;
+    border-radius: 0;
+
+    span{
+      cursor: move;
+    }
+
+    &:focus{
+      background: transparent;
+    }
+  }
+
+  .accordion-item{
+    // Override Foundation
+    &:first-child > :first-child,
+    &:last-child:not(.is-active) > .accordion-title{
+      border: 0;
+      border-radius: 0;
+    }
+  }
+
+  .accordion-content{
+    border: 0;
+
+    .tabs-title > a[aria-selected="true"],
+    .tabs-content{
+      background: transparent;
+    }
+  }
+}

--- a/decidim-elections/app/assets/stylesheets/decidim/elections/focus/_evote.scss
+++ b/decidim-elections/app/assets/stylesheets/decidim/elections/focus/_evote.scss
@@ -276,4 +276,57 @@
   &__poll-id{
     overflow-wrap: anywhere;
   }
+
+  &__preview{
+    .accordion-title::before{
+      font-size: 1.5rem;
+      margin-top: -.75rem;
+      color: $anchor-color;
+      font-weight: normal;
+    }
+  }
+
+  &__preview-question{
+    border: $border;
+    font-weight: 600;
+
+    &:not(:first-child){
+      border-top: 0;
+    }
+
+    .label{
+      margin-left: .5rem;
+    }
+  }
+
+  &__preview-result{
+    line-height: 1.2;
+    margin-bottom: 1rem;
+  }
+
+  &__preview-option{
+    margin-bottom: -.2rem;
+    font-size: 1rem;
+  }
+
+  &__preview-bar{
+    display: flex;
+    align-items: center;
+
+    .progress{
+      flex-grow: 1;
+      margin-right: 1rem;
+    }
+  }
+
+  &__preview-label{
+    font-size: .8rem;
+    margin-top: -.2rem;
+  }
+
+  &__preview-perc{
+    width: 2rem;
+    text-align: right;
+    font-weight: bold;
+  }
 }

--- a/decidim-elections/app/views/decidim/elections/elections/show.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/show.html.erb
@@ -68,7 +68,7 @@ edit_link(
     <p>
       <%= t(".questions_preview.description") %>:
     </p>
-    <ul class="accordion js-sortable mb-m evote__preview"
+    <ul class="accordion mb-m evote__preview"
         data-accordion
         data-multi-expand="true"
         data-allow-all-closed="true">

--- a/decidim-elections/app/views/decidim/elections/elections/show.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/show.html.erb
@@ -49,14 +49,42 @@ edit_link(
           <%= t(".vote") %>
         <% end %>
       <% else %>
-        <span class="title-action__action button small disabled"><%= t(".vote") %></span>
+        <span class="button disabled"><%= t(".vote") %></span>
       <% end %>
 
       <% if allowed_to? :preview, :election, election: election %>
-        <%= link_to new_election_vote_path(election.id), class: "title-action__action button small" do %>
+        <%= link_to new_election_vote_path(election.id), class: "button" do %>
           <%= t(".preview") %>
         <% end %>
       <% end %>
     </div>
+  </div>
+</div>
+
+<!-- Election questions preview -->
+<div class="row section">
+  <div class="columns large-8">
+    <h2 class="section-heading"><%= t(".questions_preview.title") %></h2>
+    <p>
+      <%= t(".questions_preview.description") %>:
+    </p>
+    <ul class="accordion js-sortable mb-m evote__preview"
+        data-accordion
+        data-multi-expand="true"
+        data-allow-all-closed="true">
+          <% election.questions.each do |question| %>
+            <li class="accordion-item evote__preview-question" data-accordion-item>
+              <a href="#" class="accordion-title flex--sbc"><%= translated_attribute(question.title) %></a>
+              <div class="accordion-content" data-tab-content>
+                <strong><%= t(".questions_preview.available_answers") %>:</strong>
+                <ul>
+                  <% question.answers.each do |answer| %>
+                  <li><%= translated_attribute(answer.title) %></li>
+                  <% end %>
+                </ul>
+              </div>
+            </li>
+          <% end %>
+      </ul>
   </div>
 </div>

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -204,8 +204,12 @@ en:
           filter_by: Filter by
           unfold: Unfold
         show:
-          back: All elections
+          back: Available elections
           preview: Preview
+          questions_preview:
+            available_answers: Available answers
+            description: These are the questions you will find in the voting process
+            title: Election questions
           vote: Vote
           voting_period_status:
             finished: Voting began on %{start_time} and ended on %{end_time}

--- a/decidim-elections/spec/system/explore_elections_spec.rb
+++ b/decidim-elections/spec/system/explore_elections_spec.rb
@@ -24,6 +24,7 @@ describe "Explore elections", :slow, type: :system do
 
         expect(page).to have_content("Voting began on")
         expect(page).not_to have_content("All elections")
+        expect(page).to have_content("These are the questions you will find in the voting process")
       end
     end
 
@@ -136,6 +137,7 @@ describe "Explore elections", :slow, type: :system do
   describe "show" do
     let(:elections_count) { 1 }
     let(:election) { elections.first }
+    let(:question) { election.questions.first }
     let(:image) { create(:attachment, :with_image, attached_to: election) }
 
     before do
@@ -147,6 +149,16 @@ describe "Explore elections", :slow, type: :system do
       expect(page).to have_i18n_content(election.title)
       expect(page).to have_i18n_content(election.description)
       expect(page).to have_content(election.end_time.day)
+    end
+
+    it "shows accordion with questions and answers" do
+      expect(page).to have_css(".accordion-item", count: election.questions.count)
+      expect(page).not_to have_css(".accordion-content")
+
+      within ".accordion-item:first-child" do
+        click_link translated(question.title)
+        expect(page).to have_css("li", count: question.answers.count)
+      end
     end
 
     context "with attached photos" do


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds an accordion to an election page that shows the related questions and answers.

#### :pushpin: Related Issues
- Fixes #6531 

#### Testing
Go to the public elections module and click on one of the elections. That page shows an accordion below the election information.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
By default, the accordion is collapsed:
<img width="1351" alt="accordion collapsed" src="https://user-images.githubusercontent.com/19774772/97205596-f4e47900-17b7-11eb-94e0-233078593a07.png">

You can see the answers when you click on the question:
<img width="1388" alt="accordion expanded" src="https://user-images.githubusercontent.com/19774772/97205630-ff067780-17b7-11eb-901f-fe255f0bf51b.png">

:hearts: Thank you!
