### PR TITLE
Fix initiative answer titles

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_result.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_result.html.erb
@@ -2,7 +2,7 @@
   <br>
   <div class="row column">
     <div class="callout success">
-      <h5><%= t(initiative.state, scope: "decidim.initiatives.initiatives.result.answer_title") %>:</h5>
+      <h5><%= t("decidim.initiatives.initiatives.result.answer_title") %>:</h5>
       <p>
         <% if initiative.answer_url.present? %>
           <a href="<%= initiative.answer_url %>" target="_blank">

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -488,13 +488,7 @@ en:
           section: 'If requested by the organization, please print and fill out this form to submit where indicated:'
           signature: Signature
         result:
-          answer_title:
-            accepted: This proposal has been accepted because
-            created: This proposal has been created
-            discarded: This proposal has been discarded because
-            published: This proposal is published because
-            rejected: This proposal has been rejected because
-            validating: This proposal is being evaluated
+          answer_title: This initiative has been answered
           initiative_rejected_reason: This initiative has been rejected due to its lack of signatures.
         show:
           any_vote_method: This initiative collects both online and in-person signatures.


### PR DESCRIPTION
#### :tophat: What? Why?

When making some initiatives docs I saw that the answers don't make much sense: 
* we're saying "This proposal has been X" --> these aren't proposals, they're initiatives
* the string depends in which kind of state the initiative is in. This don't make much sense.

#### :pushpin: Related Issues

- Related to #4881

#### Testing

1. Sign in as admin
2. Answer an initiative
3. See the public initiative page

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

#### Before
![imatge](https://user-images.githubusercontent.com/717367/104919587-c92bf600-5996-11eb-9fb6-c207b77e2b72.png)
https://www.decidim.barcelona/initiatives/i-1101

![imatge](https://user-images.githubusercontent.com/717367/104919618-d34df480-5996-11eb-9ede-a9f386216285.png)
https://www.decidim.barcelona/initiatives/i-1105

#### After
![imatge](https://user-images.githubusercontent.com/717367/104919632-d9dc6c00-5996-11eb-9f87-3e50c757eea6.png)


:hearts: Thank you!
