### PR TITLE
Fix to suppress error when "forms.length_validator.minimum.one" is missing

### DIFF
--- a/decidim-core/app/views/layouts/decidim/_js_configuration.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_js_configuration.html.erb
@@ -10,7 +10,7 @@ js_configs = {
 }
 character_messages = {
   "charactersAtLeast": {
-    one: t("forms.length_validator.minimum.one", count: "%count%"),
+    one: t("forms.length_validator.minimum.one", count: "%count%", default: "forms.length_validator.minimum.other"),
     other: t("forms.length_validator.minimum.other", count: "%count%")
   },
   "charactersLeft": {


### PR DESCRIPTION
#### :tophat: What? Why?

Add `:default` argument for `I18n.t` method to fall back when missing the key.

#### :pushpin: Related Issues
- Fixes #6864 

#### Testing
Execute `To Reproduce` steps in #6864 .

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

With this fix, I got valid top page in `ja` locale.

<img width="1203" alt="i18n-error-fixed" src="https://user-images.githubusercontent.com/10401/99152928-642ef800-26e8-11eb-8b96-74ccc10b77f3.png">


:hearts: Thank you!
