### PR TITLE
Backport "Require the necessary 'zip' gem in the open data exporter" to 0.23

### DIFF
--- a/decidim-core/app/services/decidim/open_data_exporter.rb
+++ b/decidim-core/app/services/decidim/open_data_exporter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "zip"
+
 module Decidim
   # Public: It generates a ZIP file with Open Data CSV files ready
   # to be uploaded somewhere so users can download an organization


### PR DESCRIPTION
#### :tophat: What? Why?
Backports the fix from #6464 to 0.23.

#### :pushpin: Related Issues
- Related to #6464

#### Testing
See original issue.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.