### PR TITLE
Fix form string length validation with carriage returns

### DIFF
--- a/decidim-comments/app/forms/decidim/comments/comment_form.rb
+++ b/decidim-comments/app/forms/decidim/comments/comment_form.rb
@@ -5,7 +5,7 @@ module Decidim
     # A form object used to create comments from the graphql api.
     #
     class CommentForm < Form
-      attribute :body, String
+      attribute :body, Decidim::Attributes::CleanString
       attribute :alignment, Integer
       attribute :user_group_id, Integer
       attribute :commentable

--- a/decidim-comments/spec/forms/comment_form_spec.rb
+++ b/decidim-comments/spec/forms/comment_form_spec.rb
@@ -48,6 +48,12 @@ module Decidim
         let(:body) { "c" * 1001 }
 
         it { is_expected.not_to be_valid }
+
+        context "with carriage return characters that cause it to exceed" do
+          let(:body) { "#{("c" * 500)}\r\n#{("c" * 499)}" }
+
+          it { is_expected.to be_valid }
+        end
       end
 
       context "when alignment is not present" do

--- a/decidim-core/app/forms/decidim/messaging/conversation_form.rb
+++ b/decidim-core/app/forms/decidim/messaging/conversation_form.rb
@@ -6,7 +6,7 @@ module Decidim
     class ConversationForm < Decidim::Form
       mimic :conversation
 
-      attribute :body, String
+      attribute :body, Decidim::Attributes::CleanString
       attribute :recipient_id, Integer
 
       validates :body, :recipient, presence: true

--- a/decidim-core/app/forms/decidim/messaging/message_form.rb
+++ b/decidim-core/app/forms/decidim/messaging/message_form.rb
@@ -6,7 +6,7 @@ module Decidim
     class MessageForm < Decidim::Form
       mimic :message
 
-      attribute :body, String
+      attribute :body, Decidim::Attributes::CleanString
 
       validates :body, presence: true
     end

--- a/decidim-core/lib/decidim/attributes.rb
+++ b/decidim-core/lib/decidim/attributes.rb
@@ -4,5 +4,6 @@ module Decidim
   module Attributes
     autoload :TimeWithZone, "decidim/attributes/time_with_zone"
     autoload :LocalizedDate, "decidim/attributes/localized_date"
+    autoload :CleanString, "decidim/attributes/clean_string"
   end
 end

--- a/decidim-core/lib/decidim/attributes/clean_string.rb
+++ b/decidim-core/lib/decidim/attributes/clean_string.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Attributes
+    # Custom Virtus value to "standardize" the newline characters within strings
+    # that are sent through user entered forms. This strips out the carriage
+    # return characters from the strings in order to avoid validation mismatches
+    # with the string lengths between the frontend and the backend.
+    #
+    # This type should be used with forms that have:
+    # - A user input defined with the <textarea> element
+    # - The input element having the `maxlength` attribute defined for it
+    # - The backend having a maximum length validation for the input
+    class CleanString < Virtus::Attribute
+      # When using Windows or copying texts from existing documents, the text
+      # can contain the carriage return characters (\r) that the front-end
+      # character counter does not consider as actual characters. This happens
+      # because the character counter currently counts the characters using
+      # jQuery's `$input.val()` method which strips out the carriage return
+      # characters as explained at:
+      #   https://api.jquery.com/val/
+      #
+      #   Note: At present, using .val() on <textarea> elements strips carriage
+      #   return characters from the browser-reported value.
+      #
+      # The backend, on the other hand, calculates these as characters as they
+      # are included in the data that gets sent to the server. In order to fix
+      # this mismatch, remove the carriage return characters from the text
+      # using this attribute type.
+      def coerce(value)
+        return value unless value.is_a?(String)
+
+        value.gsub(/\r/, "")
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/translatable_attributes.rb
+++ b/decidim-core/lib/decidim/translatable_attributes.rb
@@ -43,7 +43,8 @@ module Decidim
 
           define_method attribute_name do
             field = public_send(name) || {}
-            field[locale.to_s] || field[locale.to_sym]
+            value = field[locale.to_s] || field[locale.to_sym]
+            attribute_set[attribute_name].coerce(value)
           end
 
           define_method "#{attribute_name}=" do |value|

--- a/decidim-core/spec/commands/decidim/messaging/reply_to_conversation_spec.rb
+++ b/decidim-core/spec/commands/decidim/messaging/reply_to_conversation_spec.rb
@@ -90,8 +90,9 @@ module Decidim::Messaging
     end
 
     context "when the form is valid" do
+      let(:body) { "<3 from Patagonia" }
       let(:params) do
-        { body: "<3 from Patagonia" }
+        { body: body }
       end
 
       it_behaves_like "valid message with receipts", 2
@@ -137,6 +138,18 @@ module Decidim::Messaging
           it_behaves_like "valid message with receipts", 3
           it_behaves_like "send emails", 1
         end
