### PR TITLE
Fix initiative finish actions

### DIFF
--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -328,10 +328,10 @@ en:
           back_to_initiatives: Back to initiatives
           callout_text: Congratulations! Your initiative has been successfully created.
           confirm: You are going to send the initiative for an admin to review it and publish it. Once published you will not be able to edit it. Are you sure?
-          edit_my_initiative: Edit my initiatives
+          edit_my_initiative: Edit my initiative
           go_to_my_initiatives: Go to my initiatives
           more_information: "(More information)"
-          send_my_initiative: Send my initiative
+          send_my_initiative: Send my initiative to technical validation
         finish_help:
           access_reminder: You can access your initiatives through the %{link} filter on the Initiatives page.
           publish_helper_text: Remember that for your initiative to be published you must complete the required information and <strong>send it to technical validation</strong> for an administrator to review it.


### PR DESCRIPTION
#### :tophat: What? Why?

When making some initiatives docs, I found out that we could improve some of the buttons in the finish step of the wizard:

* Send my initiative. Where?
* Edit my initiatives: it's in plural but the link points to the edit initiative form. After #5736 the original flow (accessing to the admin panel with a list of all the initiatives) changed.  

#### :pushpin: Related Issues

- Related to #5736 

#### Testing

1. Create an initiative
2. See the finish step 

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

#### Before
![imatge](https://user-images.githubusercontent.com/717367/104920671-705d5d00-5998-11eb-9f20-9e489622e0ff.png)

#### After 

![imatge](https://user-images.githubusercontent.com/717367/104920787-a4d11900-5998-11eb-90cc-8e9dbeea6337.png)

:hearts: Thank you!
