### PR TITLE
Ensure only installed content blocks are loaded in admin

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/organization_homepage_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/organization_homepage_controller.rb
@@ -31,11 +31,15 @@ module Decidim
       end
 
       def active_blocks
-        @active_blocks ||= content_blocks.published
+        @active_blocks ||= content_blocks.published.where(manifest_name: Decidim.content_blocks.for(:homepage).map(&:name))
+      end
+
+      def unpublished_blocks
+        @unpublished_blocks ||= content_blocks.unpublished.where(manifest_name: Decidim.content_blocks.for(:homepage).map(&:name))
       end
 
       def inactive_blocks
-        @inactive_blocks ||= content_blocks.unpublished + unused_manifests
+        @inactive_blocks ||= unpublished_blocks + unused_manifests
       end
 
       def used_manifests

--- a/decidim-admin/spec/system/admin_manages_organization_homepage_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_homepage_spec.rb
@@ -56,4 +56,22 @@ describe "Admin manages organization homepage", type: :system do
       expect(page.html).to include("city2.jpeg")
     end
   end
+
+  context "when loading non-existing content blocks" do
+    let!(:unpublished_block) { create :content_block, organization: organization, scope_name: :homepage, published_at: nil }
+    let!(:published_block) { create :content_block, organization: organization, scope_name: :homepage }
+
+    before do
+      # We do this to simulate content blocks from some modules that have been
+      # uninstalled from the app.
+      unpublished_block.update(manifest_name: :fake_name)
+      published_block.update(manifest_name: :fake_name)
+    end
+
+    it "loads the page as expected" do
+      visit decidim_admin.edit_organization_homepage_path
+
+      expect(page).to have_text("Active content blocks")
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR improves on #6788.

This PR makes sure only currently-installed content blocks are loaded from the admin area, otherwise we might get a crash. See #6788 and #6787 for more info.

#### :pushpin: Related Issues

- Fixes #6787

#### Testing
Have an instance with initiatives. Add the initiatives content block tot he home page. Remove initiatives. Use this PR. Admin area for content blocks should not crash.