### PR TITLE
Backport "Do not html_escape twice meetings title in cells" to v0.23

### DIFF
--- a/decidim-meetings/app/cells/decidim/meetings/meeting_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_cell.rb
@@ -28,7 +28,7 @@ module Decidim
       end
 
       def title
-        decidim_html_escape(present(model).title)
+        present(model).title
       end
 
       def resource_icon

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_list_item_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_list_item_cell.rb
@@ -18,7 +18,7 @@ module Decidim
       end
 
       def title
-        decidim_html_escape(present(model).title)
+        present(model).title
       end
 
       def resource_date_time

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_m_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_m_cell.rb
@@ -24,7 +24,7 @@ module Decidim
       end
 
       def title
-        decidim_html_escape(present(model).title)
+        present(model).title
       end
 
       private

--- a/decidim-meetings/spec/cells/decidim/meetings/meeting_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/meeting_cell_spec.rb
@@ -8,10 +8,27 @@ module Decidim::Meetings
 
     let!(:meeting) { create(:meeting) }
 
+    let(:cell_html) { cell("decidim/meetings/meeting", meeting).call }
+
     context "when rendering" do
       it "renders the card" do
-        html = cell("decidim/meetings/meeting", meeting).call
-        expect(html).to have_css(".card--meeting")
+        expect(cell_html).to have_css(".card--meeting")
+      end
+    end
+
+    context "when title contains special html entities" do
+      let(:show_space) { true }
+
+      before do
+        @original_title = meeting.title["en"]
+        meeting.update!(title: { en: "#{meeting.title["en"]} &'<" })
+        meeting.reload
+      end
+
+      it "escapes them correclty" do
+        # as the `cell` test helper wraps conent in a Capybara artifact that already converts html entities
+        # we should compare with the expected visual result, as we were checking the DOM instead of the html
+        expect(cell_html).to have_content("#{@original_title} &'<")
       end
     end
   end

--- a/decidim-meetings/spec/cells/decidim/meetings/meeting_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/meeting_cell_spec.rb
@@ -8,7 +8,8 @@ module Decidim::Meetings
 
     let!(:meeting) { create(:meeting) }
 
-    let(:cell_html) { cell("decidim/meetings/meeting", meeting).call }
+    let(:the_cell) { cell("decidim/meetings/meeting", meeting) }
+    let(:cell_html) { the_cell.call }
 
     context "when rendering" do
       it "renders the card" do

--- a/decidim-meetings/spec/cells/decidim/meetings/meeting_m_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/meeting_m_cell_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 module Decidim::Meetings
-  describe MeetingCell, type: :cell do
+  describe MeetingMCell, type: :cell do
     controller Decidim::Meetings::MeetingsController
 
     let!(:meeting) { create(:meeting) }
@@ -17,6 +17,22 @@ module Decidim::Meetings
 
       it "renders the card" do
         expect(cell_html).to have_css(".card--meeting")
+      end
+    end
+
+    context "when title contains special html entities" do
+      let(:show_space) { true }
+
+      before do
+        @original_title = meeting.title["en"]
+        meeting.update!(title: { en: "#{meeting.title["en"]} &'<" })
+        meeting.reload
+      end
+
+      it "escapes them correclty" do
+        # as the `cell` test helper wraps conent in a Capybara artifact that already converts html entities
+        # we should compare with the expected visual result, as we were checking the DOM instead of the html
+        expect(cell_html).to have_content("#{@original_title} &'<")
       end
     end
   end

--- a/decidim-meetings/spec/cells/decidim/meetings/meeting_m_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/meeting_m_cell_spec.rb
@@ -8,7 +8,8 @@ module Decidim::Meetings
 
     let!(:meeting) { create(:meeting) }
     let(:model) { meeting }
-    let(:cell_html) { cell("decidim/meetings/meeting_m", meeting, context: { show_space: show_space }).call }
+    let(:the_cell) { cell("decidim/meetings/meeting_m", meeting, context: { show_space: show_space }) }
+    let(:cell_html) { the_cell.call }
 
     it_behaves_like "has space in m-cell"
 
@@ -30,6 +31,7 @@ module Decidim::Meetings
       end
 
       it "escapes them correclty" do
+        expect(the_cell.title).to eq("#{@original_title} &amp;&#39;&lt;")
         # as the `cell` test helper wraps conent in a Capybara artifact that already converts html entities
         # we should compare with the expected visual result, as we were checking the DOM instead of the html
         expect(cell_html).to have_content("#{@original_title} &'<")


### PR DESCRIPTION
#### :tophat: What? Why?
*Please describe your pull request.*
Port #6763 to correctly render html entities, like apostrophe symbols, in meetings titles for list and m cells.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #6763

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