+      end
+
+      context "and the body has just the right length without carriage returns" do
+        let(:body) { "This text is just the correct length\r\nwith the carriage return characters removed" }
+
+        before do
+          allow(Decidim.config).to receive(
+            :maximum_conversation_message_length
+          ).and_return(80)
+        end
+
+        it_behaves_like "valid message with receipts", 2
       end
     end
   end

--- a/decidim-core/spec/commands/decidim/messaging/start_conversation_spec.rb
+++ b/decidim-core/spec/commands/decidim/messaging/start_conversation_spec.rb
@@ -48,9 +48,10 @@ module Decidim::Messaging
     end
 
     shared_examples "a valid conversation" do |num_recipients, num_emails|
+      let(:body) { "<3 from Patagonia" }
       let(:params) do
         {
-          body: "<3 from Patagonia",
+          body: body,
           recipient_id: interlocutor.id
         }
       end
@@ -129,6 +130,18 @@ module Decidim::Messaging
         end
 
         it_behaves_like "a valid conversation", 2, 1
+      end
+    end
+
+    context "when the body has just the right length without carriage returns" do
+      before do
+        allow(Decidim.config).to receive(
+          :maximum_conversation_message_length
+        ).and_return(80)
+      end
+
+      it_behaves_like "a valid conversation", 1, 1 do
+        let(:body) { "This text is just the correct length\r\nwith the carriage return characters removed" }
       end
     end
   end

--- a/decidim-core/spec/lib/attributes/clean_string_spec.rb
+++ b/decidim-core/spec/lib/attributes/clean_string_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe Attributes::CleanString do
+    describe "#coerce" do
+      subject { described_class.build(Attributes::CleanString, {}).coerce(value) }
+
+      context "with long string with carriage returns" do
+        let(:value) do
+          [
+            "This is a string with many carriage return characters and also \n",
+            "some newlines without the carriage return.",
+            "\r\n",
+            "Using this string we\r test that the carriage return \n",
+            "characters are stripped from the final result correctly.",
+            "\r\r\n\r",
+            "The carriage return characters are causing problems with the UI\n",
+            "interacting with the backend, so we want to 'standardize' them \n",
+            "to a common format so that the string length calculations are \n",
+            "working consistently between the UI and the backend.\r"
+          ].join
+        end
+
+        it "returns the date" do
+          expect(subject).to eq(value.gsub(/\r/, ""))
+        end
+      end
+    end
+  end
+end

--- a/decidim-debates/app/forms/decidim/debates/admin/close_debate_form.rb
+++ b/decidim-debates/app/forms/decidim/debates/admin/close_debate_form.rb
@@ -9,7 +9,7 @@ module Decidim
 
         mimic :debate
 
-        translatable_attribute :conclusions, String do |translated_attribute, locale|
+        translatable_attribute :conclusions, Decidim::Attributes::CleanString do |translated_attribute, locale|
           validates translated_attribute, presence: true, if: ->(record) { record.default_locale?(locale) }
           validates translated_attribute, length: { minimum: 10, maximum: 10_000 }, if: ->(record) { record.default_locale?(locale) }
         end

--- a/decidim-debates/app/forms/decidim/debates/close_debate_form.rb
+++ b/decidim-debates/app/forms/decidim/debates/close_debate_form.rb
@@ -6,7 +6,7 @@ module Decidim
     class CloseDebateForm < Decidim::Form
       mimic :debate
 
-      attribute :conclusions, String
+      attribute :conclusions, Decidim::Attributes::CleanString
       attribute :debate, Debate
 
       validates :debate, presence: true

--- a/decidim-debates/spec/forms/decidim/debates/admin/close_debate_form_spec.rb
+++ b/decidim-debates/spec/forms/decidim/debates/admin/close_debate_form_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Debates::Admin::CloseDebateForm do
+  subject(:form) { described_class.from_params(attributes).with_context(context) }
+
+  let(:organization) { create(:organization) }
+  let(:participatory_process) { create :participatory_process, organization: organization }
+  let(:current_component) { create :component, participatory_space: participatory_process, manifest_name: "debates" }
+  let(:context) do
+    {
+      current_organization: organization
+    }
+  end
+  let(:debate) { create :debate, :official, component: current_component }
+  let(:conclusions) { Decidim::Faker::Localized.localized { "We found a conlcusion." } }
+  let(:attributes) do
+    {
+      debate: debate,
+      conclusions: conclusions
+    }
+  end
+
+  context "when the conclusions exceeds the permited length" do
+    let(:conclusions) { Decidim::Faker::Localized.localized { "c" * 10_001 } }
+
+    it { is_expected.to be_invalid }
+
+    context "with carriage return characters that cause it to exceed" do
+      let(:conclusions) { Decidim::Faker::Localized.localized { "#{"c" * 5000}\r\n#{"c" * 4999}" } }
+
+      it { is_expected.to be_valid }
+    end
+  end
+end

