### PR TITLE
Fix budgeting projects ordered ids

### DIFF
--- a/decidim-budgets/app/models/decidim/budgets/project.rb
+++ b/decidim-budgets/app/models/decidim/budgets/project.rb
@@ -37,7 +37,11 @@ module Decidim
       )
 
       def self.ordered_ids(ids)
-        order(Arel.sql("position(id::text in '#{ids.join(",")}')"))
+        # Make sure each ID in the matching text has a "," character as their
+        # delimiter. Otherwise e.g. ID 2 would match ID "26" in the original
+        # array. This is why we search for match ",2," instead to get the actual
+        # position for ID 2.
+        order(Arel.sql("position(concat(',', id::text, ',') in ',#{ids.join(",")},')"))
       end
 
       def self.log_presenter_class_for(_log)


### PR DESCRIPTION
#### :tophat: What? Why?
The [`ordered_ids`](https://github.com/decidim/decidim/blob/e7966b99eefd1b8ab02fef9813f3a4fcc657835c/decidim-budgets/app/models/decidim/budgets/project.rb#L39-L41) sorting method for the budgeting projects is currently broken.

If you have e.g. a case with IDs 1-49 in the database, this method would cause incorrect orders when called with ID arrays where numbers 1, 2, 3 and 4 are AFTER numbers such as 12, 23, 22, 11, 46, etc. This is because e.g. "4" matches with "46" when you do a string match.

This fixes the method by adding the comma character as a delimiter for the IDs. Thefore, if we search for `,2,` instead of `2`, it will only match with the correct position with delimiters on both sides of the number.

This method is used for [sorting the projects based on the number of votes](https://github.com/decidim/decidim/blob/e7966b99eefd1b8ab02fef9813f3a4fcc657835c/decidim-budgets/app/controllers/concerns/decidim/budgets/orderable.rb#L44) after the budget votes become visible on the site.

#### Testing
- Create a fresh and clean Decidim instance
- Create a process
- Create the budgeting component for the process
- Create one budget and 20 projects for the budget
- Leave e.g. 10 votes with various accounts to the budgeting component for project with IDs > 10
- Disable voting and enable display of votes
- See incorrect order for the projects list for the "most voted" order

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![budget-projects-most-voted-incorrect-order](https://user-images.githubusercontent.com/864340/97455106-26884c00-1940-11eb-8bce-ce1ee69c9850.png)