### PR TITLE
Fix the proposal body validation error messages

### DIFF
--- a/decidim-proposals/app/forms/decidim/proposals/proposal_wizard_create_step_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/proposal_wizard_create_step_form.rb
@@ -18,7 +18,6 @@ module Decidim
         maximum: ->(record) { record.component.settings.proposal_length }
       }
 
-      validate :proposal_length
       validate :body_is_not_bare_template
 
       alias component current_component
@@ -31,13 +30,6 @@ module Decidim
       end
 
       private
-
-      def proposal_length
-        return unless body.presence
-
-        length = current_component.settings.proposal_length
-        errors.add(:body, :too_long, count: length) if body.length > length
-      end
 
       def body_is_not_bare_template
         return if body_template.blank?

--- a/decidim-proposals/app/validators/proposal_length_validator.rb
+++ b/decidim-proposals/app/validators/proposal_length_validator.rb
@@ -20,7 +20,8 @@ class ProposalLengthValidator < ActiveModel::EachValidator
     if min && min.positive? && value.length < min
       record.errors.add(
         attribute,
-        options[:message] || :too_short
+        options[:message] || :too_short,
+        count: min
       )
     end
   end
@@ -31,7 +32,8 @@ class ProposalLengthValidator < ActiveModel::EachValidator
     if max && max.positive? && value.length > max
       record.errors.add(
         attribute,
-        options[:message] || :too_long
+        options[:message] || :too_long,
+        count: max
       )
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Currently the `count` variable is not passed correctly to the validation error message for proposal body length validation which causes the validation message to be incorrect (see screenshot).

Also, as you can see from the screenshots, the proposal body maximum length validation is run twice which causes the error message to appear twice.

First time here (through the [ProposalLengthValidator](https://github.com/decidim/decidim/blob/3458bec170d3993bb48490385d81f5fa6c77a238/decidim-proposals/app/validators/proposal_length_validator.rb)):
https://github.com/decidim/decidim/blob/3458bec170d3993bb48490385d81f5fa6c77a238/decidim-proposals/app/forms/decidim/proposals/proposal_wizard_create_step_form.rb#L18

Second time here:
https://github.com/decidim/decidim/blob/3458bec170d3993bb48490385d81f5fa6c77a238/decidim-proposals/app/forms/decidim/proposals/proposal_wizard_create_step_form.rb#L21

The second check is unnecessary as it duplicates the first.

#### :pushpin: Related Issues

#### Testing
- Create a default Decidim instance
- Create a new proposal
- Inspect the body element and remove the min/max length attributes from the text area (there's a way to replicate without any "hacks" but this is easier to explain)
- You will see the incorrect error message in tie view (see screenshot)

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![Proposal body incorrect error message](https://user-images.githubusercontent.com/864340/104632394-4bba6a00-56a6-11eb-89bd-0e1f92a9a2c9.png)