### PR TITLE
Fix broken comments index redirect for non-XHR requests

### DIFF
--- a/decidim-budgets/spec/system/comments_spec.rb
+++ b/decidim-budgets/spec/system/comments_spec.rb
@@ -6,8 +6,27 @@ describe "Comments", type: :system do
   let!(:component) { create(:budgets_component, organization: organization) }
   let!(:budget) { create(:budget, component: component) }
   let!(:commentable) { create(:project, budget: budget) }
-
   let(:resource_path) { resource_locator([budget, commentable]).path }
 
   include_examples "comments"
+
+  context "when requesting the comments index with a non-XHR request" do
+    it "redirects the user to the correct commentable path" do
+      visit decidim_comments.comments_path(commentable_gid: commentable.to_signed_global_id.to_s)
+
+      expect(page).to have_current_path(
+        decidim_budgets.budget_project_path(budget, commentable)
+      )
+    end
+  end
+
+  private
+
+  def decidim_comments
+    Decidim::Comments::Engine.routes.url_helpers
+  end
+
+  def decidim_budgets
+    Decidim::EngineRouter.main_proxy(component)
+  end
 end

--- a/decidim-comments/app/controllers/decidim/comments/comments_controller.rb
+++ b/decidim-comments/app/controllers/decidim/comments/comments_controller.rb
@@ -33,7 +33,7 @@ module Decidim
           end
 
           # This makes sure bots are not causing unnecessary log entries.
-          format.html { redirect_to resource_locator(commentable).path }
+          format.html { redirect_to commentable_path }
         end
       end
 
@@ -110,6 +110,12 @@ module Decidim
 
       def root_depth
         params.fetch(:root_depth, 0).to_i
+      end
+
+      def commentable_path
+        return commentable.polymorphic_resource_path({}) if commentable&.respond_to?(:polymorphic_resource_path)
+
+        resource_locator(commentable).path
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
This applies the fix for notifications at #6815 also to the comments page index requests (mainly bots).

This is generally not that visible to users but it causes unnecessary exceptions in the logs.

#### :pushpin: Related Issues
- Related to #6815, #6223, #6740

#### Testing
- Follow the replication instructions at #6815 
- Finally open the project that was commented and follow the replication instructions at #6740 

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.