### PR TITLE
Fix meeting closing issues

### DIFF
--- a/decidim-meetings/app/controllers/decidim/meetings/meeting_closes_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meeting_closes_controller.rb
@@ -23,7 +23,7 @@ module Decidim
         CloseMeeting.call(@form, meeting) do
           on(:ok) do
             flash[:notice] = I18n.t("meetings.close.success", scope: "decidim.meetings.admin")
-            redirect_to meetings_path
+            redirect_to meeting_path(meeting)
           end
 
           on(:invalid) do

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -226,11 +226,11 @@ module Decidim
       end
 
       def has_contributions?
-        contributions_count && contributions_count.positive?
+        !!contributions_count && contributions_count.positive?
       end
 
       def has_attendees?
-        attendees_count && attendees_count.positive?
+        !!attendees_count && attendees_count.positive?
       end
 
       private

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -225,6 +225,14 @@ module Decidim
         registration_type == "on_different_platform"
       end
 
+      def has_contributions?
+        contributions_count && contributions_count.positive?
+      end
+
+      def has_attendees?
+        attendees_count && attendees_count.positive?
+      end
+
       private
 
       def can_participate_in_meeting?(user)

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -55,26 +55,26 @@ edit_link(
         <%= render partial: "decidim/shared/follow_button", locals: { followable: meeting, large: false  } %>
       </div>
       <% if meeting.closed? %>
+        <% double = meeting.has_contributions? && meeting.has_attendees? %>
         <div class="card card--secondary extra definition-data">
-          <% if meeting.contributions_count && meeting.contributions_count.positive? %>
-            <div class="definition-data__item definition-data__item--double">
-              <span class="definition-data__title"><%= t(".attendees") %></span>
-              <span class="definition-data__number"><%= meeting.attendees_count %></span>
-            </div>
-            <div class="definition-data__item definition-data__item--double">
+          <% if meeting.has_contributions? %>
+            <div class="definition-data__item <%= "definition-data__item--double" if double %>">
               <span class="definition-data__title"><%= t(".contributions") %></span>
               <span class="definition-data__number"><%= meeting.contributions_count %></span>
             </div>
-          <% else %>
-            <div class="definition-data__item">
+          <% end %>
+          <% if meeting.has_attendees? %>
+            <div class="definition-data__item <%= "definition-data__item--double" if double %>">
               <span class="definition-data__title"><%= t(".attendees") %></span>
               <span class="definition-data__number"><%= meeting.attendees_count %></span>
             </div>
           <% end %>
-          <div class="definition-data__item">
-            <span class="definition-data__title"><%= t(".organizations") %></span>
-            <span class="definition-data__text"><%= simple_format(meeting.attending_organizations) %></span>
-          </div>
+          <% if meeting.attending_organizations %>
+            <div class="definition-data__item">
+              <span class="definition-data__title"><%= t(".organizations") %></span>
+              <span class="definition-data__text"><%= simple_format(meeting.attending_organizations) %></span>
+            </div>
+          <% end %>
         </div>
       <% end %>
     </div>

--- a/decidim-meetings/spec/models/meeting_spec.rb
+++ b/decidim-meetings/spec/models/meeting_spec.rb
@@ -280,5 +280,41 @@ module Decidim::Meetings
         end
       end
     end
+
+    describe "#has_contributions?" do
+      context "when the meeting has contributions" do
+        let(:meeting) { build :meeting, contributions_count: 10 }
+
+        it "returns true" do
+          expect(subject.has_contributions?).to be true
+        end
+      end
+
+      context "when the meeting does not have contributions" do
+        let(:meeting) { build :meeting }
+
+        it "returns false" do
+          expect(subject.has_contributions?).to be false
+        end
+      end
+    end
+
+    describe "#has_attendees?" do
+      context "when the meeting has attendees" do
+        let(:meeting) { build :meeting, attendees_count: 10 }
+
+        it "returns true" do
+          expect(subject.has_attendees?).to be true
+        end
+      end
+
+      context "when the meeting does not have attendees" do
+        let(:meeting) { build :meeting }
+
+        it "returns false" do
+          expect(subject.has_attendees?).to be false
+        end
+      end
+    end
   end
 end

--- a/decidim-meetings/spec/system/user_close_meeting.rb
+++ b/decidim-meetings/spec/system/user_close_meeting.rb
@@ -48,8 +48,6 @@ describe "User edit meeting", type: :system do
         click_button "Close meeting"
       end
 
-      click_link translated(meeting.title)
-
       expect(page).to have_content(closing_report)
       expect(page).not_to have_content "Close meeting"
       expect(page).not_to have_content "ATTENDEES COUNT"

--- a/decidim-meetings/spec/system/user_close_meeting.rb
+++ b/decidim-meetings/spec/system/user_close_meeting.rb
@@ -52,6 +52,8 @@ describe "User edit meeting", type: :system do
 
       expect(page).to have_content(closing_report)
       expect(page).not_to have_content "Close meeting"
+      expect(page).not_to have_content "ATTENDEES COUNT"
+      expect(page).not_to have_content "ATTENDING ORGANIZATIONS"
       expect(meeting.reload.closed_at).not_to be nil
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes 2 small issues related with the action of closing a meeting:
 1. When a meeting is closed, the right-hand side card would always the meeting stats _titles_ (ATTENDEES COUNT, ATTENDING ORGANIZATIONS) even when the actual numbers were not available (this always happens when a meeting is closed from the public area, where the user cannot add the stats upon meeting closing). FIX: the stats titles are shown only when the corresponding numbers are available.
2. Upon meeting closing (hitting the 'close meeting' button after filling in the meeting closing form), the user was redirected to the meeting list page. FIX: the user is now redirected to the meeting detail page.

#### Testing
1. 
   - As a user, create a meeting from the common area;
   - Close the meeting;
   - _(test)_ Make sure that the card on the righthand side doesn't show "ATTENDEES COUNT" nor "ATTENDING ORGANIZATIONS"

2. 
   - As a user, create a meeting from the common area;
   - Close the meeting;
   - _(test)_ Make sure that you're redirected to the meeting's detail page

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.


### :camera: Screenshots
Closed meeting with attendee count, contribution count and attending organizations
<img width="285" alt="Screenshot 2020-12-02 at 14 35 57" src="https://user-images.githubusercontent.com/5033945/100886613-5208d400-34b4-11eb-868d-c16809eefd1f.png">

Closed meeting with contribution count and attending organizations
<img width="285" alt="Screenshot 2020-12-02 at 14 45 08" src="https://user-images.githubusercontent.com/5033945/100886616-533a0100-34b4-11eb-8d5b-d43b26386259.png">

Closed meeting with attendee count and attending organizations
<img width="285" alt="Screenshot 2020-12-02 at 14 46 05" src="https://user-images.githubusercontent.com/5033945/100886618-53d29780-34b4-11eb-8a8d-44873bfb9453.png">

Closed meeting with only attending organizations
<img width="285" alt="Screenshot 2020-12-02 at 14 46 30" src="https://user-images.githubusercontent.com/5033945/100886622-546b2e00-34b4-11eb-9462-b92143180e1b.png">

Closed meeting with no stats (as when closed from the public area)
<img width="285" alt="Screenshot 2020-12-02 at 14 51 01" src="https://user-images.githubusercontent.com/5033945/100886624-5503c480-34b4-11eb-9ffe-83297c5f6f61.png">


:hearts: Thank you!
