### PR TITLE
Fix possible infinite redirection loop with internal server error on the TOS acceptance page

### DIFF
--- a/decidim-core/app/controllers/decidim/errors_controller.rb
+++ b/decidim-core/app/controllers/decidim/errors_controller.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   class ErrorsController < Decidim::ApplicationController
-    skip_before_action :verify_authenticity_token
+    skip_before_action :verify_authenticity_token, :tos_accepted_by_user
     skip_after_action :verify_same_origin_request
 
     def not_found

--- a/decidim-core/spec/controllers/errors_controller_spec.rb
+++ b/decidim-core/spec/controllers/errors_controller_spec.rb
@@ -75,6 +75,24 @@ module Decidim
           end
         end
       end
+
+      context "when the user is signed in but has not agreed to terms of service" do
+        let(:user) { create(:user, :confirmed, accepted_tos_version: nil) }
+
+        before do
+          routes { Decidim::Core::Engine.routes }
+
+          request.env["devise.mapping"] = ::Devise.mappings[:user]
+
+          sign_in user
+        end
+
+        it "displays the error page without a redirection to the terms page" do
+          get :internal_server_error
+
+          expect(response).to have_http_status(:internal_server_error)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
When an internal server error occurs on the TOS acceptance page, this can cause an infinite redirection loop causing the browser to show an error code `ERR_TOO_MANY_REDIRECTS` or similar (depends on the browser).

This happens in case when a new user tries to login to the site and has not yet accepted the TOS (`accepted_tos_version` is set to `nil` on the `Decidim::User` record). In case the TOS page has errors, it tries to redirect to the internal server error page. At the error page, the `tos_accepted_by_user` before action kicks in and tries to redirect the user back to the TOS page. Then the same thing happens over and over again causing an infinite redirection loop.

This can make identifying the problem extremely difficult as the user will report the `ERR_TOO_MANY_REDIRECTS` error instead of reporting the usual "There was a problem with our server" message which will give a better hint where to look for the error.

#### :pushpin: Related Issues

#### Testing
Add a random raise on this page template:
https://github.com/decidim/decidim/blob/001645e01b87613b22de311257ab7e0ca39ebfeb/decidim-core/app/views/decidim/pages/show.html.erb

E.g. add this to some section of the template:

```ruby
<% raise "some error" %>
```

Then:

- Create a new Decidim instance with the default seed data
- Set the `user@example.org` account not to have TOS accepted with the following command in the Rails console `Decidim::User.find_by(email: "user@example.org").update!(accepted_tos_version: nil)`
- Login with that user to the site
- See the infinite redirection loop

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![Chrome ERR_TOO_MANY_REDIRECTS](https://user-images.githubusercontent.com/864340/104593637-a50ba480-5678-11eb-9203-63cdba0dd650.png)