### PR TITLE
Fix broken notifications page due to multi-budget changes

### DIFF
--- a/decidim-budgets/spec/system/explore_budget_notifications_spec.rb
+++ b/decidim-budgets/spec/system/explore_budget_notifications_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Explore budget notifications", :slow, type: :system do
+  include_context "with a component"
+  let(:manifest_name) { "budgets" }
+  let(:budget) { create :budget, component: component }
+  let(:projects_count) { 5 }
+  let!(:projects) do
+    create_list(:project, projects_count, budget: budget)
+  end
+  let!(:project) { projects.first }
+
+  describe "index" do
+    context "when a budgeting project was commented in a followed space" do
+      let(:user) { create(:user, :confirmed, organization: component.organization) }
+      let(:other_user) { create(:user, :confirmed, organization: component.organization) }
+
+      before do
+        switch_to_host(organization.host)
+        login_as(user, scope: :user)
+
+        # Create a notification for the follower
+        create(:follow, followable: component.participatory_space, user: user)
+        comment = create(:comment, commentable: project, author: other_user)
+        perform_enqueued_jobs do
+          Decidim::Comments::NewCommentNotificationCreator.new(comment, [], []).create
+        end
+      end
+
+      it "displays the notification for the comment" do
+        visit_notifications
+
+        within "#notifications" do
+          expect(page).to have_content(translated(project.title))
+        end
+      end
+    end
+  end
+
+  private
+
+  def visit_notifications
+    page.visit decidim.notifications_path
+  end
+end

--- a/decidim-comments/app/events/decidim/comments/comment_event.rb
+++ b/decidim-comments/app/events/decidim/comments/comment_event.rb
@@ -9,14 +9,6 @@ module Decidim
       include Decidim::Events::AuthorEvent
 
       included do
-        def resource_path
-          resource_locator.path(url_params)
-        end
-
-        def resource_url
-          resource_locator.url(url_params)
-        end
-
         def resource_text
           comment.formatted_body
         end
@@ -42,7 +34,7 @@ module Decidim
           @comment ||= Decidim::Comments::Comment.find(extra[:comment_id])
         end
 
-        def url_params
+        def resource_url_params
           { anchor: "comment_#{comment.id}" }
         end
       end

--- a/decidim-core/lib/decidim/events/base_event.rb
+++ b/decidim-core/lib/decidim/events/base_event.rb
@@ -59,12 +59,24 @@ module Decidim
 
       # Caches the path for the given resource.
       def resource_path
-        @resource_path ||= resource_locator.path
+        @resource_path ||= begin
+          if resource&.respond_to?(:polymorphic_resource_path)
+            resource.polymorphic_resource_path(resource_url_params)
+          else
+            resource_locator.path(resource_url_params)
+          end
+        end
       end
 
       # Caches the URL for the given resource.
       def resource_url
-        @resource_url ||= resource_locator.url
+        @resource_url ||= begin
+          if resource&.respond_to?(:polymorphic_resource_url)
+            resource.polymorphic_resource_url(resource_url_params)
+          else
+            resource_locator.url(resource_url_params)
+          end
+        end
       end
 
       def resource_text; end
@@ -97,6 +109,10 @@ module Decidim
         return resource if resource.is_a?(Decidim::Participable)
 
         resource.try(:participatory_space)
+      end
+
+      def resource_url_params
+        {}
       end
 
       attr_reader :event_name, :resource, :user, :user_role, :extra


### PR DESCRIPTION
#### :tophat: What? Why?
When notifications are created for the budgeting project comments, the notification pages are broken.

The following exception will be visible in the logs:

```
ActionView::Template::Error:
  undefined method `project_path' for #<ActionDispatch::Routing::RoutesProxy:0x000055b806a6f248>

# /.../decidim/decidim-core/lib/decidim/engine_router.rb:47:in `method_missing'
# /.../decidim/decidim-core/app/presenters/decidim/resource_locator_presenter.rb:101:in `member_route'
# /.../decidim/decidim-core/app/presenters/decidim/resource_locator_presenter.rb:20:in `path'
# /.../decidim/decidim-comments/app/events/decidim/comments/comment_event.rb:13:in `resource_path'
```

This is because the resource locator does not automatically work for the resources with "polymorphic" routes, e.g. in this case the budgeting project which is under a budget (and therefore the route helper is `budget_project_path` instead).

#### :pushpin: Related Issues
- Related to #6223

The same issue applied to the activity feed items related to the budgeting component and this was fixed by @agustibr at this commit:
https://github.com/decidim/decidim/pull/6223/commits/5d6cf9af0d17cb4acef6471dcb452b8674653879

This PR applies the same fix to the notifications.

#### Testing
- Create a Decidim instance with the seed content
- Login as admin
- Go to a participatory process with a budgeting component
- Follow the participatory process
- Open another window (incognito) and login as "user@example.org"
- Go to the same participatory space which you just followed as admin
- Go to budgets
- Open one of the projects
- Leave a comment in that project
- Now as the admin user, refresh the page, you should have one notification
- Go to the notifications view
- See an exception

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.