### PR TITLE
Allow customizing SMTP settings for seed data

### DIFF
--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -17,8 +17,8 @@ if !Rails.env.production? || ENV["SEED"]
     table.tr("_", "/").classify.safe_constantize
   end.compact.each(&:reset_column_information)
 
-  smtp_label = Faker::Twitter.unique.screen_name
-  smtp_email = Faker::Internet.email
+  smtp_label = ENV["SMTP_FROM_LABEL"] || Faker::Twitter.unique.screen_name
+  smtp_email = ENV["SMTP_FROM_EMAIL"] || Faker::Internet.email
 
   organization = Decidim::Organization.first || Decidim::Organization.create!(
     name: Faker::Company.name,
@@ -31,10 +31,10 @@ if !Rails.env.production? || ENV["SEED"]
       from: "#{smtp_label} <#{smtp_email}>",
       from_email: smtp_email,
       from_label: smtp_label,
-      user_name: Faker::Twitter.unique.screen_name,
-      encrypted_password: Decidim::AttributeEncryptor.encrypt(Faker::Internet.password(min_length: 8)),
-      address: ENV["DECIDIM_HOST"] || "localhost",
-      port: ENV["DECIDIM_SMTP_PORT"] || "25"
+      user_name: ENV["SMTP_USERNAME"] || Faker::Twitter.unique.screen_name,
+      encrypted_password: Decidim::AttributeEncryptor.encrypt(ENV["SMTP_PASSWORD"] || Faker::Internet.password(min_length: 8)),
+      address: ENV["SMTP_ADDRESS"] || ENV["DECIDIM_HOST"] || "localhost",
+      port: ENV["SMTP_PORT"] || ENV["DECIDIM_SMTP_PORT"] || "25"
     },
     host: ENV["DECIDIM_HOST"] || "localhost",
     description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do

--- a/decidim-system/db/seeds.rb
+++ b/decidim-system/db/seeds.rb
@@ -3,9 +3,11 @@
 if !Rails.env.production? || ENV["SEED"]
   print "Creating seeds for decidim-system...\n" unless Rails.env.test?
 
+  password = ENV["DECIDIM_SYSTEM_USER_PASSWORD"] || "decidim123456"
+
   Decidim::System::Admin.find_or_initialize_by(email: "system@example.org").update!(
-    password: "decidim123456",
-    password_confirmation: "decidim123456"
+    password: password,
+    password_confirmation: password
   )
 
   Decidim::Organization.find_each do |organization|


### PR DESCRIPTION
#### :tophat: What? Why?
This PR lets devs overwrite organization SMTP settings using ENV variables. This only applies to the seed data, used for development and staging environments.

Since the SMTP settings are visible in the clear from the system area, this PR also allows devs to customize the system user password to protect those settings and keep them secret.

#### :pushpin: Related Issues
None

#### Testing
None
