### PR TITLE
Add caching to proposals

### DIFF
--- a/decidim-core/app/helpers/decidim/filters_helper.rb
+++ b/decidim-core/app/helpers/decidim/filters_helper.rb
@@ -32,6 +32,7 @@ module Decidim
     def filter_cache_hash(filter)
       hash = []
       hash << "decidim/proposals/filters"
+      hash << I18n.locale.to_s
       hash << Digest::MD5.hexdigest(filter.to_json)
 
       hash.join("/")

--- a/decidim-core/app/helpers/decidim/filters_helper.rb
+++ b/decidim-core/app/helpers/decidim/filters_helper.rb
@@ -29,6 +29,14 @@ module Decidim
       end
     end
 
+    def filter_cache_hash(filter)
+      hash = []
+      hash << "decidim/proposals/filters"
+      hash << Digest::MD5.hexdigest(filter.to_json)
+
+      hash.join("/")
+    end
+
     private
 
     # Creates a unique namespace for a filter form to prevent dupliacte IDs in

--- a/decidim-core/spec/helpers/decidim/filters_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/filters_helper_spec.rb
@@ -84,6 +84,17 @@ module Decidim
         expect(helper.filter_cache_hash(filter)).to eq(old_hash)
       end
 
+      context "when current locale changes" do
+        let(:alt_locale) { :ca }
+
+        it "generate a different hash" do
+          old_hash = helper.filter_cache_hash(filter)
+          allow(I18n).to receive(:locale).and_return(alt_locale)
+
+          expect(helper.filter_cache_hash(filter)).not_to eq(old_hash)
+        end
+      end
+
       context "when filter is different" do
         it "generate a different hash" do
           old_hash = helper.filter_cache_hash(filter)

--- a/decidim-core/spec/helpers/decidim/filters_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/filters_helper_spec.rb
@@ -25,9 +25,9 @@ module Decidim
 
       it "wraps everything in a div with class 'filters'" do
         expect(helper)
-          .to receive(:content_tag)
-          .with(:div, { class: "filters" }, any_args)
-          .and_call_original
+            .to receive(:content_tag)
+                    .with(:div, { class: "filters" }, any_args)
+                    .and_call_original
 
         helper.filter_form_for(filter) do
         end
@@ -35,8 +35,8 @@ module Decidim
 
       it "calls form_for helper with specific arguments" do
         expect(helper)
-          .to receive(:form_for)
-          .with(filter, { namespace: match(/^filters_[a-z0-9-]+$/), builder: FilterFormBuilder, url: helper.url_for, as: :filter, method: :get, remote: true, html: { id: nil } }, any_args)
+            .to receive(:form_for)
+                    .with(filter, { namespace: match(/^filters_[a-z0-9-]+$/), builder: FilterFormBuilder, url: helper.url_for, as: :filter, method: :get, remote: true, html: { id: nil } }, any_args)
 
         helper.filter_form_for(filter) do
         end
@@ -57,22 +57,39 @@ module Decidim
         end.join("")
 
         expect(dom).to have_tag(
-          "input",
-          count: 2,
-          with: {
-            type: "text",
-            name: "filter[test_attribute]"
-          }
-        )
+                           "input",
+                           count: 2,
+                           with: {
+                               type: "text",
+                               name: "filter[test_attribute]"
+                           }
+                       )
         namespaces.each do |ns|
           expect(dom).to have_tag(
-            "input",
-            count: 1,
-            with: {
-              type: "text",
-              id: "#{ns}_filter_test_attribute"
-            }
-          )
+                             "input",
+                             count: 1,
+                             with: {
+                                 type: "text",
+                                 id: "#{ns}_filter_test_attribute"
+                             }
+                         )
+        end
+      end
+    end
+
+    describe "#filter_cache_hash" do
+      it "generate a unique hash" do
+        old_hash = helper.filter_cache_hash(filter)
+
+        expect(helper.filter_cache_hash(filter)).to eq(old_hash)
+      end
+
+      context "when filter is different" do
+        it "generate a different hash" do
+          old_hash = helper.filter_cache_hash(filter)
+          filter.test_attribute = "dummy-filter"
+
+          expect(helper.filter_cache_hash(filter)).not_to eq(old_hash)
         end
       end
     end

