### PR TITLE
Ensure Bulletin Board is configured for trustee zone

### DIFF
--- a/decidim-elections/app/controllers/decidim/elections/trustee_zone/application_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/trustee_zone/application_controller.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Elections
+    module TrusteeZone
+      # This controller is the abstract class from which all trustee_zone
+      # controllers in their public engines should inherit from.
+
+      class ApplicationController < ::Decidim::ApplicationController
+        include Decidim::UserProfile
+
+        helper_method :trustee
+
+        before_action :ensure_configured_bulletin_board!
+
+        private
+
+        def ensure_configured_bulletin_board!
+          return if Decidim::Elections.bulletin_board.configured?
+
+          announcement_args = {
+            callout_class: "alert",
+            announcement: {
+              title: "<strong>#{t("no_bulletin_board.title", scope: "decidim.elections.trustee_zone")}",
+              body: t("no_bulletin_board.body", scope: "decidim.elections.trustee_zone")
+            }
+          }
+          render html: cell("decidim/announcement", announcement_args), layout: true
+        end
+
+        def trustee
+          @trustee ||= Decidim::Elections::Trustee.for(current_user)
+        end
+
+        def permission_scope
+          :trustee_zone
+        end
+
+        def permission_class_chain
+          [
+            Decidim::Elections::Permissions,
+            Decidim::Permissions
+          ]
+        end
+      end
+    end
+  end
+end

--- a/decidim-elections/app/controllers/decidim/elections/trustee_zone/application_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/trustee_zone/application_controller.rb
@@ -21,7 +21,7 @@ module Decidim
           announcement_args = {
             callout_class: "alert",
             announcement: {
-              title: "<strong>#{t("no_bulletin_board.title", scope: "decidim.elections.trustee_zone")}",
+              title: "<strong>#{t("no_bulletin_board.title", scope: "decidim.elections.trustee_zone")}</strong>",
               body: t("no_bulletin_board.body", scope: "decidim.elections.trustee_zone")
             }
           }

--- a/decidim-elections/app/controllers/decidim/elections/trustee_zone/elections_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/trustee_zone/elections_controller.rb
@@ -4,10 +4,8 @@ module Decidim
   module Elections
     module TrusteeZone
       # Handles the KeyCeremony for trustee users
-      class ElectionsController < ::Decidim::ApplicationController
-        include Decidim::UserProfile
-
-        helper_method :election, :trustee
+      class ElectionsController < Decidim::Elections::TrusteeZone::ApplicationController
+        helper_method :election
 
         def show
           enforce_permission_to :view, :election, trustee: trustee
@@ -28,23 +26,8 @@ module Decidim
 
         private
 
-        def permission_scope
-          :trustee_zone
-        end
-
-        def permission_class_chain
-          [
-            Decidim::Elections::Permissions,
-            Decidim::Permissions
-          ]
-        end
-
         def election
           @election ||= Decidim::Elections::Election.find(params[:election_id])
-        end
-
-        def trustee
-          @trustee ||= Decidim::Elections::Trustee.for(current_user)
         end
       end
     end

--- a/decidim-elections/app/controllers/decidim/elections/trustee_zone/trustees_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/trustee_zone/trustees_controller.rb
@@ -4,11 +4,8 @@ module Decidim
   module Elections
     module TrusteeZone
       # Exposes the trustee zone for trustee users
-      class TrusteesController < ::Decidim::ApplicationController
-        include Decidim::UserProfile
+      class TrusteesController < Decidim::Elections::TrusteeZone::ApplicationController
         include Decidim::FormFactory
-
-        helper_method :trustee
 
         def show
           enforce_permission_to :view, :trustee, trustee: trustee
@@ -32,23 +29,6 @@ module Decidim
           end
 
           redirect_to trustee_path
-        end
-
-        private
-
-        def trustee
-          @trustee ||= Decidim::Elections::Trustee.for(current_user)
-        end
-
-        def permission_scope
-          :trustee_zone
-        end
-
-        def permission_class_chain
-          [
-            Decidim::Elections::Permissions,
-            Decidim::Permissions
-          ]
         end
       end
     end

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -371,6 +371,9 @@ en:
             success: 'The election status is: %{status}'
         menu:
           trustee_zone: Trustee zone
+        no_bulletin_board:
+          body: A configured Bulletin Board is required for this section. Contact the Administrator for more details.
+          title: Sorry, the Bulletin Board is not configured yet.
         trustees:
           show:
             elections:

--- a/decidim-elections/spec/system/trustee_zone_spec.rb
+++ b/decidim-elections/spec/system/trustee_zone_spec.rb
@@ -100,4 +100,22 @@ describe "Trustee zone", type: :system do
       expect(page).to have_current_path(decidim.root_path)
     end
   end
+
+  context "when the bulletin_board is not configured" do
+    before do
+      allow(Decidim::Elections.bulletin_board).to receive(:api_key).and_return(nil)
+      trustee
+      login_as user, scope: :user
+    end
+
+    it "notifies that it is not configured" do
+      visit decidim.account_path
+
+      expect(page).to have_content("Trustee zone")
+
+      visit decidim.decidim_elections_trustee_zone_path
+
+      expect(page).to have_content("Sorry, the Bulletin Board is not configured yet")
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
When Decidim has no Bulletin Board configured, the trustee zone shows a warning informing the user.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing

_Decidim app has to be with no Bulletin Board configured_

1. Log in with a user with a Trustee role, and navigate to the trustee zone, an alert will show up informing the trustee user that the configuration is missing:
  <img width="803" alt="Screenshot 2021-01-04 at 13 23 59" src="https://user-images.githubusercontent.com/210216/103535066-5e57c680-4e90-11eb-9d8d-00de069d4dee.png">


#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
