### PR TITLE
Improve highlights of Process Groups

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/promoted_participatory_processes_shared_examples.rb
+++ b/decidim-dev/lib/decidim/dev/test/promoted_participatory_processes_shared_examples.rb
@@ -1,12 +1,46 @@
 # frozen_string_literal: true
 
-shared_examples "with promoted participatory processes" do
+shared_examples "with promoted participatory processes and groups" do
   before do
     request.env["decidim.current_organization"] = organization
   end
 
-  describe "promoted_participatory_processes" do
-    it "orders them by active_step end_date" do
+  describe "promoted_collection" do
+    it "includes promoted participatory processes and groups placing groups in first place" do
+      create(
+        :participatory_process_group,
+        organization: organization
+      )
+
+      unpromoted_process = create(
+        :participatory_process,
+        :with_steps,
+        :published,
+        organization: organization
+      )
+      unpromoted_process.active_step.update!(end_date: Time.current.advance(days: 1))
+
+      promoted_process = create(
+        :participatory_process,
+        :with_steps,
+        :published,
+        :promoted,
+        organization: organization
+      )
+      promoted_process.active_step.update!(end_date: Time.current.advance(days: 2))
+
+      promoted_group = create(
+        :participatory_process_group,
+        :promoted,
+        organization: organization
+      )
+
+      expect(controller.helpers.promoted_collection).to(
+        match_array([promoted_group, promoted_process])
+      )
+    end
+
+    it "orders participatory processes by active_step end_date" do
       create(
         :participatory_process,
         :with_steps,
@@ -57,7 +91,7 @@ shared_examples "with promoted participatory processes" do
 
       second.active_step.update!(end_date: Time.current.advance(days: 4))
 
-      expect(controller.helpers.promoted_participatory_processes).to(
+      expect(controller.helpers.promoted_collection).to(
         match_array([first, second, last])
       )
     end

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process_group.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process_group.rb
@@ -57,7 +57,8 @@ module Decidim
                 meta_scope: form.meta_scope,
                 participatory_scope: form.participatory_scope,
                 participatory_structure: form.participatory_structure,
-                target: form.target
+                target: form.target,
+                promoted: form.promoted
               )
             end
           end

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/update_participatory_process_group.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/update_participatory_process_group.rb
@@ -63,7 +63,8 @@ module Decidim
             meta_scope: form.meta_scope,
             participatory_scope: form.participatory_scope,
             participatory_structure: form.participatory_structure,
-            target: form.target
+            target: form.target,
+            promoted: form.promoted
           }
         end
 

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
@@ -10,8 +10,7 @@ module Decidim
       include FilterResource
 
       helper_method :collection,
-                    :promoted_participatory_processes,
-                    :promoted_participatory_process_groups,
+                    :promoted_collection,
                     :participatory_processes,
                     :stats,
                     :metrics,
@@ -75,6 +74,10 @@ module Decidim
 
       def promoted_participatory_process_groups
         @promoted_participatory_process_groups ||= PromotedParticipatoryProcessGroups.new
+      end
+
+      def promoted_collection
+        @promoted_collection ||= promoted_participatory_processes.query + promoted_participatory_process_groups.query
       end
 
       def collection

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
@@ -14,6 +14,7 @@ module Decidim
                     :participatory_processes,
                     :stats,
                     :metrics,
+                    :participatory_process_group,
                     :default_date_filter,
                     :related_processes,
                     :linked_assemblies
@@ -94,6 +95,10 @@ module Decidim
 
       def metrics
         @metrics ||= ParticipatoryProcessMetricChartsPresenter.new(participatory_process: current_participatory_space)
+      end
+
+      def participatory_process_group
+        @participatory_process_group ||= current_participatory_space.participatory_process_group
       end
 
       def default_date_filter

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
@@ -11,6 +11,7 @@ module Decidim
 
       helper_method :collection,
                     :promoted_participatory_processes,
+                    :promoted_participatory_process_groups,
                     :participatory_processes,
                     :stats,
                     :metrics,
@@ -70,6 +71,10 @@ module Decidim
 
       def promoted_participatory_processes
         @promoted_participatory_processes ||= published_processes | PromotedParticipatoryProcesses.new
