### PR TITLE
Send notification to resource's authors when it is hidden by a moderator

### DIFF
--- a/decidim-admin/app/events/decidim/resource_hidden_event.rb
+++ b/decidim-admin/app/events/decidim/resource_hidden_event.rb
@@ -1,8 +1,8 @@
 # frozen-string_literal: true
 
 module Decidim
-  class ReportCreatedEvent < Decidim::Events::SimpleEvent
-    i18n_attributes :resource_path, :report_reason, :resource_type
+  class ResourceHiddenEvent < Decidim::Events::SimpleEvent
+    i18n_attributes :resource_path, :report_reasons, :resource_type
 
     def resource_path
       @resource.reported_content_url
@@ -12,8 +12,10 @@ module Decidim
       @resource.reported_content_url
     end
 
-    def report_reason
-      I18n.t("decidim.admin.moderations.report.reasons.#{extra["report_reason"]}").downcase
+    def report_reasons
+      extra["report_reasons"].map do |reason|
+        I18n.t("decidim.admin.moderations.report.reasons.#{reason}").downcase
+      end.join(", ")
     end
 
     def resource_title

--- a/decidim-admin/app/events/decidim/resource_hidden_event.rb
+++ b/decidim-admin/app/events/decidim/resource_hidden_event.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   class ResourceHiddenEvent < Decidim::Events::SimpleEvent
-    i18n_attributes :resource_path, :report_reasons, :resource_type
+    i18n_attributes :resource_path, :report_reasons, :resource_type, :resource_content
 
     def resource_path
       @resource.reported_content_url
@@ -20,6 +20,14 @@ module Decidim
 
     def resource_title
       nil
+    end
+
+    def resource_content
+      translated_attribute(@resource[@resource.reported_attributes.first]).truncate(100, separator: " ")
+    end
+
+    def resource_text
+      "<i>#{resource_content}</i>"
     end
 
     def resource_type

--- a/decidim-admin/spec/events/decidim/resource_hidden_event_spec.rb
+++ b/decidim-admin/spec/events/decidim/resource_hidden_event_spec.rb
@@ -3,15 +3,15 @@
 require "spec_helper"
 
 module Decidim
-  describe ReportCreatedEvent do
+  describe ResourceHiddenEvent do
     include_context "when a simple event"
 
     let(:comment) { create :comment }
     let(:moderation) { create :moderation, reportable: comment }
     let(:report) { create :report, moderation: moderation }
     let(:resource) { comment }
-    let(:event_name) { "decidim.events.reports.report_created" }
-    let(:extra) { { report_reason: "spam" } }
+    let(:event_name) { "decidim.events.reports.resource_hidden" }
+    let(:extra) { { report_reasons: ["spam"] } }
 
     describe "notification_title" do
       it "includes the report reason" do
@@ -25,19 +25,19 @@ module Decidim
 
     describe "email_subject" do
       it "is generated correctly" do
-        expect(subject.email_subject).to eq("Your comment has been reported")
+        expect(subject.email_subject).to eq("Your comment has been removed")
       end
     end
 
     describe "email_outro" do
       it "is generated correctly" do
-        expect(subject.email_outro).to eq("You have received this notification because you are an author of the reported content.")
+        expect(subject.email_outro).to eq("You have received this notification because you are an author of the removed content.")
       end
     end
 
     describe "email_intro" do
       it "is generated correctly" do
-        expect(subject.email_intro).to eq("<a href=\"#{comment.reported_content_url}\">Your comment</a> has been reported as \"spam\". An administrator will review it shortly.")
+        expect(subject.email_intro).to eq("An administrator removed <a href=\"#{comment.reported_content_url}\">your comment</a> because it has been reported as spam.")
       end
     end
   end

--- a/decidim-admin/spec/events/decidim/resource_hidden_event_spec.rb
+++ b/decidim-admin/spec/events/decidim/resource_hidden_event_spec.rb
@@ -6,7 +6,7 @@ module Decidim
   describe ResourceHiddenEvent do
     include_context "when a simple event"
 
-    let(:comment) { create :comment }
+    let(:comment) { create :comment, body: { "en" => "a reported comment" } }
     let(:moderation) { create :moderation, reportable: comment }
     let(:report) { create :report, moderation: moderation }
     let(:resource) { comment }
@@ -16,10 +16,6 @@ module Decidim
     describe "notification_title" do
       it "includes the report reason" do
         expect(subject.notification_title).to include("spam")
-      end
-
-      it "includes the reportable link" do
-        expect(subject.notification_title).to include(comment.reported_content_url)
       end
     end
 
@@ -37,7 +33,13 @@ module Decidim
 
     describe "email_intro" do
       it "is generated correctly" do
-        expect(subject.email_intro).to eq("An administrator removed <a href=\"#{comment.reported_content_url}\">your comment</a> because it has been reported as spam.")
+        expect(subject.email_intro).to include("An administrator removed your comment because it has been reported as spam.")
+      end
+    end
+
+    describe "resource_text" do
+      it "is generated correctly" do
+        expect(subject.resource_text).to include("<i>#{comment.body["en"]}</i>")
       end
     end
   end

--- a/decidim-core/app/commands/decidim/create_report.rb
+++ b/decidim-core/app/commands/decidim/create_report.rb
@@ -31,7 +31,6 @@ module Decidim
       end
 
       send_report_notification_to_moderators
-      send_report_notification_to_author
 
       if hideable?
         hide!
