### PR TITLE
Filter assemblies by assembly type in admin

### DIFF
--- a/decidim-assemblies/app/controllers/concerns/decidim/assemblies/admin/filterable.rb
+++ b/decidim-assemblies/app/controllers/concerns/decidim/assemblies/admin/filterable.rb
@@ -23,6 +23,26 @@ module Decidim
           def extra_filters
             [:parent_id_eq]
           end
+
+          def filters
+            [:private_space_eq, :published_at_null, :decidim_assemblies_type_id_eq]
+          end
+
+          def filters_with_values
+            {
+              private_space_eq: [true, false],
+              published_at_null: [true, false],
+              decidim_assemblies_type_id_eq: AssembliesType.where(organization: current_organization).pluck(:id)
+            }
+          end
+
+          def dynamically_translated_filters
+            [:decidim_assemblies_type_id_eq]
+          end
+
+          def translated_decidim_assemblies_type_id_eq(id)
+            translated_attribute(Decidim::AssembliesType.find_by(id: id).title[I18n.locale.to_s])
+          end
         end
       end
     end

--- a/decidim-assemblies/app/controllers/concerns/decidim/assemblies/admin/filterable.rb
+++ b/decidim-assemblies/app/controllers/concerns/decidim/assemblies/admin/filterable.rb
@@ -41,7 +41,7 @@ module Decidim
           end
 
           def translated_decidim_assemblies_type_id_eq(id)
-            translated_attribute(Decidim::AssembliesType.find_by(id: id).title[I18n.locale.to_s])
+            translated_attribute(Decidim::AssembliesType.find(id).title)
           end
         end
       end

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -183,6 +183,9 @@ en:
         update:
           error: There was a problem updating an admin for this assembly.
           success: Admin updated successfully for this assembly.
+      filters:
+        decidim_assemblies_type_id_eq:
+          label: Assembly type
       menu:
         assemblies: Assemblies
         assemblies_settings: Settings

--- a/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
@@ -85,6 +85,37 @@ describe "Admin manages assemblies", type: :system do
     describe "listing parent assemblies" do
       it_behaves_like "filtering collection by published/unpublished"
       it_behaves_like "filtering collection by private/public"
+
+      context "when filtering by assemblies type" do
+        include_context "with filterable context"
+
+        let!(:assemblies_type_1) { create(:assemblies_type) }
+        let!(:assemblies_type_2) { create(:assemblies_type) }
+
+        Decidim::AssembliesType.all.each do |assemblies_type|
+          i18n_assemblies_type = assemblies_type.name[I18n.locale.to_s]
+
+          context "filtering collection by assemblies_type: #{i18n_assemblies_type}" do
+            let!(:assembly_1) { create(:assembly, organization: organization, assemblies_type: assemblies_type_1) }
+            let!(:assembly_2) { create(:assembly, organization: organization, assemblies_type: assemblies_type_2) }
+
+            it_behaves_like "a filtered collection", options: "Assembly type", filter: i18n_assemblies_type do
+              let(:in_filter) { translated(assembly_with_type(type).title) }
+              let(:not_in_filter) { translated(assembly_without_type(type).title) }
+            end
+          end
+        end
+
+        it_behaves_like "paginating a collection"
+
+        def assembly_with_type(type)
+          Decidim::Assembly.find_by(decidim_assemblies_type_id: type)
+        end
+
+        def assembly_without_type(type)
+          Decidim::Assembly.where.not(decidim_assemblies_type_id: type).sample
+        end
+      end
     end
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds filtering by `assemblies_type` in the assemblies admin.

#### :pushpin: Related Issues
- Related to [MetaDecidim proposal \#15839](https://meta.decidim.org/processes/roadmap/f/122/proposals/15839)

#### Testing
- Go to assemblies section in admin
- Hover over the blue "Filter" button
- Hover over the "Assembly type" sub-menu
- Click on any of the assembly types appearing in another sub-menu
- Check that only assemblies with that type appear in the list

#### :clipboard: Checklist
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

![Filter assemblies by type in admin](https://user-images.githubusercontent.com/8806781/104614933-00459300-5689-11eb-982e-201308bcc33f.gif)


:hearts: Thank you!
