### PR TITLE
 Fix mixing answers exports and admin management in questionnaires

### DIFF
--- a/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_participant_presenter.rb
+++ b/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_participant_presenter.rb
@@ -52,7 +52,7 @@ module Decidim
         private
 
         def sibilings
-          Answer.where(session_token: participant.session_token).joins(:question).order("decidim_forms_questions.position ASC")
+          Answer.where(questionnaire: questionnaire, session_token: participant.session_token).joins(:question).order("decidim_forms_questions.position ASC")
         end
       end
     end

--- a/decidim-forms/spec/presenters/decidim/admin/questionnaire_participant_presenter_spec.rb
+++ b/decidim-forms/spec/presenters/decidim/admin/questionnaire_participant_presenter_spec.rb
@@ -64,7 +64,7 @@ module Decidim
       end
     end
 
-    describe "there are more than one questionnaire" do
+    describe "user answers more than one questionnaire" do
       let!(:component) { create(:component, participatory_space: questionnaire.questionnaire_for, organization: questionnaire.questionnaire_for.organization) }
       let!(:questionnaire2) { create(:questionnaire, questionnaire_for: component) }
       let!(:questions2) { 3.downto(1).map { |n| create :questionnaire_question, questionnaire: questionnaire2, position: n } }
@@ -75,7 +75,7 @@ module Decidim
       let!(:participant2) { answers2.first }
 
       context "when completion of different questionnaires" do
-        it "returns the participant's completion percentage of two different questionnaires" do
+        it "returns the participant's completion percentage without mixing different questionnaires" do
           expect(subject.completion).to eq(100)
         end
       end

--- a/decidim-forms/spec/presenters/decidim/admin/questionnaire_participant_presenter_spec.rb
+++ b/decidim-forms/spec/presenters/decidim/admin/questionnaire_participant_presenter_spec.rb
@@ -58,9 +58,26 @@ module Decidim
       end
     end
 
-    describe "commpletion" do
+    describe "commpletion of just one questionnaire" do
       it "returns the participant's completion percentage" do
         expect(subject.completion).to eq(100)
+      end
+    end
+
+    describe "there are more than one questionnaire" do
+      let!(:component) { create(:component, participatory_space: questionnaire.questionnaire_for, organization: questionnaire.questionnaire_for.organization) }
+      let!(:questionnaire2) { create(:questionnaire, questionnaire_for: component) }
+      let!(:questions2) { 3.downto(1).map { |n| create :questionnaire_question, questionnaire: questionnaire2, position: n } }
+      let!(:answers2) do
+        questions2.map { |question| create :answer, user: user, questionnaire: questionnaire2, question: question }.sort_by { |a| a.question.position }
+      end
+      let!(:answer) { subject.answers.first.answer }
+      let!(:participant2) { answers2.first }
+
+      context "when completion of different questionnaires" do
+        it "returns the participant's completion percentage of two different questionnaires" do
+          expect(subject.completion).to eq(100)
+        end
       end
     end
   end

--- a/decidim-surveys/lib/decidim/surveys/component.rb
+++ b/decidim-surveys/lib/decidim/surveys/component.rb
@@ -151,11 +151,12 @@ Decidim.register_component(:surveys) do |component|
       )
     end
 
-    %w(matrix_single matrix_multiple).each do |matrix_question_type|
+    %w(matrix_single matrix_multiple).each_with_index do |matrix_question_type, index|
       question = Decidim::Forms::Question.create!(
         questionnaire: questionnaire,
         body: Decidim::Faker::Localized.paragraph,
-        question_type: matrix_question_type
+        question_type: matrix_question_type,
+        position: index
       )
 
       3.times do


### PR DESCRIPTION
#### :tophat: What? Why?

Currently, if more than questionnaire is answered by the user with the same session token, results are mix up in the admin answers page, also when exporting in csv o pdf. This is because answers exports are missing the questionnaire constraint.
This also affect the calculations in answer completion, which can reach more than 100% in these cases:
![image](https://user-images.githubusercontent.com/1401520/99777055-0c422800-2b12-11eb-8c74-373b7cdcad04.png)
![image](https://user-images.githubusercontent.com/41389482/99793609-35ba7e00-2b29-11eb-9776-5214a4c84780.png)


Additionally, this PR also fix an error when generating seeds for matrix-type questions, position was missing and exporting in development apps became impossible.


#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to [this PR](https://github.com/Platoniq/decidim-demo/issues/8)

#### Testing
*Describe the best way to test or validate your PR.*

Create two surveys in a participatory space. Answer questions with the same token_session. Check the sum in the admin section.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [X] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
