### PR TITLE
Automatically enable registrations when meeting is "on this platform"

### DIFF
--- a/decidim-meetings/app/commands/decidim/meetings/create_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/create_meeting.rb
@@ -50,6 +50,7 @@ module Decidim
           registration_url: form.registration_url,
           available_slots: form.available_slots,
           registration_terms: { I18n.locale => form.registration_terms },
+          registrations_enabled: form.registrations_enabled,
           type_of_meeting: form.clean_type_of_meeting,
           component: form.current_component
         }

--- a/decidim-meetings/app/commands/decidim/meetings/update_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/update_meeting.rb
@@ -60,6 +60,7 @@ module Decidim
             registration_url: form.registration_url,
             available_slots: form.available_slots,
             registration_terms: { I18n.locale => form.registration_terms },
+            registrations_enabled: form.registrations_enabled,
             type_of_meeting: form.clean_type_of_meeting,
             online_meeting_url: form.online_meeting_url
           },

--- a/decidim-meetings/app/forms/decidim/meetings/meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/meeting_form.rb
@@ -20,6 +20,7 @@ module Decidim
       attribute :online_meeting_url, String
       attribute :type_of_meeting, String
       attribute :registration_type, String
+      attribute :registrations_enabled, Boolean, default: false
       attribute :registration_url, String
       attribute :available_slots, Integer, default: 0
       attribute :registration_terms, String
@@ -135,6 +136,10 @@ module Decidim
             type
           ]
         end
+      end
+
+      def registrations_enabled
+        on_this_platform?
       end
     end
   end

--- a/decidim-meetings/spec/commands/create_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/create_meeting_spec.rb
@@ -22,6 +22,7 @@ module Decidim::Meetings
     let(:registration_url) { "http://decidim.org" }
     let(:online_meeting_url) { "http://decidim.org" }
     let(:registration_type) { "on_this_platform" }
+    let(:registrations_enabled) { true }
     let(:available_slots) { 0 }
     let(:registration_terms) { Faker::Lorem.sentence(word_count: 3) }
     let(:form) do
@@ -46,6 +47,7 @@ module Decidim::Meetings
         available_slots: available_slots,
         registration_url: registration_url,
         registration_terms: registration_terms,
+        registrations_enabled: registrations_enabled,
         clean_type_of_meeting: type_of_meeting,
         online_meeting_url: online_meeting_url
       )
@@ -79,6 +81,11 @@ module Decidim::Meetings
       it "sets the registration_terms" do
         subject.call
         expect(meeting.registration_terms).to eq("en" => registration_terms)
+      end
+
+      it "sets the registrations_enabled flag" do
+        subject.call
+        expect(meeting.registrations_enabled).to eq registrations_enabled
       end
 
       it "sets the component" do

--- a/decidim-meetings/spec/commands/update_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/update_meeting_spec.rb
@@ -45,6 +45,7 @@ module Decidim::Meetings
         available_slots: available_slots,
         registration_url: registration_url,
         registration_terms: "The meeting registration terms",
+        registrations_enabled: true,
         clean_type_of_meeting: type_of_meeting,
         online_meeting_url: online_meeting_url
       )
@@ -141,6 +142,7 @@ module Decidim::Meetings
             available_slots: available_slots,
             registration_url: registration_url,
             registration_terms: meeting.registration_terms,
+            registrations_enabled: true,
             clean_type_of_meeting: type_of_meeting,
             online_meeting_url: online_meeting_url
           )

--- a/decidim-meetings/spec/forms/meeting_form_spec.rb
+++ b/decidim-meetings/spec/forms/meeting_form_spec.rb
@@ -58,6 +58,7 @@ module Decidim::Meetings
         registration_type: registration_type,
         available_slots: available_slots,
         registration_terms: registration_terms,
+        registrations_enabled: true,
         registration_url: registration_url
       }
     end

