### PR TITLE
Add margin between back link and title

### DIFF
--- a/decidim-blogs/app/views/decidim/blogs/posts/show.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/posts/show.html.erb
@@ -16,10 +16,12 @@
 %>
 
 <div class="row column view-header">
-  <%= link_to :posts, class: "small hollow" do %>
-    <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
-    <%= t(".back") %>
-  <% end %>
+  <div class="m-bottom">
+    <%= link_to :posts, class: "small hollow" do %>
+      <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+      <%= t(".back") %>
+    <% end %>
+  </div>
   <h2 class="heading2"><%= translated_attribute post.title %></h2>
   <%= cell "decidim/author", present(post.author), from: post %>
 </div>

--- a/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
@@ -19,10 +19,12 @@ edit_link(
     <%= render partial: "budget_summary", locals: { include_heading: false } %>
   <% end %>
 
-  <%= link_to resource_locator(budget).path(filter_link_params), class: "muted-link" do %>
-    <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
-    <%= t(".view_all_projects") %>
-  <% end %>
+  <div class="m-bottom">
+    <%= link_to resource_locator(budget).path(filter_link_params), class: "muted-link" do %>
+      <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+      <%= t(".view_all_projects") %>
+    <% end %>
+  </div>
   <h2 class="heading2"><%= translated_attribute project.title %></h2>
 </div>
 <div class="row">

--- a/decidim-debates/app/views/decidim/debates/debates/edit.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/edit.html.erb
@@ -1,8 +1,10 @@
 <div class="row columns">
-  <%= link_to :back, class: "muted-link" do %>
-    <%= icon "chevron-left", class: "icon--small", role: "img" %>
-    <%= t(".back") %>
-  <% end %>
+  <div class="m-bottom">
+    <%= link_to :back, class: "muted-link" do %>
+      <%= icon "chevron-left", class: "icon--small", role: "img" %>
+      <%= t(".back") %>
+    <% end %>
+  </div>
   <h2 class="section-heading"><%= t(".title") %></h2>
 </div>
 

--- a/decidim-debates/app/views/decidim/debates/debates/new.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/new.html.erb
@@ -1,8 +1,10 @@
 <div class="row columns">
-  <%= link_to :back, class: "muted-link" do %>
-    <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
-    <%= t(".back") %>
-  <% end %>
+  <div class="m-bottom">
+    <%= link_to :back, class: "muted-link" do %>
+      <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+      <%= t(".back") %>
+    <% end %>
+  </div>
   <h2 class="section-heading"><%= t(".title") %></h2>
 </div>
 

--- a/decidim-debates/app/views/decidim/debates/debates/show.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/show.html.erb
@@ -14,10 +14,12 @@ edit_link(
 %>
 
 <div class="row column view-header">
-  <%= link_to debates_path(filter_link_params), class: "small hollow" do %>
-    <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
-    <%= t(".back") %>
-  <% end %>
+  <div class="m-bottom">
+    <%= link_to debates_path(filter_link_params), class: "small hollow" do %>
+      <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+      <%= t(".back") %>
+    <% end %>
+  </div>
 
   <h2 class="heading3">
     <%== present(debate).title(links: true) %>

--- a/decidim-elections/app/views/decidim/elections/elections/show.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/show.html.erb
@@ -18,10 +18,12 @@ edit_link(
   <div class="columns">
 
     <% unless single? %>
-      <%= link_to :elections, class: "small hollow" do %>
-        <%= icon "caret-left", class: "icon--small" %>
-        <%= t(".back") %>
-      <% end %>
+      <div class="m-bottom">
+        <%= link_to :elections, class: "small hollow" do %>
+          <%= icon "caret-left", class: "icon--small" %>
+          <%= t(".back") %>
+        <% end %>
+      </div>
     <% end %>
 
     <h1 class="heading2">

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -16,10 +16,12 @@ edit_link(
 %>
 
 <div class="row column view-header">
-  <%= link_to meetings_path(filter_link_params), class: "small hollow" do %>
-    <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
-    <%= t(".back") %>
-  <% end %>
+  <div class="m-bottom">
+    <%= link_to meetings_path(filter_link_params), class: "small hollow" do %>
+      <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+      <%= t(".back") %>
+    <% end %>
+  </div>
 
   <h2 class="heading2"><%= present(meeting).title(links: true) %></h2>
 

--- a/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/edit.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/edit.html.erb
@@ -1,10 +1,12 @@
 <% add_decidim_page_title(proposal_wizard_step_title(action_name)) %>
 
 <div class="row columns">
-  <%= link_to :back, class: "muted-link" do %>
-    <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
-    <%= t(".back") %>
-  <% end %>
+  <div class="m-bottom">
+    <%= link_to :back, class: "muted-link" do %>
+      <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+      <%= t(".back") %>
+    <% end %>
+  </div>
   <h2 class="section-heading"><%= t(".title") %></h2>
 </div>
 

--- a/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/show.html.erb
@@ -14,10 +14,12 @@
 <% end %>
 
 <div class="row column view-header">
-  <%= link_to collaborative_drafts_path do %>
-    <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
-    <%= t(".back") %>
-  <% end %>
+  <div class="m-bottom">
+    <%= link_to collaborative_drafts_path do %>
+      <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+      <%= t(".back") %>
+    <% end %>
+  </div>
 
   <h2 class="heading2">
     <%= present(@collaborative_draft).title(links: true, html_escape: true) %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/edit.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/edit.html.erb
@@ -1,10 +1,12 @@
 <% add_decidim_page_title(proposal_wizard_step_title(action_name)) %>
 
 <div class="row columns">
-  <%= link_to :back, class: "muted-link" do %>
-    <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
-    <%= t(".back") %>
-  <% end %>
+  <div class="m-bottom">
+    <%= link_to :back, class: "muted-link" do %>
+      <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+      <%= t(".back") %>
+    <% end %>
+  </div>
   <h2 class="section-heading"><%= t(".title") %></h2>
 </div>
 

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -34,10 +34,12 @@ extra_admin_link(
 <%= emendation_announcement_for @proposal %>
 <div class="row column view-header">
 
-  <%= link_to proposals_path(filter_link_params), class: "small hollow" do %>
-    <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
-    <%= t(".back_to_list") %>
-  <% end %>
+  <div class="m-bottom">
+    <%= link_to proposals_path(filter_link_params), class: "small hollow" do %>
+      <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+      <%= t(".back_to_list") %>
+    <% end %>
+  </div>
 
   <% if @proposal.emendation? %>
     <h3 class="heading3"><%= t(".changes_at_title", title: present(@proposal.amendable).title(links: true, html_escape: true)) %></h3>

--- a/decidim-sortitions/app/views/decidim/sortitions/sortitions/show.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/sortitions/show.html.erb
@@ -12,10 +12,12 @@
 
 <div class="row column view-header">
 
-  <%= link_to :sortitions, class: "small hollow" do %>
-    <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
-    <%= t(".back") %>
-  <% end %>
+  <div class="m-bottom">
+    <%= link_to :sortitions, class: "small hollow" do %>
+      <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+      <%= t(".back") %>
+    <% end %>
+  </div>
 
   <h2 class="heading2"><%= decidim_html_escape(translated_attribute(sortition.title)) %></h2>
   <div class="author-data">


### PR DESCRIPTION
#### :tophat: What? Why?
On pages where back link appears, the margin between it and the title doesn't exist. This fix encapsulate the link on a div with a margin bottom

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
before:
![Captura de pantalla de 2020-11-11 19-47-59](https://user-images.githubusercontent.com/5037794/98851716-f8822c00-2456-11eb-96eb-414c14b7d48a.png)

after:
![Captura de pantalla de 2020-11-11 19-48-36](https://user-images.githubusercontent.com/5037794/98851739-ff10a380-2456-11eb-87f2-aafa4e908026.png)

:hearts: Thank you!
