### PR TITLE
Fix mailer meeting registration invitation using path instead of URL

### DIFF
--- a/decidim-meetings/app/views/decidim/meetings/admin/invite_join_meeting_mailer/invite.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/invite_join_meeting_mailer/invite.html.erb
@@ -4,5 +4,5 @@
   <%= t ".invited_you_to_join_a_meeting", invited_by: @invited_by.name, application: @user.organization.name %>
 </p>
 
-<p><%= link_to t(".decline", meeting_title: present(@meeting).title),routes.decline_invitation_meeting_registration_path(meeting_id: @meeting, participatory_space_id: @meeting.component.participatory_space) %>
+<p><%= link_to t(".decline", meeting_title: present(@meeting).title),routes.decline_invitation_meeting_registration_url(meeting_id: @meeting, participatory_space_id: @meeting.component.participatory_space) %>
 <p><%= link_to t(".join", meeting_title: present(@meeting).title),routes.meeting_registration_url(meeting_id: @meeting, participatory_space_id: @meeting.component.participatory_space) %>


### PR DESCRIPTION
#### :tophat: What? Why?

There's a bug with the Meetings registration invitations, where it's impossible to decline an invitation because the URL is not generated correctly in the mailer. 

#### :pushpin: Related Issues

None

#### Testing

1. Sign in as admin
2. Go to Admin Dashboard -> Participatory Process -> Meetings -> Enable registration in this platform -> Invite a user
3. Go to the email sent to the user 
4. See error

Mind that if you're using Letter Opener is not easy to spot this bug as it's the same URL. When sent to a real mail it breaks, especially in Outlook where the URL isn't generated correctly (see screenshot below)  

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

![imatge](https://user-images.githubusercontent.com/717367/100847333-fb81a280-347f-11eb-87df-57482b3d8c00.png)

:hearts: Thank you!
