### PR TITLE
Fix searchable issues with resources with unexisting organization

### DIFF
--- a/decidim-core/lib/decidim/search_resource_fields_mapper.rb
+++ b/decidim-core/lib/decidim/search_resource_fields_mapper.rb
@@ -63,9 +63,9 @@ module Decidim
     def retrieve_organization(resource)
       if @declared_fields[:organization_id].present?
         organization_id = read_field(resource, @declared_fields, :organization_id)
-        Decidim::Organization.find(organization_id)
+        Decidim::Organization.find_by(id: organization_id)
       else
-        participatory_space(resource).organization
+        participatory_space(resource)&.organization
       end
     end
 

--- a/decidim-core/lib/decidim/searchable.rb
+++ b/decidim-core/lib/decidim/searchable.rb
@@ -84,6 +84,8 @@ module Decidim
         return unless self.class.searchable_resource?(self)
 
         org = self.class.search_resource_fields_mapper.retrieve_organization(self)
+        return unless org
+
         searchables_in_org = searchable_resources.by_organization(org.id)
         if self.class.search_resource_fields_mapper.index_on_update?(self)
           if searchables_in_org.empty?


### PR DESCRIPTION
#### :tophat: What? Why?
When there are resources in the database which are not mapped to any existing organization, the searchable classes cause issues with the "move proposals to i18n" migration.

#### :pushpin: Related Issues
- Related to #6285, #6838

#### Testing
- Add a resource with an unexisting component or unexisting organization to the DB
- Try to run the "move proposals to i18n" migration

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.