### PR TITLE
Fix duplicated error in datetime_fields

### DIFF
--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -372,7 +372,7 @@ module Decidim
         options.merge(data: data)
       )
       help_text = I18n.t("decidim.datepicker.help_text", datepicker_format: datepicker_format)
-      template += error_and_help_text(attribute, options.merge(help_text: help_text))
+      template += content_tag(:span, help_text, class: "help-text")
       template.html_safe
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
When you create a form with a pair of dates, for example, meetings, and this dates are:
end_time <= start_time , the validation error was duplicated in frontend.

The change is remove call to `error_and_help_text`  because `text_field` put errors too. So, when date was wrong, the validation errors was put twice.

#### :pushpin: Related Issues
- Related to ticket -> https://3.basecamp.com/4186608/buckets/11242950/todos/3165973090
- Fixes #?

#### Testing

Steps to test:
1. Go to admin panel.
2. Processes
3. Select a participatory process
4. Go to componentes -> meetings
5. Create a new meeting.
6. Complete the form where  end_time <= start_time.
7. Now, the validation error must show once.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
Error
![Before](https://user-images.githubusercontent.com/75725233/101771175-d0372d00-3ae9-11eb-9dfa-32cb4f245bd9.png)
Fix
![Now](https://user-images.githubusercontent.com/75725233/101771221-e1803980-3ae9-11eb-9ff6-bde37ccc4a2d.png)


:hearts: Thank you!
