### PR TITLE
Ensure election data is sent to BB in the default locale

### DIFF
--- a/decidim-elections/app/commands/decidim/elections/admin/setup_election.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/setup_election.rb
@@ -34,7 +34,7 @@ module Decidim
 
         attr_reader :form
 
-        delegate :election, :bulletin_board, to: :form
+        delegate :election, :bulletin_board, :current_organization, to: :form
 
         def questions
           @questions ||= election.questions
@@ -73,8 +73,8 @@ module Decidim
             description: {
               name: {
                 text: [{
-                  value: election.title[I18n.default_locale.to_s],
-                  language: I18n.default_locale.to_s
+                  value: election.title[current_organization.default_locale.to_s],
+                  language: current_organization.default_locale.to_s
                 }]
               },
               start_date: election.start_time,
@@ -85,8 +85,8 @@ module Decidim
                       object_id: answer.id.to_s,
                       ballot_name: {
                         text: [{
-                          value: answer.title[I18n.default_locale.to_s],
-                          language: I18n.default_locale.to_s
+                          value: answer.title[current_organization.default_locale.to_s],
+                          language: current_organization.default_locale.to_s
                         }]
                       }
                     }
@@ -98,19 +98,19 @@ module Decidim
                     object_id: question.id.to_s,
                     sequence_order: question.weight,
                     vote_variation: question.vote_variation,
-                    name: question.title[I18n.default_locale.to_s],
+                    name: question.title[current_organization.default_locale.to_s],
                     number_elected: question.answers.count,
                     votes_allowed: 1,
                     ballot_title: {
                       text: [{
-                        value: question.title[I18n.default_locale.to_s],
-                        language: I18n.default_locale.to_s
+                        value: question.title[current_organization.default_locale.to_s],
+                        language: current_organization.default_locale.to_s
                       }]
                     },
                     ballot_subtitle: {
                       text: [{
-                        value: question.description[I18n.default_locale.to_s],
-                        language: I18n.default_locale.to_s
+                        value: question.description[current_organization.default_locale.to_s],
+                        language: current_organization.default_locale.to_s
                       }]
                     },
                     ballot_selections:

--- a/decidim-elections/app/commands/decidim/elections/admin/setup_election.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/setup_election.rb
@@ -73,8 +73,8 @@ module Decidim
             description: {
               name: {
                 text: [{
-                  value: election.title[I18n.locale.to_s],
-                  language: I18n.locale.to_s
+                  value: election.title[I18n.default_locale.to_s],
+                  language: I18n.default_locale.to_s
                 }]
               },
               start_date: election.start_time,
@@ -85,8 +85,8 @@ module Decidim
                       object_id: answer.id.to_s,
                       ballot_name: {
                         text: [{
-                          value: answer.title[I18n.locale.to_s],
-                          language: I18n.locale.to_s
+                          value: answer.title[I18n.default_locale.to_s],
+                          language: I18n.default_locale.to_s
                         }]
                       }
                     }
@@ -98,19 +98,19 @@ module Decidim
                     object_id: question.id.to_s,
                     sequence_order: question.weight,
                     vote_variation: question.vote_variation,
-                    name: question.title[I18n.locale.to_s],
+                    name: question.title[I18n.default_locale.to_s],
                     number_elected: question.answers.count,
                     votes_allowed: 1,
                     ballot_title: {
                       text: [{
-                        value: question.title[I18n.locale.to_s],
-                        language: I18n.locale.to_s
+                        value: question.title[I18n.default_locale.to_s],
+                        language: I18n.default_locale.to_s
                       }]
                     },
                     ballot_subtitle: {
                       text: [{
-                        value: question.description[I18n.locale.to_s],
-                        language: I18n.locale.to_s
+                        value: question.description[I18n.default_locale.to_s],
+                        language: I18n.default_locale.to_s
                       }]
                     },
                     ballot_selections:


### PR DESCRIPTION
#### :tophat: What? Why?

This PR ensures the (translatable) data from an election is sent to the bulletin board in the decidim instance default locale.

#### :pushpin: Related Issues

- Related to #?
- Fixes #?

#### Testing

1. Create or edit an election with only the default locale (en):  
  <img width="1056" alt="Screenshot 2020-12-30 at 19 59 02" src="https://user-images.githubusercontent.com/210216/103375475-a1a1e600-4ada-11eb-9918-dad0e62bfdfe.png">  
  <img width="1059" alt="Screenshot 2020-12-30 at 20 00 29" src="https://user-images.githubusercontent.com/210216/103375498-ae263e80-4ada-11eb-93b3-19950a984098.png">
2. Change the admin's locale to a language different to the default locale:  
  <img width="1065" alt="Screenshot 2020-12-30 at 20 01 59" src="https://user-images.githubusercontent.com/210216/103375539-c1390e80-4ada-11eb-8136-e3bf10b2c69b.png">
3. Go to election setup and submit to the bulletin board:  
  <img width="1001" alt="Screenshot 2020-12-30 at 20 02 47" src="https://user-images.githubusercontent.com/210216/103375570-d2821b00-4ada-11eb-898d-b12411b44977.png">  
  <img width="1062" alt="Screenshot 2020-12-30 at 20 05 12" src="https://user-images.githubusercontent.com/210216/103375615-eb8acc00-4ada-11eb-909a-1190c692bb2e.png">
4. It worked with success!  
  <img width="1054" alt="Screenshot 2020-12-30 at 20 06 06" src="https://user-images.githubusercontent.com/210216/103375669-1117d580-4adb-11eb-9823-d6a0d9b299a7.png">


#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
