### PR TITLE
Fix subhero removing strip_tags from it

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/layouts/_home.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/layouts/_home.scss
@@ -195,6 +195,11 @@
   padding: 4rem 0;
   text-align: center;
 
+  ul,
+  ol{
+    list-style-position: inside;
+  }
+
   .heading3{
     @include breakpoint(medium down){
       font-size: 1.3em;

--- a/decidim-core/app/cells/decidim/content_blocks/sub_hero/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/sub_hero/show.erb
@@ -1,7 +1,7 @@
   <section class="extended subhero home-section">
     <div class="row">
       <div class="columns small-centered large-10">
-        <h2 class="heading2">%
+        <h2 class="heading2">
           <%= decidim_sanitize translated_attribute current_organization.description %>
         </h2>
         <% unless current_user %>

--- a/decidim-core/app/cells/decidim/content_blocks/sub_hero/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/sub_hero/show.erb
@@ -1,7 +1,9 @@
   <section class="extended subhero home-section">
     <div class="row">
       <div class="columns small-centered large-10">
-        <h2 class="heading2"><%= decidim_sanitize translated_attribute(current_organization.description), strip_tags: true %></h2>
+        <h2 class="heading2">%
+          <%= decidim_sanitize translated_attribute current_organization.description %>
+        </h2>
         <% unless current_user %>
           <%= link_to decidim.new_user_registration_path, class: "button--sc link subhero-cta", title: t("decidim.pages.home.sub_hero.register_title") do %>
             <%= t("decidim.pages.home.sub_hero.register") %>

--- a/decidim-core/spec/cells/decidim/content_blocks/sub_hero_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/content_blocks/sub_hero_cell_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::ContentBlocks::SubHeroCell, type: :cell do
+  subject { cell(content_block.cell, content_block).call }
+
+  let(:organization) { create(:organization, description: description) }
+  let(:content_block) { create :content_block, organization: organization, manifest_name: :sub_hero, scope_name: :homepage }
+
+  controller Decidim::PagesController
+
+  context "when description is not filled" do
+    let(:description) { {} }
+
+    it "displays nothing" do
+      expect(subject).to have_no_css(".subhero")
+    end
+  end
+
+  context "when description is filled" do
+    let(:description) do
+      {
+        "en" => "<h2><strong>Bold titled text</strong></h2>"
+      }
+    end
+
+    it "shows the custom welcome text with formating" do
+      expect(subject).to have_css(".subhero")
+      expect(subject.find("h2 strong")).to have_text("Bold titled text")
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Currently, the description given in the admin panel isn't rendered with formating (bold, lists etc.)

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #6598 ?
- Fixes #?

#### Testing
- Go to admin panel and edit description with formated text (http://localhost:3000/admin/organization/appearance/edit)
- Save and go to main page (http://localhost:3000)
- Check that the description you've written is here, and correctly displayed

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
With this config
![image](https://user-images.githubusercontent.com/33259633/98281566-32f25180-1f9d-11eb-809f-5e9e44a02726.png)

Before
![image](https://user-images.githubusercontent.com/33259633/98281629-44d3f480-1f9d-11eb-96fa-9f932ca06f07.png)

After
![image](https://user-images.githubusercontent.com/33259633/98380835-61c60180-2049-11eb-8d4e-3a345648b123.png)


:hearts: Thank you!
