### PR TITLE
Fix missing translation keys for mime types

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -239,6 +239,8 @@ ignore_unused:
   - decidim.assemblies.filter.*
   - decidim.initiatives.initiatives.votes_count.count.*
   - decidim.proposals.admin.participatory_texts.new_import.accepted_mime_types.*
+  - decidim.participatory_processes.admin.new_import.accepted_types.*
+  - decidim.assemblies.admin.new_import.accepted_types.*
   - decidim.amendments.visibility_options.*
   - decidim.wizard_step_form.*
   - decidim.proposals.proposals.filters.*

--- a/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_import_form.rb
+++ b/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_import_form.rb
@@ -13,6 +13,9 @@ module Decidim
         # Accepted mime types
         # keys: are used for dynamic help text on admin form.
         # values: are used to validate the file format of imported document.
+        #
+        # WARNING: consider adding/removing the relative translation key at
+        # decidim.assemblies.admin.new_import.accepted_types when modifying this hash
         ACCEPTED_TYPES = {
           json: JSON_MIME_TYPE
         }.freeze

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -306,6 +306,9 @@ en:
         content_blocks:
           highlighted_assemblies:
             max_results: Maximum amount of elements to show
+        new_import:
+          accepted_types:
+            json: JSON
       assembly_members:
         index:
           members: Members

--- a/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_import_form.rb
+++ b/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_import_form.rb
@@ -13,6 +13,9 @@ module Decidim
         # Accepted mime types
         # keys: are used for dynamic help text on admin form.
         # values: are used to validate the file format of imported document.
+        #
+        # WARNING: consider adding/removing the relative translation key at
+        # decidim.participatory_processes.admin.new_import.accepted_types when modifying this hash
         ACCEPTED_TYPES = {
           json: JSON_MIME_TYPE
         }.freeze

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -316,6 +316,9 @@ en:
         content_blocks:
           highlighted_processes:
             max_results: Maximum amount of elements to show
+        new_import:
+          accepted_types:
+            json: JSON
         participatory_process_copies:
           form:
             slug_help: 'URL slugs are used to generate the URLs that point to this process. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'

--- a/decidim-proposals/app/forms/decidim/proposals/admin/import_participatory_text_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/import_participatory_text_form.rb
@@ -8,6 +8,8 @@ module Decidim
       class ImportParticipatoryTextForm < Decidim::Form
         include TranslatableAttributes
 
+        # WARNING: consider adding/removing the relative translation key at
+        # decidim.assemblies.admin.new_import.accepted_types when modifying this hash
         ACCEPTED_MIME_TYPES = Decidim::Proposals::DocToMarkdown::ACCEPTED_MIME_TYPES
 
         translatable_attribute :title, String


### PR DESCRIPTION
#### :tophat: What? Why?
The import page for Participatory Processes and Assemblies was lacking a translation for an error.

This PR adds the missing translation keys.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
- Login as admin
- Navigate to `admin/assemblies/imports/new` or `admin/participatory_processes/imports/new`
- Fill out the form and as 'Document' load a file with an extension other than '.json'. Click 'Import'
- `Invalid document type. Accepted formats are: JSON` should appear next to the document uploader 

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
#### BEFORE
![image](https://user-images.githubusercontent.com/5033945/97602274-66683580-1a0b-11eb-972a-f97924aad72d.png)

#### AFTER
![image](https://user-images.githubusercontent.com/5033945/97602286-6a945300-1a0b-11eb-8fbb-50705fa3d39e.png)

:hearts: Thank you!