--- a/decidim-debates/spec/forms/decidim/debates/close_debate_form_spec.rb
+++ b/decidim-debates/spec/forms/decidim/debates/close_debate_form_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Debates::CloseDebateForm do
+  subject(:form) { described_class.from_params(attributes).with_context(context) }
+
+  let(:organization) { create(:organization) }
+  let(:participatory_process) { create :participatory_process, organization: organization }
+  let(:current_component) { create :component, participatory_space: participatory_process, manifest_name: "debates" }
+  let(:user) { create :user, organization: organization }
+  let(:context) do
+    {
+      current_user: user
+    }
+  end
+  let(:debate) { create :debate, :citizen_author, component: current_component, author: user }
+  let(:conclusions) { "We found a conlcusion." }
+  let(:attributes) do
+    {
+      debate: debate,
+      conclusions: conclusions
+    }
+  end
+
+  context "when the conclusions exceeds the permited length" do
+    let(:conclusions) { "c" * 10_001 }
+
+    it { is_expected.to be_invalid }
+
+    context "with carriage return characters that cause it to exceed" do
+      let(:conclusions) { "#{"c" * 5000}\r\n#{"c" * 4999}" }
+
+      it { is_expected.to be_valid }
+    end
+  end
+end

--- a/decidim-proposals/app/forms/decidim/proposals/proposal_wizard_create_step_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/proposal_wizard_create_step_form.rb
@@ -7,7 +7,7 @@ module Decidim
       mimic :proposal
 
       attribute :title, String
-      attribute :body, String
+      attribute :body, Decidim::Attributes::CleanString
       attribute :body_template, String
       attribute :user_group_id, Integer
 

--- a/decidim-proposals/spec/forms/decidim/proposals/proposal_wizard_create_step_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/proposal_wizard_create_step_form_spec.rb
@@ -54,11 +54,19 @@ module Decidim
         it { is_expected.to be_invalid }
       end
 
-      context "when the body exceed the permited length" do
-        let(:component) { create(:proposal_component, :with_proposal_length, participatory_space: participatory_space, proposal_length: 15) }
+      context "when the body exceeds the permited length" do
+        let(:component) { create(:proposal_component, :with_proposal_length, participatory_space: participatory_space, proposal_length: allowed_length) }
+        let(:allowed_length) { 15 }
         let(:body) { "A body longer than the permitted" }
 
         it { is_expected.to be_invalid }
+
+        context "with carriage return characters that cause it to exceed" do
+          let(:allowed_length) { 80 }
+          let(:body) { "This text is just the correct length\r\nwith the carriage return characters removed" }
+
+          it { is_expected.to be_valid }
+        end
       end
 
       context "when there's a body template set" do


### PR DESCRIPTION
#### :tophat: What? Why?
When text is written in Windows or when it is copy-pasted from a document containing carriage return characters (\r), the length validations work inconsistently. The frontend character counter will not count the carriage return characters to the total length because the value is fetched from the `<textarea>` elements with jQuery's `$input.val()` method.

This strips the carriage return characters from `<textarea>` elements as explained here:
https://api.jquery.com/val/

> Note: At present, using .val() on <textarea> elements strips carriage return characters from the browser-reported value.

This causes the frontend to allow more characters than the backend. The user thinks they are OK when they have 0 characters left as they cannot write anymore. However, when they submit the form, the value is submitted with the carriage return characters causing the backend length validation to fail due to the string being too long.

I fixed this by introducing a new form attribute type which removes the carriage return characters from its values. This causes the backend string values to match what was calculated by the frontend character counter.

I applied this new type to most forms where I found a maximum length validation being applied to the field that is assumingly submitted through a `<textarea>` element where the character counter kicks in automatically if it has the `maxlength` attribute defined.

#### :pushpin: Related Issues

#### Testing
- Create a default Decidim instance
- Create a text document e.g. programmatically and add there a text that has **at least** 500 characters in it + some carriage return characters (\r) in-between
- Go to create a new proposal
- For the proposal body, paste in the text to the body field from the text document (using copy + paste)
- You will see the character counter does not count the carriage returns as characters
- Submit the form
- See the error

To help you creating the text document, here's a one-liner that you can run in bash to create it:

```bash
$ echo $'Lorem ipsum dolor sit amet, consectetur adipiscing elit.\r\nDonec placerat lacus eget tellus pharetra tincidunt.\r\nCurabitur vel placerat arcu.\r\nNam velit velit, sodales eu volutpat ac, pellentesque congue purus.\r\nUt in nisi id nisi volutpat vehicula eu eu nisl.\r\nSuspendisse dictum felis nec tellus semper pharetra.\r\nPhasellus rhoncus nisl sit amet venenatis commodo.\r\nPhasellus ac tellus ac nulla iaculis laoreet.\r\nMauris interdum dictum placerat.\r\nAenean feugiat lorem massa, sed aliquet orci varius id.\r\nPellentesque vitae accumsan arcu. Donec eu blandit enim.\r\nPhasellus non eleifend ante, vitae finibus urna. Aenean molestie sed ipsum vitae pellentesque.' > test.txt && cat test.txt
```

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots