### PR TITLE
Encrypt authorization metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,36 @@ As per [\#6498](https://github.com/decidim/decidim/pull/6498), the comments comp
 
 ### Changed
 
+- **Authorization metadata is now encrypted in the database**
+
+As per [\#6947](https://github.com/decidim/decidim/pull/6947), the JSON values for the authorizations' `metadata` and `verification_metadata` columns in the `decidim_authorizations` database table are now automatically encrypted because they can contain identifiable or sensitive personal information connected to a user account. Storing this data in plain text in the database would be a security risk.
+
+You need to do changes to your code if you have been querying these tables in the past through the `Decidim::Authorization` model as follows:
+
+```ruby
+Decidim::Authorization.where(
+  name: "your_authorization_handler"
+).where("metadata ->> 'gender' = ?", "f").find_each do |authorization|
+  puts "#{authorization.user.name} is a #{authorization.metadata["gender"]}"
+end
+```
+
+The problem with this code is that the data in the `metadata ->> 'gender'` column is now encrypted, so your search would not match any records in the database. Instead, you can do the following:
+
+```ruby
+Decidim::Authorization.where(
+  name: "your_authorization_handler"
+).find_each do |authorization|
+  next unless authorization.metadata["gender"] == "f"
+
+  puts "#{authorization.user.name} is a #{authorization.metadata["gender"]}"
+end
+```
+
+As you notice, when you are accessing the `metadata` or `verification_metadata` columns through the Active Record object, you can utilize the data in plain text. This is because the accessor method for these columns will automatically decrypt the data in the hash object.
+
+This is less performant but it is more secure. Security weighs more.
+
 ### Fixed
 
 ### Removed

--- a/decidim-core/app/models/decidim/authorization.rb
+++ b/decidim-core/app/models/decidim/authorization.rb
@@ -13,6 +13,10 @@ module Decidim
   class Authorization < ApplicationRecord
     include Decidim::Traceable
     include Decidim::HasUploadValidations
+    include Decidim::RecordEncryptor
+
+    encrypt_attribute :metadata, type: :hash
+    encrypt_attribute :verification_metadata, type: :hash
 
     validates_upload :verification_attachment
     mount_uploader :verification_attachment, Decidim::Verifications::AttachmentUploader

--- a/decidim-core/db/migrate/20201127114444_encrypt_authorization_metadatas.rb
+++ b/decidim-core/db/migrate/20201127114444_encrypt_authorization_metadatas.rb
@@ -26,8 +26,9 @@ class EncryptAuthorizationMetadatas < ActiveRecord::Migration[5.2]
   private
 
   def decrypt_hash(hash)
+    # ActiveSupport::JSON.decode(decrypt_value(value))
     hash.transform_values do |value|
-      Decidim::AttributeEncryptor.decrypt(value)
+      ActiveSupport::JSON.decode(Decidim::AttributeEncryptor.decrypt(value))
     rescue ActiveSupport::MessageEncryptor::InvalidMessage
       value
     end

--- a/decidim-core/db/migrate/20201127114444_encrypt_authorization_metadatas.rb
+++ b/decidim-core/db/migrate/20201127114444_encrypt_authorization_metadatas.rb
@@ -26,7 +26,6 @@ class EncryptAuthorizationMetadatas < ActiveRecord::Migration[5.2]
   private
 
   def decrypt_hash(hash)
-    # ActiveSupport::JSON.decode(decrypt_value(value))
     hash.transform_values do |value|
       ActiveSupport::JSON.decode(Decidim::AttributeEncryptor.decrypt(value))
     rescue ActiveSupport::MessageEncryptor::InvalidMessage

--- a/decidim-core/db/migrate/20201127114444_encrypt_authorization_metadatas.rb
+++ b/decidim-core/db/migrate/20201127114444_encrypt_authorization_metadatas.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class EncryptAuthorizationMetadatas < ActiveRecord::Migration[5.2]
+  def up
+    Decidim::Authorization.all.each do |auth|
+      # Re-setting these values will internally convert the hash values to
+      # encypted values
+      auth.update!(
+        metadata: auth.metadata,
+        verification_metadata: auth.verification_metadata
+      )
+    end
+  end
+
+  def down
+    Decidim::Authorization.all.each do |auth|
+      # rubocop:disable Rails/SkipsModelValidations
+      auth.update_columns(
+        metadata: decrypt_hash(auth.metadata),
+        verification_metadata: decrypt_hash(auth.verification_metadata)
+      )
+      # rubocop:enable Rails/SkipsModelValidations
+    end
+  end
+
+  private
+
+  def decrypt_hash(hash)
+    hash.transform_values do |value|
+      Decidim::AttributeEncryptor.decrypt(value)
+    rescue ActiveSupport::MessageEncryptor::InvalidMessage
+      value
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -93,6 +93,7 @@ module Decidim
   autoload :HasUploadValidations, "decidim/has_upload_validations"
   autoload :FileValidatorHumanizer, "decidim/file_validator_humanizer"
   autoload :ShareableWithToken, "decidim/shareable_with_token"
+  autoload :RecordEncryptor, "decidim/record_encryptor"
 
   include ActiveSupport::Configurable
   # Loads seeds from all engines.

--- a/decidim-core/lib/decidim/record_encryptor.rb
+++ b/decidim-core/lib/decidim/record_encryptor.rb
@@ -71,6 +71,7 @@ module Decidim
           end
 
           def #{attribute}=(value)
+            remove_instance_variable(:@#{attribute}_decrypted) if instance_variable_defined?(:@#{attribute}_decrypted)
             encrypted_value = encrypt_#{method_suffix}(value)
 
             if defined?(super)
@@ -102,6 +103,8 @@ module Decidim
     # re-fetched after the save.
     def clear_encrypted_attributes_cache
       self.class.encrypted_attributes.each do |attr|
+        next unless instance_variable_defined?("@#{attr}_decrypted")
+
         remove_instance_variable("@#{attr}_decrypted")
       end
     end

--- a/decidim-core/lib/decidim/record_encryptor.rb
+++ b/decidim-core/lib/decidim/record_encryptor.rb
@@ -21,7 +21,6 @@ module Decidim
       cattr_accessor :encrypted_attributes
 
       before_save :ensure_encrypted_attributes if respond_to?(:before_save)
-      after_save :clear_encrypted_attributes_cache if respond_to?(:after_save)
     end
 
     class_methods do
@@ -93,19 +92,12 @@ module Decidim
     #  record = Example.find(1)
     #  record.metadata["foo"] = "bar"
     #  record.save!
+    #
+    # This will also clear the cached attributes during saving so that next time
+    # they are accessed, they will be updated according to the stored values.
     def ensure_encrypted_attributes
       self.class.encrypted_attributes.each do |attr|
         send("#{attr}=", send(attr))
-      end
-    end
-
-    # This clears the cache after the record is saved so that the values are
-    # re-fetched after the save.
-    def clear_encrypted_attributes_cache
-      self.class.encrypted_attributes.each do |attr|
-        next unless instance_variable_defined?("@#{attr}_decrypted")
-
-        remove_instance_variable("@#{attr}_decrypted")
       end
     end
 

--- a/decidim-core/lib/decidim/record_encryptor.rb
+++ b/decidim-core/lib/decidim/record_encryptor.rb
@@ -104,7 +104,8 @@ module Decidim
     def decrypt_value(value)
       Decidim::AttributeEncryptor.decrypt(value)
     rescue ActiveSupport::MessageEncryptor::InvalidMessage
-      # Support for legacy unencrypted values
+      # Support for legacy unencrypted values. This is necessary e.g. when
+      # migrating the original unencrypted values to encrypted values.
       value
     end
 

--- a/decidim-core/lib/decidim/record_encryptor.rb
+++ b/decidim-core/lib/decidim/record_encryptor.rb
@@ -123,13 +123,16 @@ module Decidim
     def decrypt_hash_values(hash)
       return hash unless hash.is_a?(Hash)
 
-      hash.transform_values { |value| decrypt_value(value) }
+      hash.transform_values { |value| ActiveSupport::JSON.decode(decrypt_value(value)) }
     end
 
     def encrypt_hash_values(hash)
       return hash unless hash.is_a?(Hash)
 
-      hash.transform_values { |value| encrypt_value(value) }
+      # The values are stored in JSON encoded format in order to match the
+      # PostgreSQL adapter's default functionality as you can see at:
+      # https://git.io/JkdYJ
+      hash.transform_values { |value| encrypt_value(ActiveSupport::JSON.encode(value)) }
     end
   end
 end

--- a/decidim-core/lib/decidim/record_encryptor.rb
+++ b/decidim-core/lib/decidim/record_encryptor.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  # A concern that provides attribute encryption e.g. to active record models.
+  #
+  # Use this e.g. in models as follows:
+  #
+  # class Example < ApplicationRecord
+  #   include Decidim::RecordEncryptor
+  #
+  #   encrypt_attribute :name, type: :string
+  #   encrypt_attribute :metadata, type: :hash
+  # end
+  module RecordEncryptor
+    extend ActiveSupport::Concern
+
+    class_methods do
+      # Public: Defines an attribute that should be encrypted
+      def encrypt_attribute(attribute, type:)
+        # Defines the suffix for the encrypt and decrypt methods. E.g. when
+        # the `type` is `:hash`, method `decrypt_hash_values` would be called
+        # for decryption and `encrypt_hash_values` would be called for
+        # encryption.
+        method_suffix = begin
+          case type
+          when :hash
+            "hash_values"
+          else
+            "value"
+          end
+        end
+
+        # Dynamically defines the getter and setter for the encrypted attribute.
+        # E.g. when called as `encrypt_attribute :name, type: :string`, this
+        # would define the following methods:
+        #
+        #   def name
+        #     decrypt_value(super)
+        #   end
+        #
+        #   def name=(value)
+        #     super(encrypt_value(value))
+        #   end
+        class_eval <<-RUBY, __FILE__, __LINE__ + 1
+          def #{attribute}
+            encrypted_value = begin
+              if defined?(super)
+                super
+              elsif instance_variable_defined?(:@#{attribute})
+                @#{attribute}
+              else
+                nil
+              end
+            end
+
+            decrypt_#{method_suffix}(encrypted_value)
+          end
+
+          def #{attribute}=(value)
+            encrypted_value = encrypt_#{method_suffix}(value)
+
+            if defined?(super)
+              super(encrypted_value)
+            else
+              @#{attribute} = encrypted_value
+            end
+          end
+        RUBY
+      end
+    end
+
+    private
+
+    def decrypt_value(value)
+      Decidim::AttributeEncryptor.decrypt(value)
+    rescue ActiveSupport::MessageEncryptor::InvalidMessage
+      # Support for legacy unencrypted values
+      value
+    end
+
+    def encrypt_value(value)
+      Decidim::AttributeEncryptor.encrypt(value)
+    end
+
+    def decrypt_hash_values(hash)
+      return hash unless hash.is_a?(Hash)
+
+      hash.transform_values { |value| decrypt_value(value) }
+    end
+
+    def encrypt_hash_values(hash)
+      return hash unless hash.is_a?(Hash)
+
+      hash.transform_values { |value| encrypt_value(value) }
+    end
+  end
+end

--- a/decidim-core/lib/decidim/record_encryptor.rb
+++ b/decidim-core/lib/decidim/record_encryptor.rb
@@ -60,23 +60,23 @@ module Decidim
           def #{attribute}
             return @#{attribute}_decrypted if instance_variable_defined?(:@#{attribute}_decrypted)
 
-            @#{attribute}_encrypted ||= begin
+            encrypted_value = begin
               if defined?(super)
                 super
               elsif instance_variable_defined?(:@#{attribute})
                 @#{attribute}
               end
             end
-            @#{attribute}_decrypted = decrypt_#{method_suffix}(@#{attribute}_encrypted)
+            @#{attribute}_decrypted = decrypt_#{method_suffix}(encrypted_value)
           end
 
           def #{attribute}=(value)
-            @#{attribute}_encrypted = encrypt_#{method_suffix}(value)
+            encrypted_value = encrypt_#{method_suffix}(value)
 
             if defined?(super)
-              super(@#{attribute}_encrypted)
+              super(encrypted_value)
             else
-              @#{attribute} = @#{attribute}_encrypted
+              @#{attribute} = encrypted_value
             end
           end
         RUBY
@@ -103,7 +103,6 @@ module Decidim
     def clear_encrypted_attributes_cache
       self.class.encrypted_attributes.each do |attr|
         remove_instance_variable("@#{attr}_decrypted")
-        remove_instance_variable("@#{attr}_encrypted")
       end
     end
 

--- a/decidim-core/spec/lib/record_encryptor_spec.rb
+++ b/decidim-core/spec/lib/record_encryptor_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe RecordEncryptor do
+    subject do
+      instance = klass.new
+      instance.name = name
+      instance.year = year
+      instance.coverage = coverage
+      instance.metadata = metadata
+      instance
+    end
+
+    let(:ae) { Decidim::AttributeEncryptor }
+
+    let(:klass) do
+      mod = described_class
+      Class.new do
+        include mod
+
+        attr_accessor :name
+        attr_accessor :year
+        attr_accessor :coverage
+        attr_accessor :metadata
+
+        encrypt_attribute :name, type: :string
+        encrypt_attribute :year, type: :integer
+        encrypt_attribute :coverage, type: :float
+        encrypt_attribute :metadata, type: :hash
+      end
+    end
+
+    let(:name) { "Decidim" }
+    let(:year) { 2016 }
+    let(:coverage) { 87.4 }
+    let(:metadata) { { foo: "bar" } }
+
+    shared_examples_for "encrypted record" do
+      it "returns the unencrypted values for all accessors with correct types" do
+        # If the stored instance values are note encrypted properly, the decrypt
+        # calls would throw an ActiveSupport::MessageEncryptor::InvalidMessage.
+        expect(subject.name).to eq(name)
+        expect(ae.decrypt(subject.instance_variable_get(:@name))).to eq(name)
+        expect(subject.name).to be_instance_of(String)
+        expect(subject.year).to eq(year)
+        expect(ae.decrypt(subject.instance_variable_get(:@year))).to eq(year)
+        expect(subject.year).to be_instance_of(Integer)
+        expect(subject.coverage).to eq(coverage)
+        expect(ae.decrypt(subject.instance_variable_get(:@coverage))).to eq(coverage)
+        expect(subject.coverage).to be_instance_of(Float)
+        expect(subject.metadata).to eq(metadata)
+        expect(
+          ae.decrypt(subject.instance_variable_get(:@metadata)[:foo])
+        ).to eq(metadata[:foo])
+        expect(subject.metadata).to be_instance_of(Hash)
+      end
+    end
+
+    it_behaves_like "encrypted record"
+
+    context "with a superclass responding to the attribute accessors" do
+      let(:superklass) do
+        mod = described_class
+        Class.new do
+          include mod
+
+          attr_accessor :name
+          attr_accessor :year
+          attr_accessor :coverage
+          attr_accessor :metadata
+
+          def original_name
+            @name
+          end
+
+          def original_year
+            @year
+          end
+
+          def original_coverage
+            @coverage
+          end
+
+          def original_metadata
+            @metadata
+          end
+        end
+      end
+
+      let(:klass) do
+        Class.new(superklass) do
+          encrypt_attribute :name, type: :string
+          encrypt_attribute :year, type: :integer
+          encrypt_attribute :coverage, type: :float
+          encrypt_attribute :metadata, type: :hash
+        end
+      end
+
+      it_behaves_like "encrypted record"
+
+      it "encrypts the original values" do
+        # If the values are note encrypted properly, the decrypt calls would
+        # throw an ActiveSupport::MessageEncryptor::InvalidMessage.
+        expect(ae.decrypt(subject.original_name)).to eq(name)
+        expect(ae.decrypt(subject.original_year)).to eq(year)
+        expect(ae.decrypt(subject.original_coverage)).to eq(coverage)
+        expect(ae.decrypt(subject.original_metadata[:foo])).to eq(metadata[:foo])
+      end
+    end
+
+    context "without a superclass and without an instance variable" do
+      subject { klass.new }
+
+      let(:klass) do
+        mod = described_class
+        Class.new do
+          include mod
+
+          encrypt_attribute :name, type: :string
+          encrypt_attribute :year, type: :integer
+          encrypt_attribute :coverage, type: :float
+          encrypt_attribute :metadata, type: :hash
+        end
+      end
+
+      it "returns nil for all getters" do
+        expect(subject.name).to be(nil)
+        expect(subject.year).to be(nil)
+        expect(subject.coverage).to be(nil)
+        expect(subject.metadata).to be(nil)
+      end
+    end
+  end
+end

--- a/decidim-core/spec/lib/record_encryptor_spec.rb
+++ b/decidim-core/spec/lib/record_encryptor_spec.rb
@@ -53,6 +53,15 @@ module Decidim
         ).to eq(ActiveSupport::JSON.encode(metadata[:foo]))
         expect(subject.metadata).to be_instance_of(Hash)
       end
+
+      it "returns the original value when the value is not encrypted" do
+        subject.instance_variable_set(:@name, "Unencrypted")
+
+        # This would throw an ActiveSupport::MessageEncryptor::InvalidMessage
+        # which happens if the decryption fails. This is catched and the
+        # original value is returned instead.
+        expect(subject.name).to eq("Unencrypted")
+      end
     end
 
     it_behaves_like "encrypted record"
@@ -165,7 +174,7 @@ module Decidim
         expect(subject.reference).to be_instance_of(String)
       end
 
-      context "when changing a JSON attribute values directly" do
+      context "when changing JSON attribute values directly" do
         before do
           subject.title[:en] = "Updated title"
           subject.save!

--- a/decidim-core/spec/lib/record_encryptor_spec.rb
+++ b/decidim-core/spec/lib/record_encryptor_spec.rb
@@ -53,7 +53,7 @@ module Decidim
         expect(subject.metadata).to eq(metadata)
         expect(
           ae.decrypt(subject.instance_variable_get(:@metadata)[:foo])
-        ).to eq(metadata[:foo])
+        ).to eq(ActiveSupport::JSON.encode(metadata[:foo]))
         expect(subject.metadata).to be_instance_of(Hash)
       end
     end
@@ -106,7 +106,9 @@ module Decidim
         expect(ae.decrypt(subject.original_name)).to eq(name)
         expect(ae.decrypt(subject.original_year)).to eq(year)
         expect(ae.decrypt(subject.original_coverage)).to eq(coverage)
-        expect(ae.decrypt(subject.original_metadata[:foo])).to eq(metadata[:foo])
+        expect(ae.decrypt(subject.original_metadata[:foo])).to eq(
+          ActiveSupport::JSON.encode(metadata[:foo])
+        )
       end
     end
 

--- a/decidim-core/spec/models/decidim/authorization_spec.rb
+++ b/decidim-core/spec/models/decidim/authorization_spec.rb
@@ -6,6 +6,75 @@ module Decidim
   describe Authorization do
     let(:authorization) { build(:authorization) }
 
+    shared_examples_for "encrypted authorization metadata decryption" do
+      it "encrypts the metadata to the database" do
+        expect(
+          Decidim::AttributeEncryptor.decrypt(database_metadata["foo"])
+        ).to eq(
+          ActiveSupport::JSON.encode(expected_foo)
+        )
+      end
+
+      it "decrypts the final values automatically" do
+        final = Decidim::Authorization.find(authorization.id)
+        data = final.send(authorization_metadata_key)
+        expect(data["foo"]).to eq(expected_foo)
+      end
+    end
+
+    shared_context "with encrypted authorization metadata" do
+      let(:authorization_metadata) { { foo: "bar" } }
+      let!(:authorization) do
+        data = {}
+        data[authorization_metadata_key] = authorization_metadata
+        create(:authorization, authorization_status, data)
+      end
+      let(:database_metadata) do
+        JSON.parse(
+          ActiveRecord::Base.connection.select_one(
+            "SELECT #{authorization_metadata_key} FROM #{described_class.table_name} WHERE id = #{authorization.id}"
+          )[authorization_metadata_key.to_s]
+        )
+      end
+      let(:expected_foo) { "bar" }
+
+      it_behaves_like "encrypted authorization metadata decryption"
+
+      context "when storing with update!" do
+        let(:expected_foo) { "baz" }
+        let(:authorization_metadata) { { foo: "baz" } }
+
+        it_behaves_like "encrypted authorization metadata decryption"
+      end
+
+      context "when storing with attribute update" do
+        let(:expected_foo) { "biz" }
+        let(:authorization_metadata) { { foo: "biz" } }
+
+        before do
+          authorization.send("#{authorization_metadata_key}=", authorization_metadata)
+          authorization.save!
+        end
+
+        it_behaves_like "encrypted authorization metadata decryption"
+      end
+
+      context "when storing with attributes=" do
+        let(:expected_foo) { "buz" }
+        let(:authorization_metadata) { { foo: "buz" } }
+
+        before do
+          attributes = {}
+          attributes[authorization_metadata_key] = authorization_metadata
+
+          authorization.attributes = attributes
+          authorization.save!
+        end
+
+        it_behaves_like "encrypted authorization metadata decryption"
+      end
+    end
+
     it "is valid" do
       expect(authorization).to be_valid
     end
@@ -33,124 +102,16 @@ module Decidim
     end
 
     context "with metadata" do
-      let!(:authorization) { create(:authorization, :granted, metadata: { foo: "bar" }) }
-      let(:database_metadata) do
-        JSON.parse(
-          ActiveRecord::Base.connection.select_one(
-            "SELECT metadata FROM #{described_class.table_name} WHERE id = #{authorization.id}"
-          )["metadata"]
-        )
-      end
-      let(:expected_foo) { "bar" }
-
-      shared_examples_for "encrypted authorization metadata" do
-        it "encrypts the metadata to the database" do
-          expect(
-            Decidim::AttributeEncryptor.decrypt(database_metadata["foo"])
-          ).to eq(
-            ActiveSupport::JSON.encode(expected_foo)
-          )
-        end
-
-        it "decrypts the final values automatically" do
-          final = Decidim::Authorization.find(authorization.id)
-          expect(final.metadata["foo"]).to eq(expected_foo)
-        end
-      end
-
-      it_behaves_like "encrypted authorization metadata"
-
-      context "when storing with update!" do
-        let(:expected_foo) { "baz" }
-
-        before do
-          authorization.update!(metadata: { foo: "baz" })
-        end
-
-        it_behaves_like "encrypted authorization metadata"
-      end
-
-      context "when storing with attribute update" do
-        let(:expected_foo) { "biz" }
-
-        before do
-          authorization.metadata = { foo: "biz" }
-          authorization.save!
-        end
-
-        it_behaves_like "encrypted authorization metadata"
-      end
-
-      context "when storing with attributes=" do
-        let(:expected_foo) { "buz" }
-
-        before do
-          authorization.attributes = { metadata: { foo: "buz" } }
-          authorization.save!
-        end
-
-        it_behaves_like "encrypted authorization metadata"
+      include_context "with encrypted authorization metadata" do
+        let(:authorization_metadata_key) { :metadata }
+        let(:authorization_status) { :granted }
       end
     end
 
     context "with verification metadata" do
-      let!(:authorization) { create(:authorization, :pending, verification_metadata: { foo: "bar" }) }
-      let(:database_metadata) do
-        JSON.parse(
-          ActiveRecord::Base.connection.select_one(
-            "SELECT verification_metadata FROM #{described_class.table_name} WHERE id = #{authorization.id}"
-          )["verification_metadata"]
-        )
-      end
-      let(:expected_foo) { "bar" }
-
-      shared_examples_for "encrypted authorization verification metadata" do
-        it "encrypts the metadata to the database" do
-          expect(
-            Decidim::AttributeEncryptor.decrypt(database_metadata["foo"])
-          ).to eq(
-            ActiveSupport::JSON.encode(expected_foo)
-          )
-        end
-
-        it "decrypts the final values automatically" do
-          final = Decidim::Authorization.find(authorization.id)
-          expect(final.verification_metadata["foo"]).to eq(expected_foo)
-        end
-      end
-
-      it_behaves_like "encrypted authorization verification metadata"
-
-      context "when storing with update!" do
-        let(:expected_foo) { "baz" }
-
-        before do
-          authorization.update!(verification_metadata: { foo: "baz" })
-        end
-
-        it_behaves_like "encrypted authorization verification metadata"
-      end
-
-      context "when storing with attribute update" do
-        let(:expected_foo) { "biz" }
-
-        before do
-          authorization.verification_metadata = { foo: "biz" }
-          authorization.save!
-        end
-
-        it_behaves_like "encrypted authorization verification metadata"
-      end
-
-      context "when storing with attributes=" do
-        let(:expected_foo) { "buz" }
-
-        before do
-          authorization.attributes = { verification_metadata: { foo: "buz" } }
-          authorization.save!
-        end
-
-        it_behaves_like "encrypted authorization verification metadata"
+      include_context "with encrypted authorization metadata" do
+        let(:authorization_metadata_key) { :verification_metadata }
+        let(:authorization_status) { :pending }
       end
     end
   end

--- a/decidim-core/spec/models/decidim/authorization_spec.rb
+++ b/decidim-core/spec/models/decidim/authorization_spec.rb
@@ -31,5 +31,123 @@ module Decidim
         expect(authorization.metadata_cell).to be_kind_of String
       end
     end
+
+    context "with metadata" do
+      let!(:authorization) { create(:authorization, :granted, metadata: { foo: "bar" }) }
+      let(:database_metadata) do
+        JSON.parse(
+          ActiveRecord::Base.connection.select_one(
+            "SELECT metadata FROM #{described_class.table_name} WHERE id = #{authorization.id}"
+          )["metadata"]
+        )
+      end
+      let(:expected_foo) { "bar" }
+
+      shared_examples_for "encrypted authorization metadata" do
+        it "encrypts the metadata to the database" do
+          expect(
+            Decidim::AttributeEncryptor.decrypt(database_metadata["foo"])
+          ).to eq(expected_foo)
+        end
+
+        it "decrypts the final values automatically" do
+          final = Decidim::Authorization.find(authorization.id)
+          expect(final.metadata["foo"]).to eq(expected_foo)
+        end
+      end
+
+      it_behaves_like "encrypted authorization metadata"
+
+      context "when storing with update!" do
+        let(:expected_foo) { "baz" }
+
+        before do
+          authorization.update!(metadata: { foo: "baz" })
+        end
+
+        it_behaves_like "encrypted authorization metadata"
+      end
+
+      context "when storing with attribute update" do
+        let(:expected_foo) { "biz" }
+
+        before do
+          authorization.metadata = { foo: "biz" }
+          authorization.save!
+        end
+
+        it_behaves_like "encrypted authorization metadata"
+      end
+
+      context "when storing with attributes=" do
+        let(:expected_foo) { "buz" }
+
+        before do
+          authorization.attributes = { metadata: { foo: "buz" } }
+          authorization.save!
+        end
+
+        it_behaves_like "encrypted authorization metadata"
+      end
+    end
+
+    context "with verification metadata" do
+      let!(:authorization) { create(:authorization, :pending, verification_metadata: { foo: "bar" }) }
+      let(:database_metadata) do
+        JSON.parse(
+          ActiveRecord::Base.connection.select_one(
+            "SELECT verification_metadata FROM #{described_class.table_name} WHERE id = #{authorization.id}"
+          )["verification_metadata"]
+        )
+      end
+      let(:expected_foo) { "bar" }
+
+      shared_examples_for "encrypted authorization verification metadata" do
+        it "encrypts the metadata to the database" do
+          expect(
+            Decidim::AttributeEncryptor.decrypt(database_metadata["foo"])
+          ).to eq(expected_foo)
+        end
+
+        it "decrypts the final values automatically" do
+          final = Decidim::Authorization.find(authorization.id)
+          expect(final.verification_metadata["foo"]).to eq(expected_foo)
+        end
+      end
+
+      it_behaves_like "encrypted authorization verification metadata"
+
+      context "when storing with update!" do
+        let(:expected_foo) { "baz" }
+
+        before do
+          authorization.update!(verification_metadata: { foo: "baz" })
+        end
+
+        it_behaves_like "encrypted authorization verification metadata"
+      end
+
+      context "when storing with attribute update" do
+        let(:expected_foo) { "biz" }
+
+        before do
+          authorization.verification_metadata = { foo: "biz" }
+          authorization.save!
+        end
+
+        it_behaves_like "encrypted authorization verification metadata"
+      end
+
+      context "when storing with attributes=" do
+        let(:expected_foo) { "buz" }
+
+        before do
+          authorization.attributes = { verification_metadata: { foo: "buz" } }
+          authorization.save!
+        end
+
+        it_behaves_like "encrypted authorization verification metadata"
+      end
+    end
   end
 end

--- a/decidim-core/spec/models/decidim/authorization_spec.rb
+++ b/decidim-core/spec/models/decidim/authorization_spec.rb
@@ -47,7 +47,9 @@ module Decidim
         it "encrypts the metadata to the database" do
           expect(
             Decidim::AttributeEncryptor.decrypt(database_metadata["foo"])
-          ).to eq(expected_foo)
+          ).to eq(
+            ActiveSupport::JSON.encode(expected_foo)
+          )
         end
 
         it "decrypts the final values automatically" do
@@ -106,7 +108,9 @@ module Decidim
         it "encrypts the metadata to the database" do
           expect(
             Decidim::AttributeEncryptor.decrypt(database_metadata["foo"])
-          ).to eq(expected_foo)
+          ).to eq(
+            ActiveSupport::JSON.encode(expected_foo)
+          )
         end
 
         it "decrypts the final values automatically" do

--- a/decidim-verifications/app/commands/decidim/verifications/id_documents/admin/confirm_user_offline_authorization.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/id_documents/admin/confirm_user_offline_authorization.rb
@@ -58,8 +58,8 @@ module Decidim
                                .new(organization: form.current_organization, name: "id_documents", granted: false)
                                .query
                                .where("verification_metadata->'rejected' IS NULL")
-                               .where("verification_metadata->>'verification_type' = 'offline'")
-                               .find_by(user: authorization_user)
+                               .where(user: authorization_user)
+                               .find { |auth| auth.verification_metadata["verification_type"] == "offline" }
           end
 
           def authorization_user

--- a/decidim-verifications/app/controllers/decidim/verifications/id_documents/admin/pending_authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/id_documents/admin/pending_authorizations_controller.rb
@@ -22,7 +22,7 @@ module Decidim
               .new(organization: current_organization, name: "id_documents", granted: false)
               .query
               .where("verification_metadata->'rejected' IS NULL")
-              .where("verification_metadata->>'verification_type' = 'online'")
+              .select { |auth| auth.verification_metadata["verification_type"] == "online" }
           end
 
           def has_offline_method?


### PR DESCRIPTION
#### :tophat: What? Why?
The authorization metadata can contain sensitive personal information and it should be therefore encrypted.

This PR implements a new concern that provides automated encryption for active record attributes so that they will be stored encrypted in the database but when accessed through the code, they are available as plain text.

This is applied to the metadata attributes in the `Decidim::Authorization` record.

The change is transparent and should not affect any Decidim APIs or code relying on the metadata. The only implication to existing code can be if the JSON object has been queried directly through the database. Now that the values are encrypted in the database, these kinds of queries no longer work.

#### Testing
- Create a new authorization from the rails console, e.g. `Decidim::Authorization.create!(name: "testing", metadata: { foo: "bar" }, decidim_user_id: 1, unique_id: "uniqid", granted_at: DateTime.now)`
- Fetch that record and display it in the console to see that the metadata values are encrypted `Decidim::Authorization.last`
- Access the record's metadata in order to verify it is decrypted through the accessor method `Decidim::Authorization.last.metadata`

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.