### PR TITLE
Fix security token generation in anonymous surveys and pads

### DIFF
--- a/decidim-core/app/services/decidim/tokenizer.rb
+++ b/decidim-core/app/services/decidim/tokenizer.rb
@@ -11,8 +11,8 @@ module Decidim
     # salt      - The salt fr the encryption (it should be at leas 30 chars long)
     # length    - How long the key generated should be (in bytes)
     #
-    def initialize(salt:, length: 10)
-      @salt = salt
+    def initialize(salt: nil, length: 32)
+      @salt = salt.presence || Tokenizer.random_salt
       @length = length
     end
 

--- a/decidim-core/app/services/decidim/tokenizer.rb
+++ b/decidim-core/app/services/decidim/tokenizer.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "openssl"
+
+module Decidim
+  # This class is used to generate secure tokens
+  class Tokenizer
+    #
+    # Initializes the Tokenizer.
+    #
+    # salt      - The salt fr the encryption (it should be at leas 30 chars long)
+    # length    - How long the key generated should be (in bytes)
+    #
+    def initialize(salt:, length: 10)
+      @salt = salt
+      @length = length
+    end
+
+    def self.random_salt
+      SecureRandom.hex(32)
+    end
+
+    attr_reader :salt, :length
+
+    # returns a securely generated string of bytes
+    def digest(string)
+      OpenSSL::PKCS5.pbkdf2_hmac(string.to_s, salt, 20_000, length, "sha256")
+    end
+
+    def int_digest(string)
+      digest(string).bytes.inject { |a, b| (a << 8) + b }
+    end
+
+    def hex_digest(string)
+      digest(string).bytes.map { |c| c.ord.to_s(16) }.join
+    end
+  end
+end

--- a/decidim-core/app/services/decidim/tokenizer.rb
+++ b/decidim-core/app/services/decidim/tokenizer.rb
@@ -28,11 +28,11 @@ module Decidim
     end
 
     def int_digest(string)
-      digest(string).bytes.inject { |a, b| (a << 8) + b }
+      digest(string.to_s).bytes.inject { |a, b| (a << 8) + b }
     end
 
     def hex_digest(string)
-      digest(string).bytes.map { |c| c.ord.to_s(16) }.join
+      digest(string.to_s).bytes.map { |c| c.ord.to_s(16) }.join
     end
   end
 end

--- a/decidim-core/lib/decidim/paddable.rb
+++ b/decidim-core/lib/decidim/paddable.rb
@@ -64,10 +64,17 @@ module Decidim
       end
 
       def pad_id
-        @pad_id ||= [
-          reference,
-          Digest::MD5.hexdigest("#{id}-#{Rails.application.secrets.secret_key_base}")
-        ].join("-").slice(0, 50)
+        @pad_id ||= [reference, token].join("-").slice(0, 50)
+      end
+
+      # compatibilize with old versions if no salt available (less secure)
+      def token
+        if defined?(salt) && salt.present?
+          tokenizer = Decidim::Tokenizer.new(salt: salt)
+          return tokenizer.hex_digest(id)
+        end
+
+        Digest::MD5.hexdigest("#{id}-#{Rails.application.secrets.secret_key_base}")
       end
 
       def build_pad_url(id)

--- a/decidim-core/spec/lib/paddable_spec.rb
+++ b/decidim-core/spec/lib/paddable_spec.rb
@@ -14,10 +14,10 @@ module Decidim
       }
     end
     let(:pad) { instance_double(EtherpadLite::Pad, id: "pad-id", read_only_id: "read-only-id") }
+    let(:salt) { "super-secret" }
 
     before do
       allow(Decidim).to receive(:etherpad).and_return(etherpad_config)
-      allow(paddable).to receive(:pad_id).and_return("secret-id")
       paddable.component.settings = { enable_pads_creation: true }
     end
 
@@ -76,12 +76,60 @@ module Decidim
         end
       end
 
-      it "finds a pad in the server" do
-        etherpad_service = instance_double(EtherpadLite::Instance)
-        expect(paddable).to receive(:etherpad).and_return(etherpad_service)
-        expect(etherpad_service).to receive(:pad).with("secret-id").and_return(pad)
+      context "when pad_id is faked" do
+        before do
+          allow(paddable).to receive(:pad_id).and_return("secret-id")
+        end
 
