### PR TITLE
[Fix] Add logic in view to prevent visual error in blog post

### DIFF
--- a/decidim-blogs/app/views/decidim/blogs/posts/show.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/posts/show.html.erb
@@ -48,7 +48,7 @@
         </div>
       </div>
   <% end %>
-  <div class="columns mediumlarge-8 mediumlarge-pull-4">
+  <div class="columns mediumlarge-8 <%= "mediumlarge-pull-4" if show_endorsements_card? %>">
     <div class="section">
       <%= decidim_sanitize translated_attribute post.body %>
     </div>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR makes the `mediumlarge-pull-4` class be rendered for the blog post body only if `show_endorsements_card?`, otherwise it pulls the content to the left regardless if the endorsements section is shown.

#### Testing
Visiting a blog post with endorsements disabled.

### :camera: Screenshots

#### Before
![image](https://user-images.githubusercontent.com/8806781/100362447-b848af00-2ffb-11eb-84b2-c744669784c8.png)

#### After
![image](https://user-images.githubusercontent.com/8806781/100362507-c991bb80-2ffb-11eb-962d-e8f1280a1005.png)



:hearts: Thank you!
