### PR TITLE
Add time type for settings manifest attributes

### DIFF
--- a/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
@@ -13,7 +13,8 @@ module Decidim
         string: :text_field,
         text: :text_area,
         scope: :scope_field,
-        enum: :collection_radio_buttons
+        enum: :collection_radio_buttons,
+        time: :datetime_field
       }.freeze
 
       # Public: Renders a form field that matches a settings attribute's

--- a/decidim-admin/spec/helpers/settings_helper_spec.rb
+++ b/decidim-admin/spec/helpers/settings_helper_spec.rb
@@ -130,6 +130,15 @@ module Decidim
           render_input
         end
       end
+
+      describe "times" do
+        let(:type) { :time }
+
+        it "is supported" do
+          expect(form).to receive(:datetime_field).with(:test, options)
+          render_input
+        end
+      end
     end
   end
 end

--- a/decidim-core/lib/decidim/settings_manifest.rb
+++ b/decidim-core/lib/decidim/settings_manifest.rb
@@ -95,7 +95,8 @@ module Decidim
         text: { klass: String, default: nil },
         array: { klass: Array, default: [] },
         enum: { klass: String, default: nil },
-        scope: { klass: Integer, default: nil }
+        scope: { klass: Integer, default: nil },
+        time: { klass: Time, default: nil }
       }.freeze
 
       attribute :type, Symbol, default: :boolean


### PR DESCRIPTION
#### :tophat: What? Why?
This PR creates a `:time` attribute type in `SettingsManifest` and sets the corresponding form field type `datetime_field` so the settings are render properly.

#### Testing
- In a component manifest of your choice, add a settings attribute of type `:time`

```ruby
  component.settings(:global do |settings|
    settings.attribute :starts_at, type: :time
  end
```

- Then visit the configuration for an instance of that component in the admin and 

#### :clipboard: Checklist

- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/8806781/100479557-d93dfc80-30ee-11eb-8046-8cebc56e8f27.png)

:hearts: Thank you!