-        expect(paddable.pad).to eq(pad)
+        it "finds a pad in the server" do
+          etherpad_service = instance_double(EtherpadLite::Instance)
+          expect(paddable).to receive(:etherpad).and_return(etherpad_service)
+          expect(etherpad_service).to receive(:pad).with("secret-id").and_return(pad)
+
+          expect(paddable.pad).to eq(pad)
+        end
+      end
+
+      # Testing some private methods to ensure compatibility with old pad id generation
+      context "when pad_id is auto-generated" do
+        before do
+          allow(paddable).to receive(:id).and_return(12_345)
+          allow(paddable).to receive(:reference).and_return("REF")
+        end
+
+        context "when salt is undefined" do
+          it "returns unsecure hash" do
+            expect(paddable.send(:pad_id)).to eq("REF-#{unsecure_hash(12_345)}")
+          end
+        end
+
+        context "when salt is empty" do
+          before do
+            allow(paddable).to receive(:salt).and_return("")
+          end
+
+          it "retuns unsecure hash" do
+            expect(paddable.send(:pad_id)).to eq("REF-#{unsecure_hash(12_345)}")
+          end
+        end
+
+        context "when salt is present" do
+          before do
+            allow(paddable).to receive(:salt).and_return(salt)
+          end
+
+          it "retuns secure hash" do
+            expect("REF-#{secure_hash(12_345)}").to include(paddable.send(:pad_id))
+          end
+        end
+      end
+
+      def unsecure_hash(id)
+        Digest::MD5.hexdigest("#{id}-#{Rails.application.secrets.secret_key_base}")
+      end
+
+      def secure_hash(id)
+        Decidim::Tokenizer.new(salt: salt).hex_digest(id)
       end
     end
   end

--- a/decidim-core/spec/services/decidim/tokenizer_spec.rb
+++ b/decidim-core/spec/services/decidim/tokenizer_spec.rb
@@ -10,6 +10,10 @@ describe Decidim::Tokenizer do
   let(:string) { "Poems everybody!" }
 
   describe "digest" do
+    it "returns the salt initilzed" do
+      expect(subject.salt).to eq(secret)
+    end
+
     it "generates an integer key" do
       expect(subject.int_digest(string)).to be_a(Integer)
       expect(subject.int_digest(string).size).to eq(10)
@@ -30,6 +34,15 @@ describe Decidim::Tokenizer do
 
       it "generates a digest of the propser size" do
         expect(subject.int_digest(string).size).to eq(15)
+      end
+    end
+
+    context "when no salt is specified" do
+      subject { described_class.new }
+
+      it "generates a random string as salt" do
+        expect(subject.salt).to be_a(String)
+        expect(subject.salt.size).to eq(64)
       end
     end
   end

--- a/decidim-core/spec/services/decidim/tokenizer_spec.rb
+++ b/decidim-core/spec/services/decidim/tokenizer_spec.rb
@@ -19,6 +19,11 @@ describe Decidim::Tokenizer do
       expect(subject.int_digest(string).size).to eq(10)
     end
 
+    it "encodes integers and strings equally" do
+      expect(subject.int_digest(10)).to eq(subject.int_digest("10"))
+      expect(subject.hex_digest(0.10)).to eq(subject.hex_digest("0.1"))
+    end
+
     it "generates an hexadecimal key" do
       expect(subject.hex_digest(string)).to be_a(String)
       expect(subject.hex_digest(string).size <= 20).to eq(true)

--- a/decidim-core/spec/services/decidim/tokenizer_spec.rb
+++ b/decidim-core/spec/services/decidim/tokenizer_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Tokenizer do
+  subject { described_class.new(salt: secret, length: length) }
+
+  let(:secret) { "secret" }
+  let(:length) { 10 }
+  let(:string) { "Poems everybody!" }
+
+  describe "digest" do
+    it "generates an integer key" do
+      expect(subject.int_digest(string)).to be_a(Integer)
+      expect(subject.int_digest(string).size).to eq(10)
+    end
+
+    it "generates an hexadecimal key" do
+      expect(subject.hex_digest(string)).to be_a(String)
+      expect(subject.hex_digest(string).size <= 20).to eq(true)
+    end
+
+    it "generates random secrets" do
+      expect(described_class.random_salt).not_to eq(described_class.random_salt)
+      expect(described_class.random_salt.size).to eq(64)
+    end
+
+    context "when the size is different" do
+      let(:length) { 15 }
+
+      it "generates a digest of the propser size" do
+        expect(subject.int_digest(string).size).to eq(15)
+      end
+    end
+  end
+end

