### PR TITLE
Fix private participants pagination crash

### DIFF
--- a/decidim-admin/spec/system/participatory_space_private_user_spec.rb
+++ b/decidim-admin/spec/system/participatory_space_private_user_spec.rb
@@ -8,9 +8,8 @@ describe "Admin checks pagination on participatory space private users", type: :
   let!(:user) { create(:user, :admin, :confirmed, organization: organization) }
   let(:assembly) { create(:assembly, organization: organization) }
 
-
   before do
-    (0..20).each do |i|
+    (0..20).each do |_i|
       user = create :user, organization: organization
       create :assembly_private_user, user: user, privatable_to: assembly
     end

--- a/decidim-admin/spec/system/participatory_space_private_user_spec.rb
+++ b/decidim-admin/spec/system/participatory_space_private_user_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin checks pagination on participatory space private users", type: :system do
+  let(:organization) { create(:organization) }
+
+  let!(:user) { create(:user, :admin, :confirmed, organization: organization) }
+  let(:assembly) { create(:assembly, organization: organization) }
+
+
+  before do
+    (0..20).each do |i|
+      user = create :user, organization: organization
+      create :assembly_private_user, user: user, privatable_to: assembly
+    end
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim_admin_assemblies.edit_assembly_path(assembly)
+    find("a[href*='participatory_space_private_users']").click
+  end
+
+  it "shows private users of the participatory space and changes page correctly" do
+    find("li[class='pagination-next']").click
+  end
+end

--- a/decidim-core/app/helpers/decidim/paginate_helper.rb
+++ b/decidim-core/app/helpers/decidim/paginate_helper.rb
@@ -9,16 +9,7 @@ module Decidim
     # collection - a collection of elements that need to be paginated
     # paginate_params - a Hash with options to delegate to the pagination helper.
     def decidim_paginate(collection, paginate_params = {})
-      # Kaminari uses url_for to generate the url, but this doesn't play nice with our engine system
-      # and unless we remove these params they are added again as query string :(
-      default_params = {
-        participatory_process_slug: nil,
-        assembly_slug: nil,
-        initiative_slug: nil,
-        component_id: nil
-      }
-
-      paginate collection, theme: "decidim", params: paginate_params.merge(default_params)
+      paginate collection, theme: "decidim", params: paginate_params
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Remove default params hash to avoid crashes when paginating private participants pages.
The problem is that the hash of default_params initializes all the parameters of the participatory spaces to null, causing it to subsequently not be able to generate the paging links correctly

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*
To execute the test, more than 20 private participants must be generated in a participatory space. Accessing the private participants section is when the error previously appeared. Now is working correctly

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*

:hearts: Thank you!