### PR TITLE
Fix issue trying to add references to unexisting records

### DIFF
--- a/decidim-core/db/migrate/20180206143340_fix_reference_for_all_resources.rb
+++ b/decidim-core/db/migrate/20180206143340_fix_reference_for_all_resources.rb
@@ -5,6 +5,8 @@ class FixReferenceForAllResources < ActiveRecord::Migration[5.1]
     models = ActiveRecord::Base.descendants.select { |c| c.included_modules.include?(Decidim::HasReference) }
 
     models.each do |model|
+      next unless model.table_exists?
+
       model.find_each(&:touch)
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Bumped into the following error when trying to run the migrations on a newly created instance against an empty database:

```
== 20180621083659 FixReferenceForAllResources: migrating ======================
rake stderr: rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:

PG::UndefinedTable: ERROR:  relation "decidim_accountability_results" does not exist
LINE 1: SELECT  "decidim_accountability_results".* FROM "decidim_acc...
```

I guess it has something to do with the run order of the migrations.

#### :pushpin: Related Issues

#### Testing
I don't know exactly how to replicate this issue. It depends on the order in which the migrations are run. This has something to do when creating a new instance and the migrations are copied to the new code. In some of these situations, this migration can come AFTER some records that have the module `Decidim::HasReference`.

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots