### PR TITLE
Fix proposals selection when closing a meeting

### DIFF
--- a/decidim-meetings/app/forms/decidim/meetings/admin/close_meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/close_meeting_form.rb
@@ -28,10 +28,10 @@ module Decidim
         end
 
         def proposals
-          @proposals ||= Decidim.find_resource_manifest(:proposals)
-                                .try(:resource_scope, current_component)
-                                &.where(id: proposal_ids)
-                                &.order(title: :asc)
+          @proposals = Decidim.find_resource_manifest(:proposals)
+                              .try(:resource_scope, current_component)
+                              &.where(id: proposal_ids)
+                              &.order(title: :asc)
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
When a meeting's close action fails due to an invalid form (i. e. a required field is empty) and the `edit` view is re-rendered, the selection of proposals made by the user changes and all proposals are picked instead.

#### :pushpin: Related Issues
- Related to #6745 

#### Testing

1. Click '🔒 Close' through administration options on a concrete meeting
2. Scroll down to 'Proposals' (select proposals), do not full-field any other field
3. Search for proposals you want to link to this meeting and mark them
4. Click blue button 'Close'.
5. System will return you an error, marking in red empty mandatory fields for closing (all except first one 'Report' that will not be shown marked on red).
6. Full-field the empty fields marked as an error, do not full-field "Report" one.
7. Click blue button 'Close'.
8. A new error message will be shown and marked in red: "Report" field is empty.
9. Now have a look on proposals linked to the meeting: every single proposal on participatory space have suddenly been linked to the meeting.

### :camera: Screenshots
<img width="769" alt="Screenshot 2020-11-05 at 10 50 34" src="https://user-images.githubusercontent.com/12495882/98225530-17635880-1f55-11eb-9e42-aef350269bd5.png">
<img width="768" alt="Screenshot 2020-11-05 at 10 50 40" src="https://user-images.githubusercontent.com/12495882/98225537-192d1c00-1f55-11eb-93f8-6ca9f27a0e45.png">
<img width="768" alt="Screenshot 2020-11-05 at 10 50 40" src="https://user-images.githubusercontent.com/12495882/98225896-95bffa80-1f55-11eb-8954-5fb65f052463.png">

