### PR TITLE
Admin panel budgets count users with finished and pending votes

### DIFF
--- a/decidim-budgets/app/controllers/decidim/budgets/admin/budgets_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/admin/budgets_controller.rb
@@ -5,7 +5,8 @@ module Decidim
     module Admin
       # This controller allows the create or update a budget.
       class BudgetsController < Admin::ApplicationController
-        helper_method :budgets, :budget, :finished_orders, :pending_orders
+        helper_method :budgets, :budget, :finished_orders, :pending_orders,
+                      :users_with_pending_orders, :users_with_finished_orders
 
         def new
           enforce_permission_to :create, :budget
@@ -87,6 +88,14 @@ module Decidim
 
         def finished_orders
           orders.finished
+        end
+
+        def users_with_pending_orders
+          orders.pending.pluck(:decidim_user_id).uniq
+        end
+
+        def users_with_finished_orders
+          orders.finished.pluck(:decidim_user_id).uniq
         end
       end
     end

--- a/decidim-budgets/app/views/decidim/budgets/admin/budgets/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/budgets/index.html.erb
@@ -67,5 +67,9 @@
     <strong><%= t ".finished_orders" %>:&nbsp;</strong><span><%= finished_orders.count %></span>
     <span>&nbsp;|&nbsp;</span>
     <strong><%= t ".pending_orders" %>:&nbsp;</strong><span><%= pending_orders.count %></span>
+    <span>&nbsp;|&nbsp;</span>
+    <strong><%= t ".users_with_finished_orders" %>:&nbsp;</strong><span><%= users_with_finished_orders.count %></span>
+    <span>&nbsp;|&nbsp;</span>
+    <strong><%= t ".users_with_pending_orders" %>:&nbsp;</strong><span><%= users_with_pending_orders.count %></span>
   </div>
 </div>

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -48,8 +48,6 @@ en:
           index:
             finished_orders: Finished votes
             pending_orders: Pending votes
-            users_with_finished_orders: Users with finished votes
-            users_with_pending_orders: Users with pending votes
             title: Budgets
             users_with_finished_orders: Users with finished votes
             users_with_pending_orders: Users with pending votes

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -48,9 +48,9 @@ en:
           index:
             finished_orders: Finished votes
             pending_orders: Pending votes
+            title: Budgets
             users_with_finished_orders: Users with finished votes
             users_with_pending_orders: Users with pending votes
-            title: Budgets
           new:
             create: Create budget
             title: New budget

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -48,6 +48,8 @@ en:
           index:
             finished_orders: Finished votes
             pending_orders: Pending votes
+            users_with_finished_orders: Users with finished votes
+            users_with_pending_orders: Users with pending votes
             title: Budgets
             users_with_finished_orders: Users with finished votes
             users_with_pending_orders: Users with pending votes

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -46,8 +46,10 @@ en:
             title: Edit budget
             update: Update budget
           index:
-            finished_orders: Finished orders
-            pending_orders: Pending orders
+            finished_orders: Finished votes
+            pending_orders: Pending votes
+            users_with_finished_orders: Users with finished votes
+            users_with_pending_orders: Users with pending votes
             title: Budgets
           new:
             create: Create budget

--- a/decidim-budgets/spec/system/admin_manages_budgets.rb
+++ b/decidim-budgets/spec/system/admin_manages_budgets.rb
@@ -128,16 +128,43 @@ describe "Admin manages budgets", type: :system do
       let(:project2) { create(:project, budget: budget2, budget_amount: 95_000_000) }
       let(:user2) { create :user, :confirmed, organization: organization }
       let(:user3) { create :user, :confirmed, organization: organization }
+
+      # User has one finished and pending order
       let!(:finished_order) do
-        order = create(:order, user: user2, budget: budget)
+        order = create(:order, user: user, budget: budget)
         order.projects << project
         order.checked_out_at = Time.current
         order.save!
         order
       end
       let!(:pending_order) do
+        order = create(:order, user: user, budget: budget2)
+        order.projects << project2
+        order.save!
+        order
+      end
+
+      # User2 has two finished orders
+      let!(:finished_order2) do
+        order = create(:order, user: user2, budget: budget)
+        order.projects << project
+        order.checked_out_at = Time.current
+        order.save!
+        order
+      end
+      let!(:finished_order3) do
+        order = create(:order, user: user2, budget: budget2)
+        order.projects << project2
+        order.checked_out_at = Time.current
+        order.save!
+        order
+      end
+
+      # User3 has one finished order
+      let!(:finished_order4) do
         order = create(:order, user: user3, budget: budget2)
         order.projects << project2
+        order.checked_out_at = Time.current
         order.save!
         order
       end
@@ -145,8 +172,16 @@ describe "Admin manages budgets", type: :system do
       it "shows finished and pending orders" do
         visit current_path
         within find_all(".card-divider").last do
-          expect(page).to have_content("Finished orders: \n1")
-          expect(page).to have_content("Pending orders: \n1")
+          expect(page).to have_content("Finished votes: \n4")
+          expect(page).to have_content("Pending votes: \n1")
+        end
+      end
+
+      it "shows count of users with finished and pending orders" do
+        visit current_path
+        within find_all(".card-divider").last do
+          expect(page).to have_content("Users with finished votes: \n3")
+          expect(page).to have_content("Users with pending votes: \n1")
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
After [PR-7010](https://github.com/decidim/decidim/pull/7010) we can see easily how many votes budget component has in total. But for now there is not way to know how many individual voters there has been. This PR adds counts of users with finished and pending votes to component's admin index view. 

#### :pushpin: Related Issues
[https://meta.decidim.org/processes/roadmap/f/122/proposals/15922](https://meta.decidim.org/processes/roadmap/f/122/proposals/15922)

#### Testing
Admin dashboard -> Processes -> Pick a process -> Budgets -> See how many user there is with finished and pending votes.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/19709320/105366939-92f5ad00-5c08-11eb-951b-22318627a945.png)


:hearts: Thank you!
