### PR TITLE
Fix images url in assemblies presenter on cloud storage

### DIFF
--- a/decidim-assemblies/app/presenters/decidim/assemblies/assembly_presenter.rb
+++ b/decidim-assemblies/app/presenters/decidim/assemblies/assembly_presenter.rb
@@ -10,10 +10,14 @@ module Decidim
       delegate :url, to: :banner_image, prefix: true
 
       def hero_image_url
+        return if assembly.hero_image.blank?
+
         URI.join(decidim.root_url(host: assembly.organization.host), assembly.hero_image_url).to_s
       end
 
       def banner_image_url
+        return if assembly.banner_image.blank?
+
         URI.join(decidim.root_url(host: assembly.organization.host), assembly.banner_image_url).to_s
       end
 

--- a/decidim-assemblies/app/presenters/decidim/assemblies/assembly_presenter.rb
+++ b/decidim-assemblies/app/presenters/decidim/assemblies/assembly_presenter.rb
@@ -10,17 +10,11 @@ module Decidim
       delegate :url, to: :banner_image, prefix: true
 
       def hero_image_url
-        uri = URI(assembly.hero_image.file.file)
-        return uri unless uri.scheme.nil?
-
         URI.join(decidim.root_url(host: assembly.organization.host), assembly.hero_image_url).to_s
       end
 
       def banner_image_url
-        uri = URI(assembly.hero_image.file.file)
-        return uri unless uri.scheme.nil?
-
-        URI.join(decidim.root_url(host: assembly.organization.host), assembly.hero_image_url).to_s
+        URI.join(decidim.root_url(host: assembly.organization.host), assembly.banner_image_url).to_s
       end
 
       def assembly

--- a/decidim-assemblies/spec/presenters/decidim/assemblies/assembly_presenter_spec.rb
+++ b/decidim-assemblies/spec/presenters/decidim/assemblies/assembly_presenter_spec.rb
@@ -9,6 +9,20 @@ module Decidim
     let!(:assembly) { create(:assembly) }
     let(:organization_host) { assembly.organization.host }
 
+    describe "when no images were uploaded" do
+      before do
+        assembly.update!(hero_image: nil, banner_image: nil)
+      end
+
+      it "return nil for hero_image_url" do
+        expect(subject.hero_image_url).to be_nil
+      end
+
+      it "return nil for banner_image_url" do
+        expect(subject.banner_image_url).to be_nil
+      end
+    end
+
     describe "when images are stored in the local filesystem" do
       it "resolves hero_image_url" do
         expect(subject.hero_image_url).to eq("http://#{organization_host}#{assembly.hero_image_url}")

--- a/decidim-assemblies/spec/presenters/decidim/assemblies/assembly_presenter_spec.rb
+++ b/decidim-assemblies/spec/presenters/decidim/assemblies/assembly_presenter_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe Assemblies::AssemblyPresenter do
+    subject { described_class.new(assembly) }
+
+    let!(:assembly) { create(:assembly) }
+    let(:organization_host) { assembly.organization.host }
+
+    describe "when images are stored in the local filesystem" do
+      it "resolves hero_image_url" do
+        expect(subject.hero_image_url).to eq("http://#{organization_host}#{assembly.hero_image_url}")
+      end
+
+      it "resolves banner_image_url" do
+        expect(subject.banner_image_url).to eq("http://#{organization_host}#{assembly.banner_image_url}")
+      end
+    end
+
+    describe "when images are stored in a cloud service" do
+      it "resolves hero_image_url" do
+        avoid_the_use_of_file_storage_specific_methods(:hero_image)
+        expect(subject.hero_image_url).to eq("http://#{organization_host}#{assembly.hero_image_url}")
+      end
+
+      it "resolves banner_image_url" do
+        avoid_the_use_of_file_storage_specific_methods(:banner_image)
+        expect(subject.banner_image_url).to eq("http://#{organization_host}#{assembly.banner_image_url}")
+      end
+
+      def avoid_the_use_of_file_storage_specific_methods(uploader_name)
+        # we're avoiding the use of `assembly.hero_image.file.file` in
+        expect(assembly.send(uploader_name).file).not_to receive(:file)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
*Please describe your pull request.*
The `Decidim::Assemblies::AssemblyPresenter` is implemented using File storage specific methods. Then in installations that store files in a cloud service like Amazon S3 this presenter crashes.

This PR refactors the presenter in order to not be dependant on the configured storage system.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #6697 

#### Testing
*Describe the best way to test or validate your PR.*
 Export an assembly in an installation configured to use S3.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
