### PR TITLE
Fix decidim-templates gem definition to include templates migrations

### DIFF
--- a/decidim-generators/Gemfile
+++ b/decidim-generators/Gemfile
@@ -5,7 +5,9 @@ source "https://rubygems.org"
 ruby RUBY_VERSION
 
 gem "decidim", path: ".."
+gem "decidim-conferences", path: ".."
 gem "decidim-consultations", path: ".."
+gem "decidim-elections", path: ".."
 gem "decidim-initiatives", path: ".."
 gem "decidim-templates", path: ".."
 

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -59,6 +59,11 @@ PATH
       decidim-core (= 0.24.0.dev)
       jquery-rails (~> 4.4)
       redcarpet (~> 3.4)
+    decidim-conferences (0.24.0.dev)
+      decidim-core (= 0.24.0.dev)
+      decidim-meetings (= 0.24.0.dev)
+      wicked_pdf (~> 1.4)
+      wkhtmltopdf-binary (~> 0.12)
     decidim-consultations (0.24.0.dev)
       decidim-admin (= 0.24.0.dev)
       decidim-comments (= 0.24.0.dev)
@@ -153,6 +158,11 @@ PATH
       vcr (~> 6.0)
       webmock (~> 3.6)
       wisper-rspec (~> 1.0)
+    decidim-elections (0.24.0.dev)
+      decidim-core (= 0.24.0.dev)
+      decidim-forms (= 0.24.0.dev)
+      decidim-proposals (= 0.24.0.dev)
+      graphlient (~> 0.4.0)
     decidim-forms (0.24.0.dev)
       decidim-core (= 0.24.0.dev)
       wicked_pdf (~> 1.4)
@@ -393,8 +403,11 @@ GEM
       railties (>= 3.0.0)
     faker (2.14.0)
       i18n (>= 1.6, < 2)
-    faraday (1.0.1)
+    faraday (1.1.0)
       multipart-post (>= 1.2, < 3)
+      ruby2_keywords
+    faraday_middleware (1.0.0)
+      faraday (~> 1.0)
     ffi (1.13.1)
     file_validators (2.3.0)
       activemodel (>= 3.2)
@@ -415,7 +428,14 @@ GEM
     graphiql-rails (1.4.11)
       railties
       sprockets-rails
-    graphql (1.11.5)
+    graphlient (0.4.0)
+      faraday (>= 1.0)
+      faraday_middleware
+      graphql-client
+    graphql (1.11.6)
+    graphql-client (0.16.0)
+      activesupport (>= 3.0)
+      graphql (~> 1.8)
     hashdiff (1.0.1)
     hashie (4.1.0)
     highline (2.0.3)
@@ -492,16 +512,16 @@ GEM
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2020.0512)
+    mime-types-data (3.2020.1104)
     mimemagic (0.3.5)
-    mini_magick (4.10.1)
+    mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)
     mixlib-cli (2.1.8)
     mixlib-config (3.0.9)
       tomlrb
-    mixlib-shellout (3.1.7)
+    mixlib-shellout (3.2.2)
       chef-utils
     msgpack (1.3.3)
     multi_json (1.15.0)
@@ -547,11 +567,11 @@ GEM
     paper_trail (10.3.1)
       activerecord (>= 4.2)
       request_store (~> 1.1)
-    parallel (1.19.2)
+    parallel (1.20.1)
     parser (2.7.2.0)
       ast (~> 2.4.1)
     pg (1.1.4)
-    pg_search (2.3.3)
+    pg_search (2.3.5)
       activerecord (>= 5.2)
       activesupport (>= 5.2)
     premailer (1.14.2)
@@ -619,7 +639,7 @@ GEM
       virtus (~> 1.0.5)
       wisper (>= 1.6.1)
     redcarpet (3.5.0)
-    redis (4.2.2)
+    redis (4.2.5)
     regexp_parser (1.8.2)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -683,6 +703,7 @@ GEM
       rubocop-ast (>= 0.7.1)
     ruby-ole (1.2.12.2)
     ruby-progressbar (1.10.1)
