### PR TITLE
Block election and set `key_ceremony` bb_status

### DIFF
--- a/decidim-elections/app/commands/decidim/elections/admin/setup_election.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/setup_election.rb
@@ -153,6 +153,8 @@ module Decidim
             error = response.data.create_election.error
             form.errors.add(:base, error)
             raise ActiveRecord::Rollback
+          else
+            election_status(response.data.create_election.election.status)
           end
         end
 
@@ -175,6 +177,13 @@ module Decidim
           }
 
           Decidim::EventsManager.publish(data)
+        end
+
+        def election_status(bb_status)
+          @election.update!(
+            blocked_at: Time.current,
+            bb_status: bb_status
+          )
         end
       end
     end

--- a/decidim-elections/app/commands/decidim/elections/admin/setup_election.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/setup_election.rb
@@ -154,7 +154,7 @@ module Decidim
             form.errors.add(:base, error)
             raise ActiveRecord::Rollback
           else
-            election_status(response.data.create_election.election.status)
+            store_bulletin_board_status(response.data.create_election.election.status)
           end
         end
 
@@ -179,7 +179,7 @@ module Decidim
           Decidim::EventsManager.publish(data)
         end
 
-        def election_status(bb_status)
+        def store_bulletin_board_status(bb_status)
           @election.update!(
             blocked_at: Time.current,
             bb_status: bb_status

--- a/decidim-elections/app/controllers/decidim/elections/admin/setup_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/admin/setup_controller.rb
@@ -9,10 +9,13 @@ module Decidim
 
         def show
           enforce_permission_to :setup, :election, election: election
+
           @form = form(SetupForm).from_model(election, number_of_trustees: Decidim::Elections.bulletin_board.number_of_trustees)
         end
 
         def update
+          enforce_permission_to :setup, :election, election: election
+
           @form = form(SetupForm).from_params(params, election: election, trustee_ids: params[:setup][:trustee_ids])
           SetupElection.call(@form) do
             on(:ok) do

--- a/decidim-elections/app/models/decidim/elections/election.rb
+++ b/decidim-elections/app/models/decidim/elections/election.rb
@@ -105,6 +105,13 @@ module Decidim
         end
       end
 
+      # Public: Checks if the election has a blocked_at value
+      #
+      # Returns a boolean.
+      def blocked?
+        blocked_at.present?
+      end
+
       # Public: Overrides the Resourceable concern method to allow setting permissions at resource level
       def allow_resource_permissions?
         true

--- a/decidim-elections/app/models/decidim/elections/election.rb
+++ b/decidim-elections/app/models/decidim/elections/election.rb
@@ -16,6 +16,7 @@ module Decidim
       include Decidim::Forms::HasQuestionnaire
 
       translatable_fields :title, :description
+      enum bb_status: [:key_ceremony, :ready, :vote, :tally, :results, :results_published].map { |status| [status, status.to_s] }.to_h, _suffix: true
 
       component_manifest_name "elections"
 

--- a/decidim-elections/app/permissions/decidim/elections/admin/permissions.rb
+++ b/decidim-elections/app/permissions/decidim/elections/admin/permissions.rb
@@ -10,19 +10,17 @@ module Decidim
           case permission_action.subject
           when :question, :answer
             case permission_action.action
-            when :create, :update, :delete
-              allow_if_not_started
-            when :import_proposals
-              allow_if_not_started
+            when :create, :update, :delete, :import_proposals
+              allow_if_not_blocked
             end
           when :election
             case permission_action.action
-            when :create, :read, :setup
+            when :create, :read
               allow!
-            when :delete, :update, :unpublish
-              allow_if_not_started
+            when :delete, :update, :unpublish, :setup
+              allow_if_not_blocked
             when :publish
-              allow_if_valid_and_not_started
+              allow_if_valid_and_not_blocked
             end
           when :trustee_participatory_space
             case permission_action.action
@@ -62,12 +60,12 @@ module Decidim
           @trustee_participatory_space ||= context.fetch(:trustee_participatory_space, nil)
         end
 
-        def allow_if_not_started
-          toggle_allow(election && !election.started?)
+        def allow_if_not_blocked
+          toggle_allow(election && !election.blocked?)
         end
 
-        def allow_if_valid_and_not_started
-          toggle_allow(election && !election.started? && election.valid_questions?)
+        def allow_if_valid_and_not_blocked
+          toggle_allow(election && !election.blocked? && election.valid_questions?)
         end
 
         def allow_if_not_related_to_any_election

--- a/decidim-elections/app/types/decidim/elections/election_type.rb
+++ b/decidim-elections/app/types/decidim/elections/election_type.rb
@@ -20,6 +20,8 @@ module Decidim
       field :createdAt, Decidim::Core::DateTimeType, "When this election was created", property: :created_at
       field :updatedAt, Decidim::Core::DateTimeType, "When this election was updated", property: :updated_at
       field :publishedAt, Decidim::Core::DateTimeType, "When this election was published", property: :published_at
+      field :blocked, types.Boolean, "Whether this election has it's parameters blocked or not", property: :blocked?
+      field :bb_status, types.String, "The status for this election in the bulletin board"
 
       field :questions, !types[Decidim::Elections::ElectionQuestionType], "The questions for this election"
       field :trustees, !types[Decidim::Elections::TrusteeType], "The trustees for this election"

--- a/decidim-elections/app/views/decidim/elections/admin/answers/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/answers/index.html.erb
@@ -32,10 +32,14 @@
               <td class="table-list__actions">
                 <% if allowed_to? :update, :answer, election: election, question: question, answer: answer %>
                   <%= icon_link_to "pencil", edit_election_question_answer_path(election, question, answer), t("actions.edit", scope: "decidim.elections"), class: "action-icon--edit" %>
+                <% else %>
+                  <%= icon "pencil", class: "action-icon action-icon--disabled", role: "img" %>
                 <% end %>
 
                 <% if allowed_to? :delete, :answer, election: election, question: question, answer: answer %>
                   <%= icon_link_to "circle-x", election_question_answer_path(election, question, answer), t("actions.destroy", scope: "decidim.elections"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.elections") } %>
+                <% else %>
+                  <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img" %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-elections/app/views/decidim/elections/admin/elections/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/index.html.erb
@@ -39,7 +39,11 @@
 
                 <%= icon_link_to "list", election_questions_path(election), t("actions.edit_questions", scope: "decidim.elections"), class: "action-icon--edit-questions" %>
 
-                <%= icon_link_to "power-standby", url_for(action: :show, id: election, controller: "setup"), t("actions.setup", scope: "decidim.elections"), class: "action-icon--setup-election" %>
+                <% if allowed_to? :setup, :election, election: election %>
+                  <%= icon_link_to "power-standby", url_for(action: :show, id: election, controller: "setup"), t("actions.setup", scope: "decidim.elections"), class: "action-icon--setup-election" %>
+                <% else %>
+                  <%= icon "power-standby", class: "action-icon action-icon--disabled", role: "img" %>
+                <% end %>
 
                 <% if allowed_to? :update, :election, election: election %>
                   <%= icon_link_to "pencil", edit_election_path(election), t("actions.edit", scope: "decidim.elections"), class: "action-icon--edit" %>

--- a/decidim-elections/app/views/decidim/elections/admin/elections/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/index.html.erb
@@ -37,7 +37,7 @@
               <td class="table-list__actions">
                 <%= icon_link_to "eye", resource_locator(election).path, t("actions.preview", scope: "decidim.elections"), class: "action-icon--preview", target: :blank %>
 
-                <%= icon_link_to "list", election_questions_path(election), t("actions.edit_questions", scope: "decidim.elections"), class: "action-icon--edit-questions" %>
+                <%= icon_link_to "list", election_questions_path(election), t("actions.manage_questions", scope: "decidim.elections"), class: "action-icon--manage-questions" %>
 
                 <% if allowed_to? :setup, :election, election: election %>
                   <%= icon_link_to "power-standby", url_for(action: :show, id: election, controller: "setup"), t("actions.setup", scope: "decidim.elections"), class: "action-icon--setup-election" %>

--- a/decidim-elections/app/views/decidim/elections/admin/questions/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/questions/index.html.erb
@@ -36,7 +36,7 @@
                 <% end %>
               </td>
               <td class="table-list__actions">
-                <%= icon_link_to "list", election_question_answers_path(election, question), t("actions.edit_answers", scope: "decidim.elections"), class: "action-icon--edit-answers" %>
+                <%= icon_link_to "list", election_question_answers_path(election, question), t("actions.manage_answers", scope: "decidim.elections"), class: "action-icon--manage-answers" %>
 
                 <% if allowed_to? :update, :question, election: election, question: question %>
                   <%= icon_link_to "pencil", edit_election_question_path(election, question), t("actions.edit", scope: "decidim.elections"), class: "action-icon--edit" %>

--- a/decidim-elections/app/views/decidim/elections/admin/questions/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/questions/index.html.erb
@@ -40,10 +40,14 @@
 
                 <% if allowed_to? :update, :question, election: election, question: question %>
                   <%= icon_link_to "pencil", edit_election_question_path(election, question), t("actions.edit", scope: "decidim.elections"), class: "action-icon--edit" %>
+                <% else %>
+                  <%= icon "pencil", class: "action-icon action-icon--disabled", role: "img" %>
                 <% end %>
 
                 <% if allowed_to? :delete, :question, election: election, question: question %>
                   <%= icon_link_to "circle-x", election_question_path(election, question), t("actions.destroy", scope: "decidim.elections"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.elections") } %>
+                <% else %>
+                  <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img" %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -58,10 +58,10 @@ en:
         confirm_destroy: Are you sure?
         destroy: Destroy
         edit: Edit
-        edit_answers: Edit answers
-        edit_questions: Edit questions
         feedback: Voter feedback
         import: Import proposals to answers
+        manage_answers: Manage answers
+        manage_questions: Manage questions
         new: New %{name}
         preview: Preview
         publish: Publish

--- a/decidim-elections/db/migrate/20201026163334_add_blocked_at_and_bb_status_to_elections.rb
+++ b/decidim-elections/db/migrate/20201026163334_add_blocked_at_and_bb_status_to_elections.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddBlockedAtAndBbStatusToElections < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_elections_elections, :blocked_at, :datetime
+    add_column :decidim_elections_elections, :bb_status, :string
+  end
+end

--- a/decidim-elections/lib/decidim/elections/test/factories.rb
+++ b/decidim-elections/lib/decidim/elections/test/factories.rb
@@ -16,15 +16,21 @@ FactoryBot.define do
     description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     end_time { 3.days.from_now }
     published_at { nil }
+    blocked_at { nil }
+    bb_status { nil }
     questionnaire
     component { create(:elections_component) }
 
     trait :upcoming do
       start_time { 1.day.from_now }
+      blocked_at { Time.current }
+      bb_status { "key_ceremony" }
     end
 
     trait :started do
       start_time { 2.days.ago }
+      blocked_at { Time.current }
+      bb_status { "key_ceremony" }
     end
 
     trait :ongoing do
@@ -34,6 +40,8 @@ FactoryBot.define do
     trait :finished do
       started
       end_time { 1.day.ago }
+      blocked_at { Time.current }
+      bb_status { "key_ceremony" }
     end
 
     trait :published do

--- a/decidim-elections/spec/commands/decidim/elections/admin/setup_election_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/admin/setup_election_spec.rb
@@ -72,6 +72,8 @@ describe Decidim::Elections::Admin::SetupElection do
         )
 
       expect { subject.call }.to change { election.trustees.count }.by(5)
+      expect(election.blocked_at).to be_within(1.second).of election.updated_at
+      expect(election.blocked?).to be true
     end
   end
 end

--- a/decidim-elections/spec/permissions/decidim/elections/admin/permissions_spec.rb
+++ b/decidim-elections/spec/permissions/decidim/elections/admin/permissions_spec.rb
@@ -87,7 +87,6 @@ describe Decidim::Elections::Admin::Permissions do
     let(:action) do
       { scope: :admin, action: :setup, subject: :election }
     end
-    let(:election) { nil }
 
     it { is_expected.to eq true }
   end

--- a/decidim-elections/spec/system/admin_manages_answers_spec.rb
+++ b/decidim-elections/spec/system/admin_manages_answers_spec.rb
@@ -19,11 +19,11 @@ describe "Admin manages answers", type: :system do
     visit_component_admin
 
     within find("tr", text: translated(election.title)) do
-      page.find(".action-icon--edit-questions").click
+      page.find(".action-icon--manage-questions").click
     end
 
     within find("tr", text: translated(question.title)) do
-      page.find(".action-icon--edit-answers").click
+      page.find(".action-icon--manage-answers").click
     end
   end
 

--- a/decidim-elections/spec/system/admin_manages_answers_spec.rb
+++ b/decidim-elections/spec/system/admin_manages_answers_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe "Admin manages answers", type: :system do
   let!(:proposals) { create_list :proposal, 3, :accepted, component: origin_component }
   let!(:origin_component) { create :proposal_component, participatory_space: current_component.participatory_space }
-  let(:election) { create :election, :upcoming, component: current_component }
+  let(:election) { create :election, component: current_component }
   let(:question) { create :question, election: election }
   let(:answer) { create :election_answer, question: question }
   let(:manifest_name) { "elections" }

--- a/decidim-elections/spec/system/admin_manages_elections_spec.rb
+++ b/decidim-elections/spec/system/admin_manages_elections_spec.rb
@@ -74,6 +74,8 @@ describe "Admin manages elections", type: :system do
   end
 
   describe "updating an election" do
+    let(:election) { create :election, :published, component: current_component }
+
     it "updates an election" do
       within find("tr", text: translated(election.title)) do
         page.find(".action-icon--edit").click
@@ -110,7 +112,7 @@ describe "Admin manages elections", type: :system do
 
   describe "publishing an election" do
     context "when the election is unpublished" do
-      let!(:election) { create(:election, :upcoming, :complete, component: current_component) }
+      let!(:election) { create(:election, :complete, component: current_component) }
 
       it "publishes the election" do
         within find("tr", text: translated(election.title)) do
@@ -130,7 +132,7 @@ describe "Admin manages elections", type: :system do
 
   describe "set up an election" do
     context "when the election is published", :vcr do
-      let!(:election) { create :election, :upcoming, :published, :ready_for_setup, component: current_component }
+      let!(:election) { create :election, :published, :ready_for_setup, component: current_component }
 
       it "sets up an election" do
         within find("tr", text: translated(election.title)) do
@@ -157,6 +159,8 @@ describe "Admin manages elections", type: :system do
   end
 
   describe "unpublishing an election" do
+    let!(:election) { create :election, :published, :ready_for_setup, component: current_component }
+
     it "unpublishes an election" do
       within find("tr", text: translated(election.title)) do
         page.find(".action-icon--unpublish").click
@@ -193,6 +197,8 @@ describe "Admin manages elections", type: :system do
   end
 
   describe "deleting an election" do
+    let!(:election) { create(:election, component: current_component) }
+
     it "deletes an election" do
       within find("tr", text: translated(election.title)) do
         accept_confirm do

--- a/decidim-elections/spec/system/admin_manages_questions_spec.rb
+++ b/decidim-elections/spec/system/admin_manages_questions_spec.rb
@@ -16,7 +16,7 @@ describe "Admin manages questions", type: :system do
     visit_component_admin
 
     within find("tr", text: translated(election.title)) do
-      page.find(".action-icon--edit-questions").click
+      page.find(".action-icon--manage-questions").click
     end
   end
 

--- a/decidim-elections/spec/system/admin_manages_questions_spec.rb
+++ b/decidim-elections/spec/system/admin_manages_questions_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "Admin manages questions", type: :system do
-  let(:election) { create :election, :upcoming, component: current_component }
+  let(:election) { create :election, component: current_component }
   let(:question) { create :question, election: election }
   let(:manifest_name) { "elections" }
 

--- a/decidim-elections/spec/types/decidim/elections/election_type_spec.rb
+++ b/decidim-elections/spec/types/decidim/elections/election_type_spec.rb
@@ -66,6 +66,34 @@ module Decidim
         end
       end
 
+      describe "blocked" do
+        let(:query) { "{ blocked }" }
+
+        context "when the election's parameters are blocked" do
+          let!(:model) { create(:election, :started, :ready_for_setup) }
+
+          it "returns true " do
+            expect(response["blocked"]).to be true
+          end
+        end
+
+        context "when the election's parameters are not blocked" do
+          let(:model) { create(:election) }
+
+          it "returns false" do
+            expect(response["blocked"]).to be_falsey
+          end
+        end
+      end
+
+      describe "bb_status" do
+        let(:query) { "{ bb_status }" }
+
+        it "returns the bb_status" do
+          expect(response["bb_status"]).to eq(model.bb_status)
+        end
+      end
+
       describe "questions" do
         let!(:election2) { create(:election, :complete) }
         let(:query) { "{ questions { id } }" }


### PR DESCRIPTION
#### :tophat: What? Why?

Once the election parameters are sent to the Bulletin Board, and it succeeds the election setup is blocked and the status updated to `key_ceremony`.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #6621
- Depends on #6813

#### Testing
*Describe the best way to test or validate your PR.*

 
  

<table>
<tr>
	<td>1. Go to the election setup:
	<td><img width="888" alt="Screenshot 2020-11-09 at 16 20 37" src="https://user-images.githubusercontent.com/210216/98560445-12314100-22a8-11eb-965a-99277f8c2a9b.png">

<tr>
	<td>2. All checks sould be ok, click setup election button:
	<td><img width="891" alt="Screenshot 2020-11-09 at 16 20 58" src="https://user-images.githubusercontent.com/210216/98560582-30973c80-22a8-11eb-8ad4-619c7493eee9.png">

<tr>
	<td>3. A success callout that the **election** is successfully setup should appear.
The elections parameters can't be changed, as the election params have been sent to the Bulletin Board and the election is now blocked:
	<td><img width="918" alt="Screenshot 2020-11-09 at 16 21 16" src="https://user-images.githubusercontent.com/210216/98560780-6c320680-22a8-11eb-9e74-78fdde07eaf9.png">

<tr>
	<td>4. Edit/destroy **questions are also blocked**  due to the election setup sent to the bulletin board:
	<td><img width="892" alt="Screenshot 2020-11-09 at 16 21 30" src="https://user-images.githubusercontent.com/210216/98561093-bf0bbe00-22a8-11eb-9832-0d9e6ad66fe1.png">

<tr>
	<td>5. Edit/destroy **answers are also blocked** due to the election setup sent to the bulletin board:
	<td><img width="887" alt="Screenshot 2020-11-09 at 16 21 42" src="https://user-images.githubusercontent.com/210216/98561191-e06caa00-22a8-11eb-8e6d-11e53ec93a07.png">

</table>

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
