### PR TITLE
Fix to use `tail_before_final_tag: false` option

### DIFF
--- a/decidim-core/app/helpers/decidim/application_helper.rb
+++ b/decidim-core/app/helpers/decidim/application_helper.rb
@@ -22,7 +22,7 @@ module Decidim
       options[:tail] = options.delete(:separator) || options[:tail] || "..."
       options[:count_tags] ||= false
       options[:count_tail] ||= false
-      options[:tail_before_final_tag] ||= true
+      options[:tail_before_final_tag] = true unless options.has_key?(:tail_before_final_tag)
 
       Truncato.truncate(text, options)
     end

--- a/decidim-core/spec/helpers/decidim/application_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/application_helper_spec.rb
@@ -39,6 +39,7 @@ module Decidim
 
       context "when :tail_before_final_tag is false" do
         subject { helper.html_truncate(text, length: length, tail_before_final_tag: false) }
+
         describe "truncating HTML text" do
           let(:text) { "<div><p>Hello, this is dog</p></div>" }
           let(:length) { 10 }
@@ -49,6 +50,7 @@ module Decidim
 
       context "when :tail_before_final_tag is true" do
         subject { helper.html_truncate(text, length: length, tail_before_final_tag: true) }
+
         describe "truncating HTML text" do
           let(:text) { "<p>Hello, <b>this is dog</b></p>" }
           let(:length) { 10 }
@@ -59,6 +61,7 @@ module Decidim
 
       context "when :tail_before_final_tag is missing" do
         subject { helper.html_truncate(text, length: length) }
+
         describe "truncating HTML text" do
           let(:text) { "<p>Hello, <b>this is dog</b></p>" }
           let(:length) { 10 }

--- a/decidim-core/spec/helpers/decidim/application_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/application_helper_spec.rb
@@ -36,6 +36,36 @@ module Decidim
 
         it { is_expected.to eq("Hello ...read more") }
       end
+
+      context "when :tail_before_final_tag is false" do
+        subject { helper.html_truncate(text, length: length, tail_before_final_tag: false) }
+        describe "truncating HTML text" do
+          let(:text) { "<div><p>Hello, this is dog</p></div>" }
+          let(:length) { 10 }
+
+          it { is_expected.to eq("<div><p>Hello, thi...</p></div>") }
+        end
+      end
+
+      context "when :tail_before_final_tag is true" do
+        subject { helper.html_truncate(text, length: length, tail_before_final_tag: true) }
+        describe "truncating HTML text" do
+          let(:text) { "<p>Hello, <b>this is dog</b></p>" }
+          let(:length) { 10 }
+
+          it { is_expected.to eq("<p>Hello, <b>thi</b>...</p>") }
+        end
+      end
+
+      context "when :tail_before_final_tag is missing" do
+        subject { helper.html_truncate(text, length: length) }
+        describe "truncating HTML text" do
+          let(:text) { "<p>Hello, <b>this is dog</b></p>" }
+          let(:length) { 10 }
+
+          it { is_expected.to eq("<p>Hello, <b>thi</b>...</p>") }
+        end
+      end
     end
 
     describe "#present" do


### PR DESCRIPTION
#### :tophat: What? Why?
In current implementation of `Decidim::ApplicationHelper.html_truncate`, the `:tail_before_final_tag` option such like `html_truncate(some_text, tail_before_final_tag: false)` seems to be just ignored. This PR fix it.

#### :pushpin: Related Issues
- Related to #5830

#### Testing
Added some tests in `decidim-core/spec/helpers/decidim/application_helper_spec.rb` so see them.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
(This PR just fix helper method, so there is no screenshot.)

:hearts: Thank you!
