### PR TITLE
Backport "Fix question#show view when question has no hero_image" to v0.22

### DIFF
--- a/decidim-consultations/app/views/decidim/consultations/questions/show.html.erb
+++ b/decidim-consultations/app/views/decidim/consultations/questions/show.html.erb
@@ -36,7 +36,7 @@
 <%= content_for :question_header_details do %>
   <div id="question-header-details" class="row consultations-home-intro">
     <div class="columns medium-5">
-      <%= image_tag current_question.hero_image&.url, alt: t("question.hero_image", scope: "activemodel.attributes") %>
+      <%= image_tag current_question.hero_image&.url, alt: t("question.hero_image", scope: "activemodel.attributes") if current_question.hero_image&.url %>
     </div>
 
     <div class="columns medium-5">

--- a/decidim-consultations/spec/system/question_spec.rb
+++ b/decidim-consultations/spec/system/question_spec.rb
@@ -115,4 +115,20 @@ describe "Question", type: :system do
       end
     end
   end
+
+  context "when question has no hero image" do
+    let(:question_without_hero) { create :question, consultation: consultation, hero_image: nil }
+
+    before do
+      switch_to_host(organization.host)
+      visit decidim_consultations.question_path(question_without_hero)
+    end
+
+    it "Shows the basic question data" do
+      expect(page).to have_i18n_content(question_without_hero.promoter_group)
+      expect(page).to have_i18n_content(question_without_hero.scope.name)
+      expect(page).to have_i18n_content(question_without_hero.participatory_scope)
+      expect(page).to have_i18n_content(question_without_hero.question_context)
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Fixed question#show view when question has no hero image.

#### :pushpin: Related Issues

Related to #6775

#### Testing

The consultation' question page should work when the question doesn't have a `hero_image`.

#### Related

supersedes #6777 