### PR TITLE
Update Dockerfile.design to not depend on decidim/docker

### DIFF
--- a/Dockerfile.design
+++ b/Dockerfile.design
@@ -1,4 +1,4 @@
-FROM decidim/decidim:latest
+FROM ruby:2.7.1
 LABEL maintainer="info@codegram.com"
 
 ENV LANG C.UTF-8
@@ -7,6 +7,17 @@ ENV RAILS_ENV production
 ENV PORT 3000
 ENV SECRET_KEY_BASE=no_need_for_such_secrecy
 ENV RAILS_SERVE_STATIC_FILES=true
+
+RUN apt-get install -y git imagemagick wget \
+  && apt-get clean
+
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+  && apt-get install -y nodejs \
+  && apt-get clean
+
+RUN npm install -g npm@6.3.0
+
+RUN gem install bundler --version '>= 2.1.4'
 
 WORKDIR /code
 COPY . .
@@ -21,5 +32,7 @@ WORKDIR /code/decidim_app-design
 
 RUN bundle install
 RUN bundle exec rails assets:precompile
+
 ENTRYPOINT []
-CMD bundle exec rails s -p $PORT
+
+CMD bundle exec rails s -b 0.0.0.0 -p $PORT


### PR DESCRIPTION
#### :tophat: What? Why?
Updates Dockerfile.design so it doesn't depend on decidim/docker image

Dockerfile.design is now decoupled from the decidim/decidim-generator image (previously called decidim/decidim - this name is now used by the deployment app image)

It also now spins up rails s with 0.0.0.0 - it wasn't accessible locally without this. Should work on Heroku as well.

The decoupling was done because decidim/docker images are now built dynamically and get the ruby version from the latest release tag. So these images are at ruby 2.6.6, while the `develop` branch and v0.24.dev are at 2.7. Since Dockerfile.design builds from `develop`, it was no longer compatible with the decidim/decidim-generator image.

Don't know what's up with codecov, it's been reporting less coverage from develop on PRs I've been involved in. But it's unrelated to the PR itself - comes from the `develop` branch itself 🤷 

#### :pushpin: Related Issues

The new decidim/docker updates is documented on [decidim/docker's README](https://github.com/decidim/docker#images-available)

#### Testing

Run `docker build --file Dockerfile.design -t decidim-design .` and that should build an image runnable locally and on heroku.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*

Changes aren't visual.

:hearts: Thank you!
