### PR TITLE
fix: show generic error on minimagick processing error 

### DIFF
--- a/decidim-core/app/uploaders/decidim/application_uploader.rb
+++ b/decidim-core/app/uploaders/decidim/application_uploader.rb
@@ -5,6 +5,8 @@ module Decidim
   # hold the uploads configuration, so you should inherit from this class and
   # then tweak any configuration you need.
   class ApplicationUploader < CarrierWave::Uploader::Base
+    include CarrierWave::MiniMagick
+
     process :validate_inside_organization
 
     # Override the directory where uploaded files will be stored.

--- a/decidim-core/app/uploaders/decidim/attachment_uploader.rb
+++ b/decidim-core/app/uploaders/decidim/attachment_uploader.rb
@@ -3,8 +3,6 @@
 module Decidim
   # This class deals with uploading attachments to a participatory space.
   class AttachmentUploader < ApplicationUploader
-    include CarrierWave::MiniMagick
-
     process :set_content_type_and_size_in_model
     process :validate_dimensions
     process :strip

--- a/decidim-core/app/uploaders/decidim/image_uploader.rb
+++ b/decidim-core/app/uploaders/decidim/image_uploader.rb
@@ -3,8 +3,6 @@
 module Decidim
   # This class deals with uploading hero images to ParticipatoryProcesses.
   class ImageUploader < ApplicationUploader
-    include CarrierWave::MiniMagick
-
     process :validate_size, :validate_dimensions, :strip
     process quality: Decidim.image_uploader_quality
 


### PR DESCRIPTION
#### :tophat: What? Why?
In https://github.com/decidim/decidim/pull/6754, the overwriting of `CarrierWave::MiniMagick`'s `manipulate!` method was moved from `ImageUploader` to its parent `ApplicationUploader`, so that also `AttachmentUploader` could take advantage of it.

The `CarrierWave::MiniMagick` concern, though, was still imported in both `ImageUploader` and `AttachmentUploader`. This way, the `ApplicationUploader`'s `manipulate!` was ignored because `CarrierWave::MiniMagick` was coming first in the ancestor chain.

Moving the `CarrierWave::MiniMagick` concern inclusion to `ApplicationUploader` makes it come after in the ancestor chain and thus the correct `manipulate!` is called.

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/pull/6754
- Fixes: https://tremend.atlassian.net/browse/DIFE-306

#### Testing
- Create an HTLM document and change its extension to `.jpg`.
- Upload the document to a form with a file upload accepting jpgs (e.g.: `admin/conferences/<conference-slug>/attachments/new`)
- Check that the error message doesn't disclose internal implementation.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

#### Before
<img width="1045" alt="before" src="https://user-images.githubusercontent.com/5033945/97334669-4b67bb00-187d-11eb-99d6-39f8d909375f.png">

#### After
<img width="614" alt="after" src="https://user-images.githubusercontent.com/5033945/97334687-502c6f00-187d-11eb-8f9d-ee80c78b06e7.png">

:hearts: Thank you!
