### PR TITLE
Fix newsletter html containing style tag content

### DIFF
--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -28,6 +28,7 @@ require "omniauth-twitter"
 require "omniauth-google-oauth2"
 require "invisible_captcha"
 require "premailer/rails"
+require "premailer/adapter/decidim"
 require "geocoder"
 require "paper_trail"
 require "cells/rails"
@@ -504,6 +505,10 @@ module Decidim
 
       initializer "nbspw" do
         NOBSPW.configuration.use_ruby_grep = true
+      end
+
+      initializer "decidim.premailer" do
+        Premailer::Adapter.use = :decidim
       end
 
       config.to_prepare do

--- a/decidim-core/lib/premailer/adapter/decidim.rb
+++ b/decidim-core/lib/premailer/adapter/decidim.rb
@@ -15,16 +15,16 @@ class Premailer
       #
       # @return [String] a plain text.
       def to_plain_text
-        html_src = ""
-        begin
-          html_src = @doc.at("body").inner_html
-        rescue;
+        html_src = begin
+          @doc.at("body").inner_html
+        rescue StandardError
+          ""
         end
 
-        html_src = @doc.to_html unless html_src and not html_src.empty?
+        html_src = @doc.to_html unless html_src && html_src.present?
 
         # remove style tags and content
-        html_src.gsub!(/<style.*?\/style>/m, "")
+        html_src.gsub!(%r{<style.*?/style>}m, "")
 
         convert_to_text(html_src, @options[:line_length], @html_encoding)
       end

--- a/decidim-core/lib/premailer/adapter/decidim.rb
+++ b/decidim-core/lib/premailer/adapter/decidim.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class Premailer
+  module Adapter
+    # Decidim adapter for Premailer
+    module Decidim
+      include ::Premailer::Adapter::Nokogiri
+
+      # Converts the HTML document to a format suitable for plain-text e-mail.
+      #
+      # If present, uses the <body> element as its base; otherwise uses the whole document.
+      #
+      # Customized for Decidim in order to strip the inline <style> tags away
+      # from the plain text body.
+      #
+      # @return [String] a plain text.
+      def to_plain_text
+        html_src = ""
+        begin
+          html_src = @doc.at("body").inner_html
+        rescue;
+        end
+
+        html_src = @doc.to_html unless html_src and not html_src.empty?
+
+        # remove style tags and content
+        html_src.gsub!(/<style.*?\/style>/m, "")
+
+        convert_to_text(html_src, @options[:line_length], @html_encoding)
+      end
+    end
+  end
+end

--- a/decidim-core/spec/lib/premailer/adapter/decidim_spec.rb
+++ b/decidim-core/spec/lib/premailer/adapter/decidim_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Premailer::Adapter::Decidim do
+  let(:document) { ::Nokogiri::HTML(document_template, nil, "UTF-8") { |c| c.recover } }
+  let(:document_template) do
+    <<~HTML
+      <html>
+      <head>
+        <title>Test document</title>
+      </head>
+      <body>
+        <div class="container">
+          #{document_content}
+        </div>
+      </body>
+      </html>
+    HTML
+  end
+  let(:document_content) { "" }
+  let(:utility_class) do
+    adapter = described_class
+
+    Class.new do
+      include HtmlToPlainText
+      include adapter
+
+      def initialize(doc)
+        @doc = doc
+        @options = { line_length: 65 }
+      end
+    end
+  end
+  let(:utility) { utility_class.new(document) }
+
+  describe "#to_plain_text" do
+    let(:document_content) do
+      <<~HTML
+        <style>
+        table.button table td {
+          background: #f0f0f0 !important
+        }
+        </style>
+        <p>This is a document with an inline style tag inside the content node.</p>
+      HTML
+    end
+
+    it "strips out the style tags from the document" do
+      expect(utility.to_plain_text).to eq("This is a document with an inline style tag inside the content\nnode.")
+    end
+
+    context "when the document is not wrapped within HTML body" do
+      let(:document_template) { document_content }
+
+      it "strips out the style tags from the document" do
+        expect(utility.to_plain_text).to eq("This is a document with an inline style tag inside the content\nnode.")
+      end
+    end
+  end
+end

--- a/decidim-core/spec/lib/premailer/adapter/decidim_spec.rb
+++ b/decidim-core/spec/lib/premailer/adapter/decidim_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe Premailer::Adapter::Decidim do
-  let(:document) { ::Nokogiri::HTML(document_template, nil, "UTF-8") { |c| c.recover } }
+  let(:document) { ::Nokogiri::HTML(document_template, nil, "UTF-8", &:recover) }
   let(:document_template) do
     <<~HTML
       <html>


### PR DESCRIPTION
#### :tophat: What? Why?
Decidim is using [Premailer](https://github.com/premailer/premailer) to convert the HTML to plain text. A part of the message is displayed in the beginning of the HTML emails as well.

In #5887 newsletter templates were added which apparently contain inline `<style>` tags within the HTML content of the message:
https://github.com/decidim/decidim/blob/98a27097d17460b015c2eaf65b2bdcf9eae0f11c/decidim-core/app/cells/decidim/newsletter_templates/image_text_cta/show.erb#L2-L6

The problem is that premailer does not strip out the style tags by default and it leaves the content inside the `<style>` tag to the final plain text email:
https://github.com/premailer/premailer/blob/ae21ddab9302cf3e3b9dad9c3cd1115487f06acb/lib/premailer/html_to_plain_text.rb#L16-L129

This causes the beginning of the emails to contain the contents of the inline `<style>` tags within the emails (see the screenshot).

This PR fixes the issue by customizing the Premailer adapter for stripping out the `<style>` tags before passing the HTML content to the Premailer's method.

#### :pushpin: Related Issues
- Related to #5887

#### Testing
- Create a Decidim instance with the default seed data
- Make sure you have defined the organization primary color
- Send a newsletter email
- See the beginning of the email text

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
An image how this shows up in the email:
![Style tag contents at the beginning of the emails](https://user-images.githubusercontent.com/864340/99383808-16c4ad80-28d7-11eb-8ec4-cb1af1c2130c.png)