### PR TITLE
Backport "Add translation for 'selected' projects" to 0.23

### DIFF
--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -14,6 +14,7 @@ en:
         decidim_scope_id: Scope
         description: Description
         proposal_ids: Related proposals
+        selected: Selected for implementation
         title: Title
   activerecord:
     models:


### PR DESCRIPTION
#### :tophat: What? Why?
Backports the missing translation key to 0.23 from #6770.

#### :pushpin: Related Issues
- Related to #6770

#### Testing
See original issue.

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.