### PR TITLE
Fix newsletter delivery issue to all recipients with no scopes

### DIFF
--- a/decidim-admin/app/forms/decidim/admin/selective_newsletter_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/selective_newsletter_form.rb
@@ -24,6 +24,12 @@ module Decidim
         end
       end
 
+      # Make sure the empty scope is not passed because then some logic could
+      # assume erroneously that some scope is selected.
+      def scope_ids
+        super.select(&:presence)
+      end
+
       private
 
       def at_least_one_participatory_space_selected

--- a/decidim-admin/spec/forms/selective_newsletter_form_spec.rb
+++ b/decidim-admin/spec/forms/selective_newsletter_form_spec.rb
@@ -111,6 +111,19 @@ module Decidim
           it { is_expected.to be_invalid }
         end
       end
+
+      describe "#scope_ids" do
+        context "when the scope IDs contain an empty value" do
+          # When the scope is selected from a dropdown and no value is selected
+          # this is what will be sent by the form
+          # (<option value="">...</option>).
+          let(:scope_ids) { [""] }
+
+          it "returns an empty array" do
+            expect(subject.scope_ids.empty?).to be(true)
+          end
+        end
+      end
     end
   end
 end

--- a/decidim-admin/spec/queries/newsletter_recipients_spec.rb
+++ b/decidim-admin/spec/queries/newsletter_recipients_spec.rb
@@ -39,6 +39,15 @@ module Decidim::Admin
           expect(subject.query).to match_array recipients
           expect(recipients.count).to eq 5
         end
+
+        context "with the scope_ids array containing an empty value" do
+          let(:scope_ids) { [""] }
+
+          it "returns all users" do
+            expect(subject.query).to match_array recipients
+            expect(recipients.count).to eq 5
+          end
+        end
       end
 
       context "when sending to followers" do

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -54,8 +54,16 @@ module Decidim
     scope :not_confirmed, -> { where(confirmed_at: nil) }
 
     scope :interested_in_scopes, lambda { |scope_ids|
-      ids = scope_ids.map { |i| "%#{i}%" }.join(",")
-      where("extended_data->>'interested_scopes' ~~ ANY('{#{ids}}')")
+      actual_ids = scope_ids.select(&:presence)
+      if actual_ids.count.positive?
+        ids = actual_ids.map(&:to_i).join(",")
+        where("extended_data->'interested_scopes' @> ANY('{#{ids}}')")
+      else
+        # Do not apply the scope filter when there are scope ids available. Note
+        # that the active record scope must always return an active record
+        # collection.
+        self
+      end
     }
 
     scope :org_admins_except_me, ->(user) { where(organization: user.organization, admin: true).where.not(id: user.id) }

--- a/decidim-core/spec/models/decidim/user_spec.rb
+++ b/decidim-core/spec/models/decidim/user_spec.rb
@@ -252,5 +252,112 @@ module Decidim
         expect(described_class.find_for_authentication(conditions)).to eq user
       end
     end