+    ruby2_keywords (0.0.2)
     rubyzip (2.0.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -767,7 +788,7 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
-    webmock (3.9.3)
+    webmock (3.10.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
@@ -780,7 +801,7 @@ GEM
       activesupport
     wisper (2.0.1)
     wisper-rspec (1.1.0)
-    wkhtmltopdf-binary (0.12.6.4)
+    wkhtmltopdf-binary (0.12.6.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -791,8 +812,10 @@ DEPENDENCIES
   bootsnap (~> 1.3)
   byebug (~> 11.0)
   decidim!
+  decidim-conferences!
   decidim-consultations!
   decidim-dev!
+  decidim-elections!
   decidim-initiatives!
   decidim-templates!
   faker (~> 2.14)

--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -35,7 +35,7 @@ module Decidim
 
       class_option :edge, type: :boolean,
                           default: false,
-                          desc: "Use GitHub's edge version from master branch"
+                          desc: "Use GitHub's edge version from develop branch"
 
       class_option :branch, type: :string,
                             default: nil,

--- a/decidim-generators/spec/generators_spec.rb
+++ b/decidim-generators/spec/generators_spec.rb
@@ -58,6 +58,9 @@ module Decidim
           expect(File.read("#{test_app}/Gemfile"))
             .to match(/^# gem "decidim-initiatives"/)
             .and match(/^# gem "decidim-consultations"/)
+            .and match(/^# gem "decidim-elections"/)
+            .and match(/^# gem "decidim-conferences"/)
+            .and match(/^# gem "decidim-templates"/)
         end
       end
 
@@ -68,6 +71,26 @@ module Decidim
           expect(File.read("#{test_app}/Gemfile"))
             .to match(/^gem "decidim-initiatives"/)
             .and match(/^gem "decidim-consultations"/)
+            .and match(/^gem "decidim-elections"/)
+            .and match(/^gem "decidim-conferences"/)
+            .and match(/^gem "decidim-templates"/)
+
+          # Checks that every table from a migration is included in the generated schema
+          schema = File.read("#{test_app}/db/schema.rb")
+          tables = []
+          dropped = []
+          Decidim::GemManager.plugins.each do |plugin|
+            Dir.glob("#{plugin}db/migrate/*.rb").each do |migration|
+              lines = File.readlines(migration)
+              tables.concat(lines.filter { |line| line.match? "create_table" }.map { |line| line.match(/(:)([a-z_0-9]+)/)[2] })
+              dropped.concat(lines.filter { |line| line.match? "drop_table" }.map { |line| line.match(/(:)([a-z_0-9]+)/)[2] })
+            end
+          end
+          tables.each do |table|
+            next if dropped.include? table
+
+            expect(schema).to match(/create_table "#{table}"|create_table :#{table}/)
+          end
         end
       end
 
@@ -77,7 +100,7 @@ module Decidim
         it_behaves_like "a new production application"
       end
 
-      if ENV["CIRCLE_BRANCH"] == "master"
+      if ENV["GITHUB_REF"] && ENV["GITHUB_REF"].match?("develop")
         context "with --edge flag" do
           let(:command) { "decidim --edge #{test_app}" }
 
@@ -95,6 +118,12 @@ module Decidim
         let(:command) { "decidim --path #{repo_root} #{test_app}" }
 
         it_behaves_like "a new production application"
+      end
+
+      context "with a full featured application" do
+        let(:command) { "decidim #{test_app} --recreate_db --demo" }
+
+        it_behaves_like "a new development application"
       end
 
       context "with a development application" do

--- a/decidim-generators/spec/generators_spec.rb
+++ b/decidim-generators/spec/generators_spec.rb
@@ -82,8 +82,10 @@ module Decidim
           Decidim::GemManager.plugins.each do |plugin|
             Dir.glob("#{plugin}db/migrate/*.rb").each do |migration|
               lines = File.readlines(migration)
-              tables.concat(lines.filter { |line| line.match? "create_table" }.map { |line| line.match(/(:)([a-z_0-9]+)/)[2] })
-              dropped.concat(lines.filter { |line| line.match? "drop_table" }.map { |line| line.match(/(:)([a-z_0-9]+)/)[2] })
+              tables.concat(lines.filter { |line| line.match? "create_table" }.map { |line| line.match(/(\:)([a-z_0-9]+)/)[2] })
+              dropped.concat(lines.filter { |line| line.match? "drop_table" }.map { |line| line.match(/(\:)([a-z_0-9]+)/)[2] })
+              tables.concat(lines.filter { |line| line.match? "rename_table" }.map { |line| line.match(/(, \:)([a-z_0-9]+)/)[2] })
+              dropped.concat(lines.filter { |line| line.match? "rename_table" }.map { |line| line.match(/(\:)([a-z_0-9]+)/)[2] })
             end
           end
           tables.each do |table|

--- a/decidim-generators/spec/generators_spec.rb
+++ b/decidim-generators/spec/generators_spec.rb
@@ -82,10 +82,10 @@ module Decidim
           Decidim::GemManager.plugins.each do |plugin|
             Dir.glob("#{plugin}db/migrate/*.rb").each do |migration|
               lines = File.readlines(migration)
-              tables.concat(lines.filter { |line| line.match? "create_table" }.map { |line| line.match(/(\:)([a-z_0-9]+)/)[2] })
-              dropped.concat(lines.filter { |line| line.match? "drop_table" }.map { |line| line.match(/(\:)([a-z_0-9]+)/)[2] })
-              tables.concat(lines.filter { |line| line.match? "rename_table" }.map { |line| line.match(/(, \:)([a-z_0-9]+)/)[2] })
-              dropped.concat(lines.filter { |line| line.match? "rename_table" }.map { |line| line.match(/(\:)([a-z_0-9]+)/)[2] })
+              tables.concat(lines.filter { |line| line.match? "create_table" }.map { |line| line.match(/(:)([a-z_0-9]+)/)[2] })
+              dropped.concat(lines.filter { |line| line.match? "drop_table" }.map { |line| line.match(/(:)([a-z_0-9]+)/)[2] })
+              tables.concat(lines.filter { |line| line.match? "rename_table" }.map { |line| line.match(/(, :)([a-z_0-9]+)/)[2] })
+              dropped.concat(lines.filter { |line| line.match? "rename_table" }.map { |line| line.match(/(:)([a-z_0-9]+)/)[2] })
             end
           end
           tables.each do |table|

--- a/decidim-templates/decidim-templates.gemspec
+++ b/decidim-templates/decidim-templates.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.summary = "A decidim templates module"
   s.description = "This module provides a solution to create templates for different Decidim models, such as Proposals and Questionnaires.."
 
-  s.files = Dir["{app,config,lib}/**/*", "LICENSE-AGPLv3.txt", "Rakefile", "README.md"]
+  s.files = Dir["{app,config,db,lib}/**/*", "LICENSE-AGPLv3.txt", "Rakefile", "README.md"]
 
   s.add_dependency "decidim-core", Decidim::Templates.version
   s.add_dependency "decidim-forms", Decidim::Templates.version


### PR DESCRIPTION
#### :tophat: What? Why?

The definition of the gem `decidim-templates` does not include the `db` folder meaning it cannot be installed from rubygems.org.
This should fix it but requires to create a new version of the gem (see the backport for 0.23).

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #6897
- Fixes #6897 

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