+      end
+
+      def promoted_participatory_process_groups
+        @promoted_participatory_process_groups ||= PromotedParticipatoryProcessGroups.new
       end
 
       def collection

--- a/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_group_form.rb
+++ b/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_group_form.rb
@@ -23,6 +23,8 @@ module Decidim
         attribute :hashtag, String
         attribute :participatory_process_ids, Array[Integer]
 
+        attribute :promoted, Boolean
+
         mimic :participatory_process_group
 
         attribute :hero_image

--- a/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
+++ b/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
@@ -38,20 +38,34 @@ module Decidim
       #
       # Returns a Hash with content block settings or nil
       def participatory_process_group_cta_settings(process_group)
-        cta_settings = Decidim::ContentBlock.for_scope(
+        block = Decidim::ContentBlock.for_scope(
           :participatory_process_group_homepage,
           organization: current_organization
         ).find_by(
           manifest_name: "cta",
           scoped_resource_id: process_group.id
-        )&.settings
+        )
+
+        cta_settings = block&.settings
 
         return if cta_settings.blank? || cta_settings.button_url.blank?
 
         OpenStruct.new(
           text: translated_attribute(cta_settings.button_text),
-          path: cta_settings.button_url
+          path: cta_settings.button_url,
+          image_url: block.images_container.background_image.big.url
         )
+      end
+
+      # Public: Invokes the appropriate partial for a promoted
+      # participatory process or group based on the type name
+      #
+      # promoted_item - Can be a Decidim::ParticipatoryProcess or
+      #                 Decidim::ParticipatoryProcessGroup
+      def render_highlighted_partial_for(promoted_item)
+        name = promoted_item.class.name.demodulize.underscore.gsub("participatory_", "promoted_")
+
+        render partial: name, locals: { name => promoted_item }.symbolize_keys
       end
     end
   end

--- a/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
+++ b/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
@@ -32,6 +32,27 @@ module Decidim
 
         "#{path}/#{process.active_step.cta_path}" + (params.present? ? "?#{params}" : "")
       end
+
+      # Public: Returns the settings of a cta content block associated if
+      # exists
+      #
+      # Returns a Hash with content block settings or nil
+      def participatory_process_group_cta_settings(process_group)
+        cta_settings = Decidim::ContentBlock.for_scope(
+          :participatory_process_group_homepage,
+          organization: current_organization
+        ).find_by(
+          manifest_name: "cta",
+          scoped_resource_id: process_group.id
+        )&.settings
+
+        return if cta_settings.blank? || cta_settings.button_url.blank?
+
+        OpenStruct.new(
+          text: translated_attribute(cta_settings.button_text),
+          path: cta_settings.button_url
+        )
+      end
     end
   end
 end

--- a/decidim-participatory_processes/app/models/decidim/participatory_process_group.rb
+++ b/decidim-participatory_processes/app/models/decidim/participatory_process_group.rb
@@ -23,6 +23,13 @@ module Decidim
     validates_upload :hero_image
     mount_uploader :hero_image, Decidim::HeroImageUploader
 
+    # Scope to return only the promoted groups.
+    #
+    # Returns an ActiveRecord::Relation.
+    def self.promoted
+      where(promoted: true)
+    end
+
     def self.log_presenter_class_for(_log)
       Decidim::ParticipatoryProcesses::AdminLog::ParticipatoryProcessGroupPresenter
     end

--- a/decidim-participatory_processes/app/queries/decidim/participatory_processes/promoted_participatory_process_groups.rb
+++ b/decidim-participatory_processes/app/queries/decidim/participatory_processes/promoted_participatory_process_groups.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ParticipatoryProcesses
+    # This query filters participatory process groups so only promoted ones are returned.
+    class PromotedParticipatoryProcessGroups < Rectify::Query
+      def query
+        Decidim::ParticipatoryProcessGroup.promoted
+      end
+    end
+  end
+end

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_groups/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_groups/_form.html.erb
@@ -59,4 +59,14 @@
       <%= form.translated :text_field, :participatory_structure %>
     </div>
   </div>
