### PR TITLE
Localize a string in conference speaker

### DIFF
--- a/decidim-conferences/app/cells/decidim/conferences/conference_speaker/show.erb
+++ b/decidim-conferences/app/cells/decidim/conferences/conference_speaker/show.erb
@@ -70,7 +70,7 @@
       <hr class="reset mt-none mb-s">
       <div class="row">
         <div class="column medium-12">
-          <div class="bio-acts"><%= t(".speaking_at") %></div>
+          <div class="bio-acts"><%= t("conferences.conference_speaker.show.speaking_at", scope: "decidim") %></div>
 
           <ul class="list-reset">
             <% meetings.each do |meeting| %>

--- a/decidim-conferences/app/cells/decidim/conferences/conference_speaker/show.erb
+++ b/decidim-conferences/app/cells/decidim/conferences/conference_speaker/show.erb
@@ -70,7 +70,7 @@
       <hr class="reset mt-none mb-s">
       <div class="row">
         <div class="column medium-12">
-          <div class="bio-acts">Speaking at</div>
+          <div class="bio-acts"><%= t(".speaking_at") %></div>
 
           <ul class="list-reset">
             <% meetings.each do |meeting| %>

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -404,7 +404,6 @@ en:
         show:
           more_info: more info
           speaking_at: Speaking at
-        speaking_at: Speaking at
       conference_speaker_cell:
         personal_url:
           personal_website: Personal website

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -401,9 +401,10 @@ en:
         go_to_twitter: Go to Twitter
         more_info: more info
         personal_website: Personal website
-        speaking_at: Speaking at
         show:
           more_info: more info
+          speaking_at: Speaking at
+        speaking_at: Speaking at
       conference_speaker_cell:
         personal_url:
           personal_website: Personal website

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -401,6 +401,7 @@ en:
         go_to_twitter: Go to Twitter
         more_info: more info
         personal_website: Personal website
+        speaking_at: Speaking at
         show:
           more_info: more info
       conference_speaker_cell:


### PR DESCRIPTION
#### :tophat: What? Why?
Fix #6733 in English (en.yml).
I tried to use it in ja locale (with same fix in ja.yml), it seems to be valid.

#### :pushpin: Related Issues
- Fixes #6733

#### Testing
1. build development_app
2. login as admin
3. fix conference speaker to add Conference meeting ids
4. show conference page

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*

EN:
<img width="372" alt="speaker-en" src="https://user-images.githubusercontent.com/10401/99171404-24016100-274c-11eb-800c-85b6edb15701.png">

JA:
<img width="359" alt="speaker-ja" src="https://user-images.githubusercontent.com/10401/99171428-51e6a580-274c-11eb-896b-0d803f29f374.png">



:hearts: Thank you!
