### PR TITLE
Fix issues with move proposal fields to i18n

### DIFF
--- a/decidim-proposals/db/migrate/20200708091228_move_proposals_fields_to_i18n.rb
+++ b/decidim-proposals/db/migrate/20200708091228_move_proposals_fields_to_i18n.rb
@@ -11,7 +11,13 @@ class MoveProposalsFieldsToI18n < ActiveRecord::Migration[5.2]
       Decidim::Proposals::Proposal.find_each do |proposal|
         author = proposal.coauthorships.first.author
 
-        locale = author.try(:locale).presence || author.try(:default_locale).presence || author.try(:organization).try(:default_locale).presence
+        locale = if author
+                   author.try(:locale).presence || author.try(:default_locale).presence || author.try(:organization).try(:default_locale).presence
+                 elsif proposal.component && proposal.component.participatory_space
+                   proposal.component.participatory_space.organization.default_locale
+                 else
+                   I18n.default_locale.to_s
+                 end
 
         proposal.new_title = {
           locale => proposal.title
@@ -20,7 +26,7 @@ class MoveProposalsFieldsToI18n < ActiveRecord::Migration[5.2]
           locale => proposal.body
         }
 
-        proposal.save!
+        proposal.save(validate: false)
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
There are few noticed issues with the move proposal fields to i18n migration that seem to repeat in most older instances when trying to run the migrations:
- There may not be an existing author for the proposal (e.g. deleted users)
- The old proposals may not follow all the validation criteria which causes the whole migration to fail

#### :pushpin: Related Issues
- Related to #6285

#### Testing
Try to run the migration in an instance with a proposal left by a deleted user or an instance with proposals in the database that do not follow the validation criteria.

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.