### PR TITLE
Fix proposals admin form when editing

### DIFF
--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
@@ -13,6 +13,14 @@ module Decidim
         validates :title, :body, translatable_presence: true
 
         validate :notify_missing_attachment_if_errored
+
+        def map_model(model)
+          super(model)
+          presenter = ProposalPresenter.new(model)
+
+          self.title = presenter.title(all_locales: title.is_a?(Hash))
+          self.body = presenter.body(all_locales: body.is_a?(Hash))
+        end
       end
     end
   end

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
@@ -5,11 +5,11 @@
 
   <div class="card-section">
     <div class="row column hashtags__container">
-      <%= form.translated :text_field, :title, class: "js-hashtags", value: form_presenter.title(extras: false).strip, hashtaggable: true %>
+      <%= form.translated :text_field, :title, autofocus: true, class: "js-hashtags", hashtaggable: true %>
     </div>
 
     <div class="row column hashtags__container">
-      <%= form.translated :editor, :body, hashtaggable: true, value: form_presenter.body(extras: false).strip %>
+      <%= form.translated :editor, :body, hashtaggable: true %>
     </div>
 
     <% if @form.component_automatic_hashtags.any? %>


### PR DESCRIPTION
#### :tophat: What? Why?

When editing an official proposal fromt he admin there was no title or body content in the input fields, this fixes it.

#### :pushpin: Related Issues

- Fixes #7031 

#### Testing

Edit an official proposal from the admin, the title and body input should have the content of the proposal.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
