### PR TITLE
Fix a mistake in a string

### DIFF
--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -218,7 +218,7 @@ en:
             landing_page_content: Budgets landing page
             more_information_modal: More information modal
             projects_per_page: Projects per page
-            resources_permissions_enabled: Actions permissions can be set for each meeting
+            resources_permissions_enabled: Actions permissions can be set for each project
             scope_id: Scope
             scopes_enabled: Scopes enabled
             title: Title


### PR DESCRIPTION
#### :tophat: What? Why?

Apparently, [a string](https://github.com/decidim/decidim/blob/cc45c82c5c04525df4cd88efec8640338e64a57d/decidim-budgets/config/locales/en.yml#L221) was copied and not modified when copy-pasting a function from decidim-meetings to decidim-budgets

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #3804

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

It's just a typo, no need to add to the changelog?
