### PR TITLE
Restore consultation description HTML format tags

### DIFF
--- a/decidim-consultations/app/views/decidim/consultations/consultations/_consultation_details.html.erb
+++ b/decidim-consultations/app/views/decidim/consultations/consultations/_consultation_details.html.erb
@@ -1,6 +1,6 @@
 <div class="row section" id="consultation-details">
   <div class="columns medium-6 large-5 large-push-1">
-    <p class="lead"><%= decidim_sanitize translated_attribute(consultation.description), strip_tags: true %></p>
+    <p class="lead"><%= decidim_sanitize translated_attribute(consultation.description) %></p>
   </div>
   <div class="columns medium-6 large-5 large-pull-1">
     <% if consultation.introductory_video_url.blank? %>


### PR DESCRIPTION
#### :tophat: What? Why?

This fixes a regression introduced in https://github.com/decidim/decidim/pull/5684. The formatting of a consultation's description was totally gone.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #? https://github.com/decidim/decidim/pull/5684
- Fixes #?

#### Testing
Checking the consultation's public page is enough to see whether the formatting is applied or not.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

Before: 
![Screenshot from 2020-11-19 09-24-36](https://user-images.githubusercontent.com/762088/99640419-22d07c80-2a49-11eb-89a6-d72095edce0d.png)


After: ![Screenshot from 2020-11-19 09-20-26](https://user-images.githubusercontent.com/762088/99640364-13513380-2a49-11eb-91f2-0e2a76a49325.png)
