### PR TITLE
Allow selecting multiple files on gallery forms

### DIFF
--- a/decidim-admin/app/views/decidim/admin/shared/_gallery.html.erb
+++ b/decidim-admin/app/views/decidim/admin/shared/_gallery.html.erb
@@ -15,7 +15,7 @@
     <% end %>
 
     <div class="row column">
-      <%= form.file_field :add_photos, multiple: false, label: t(".add_images") %>
+      <%= form.file_field :add_photos, multiple: true, label: t(".add_images") %>
     </div>
   </fieldset>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?
@microstudi's original code in https://github.com/decidim/decidim/pull/5339/files#diff-34c27143672764d3e3dd567259750f423d06af9e0435d0cd0c02c0e9d194646dR90 allowed selecting multiple files when uploading images to a gallery. But when @agustibr extracted that code to be able to reuse it, he removed the multiple selection feature (see https://github.com/decidim/decidim/pull/5809/files#diff-748a0de7b9618b6d7715b74a3b7e6903883a9843aec2a18cf3a68e05f48f76c0R18)

This PR reallows users to select multiple files from a Gallery form (in budgets, for example).

#### :pushpin: Related Issues

- Related to #5339 and #5809)


#### Testing
Manually check that you can select multiple files.

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/491891/102770006-b916fb80-4383-11eb-8be8-7bac203d5889.png)

:hearts: Thank you!