@@ -75,19 +74,6 @@ module Decidim
       participatory_space_moderators.each do |moderator|
         ReportedMailer.report(moderator, @report).deliver_later
       end
-    end
-
-    def send_report_notification_to_author
-      data = {
-        event: "decidim.events.reports.report_created",
-        event_class: Decidim::ReportCreatedEvent,
-        resource: @report.moderation.reportable,
-        extra: {
-          report_reason: @report.reason
-        },
-        affected_users: @report.moderation.reportable.try(:authors) || [@report.moderation.reportable.try(:normalized_author)]
-      }
-      Decidim::EventsManager.publish(data)
     end
 
     def hideable?

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -617,10 +617,12 @@ en:
         notification_title: An event occured to <a href="%{resource_path}">%{resource_title}</a>.
       reports:
         resource_hidden:
-          email_intro: An administrator removed <a href="%{resource_url}">your %{resource_type}</a> because it has been reported as %{report_reasons}.
+          email_intro: An administrator removed your %{resource_type} because it has been reported as %{report_reasons}.
           email_outro: You have received this notification because you are an author of the removed content.
           email_subject: Your %{resource_type} has been removed
-          notification_title: An administrator removed <a href="%{resource_url}">your %{resource_type}</a> because it has been reported as %{report_reasons}.
+          notification_title: |-
+            An administrator removed your %{resource_type} because it has been reported as %{report_reasons}.</br>
+            <i>%{resource_content}</i>
       resource_endorsed:
         email_intro: '%{endorser_name} %{endorser_nickname}, who you are following, has just endorsed "%{resource_title}" and we think it may be interesting to you. Check it out and contribute:'
         email_outro: You have received this notification because you are following %{endorser_nickname}. You can stop receiving notifications following the previous link.

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -616,11 +616,11 @@ en:
       notification_event:
         notification_title: An event occured to <a href="%{resource_path}">%{resource_title}</a>.
       reports:
-        report_created:
-          email_intro: <a href="%{resource_url}">Your %{resource_type}</a> has been reported as "%{report_reason}". An administrator will review it shortly.
-          email_outro: You have received this notification because you are an author of the reported content.
-          email_subject: Your %{resource_type} has been reported
-          notification_title: <a href="%{resource_path}">Your %{resource_type}</a> has been reported as "%{report_reason}".
+        resource_hidden:
+          email_intro: An administrator removed <a href="%{resource_url}">your %{resource_type}</a> because it has been reported as %{report_reasons}.
+          email_outro: You have received this notification because you are an author of the removed content.
+          email_subject: Your %{resource_type} has been removed
+          notification_title: An administrator removed <a href="%{resource_url}">your %{resource_type}</a> because it has been reported as %{report_reasons}.
       resource_endorsed:
         email_intro: '%{endorser_name} %{endorser_nickname}, who you are following, has just endorsed "%{resource_title}" and we think it may be interesting to you. Check it out and contribute:'
         email_outro: You have received this notification because you are following %{endorser_nickname}. You can stop receiving notifications following the previous link.

--- a/decidim-core/spec/commands/decidim/create_report_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_report_spec.rb
@@ -16,17 +16,6 @@ module Decidim
           reason: "spam"
         }
       end
-      let(:author_notification) do
-        {
-          event: "decidim.events.reports.report_created",
-          event_class: Decidim::ReportCreatedEvent,
-          resource: reportable,
-          extra: {
-            report_reason: form[:reason]
-          },
-          affected_users: reportable.try(:authors) || [reportable.try(:author)]
-        }
-      end
 
       let(:command) { described_class.new(form, reportable, user) }
 
@@ -90,11 +79,6 @@ module Decidim
             .with(admin, last_report)
         end
 
-        it "sends a notification to the reportable's author" do
-          expect(Decidim::EventsManager).to receive(:publish).with(author_notification)
-          command.call
-        end
-
         context "and the reportable has been already reported two times" do
           before do
             expect(form).to receive(:invalid?).at_least(:once).and_return(false)
@@ -122,11 +106,6 @@ module Decidim
             expect(ReportedMailer)
               .to have_received(:hide)
               .with(admin, last_report)
-          end
-
-          it "sends a notification to the reportable's author" do
-            expect(Decidim::EventsManager).to receive(:publish).with(author_notification)
-            command.call
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
https://github.com/decidim/decidim/pull/6747 introduced sending a notification to the authors when their content gets reported.
Now we want to send the notification when the reported content is hidden (removed) by a moderator instead of when it has been reported.

The notification/email will report to the author(s) the reason(s) why their content was reported to the moderators.

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/pull/6747
- Related to https://meta.decidim.org/processes/roadmap/f/122/proposals/15781

#### Testing
REVIEW APP: https://decidim-staging-pr-244.herokuapp.com/
Login with a user (say: user@example.org | decidim123456);
Create a reportable content (e.g. a comment, proposal, etc.);
On another browser/session, login with another user (say: admin@example.org | decidim123456);
Report the content created with the previous user;
As an admin (say: admin@example.org | decidim123456), navigate to the process' moderation panel and 'hide' the moderation created in the previous step;
The first user (user@example.org in the example) shell receive a notification saying that their content has been removed;

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
Notification
![notification](https://user-images.githubusercontent.com/5033945/99522700-44246080-2996-11eb-93c8-2a6dab10d12a.png)

Email
![email](https://user-images.githubusercontent.com/5033945/99522713-471f5100-2996-11eb-81ce-27b9855b5523.png)


:hearts: Thank you!
