### PR TITLE
Backport "Fix visible_meeting_for scope if Decidim::Conference is not defined" to v0.23

### DIFF
--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -45,20 +45,16 @@ module Decidim
         (all.distinct if user&.admin?) ||
           if user.present?
             user_role_queries = %w(conference assembly participatory_process).map do |participatory_space_name|
-              # rubocop: disable Style/RedundantBegin
-              begin
-                if "Decidim::#{participatory_space_name.classify}".constantize
-                  "SELECT decidim_components.id FROM decidim_components
-                  WHERE CONCAT(decidim_components.participatory_space_id, '-', decidim_components.participatory_space_type)
-                  IN
-                  (SELECT CONCAT(decidim_#{participatory_space_name}_user_roles.decidim_#{participatory_space_name}_id, '-Decidim::#{participatory_space_name.classify}')
-                  FROM decidim_#{participatory_space_name}_user_roles WHERE decidim_#{participatory_space_name}_user_roles.decidim_user_id = ?)
-                  "
-                end
-              rescue NameError
-                nil
+              spaces = %w(assembly participatory_process)
+              spaces << "conference" if defined?(Decidim::Conference)
+              user_role_queries = spaces.map do |participatory_space_name|
+                "SELECT decidim_components.id FROM decidim_components
+                WHERE CONCAT(decidim_components.participatory_space_id, '-', decidim_components.participatory_space_type)
+                IN
+                (SELECT CONCAT(decidim_#{participatory_space_name}_user_roles.decidim_#{participatory_space_name}_id, '-Decidim::#{participatory_space_name.classify}')
+                FROM decidim_#{participatory_space_name}_user_roles WHERE decidim_#{participatory_space_name}_user_roles.decidim_user_id = ?)
+                "
               end
-              # rubocop: enable Style/RedundantBegin
             end
 
             where("decidim_meetings_meetings.private_meeting = ?

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -44,17 +44,15 @@ module Decidim
       scope :visible_meeting_for, lambda { |user|
         (all.distinct if user&.admin?) ||
           if user.present?
-            user_role_queries = %w(conference assembly participatory_process).map do |participatory_space_name|
-              spaces = %w(assembly participatory_process)
-              spaces << "conference" if defined?(Decidim::Conference)
-              user_role_queries = spaces.map do |participatory_space_name|
-                "SELECT decidim_components.id FROM decidim_components
-                WHERE CONCAT(decidim_components.participatory_space_id, '-', decidim_components.participatory_space_type)
-                IN
-                (SELECT CONCAT(decidim_#{participatory_space_name}_user_roles.decidim_#{participatory_space_name}_id, '-Decidim::#{participatory_space_name.classify}')
-                FROM decidim_#{participatory_space_name}_user_roles WHERE decidim_#{participatory_space_name}_user_roles.decidim_user_id = ?)
-                "
-              end
+            spaces = %w(assembly participatory_process)
+            spaces << "conference" if defined?(Decidim::Conference)
+            user_role_queries = spaces.map do |participatory_space_name|
+              "SELECT decidim_components.id FROM decidim_components
+              WHERE CONCAT(decidim_components.participatory_space_id, '-', decidim_components.participatory_space_type)
+              IN
+              (SELECT CONCAT(decidim_#{participatory_space_name}_user_roles.decidim_#{participatory_space_name}_id, '-Decidim::#{participatory_space_name.classify}')
+              FROM decidim_#{participatory_space_name}_user_roles WHERE decidim_#{participatory_space_name}_user_roles.decidim_user_id = ?)
+              "
             end
 
             where("decidim_meetings_meetings.private_meeting = ?


### PR DESCRIPTION
#### :tophat: What? Why?
In some organizations, the Decidim::Conference is not defined. This PR fix it with checking if Decidim::Conference is defined before generating the subquery on this participatory space

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #6925 
- Fixes #6934 

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

:hearts: Thank you!
