### PR TITLE
Fix display conditions validations with choices

### DIFF
--- a/decidim-forms/app/assets/javascripts/decidim/forms/display_conditions.component.js.es6
+++ b/decidim-forms/app/assets/javascripts/decidim/forms/display_conditions.component.js.es6
@@ -30,18 +30,17 @@
 
       $conditionWrapperField.find(".radio-button-collection, .check-box-collection").find(".collection-input").each((idx, el) => {
         const $label = $(el).find("label");
-        const checked = !$label.find("input[type='hidden']").is("[disabled]");
+        const $input = $(el).find("input[name$=\\[body\\]]");
+        const checked = $input.is(":checked");
 
         if (checked) {
-          const $textField = $(el).find("input[name$=\\[custom_body\\]]");
-          const text = $textField.val();
-          const value = $label.find("input:not([type='hidden'])").val();
-          const id = $label.find("input[type='hidden']").val();
+          const text = $(el).find("input[name$=\\[custom_body\\]]").val();
+          const value = $input.val();
+          const id = $(el).find("input[name$=\\[answer_option_id\\]]").val();
 
           multipleInput.push({ id, value, text });
         }
       });
-
       return multipleInput;
     }
 

--- a/decidim-forms/app/assets/javascripts/decidim/forms/display_conditions.component.js.es6
+++ b/decidim-forms/app/assets/javascripts/decidim/forms/display_conditions.component.js.es6
@@ -29,7 +29,6 @@
       let multipleInput = [];
 
       $conditionWrapperField.find(".radio-button-collection, .check-box-collection").find(".collection-input").each((idx, el) => {
-        const $label = $(el).find("label");
         const $input = $(el).find("input[name$=\\[body\\]]");
         const checked = $input.is(":checked");
 
@@ -41,6 +40,7 @@
           multipleInput.push({ id, value, text });
         }
       });
+
       return multipleInput;
     }
 

--- a/decidim-forms/app/forms/decidim/forms/answer_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/answer_form.rb
@@ -51,7 +51,7 @@ module Decidim
 
       def display_conditions_fulfilled?
         question.display_conditions.all? do |condition|
-          answer = question.questionnaire.answers.find_by(question: condition.condition_question)
+          answer = context.responses&.find { |r| r.question_id&.to_i == condition.condition_question.id }
           condition.fulfilled?(answer)
         end
       end

--- a/decidim-forms/app/forms/decidim/forms/questionnaire_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/questionnaire_form.rb
@@ -23,6 +23,11 @@ module Decidim
         end
       end
 
+      # Add other responses to the context so AnswerForm can validate conditional questions
+      def before_validation
+        context.responses = attributes[:responses]
+      end
+
       # Public: Splits reponses by step, keeping the separator.
       #
       # Returns an array of steps. Each step is a list of the questions in that

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_display_conditions.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_display_conditions.rb
@@ -101,7 +101,7 @@ shared_examples_for "add display conditions" do
 
             within "select[id$=decidim_condition_question_id]" do
               elements = page.all("option[data-type]")
-              expect(elements.map { |element| element[:"data-type"] }).to eq(questions.map(&:question_type))
+              expect(elements.map { |element| element[:"data-type"] }).to match_array(questions.map(&:question_type))
               expect(page.find("option[value='#{questions.last.id}']")).to be_disabled
             end
           end


### PR DESCRIPTION
#### :tophat: What? Why?

Solves a couple of bugs:

1. when admins create a questionnaire using the logic conditions "match text" and this match involves questions with options (such as matrix questions, single option or multiple options).
The current code tries to use the body of the answer and this is not available if it is a choice, resulting in a 500 error.

2. Currently, the display_condition method `fulffilled?` is used for form validations, and it is checking against responses in the database completely unrelated with the current user. As the answer is being validated is not in the database yet so it should check the rectify form. As the form is not created via a model, new context must be added (the other responses) so an answer validation can get information about the related questions involving display conditions.

3. Matrix questions do not work properly with display conditions. The new approach treats matrixs columns (answer choices) as the source of whats being checked by the user: if the column has a title and the user selects that column in some row, then is a match. This is more predictable.

This needs to be backported to 0.23.

#### :pushpin: Related Issues

- Related to #6819
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
