### PR TITLE
Fix error in removed modules in Content Blocks

### DIFF
--- a/decidim-admin/app/views/decidim/admin/organization_homepage/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization_homepage/edit.html.erb
@@ -18,6 +18,7 @@
           <p class="mb-m"><%= t(".inactive_content_blocks") %></p>
           <ul class="draggable-list js-connect js-list-availables">
             <% inactive_blocks.each do |content_block_or_manifest| %>
+              <% next unless not content_block_or_manifest.respond_to?(:manifest) or content_block_or_manifest.manifest %>
               <%= cell "decidim/admin/content_block", content_block_or_manifest %>
             <% end %>
           </ul>


### PR DESCRIPTION
#### :tophat: What? Why?
Simple guard that fixes #6787. It protects the homepage editor to read content_blocks from gems that have been removed.

#### :pushpin: Related Issues
- Fixes #6787

#### Testing
Repeat the procedure described in the bug for its reproduction and check that no longer a Internal Server Error comes out

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
