### PR TITLE
Notify users when their comments are voted

### DIFF
--- a/decidim-comments/app/commands/decidim/comments/vote_comment.rb
+++ b/decidim-comments/app/commands/decidim/comments/vote_comment.rb
@@ -53,11 +53,9 @@ module Decidim
           event: "decidim.events.comments.comment_#{upvote? ? "upvoted" : "downvoted"}",
           event_class: upvote? ? Decidim::Comments::CommentUpvotedEvent : Decidim::Comments::CommentDownvotedEvent,
           resource: @comment.commentable,
-          affected_users: [@author],
-          followers: [@comment.author],
+          affected_users: [@comment.author],
           extra: {
             comment_id: @comment.id,
-            author_id: @author.id,
             weight: @weight,
             downvotes: @comment.down_votes.count,
             upvotes: @comment.up_votes.count

--- a/decidim-comments/app/commands/decidim/comments/vote_comment.rb
+++ b/decidim-comments/app/commands/decidim/comments/vote_comment.rb
@@ -58,7 +58,9 @@ module Decidim
           extra: {
             comment_id: @comment.id,
             author_id: @author.id,
-            weight: @weight
+            weight: @weight,
+            downvotes: @comment.down_votes.count,
+            upvotes: @comment.up_votes.count
           }
         )
       end

--- a/decidim-comments/app/commands/decidim/comments/vote_comment.rb
+++ b/decidim-comments/app/commands/decidim/comments/vote_comment.rb
@@ -50,8 +50,8 @@ module Decidim
 
       def notify_comment_author
         Decidim::EventsManager.publish(
-          event: "decidim.events.comments.comment_voted",
-          event_class: Decidim::Comments::CommentVotedEvent,
+          event: "decidim.events.comments.comment_#{upvote? ? "upvoted" : "downvoted"}",
+          event_class: upvote? ? Decidim::Comments::CommentUpvotedEvent : Decidim::Comments::CommentDownvotedEvent,
           resource: @comment.commentable,
           affected_users: [@author],
           followers: [@comment.author],
@@ -61,6 +61,12 @@ module Decidim
             weight: @weight
           }
         )
+      end
+
+      private
+
+      def upvote?
+        @weight.positive?
       end
     end
   end