--- a/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
+++ b/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
@@ -138,7 +138,8 @@ module Decidim
           end
 
           def tokenize(id)
-            Digest::MD5.hexdigest("#{id}-#{Rails.application.secrets.secret_key_base}")
+            tokenizer = Decidim::Tokenizer.new(key: questionnaire.salt || questionnaire.id)
+            tokenizer.int_digest(id)
           end
         end
       end

--- a/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
+++ b/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
@@ -137,9 +137,9 @@ module Decidim
             @session_token ||= tokenize(id || session_id)
           end
 
-          def tokenize(id)
-            tokenizer = Decidim::Tokenizer.new(key: questionnaire.salt || questionnaire.id)
-            tokenizer.int_digest(id)
+          def tokenize(id, length: 10)
+            tokenizer = Decidim::Tokenizer.new(salt: questionnaire.salt || questionnaire.id, length: length)
+            tokenizer.int_digest(id).to_s
           end
         end
       end

--- a/decidim-forms/app/helpers/decidim/forms/admin/questionnaire_answers_helper.rb
+++ b/decidim-forms/app/helpers/decidim/forms/admin/questionnaire_answers_helper.rb
@@ -16,7 +16,7 @@ module Decidim
         end
 
         def first_table_td(answer)
-          return answer.first_short_answer.body if @first_short_answer
+          return answer.first_short_answer&.body if @first_short_answer
 
           answer.session_token
         end

--- a/decidim-forms/app/helpers/decidim/forms/admin/questionnaire_answers_helper.rb
+++ b/decidim-forms/app/helpers/decidim/forms/admin/questionnaire_answers_helper.rb
@@ -7,13 +7,16 @@ module Decidim
       #
       module QuestionnaireAnswersHelper
         def first_table_th(answer)
-          return translated_attribute answer.first_short_answer.question.body if answer.first_short_answer
+          if answer.first_short_answer
+            @first_short_answer = answer.first_short_answer
+            return translated_attribute @first_short_answer.question.body
+          end
 
           t("session_token", scope: "decidim.forms.user_answers_serializer")
         end
 
         def first_table_td(answer)
-          return answer.first_short_answer.body if answer.first_short_answer
+          return answer.first_short_answer.body if @first_short_answer
 
           answer.session_token
         end

--- a/decidim-forms/app/models/decidim/forms/questionnaire.rb
+++ b/decidim-forms/app/models/decidim/forms/questionnaire.rb
@@ -14,6 +14,8 @@ module Decidim
       has_many :questions, -> { order(:position) }, class_name: "Question", foreign_key: "decidim_questionnaire_id", dependent: :destroy
       has_many :answers, class_name: "Answer", foreign_key: "decidim_questionnaire_id", dependent: :destroy
 
+      after_initialize :set_default_salt
+
       # Public: returns whether the questionnaire questions can be modified or not.
       def questions_editable?
         has_component = questionnaire_for.respond_to? :component
@@ -28,6 +30,13 @@ module Decidim
 
       def pristine?
         created_at.to_i == updated_at.to_i && questions.empty?
+      end
+
+      private
+
+      # salt is used to generate secure hash in anonymous answers
+      def set_default_salt
+        self.salt ||= Tokenizer.random_salt
       end
     end
   end

--- a/decidim-forms/db/migrate/20201110152921_add_salt_to_decidim_forms_questionnaires.rb
+++ b/decidim-forms/db/migrate/20201110152921_add_salt_to_decidim_forms_questionnaires.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddSaltToDecidimFormsQuestionnaires < ActiveRecord::Migration[5.2]
+  class Questionnaire < ApplicationRecord
+    self.table_name = :decidim_forms_questionnaires
+  end
+
+  def change
+    add_column :decidim_forms_questionnaires, :salt, :string
+
+    Questionnaire.find_each do |questionnaire|
+      questionnaire.salt = Decidim::Tokenizer.random_salt
+      questionnaire.save!
+    end
+  end
+end