+
+  <div class="card-divider">
+    <h2 class="card-title"><%= t(".visibility") %></h2>
+  </div>
+
+  <div class="card-section">
+    <div class="row column">
+      <%= form.check_box :promoted %>
+    </div>
+  </div>
 </div>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_groups/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_groups/index.html.erb
@@ -26,6 +26,11 @@
           <% collection.each do |group| %>
             <tr>
               <td>
+                <% if group.promoted? %>
+                  <span data-tooltip class="icon-state icon-highlight" aria-haspopup="true" data-disable-hover="false" title="<%= t("models.participatory_process.fields.promoted", scope: "decidim.admin") %>">
+                    <%= icon "star" %>
+                  </span>
+                <% end %>
                 <% if allowed_to? :update, :process_group, process_group: group %>
                   <%= link_to translated_attribute(group.title), ["edit", group] %><br>
                 <% else %>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_process_groups/show.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_process_groups/show.html.erb
@@ -1,6 +1,15 @@
 <% add_decidim_page_title(translated_attribute(group.title)) %>
 <% add_decidim_meta_tags(title: t("participatory_process_groups.show.title", scope: "decidim")) %>
 
+<%
+  edit_link(
+    decidim_admin_participatory_processes.edit_participatory_process_group_path(group),
+    :update,
+    :process_group,
+    process_group: group
+  )
+%>
+
 <div class="wrapper">
   <div class="row column">
     <% Decidim::ContentBlock.published.for_scope(:participatory_process_group_homepage, organization: current_organization).where(scoped_resource_id: group.id).each do |content_block| %>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/_participatory_process_group.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/_participatory_process_group.html.erb
@@ -1,0 +1,4 @@
+<p>
+  <span class="text-small text-uppercase text-muted mr-s"><%= t("belongs_to_group", scope: "decidim.participatory_processes.show") %></span>
+  <%= link_to translated_attribute(participatory_process_group.title), participatory_process_group_path(participatory_process_group) %>
+</p>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/_promoted_process_group.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/_promoted_process_group.html.erb
@@ -1,3 +1,4 @@
+<% cta_settings = participatory_process_group_cta_settings(promoted_process_group) %>
 <div class="card card--full card--process">
   <div class="row collapse card--process__row">
     <div class="columns mediumlarge-8 large-6 card--process__column">
@@ -13,7 +14,18 @@
       </div>
     </div>
     <div class="columns mediumlarge-8 large-6 card--process__column">
-      <div class="card--full__image" style="background-image:url(<%= promoted_process_group.hero_image.url %>)"></div>
+      <div class="card--full__image" style="background-image:url(<%= promoted_process_group.hero_image.url %>)">
+        <% if cta_settings.present? %>
+          <div class="card__content row collapse">
+            <div class="large-6 large-offset-6 columns">
+              <%= link_to cta_settings.path, class: "button expanded button--sc" do %>
+                <span class="show-for-sr"><%= cta_settings.text %></span>
+                <span aria-hidden="true"><%= cta_settings.text %></span>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/_promoted_process_group.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/_promoted_process_group.html.erb
@@ -1,0 +1,19 @@
+<div class="card card--full card--process">
+  <div class="row collapse card--process__row">
+    <div class="columns mediumlarge-8 large-6 card--process__column">
+      <div class="card__content">
+        <%= link_to participatory_process_group_path(promoted_process_group), class: "card__link" do %>
+          <h2 class="card__title"><%= decidim_html_escape(translated_attribute(promoted_process_group.title)) %></h2>
+        <% end %>
+        <%= decidim_sanitize html_truncate(translated_attribute(promoted_process_group.description), length: 630, separator: "...") %>
+        <%= link_to participatory_process_group_path(promoted_process_group), class: "button small hollow card__button" do %>
+          <span class="show-for-sr"><%= decidim_html_escape(translated_attribute(promoted_process_group.title)) %></span>
+          <%= t("participatory_processes.promoted_process_group.more_info", scope: "layouts.decidim") %>
+        <% end %>
+      </div>
+    </div>
+    <div class="columns mediumlarge-8 large-6 card--process__column">
+      <div class="card--full__image" style="background-image:url(<%= promoted_process_group.hero_image.url %>)"></div>
+    </div>
+  </div>
+</div>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/_promoted_process_group.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/_promoted_process_group.html.erb
@@ -14,7 +14,7 @@
       </div>
     </div>
     <div class="columns mediumlarge-8 large-6 card--process__column">
