### PR TITLE
Improve layout for standalone T&C page

### DIFF
--- a/decidim-core/app/views/decidim/pages/_standalone.html.erb
+++ b/decidim-core/app/views/decidim/pages/_standalone.html.erb
@@ -15,7 +15,9 @@
         </div>
       </div>
 
-      <%= cell "decidim/tos_page", :form %>
+      <div class="columns small-12">
+        <%= cell "decidim/tos_page", :form %>
+      </div>
     </main>
   </div>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?
With the #6716 fix that restored the correct display of the T&C, elements are nested so that the T&C body card is displayed inside a bigger one, resulting in a not-so-pretty visual effect. This PR fixes the nesting so that cards are displayed independently, preventing the card-inside-a-card visual effect.

#### Testing
- Login with a user for the first time to be displayed the standalone T&C page.

### :camera: Screenshots

#### Before 👇🏽 

![Screenshot_2020-11-26 Default title for terms-and-conditions - Schamberger-Daniel(1)](https://user-images.githubusercontent.com/8806781/100368944-838d2580-3004-11eb-9b56-c9ad7c181351.png)

#### After 👇🏽 

![Screenshot_2020-11-26 Default title for terms-and-conditions - Schamberger-Daniel](https://user-images.githubusercontent.com/8806781/100368952-84be5280-3004-11eb-8af4-a0e4fcd85be3.png)

:hearts: Thank you!