--- a/decidim-meetings/spec/system/user_creates_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_creates_meeting_spec.rb
@@ -49,6 +49,8 @@ describe "User creates meeting", type: :system do
         let(:longitude) { 2.1234 }
         let!(:meeting_start_time) { Time.current + 2.days }
         let(:meeting_end_time) { meeting_start_time + 4.hours }
+        let(:meeting_available_slots) { 30 }
+        let(:meeting_registration_terms) { "These are the registration terms for this meeting" }
         let(:online_meeting_url) { "http://decidim.org" }
         let(:meeting_scope) { create :scope, organization: organization }
         let(:datetime_format) { I18n.t("time.formats.decidim_short") }
@@ -164,6 +166,45 @@ describe "User creates meeting", type: :system do
             expect(page).to have_content(meeting_address)
             expect(page).to have_content(meeting_start_time.strftime(time_format))
             expect(page).to have_content(meeting_end_time.strftime(time_format))
+            expect(page).not_to have_css(".button", text: "JOIN MEETING")
+            expect(page).to have_selector(".author-data", text: user_group.name)
+          end
+
+          it "creates a new meeting with registrations on this platform", :slow do
+            stub_geocoding(meeting_address, [latitude, longitude])
+
+            visit_component
+
+            click_link "New meeting"
+
+            within ".new_meeting" do
+              fill_in :meeting_title, with: meeting_title
+              fill_in :meeting_description, with: meeting_description
+              select "In person", from: :meeting_type_of_meeting
+              fill_in :meeting_location, with: meeting_location
+              fill_in :meeting_location_hints, with: meeting_location_hints
+              fill_in_geocoding :meeting_address, with: meeting_address
+              fill_in :meeting_start_time, with: meeting_start_time.strftime(datetime_format)
+              fill_in :meeting_end_time, with: meeting_end_time.strftime(datetime_format)
+              select "On this platform", from: :meeting_registration_type
+              fill_in :meeting_available_slots, with: meeting_available_slots
+              fill_in :meeting_registration_terms, with: meeting_registration_terms
+              select translated(category.name), from: :meeting_decidim_category_id
+              scope_pick select_data_picker(:meeting_decidim_scope_id), meeting_scope
+              select user_group.name, from: :meeting_user_group_id
+
+              find("*[type=submit]").click
+            end
+
+            expect(page).to have_content("successfully")
+            expect(page).to have_content(meeting_title)
+            expect(page).to have_content(meeting_description)
+            expect(page).to have_content(translated(category.name))
+            expect(page).to have_content(translated(meeting_scope.name))
+            expect(page).to have_content(meeting_address)
+            expect(page).to have_content(meeting_start_time.strftime(time_format))
+            expect(page).to have_content(meeting_end_time.strftime(time_format))
+            expect(page).to have_css(".button", text: "JOIN MEETING")
             expect(page).to have_selector(".author-data", text: user_group.name)
           end
         end


### PR DESCRIPTION
#### :tophat: What? Why?
https://github.com/decidim/decidim/pull/6662 allowed a user to create a meeting selecting a registration type ("Registrations disabled", "On this platform", "On a different platform").

When the user creates a meeting with registration type "On this platform", though, the registrations would never be opened (nor the 'JOIN MEETING' button shown).

This PR automatically opens the registrations for meetings created from the public area when the registration type is "On this platform" by setting the `registration_enabled` flag to `true`.
Notice that the other two options ("Registrations disabled", "On a different platform") where already working correctly and are not affected by the current changes.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related PR: https://github.com/decidim/decidim/pull/6662
- MetaDecidim: https://meta.decidim.org/processes/roadmap/f/122/proposals/15641

#### Testing
REVIEW APP: https://decidim-staging-pr-241.herokuapp.com/

- from the public area, navigate to a participatory process and create a new meeting.
- change the meeting's "Registration type". After saving and being redirected to the meeting detail page, you shall expect:
  - Registration type = "Registration disabled" -> No join button;
  - Registration type = "On this platform" -> "Join meeting" button with number of available slots;
  - Registration type = "On a different platform" -> "Join meeting" button redirecting to the external URL specified when creating the meeting.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
