### PR TITLE
Remove question from blocked user mailer subject

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -336,7 +336,7 @@ en:
         body_2: 'Reason: %{justification}'
         greetings: Greetings,<br/>%{organization_name}<br/><a href="%{organization_url}">%{organization_url}</a>
         hello: Hello,
-        subject: Your account was blocked by %{organization_name}?
+        subject: Your account was blocked by %{organization_name}
     collapsible_list:
       hidden_elements_count:
         one: and %{count} more

--- a/decidim-core/spec/mailers/block_user_mailer_spec.rb
+++ b/decidim-core/spec/mailers/block_user_mailer_spec.rb
@@ -14,7 +14,7 @@ module Decidim
       let(:mail) { described_class.notify(user, token) }
 
       it "parses the subject" do
-        expect(mail.subject).to eq("Your account was blocked by #{organization.name}?")
+        expect(mail.subject).to eq("Your account was blocked by #{organization.name}")
       end
 
       it "parses the body" do


### PR DESCRIPTION
#### :tophat: What? Why?

When a participant is blocked the mail subject says "Your account was blocked by %{organization_name}?"
This shouldn't be a question as it's something that has happened.

Detected by @carlobeltrame at crowdin:

![image](https://user-images.githubusercontent.com/717367/104420942-f0d82400-557a-11eb-87fc-40fd3a93cfea.png)

cc / @alecslupu

#### :pushpin: Related Issues

- Related to #6804 

#### Testing

1. Sign in as admin 
2. Block a user in the admin panel
3. See the mail that she receives 

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.
 

:hearts: Thank you!