--- a/decidim-core/spec/helpers/decidim/filters_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/filters_helper_spec.rb
@@ -25,9 +25,9 @@ module Decidim
 
       it "wraps everything in a div with class 'filters'" do
         expect(helper)
-            .to receive(:content_tag)
-                    .with(:div, { class: "filters" }, any_args)
-                    .and_call_original
+          .to receive(:content_tag)
+          .with(:div, { class: "filters" }, any_args)
+          .and_call_original
 
         helper.filter_form_for(filter) do
         end
@@ -35,8 +35,8 @@ module Decidim
 
       it "calls form_for helper with specific arguments" do
         expect(helper)
-            .to receive(:form_for)
-                    .with(filter, { namespace: match(/^filters_[a-z0-9-]+$/), builder: FilterFormBuilder, url: helper.url_for, as: :filter, method: :get, remote: true, html: { id: nil } }, any_args)
+          .to receive(:form_for)
+          .with(filter, { namespace: match(/^filters_[a-z0-9-]+$/), builder: FilterFormBuilder, url: helper.url_for, as: :filter, method: :get, remote: true, html: { id: nil } }, any_args)
 
         helper.filter_form_for(filter) do
         end
@@ -57,22 +57,22 @@ module Decidim
         end.join("")
 
         expect(dom).to have_tag(
-                           "input",
-                           count: 2,
-                           with: {
-                               type: "text",
-                               name: "filter[test_attribute]"
-                           }
-                       )
+          "input",
+          count: 2,
+          with: {
+            type: "text",
+            name: "filter[test_attribute]"
+          }
+        )
         namespaces.each do |ns|
           expect(dom).to have_tag(
-                             "input",
-                             count: 1,
-                             with: {
-                                 type: "text",
-                                 id: "#{ns}_filter_test_attribute"
-                             }
-                         )
+            "input",
+            count: 1,
+            with: {
+              type: "text",
+              id: "#{ns}_filter_test_attribute"
+            }
+          )
         end
       end
     end

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
@@ -8,6 +8,8 @@ module Decidim
     class ProposalMCell < Decidim::CardMCell
       include ProposalCellsHelper
 
+      delegate :current_locale, to: :controller
+
       def badge
         render if has_badge?
       end
@@ -126,6 +128,7 @@ module Decidim
       def cache_hash
         hash = []
         hash << "decidim/proposals/proposal_m"
+        hash << I18n.locale.to_s
         hash << model.cache_version
         hash << model.proposal_votes_count
         hash << model.endorsements_count

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
@@ -127,6 +127,16 @@ module Decidim
         hash = []
         hash << "decidim/proposals/proposal_m"
         hash << model.cache_version
+        hash << model.proposal_votes_count
+        hash << model.endorsements_count
+        hash << Digest::MD5.hexdigest(model.component.settings.to_json)
+        hash << Digest::MD5.hexdigest(resource_image_path) if resource_image_path
+        if current_user
+          hash << current_user.cache_version
+          hash << current_user.follows?(model) ? 1 : 0
+        end
+        hash << Digest::MD5.hexdigest(model.followers.to_json)
+        hash << Digest::MD5.hexdigest(model.coauthorships.map(&:cache_version).to_s)
 
         hash.join("/")
       end

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
@@ -122,6 +122,14 @@ module Decidim
       def resource_image_path
         @resource_image_path ||= has_image? ? model.attachments.find_by("content_type like '%image%'").url : nil
       end
+
+      def cache_hash
+        hash = []
+        hash << "decidim/proposals/proposal_m"
+        hash << model.cache_version
+
+        hash.join("/")
+      end
     end
   end
 end

