### PR TITLE
GitHub Action workflow on release triggering decidim/docker build

### DIFF
--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -1,0 +1,18 @@
+name: "On Release"
+on:
+  release:
+    types: [published]
+
+jobs:
+  trigger_docker_build:
+    name: Trigger decidim/docker Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Send Dispatch
+      run: |
+        curl --request POST \
+        --user "decidim-bot:${{ secrets.DOCKER_WORKFLOW_PAT }}" \
+        --header "Accept: application/vnd.github.everest-preview+json" \
+        --header "Content-Type: application/json" \
+        https://api.github.com/repos/decidim/docker/actions/workflows/on_push.yml/dispatches \
+        --data '{"ref": "master"}'


### PR DESCRIPTION
#### :tophat: What? Why?
This PR automates triggering docker image build on decidim/docker on releases, once https://github.com/decidim/docker/pull/50 is merged.

It adds a "On Release" workflow to the existing Github Actions, which sends a Github API request over to decidim/docker repo's own GA workflow in the works, triggering the build there through a [workflow dispatch event handler](https://github.com/oliverbarnes/decidim-docker/blob/publish-image-on-github/.github/workflows/on_push.yml#L4).

This is **currently using a PAT_TOKEN** for authentication across repos, and we'll need to switch to something org-based, maybe a [Github App Token](https://docs.github.com/en/free-pro-team@latest/developers/apps/authenticating-with-github-apps).

Until this is done and https://github.com/decidim/docker/pull/50 is merged, this PR will remain as a Draft, but it is open for review.

#### :pushpin: Related Issues
Closes https://github.com/decidim/docker/issues/51

#### Testing
This was extensively tested by publishing [test releases on my oliverbarnes/decidim fork](https://github.com/oliverbarnes/decidim/releases), using a [tag pointing to this PR's branch](https://github.com/oliverbarnes/decidim/releases/tag/almost_there).

That triggered the build over on oliverbarnes/decidim-docker, where https://github.com/decidim/docker/pull/50 is already merged into that fork's master so the dispatch request finds the workflow.

I'd wait until after merging https://github.com/decidim/docker/pull/50 and this PR to then publish a test release here on decidim/decidim to reproduce the workflow trigger.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

<img width="1117" alt="Screen Shot 2020-11-25 at 12 41 17 PM" src="https://user-images.githubusercontent.com/21290/100229077-95df6480-2f1b-11eb-8193-a56f66eab3a0.png">

<img width="1402" alt="Screen Shot 2020-11-25 at 12 43 49 PM" src="https://user-images.githubusercontent.com/21290/100229291-ed7dd000-2f1b-11eb-83e4-d920b2e1ddd6.png">