--- a/decidim-forms/lib/decidim/forms/test/factories.rb
+++ b/decidim-forms/lib/decidim/forms/test/factories.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
     end
     tos { generate_localized_title }
     questionnaire_for { build(:participatory_process) }
+    salt { SecureRandom.hex(32) }
 
     trait :with_questions do
       questions do

--- a/decidim-forms/lib/decidim/forms/user_answers_serializer.rb
+++ b/decidim-forms/lib/decidim/forms/user_answers_serializer.rb
@@ -16,7 +16,7 @@ module Decidim
       def serialize
         @answers.each_with_index.inject({}) do |serialized, (answer, idx)|
           serialized.update(
-            answer_translated_attribute_name(:id) => answer.id,
+            answer_translated_attribute_name(:id) => answer.session_token,
             answer_translated_attribute_name(:created_at) => answer.created_at.to_s(:db),
             answer_translated_attribute_name(:ip_hash) => answer.ip_hash,
             answer_translated_attribute_name(:user_status) => answer_translated_attribute_name(answer.decidim_user_id.present? ? "registered" : "unregistered"),

--- a/decidim-forms/spec/commands/decidim/forms/answer_questionnaire_spec.rb
+++ b/decidim-forms/spec/commands/decidim/forms/answer_questionnaire_spec.rb
@@ -6,7 +6,7 @@ module Decidim
   module Forms
     describe AnswerQuestionnaire do
       def tokenize(id)
-        Digest::MD5.hexdigest("#{id}-#{Rails.application.secrets.secret_key_base}")
+        "fake-hash-for-#{id}"
       end
 
       let(:current_organization) { create(:organization) }

--- a/decidim-forms/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
+++ b/decidim-forms/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
@@ -92,7 +92,7 @@ module Decidim
 
           it "the id of the answer" do
             key = I18n.t(:id, scope: "decidim.forms.user_answers_serializer")
-            expect(serialized[key]).to eq an_answer.id
+            expect(serialized[key]).to eq an_answer.session_token
           end
 
           it "the creation of the answer" do

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -65,6 +65,8 @@ module Decidim
                         index_on_create: ->(meeting) { meeting.visible? },
                         index_on_update: ->(meeting) { meeting.visible? })
 
+      after_initialize :set_default_salt
+
       # Return registrations of a particular meeting made by users representing a group
       def user_group_registrations
         registrations.where.not(decidim_user_group_id: nil)
@@ -224,6 +226,11 @@ module Decidim
         return false unless user
 
         invites.exists?(decidim_user_id: user.id)
+      end
+
+      # salt is used to generate secure hash in pads
+      def set_default_salt
+        self.salt ||= Tokenizer.random_salt
       end
     end
   end

--- a/decidim-meetings/db/migrate/20201111133246_add_salt_to_decidim_meetings.rb
+++ b/decidim-meetings/db/migrate/20201111133246_add_salt_to_decidim_meetings.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddSaltToDecidimMeetings < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_meetings_meetings, :salt, :string
+    # we leave old entries empty to maintain the old pad reference
+  end
+end

--- a/decidim-meetings/lib/decidim/meetings/test/factories.rb
+++ b/decidim-meetings/lib/decidim/meetings/test/factories.rb
@@ -36,6 +36,7 @@ FactoryBot.define do
     registration_form_enabled { true }
     type_of_meeting { :in_person }
     component { build(:component, manifest_name: "meetings") }
+    salt { SecureRandom.hex(32) }
 
     author do
       component.try(:organization)


### PR DESCRIPTION
#### :tophat: What? Why?

This PR removes the MD5 method for generating tokens. Currently this is used in anonymous surveys and etherpad urls.
The new method adds a salt to every new created meeting model and all the quesionnaries (new and old). This salt is securely generated if not existing and used to generate noon predicable tokens.
The migration do not fill old values for meetings as this would disconnect old pad already created.
For the questionnares old values are filled in the migration because surveys exported do not need to maintain compatibility (tokens are used for mask ips and user sessions that can serve to identify repetitive submits and have no other use)

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
1. create some anonymous survey, try to export results. User/answer identifiers must be maske with random numbers.
2. create a meeting with etherpad activated. It should work as usual (though the url generated uses a different method) 

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
