### PR TITLE
Quickfix bug in seeds for 0.23-stable

### DIFF
--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -178,7 +178,7 @@ if !Rails.env.production? || ENV["SEED"]
         email: Faker::Internet.email,
         confirmed_at: Time.current,
         extended_data: {
-          document_number: Faker::Number.number(10),
+          document_number: Faker::Number.number(10).to_s,
           phone: Faker::PhoneNumber.phone_number,
           verified_at: verified_at
         },


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes bug in seeds due to `document_number: Faker::Number.number(10)` in [decidim-core/db/seeds.rb](https://github.com/decidim/decidim/pull/7061/files) not being a string

#### :pushpin: Related Issues
- Fixes #7057 

#### Testing
*Describe the best way to test or validate your PR.*
`rails db:seed`

:hearts: Thank you!
