### PR TITLE
Disable select inputs with the subform toggler as well

### DIFF
--- a/decidim-admin/app/assets/javascripts/decidim/admin/subform_multi_toggler.component.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/subform_multi_toggler.component.js.es6
@@ -23,10 +23,10 @@
       let $selectedSubform = $form.find(`#${subformWrapperClass}-${value}`)
 
       if ($target.prop("checked")) {
-        $selectedSubform.find("input,textarea").prop("disabled", false);
+        $selectedSubform.find("input,textarea,select").prop("disabled", false);
         $selectedSubform.show();
       } else {
-        $selectedSubform.find("input,textarea").prop("disabled", true);
+        $selectedSubform.find("input,textarea,select").prop("disabled", true);
         $selectedSubform.hide();
       }
     }

--- a/decidim-admin/app/assets/javascripts/decidim/admin/subform_toggler.component.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/subform_toggler.component.js.es6
@@ -23,10 +23,10 @@
       let $subforms = $form.find(`.${subformWrapperClass}`);
       let $selectedSubform = $subforms.filter(`#${subformWrapperClass}-${value}`)
 
-      $subforms.find("input,textarea").prop("disabled", true);
+      $subforms.find("input,textarea,select").prop("disabled", true);
       $subforms.hide();
 
-      $selectedSubform.find("input,textarea").prop("disabled", false);
+      $selectedSubform.find("input,textarea,select").prop("disabled", false);
       $selectedSubform.show();
     }
 


### PR DESCRIPTION
#### :tophat: What? Why?
When the manual authorizations view in the admin panel has authorization handler forms with required select elements on them, the form cannot be sent unless something is selected from each authorization's required select elements.

This fixes the issue by disabling those select elements along with the other disabled form inputs for the hidden forms.

#### Testing
- Create two authorization handlers that can perform managed user sessions
- Add a required select element in both forms
- Go to the create managed user view
- Try to submit the form after filling in the details for the first authorization.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.