--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -39,7 +39,7 @@ module Decidim
                        .results
                        .published
                        .not_hidden
-                       .includes(:amendable, :category, :component, :resource_permission, :scope)
+                       .includes(:component, :coauthorships)
 
           @voted_proposals = if current_user
                                ProposalVote.where(

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
@@ -1,46 +1,48 @@
 <%= render partial: "decidim/shared/filter_form_help", locals: { skip_to_id: "proposals" } %>
 
-<%= filter_form_for filter do |form| %>
-  <div class="filters__section">
-    <div class="filters__search">
-      <div class="input-group">
-        <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t(".search"), title: t(".search"), data: { disable_dynamic_change: true } %>
-        <div class="input-group-button">
-          <button type="submit" class="button" aria-controls="proposals">
-            <%= icon "magnifying-glass", aria_label: t(".search"), role: "img" %>
-          </button>
+<% cache filter_cache_hash(filter) do %>
+  <%= filter_form_for filter do |form| %>
+    <div class="filters__section">
+      <div class="filters__search">
+        <div class="input-group">
+          <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t(".search"), title: t(".search"), data: { disable_dynamic_change: true } %>
+          <div class="input-group-button">
+            <button type="submit" class="button" aria-controls="proposals">
+              <%= icon "magnifying-glass", aria_label: t(".search"), role: "img" %>
+            </button>
+          </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <% if component_settings.proposal_answering_enabled && current_settings.proposal_answering_enabled %>
-    <%= form.check_boxes_tree :state, filter_proposals_state_values, legend_title: t(".state"), "aria-controls": "proposals" %>
+    <% if component_settings.proposal_answering_enabled && current_settings.proposal_answering_enabled %>
+      <%= form.check_boxes_tree :state, filter_proposals_state_values, legend_title: t(".state"), "aria-controls": "proposals" %>
+    <% end %>
+
+    <% if current_component.has_subscopes? %>
+      <%= form.check_boxes_tree :scope_id, filter_scopes_values, legend_title: t(".scope"), "aria-controls": "proposals" %>
+    <% end %>
+
+    <% if current_component.categories.any? %>
+      <%= form.check_boxes_tree :category_id, filter_categories_values, legend_title: t(".category"), "aria-controls": "proposals" %>
+    <% end %>
+
+    <% if component_settings.official_proposals_enabled %>
+      <%= form.check_boxes_tree :origin, filter_origin_values, legend_title: t(".origin"), "aria-controls": "proposals" %>
+    <% end %>
+
+    <% if current_user %>
+      <%= form.collection_radio_buttons :activity, activity_filter_values, :first, :last, { legend_title: t(".activity") }, "aria-controls": "proposals" %>
+    <% end %>
+
+    <% if @proposals.only_emendations.any? %>
+      <%= form.collection_radio_buttons :type, filter_type_values, :first, :last, { legend_title: t(".amendment_type") }, "aria-controls": "proposals" %>
+    <% end %>
+
+    <% if linked_classes_for(Decidim::Proposals::Proposal).any? %>
+      <%= form.collection_radio_buttons :related_to, linked_classes_filter_values_for(Decidim::Proposals::Proposal), :first, :last, { legend_title: t(".related_to") }, "aria-controls": "proposals" %>
+    <% end %>
+
+    <%= hidden_field_tag :order, order, id: nil, class: "order_filter" %>
   <% end %>
-
-  <% if current_component.has_subscopes? %>
-    <%= form.check_boxes_tree :scope_id, filter_scopes_values, legend_title: t(".scope"), "aria-controls": "proposals" %>
-  <% end %>
-
-  <% if current_component.categories.any? %>
-    <%= form.check_boxes_tree :category_id, filter_categories_values, legend_title: t(".category"), "aria-controls": "proposals" %>
-  <% end %>
-
-  <% if component_settings.official_proposals_enabled %>
-    <%= form.check_boxes_tree :origin, filter_origin_values, legend_title: t(".origin"), "aria-controls": "proposals" %>
-  <% end %>
-
-  <% if current_user %>
-    <%= form.collection_radio_buttons :activity, activity_filter_values, :first, :last, { legend_title: t(".activity") }, "aria-controls": "proposals" %>
-  <% end %>
-
-  <% if @proposals.only_emendations.any? %>
-    <%= form.collection_radio_buttons :type, filter_type_values, :first, :last, { legend_title: t(".amendment_type") }, "aria-controls": "proposals" %>
-  <% end %>
-
-  <% if linked_classes_for(Decidim::Proposals::Proposal).any? %>
-    <%= form.collection_radio_buttons :related_to, linked_classes_filter_values_for(Decidim::Proposals::Proposal), :first, :last, { legend_title: t(".related_to") }, "aria-controls": "proposals" %>
-  <% end %>
-
-  <%= hidden_field_tag :order, order, id: nil, class: "order_filter" %>
 <% end %>

--- a/decidim-proposals/spec/cells/decidim/proposals/proposal_m_cell_spec.rb
+++ b/decidim-proposals/spec/cells/decidim/proposals/proposal_m_cell_spec.rb
@@ -94,6 +94,17 @@ module Decidim::Proposals
         expect(my_cell.send(:cache_hash)).to eq(old_hash)
       end
 
+      context "when locale change" do
+        let(:alt_locale) { :ca }
+
+        it "generate a different hash" do
+          old_hash = my_cell.send(:cache_hash)
+          allow(I18n).to receive(:locale).and_return(alt_locale)
+
+          expect(my_cell.send(:cache_hash)).not_to eq(old_hash)
+        end
+      end
+
       context "when model is updated" do
         it "generate a different hash" do
           old_hash = my_cell.send(:cache_hash)

--- a/decidim-proposals/spec/cells/decidim/proposals/proposal_m_cell_spec.rb
+++ b/decidim-proposals/spec/cells/decidim/proposals/proposal_m_cell_spec.rb
@@ -85,7 +85,7 @@ module Decidim::Proposals
       end
     end
 
-    context "#cache_hash" do
+    describe "#cache_hash" do
       let(:my_cell) { cell("decidim/proposals/proposal_m", proposal) }
 
       it "generate a unique hash" do
@@ -100,6 +100,96 @@ module Decidim::Proposals
           proposal.update!(title: { en: "New title" })
 
           expect(my_cell.send(:cache_hash)).not_to eq(old_hash)
+        end
+      end
+
+      context "when new endorsement" do
+        it "generate a different hash" do
+          old_hash = my_cell.send(:cache_hash)
+          create(:endorsement, resource: proposal, author: build(:user, organization: proposal.participatory_space.organization))
+
+          expect(my_cell.send(:cache_hash)).not_to eq(old_hash)
+        end
+      end
+
+      context "when new vote" do
+        it "generate a different hash" do
+          old_hash = my_cell.send(:cache_hash)
+          create(:proposal_vote, proposal: proposal)
+
+          expect(my_cell.send(:cache_hash)).not_to eq(old_hash)
+        end
+      end
+
+      context "when component settings changes" do
+        it "generate a different hash" do
+          component_settings = component.settings
+          old_hash = my_cell.send(:cache_hash)
+          component.settings = { foo: "bar" }
+
+          expect(my_cell.send(:cache_hash)).not_to eq(old_hash)
+
+          component.settings = component_settings
+        end
+      end
+
+      context "when model has preview" do
+        let(:my_cell) { cell("decidim/proposals/proposal_m", model, preview: true) }
+
+        it "generate a different hash" do
+          old_hash = my_cell.send(:cache_hash)
+          create(:attachment, :with_image, attached_to: proposal)
+
+          expect(my_cell.send(:cache_hash)).not_to eq(old_hash)
+        end
+      end
+
+      context "when no current user" do
+        it "generate a different hash" do
+          old_hash = my_cell.send(:cache_hash)
+          allow(controller).to receive(:current_user).and_return(nil)
+
+          expect(my_cell.send(:cache_hash)).not_to eq(old_hash)
+        end
+      end
+
+      context "when followers changes" do
+        let(:another_user) { create :user, organization: proposal.participatory_space.organization }
+
+        it "generate a different hash" do
+          old_hash = my_cell.send(:cache_hash)
+          create(:follow, followable: proposal, user: another_user)
+
+          expect(my_cell.send(:cache_hash)).not_to eq(old_hash)
+        end
+      end
+
+      context "when user follows proposal" do
+        it "generate a different hash" do
+          old_hash = my_cell.send(:cache_hash)
+          create(:follow, followable: proposal, user: user)
+
+          expect(my_cell.send(:cache_hash)).not_to eq(old_hash)
+        end
+      end
+
+      context "when authors changes" do
+        context "when new co-author" do
+          it "generate a different hash" do
+            old_hash = my_cell.send(:cache_hash)
+            model.add_coauthor(user)
+
+            expect(my_cell.send(:cache_hash)).not_to eq(old_hash)
+          end
+
+          context "when author updates profile" do
+            it "generate a different hash" do
+              old_hash = my_cell.send(:cache_hash)
+              model.authors.first.update(personal_url: "new personal url")
+
+              expect(my_cell.send(:cache_hash)).not_to eq(old_hash)
+            end
+          end
         end
       end
     end

--- a/decidim-proposals/spec/cells/decidim/proposals/proposal_m_cell_spec.rb
+++ b/decidim-proposals/spec/cells/decidim/proposals/proposal_m_cell_spec.rb
@@ -84,5 +84,24 @@ module Decidim::Proposals
         end
       end
     end
+
+    context "#cache_hash" do
+      let(:my_cell) { cell("decidim/proposals/proposal_m", proposal) }
+
+      it "generate a unique hash" do
+        old_hash = my_cell.send(:cache_hash)
+
+        expect(my_cell.send(:cache_hash)).to eq(old_hash)
+      end
+
+      context "when model is updated" do
+        it "generate a different hash" do
+          old_hash = my_cell.send(:cache_hash)
+          proposal.update!(title: { en: "New title" })
+
+          expect(my_cell.send(:cache_hash)).not_to eq(old_hash)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
We notice a lack of performance on the proposals index,

The first one is the filters, which are complex and generate a lot of rendering, and can be cached until the filter attributes change.

The second one is proposal cards, due to random seed ordering, it cannot be cached as a collection.

Therefore all proposals must be cached individually and rendered as a collection of cached objects. 

The proposal card is complex and depends on many elements, (followers, votes, a user connected, etc...)

This pull request is a proposition of implementation, feel free to discuss it.

## Performance overall
![one eu newrelic com_launcher_nr1-core explorer_pane=eyJuZXJkbGV0SWQiOiJhcG0tbmVyZGxldHMub3ZlcnZpZXciLCJlbnRpdHlJZCI6Ik1qVXpOVGcxTjN4QlVFMThRVkJRVEVsRFFWUkpUMDU4TVRBd05UQTNORGs0In0= sidebars 0 =eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiw (2)](https://user-images.githubusercontent.com/20232956/99661047-91223880-2a63-11eb-88fb-f2ec664f72bd.png)
![one eu newrelic com_launcher_nr1-core explorer_pane=eyJuZXJkbGV0SWQiOiJhcG0tbmVyZGxldHMub3ZlcnZpZXciLCJlbnRpdHlJZCI6Ik1qVXpOVGcxTjN4QlVFMThRVkJRVEVsRFFWUkpUMDU4TVRBd05UQTRNVGs1In0= sidebars 0 =eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwiZW5](https://user-images.githubusercontent.com/20232956/99661065-97b0b000-2a63-11eb-823b-1d1fbe250bc9.png)
