### PR TITLE
Vote verification client

### DIFF
--- a/decidim-elections/app/assets/config/decidim_elections_manifest.js
+++ b/decidim-elections/app/assets/config/decidim_elections_manifest.js
@@ -1,4 +1,5 @@
 //= link decidim/elections/trustee_zone/key_ceremony.js
 //= link decidim/elections/trustee_zone.js
 //= link decidim/elections/vote.js
+//= link decidim/elections/vote_verify.js
 //= link_tree ../images/decidim

--- a/decidim-elections/app/assets/javascripts/decidim/elections/trustee_zone/key_ceremony.js.es6
+++ b/decidim-elections/app/assets/javascripts/decidim/elections/trustee_zone/key_ceremony.js.es6
@@ -85,6 +85,7 @@ $(() => {
           }
         }
       });
+      window.keyCeremony = keyCeremony;
 
       $startButton.on("click", async () => {
         $startButton.prop("disabled", true);

--- a/decidim-elections/app/assets/javascripts/decidim/elections/vote_verify.js.es6
+++ b/decidim-elections/app/assets/javascripts/decidim/elections/vote_verify.js.es6
@@ -2,7 +2,7 @@
 /* eslint no-unused-vars: ["error", { "args": "none" }] */
 // = require decidim-bulletin_board
 $(() => {
-  const { Voter } = decidimBulletinBoard;
+  const { Client } = decidimBulletinBoard;
   const $voteVerifyWrapper = $(".vote-verify-wrapper");
   const $verifySubmitButton = $voteVerifyWrapper.find("a.focus__next.confirm");
 

--- a/decidim-elections/app/assets/javascripts/decidim/elections/vote_verify.js.es6
+++ b/decidim-elections/app/assets/javascripts/decidim/elections/vote_verify.js.es6
@@ -1,9 +1,8 @@
 /* eslint-disable require-jsdoc, prefer-template, func-style, id-length, no-use-before-define, init-declarations, no-invalid-this */
 /* eslint no-unused-vars: ["error", { "args": "none" }] */
 // = require decidim-bulletin_board
-console.log("verify vote")
 $(() => {
-  const { Voter, Client } = decidimBulletinBoard;
+  const { Voter } = decidimBulletinBoard;
   const $voteVerifyWrapper = $(".vote-verify-wrapper");
   const $verifySubmitButton = $voteVerifyWrapper.find("a.focus__next.confirm");
 
@@ -41,7 +40,6 @@ $(() => {
   }
 
   $verifySubmitButton.on("click", (event) => {
-    console.log('click on $verifySubmitButton')
     event.preventDefault();
     verifyVoteIdentifier();
   });

--- a/decidim-elections/app/assets/javascripts/decidim/elections/vote_verify.js.es6
+++ b/decidim-elections/app/assets/javascripts/decidim/elections/vote_verify.js.es6
@@ -1,6 +1,7 @@
 /* eslint-disable require-jsdoc, prefer-template, func-style, id-length, no-use-before-define, init-declarations, no-invalid-this */
 /* eslint no-unused-vars: ["error", { "args": "none" }] */
-// = require decidim-bulletin_board
+// = require decidim/bulletin_board/decidim-bulletin_board
+
 $(() => {
   const { Client } = decidimBulletinBoard;
   const $voteVerifyWrapper = $(".vote-verify-wrapper");

--- a/decidim-elections/app/assets/javascripts/decidim/elections/vote_verify.js.es6
+++ b/decidim-elections/app/assets/javascripts/decidim/elections/vote_verify.js.es6
@@ -1,0 +1,72 @@
+/* eslint-disable require-jsdoc, prefer-template, func-style, id-length, no-use-before-define, init-declarations, no-invalid-this */
+/* eslint no-unused-vars: ["error", { "args": "none" }] */
+// = require decidim-bulletin_board
+console.log("verify vote")
+$(() => {
+  const { Voter, Client } = decidimBulletinBoard;
+  const $voteVerifyWrapper = $(".vote-verify-wrapper");
+  const $verifySubmitButton = $voteVerifyWrapper.find("a.focus__next.confirm");
+
+  let $formData = $voteVerifyWrapper.find(".vote-identifier");
+
+  function initStep() {
+    toggleVerifyButton();
+    onVoteIdentifierChange();
+  }
+
+  initStep()
+
+  function onVoteIdentifierChange() {
+    $formData.on("keyup input", (event) => {
+      toggleVerifyButton();
+      hideSuccessCallout();
+      hideErrorCallout();
+    });
+  }
+
+  function toggleVerifyButton() {
+    if ($formData.val().length > 5) {
+      $($verifySubmitButton).removeClass("disabled")
+    } else {
+      $($verifySubmitButton).addClass("disabled")
+    }
+  }
+
+  function hideSuccessCallout() {
+    $voteVerifyWrapper.find(".verify-vote-success").addClass("hide");
+  }
+
+  function hideErrorCallout() {
+    $voteVerifyWrapper.find(".verify-vote-error").addClass("hide");
+  }
+
+  $verifySubmitButton.on("click", (event) => {
+    console.log('click on $verifySubmitButton')
+    event.preventDefault();
+    verifyVoteIdentifier();
+  });
+
+  function verifyVoteIdentifier() {
+    const bulletinBoardClient = new Client({
+      apiEndpointUrl: $voteVerifyWrapper.data("apiEndpointUrl"),
+      wsEndpointUrl: $voteVerifyWrapper.data("websocketUrl")
+    });
+
+    bulletinBoardClient.getLogEntry({
+      electionUniqueId: $voteVerifyWrapper.data("electionUniqueId"),
+      contentHash: $formData.val()
+    }).then((result) => {
+      if (result) {
+        hideErrorCallout();
+        $voteVerifyWrapper.find(".verify-vote-success").removeClass("hide");
+      } else {
+        hideSuccessCallout();
+        $voteVerifyWrapper.find(".verify-vote-error").removeClass("hide");
+      }
+    })
+  }
+
+  $(document).on("on.zf.toggler", (event) => {
+    initStep()
+  });
+});

--- a/decidim-elections/app/controllers/decidim/elections/votes_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/votes_controller.rb
@@ -31,6 +31,10 @@ module Decidim
         end
       end
 
+      def verify
+        @form = form(Ballot::VerifyVoteForm).instance(election: election)
+      end
+
       private
 
       def booth_mode

--- a/decidim-elections/app/forms/decidim/elections/ballot/verify_vote_form.rb
+++ b/decidim-elections/app/forms/decidim/elections/ballot/verify_vote_form.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Elections
+    module Ballot
+      # This class holds the data to verify a vote.
+      class VerifyVoteForm < Decidim::Form
+        attribute :vote_identifier, String
+
+        validates :vote_identifier, :election, presence: true
+
+        delegate :id, to: :election, prefix: true
+
+        def election_unique_id
+          @election_unique_id ||= Decidim::BulletinBoard::MessageIdentifier.unique_election_id(bulletin_board.authority_slug, election_id)
+        end
+
+        # Public: returns the associated election for the vote.
+        def election
+          @election ||= context.election
+        end
+
+        def bulletin_board
+          @bulletin_board ||= context[:bulletin_board] || Decidim::Elections.bulletin_board
+        end
+      end
+    end
+  end
+end

--- a/decidim-elections/app/views/decidim/elections/elections/show.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/show.html.erb
@@ -54,6 +54,14 @@ edit_link(
         <span class="button disabled"><%= t(".vote") %></span>
       <% end %>
 
+      <% if election.ongoing? || election.finished? %>
+        <%= link_to verify_election_vote_path(election.id), class: "title-action__action button secondary small" do %>
+          <%= t(".verify") %>
+        <% end %>
+      <% else %>
+        <span class="button disabled"><%= t(".verify") %></span>
+      <% end %>
+
       <% if allowed_to? :preview, :election, election: election %>
         <%= link_to new_election_vote_path(election.id), class: "button" do %>
           <%= t(".preview") %>

--- a/decidim-elections/app/views/decidim/elections/elections/show.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/show.html.erb
@@ -47,7 +47,7 @@ edit_link(
       <%= decidim_sanitize(simple_format(translated_attribute(election.description))) %>
 
       <% if election.published? && election.ongoing? %>
-        <%= action_authorized_link_to :vote, new_election_vote_path(election.id), resource: election, class: "title-action__action button small" do %>
+        <%= action_authorized_link_to :vote, new_election_vote_path(election), resource: election, class: "title-action__action button small" do %>
           <%= t(".vote") %>
         <% end %>
       <% else %>
@@ -55,7 +55,7 @@ edit_link(
       <% end %>
 
       <% if election.ongoing? || election.finished? %>
-        <%= link_to verify_election_vote_path(election.id), class: "title-action__action button secondary small" do %>
+        <%= link_to verify_election_vote_path(election), class: "title-action__action button secondary small" do %>
           <%= t(".verify") %>
         <% end %>
       <% else %>
@@ -63,7 +63,7 @@ edit_link(
       <% end %>
 
       <% if allowed_to? :preview, :election, election: election %>
-        <%= link_to new_election_vote_path(election.id), class: "button" do %>
+        <%= link_to new_election_vote_path(election), class: "button" do %>
           <%= t(".preview") %>
         <% end %>
       <% end %>

--- a/decidim-elections/app/views/decidim/elections/votes/_election_votes_confirmed.html.erb
+++ b/decidim-elections/app/views/decidim/elections/votes/_election_votes_confirmed.html.erb
@@ -31,7 +31,7 @@
       <div class="evote__content">
         <%= t("decidim.elections.votes.confirmed.text", e_vote_poll_id: encrypted_vote_hash).html_safe %>
         <p>
-          <%= t("decidim.elections.votes.confirmed.verify_text").html_safe %>
+          <%= t("decidim.elections.votes.confirmed.verify_link", link: verify_election_vote_path(election)).html_safe %>
         </p>
       </div>
 

--- a/decidim-elections/app/views/decidim/elections/votes/verify.html.erb
+++ b/decidim-elections/app/views/decidim/elections/votes/verify.html.erb
@@ -1,0 +1,79 @@
+<div class="vote-verify-wrapper"
+  data-election-id="<%= election.id %>"
+  data-api-endpoint-url="<%= Rails.application.secrets.bulletin_board[:server] %>"
+  data-websocket-url="<%= Rails.application.secrets.bulletin_board[:websocket_url] %>"
+  data-election-unique-id="<%= @form.election_unique_id %>">
+
+  <div class="focus__header">
+    <div class="row">
+      <div class="focus__steps">
+        <strong>
+          <%= t("decidim.elections.votes.verify.header.title") %>
+        </strong>
+      </div>
+
+      <div class="heading5 focus__header-title">
+        <%= translated_attribute(election.title) %>
+      </div>
+    </div>
+  </div>
+
+  <div class="focus__content evote">
+    <div class="row">
+      <h1 class="heading2">
+        <%= t("decidim.elections.votes.verify.content.heading") %>
+      </h1>
+
+      <p>
+        <%= t("decidim.elections.votes.verify.content.info") %>
+      </p>
+
+      <div class="evote__content">
+        <div class="verify-vote-success hide callout success">
+          <h2 class="heading4">
+            <%= t("decidim.elections.votes.verify.success.header") %>
+          </h2>
+
+          <p>
+            <%== t("decidim.elections.votes.verify.success.info", link: link_to(translated_attribute(election.title), election_path(election))) %>
+          </p>
+        </div>
+
+        <div class="verify-vote-error hide callout alert">
+          <h2 class="heading4">
+            <%= t("decidim.elections.votes.verify.error.header") %>
+          </h2>
+
+          <p>
+            <%== t("decidim.elections.votes.verify.error.info", link: link_to(translated_attribute(election.title), election_path(election))) %>
+          </p>
+        </div>
+
+        <form class="form">
+          <label>
+            <%= t("decidim.elections.votes.verify.form.vote_identifier") %>
+
+            <input type="text" class="vote-identifier" name="vote-identifier" data-value="qw12Sf35vVb556Hfvh7qw12Sf35vVb556Hfvh7">
+          </label>
+          <div>
+            <%= link_to(
+              "#",
+              class: "button focus__next confirm",
+              data: {
+                booth_mode: booth_mode
+              }
+            ) do %>
+
+              <%= t("decidim.elections.votes.verify.form.submit") %>
+            <% end %>
+          </div>
+
+          <%= link_to(t("decidim.elections.votes.verify.form.back"), election_path(election)) %>
+        </form>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<%= javascript_include_tag("decidim/elections/vote_verify") %>

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -425,7 +425,7 @@ en:
           header: Vote confirmed
           lead: Your vote has already been cast!
           text: 'You can check that your vote has been successfully added to the ballot box with the following identifier: <strong class="evote__poll-id">%{e_vote_poll_id}</strong>'
-          verify_text: To check it, copy the identifier and paste it on the <a href="evote-verify">vote verification page</a>
+          verify_link: To check it, copy the identifier and paste it on the <a href="%{link}">vote verification page</a>
         encrypting:
           header: Encoding vote...
           text: Your vote is being encrypted to ensure you can cast it anonymously.

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -295,6 +295,7 @@ en:
         show:
           back: Available elections
           preview: Preview
+          verify: Verify
           vote: Vote
           voting_period_status:
             finished: Voting began on %{start_time} and ended on %{end_time}
@@ -451,6 +452,22 @@ en:
         processing:
           header: Processing vote...
           text: Your vote has been received and it is being processing. Please wait.
+        verify:
+          content:
+            heading: Verify your vote
+            info: This verifier checks that your vote, identified with an encrypted text string, has been cast correctly and is inside the ballot box.
+          error:
+            header: Vote not found!
+            info: The vote code was not found in the %{link} ballot box, try again.
+          form:
+            back: Back to Decidim
+            submit: Check
+            vote_identifier: 'Identifier code:'
+          header:
+            title: Verify your vote
+          success:
+            header: Vote located!
+            info: Your encrypted vote is in the %{link} ballot box
         voting_step:
           back: Back
           continue: Next

--- a/decidim-elections/lib/decidim/elections/engine.rb
+++ b/decidim-elections/lib/decidim/elections/engine.rb
@@ -17,6 +17,7 @@ module Decidim
 
           resource :vote, only: [:new] do
             post :cast
+            get :verify
           end
         end
 

--- a/decidim-elections/spec/forms/decidim/elections/ballot/verify_vote_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/elections/ballot/verify_vote_form_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Elections::Ballot::VerifyVoteForm do
+  subject { described_class.from_params(params).with_context(context) }
+
+  let(:params) do
+    {
+      vote_identifier: "f149b928f7a00eae7e634fc5db0c3cc5531eefb81f49febce8da5bb4a153548b"
+    }
+  end
+  let(:context) do
+    {
+      election: election
+    }
+  end
+  let(:election) { create(:election) }
+
+  context "when everything is fine" do
+    it { is_expected.to be_valid }
+  end
+
+  context "when the vote identifier is not present" do
+    let(:params) do
+      {
+        vote_identifier: ""
+      }
+    end
+
+    it { is_expected.to be_invalid }
+  end
+
+  context "when the election is not present" do
+    let(:context) { {} }
+
+    it { is_expected.to be_invalid }
+  end
+
+  describe ".election_unique_id" do
+    it "returns the election unique id" do
+      expect(subject.election_unique_id).to eq("decidim-test-authority.#{election.id}")
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR implements the verification client for participants.

With the unique vote identifier, that the participant has once the vote is cast, can enter this identifier to verify the vote is in the ballot. 

#### :pushpin: Related Issues

- Fixes #5975

#### Testing

_The election should be ongoing or finished_

1. go to the election details, there click on the verify button:  
  <img width="757" alt="Screenshot 2020-12-23 at 11 34 28" src="https://user-images.githubusercontent.com/210216/102987587-dd551280-4512-11eb-9849-9956937bc6b4.png">
2. A page is rendered with an input to introduce the vote identifier:
  <img width="881" alt="Screenshot 2020-12-22 at 16 37 13" src="https://user-images.githubusercontent.com/210216/102905915-26a25500-4474-11eb-9fbc-d972574dc97b.png">
  <img width="880" alt="Screenshot 2020-12-22 at 16 37 35" src="https://user-images.githubusercontent.com/210216/102905943-2d30cc80-4474-11eb-8b57-1e484fed615d.png">
3. If the identifier is not found a red alert will be shown:  
  <img width="879" alt="Screenshot 2020-12-22 at 16 37 51" src="https://user-images.githubusercontent.com/210216/102905959-35890780-4474-11eb-8464-f707723fb903.png">
4. If it succeeds a green callout is shown:  
  <img width="1096" alt="Screenshot 2020-12-23 at 11 32 12" src="https://user-images.githubusercontent.com/210216/102987470-a3840c00-4512-11eb-8abc-c6422cb0392b.png">

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots




:hearts: Thank you!
