### PR TITLE
Fix color text for unpublish button

### DIFF
--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_buttons.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_buttons.scss
@@ -39,6 +39,7 @@
 
 .button.muted{
   background-color: $medium-gray;
+  color: $white;
 
   &:hover{
     background-color: darken($medium-gray, 10);


### PR DESCRIPTION
#### :tophat: What? Why?
Text Color on unpublish button doesn't see properly due to the background color of the button.
The button has muted class that sets color text to grey, similar to background button color. This make hard to read what the button contains.

#### :pushpin: Related Issues
*Link your PR to an issue*

#### Testing
Access to an edit participatory process and check the unpublish button

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
before:
![Captura de pantalla de 2020-11-11 12-19-57](https://user-images.githubusercontent.com/5037794/98805736-52afcc80-2418-11eb-93e0-95ae038c433d.png)

after:
![Captura de pantalla de 2020-11-11 12-20-08](https://user-images.githubusercontent.com/5037794/98805751-580d1700-2418-11eb-9fa5-3172daec864a.png)


:hearts: Thank you!
