### PR TITLE
Fix newsletter create and update actions

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/newsletters_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/newsletters_controller.rb
@@ -37,7 +37,7 @@ module Decidim
         enforce_permission_to :create, :newsletter
         @form = form(NewsletterForm).from_params(params)
         @form.images = images_block_context unless has_images_block_context?
-        
+
         CreateNewsletter.call(@form, content_block, current_user) do
           on(:ok) do |newsletter|
             flash.now[:notice] = I18n.t("newsletters.create.success", scope: "decidim.admin")

--- a/decidim-admin/app/controllers/decidim/admin/newsletters_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/newsletters_controller.rb
@@ -36,7 +36,8 @@ module Decidim
       def create
         enforce_permission_to :create, :newsletter
         @form = form(NewsletterForm).from_params(params)
-
+        @form.images = images_block_context unless has_images_block_context?
+        
         CreateNewsletter.call(@form, content_block, current_user) do
           on(:ok) do |newsletter|
             flash.now[:notice] = I18n.t("newsletters.create.success", scope: "decidim.admin")
@@ -59,6 +60,7 @@ module Decidim
       def update
         enforce_permission_to :update, :newsletter, newsletter: newsletter
         @form = form(NewsletterForm).from_params(params)
+        @form.images = images_block_context unless has_images_block_context?
 
         UpdateNewsletter.call(newsletter, @form, current_user) do
           on(:ok) do |newsletter|
@@ -155,6 +157,14 @@ module Decidim
         return nil unless @newsletter
 
         @content_block_for_newsletter ||= @newsletter.template
+      end
+
+      def images_block_context
+        form(NewsletterForm).from_model(content_block).images
+      end
+
+      def has_images_block_context?
+        @form.images && @form.valid?
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
When trying to create or update a newsletter with an invalid form (i.e. a required field is empty) the redirection fails because of the lack of images' content_block context.
This PR adds the context needed when the creation or update of a newsletter fails due to an invalid form.

#### :pushpin: Related Issues
- Related to #6735 

#### Testing
1. Select "Català" as language
2. Navitage
3. "Taulell d'Administració"
4. "Butlletins"
5. "Nou butlletí"
6. Select "Image, text, and Call To Action button" template
7. Fill the mandatory fields but leaving the English text for "Assumpte" empty
8. Click "Desar" button

#### :clipboard: Checklist
- [x] Adds images' context to `create` and `update` actions


### :camera: Screenshots
<img width="1440" alt="Screenshot 2020-10-28 at 10 29 06" src="https://user-images.githubusercontent.com/12495882/97417954-9084ff00-1908-11eb-9148-d6ca52d19dba.png">
<img width="1440" alt="Screenshot 2020-10-28 at 10 29 13" src="https://user-images.githubusercontent.com/12495882/97417967-94b11c80-1908-11eb-9711-0484b71844d0.png">
<img width="1061" alt="Screenshot 2020-10-28 at 10 29 21" src="https://user-images.githubusercontent.com/12495882/97417978-97137680-1908-11eb-9007-bd1b3d2a261f.png">
<img width="1104" alt="Screenshot 2020-10-28 at 10 29 27" src="https://user-images.githubusercontent.com/12495882/97417991-9844a380-1908-11eb-95fd-5d1b1b57770a.png">
<img width="1440" alt="Screenshot 2020-10-28 at 10 29 36" src="https://user-images.githubusercontent.com/12495882/97417999-9a0e6700-1908-11eb-94a7-35877cee743f.png">

