### PR TITLE
Remove negative margin from registration field

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_forms.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_forms.scss
@@ -43,6 +43,13 @@ label,
   display: block;
   font-size: $input-error-font-size;
   font-weight: $input-error-font-weight;
+  margin-top: $form-spacing * -1;
+}
+
+.user-nickname{
+  .form-input-extra-before{
+    margin-top: 0;
+  }
 }
 
 .form-input-extra-before{

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_forms.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_forms.scss
@@ -46,10 +46,8 @@ label,
   margin-top: $form-spacing * -1;
 }
 
-.user-nickname{
-  .form-input-extra-before{
-    margin-top: 0;
-  }
+#registration_user_nickname_characters{
+  margin-top: 1rem;
 }
 
 .form-input-extra-before{

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_forms.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_forms.scss
@@ -43,7 +43,6 @@ label,
   display: block;
   font-size: $input-error-font-size;
   font-weight: $input-error-font-weight;
-  margin-top: $form-spacing * -1;
 }
 
 .form-input-extra-before{

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -40,7 +40,7 @@
 
             <div class="user-nickname">
               <div class="field">
-                <%= f.text_field :nickname, class: "margin-top-0", help_text: t(".nickname_help", organization: current_organization.name), prefix: { value: "@", small: 1, large: 1 } %>
+                <%= f.text_field :nickname, help_text: t(".nickname_help", organization: current_organization.name), prefix: { value: "@", small: 1, large: 1 } %>
               </div>
             </div>
 

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -40,7 +40,7 @@
 
             <div class="user-nickname">
               <div class="field">
-                <%= f.text_field :nickname, help_text: t(".nickname_help", organization: current_organization.name), prefix: { value: "@", small: 1, large: 1 } %>
+                <%= f.text_field :nickname, class: "margin-top-0", help_text: t(".nickname_help", organization: current_organization.name), prefix: { value: "@", small: 1, large: 1 } %>
               </div>
             </div>
 


### PR DESCRIPTION
#### :tophat: What? Why?
In the registration field, there is overlapping error text when nickname field is erroneous. Not exactly sure why this field behaves differently, but it has something to do with form_builder and prefix in a text_field.

![image](https://user-images.githubusercontent.com/19709320/105376501-7eb6ad80-5c12-11eb-88d8-1c1e75588032.png)
 
#### Testing
Sign up -> Write something to a nickname field -> Erase what you wrote

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/19709320/105376846-dce39080-5c12-11eb-8396-af7a348229dc.png)


:hearts: Thank you!
