### PR TITLE
Redo Fix Question for Consultation can not be rendered without image

### DIFF
--- a/decidim-consultations/app/views/decidim/consultations/questions/show.html.erb
+++ b/decidim-consultations/app/views/decidim/consultations/questions/show.html.erb
@@ -36,7 +36,7 @@
 <%= content_for :question_header_details do %>
   <div id="question-header-details" class="row consultations-home-intro">
     <div class="columns medium-5">
-      <%= image_tag current_question.hero_image&.url, alt: t("question.hero_image", scope: "activemodel.attributes") unless current_question.hero_image %>
+      <%= image_tag current_question.hero_image.url, alt: t("question.hero_image", scope: "activemodel.attributes") if current_question.hero_image&.url %>
     </div>
 
     <div class="columns medium-5">


### PR DESCRIPTION
#### :tophat: What? Why?
Redo `Fix Question for Consultation can not be rendered without image` since it was faulty.

#### :pushpin: Related Issues
- Related to #6731 

