### PR TITLE
Solves #6537 Align actions on Admin panel

### DIFF
--- a/decidim-admin/app/assets/stylesheets/decidim/admin/extra/_action-icon.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/extra/_action-icon.scss
@@ -10,10 +10,12 @@
       vertical-align: bottom;
     }
   }
-  .action-space {
+
+  .action-space{
     display: inline-block;
-    &:not(:last-child) {
-    margin-right: 1rem;
+
+    &:not(:last-child){
+      margin-right: 1rem;
     }
   }
 }

--- a/decidim-admin/app/assets/stylesheets/decidim/admin/extra/_action-icon.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/extra/_action-icon.scss
@@ -10,6 +10,12 @@
       vertical-align: bottom;
     }
   }
+  .action-space {
+    display: inline-block;
+    &:not(:last-child) {
+    margin-right: 1rem;
+    }
+  }
 }
 
 a.red-icon{

--- a/decidim-admin/app/views/decidim/admin/components/_component.html.erb
+++ b/decidim-admin/app/views/decidim/admin/components/_component.html.erb
@@ -12,6 +12,8 @@
     <td class="table-list__actions">
       <% if component.manifest.admin_engine %>
         <%= icon_link_to "pencil", manage_component_path(component), t("actions.manage", scope: "decidim.admin"), class: "action-icon--manage" %>
+      <% else %>
+        <span class="action-space icon"></span>
       <% end %>
 
       <% if allowed_to?(:update, :component, component: component) %>
@@ -20,10 +22,14 @@
         <% else %>
           <%= icon_link_to "check", url_for(action: :publish, id: component, controller: "components"), t("actions.publish", scope: "decidim.admin"), class: "action-icon--publish", method: :put %>
         <% end %>
+      <% else %>
+        <span class="action-space icon"></span>
       <% end %>
 
       <% if allowed_to? :update, :component, component: component %>
         <%= icon_link_to "cog", url_for(action: :edit, id: component, controller: "components"), t("actions.configure", scope: "decidim.admin"), class: "action-icon--configure" %>
+      <% else %>
+        <span class="action-space icon"></span>
       <% end %>
 
       <% if allowed_to? :update, :component, component: component %>
@@ -32,14 +38,20 @@
         <% else %>
           <%= icon_link_to "key", url_for(action: :edit, component_id: component, controller: "component_permissions"), t("actions.permissions", scope: "decidim.admin"), class: "action-icon--permissions" %>
         <% end %>
+      <% else %>
+        <span class="action-space icon"></span>
       <% end %>
 
       <% if allowed_to? :share, :component, component: component %>
         <%= icon_link_to "share", url_for(action: :share, id: component, controller: "components"), t("actions.share", scope: "decidim.admin"), class: "action-icon--share", target: "_blank" %>
+      <% else %>
+        <span class="action-space icon"></span>
       <% end %>
 
       <% if allowed_to? :destroy, :component, component: component %>
         <%= icon_link_to "circle-x", url_for(action: :destroy, id: component, controller: "components"), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete %>
+      <% else %>
+        <span class="action-space icon"></span>
       <% end %>
     </td>
   </tr>

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.html.erb
@@ -84,14 +84,20 @@
               <td class="table-list__actions">
                 <% if allowed_to? :create, :assembly, assembly: assembly %>
                   <%= icon_link_to "data-transfer-download", assembly_export_path(assembly), t("actions.export", scope: "decidim.admin"), method: :post, class: "action-icon--export" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
 
                 <% if allowed_to? :create, :assembly, assembly: assembly %>
                   <%= icon_link_to "clipboard", new_assembly_copy_path(assembly), t("actions.duplicate", scope: "decidim.admin"), class: "action-icon--copy" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
 
                 <% if allowed_to? :update, :assembly, assembly: assembly %>
                   <%= icon_link_to "pencil", edit_assembly_path(assembly), t("actions.configure", scope: "decidim.admin"), class: "action-icon--new" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
 
                 <% if assembly.children.count.positive? || allowed_to?(:create, :assembly) %>
@@ -99,10 +105,14 @@
                       url_for(query_params_with(parent_id_eq: assembly.id)),
                       t("decidim.admin.titles.assemblies"),
                       class: "action-icon--dial #{'highlighted' if assembly.children.count.positive?}" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
 
                 <% if allowed_to? :preview, :assembly, assembly: assembly %>
                   <%= icon_link_to "eye", decidim_assemblies.assembly_path(assembly), t("actions.preview", scope: "decidim.admin"), class: "action-icon--preview" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
               </td>
             </tr>

--- a/decidim-consultations/app/views/decidim/consultations/admin/consultations/index.html.erb
+++ b/decidim-consultations/app/views/decidim/consultations/admin/consultations/index.html.erb
@@ -56,6 +56,8 @@
                                    edit_consultation_path(consultation),
                                    t("actions.configure", scope: "decidim.admin"),
                                    class: "action-icon--edit" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
 
                 <% if allowed_to? :preview, :consultation, consultation: consultation %>
@@ -64,6 +66,8 @@
                                    t("actions.preview", scope: "decidim.admin"),
                                    class: "action-icon--preview",
                                    target: "_blank" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
               </td>
             </tr>

--- a/decidim-consultations/app/views/decidim/consultations/admin/questions/index.html.erb
+++ b/decidim-consultations/app/views/decidim/consultations/admin/questions/index.html.erb
@@ -56,6 +56,8 @@
                                    edit_question_path(question),
                                    t("actions.configure", scope: "decidim.admin"),
                                    class: "action-icon--edit" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
 
                 <%= free_resource_permissions_link(question) %>
@@ -66,6 +68,8 @@
                                    t("actions.preview", scope: "decidim.admin"),
                                    class: "action-icon--preview",
                                    target: "_blank" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
 
               </td>

--- a/decidim-consultations/app/views/decidim/consultations/admin/response_groups/index.html.erb
+++ b/decidim-consultations/app/views/decidim/consultations/admin/response_groups/index.html.erb
@@ -45,6 +45,8 @@
                                    edit_response_group_path(current_question, group),
                                    t("actions.configure", scope: "decidim.admin"),
                                    class: "action-icon--edit" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
               </td>
             </tr>

--- a/decidim-consultations/app/views/decidim/consultations/admin/responses/index.html.erb
+++ b/decidim-consultations/app/views/decidim/consultations/admin/responses/index.html.erb
@@ -48,6 +48,8 @@
                                    edit_response_path(current_question, response),
                                    t("actions.configure", scope: "decidim.admin"),
                                    class: "action-icon--edit" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
               </td>
             </tr>

--- a/decidim-debates/app/views/decidim/debates/admin/debates/index.html.erb
+++ b/decidim-debates/app/views/decidim/debates/admin/debates/index.html.erb
@@ -39,14 +39,20 @@
               <td class="table-list__actions">
                 <% if allowed_to? :update, :debate, debate: debate %>
                   <%= icon_link_to "pencil", edit_debate_path(debate), t("actions.edit", scope: "decidim.debates"), class: "action-icon--edit" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
 
                 <% if allowed_to? :close, :debate, debate: debate %>
                   <%= icon_link_to "lock-locked", edit_debate_debate_close_path(debate_id: debate.id, id: debate.id), t("actions.close", scope: "decidim.debates"), class: "action-icon--close" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
 
                 <% if allowed_to? :delete, :debate, debate: debate %>
                   <%= icon_link_to "circle-x", debate_path(debate), t("actions.destroy", scope: "decidim.debates"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.debates") } %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
               </td>
             </tr>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
@@ -45,6 +45,8 @@
                                  t(".preview"),
                                  class: "action-icon--preview",
                                  target: "_blank" %>
+              <% else %>
+               <span class="action-space icon"></span>
               <% end %>
 
               <% if allowed_to? :edit, :initiative, initiative: initiative %>
@@ -52,6 +54,8 @@
                                  decidim_admin_initiatives.edit_initiative_path(initiative.to_param),
                                  t("actions.configure", scope: "decidim.admin"),
                                  class: "action-icon--edit" %>
+              <% else %>
+               <span class="action-space icon"></span>
               <% end %>
 
               <% if allowed_to?(:answer, :initiative, initiative: initiative) %>
@@ -65,6 +69,8 @@
                                  decidim_admin_initiatives.initiative_path(initiative.to_param),
                                  t(".print",),
                                  class: "action-icon--print" %>
+              <% else %>
+                <span class="action-space icon"></span>
               <% end %>
             </td>
           <% end %>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
@@ -55,6 +55,8 @@
 
                 <% if allowed_to? :copy, :meeting, meeting: meeting %>
                   <%= icon_link_to "clipboard", new_meeting_copy_path(meeting), t("actions.duplicate", scope: "decidim.admin"), class: "action-icon--copy" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
 
                 <% if allowed_to? :update, :meeting, meeting: meeting %>
@@ -62,18 +64,29 @@
                   <%= icon_link_to "people", edit_meeting_registrations_path(meeting), t("actions.registrations", scope: "decidim.meetings"), class: "action-icon--registrations" %>
                   <%= icon_link_to "clock", meeting.minutes.present? ? edit_meeting_minute_path(meeting, meeting.minutes) : new_meeting_minute_path(meeting), t("actions.minutes", scope: "decidim.meetings"), class: "action-icon--minutes" %>
                   <%= icon_link_to "calendar", meeting.agenda.present? ? edit_meeting_agenda_path(meeting, meeting.agenda) : new_meeting_agenda_path(meeting), t("actions.agenda", scope: "decidim.meetings"), class: "action-icon--agenda" %>
+                <% else %>
+                  <span class="action-space icon"></span>
+                  <span class="action-space icon"></span>
+                  <span class="action-space icon"></span>
+                  <span class="action-space icon"></span>
                 <% end %>
 
                 <% if allowed_to? :close, :meeting, meeting: meeting %>
                   <%= icon_link_to "lock-locked", edit_meeting_meeting_close_path(meeting_id: meeting.id, id: meeting.id), t("actions.close", scope: "decidim.meetings"), class: "action-icon--close" %>
+                <% else %>
+                    <span class="action-space icon"></span>
                 <% end %>
 
                 <% if allowed_to? :update, :meeting, meeting: meeting %>
                     <%= icon_link_to "folder", meeting_attachment_collections_path(meeting), t("actions.attachment_collections", scope: "decidim.meetings"), class: "action-icon--attachment_collections" %>
+                <% else %>
+                    <span class="action-space icon"></span>
                 <% end %>
 
                 <% if allowed_to? :update, :meeting, meeting: meeting %>
                   <%= icon_link_to "paperclip", meeting_attachments_path(meeting), t("actions.attachments", scope: "decidim.meetings"), class: "action-icon--attachments" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
 
                 <%= resource_permissions_link(meeting) %>
@@ -95,6 +108,8 @@
                       end
                     %>
                   <% end %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
               </td>
             </tr>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_groups/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_groups/index.html.erb
@@ -35,12 +35,16 @@
               <td class="table-list__actions">
                 <% if allowed_to? :update, :process_group, process_group: group %>
                   <%= icon_link_to "pencil", ["edit", group], t("actions.edit", scope: "decidim.admin"), class: "action-icon--edit" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
 
                 <%= icon_link_to "eye", decidim_participatory_processes.participatory_process_group_path(group), t("actions.preview", scope: "decidim.admin"), class: "action-icon--preview" %>
 
                 <% if allowed_to? :destroy, :process_group, process_group: group %>
                   <%= icon_link_to "circle-x", group, t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
               </td>
             </tr>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_steps/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_steps/index.html.erb
@@ -43,14 +43,20 @@
                 <td class="table-list__actions">
                   <% if allowed_to?(:activate, :process_step, process_step: step) && !step.active? %>
                     <%= icon_link_to "circle-check", participatory_process_step_activate_path(current_participatory_process, step), t("actions.activate", scope: "decidim.admin"), class: "action-icon--activate", method: :post %>
+                  <% else %>
+                    <span class="action-space icon"></span>
                   <% end %>
 
                   <% if allowed_to? :update, :process_step, process_step: step %>
                     <%= icon_link_to "pencil", edit_participatory_process_step_path(current_participatory_process, step), t("actions.edit", scope: "decidim.admin"), class: "action-icon--edit" %>
+                  <% else %>
+                    <span class="action-space icon"></span>
                   <% end %>
 
                   <% if allowed_to? :destroy, :process_step, process_step: step %>
                     <%= icon_link_to "circle-x", participatory_process_step_path(current_participatory_process, step), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
+                  <% else %>
+                    <span class="action-space icon"></span>
                   <% end %>
                 </td>
               </tr>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_user_roles/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_user_roles/index.html.erb
@@ -46,14 +46,20 @@
               <td class="table-list__actions">
                 <% if allowed_to?(:invite, :process_user_role, user_role: role) && role.user.invited_to_sign_up? %>
                   <%= icon_link_to "reload", resend_invitation_participatory_process_user_role_path(current_participatory_process, role), t("actions.resend_invitation", scope: "decidim.admin"), class: "resend-invitation", method: :post %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
 
                 <% if allowed_to? :update, :process_user_role, user_role: role %>
                   <%= icon_link_to "pencil", edit_participatory_process_user_role_path(current_participatory_process, role), t("actions.edit", scope: "decidim.admin"), class: "action-icon--edit" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
 
                 <% if allowed_to? :destroy, :process_user_role, user_role: role %>
                   <%= icon_link_to "circle-x", participatory_process_user_role_path(current_participatory_process, role), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
               </td>
             </tr>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/index.html.erb
@@ -101,18 +101,26 @@
               <td class="table-list__actions">
                 <% if allowed_to? :create, :process, process: process %>
                   <%= icon_link_to "data-transfer-download", participatory_process_export_path(process), t("actions.export", scope: "decidim.admin"), method: :post, class: "action-icon--export" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
 
                 <% if allowed_to? :create, :process, process: process %>
                   <%= icon_link_to "clipboard", new_participatory_process_copy_path(process), t("actions.duplicate", scope: "decidim.admin"), class: "action-icon--copy" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
 
                 <% if allowed_to? :update, :process, process: process %>
                   <%= icon_link_to "pencil", edit_participatory_process_path(process), t("actions.configure", scope: "decidim.admin"), class: "action-icon--new" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
 
                 <% if allowed_to? :preview, :process, process: process %>
                   <%= icon_link_to "eye", decidim_participatory_processes.participatory_process_path(process), t("actions.preview", scope: "decidim.admin"), class: "action-icon--preview" %>
+                <% else %>
+                  <span class="action-space icon"></span>
                 <% end %>
               </td>
             </tr>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
@@ -61,6 +61,8 @@
   <td class="table-list__actions">
     <% if allowed_to? :edit, :proposal, proposal: proposal %>
       <%= icon_link_to "pencil", edit_proposal_path(proposal), t("actions.edit_proposal", scope: "decidim.proposals"), class: "action-icon--edit-proposal" %>
+    <% else %>
+      <span class="action-space icon"></span>
     <% end %>
 
     <%= icon_with_link_to_proposal(proposal) %>

--- a/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/index.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/index.html.erb
@@ -38,13 +38,17 @@
                                 edit_sortition_path(sortition),
                                 t("actions.edit", scope: "decidim.sortitions.admin"),
                                 class: "action-icon--edit" %>
-             <% end %>
+              <% else %>
+                <span class="action-space icon"></span>
+              <% end %>
 
               <% if allowed_to? :destroy, :sortition, sortition: sortition %>
                 <%= icon_link_to "circle-x",
                                  confirm_destroy_sortition_path(sortition),
                                  t("actions.destroy", scope: "decidim.sortitions.admin"),
                                  class: "action-icon--remove" %>
+              <% else %>
+                 <span class="action-space icon"></span>
               <% end %>
             </td>
           </tr>


### PR DESCRIPTION
I took the route of adding a blank space that takes the same space as icon would.

#### :tophat: What? Why?
For issue #6537, on admin panel for every component's index view, we have a table that describes what actions can be done to that element (table-list__actions). When not all of them are available, they would not be consistently ordered showing this effect which confuses users:

![image](https://user-images.githubusercontent.com/8941178/98194234-8359a880-1ee4-11eb-9034-5206534637af.png)


The solution consists on adding a blank space whenever an action is not available so the space of the action is always on the same place.

Issues:

- [ ] As an admin when I go to X component I see the actions ordered by columns vertically aligned:
  - [x] Proposals 
  - [x] Meetings
  - [x] Debates
  - [x] Initiatives
  - [x] Sortitions
  - [ ] Results (Accountability)
  - [x] Surveys N/A
  - [x] Assemblies
  - [x] Budgets
  - [x] Participatory Processes
  - [x] Consultations

#### :pushpin: Related Issues
- Fixes #6537

#### Testing
Since this is a design feature, I would visually check the elements aligned on each screen. Including screenshots below.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
Before
![before](https://user-images.githubusercontent.com/8941178/98194647-7a1d0b80-1ee5-11eb-8cc6-40d2fd29e9f1.png)

After
![after](https://user-images.githubusercontent.com/8941178/98194600-67a2d200-1ee5-11eb-8c59-9350e7a57ef7.png)

:hearts: Thank you!
