### PR TITLE
Add some missing i18n keys

### DIFF
--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -91,6 +91,8 @@ en:
         name: Name
         organization: Organization
         plural: Plural
+      settings:
+        scope_id: Scope
       static_page:
         allow_public_access: Allow access without authentication
         changed_notably: There have been noticeable changes.

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -61,10 +61,13 @@ en:
         full_name: Full name
         gender: Gender
         position: Position
+        user_id: User
       assembly_user_role:
         email: Email
         name: Name
         role: Role
+      assemblies_setting:
+        enable_organization_chart: Enable organization chart
     errors:
       models:
         assembly:

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -2,6 +2,8 @@
 en:
   activemodel:
     attributes:
+      assemblies_setting:
+        enable_organization_chart: Enable organization chart
       assembly:
         area_id: Area
         assembly_type: Assembly type
@@ -66,8 +68,6 @@ en:
         email: Email
         name: Name
         role: Role
-      assemblies_setting:
-        enable_organization_chart: Enable organization chart
     errors:
       models:
         assembly:

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -405,11 +405,12 @@ module Decidim
     def upload(attribute, options = {})
       self.multipart = true
       options[:optional] = options[:optional].nil? ? true : options[:optional]
-      alt_text = label_for(attribute)
+      label_text = options[:label] || label_for(attribute)
+      alt_text = label_text
 
       file = object.send attribute
       template = ""
-      template += label(attribute, label_for(attribute) + required_for_attribute(attribute))
+      template += label(attribute, label_text + required_for_attribute(attribute))
       template += upload_help(attribute, options)
       template += @template.file_field @object_name, attribute
 


### PR DESCRIPTION
#### :tophat: What? Why?
We got a report of some missing i18n keys. This PR adds them so they can be properly translated.

#### :pushpin: Related Issues
None

#### Testing
None

### :camera: Screenshots
This Pr fixes these:

In newsletters:
![image](https://user-images.githubusercontent.com/491891/102498627-82d33680-407a-11eb-80f0-65833e66ef35.png)

In assemblies config:
![image](https://user-images.githubusercontent.com/491891/102498656-8961ae00-407a-11eb-9d65-b4aa442aee46.png)

In assembly members:
![image](https://user-images.githubusercontent.com/491891/102498670-8ff02580-407a-11eb-903d-e7905ae35cbd.png)

In component settings:
![image](https://user-images.githubusercontent.com/491891/102498687-967e9d00-407a-11eb-8dd0-5105d52ab197.png)


:hearts: Thank you!
