### PR TITLE
Fix space private user in process admin

### DIFF
--- a/decidim-participatory_processes/app/permissions/decidim/participatory_processes/permissions.rb
+++ b/decidim-participatory_processes/app/permissions/decidim/participatory_processes/permissions.rb
@@ -233,6 +233,7 @@ module Decidim
           :process,
           :process_step,
           :process_user_role,
+          :space_private_user,
           :export_space,
           :import
         ].include?(permission_action.subject)

--- a/decidim-participatory_processes/spec/permissions/decidim/participatory_processes/permissions_spec.rb
+++ b/decidim-participatory_processes/spec/permissions/decidim/participatory_processes/permissions_spec.rb
@@ -396,6 +396,7 @@ describe Decidim::ParticipatoryProcesses::Permissions do
       it_behaves_like "allows any action on subject", :process
       it_behaves_like "allows any action on subject", :process_step
       it_behaves_like "allows any action on subject", :process_user_role
+      it_behaves_like "allows any action on subject", :space_private_user
     end
 
     context "when user is an org admin" do

--- a/decidim-participatory_processes/spec/system/admin/invite_process_admin_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/invite_process_admin_spec.rb
@@ -42,7 +42,7 @@ describe "Invite process administrator", type: :system do
       end
 
       within ".secondary-nav" do
-        expect(page.text).to eq "View public page\nInfo\nPhases\nComponents\nCategories\nAttachments\nFolders\nFiles\nProcess admins\nModerations"
+        expect(page.text).to eq "View public page\nInfo\nPhases\nComponents\nCategories\nAttachments\nFolders\nFiles\nProcess admins\nPrivate participants\nModerations"
       end
     end
   end
@@ -72,7 +72,7 @@ describe "Invite process administrator", type: :system do
       end
 
       within ".secondary-nav" do
-        expect(page.text).to eq "View public page\nInfo\nPhases\nComponents\nCategories\nAttachments\nFolders\nFiles\nProcess admins\nModerations"
+        expect(page.text).to eq "View public page\nInfo\nPhases\nComponents\nCategories\nAttachments\nFolders\nFiles\nProcess admins\nPrivate participants\nModerations"
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
A participatory process admin can't access to space private user in processes.

#### :pushpin: Related Issues
- Related to #6912

#### Testing
1. Login as participatory process admin
2. Processes > Private participants
3. Import via CSV
4. See success message.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![Captura de pantalla de 2020-12-29 11-41-44](https://user-images.githubusercontent.com/75725233/103279003-1c7cdb00-49cd-11eb-950e-fd49becb84b1.png)


:hearts: Thank you!
