### PR TITLE
Only show header snippets input if feature is enabled

### DIFF
--- a/decidim-admin/app/views/decidim/admin/organization_appearance/form/_colors.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization_appearance/form/_colors.html.erb
@@ -13,7 +13,7 @@
       <%= form.color_field :highlight_alternative_color, value: current_organization.colors["highlight-alternative"] %>
     </div>
 
-    <% if true %>
+    <% if Decidim.enable_html_header_snippets %>
       <div class="row column">
         <%= form.text_area :header_snippets %>
         <p class="help-text"><%= t(".header_snippets_help") %></p>

--- a/decidim-admin/spec/system/admin_manages_organization_appearance_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_appearance_spec.rb
@@ -17,7 +17,7 @@ describe "Admin manages organization", type: :system do
         allow(Decidim).to receive(:enable_html_header_snippets).and_return(true)
       end
 
-      it "should not show the HTML header snippet form field" do
+      it "shows the HTML header snippet form field" do
         visit decidim_admin.edit_organization_appearance_path
 
         expect(page).to have_field(:organization_header_snippets)
@@ -29,7 +29,7 @@ describe "Admin manages organization", type: :system do
         allow(Decidim).to receive(:enable_html_header_snippets).and_return(false)
       end
 
-      it "should not show the HTML header snippet form field" do
+      it "does not show the HTML header snippet form field" do
         visit decidim_admin.edit_organization_appearance_path
 
         expect(page).to have_no_field(:organization_header_snippets)

--- a/decidim-admin/spec/system/admin_manages_organization_appearance_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_appearance_spec.rb
@@ -12,6 +12,30 @@ describe "Admin manages organization", type: :system do
   end
 
   describe "edit" do
+    context "when the HTML header snippets feature is enabled" do
+      before do
+        allow(Decidim).to receive(:enable_html_header_snippets).and_return(true)
+      end
+
+      it "should not show the HTML header snippet form field" do
+        visit decidim_admin.edit_organization_appearance_path
+
+        expect(page).to have_field(:organization_header_snippets)
+      end
+    end
+
+    context "when the HTML header snippets feature is disabled" do
+      before do
+        allow(Decidim).to receive(:enable_html_header_snippets).and_return(false)
+      end
+
+      it "should not show the HTML header snippet form field" do
+        visit decidim_admin.edit_organization_appearance_path
+
+        expect(page).to have_no_field(:organization_header_snippets)
+      end
+    end
+
     it "updates the values from the form" do
       visit decidim_admin.edit_organization_appearance_path
 


### PR DESCRIPTION
#### :tophat: What? Why?
The `header_snippets` form input was being shown to the user, but not being actually updated. We found that it was not updated because the command checks if `Decidim.enable_html_header_snippets` is set. In our case, it wasn't, so it was not being updated, but then the field should not appear to the user.

We found that #6089 modified the behavior of the `if` around the form field:

https://github.com/decidim/decidim/pull/6089/files#diff-5c2f1c4e2e730121deba3bf4878392ead90a1bba7d5505b0b7c0668f388ac22dR14

This PR fixes the `if` condition to use the proper one.

#### :pushpin: Related Issues
- Related to #6089

#### Testing
When the feature is set to false, the field should not appear. When it's set to true, the user can update the field.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
None

:hearts: Thank you!
