### PR TITLE
Backport "Fix editor image alt tag" to 0.23

### DIFF
--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -80,6 +80,29 @@ describe "Admin manages organization", type: :system do
           )["innerHTML"]).to eq(terms_content.gsub("\n", ""))
         end
       end
+
+      context "when the admin terms of use content has an image with an alt tag" do
+        let(:another_organization) { create(:organization) }
+        let(:image) { create(:attachment, attached_to: another_organization) }
+        let(:organization) do
+          create(
+            :organization,
+            admin_terms_of_use_body: Decidim::Faker::Localized.localized { terms_content }
+          )
+        end
+        let(:terms_content) do
+          <<~HTML
+            <p>Paragraph</p>
+            <p><img src="#{image.url}" alt="foo bar"></p>
+          HTML
+        end
+
+        it "renders an image and its attributes inside the editor" do
+          expect(find(
+            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+          )["innerHTML"]).to eq(terms_content.gsub("\n", ""))
+        end
+      end
     end
   end
 

--- a/decidim-core/app/assets/javascripts/decidim/editor.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/editor.js.es6
@@ -2,7 +2,7 @@
 // = require_self
 
 ((exports) => {
-  const quillFormats = ["bold", "italic", "link", "underline", "header", "list", "video"];
+  const quillFormats = ["bold", "italic", "link", "underline", "header", "list", "video", "image", "alt"];
 
   const createQuillEditor = (container) => {
     const toolbar = $(container).data("toolbar");


### PR DESCRIPTION
#### :tophat: What? Why?
Backports the fix from #6920 to 0.23.

#### :pushpin: Related Issues
- Related to #6920

#### Testing
Add an img tag manually to the content and reload the page that shows the editor.

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.