### PR TITLE
Security: hide uploader's internal tool details to users

### DIFF
--- a/decidim-core/app/uploaders/decidim/application_uploader.rb
+++ b/decidim-core/app/uploaders/decidim/application_uploader.rb
@@ -17,6 +17,16 @@ module Decidim
       default_path
     end
 
+    # When the uploaded content can't be processed, we want to make sure
+    # not to expose internal tools errors to the users.
+    # We'll show a generic error instead.
+    def manipulate!
+      super
+    rescue CarrierWave::ProcessingError => e
+      Rails.logger.error(e)
+      raise CarrierWave::ProcessingError, I18n.t("carrierwave.errors.general")
+    end
+
     protected
 
     # Validates that the associated model is always within an organization in

--- a/decidim-core/app/uploaders/decidim/image_uploader.rb
+++ b/decidim-core/app/uploaders/decidim/image_uploader.rb
@@ -66,13 +66,6 @@ module Decidim
       3840
     end
 
-    def manipulate!
-      super
-    rescue CarrierWave::ProcessingError => e
-      Rails.logger.error(e)
-      raise CarrierWave::ProcessingError, I18n.t("carrierwave.errors.general")
-    end
-
     private
 
     def validation_error!(text)


### PR DESCRIPTION
#### :tophat: What? Why?
When uploading a normal file with an image extension (e.g. a file containing HTML named 'document.jpg') in a Decidim file uploader, the form would show an error that discloses the usage of an internal tool - representing a security issue.

This PR replaces `CarrierWave::ProcessingError` error messages with a more generic error message, in order to hide internal tool details to the user.

This was already implemented for `Decidim::ImageUploader` by overwriting `CarrierWave::MiniMagick`'s `manipulate!` method.

Moved the overwritten method to `Decidim::ApplicationUploader` so that also `Decidim::AttachmentUploader` can take advantage of it when it is set to accept images.

#### :pushpin: Related Issues
- Fixes DIFE-217

#### Testing
- Create an HTLM document and change its extension to `.jpg`.
- Upload the document to a form with a file upload accepting jpgs (e.g.: `admin/conferences/<conference-slug>/attachments/new`)
- Check that the error message doesn't disclose internal implementation.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
#### Before
<img width="1045" alt="before" src="https://user-images.githubusercontent.com/5033945/97334669-4b67bb00-187d-11eb-99d6-39f8d909375f.png">

#### After
<img width="614" alt="after" src="https://user-images.githubusercontent.com/5033945/97334687-502c6f00-187d-11eb-8f9d-ee80c78b06e7.png">

:hearts: Thank you!
