### PR TITLE
Fix conditions to autocancel CI builds

### DIFF
--- a/.github/workflows/ci_accountability.yml
+++ b/.github/workflows/ci_accountability.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_admin.yml
+++ b/.github/workflows/ci_admin.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_assemblies.yml
+++ b/.github/workflows/ci_assemblies.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_blogs.yml
+++ b/.github/workflows/ci_blogs.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_budgets.yml
+++ b/.github/workflows/ci_budgets.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_comments.yml
+++ b/.github/workflows/ci_comments.yml
@@ -39,7 +39,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_conferences.yml
+++ b/.github/workflows/ci_conferences.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_consultations.yml
+++ b/.github/workflows/ci_consultations.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_core.yml
+++ b/.github/workflows/ci_core.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_debates.yml
+++ b/.github/workflows/ci_debates.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_elections.yml
+++ b/.github/workflows/ci_elections.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_forms.yml
+++ b/.github/workflows/ci_forms.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_initiatives.yml
+++ b/.github/workflows/ci_initiatives.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_meetings.yml
+++ b/.github/workflows/ci_meetings.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_pages.yml
+++ b/.github/workflows/ci_pages.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_participatory_processes.yml
+++ b/.github/workflows/ci_participatory_processes.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_proposals_system_admin.yml
+++ b/.github/workflows/ci_proposals_system_admin.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_proposals_system_public.yml
+++ b/.github/workflows/ci_proposals_system_public.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_proposals_unit_tests.yml
+++ b/.github/workflows/ci_proposals_unit_tests.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_sortitions.yml
+++ b/.github/workflows/ci_sortitions.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_surveys.yml
+++ b/.github/workflows/ci_surveys.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_system.yml
+++ b/.github/workflows/ci_system.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_templates.yml
+++ b/.github/workflows/ci_templates.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_verifications.yml
+++ b/.github/workflows/ci_verifications.yml
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -23,7 +23,7 @@ jobs:
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0


### PR DESCRIPTION
#### :tophat: What? Why?
When we moved the CI to GitHub Actions in #5843, I added a step using https://github.com/rokroskar/workflow-run-cleanup-action. This action autocancels actions, see the repo for more info. 

We didn't want this autocancel feature to run in all conditions. More precisely, for the `master` and `develop` branch we don't want to autocancel, because it helps finding out what PR broke the suite. I calculated everything but oh boy am I bad at logic.

Turns out I wrote this:

```
if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
```

The idea behind this was to not run the action if we were on any of these branches... But I brote an `||` instead of an `&&`, so this wasn't working at all as I wanted.

This PR moves the `||` to an `&&` for all the GitHub Actions workflows in the repo.

#### :pushpin: Related Issues

- Fixes #7140

#### Testing
Merge two consecutive PRs to develop. CI suite should not be cancelled.

:hearts: Thank you!