-      <div class="card--full__image" style="background-image:url(<%= promoted_process_group.hero_image.url %>)">
+      <div class="card--full__image" style="background-image:url(<%= cta_settings&.image_url || promoted_process_group.hero_image&.url %>)">
         <% if cta_settings.present? %>
           <div class="card__content row collapse">
             <div class="large-6 large-offset-6 columns">

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/index.html.erb
@@ -9,17 +9,12 @@ edit_link(
 %>
 
 <%= participatory_space_wrapper do %>
-  <% if promoted_participatory_process_groups.any? %>
-    <section id="highlighted-process-groups" class="row section">
-      <h1 class="section-heading"><%= t("participatory_processes.index.promoted_process_groups", scope: "layouts.decidim") %></h1>
-      <%= render partial: "promoted_process_group", collection: promoted_participatory_process_groups, as: :promoted_process_group %>
-    </section>
-  <% end %>
-
-  <% if promoted_participatory_processes.any? %>
+  <% if promoted_collection.any? %>
     <section id="highlighted-processes" class="row section">
       <h1 class="section-heading"><%= t("participatory_processes.index.promoted_processes", scope: "layouts.decidim") %></h1>
-      <%= render partial: "promoted_process", collection: promoted_participatory_processes, as: :promoted_process %>
+      <% promoted_collection.each do |promoted_item| %>
+        <%= render_highlighted_partial_for promoted_item %>
+      <% end %>
     </section>
   <% end %>
 

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/index.html.erb
@@ -9,6 +9,13 @@ edit_link(
 %>
 
 <%= participatory_space_wrapper do %>
+  <% if promoted_participatory_process_groups.any? %>
+    <section id="highlighted-process-groups" class="row section">
+      <h1 class="section-heading"><%= t("participatory_processes.index.promoted_process_groups", scope: "layouts.decidim") %></h1>
+      <%= render partial: "promoted_process_group", collection: promoted_participatory_process_groups, as: :promoted_process_group %>
+    </section>
+  <% end %>
+
   <% if promoted_participatory_processes.any? %>
     <section id="highlighted-processes" class="row section">
       <h1 class="section-heading"><%= t("participatory_processes.index.promoted_processes", scope: "layouts.decidim") %></h1>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
@@ -30,6 +30,9 @@
   <div class="row">
     <div class="columns medium-7 mediumlarge-8">
       <div class="section">
+        <% if participatory_process_group.present? %>
+          <%= render partial: "participatory_process_group" %>
+        <% end %>
         <div class="lead">
           <%= decidim_sanitize translated_attribute(current_participatory_space.short_description) %>
         </div>

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -481,6 +481,7 @@ en:
           take_part: Take part
       participatory_processes:
         index:
+          promoted_process_groups: Highlighted process groups
           promoted_processes: Highlighted processes
         participatory_process:
           active_step: 'Current phase:'
@@ -494,6 +495,8 @@ en:
           more_info_about: More info about process %{resource_name}
           take_part: Take part
           take_part_in: Take part in process %{resource_name}
+        promoted_process_group:
+          more_info: More info
       process_header_steps:
         step: Phase %{current} of %{total}
         view_steps: Process phases

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -435,6 +435,7 @@ en:
           loading: Loading results...
       show:
         area: Area
+        belongs_to_group: This process belongs to
         dates: Dates
         developer_group: Promoter group
         end_date: End date

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -364,6 +364,7 @@ en:
           form:
             metadata: Metadata
             title: General Information
+            visibility: Visibility
         participatory_process_imports:
           form:
             document_legend: Add a document

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -481,7 +481,6 @@ en:
           take_part: Take part
       participatory_processes:
         index:
-          promoted_process_groups: Highlighted process groups
           promoted_processes: Highlighted processes
         participatory_process:
           active_step: 'Current phase:'

--- a/decidim-participatory_processes/db/migrate/20201030133444_add_promoted_flag_to_decidim_participatory_process_groups.rb
+++ b/decidim-participatory_processes/db/migrate/20201030133444_add_promoted_flag_to_decidim_participatory_process_groups.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPromotedFlagToDecidimParticipatoryProcessGroups < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_participatory_process_groups, :promoted, :boolean, default: false, index: true
+  end
+end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
@@ -98,6 +98,10 @@ FactoryBot.define do
     participatory_scope { generate_localized_title }
     participatory_structure { generate_localized_title }
 
+    trait :promoted do
+      promoted { true }
+    end
+
     trait :with_participatory_processes do
       after(:create) do |participatory_process_group|
         create_list(:participatory_process, 2, :published, organization: participatory_process_group.organization, participatory_process_group: participatory_process_group)

--- a/decidim-participatory_processes/spec/commands/decidim/participatory_processes/admin/create_participatory_process_group_spec.rb
+++ b/decidim-participatory_processes/spec/commands/decidim/participatory_processes/admin/create_participatory_process_group_spec.rb
@@ -26,7 +26,8 @@ module Decidim::ParticipatoryProcesses
         meta_scope: { en: "meta scope" },
         target: { en: "target" },
         participatory_scope: { en: "participatory scope" },
-        participatory_structure: { en: "participatory structure" }
+        participatory_structure: { en: "participatory structure" },
+        promoted: true
       )
     end
     let(:invalid) { false }

--- a/decidim-participatory_processes/spec/controllers/participatory_processes_controller_spec.rb
+++ b/decidim-participatory_processes/spec/controllers/participatory_processes_controller_spec.rb
@@ -41,7 +41,7 @@ module Decidim
         end
       end
 
-      include_examples "with promoted participatory processes"
+      include_examples "with promoted participatory processes and groups"
 
       describe "collection" do
         before do

--- a/decidim-participatory_processes/spec/system/participatory_process_groups_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_process_groups_spec.rb
@@ -59,6 +59,12 @@ describe "Participatory Process Groups", type: :system do
     end
   end
 
+  context "when the group exists" do
+    it_behaves_like "editable content for admins" do
+      let(:target_path) { decidim_participatory_processes.participatory_process_group_path(participatory_process_group) }
+    end
+  end
+
   describe "show" do
     context "when the title_content block is enabled" do
       before do

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -227,31 +227,21 @@ describe "Participatory Processes", type: :system do
         end
       end
 
-      context "when there are no promoted participatory process groups" do
-        before do
-          visit decidim_participatory_processes.participatory_processes_path
-        end
-
-        it "doesn't show a highlighted groups section" do
-          expect(page).to have_no_content("HIGHLIGHTED PROCESS GROUPS")
-        end
-      end
-
       context "when there are promoted participatory process groups" do
         let!(:promoted_group) { create(:participatory_process_group, :promoted, :with_participatory_processes) }
-        let(:promoted_group_titles) { page.all("#highlighted-process-groups .card__title").map(&:text) }
+        let(:promoted_items_titles) { page.all("#highlighted-processes .card__title").map(&:text) }
 
         before do
           visit decidim_participatory_processes.participatory_processes_path
         end
 
-        it "shows a highligted groups section" do
-          expect(page).to have_content("HIGHLIGHTED PROCESS GROUPS")
+        it "shows a highligted processes section" do
+          expect(page).to have_content("HIGHLIGHTED PROCESSES")
         end
 
         it "lists only promoted groups" do
-          expect(promoted_group_titles).to include(translated(promoted_group.title, locale: :en))
-          expect(promoted_group_titles).not_to include(translated(group.title, locale: :en))
+          expect(promoted_items_titles).to include(translated(promoted_group.title, locale: :en))
+          expect(promoted_items_titles).not_to include(translated(group.title, locale: :en))
         end
 
         context "and promoted group has defined a CTA content block" do
@@ -276,7 +266,7 @@ describe "Participatory Processes", type: :system do
           end
 
           it "shows a CTA button inside group card" do
-            within("#highlighted-process-groups") do
+            within("#highlighted-processes") do
               expect(page).to have_link(cta_settings[:button_text_en], href: cta_settings[:button_url])
             end
           end

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -275,6 +275,16 @@ describe "Participatory Processes", type: :system do
           let(:collection_for) { participatory_process }
         end
 
+        context "and it belongs to a group" do
+          let!(:group) { create :participatory_process_group, participatory_processes: [participatory_process], organization: organization }
+
+          it "has a link to the group the process belongs to" do
+            visit decidim_participatory_processes.participatory_process_path(participatory_process)
+
+            expect(page).to have_link(translated(group.title, locale: :en), href: decidim_participatory_processes.participatory_process_group_path(group))
+          end
+        end
+
         context "when it has some linked processes" do
           let(:published_process) { create :participatory_process, :published, organization: organization }
           let(:unpublished_process) { create :participatory_process, :unpublished, organization: organization }

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -226,6 +226,62 @@ describe "Participatory Processes", type: :system do
           end
         end
       end
+
+      context "when there are no promoted participatory process groups" do
+        before do
+          visit decidim_participatory_processes.participatory_processes_path
+        end
+
+        it "doesn't show a highlighted groups section" do
+          expect(page).to have_no_content("HIGHLIGHTED PROCESS GROUPS")
+        end
+      end
+
+      context "when there are promoted participatory process groups" do
+        let!(:promoted_group) { create(:participatory_process_group, :promoted, :with_participatory_processes) }
+        let(:promoted_group_titles) { page.all("#highlighted-process-groups .card__title").map(&:text) }
+
+        before do
+          visit decidim_participatory_processes.participatory_processes_path
+        end
+
+        it "shows a highligted groups section" do
+          expect(page).to have_content("HIGHLIGHTED PROCESS GROUPS")
+        end
+
+        it "lists only promoted groups" do
+          expect(promoted_group_titles).to include(translated(promoted_group.title, locale: :en))
+          expect(promoted_group_titles).not_to include(translated(group.title, locale: :en))
+        end
+
+        context "and promoted group has defined a CTA content block" do
+          let(:cta_settings) do
+            {
+              button_url: "https://example.org/action",
+              button_text_en: "cta text",
+              description_en: "cta description"
+            }
+          end
+
+          before do
+            create(
+              :content_block,
+              organization: organization,
+              scope_name: :participatory_process_group_homepage,
+              scoped_resource_id: promoted_group.id,
+              manifest_name: :cta,
+              settings: cta_settings
+            )
+            visit decidim_participatory_processes.participatory_processes_path
+          end
+
+          it "shows a CTA button inside group card" do
+            within("#highlighted-process-groups") do
+              expect(page).to have_link(cta_settings[:button_text_en], href: cta_settings[:button_url])
+            end
+          end
+        end
+      end
     end
   end
 

--- a/decidim_app-design/app/views/public/info.html.erb
+++ b/decidim_app-design/app/views/public/info.html.erb
@@ -14,6 +14,8 @@
     <div class="row">
       <div class="columns medium-7 mediumlarge-8">
         <div class="section">
+          <p><span class="text-small text-uppercase text-muted mr-s">Este proceso pertenece a</span>&nbsp;<a href="#">Nombre del
+              grupo de procesos</a></p>
           <p class="lead">
             Millores en un conjunt de carrers dels barris del districte que
             incorporin la renovació integral de les seves infraestructures


### PR DESCRIPTION
#### :tophat: What? Why?

* Adds a `promoted` flag to `Decidim::ParticipatoryProcessGroup` model, false by default
* Adds management of this attribute on groups admin panel
* Displays promoted groups on processes index and shows a CTA button if defined as a content block on group landing page
* Adds some system tests in participatory process group landing page

Note: This PR is built on top of `feature/process_groups_improvements-edit_link`, the branch of #6827 PR.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #6481
- Fixes #6482

#### Testing

Mark as promoted some participatory process groups and add a CTA section on landing page of one at least. Visit the participatory processes index

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
