### PR TITLE
Fix incorrect order of minimum/maximum in the locales

### DIFF
--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -247,8 +247,8 @@ en:
             vote_rule_minimum_budget_projects_enabled: 'Enable rule: Minimum number of projects to be voted on'
             vote_rule_selected_projects_enabled: 'Enable rule: Selected projects with minimum and maximum number of projects to be voted on'
             vote_rule_threshold_percent_enabled: 'Enable rule: Minimum budget percentage'
-            vote_selected_projects_maximum: Minimum amount of projects to be selected
-            vote_selected_projects_minimum: Maximum amount of projects to be selected
+            vote_selected_projects_maximum: Maximum amount of projects to be selected
+            vote_selected_projects_minimum: Minimum amount of projects to be selected
             vote_threshold_percent: Vote threshold percent
             workflow: Workflow
             workflow_choices:


### PR DESCRIPTION
#### :tophat: What? Why?
@PierreMesure mentioned at #6753 the min/max translations are inverted. This fixes it.

#### :pushpin: Related Issues
- Related to #6753
- Fixes https://github.com/decidim/decidim/pull/6753#discussion_r524305087

#### Testing
Go to the budgets component's management view.

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.