### PR TITLE
Backport "Fix content block image updates" to v0.23

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/update_content_block.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_content_block.rb
@@ -24,10 +24,15 @@ module Decidim
       def call
         return broadcast(:invalid) if form.invalid?
 
+        # First set the images to see if there are any errors with them. This
+        # makes the image file validations according to their uploader settings
+        # and the organization settings. The content block validation will fail
+        # in case there are processing errors on the image files.
+        update_content_block_images
+        return broadcast(:invalid) unless content_block.valid?
+
         transaction do
           update_content_block_settings
-          content_block.save!
-          update_content_block_images
           content_block.save!
         end
 

--- a/decidim-admin/app/commands/decidim/admin/update_content_block.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_content_block.rb
@@ -31,6 +31,11 @@ module Decidim
         update_content_block_images
         return broadcast(:invalid) unless content_block.valid?
 
+        # Make sure the images are actually saved when there are no errors.
+        # Otherwise this can cause the newsletter content block images not to
+        # save properly.
+        content_block.save!
+
         transaction do
           update_content_block_settings
           content_block.save!

--- a/decidim-admin/app/controllers/decidim/admin/organization_homepage_content_blocks_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/organization_homepage_content_blocks_controller.rb
@@ -22,6 +22,7 @@ module Decidim
             redirect_to edit_organization_homepage_path
           end
           on(:invalid) do
+            edit # Sets the model to the view so that it can render the form
             render :edit
           end
         end

--- a/decidim-admin/spec/commands/decidim/admin/update_content_block_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/update_content_block_spec.rb
@@ -99,14 +99,6 @@ module Decidim::Admin
             content_block.organization.settings.tap do |settings|
               settings.upload.maximum_file_size.default = 1.kilobyte.to_f / 1.megabyte
             end
-
-            # Enable processing for the test in order to catch validation errors
-            Decidim::HomepageImageUploader.enable_processing = true
-          end
-
-          after do
-            Decidim::HomepageImageUploader.enable_processing = false
-            content_block.images_container.background_image.remove!
           end
 
           it "is not valid" do

--- a/decidim-admin/spec/commands/decidim/admin/update_content_block_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/update_content_block_spec.rb
@@ -75,8 +75,16 @@ module Decidim::Admin
         end
 
         before do
+          # Enable processing for the test in order to catch validation errors
+          Decidim::HomepageImageUploader.enable_processing = true
+
           content_block.images_container.background_image = original_image
           content_block.save
+        end
+
+        after do
+          Decidim::HomepageImageUploader.enable_processing = false
+          content_block.images_container.background_image.remove! if content_block.images_container.background_image
         end
 
         it "updates the image" do
@@ -84,6 +92,26 @@ module Decidim::Admin
             subject.call
             content_block.reload
           end.to(change { content_block.images_container.background_image.url })
+        end
+
+        context "with the image being larger in size than the organization allows" do
+          before do
+            content_block.organization.settings.tap do |settings|
+              settings.upload.maximum_file_size.default = 1.kilobyte.to_f / 1.megabyte
+            end
+
+            # Enable processing for the test in order to catch validation errors
+            Decidim::HomepageImageUploader.enable_processing = true
+          end
+
+          after do
+            Decidim::HomepageImageUploader.enable_processing = false
+            content_block.images_container.background_image.remove!
+          end
+
+          it "is not valid" do
+            expect { subject.call }.to broadcast(:invalid)
+          end
         end
 
         context "when removing the image" do

--- a/decidim-core/app/models/decidim/content_block.rb
+++ b/decidim-core/app/models/decidim/content_block.rb
@@ -15,6 +15,8 @@ module Decidim
     before_save :save_images
     after_save :reload_images
 
+    validate :images_container_valid
+
     # Public: finds the published content blocks for the given scope and
     # organization. Returns them ordered by ascending weight (lowest first).
     def self.for_scope(scope, organization:)
@@ -79,7 +81,7 @@ module Decidim
         attr_reader :content_block
 
         # Needed to calculate uploads URLs
-        delegate :id, to: :content_block
+        delegate :id, :organization, to: :content_block
 
         # Needed to customize the upload URL
         def self.name
@@ -130,7 +132,17 @@ module Decidim
       @images_container = @images_container.new(self)
     end
 
+    attr_accessor :test
+
     private
+
+    def images_container_valid
+      # Note that we cannot call .valid? because it's not an ActiveRecord
+      # object. It's ActiveModel and in that case, CarrierWave will not work
+      # "normally" with the validators. It adds the errors directly after the
+      # uploader was tried to set.
+      errors.add(:images_container, :invalid) if images_container.errors.any?
+    end
 
     # Internal: Since we're using the `images_container` hack to hold the
     # uploaders, we need to manually trigger it to save the attached images.

--- a/decidim-core/app/models/decidim/content_block.rb
+++ b/decidim-core/app/models/decidim/content_block.rb
@@ -132,8 +132,6 @@ module Decidim
       @images_container = @images_container.new(self)
     end
 
-    attr_accessor :test
-
     private
 
     def images_container_valid

--- a/decidim-core/spec/models/decidim/content_block_spec.rb
+++ b/decidim-core/spec/models/decidim/content_block_spec.rb
@@ -15,6 +15,16 @@ module Decidim
     end
 
     describe ".images_container" do
+      before do
+        # Enable processing for the test in order to catch validation errors
+        Decidim::HomepageImageUploader.enable_processing = true
+      end
+
+      after do
+        Decidim::HomepageImageUploader.enable_processing = false
+        content_block.images_container.background_image.remove! if content_block.images_container.background_image
+      end
+
       it "responds to the image names" do
         expect(subject.images_container).to respond_to(:background_image)
       end
@@ -38,8 +48,35 @@ module Decidim
           subject.save
         end
 
-        it "returns nil" do
+        it "returns the image" do
           expect(subject.images_container.background_image).not_to be_nil
+        end
+      end
+
+      context "when the image is larger in size than the organization allows" do
+        let(:original_image) do
+          Rack::Test::UploadedFile.new(
+            Decidim::Dev.test_file("city.jpeg", "image/jpeg"),
+            "image/jpeg"
+          )
+        end
+
+        before do
+          content_block.organization.settings.tap do |settings|
+            settings.upload.maximum_file_size.default = 1.kilobyte.to_f / 1.megabyte
+          end
+        end
+
+        it "returns fails to save the image with validation errors" do
+          subject.test = true
+          subject.images_container.background_image = original_image
+          subject.save
+          expect(subject.valid?).to be(false)
+          expect(subject.errors[:images_container]).to eq(["is invalid"])
+          expect(subject.images_container.errors.full_messages).to eq(
+            ["Background image The image is too big"]
+          )
+          expect(subject.images).to eq({})
         end
       end
     end

--- a/decidim-core/spec/models/decidim/content_block_spec.rb
+++ b/decidim-core/spec/models/decidim/content_block_spec.rb
@@ -68,7 +68,6 @@ module Decidim
         end
 
         it "returns fails to save the image with validation errors" do
-          subject.test = true
           subject.images_container.background_image = original_image
           subject.save
           expect(subject.valid?).to be(false)


### PR DESCRIPTION
#### :tophat: What? Why?
Backports #6681 to 0.23 in order to fix the content block images not being editable.

#### :pushpin: Related Issues
- Related to #6681

#### Testing
See original issue.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.