### PR TITLE
Fix upcoming meetings content block should only show visible meetings

### DIFF
--- a/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_events_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_events_cell.rb
@@ -16,6 +16,7 @@ module Decidim
           @upcoming_events ||= Decidim::Meetings::Meeting
                                .includes(component: :participatory_space)
                                .where(component: meeting_components)
+                               .visible_meeting_for(current_user)
                                .where("end_time >= ?", Time.current)
                                .order(start_time: :asc)
                                .limit(limit)

--- a/decidim-meetings/spec/cells/decidim/meetings/content_blocks/upcoming_events_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/content_blocks/upcoming_events_cell_spec.rb
@@ -10,6 +10,8 @@ module Decidim
 
         let(:html) { cell("decidim/meetings/content_blocks/upcoming_events").call }
         let(:organization) { create(:organization) }
+        let(:current_user) { create :user, :admin, :confirmed, organization: organization }
+        let(:invited_by) { create(:user, :admin, :confirmed, organization: organization ) }
 
         before do
           expect(controller).to receive(:current_organization).at_least(:once).and_return(organization)
@@ -42,6 +44,46 @@ module Decidim
               expect(subject.length).to eq(2)
               expect(subject.first).to eq(meeting)
               expect(subject.last).to eq(second_meeting)
+            end
+
+            context "with upcoming private events" do
+              let!(:meeting) do
+                create(:meeting, start_time: 1.week.from_now, private_meeting: true, transparent: false)
+              end
+              let!(:second_meeting) do
+                create(:meeting, start_time: meeting.start_time.advance(weeks: 1), component: meeting.component, private_meeting: true, transparent: false)
+              end
+
+              it "renders nothing" do
+                expect(subject.length).to eq(0)
+              end
+            end
+
+            context "with upcoming private events but invited user" do
+              let!(:meeting) do
+                create(:meeting, start_time: 1.week.from_now, private_meeting: true, transparent: false)
+              end
+              let!(:second_meeting) do
+                create(:meeting, start_time: meeting.start_time.advance(weeks: 1), component: meeting.component, private_meeting: true, transparent: false)
+              end
+              let(:invite_form_params) do
+                {
+                  name: current_user.name,
+                  email: current_user.email,
+                  user_id: current_user.id,
+                  existing_user: true
+                }
+              end
+              let(:invite_user_form) do
+                Decidim::Meetings::Admin::MeetingRegistrationInviteForm.from_params(invite_form_params)
+              end
+              let!(:invite_user_to_meeting) do
+                Decidim::Meetings::Admin::InviteUserToJoinMeeting.call(invite_user_form, second_meeting, invited_by)
+              end
+
+              it "renders only upcoming not private meeting correctly" do
+                expect(subject.length).to eq(1)
+              end
             end
           end
         end

--- a/decidim-meetings/spec/cells/decidim/meetings/content_blocks/upcoming_events_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/content_blocks/upcoming_events_cell_spec.rb
@@ -11,7 +11,6 @@ module Decidim
         let(:html) { cell("decidim/meetings/content_blocks/upcoming_events").call }
         let(:organization) { create(:organization) }
         let(:current_user) { create :user, :admin, :confirmed, organization: organization }
-        let(:invited_by) { create(:user, :admin, :confirmed, organization: organization) }
 
         before do
           expect(controller).to receive(:current_organization).at_least(:once).and_return(organization)

--- a/decidim-meetings/spec/cells/decidim/meetings/content_blocks/upcoming_events_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/content_blocks/upcoming_events_cell_spec.rb
@@ -11,7 +11,7 @@ module Decidim
         let(:html) { cell("decidim/meetings/content_blocks/upcoming_events").call }
         let(:organization) { create(:organization) }
         let(:current_user) { create :user, :admin, :confirmed, organization: organization }
-        let(:invited_by) { create(:user, :admin, :confirmed, organization: organization ) }
+        let(:invited_by) { create(:user, :admin, :confirmed, organization: organization) }
 
         before do
           expect(controller).to receive(:current_organization).at_least(:once).and_return(organization)
@@ -60,6 +60,11 @@ module Decidim
             end
 
             context "with upcoming private events but invited user" do
+              let(:context) do
+                {
+                  current_organization: organization
+                }
+              end
               let!(:meeting) do
                 create(:meeting, start_time: 1.week.from_now, private_meeting: true, transparent: false)
               end
@@ -75,10 +80,13 @@ module Decidim
                 }
               end
               let(:invite_user_form) do
-                Decidim::Meetings::Admin::MeetingRegistrationInviteForm.from_params(invite_form_params)
+                Decidim::Meetings::Admin::MeetingRegistrationInviteForm.from_params(invite_form_params).with_context(context)
               end
               let!(:invite_user_to_meeting) do
-                Decidim::Meetings::Admin::InviteUserToJoinMeeting.call(invite_user_form, second_meeting, invited_by)
+                Decidim::Meetings::Admin::InviteUserToJoinMeeting.call(invite_user_form, meeting, invited_by)
+              end
+              let!(:accept_meeting_invitation) do
+                meeting.invites.first.accept!
               end
 
               it "renders only upcoming not private meeting correctly" do

--- a/decidim-meetings/spec/cells/decidim/meetings/content_blocks/upcoming_events_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/content_blocks/upcoming_events_cell_spec.rb
@@ -89,7 +89,7 @@ module Decidim
                 meeting.invites.first.accept!
               end
 
-              it "renders only upcoming not private meeting correctly" do
+              it "renders only user's invited upcoming private meeting correctly" do
                 expect(subject.length).to eq(1)
               end
             end

--- a/decidim-meetings/spec/cells/decidim/meetings/content_blocks/upcoming_events_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/content_blocks/upcoming_events_cell_spec.rb
@@ -60,33 +60,14 @@ module Decidim
             end
 
             context "with upcoming private events but invited user" do
-              let(:context) do
-                {
-                  current_organization: organization
-                }
-              end
               let!(:meeting) do
                 create(:meeting, start_time: 1.week.from_now, private_meeting: true, transparent: false)
               end
               let!(:second_meeting) do
                 create(:meeting, start_time: meeting.start_time.advance(weeks: 1), component: meeting.component, private_meeting: true, transparent: false)
               end
-              let(:invite_form_params) do
-                {
-                  name: current_user.name,
-                  email: current_user.email,
-                  user_id: current_user.id,
-                  existing_user: true
-                }
-              end
-              let(:invite_user_form) do
-                Decidim::Meetings::Admin::MeetingRegistrationInviteForm.from_params(invite_form_params).with_context(context)
-              end
-              let!(:invite_user_to_meeting) do
-                Decidim::Meetings::Admin::InviteUserToJoinMeeting.call(invite_user_form, meeting, invited_by)
-              end
-              let!(:accept_meeting_invitation) do
-                meeting.invites.first.accept!
+              let!(:meeting_registration) do
+                create(:registration, meeting: meeting, user: current_user)
               end
 
               it "renders only user's invited upcoming private meeting correctly" do


### PR DESCRIPTION
#### :tophat: What? Why?

When there are private meetings marked as non transparent, they are showed on upcoming meetings if the current user is logged. No matters if the user is registered to them.

#### :pushpin: Related Issues

- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