+
+    describe ".interested_in_scopes" do
+      let(:scopes) { [] }
+
+      let(:scope1) { create(:scope, organization: organization) }
+      let(:scope2) { create(:scope, organization: organization) }
+      let(:scope3) { create(:scope, organization: organization) }
+      let(:scope4) { create(:scope, organization: organization) }
+      let(:scope5) { create(:scope, organization: organization) }
+
+      let(:users_scope1) { create_list(:user, 10, organization: organization, extended_data: { "interested_scopes": scope1.id }) }
+      let(:users_scope2) { create_list(:user, 10, organization: organization, extended_data: { "interested_scopes": [scope2.id] }) }
+      let(:users_multiscope) { create_list(:user, 10, organization: organization, extended_data: { "interested_scopes": [scope1.id, scope2.id, scope3.id] }) }
+
+      # It needs to be controlled when the users are created which is why this
+      # needs to be separated to its own method instead of using the bang
+      # method assignments.
+      def create_users_and_scopes
+        scope1
+        scope2
+        scope3
+        scope4
+        scope5
+        users_scope1
+        users_scope2
+        users_multiscope
+      end
+
+      context "when searching with an empty array" do
+        before { create_users_and_scopes }
+
+        it "finds all users" do
+          expect(described_class.interested_in_scopes(scopes).count).to eq(Decidim::User.count)
+        end
+      end
+
+      context "when searching with an array containing empty values" do
+        let(:scopes) { ["", nil] }
+
+        before { create_users_and_scopes }
+
+        it "finds all users" do
+          expect(described_class.interested_in_scopes(scopes).count).to eq(Decidim::User.count)
+        end
+      end
+
+      context "when searching with a single scope" do
+        let(:scopes) { [scope1.id] }
+
+        before { create_users_and_scopes }
+
+        it "finds the correct users interested in particular scope" do
+          expected_ids = users_scope1.map(&:id) + users_multiscope.map(&:id)
+          actual_ids = described_class.interested_in_scopes(scopes).pluck(:id)
+          expect(actual_ids.count).to eq(expected_ids.count)
+          expect(actual_ids).to match_array(expected_ids)
+        end
+      end
+
+      context "when searching with a multiple scopes" do
+        let(:scopes) { [scope1.id, scope2.id, scope3.id, scope4.id, scope5.id] }
+
+        before { create_users_and_scopes }
+
+        it "finds the correct users interested in one of the scopes" do
+          expected_ids = users_scope1.map(&:id) + users_scope2.map(&:id) + users_multiscope.map(&:id)
+          actual_ids = described_class.interested_in_scopes(scopes).pluck(:id)
+          expect(actual_ids.count).to eq(expected_ids.count)
+          expect(actual_ids).to match_array(expected_ids)
+        end
+      end
+
+      context "when searching with scopes no one is intereted in" do
+        let(:scopes) { [scope4.id, scope5.id] }
+
+        before { create_users_and_scopes }
+
+        it "does not find any users" do
+          expect(described_class.interested_in_scopes(scopes).count).to eq(0)
+        end
+      end
+
+      context "when there are scopes with matching numbers in their IDs" do
+        let(:scopes) { [scope1.id] }
+        let(:extra_scopes) { create_list(:scope, 15, organization: organization) }
+        let(:users_scope11) { create_list(:user, 10, organization: organization, extended_data: { "interested_scopes": [11] }) }
+
+        before do
+          # Reset the scope IDs to start from 1 in order to get possibly
+          # "conflicting" ID sequences for the `.interested_in_scopes` call.
+          # This ensures the method that finds the matches will not consider
+          # "conflicting" matches as full matches.
+          ActiveRecord::Base.connection.reset_pk_sequence!(Decidim::Scope.table_name)
+
+          create_users_and_scopes
+          extra_scopes
+          users_scope11
+        end
+
+        it "finds the correct users interested in particular scope" do
+          expected_ids = users_scope1.map(&:id) + users_multiscope.map(&:id)
+          actual_ids = described_class.interested_in_scopes(scopes).pluck(:id)
+          expect(actual_ids.count).to eq(expected_ids.count)
+          expect(actual_ids).to match_array(expected_ids)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
When no scopes are selected and the newsletter is delivered e.g. to all recipients, only a micro subset of all users are selected.

Currently the newsletter will be only delivered to those users who have selected some scopes they are interested in. Most users who have not selected anything, will be left out of the recipients list.

This PR fixes this newsletter deliverability issue and the related active record scope in the user model. It also adds tests to ensure the bug won't be re-introduced.

#### :pushpin: Related Issues
- Related to #5039
- **POSSIBLY** Related to #5573
- **POSSIBLY** Fixes #5573

#### Testing
- Create a Decidim instance with the seed data
- Try to send a newsletter to all recipients
- You will notice the newsletter will be sent to 0 recipients

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.