### PR TITLE
Backport #6756 to 0.23 (Fix aria-label attribute in the vote modal confirm close button)

### DIFF
--- a/decidim-consultations/app/views/decidim/consultations/questions/_vote_modal_confirm.html.erb
+++ b/decidim-consultations/app/views/decidim/consultations/questions/_vote_modal_confirm.html.erb
@@ -3,7 +3,7 @@
     <h3 class="reveal__title">
       <%= t "questions.vote_modal_confirm.title", scope: "decidim" %>
     </h3>
-    <button class="close-button" data-close aria-label="<%= t("questions.vote_modal_confirm.close_modal", scope: "decidim") %>%" type="button">
+    <button class="close-button" data-close aria-label="<%= t("questions.vote_modal_confirm.close_modal", scope: "decidim") %>" type="button">
       <span aria-hidden="true">&times;</span>
     </button>
   </div>


### PR DESCRIPTION
#### :tophat: What? Why?

Backport https://github.com/decidim/decidim/pull/6756 to decidim@0.23

#### :pushpin: Related Issues

https://github.com/decidim/decidim/pull/6756

#### Testing

Test that the Close modal button in the Vote modal confirm works fine.
