### PR TITLE
Backport "Fix budgeting projects ordered ids" to 0.23

### DIFF
--- a/decidim-budgets/app/models/decidim/budgets/project.rb
+++ b/decidim-budgets/app/models/decidim/budgets/project.rb
@@ -37,7 +37,11 @@ module Decidim
       )
 
       def self.ordered_ids(ids)
-        order(Arel.sql("position(id::text in '#{ids.join(",")}')"))
+        # Make sure each ID in the matching text has a "," character as their
+        # delimiter. Otherwise e.g. ID 2 would match ID "26" in the original
+        # array. This is why we search for match ",2," instead to get the actual
+        # position for ID 2.
+        order(Arel.sql("position(concat(',', id::text, ',') in ',#{ids.join(",")},')"))
       end
 
       def self.log_presenter_class_for(_log)


### PR DESCRIPTION
#### :tophat: What? Why?
This backports the fix for broken budgeting projects order for the "most voted" order fixed at #6761.

#### :pushpin: Related Issues
- Related to #6761

#### Testing
See original issue.

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
See original issue.