### PR TITLE
Fix initiative edit

### DIFF
--- a/decidim-initiatives/app/forms/decidim/initiatives/initiative_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/initiative_form.rb
@@ -52,6 +52,38 @@ module Decidim
         @area_updatable ||= current_user.admin? || context.initiative.created?
       end
 
+      # Public: Returns a collection of photo attachments.
+      #
+      # We need this method because when an initiative has documents and there's a
+      # validation error in any other field the view template can't render if
+      # they aren't a collection of attachments but they would be a collection
+      # of String.
+      def documents
+        @documents = super.map do |document|
+          if document.is_a?(String)
+            Decidim::Attachment.find(document)
+          else
+            document
+          end
+        end
+      end
+
+      # Public: Returns a collection of photo attachments.
+      #
+      # We need this method because when an initiative has photos and there's a
+      # validation error in any other field the view template can't render if
+      # they aren't a collection of attachments but they would be a collection
+      # of String.
+      def photos
+        @photos = super.map do |photo|
+          if photo.is_a?(String)
+            Decidim::Attachment.find(photo)
+          else
+            photo
+          end
+        end
+      end
+
       def scope_id
         return nil if initiative_type.only_global_scope_enabled?
 


### PR DESCRIPTION
#### :tophat: What? Why?

When editing an initiative from the public side, if there was any validation error and the initiative had attachments an error was raised.

This is because the form is submitting the data as an array of strings with the IDs of the attachments, like `["553", "532"]`. When the view tried to render this it crashed becase `"532"` is a String instead of a `Decidim::Attachment`

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

![image](https://user-images.githubusercontent.com/5254/102917274-38d8bf00-4485-11eb-8759-d7de24e0c33a.png)


:hearts: Thank you!
