### PR TITLE
See a deprecation callout in Consultations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ We've bumped the minimum Ruby version to 2.7.1, thanks to 2 PRs:
 
 As per [\#6498](https://github.com/decidim/decidim/pull/6498), the comments component is no longer implemented with the react component. In case you had customized the react component, it will still work as you would expect as the GraphQL API has not disappeared anywhere. You should, however, gradually migrate to the "new way" (Trailblazer cells) in order to ensure compatibility with future versions too.
 
+- **Consultations module deprecation**
+
+As the new `Votings` module is being developed and will eventually replace the `Consultations` module, the latter enters the deprecation phase.
+
 ### Added
 
 - **decidim-core**: Adding functionality to report users [\#6696](https://github.com/decidim/decidim/pull/6696)

--- a/decidim-consultations/app/views/layouts/decidim/admin/consultation.html.erb
+++ b/decidim-consultations/app/views/layouts/decidim/admin/consultation.html.erb
@@ -31,6 +31,10 @@
   </div>
 
   <div class="process-content">
+    <div class="callout warning">
+      <%= icon "warning" %>
+      <span class="callout-text"><%= t("decidim.admin.consultations.deprecation_warning") %></span>
+    </div>
     <%= yield %>
   </div>
 <% end %>

--- a/decidim-consultations/app/views/layouts/decidim/admin/consultations.html.erb
+++ b/decidim-consultations/app/views/layouts/decidim/admin/consultations.html.erb
@@ -5,6 +5,10 @@
     </div>
   </div>
 
+  <div class="callout warning">
+    <%= icon "warning" %>
+    <span class="callout-text"><%= t("decidim.admin.consultations.deprecation_warning") %></span>
+  </div>
   <div class="process-content">
     <%= yield %>
   </div>

--- a/decidim-consultations/config/locales/en.yml
+++ b/decidim-consultations/config/locales/en.yml
@@ -95,6 +95,7 @@ en:
         create:
           error: There was a problem creating a new consultation.
           success: Consultation successfully created.
+        deprecation_warning: Consultations module will be deprecated in the near future. We’re working on the next criptographic secure version called Votings.
         edit:
           update: Update
         form:
@@ -113,7 +114,6 @@ en:
         update:
           error: There was a problem updating this consultation.
           success: Consultation updated successfully.
-        deprecation_warning: Consultations module will be deprecated in the near future. We’re working on the next criptographic secure version called Votings.
       menu:
         consultations: Consultations
         consultations_submenu:

--- a/decidim-consultations/config/locales/en.yml
+++ b/decidim-consultations/config/locales/en.yml
@@ -113,6 +113,7 @@ en:
         update:
           error: There was a problem updating this consultation.
           success: Consultation updated successfully.
+        deprecation_warning: Consultations module will be deprecated in the near future. We’re working in the next criptographic secure version called Votings.
       menu:
         consultations: Consultations
         consultations_submenu:

--- a/decidim-consultations/config/locales/en.yml
+++ b/decidim-consultations/config/locales/en.yml
@@ -113,7 +113,7 @@ en:
         update:
           error: There was a problem updating this consultation.
           success: Consultation updated successfully.
-        deprecation_warning: Consultations module will be deprecated in the near future. We’re working in the next criptographic secure version called Votings.
+        deprecation_warning: Consultations module will be deprecated in the near future. We’re working on the next criptographic secure version called Votings.
       menu:
         consultations: Consultations
         consultations_submenu:


### PR DESCRIPTION
#### :tophat: What? Why?
As Consultations will soon be replaced by Votings, a deprecation warning is shown to the admins when they access a Consultation from the admin panel

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/7097

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![deprecation](https://user-images.githubusercontent.com/5033945/104424452-b329ca00-557f-11eb-9d92-9e6b4fdf32ed.gif)

:hearts: Thank you!
