### PR TITLE
Limit moderation tooltips and tables to 250 chars

### DIFF
--- a/decidim-admin/app/views/decidim/admin/moderated_users/_report.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderated_users/_report.html.erb
@@ -4,7 +4,7 @@
   <span
     data-tooltip
     aria-haspopup="true"
-    title="<%= report.details %>">
+    title="<%= report.details&.truncate(250) %>">
       <%= t(".reasons.#{report.reason}") %>
   </span>
 <% end %>

--- a/decidim-admin/app/views/decidim/admin/moderations/_report.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/_report.html.erb
@@ -4,7 +4,7 @@
   <span
     data-tooltip
     aria-haspopup="true"
-    title="<%= report.details %>">
+    title="<%= report.details&.truncate(250) %>">
       <%= t(".reasons.#{report.reason}") %>
   </span>
 <% end %>

--- a/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
@@ -40,7 +40,7 @@
               </td>
               <td>
                 <%=
-                  link_to t("models.moderation.fields.visit_url", scope: "decidim.moderations"), moderation.reportable.reported_content_url, data: { tooltip: true }, aria: { haspopup: true }, title: reported_content_excerpt_for(moderation.reportable)
+                  link_to t("models.moderation.fields.visit_url", scope: "decidim.moderations"), moderation.reportable.reported_content_url, data: { tooltip: true }, aria: { haspopup: true }, title: reported_content_excerpt_for(moderation.reportable, limit: 250)
                 %>
               </td>
               <td>

--- a/decidim-admin/app/views/decidim/admin/moderations/reports/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/reports/index.html.erb
@@ -74,7 +74,7 @@
             <tr data-id="<%= report.id %>">
               <td><%= t("decidim.admin.moderations.report.reasons.#{report.reason}") %></td>
               <td><%= report.locale.present? ? locale_name(report.locale) : "" %></td>
-              <td><%= report.details %></td>
+              <td><%= report.details&.truncate(250) %></td>
               <td class="actions">
                 <%= icon_link_to "fullscreen-enter",
                                   moderation_report_path(moderation_id: moderation, id: report.id),


### PR DESCRIPTION
#### :tophat: What? Why?
Limits the content length of tooltips and excerpts in the moderation panel to 250 chars.

#### Testing
 - From the public area, create a reportable resource with a content content exceeding 250 characters (e.g.: a very long comment);
 - Report the resource, filling the report details with a long explanation (exceeding 250 chars);
 - As an admin, go to the moderation panel of the process the resource belongs to and check that the text of the reported content and the report detail in tooltips and tables are correctly truncated.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
Example of a truncated table:
![image](https://user-images.githubusercontent.com/5033945/100898717-58517d00-34c1-11eb-84b9-f98a681e1fc1.png)

Example of a truncated tooltip:
![image](https://user-images.githubusercontent.com/5033945/100898580-335d0a00-34c1-11eb-9c10-7abb512c7c5d.png)


:hearts: Thank you!
