### PR TITLE
Fix the TOS page acceptance form not displaying with layout customizations

### DIFF
--- a/decidim-core/app/cells/decidim/tos_page/form.erb
+++ b/decidim-core/app/cells/decidim/tos_page/form.erb
@@ -1,17 +1,19 @@
-<article class="card">
-  <div class="card__content">
-    <div class="card__header">
-      <h5 class="card__title text-center">
-        <%= t("form.legend", scope: "decidim.pages.terms_and_conditions") %>
-      </h5>
-    </div>
+<div class="columns small-12">
+  <div class="card">
+    <div class="card__content">
+      <div class="card__header">
+        <h5 class="card__title text-center">
+          <%= t("form.legend", scope: "decidim.pages.terms_and_conditions") %>
+        </h5>
+      </div>
 
-    <div class="row column flex-center">
-      <%= cell "decidim/tos_page", :refuse_btn_modal %>
+      <div class="row column flex-center">
+        <%= cell "decidim/tos_page", :refuse_btn_modal %>
 
-      <%= button_to decidim.accept_tos_path, method: :put, class: "button button--nomargin small" do %>
-        <%= t("form.agreement", scope: "decidim.pages.terms_and_conditions") %>
-      <% end %>
+        <%= button_to decidim.accept_tos_path, method: :put, class: "button button--nomargin small" do %>
+          <%= t("form.agreement", scope: "decidim.pages.terms_and_conditions") %>
+        <% end %>
+      </div>
     </div>
   </div>
-</article>
+</div>


### PR DESCRIPTION
#### :tophat: What? Why?
If you apply the following layout customization to Decidim:

```css
.card { border: none !important; }
```

The TOS acceptance form will not display properly on the TOS page. This is because of some flexbox related rendering issue which causes the element to get 0-width when it does not have a border.

#### :pushpin: Related Issues

#### Testing
- Apply the described layout customization in the application CSS
- Make sure your user's `accepted_tos_version` is set to `nil`
- Login to Decidim
- See the TOS page

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