--- a/decidim-comments/app/commands/decidim/comments/vote_comment.rb
+++ b/decidim-comments/app/commands/decidim/comments/vote_comment.rb
@@ -52,7 +52,7 @@ module Decidim
         Decidim::EventsManager.publish(
           event: "decidim.events.comments.comment_voted",
           event_class: Decidim::Comments::CommentVotedEvent,
-          resource: @comment,
+          resource: @comment.commentable,
           affected_users: [@author],
           followers: [@comment.author],
           extra: {

--- a/decidim-comments/app/commands/decidim/comments/vote_comment.rb
+++ b/decidim-comments/app/commands/decidim/comments/vote_comment.rb
@@ -41,9 +41,25 @@ module Decidim
         else
           return broadcast(:invalid)
         end
+        notify_comment_author
         broadcast(:ok, @comment)
       rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
         broadcast(:invalid)
+      end
+
+      def notify_comment_author
+        Decidim::EventsManager.publish(
+          event: "decidim.events.comments.vote",
+          event_class: Decidim::Comments::CommentVotedEvent,
+          resource: @comment,
+          affected_users: [@author],
+          followers: [@comment.author],
+          extra: {
+            comment_id: @comment.id,
+            author_id: @author.id,
+            weight: @weight
+          }
+        )
       end
     end
   end

--- a/decidim-comments/app/events/decidim/comments/comment_downvoted_event.rb
+++ b/decidim-comments/app/events/decidim/comments/comment_downvoted_event.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Comments
+    class CommentDownvotedEvent < Decidim::Events::SimpleEvent
+      include Decidim::Comments::CommentEvent
+
+      delegate :author, to: :comment_vote
+
+      private
+
+      def comment_vote
+        @comment_vote ||= Decidim::Comments::CommentVote.find_by(decidim_comment_id: extra[:comment_id], decidim_author_id: extra[:author_id])
+      end
+
+      def resource_url_params
+        { anchor: "comment_#{comment.id}" }
+      end
+    end
+  end
+end

--- a/decidim-comments/app/events/decidim/comments/comment_downvoted_event.rb
+++ b/decidim-comments/app/events/decidim/comments/comment_downvoted_event.rb
@@ -2,20 +2,7 @@
 
 module Decidim
   module Comments
-    class CommentDownvotedEvent < Decidim::Events::SimpleEvent
-      include Decidim::Comments::CommentEvent
-
-      delegate :author, to: :comment_vote
-
-      private
-
-      def comment_vote
-        @comment_vote ||= Decidim::Comments::CommentVote.find_by(decidim_comment_id: extra[:comment_id], decidim_author_id: extra[:author_id])
-      end
-
-      def resource_url_params
-        { anchor: "comment_#{comment.id}" }
-      end
+    class CommentDownvotedEvent < Decidim::Comments::CommentVotedEvent
     end
   end
 end

--- a/decidim-comments/app/events/decidim/comments/comment_upvoted_event.rb
+++ b/decidim-comments/app/events/decidim/comments/comment_upvoted_event.rb
@@ -2,17 +2,13 @@
 
 module Decidim
   module Comments
-    class CommentVotedEvent < Decidim::Events::SimpleEvent
+    class CommentUpvotedEvent < Decidim::Events::SimpleEvent
       include Decidim::Comments::CommentEvent
 
       delegate :author, to: :comment_vote
 
-      def upvote?
-        extra[:weight].positive?
-      end
-
       private
-      
+
       def comment_vote
         @comment_vote ||= Decidim::Comments::CommentVote.find_by(decidim_comment_id: extra[:comment_id], decidim_author_id: extra[:author_id])
       end

--- a/decidim-comments/app/events/decidim/comments/comment_upvoted_event.rb
+++ b/decidim-comments/app/events/decidim/comments/comment_upvoted_event.rb
@@ -2,20 +2,7 @@
 
 module Decidim
   module Comments
-    class CommentUpvotedEvent < Decidim::Events::SimpleEvent
-      include Decidim::Comments::CommentEvent
-
-      delegate :author, to: :comment_vote
-
-      private
-
-      def comment_vote
-        @comment_vote ||= Decidim::Comments::CommentVote.find_by(decidim_comment_id: extra[:comment_id], decidim_author_id: extra[:author_id])
-      end
-
-      def resource_url_params
-        { anchor: "comment_#{comment.id}" }
-      end
+    class CommentUpvotedEvent < Decidim::Comments::CommentVotedEvent
     end
   end
 end

--- a/decidim-comments/app/events/decidim/comments/comment_voted_event.rb
+++ b/decidim-comments/app/events/decidim/comments/comment_voted_event.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Comments
+    class CommentVotedEvent < Decidim::Events::SimpleEvent
+      include Decidim::Comments::CommentEvent
+
+      i18n_attributes :upvotes
+      i18n_attributes :downvotes
+
+      def upvotes
+        extra[:upvotes]
+      end
+
+      def downvotes
+        extra[:downvotes]
+      end
+
+      private
+
+      def comment_vote
+        @comment_vote ||= Decidim::Comments::CommentVote.find_by(decidim_comment_id: extra[:comment_id], decidim_author_id: extra[:author_id])
+      end
+
+      def resource_url_params
+        { anchor: "comment_#{comment.id}" }
+      end
+    end
+  end
+end

--- a/decidim-comments/app/events/decidim/comments/comment_voted_event.rb
+++ b/decidim-comments/app/events/decidim/comments/comment_voted_event.rb
@@ -4,6 +4,18 @@ module Decidim
   module Comments
     class CommentVotedEvent < Decidim::Events::SimpleEvent
       include Decidim::Comments::CommentEvent
+
+      delegate :author, to: :comment_vote
+
+      private
+
+      def comment_vote
+        @comment_vote ||= Decidim::Comments::CommentVote.find_by(decidim_comment_id: extra[:comment_id], decidim_author_id: extra[:author_id])
+      end
+
+      def resource_url_params
+        { anchor: "comment_#{comment.id}" }
+      end
     end
   end
 end

--- a/decidim-comments/app/events/decidim/comments/comment_voted_event.rb
+++ b/decidim-comments/app/events/decidim/comments/comment_voted_event.rb
@@ -7,8 +7,12 @@ module Decidim
 
       delegate :author, to: :comment_vote
 
-      private
+      def upvote?
+        extra[:weight].positive?
+      end
 
+      private
+      
       def comment_vote
         @comment_vote ||= Decidim::Comments::CommentVote.find_by(decidim_comment_id: extra[:comment_id], decidim_author_id: extra[:author_id])
       end

--- a/decidim-comments/app/events/decidim/comments/comment_voted_event.rb
+++ b/decidim-comments/app/events/decidim/comments/comment_voted_event.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Comments
+    class CommentVotedEvent < Decidim::Events::SimpleEvent
+      include Decidim::Comments::CommentEvent
+    end
+  end
+end

--- a/decidim-comments/app/events/decidim/comments/comment_voted_event.rb
+++ b/decidim-comments/app/events/decidim/comments/comment_voted_event.rb
@@ -18,10 +18,6 @@ module Decidim
 
       private
 
-      def comment_vote
-        @comment_vote ||= Decidim::Comments::CommentVote.find_by(decidim_comment_id: extra[:comment_id], decidim_author_id: extra[:author_id])
-      end
-
       def resource_url_params
         { anchor: "comment_#{comment.id}" }
       end

--- a/decidim-comments/config/locales/en.yml
+++ b/decidim-comments/config/locales/en.yml
@@ -105,15 +105,15 @@ en:
           email_subject: There is a new comment from %{author_name} in %{resource_title}
           notification_title: There is a new comment from <a href="%{author_path}">%{author_name} %{author_nickname}</a> in <a href="%{resource_path}">%{resource_title}</a>
         comment_downvoted:
-          email_intro: Your comment in %{resource_title} has been downvoted by %{author_name}.
+          email_intro: Your comment in "%{resource_title}" has been downvoted. It now has a total of %{upvotes} upvotes and %{downvotes} downvotes.
           email_outro: You have received this notification because you are the author of this comment.
-          email_subject: "%{author_name} downvoted your comment in %{resource_title}"
-          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> downvoted your <a href="%{resource_path}">comment</a> in %{resource_title}
+          email_subject: Your comment in "%{resource_title}" has been downvoted.
+          notification_title: Your <a href="%{resource_path}">comment</a> in "%{resource_title}" has been downvoted. It now has a total of %{upvotes} upvotes and %{downvotes} downvotes.
         comment_upvoted:
-          email_intro: Your comment in %{resource_title} has been upvoted by %{author_name}.
+          email_intro: Your comment in "%{resource_title}" has been upvoted. It now has a total of %{upvotes} upvotes and %{downvotes} downvotes.
           email_outro: You have received this notification because you are the author of this comment.
-          email_subject: "%{author_name} upvoted your comment in %{resource_title}"
-          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> upvoted your <a href="%{resource_path}">comment</a> in %{resource_title}
+          email_subject: Your comment in "%{resource_title}" has been upvoted.
+          notification_title: Your <a href="%{resource_path}">comment</a> in "%{resource_title}" has been upvoted. It now has a total of %{upvotes} upvotes and %{downvotes} downvotes.
         reply_created:
           email_intro: "%{author_name} has replied your comment in %{resource_title}. You can read it in this page:"
           email_outro: You have received this notification because your comment was replied.

--- a/decidim-comments/config/locales/en.yml
+++ b/decidim-comments/config/locales/en.yml
@@ -104,6 +104,11 @@ en:
           email_outro: You have received this notification because you are following "%{resource_title}" or its author. You can unfollow it from the previous link.
           email_subject: There is a new comment from %{author_name} in %{resource_title}
           notification_title: There is a new comment from <a href="%{author_path}">%{author_name} %{author_nickname}</a> in <a href="%{resource_path}">%{resource_title}</a>
+        comment_voted:
+          email_intro: Your comment in %{resource_title} has been voted by %{author_name}.
+          email_outro: You have received this notification because you are the author of this comment.
+          email_subject: "%{author_name} voted your comment in %{resource_title}"
+          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> voted your <a href="%{resource_path}">comment</a> in %{resource_title}
         reply_created:
           email_intro: "%{author_name} has replied your comment in %{resource_title}. You can read it in this page:"
           email_outro: You have received this notification because your comment was replied.

--- a/decidim-comments/config/locales/en.yml
+++ b/decidim-comments/config/locales/en.yml
@@ -104,11 +104,16 @@ en:
           email_outro: You have received this notification because you are following "%{resource_title}" or its author. You can unfollow it from the previous link.
           email_subject: There is a new comment from %{author_name} in %{resource_title}
           notification_title: There is a new comment from <a href="%{author_path}">%{author_name} %{author_nickname}</a> in <a href="%{resource_path}">%{resource_title}</a>
-        comment_voted:
-          email_intro: Your comment in %{resource_title} has been voted by %{author_name}.
+        comment_downvoted:
+          email_intro: Your comment in %{resource_title} has been downvoted by %{author_name}.
           email_outro: You have received this notification because you are the author of this comment.
-          email_subject: "%{author_name} voted your comment in %{resource_title}"
-          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> voted your <a href="%{resource_path}">comment</a> in %{resource_title}
+          email_subject: "%{author_name} downvoted your comment in %{resource_title}"
+          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> downvoted your <a href="%{resource_path}">comment</a> in %{resource_title}
+        comment_upvoted:
+          email_intro: Your comment in %{resource_title} has been upvoted by %{author_name}.
+          email_outro: You have received this notification because you are the author of this comment.
+          email_subject: "%{author_name} upvoted your comment in %{resource_title}"
+          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> upvoted your <a href="%{resource_path}">comment</a> in %{resource_title}
         reply_created:
           email_intro: "%{author_name} has replied your comment in %{resource_title}. You can read it in this page:"
           email_outro: You have received this notification because your comment was replied.

--- a/decidim-comments/lib/decidim/comments/test.rb
+++ b/decidim-comments/lib/decidim/comments/test.rb
@@ -2,3 +2,4 @@
 
 require "decidim/comments/test/shared_examples/create_comment_context"
 require "decidim/comments/test/shared_examples/comment_event"
+require "decidim/comments/test/shared_examples/comment_voted_event"

--- a/decidim-comments/lib/decidim/comments/test/shared_examples/comment_voted_event.rb
+++ b/decidim-comments/lib/decidim/comments/test/shared_examples/comment_voted_event.rb
@@ -13,15 +13,21 @@ shared_examples_for "a comment voted event" do
   let(:comment_vote_author) { comment_vote.author }
   let(:comment_author) { comment.author }
 
-  let(:extra) { { comment_id: comment.id, author_id: comment_vote_author.id, weight: weight } }
+  let(:extra) { { comment_id: comment.id, author_id: comment_vote_author.id, weight: weight, downvotes: 100, upvotes: 999 } }
   let(:resource_title) { decidim_html_escape(translated(resource.title)) }
   let(:resource_text) { subject.resource_text }
 
   let(:verb) { weight.positive? ? "upvoted" : "downvoted" }
 
-  describe "author" do
-    it "returns the comment vote author" do
-      expect(subject.author).to eq(comment_vote_author)
+  describe "downvotes" do
+    it "outputs the total downvotes" do
+      expect(subject.downvotes).to eq(100)
+    end
+  end
+
+  describe "upvotes" do
+    it "outputs the total upvotes" do
+      expect(subject.upvotes).to eq(999)
     end
   end
 
@@ -33,13 +39,13 @@ shared_examples_for "a comment voted event" do
 
   describe "email_subject" do
     it "is generated correctly" do
-      expect(subject.email_subject).to eq("#{comment_vote_author.name} #{verb} your comment in #{resource_title}")
+      expect(subject.email_subject).to eq("Your comment in \"#{resource_title}\" has been #{verb}.")
     end
   end
 
   describe "email_intro" do
     it "is generated correctly" do
-      expect(subject.email_intro).to eq("Your comment in #{resource_title} has been #{verb} by #{comment_vote_author.name}.")
+      expect(subject.email_intro).to eq("Your comment in \"#{resource_title}\" has been #{verb}. It now has a total of 999 upvotes and 100 downvotes.")
     end
   end
 
@@ -53,10 +59,9 @@ shared_examples_for "a comment voted event" do
   describe "notification_title" do
     it "is generated correctly" do
       expect(subject.notification_title)
-        .to include("<a href=\"/profiles/#{comment_vote_author.nickname}\">#{comment_vote_author.name} @#{comment_vote_author.nickname}</a>")
-
+        .to include("Your <a href=\"#{resource_path}#comment_#{comment.id}\">comment</a> in \"#{resource_title}\" has been #{verb}")
       expect(subject.notification_title)
-        .to include("#{verb} your <a href=\"#{resource_path}#comment_#{comment.id}\">comment</a> in #{resource_title}")
+        .to include("It now has a total of 999 upvotes and 100 downvotes.")
     end
   end
 end

--- a/decidim-comments/lib/decidim/comments/test/shared_examples/comment_voted_event.rb
+++ b/decidim-comments/lib/decidim/comments/test/shared_examples/comment_voted_event.rb
@@ -10,7 +10,6 @@ shared_examples_for "a comment voted event" do
   let(:comment) { create :comment }
   let(:comment_vote) { create :comment_vote, comment: comment }
   let(:comment_vote_author) { comment_vote.author }
-  let(:comment_author) { comment.author }
 
   let(:extra) { { comment_id: comment.id, author_id: comment_vote_author.id, weight: weight, downvotes: 100, upvotes: 999 } }
   let(:resource_title) { decidim_html_escape(translated(resource.title)) }

--- a/decidim-comments/lib/decidim/comments/test/shared_examples/comment_voted_event.rb
+++ b/decidim-comments/lib/decidim/comments/test/shared_examples/comment_voted_event.rb
@@ -4,7 +4,6 @@ require "spec_helper"
 
 shared_examples_for "a comment voted event" do
   include_context "when it's a comment event"
-  # it_behaves_like "a simple event"
 
   let(:resource) { comment.commentable }
 

--- a/decidim-comments/lib/decidim/comments/test/shared_examples/comment_voted_event.rb
+++ b/decidim-comments/lib/decidim/comments/test/shared_examples/comment_voted_event.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-shared_examples "a comment voted event" do
+shared_examples_for "a comment voted event" do
   include_context "when it's a comment event"
   # it_behaves_like "a simple event"
 

--- a/decidim-comments/lib/decidim/comments/test/shared_examples/comment_voted_event.rb
+++ b/decidim-comments/lib/decidim/comments/test/shared_examples/comment_voted_event.rb
@@ -2,10 +2,9 @@
 
 require "spec_helper"
 
-describe Decidim::Comments::CommentVotedEvent do
+shared_examples "a comment voted event" do
   include_context "when it's a comment event"
-
-  let(:event_name) { "decidim.events.comments.comment_voted" }
+  # it_behaves_like "a simple event"
 
   let(:resource) { comment.commentable }
 
@@ -15,11 +14,10 @@ describe Decidim::Comments::CommentVotedEvent do
   let(:comment_author) { comment.author }
 
   let(:extra) { { comment_id: comment.id, author_id: comment_vote_author.id, weight: weight } }
-  let(:weight) { 1 }
   let(:resource_title) { decidim_html_escape(translated(resource.title)) }
   let(:resource_text) { subject.resource_text }
 
-  it_behaves_like "a simple event"
+  let(:verb) { weight.positive? ? "upvoted" : "downvoted" }
 
   describe "author" do
     it "returns the comment vote author" do
@@ -35,13 +33,13 @@ describe Decidim::Comments::CommentVotedEvent do
 
   describe "email_subject" do
     it "is generated correctly" do
-      expect(subject.email_subject).to eq("#{comment_vote_author.name} voted your comment in #{resource_title}")
+      expect(subject.email_subject).to eq("#{comment_vote_author.name} #{verb} your comment in #{resource_title}")
     end
   end
 
   describe "email_intro" do
     it "is generated correctly" do
-      expect(subject.email_intro).to eq("Your comment in #{resource_title} has been voted by #{comment_vote_author.name}.")
+      expect(subject.email_intro).to eq("Your comment in #{resource_title} has been #{verb} by #{comment_vote_author.name}.")
     end
   end
 
@@ -58,23 +56,7 @@ describe Decidim::Comments::CommentVotedEvent do
         .to include("<a href=\"/profiles/#{comment_vote_author.nickname}\">#{comment_vote_author.name} @#{comment_vote_author.nickname}</a>")
 
       expect(subject.notification_title)
-        .to include("voted your <a href=\"#{resource_path}#comment_#{comment.id}\">comment</a> in #{resource_title}")
-    end
-  end
-
-  describe "upvote?" do
-    context "when weight is positive" do
-      let(:weight) { 1 }
-      it "returns true" do
-        expect(subject.upvote?).to eq(true)
-      end
-    end
-
-    context "when weight is negative" do
-      let(:weight) { -1 }
-      it "returns false" do
-        expect(subject.upvote?).to eq(false)
-      end
+        .to include("#{verb} your <a href=\"#{resource_path}#comment_#{comment.id}\">comment</a> in #{resource_title}")
     end
   end
 end

--- a/decidim-comments/spec/commands/vote_comment_spec.rb
+++ b/decidim-comments/spec/commands/vote_comment_spec.rb
@@ -63,7 +63,7 @@ module Decidim
             expect(Decidim::EventsManager)
               .to receive(:publish)
               .with(
-                event: "decidim.events.comments.vote",
+                event: "decidim.events.comments.comment_voted",
                 event_class: Decidim::Comments::CommentVotedEvent,
                 resource: kind_of(Comment),
                 affected_users: [author],

--- a/decidim-comments/spec/commands/vote_comment_spec.rb
+++ b/decidim-comments/spec/commands/vote_comment_spec.rb
@@ -59,22 +59,48 @@ module Decidim
         end
 
         describe "sending notification" do
-          it "notifies the comment author" do
-            expect(Decidim::EventsManager)
-              .to receive(:publish)
-              .with(
-                event: "decidim.events.comments.comment_voted",
-                event_class: Decidim::Comments::CommentVotedEvent,
-                resource: commentable,
-                affected_users: [author],
-                followers: [comment.author],
-                extra: {
-                  comment_id: comment.id,
-                  author_id: author.id,
-                  weight: weight
-                }
-              )
-            command.call
+          context "when weight is positive" do
+            let(:weight) { 1 }
+
+            it "notifies the comment author of upvote event" do
+              expect(Decidim::EventsManager)
+                .to receive(:publish)
+                .with(
+                  event: "decidim.events.comments.comment_upvoted",
+                  event_class: Decidim::Comments::CommentUpvotedEvent,
+                  resource: commentable,
+                  affected_users: [author],
+                  followers: [comment.author],
+                  extra: {
+                    comment_id: comment.id,
+                    author_id: author.id,
+                    weight: weight
+                  }
+                )
+              command.call
+            end
+          end
+
+          context "when weight is negative" do
+            let(:weight) { -1 }
+
+            it "notifies the comment author of downvote event" do
+              expect(Decidim::EventsManager)
+                .to receive(:publish)
+                .with(
+                  event: "decidim.events.comments.comment_downvoted",
+                  event_class: Decidim::Comments::CommentDownvotedEvent,
+                  resource: commentable,
+                  affected_users: [author],
+                  followers: [comment.author],
+                  extra: {
+                    comment_id: comment.id,
+                    author_id: author.id,
+                    weight: weight
+                  }
+                )
+              command.call
+            end
           end
         end
 

--- a/decidim-comments/spec/commands/vote_comment_spec.rb
+++ b/decidim-comments/spec/commands/vote_comment_spec.rb
@@ -74,7 +74,9 @@ module Decidim
                   extra: {
                     comment_id: comment.id,
                     author_id: author.id,
-                    weight: weight
+                    weight: weight,
+                    upvotes: comment.up_votes.count + 1,
+                    downvotes: comment.down_votes.count
                   }
                 )
               command.call
@@ -96,7 +98,9 @@ module Decidim
                   extra: {
                     comment_id: comment.id,
                     author_id: author.id,
-                    weight: weight
+                    weight: weight,
+                    upvotes: comment.up_votes.count,
+                    downvotes: comment.down_votes.count + 1
                   }
                 )
               command.call

--- a/decidim-comments/spec/commands/vote_comment_spec.rb
+++ b/decidim-comments/spec/commands/vote_comment_spec.rb
@@ -69,11 +69,9 @@ module Decidim
                   event: "decidim.events.comments.comment_upvoted",
                   event_class: Decidim::Comments::CommentUpvotedEvent,
                   resource: commentable,
-                  affected_users: [author],
-                  followers: [comment.author],
+                  affected_users: [comment.author],
                   extra: {
                     comment_id: comment.id,
-                    author_id: author.id,
                     weight: weight,
                     upvotes: comment.up_votes.count + 1,
                     downvotes: comment.down_votes.count
@@ -93,11 +91,9 @@ module Decidim
                   event: "decidim.events.comments.comment_downvoted",
                   event_class: Decidim::Comments::CommentDownvotedEvent,
                   resource: commentable,
-                  affected_users: [author],
-                  followers: [comment.author],
+                  affected_users: [comment.author],
                   extra: {
                     comment_id: comment.id,
-                    author_id: author.id,
                     weight: weight,
                     upvotes: comment.up_votes.count,
                     downvotes: comment.down_votes.count + 1

--- a/decidim-comments/spec/commands/vote_comment_spec.rb
+++ b/decidim-comments/spec/commands/vote_comment_spec.rb
@@ -65,7 +65,7 @@ module Decidim
               .with(
                 event: "decidim.events.comments.comment_voted",
                 event_class: Decidim::Comments::CommentVotedEvent,
-                resource: kind_of(Comment),
+                resource: commentable,
                 affected_users: [author],
                 followers: [comment.author],
                 extra: {

--- a/decidim-comments/spec/events/decidim/comments/comment_downvoted_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/comment_downvoted_event_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Comments::CommentDownvotedEvent do
+  let(:event_name) { "decidim.events.comments.comment_downvoted" }
+  let(:weight) { -1 }
+
+  it_behaves_like "a comment voted event"
+end

--- a/decidim-comments/spec/events/decidim/comments/comment_upvoted_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/comment_upvoted_event_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Comments::CommentUpvotedEvent do
+  let(:event_name) { "decidim.events.comments.comment_upvoted" }
+  let(:weight) { 1 }
+
+  it_behaves_like "a comment voted event"
+end

--- a/decidim-comments/spec/events/decidim/comments/comment_voted_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/comment_voted_event_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Comments::CommentVotedEvent do
+  include_context "when it's a comment event"
+
+  let(:event_name) { "decidim.events.comments.comment_voted" }
+
+  let(:resource) { comment.commentable }
+
+  let(:comment) { create :comment }
+  let(:comment_vote) { create :comment_vote, comment: comment }
+  let(:comment_vote_author) { comment_vote.author }
+  let(:comment_author) { comment.author }
+
+  let(:extra) { { comment_id: comment.id, author_id: comment_vote_author.id, weight: 1 } }
+  let(:resource_title) { decidim_html_escape(translated(resource.title)) }
+  let(:resource_text) { subject.resource_text }
+
+  it_behaves_like "a simple event"
+
+  describe "author" do
+    it "returns the comment vote author" do
+      expect(subject.author).to eq(comment_vote_author)
+    end
+  end
+
+  describe "resource_text" do
+    it "outputs the comment body" do
+      expect(subject.resource_text).to eq comment.formatted_body
+    end
+  end
+
+  describe "email_subject" do
+    it "is generated correctly" do
+      expect(subject.email_subject).to eq("#{comment_vote_author.name} voted your comment in #{resource_title}")
+    end
+  end
+
+  describe "email_intro" do
+    it "is generated correctly" do
+      expect(subject.email_intro).to eq("Your comment in #{resource_title} has been voted by #{comment_vote_author.name}.")
+    end
+  end
+
+  describe "email_outro" do
+    it "is generated correctly" do
+      expect(subject.email_outro)
+        .to eq("You have received this notification because you are the author of this comment.")
+    end
+  end
+
+  describe "notification_title" do
+    it "is generated correctly" do
+      expect(subject.notification_title)
+        .to include("<a href=\"/profiles/#{comment_vote_author.nickname}\">#{comment_vote_author.name} @#{comment_vote_author.nickname}</a>")
+
+      expect(subject.notification_title)
+        .to include("voted your <a href=\"#{resource_path}#comment_#{comment.id}\">comment</a> in #{resource_title}")
+    end
+  end
+end

--- a/decidim-comments/spec/events/decidim/comments/comment_voted_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/comment_voted_event_spec.rb
@@ -14,7 +14,8 @@ describe Decidim::Comments::CommentVotedEvent do
   let(:comment_vote_author) { comment_vote.author }
   let(:comment_author) { comment.author }
 
-  let(:extra) { { comment_id: comment.id, author_id: comment_vote_author.id, weight: 1 } }
+  let(:extra) { { comment_id: comment.id, author_id: comment_vote_author.id, weight: weight } }
+  let(:weight) { 1 }
   let(:resource_title) { decidim_html_escape(translated(resource.title)) }
   let(:resource_text) { subject.resource_text }
 
@@ -58,6 +59,22 @@ describe Decidim::Comments::CommentVotedEvent do
 
       expect(subject.notification_title)
         .to include("voted your <a href=\"#{resource_path}#comment_#{comment.id}\">comment</a> in #{resource_title}")
+    end
+  end
+
+  describe "upvote?" do
+    context "when weight is positive" do
+      let(:weight) { 1 }
+      it "returns true" do
+        expect(subject.upvote?).to eq(true)
+      end
+    end
+
+    context "when weight is negative" do
+      let(:weight) { -1 }
+      it "returns false" do
+        expect(subject.upvote?).to eq(false)
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds a new notification to be sent to the author of a comment when the comment has been voted up or down.

#### :pushpin: Related Issues
- Related to MetaDecidim proposal [\#15874](https://meta.decidim.org/processes/roadmap/f/122/proposals/15874)

#### Testing
- Create a comment with User A
- Vote that comment up or down with User B
- Visit notifications page for User A
- Check that a "comment voted event" notification appears

#### :clipboard: Checklist
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.
- [x] Generate single notification that gives information about total upvotes and dowvotes on that comment. With text `Your comment on %{resource title} has been %{upvoted/downvoted}. It now has a total of %{n} upvotes and %{n} downvotes`

### :camera: Screenshots
#### Email notification
![Email notification](https://user-images.githubusercontent.com/8806781/104916908-fbd3ef80-5992-11eb-954d-90dff92c9027.png)


#### Web notification
![Web notification](https://user-images.githubusercontent.com/8806781/104916385-486afb00-5992-11eb-8116-2ee03c2dab6e.png)



:hearts: Thank you!
