### PR TITLE
Allow admin to be registered as a participatory space user

### DIFF
--- a/decidim-admin/app/forms/decidim/admin/participatory_space_private_user_csv_import_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_space_private_user_csv_import_form.rb
@@ -15,11 +15,10 @@ module Decidim
       validate :validate_csv
 
       def validate_csv
-        if file.present?
-          CSV.foreach(file.path) do |email, user_name|
-            errors.add(:user_name, :invalid) unless user_name.match?(UserBaseEntity::REGEXP_NAME)
-            errors.add(:email, :taken) if context && context.current_organization && context.current_organization.admins.exists?(email: email)
-          end
+        return if file.blank?
+
+        CSV.foreach(file.path) do |_email, user_name|
+          errors.add(:user_name, :invalid) unless user_name.match?(UserBaseEntity::REGEXP_NAME)
         end
       end
     end

--- a/decidim-admin/app/forms/decidim/admin/participatory_space_private_user_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_space_private_user_form.rb
@@ -14,11 +14,6 @@ module Decidim
       validates :name, :email, presence: true
 
       validates :name, format: { with: UserBaseEntity::REGEXP_NAME }
-      validate :admin_uniqueness
-
-      def admin_uniqueness
-        errors.add(:email, :taken) if context && context.current_organization && context.current_organization.admins.exists?(email: email)
-      end
     end
   end
 end

--- a/decidim-admin/spec/forms/participatory_space_private_user_csv_import_form_spec.rb
+++ b/decidim-admin/spec/forms/participatory_space_private_user_csv_import_form_spec.rb
@@ -39,13 +39,6 @@ module Decidim
 
         it { is_expected.to be_invalid }
       end
-
-      context "when email is already being used" do
-        let(:email) { "my_user@example.org" }
-        let!(:user) { create(:user, name: "Daisy Miller", nickname: "daisy_m", email: email, organization: current_organization, admin: true) }
-
-        it { is_expected.to be_invalid }
-      end
     end
   end
 end

--- a/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_user_role_form.rb
+++ b/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_user_role_form.rb
@@ -16,7 +16,6 @@ module Decidim
         validates :role, inclusion: { in: Decidim::AssemblyUserRole::ROLES }
 
         validates :name, format: { with: UserBaseEntity::REGEXP_NAME }
-        validate :admin_uniqueness
 
         def roles
           Decidim::AssemblyUserRole::ROLES.map do |role|
@@ -25,10 +24,6 @@ module Decidim
               role
             ]
           end
-        end
-
-        def admin_uniqueness
-          errors.add(:email, :taken) if context && context.current_organization && context.current_organization.admins.exists?(email: email)
         end
       end
     end

--- a/decidim-assemblies/spec/forms/assembly_user_role_form_spec.rb
+++ b/decidim-assemblies/spec/forms/assembly_user_role_form_spec.rb
@@ -46,12 +46,6 @@ module Decidim
 
           it { is_expected.to be_invalid }
         end
-
-        context "when email is already being used" do
-          let!(:user) { create(:user, name: "Daisy Miller", nickname: "daisy_m", email: email, organization: current_organization, admin: true) }
-
-          it { is_expected.to be_invalid }
-        end
       end
     end
   end

--- a/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_user_role_form.rb
+++ b/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_user_role_form.rb
@@ -17,7 +17,6 @@ module Decidim
         validates :role, inclusion: { in: Decidim::ParticipatoryProcessUserRole::ROLES }
 
         validates :name, format: { with: UserBaseEntity::REGEXP_NAME }
-        validate :admin_uniqueness
 
         def roles
           Decidim::ParticipatoryProcessUserRole::ROLES.map do |role|
@@ -26,10 +25,6 @@ module Decidim
               role
             ]
           end
-        end
-
-        def admin_uniqueness
-          errors.add(:email, :taken) if context && context.current_organization && context.current_organization.admins.exists?(email: email)
         end
       end
     end

--- a/decidim-participatory_processes/spec/forms/participatory_process_user_role_form_spec.rb
+++ b/decidim-participatory_processes/spec/forms/participatory_process_user_role_form_spec.rb
@@ -46,12 +46,6 @@ module Decidim
 
           it { is_expected.to be_invalid }
         end
-
-        context "when email is already being used" do
-          let!(:user) { create(:user, name: "Daisy Miller", nickname: "daisy_m", email: email, organization: current_organization, admin: true) }
-
-          it { is_expected.to be_invalid }
-        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Allow admin to be registered as a participatory space user by removing faulty lines from a previous pull request.

#### :pushpin: Related Issues
- Related to #6556
- Fixes #6869

#### Testing
Register an admin as a participatory space user.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.
