### PR TITLE
Fix the data portability exporter when zip is not in the gemfile

### DIFF
--- a/decidim-core/app/services/decidim/data_portability_exporter.rb
+++ b/decidim-core/app/services/decidim/data_portability_exporter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "seven_zip_ruby"
+require "zip"
 require_relative "zip_stream/zip_stream_writer"
 
 module Decidim


### PR DESCRIPTION
#### :tophat: What? Why?
This is the same fix as already applied for the open data exporter in #6464. The problem also affected the data portability export (i.e. exporting all personal data of a user). In environments where the "zip" gem is not explicitly loaded through the Gemfile, as in most Decidim instances, the exporter would not work before.

Note: The fix in #6464 was also backported to 0.23 in #6791, let me know if you'd like me to do this as well for this fix.

I also did a global search for other uses of `Zip`, and the only places that showed up are the `data_portability_exporter`, the `open_data_exporter` and the `file_zipper` which already requires the gem.

#### :pushpin: Related Issues
- Related to #6464 