### PR TITLE
Add private message link to proposal author tooltip

### DIFF
--- a/decidim-core/app/cells/decidim/author/profile_minicard.erb
+++ b/decidim-core/app/cells/decidim/author/profile_minicard.erb
@@ -4,7 +4,7 @@
       <%= cell("decidim/user_profile", raw_model).user_data %>
     </div>
     <div class="card__text card--picture-offset">
-      <%= link_to t("decidim.profiles.show.view_full_profile"), profile_path %>
+      <%= text_link_to_current_or_new_conversation_with(model) %>
     </div>
   </div>
   <div class="ml-s">

--- a/decidim-core/app/helpers/decidim/messaging/conversation_helper.rb
+++ b/decidim-core/app/helpers/decidim/messaging/conversation_helper.rb
@@ -30,6 +30,17 @@ module Decidim
       end
 
       #
+      # Same as #link_to_current_or_new_conversation_with, but with a text body instead of an icon
+      #
+      # Links to the conversation between the current user and another user
+      #
+      def text_link_to_current_or_new_conversation_with(user, body = t("decidim.profiles.show.send_private_message"))
+        conversation_path = current_or_new_conversation_path_with(user)
+        if conversation_path
+          link_to body, conversation_path, title: body
+        end
+      end
+      #
       # Finds the right path to the conversation the current user and another
       # user (the interlocutor).
       #

--- a/decidim-core/app/helpers/decidim/messaging/conversation_helper.rb
+++ b/decidim-core/app/helpers/decidim/messaging/conversation_helper.rb
@@ -36,10 +36,9 @@ module Decidim
       #
       def text_link_to_current_or_new_conversation_with(user, body = t("decidim.profiles.show.send_private_message"))
         conversation_path = current_or_new_conversation_path_with(user)
-        if conversation_path
-          link_to body, conversation_path, title: body
-        end
+        link_to body, conversation_path, title: body if conversation_path
       end
+
       #
       # Finds the right path to the conversation the current user and another
       # user (the interlocutor).

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1136,9 +1136,9 @@ en:
         groups: Groups
         members: Members
         officialized: Official participant
+        send_private_message: Send private message
         timeline: Timeline
         view_full_profile: View full profile
-        send_private_message: Send private message
       sidebar:
         badges:
           info: Badges are earned by performing specific activity in the platform.

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1138,6 +1138,7 @@ en:
         officialized: Official participant
         timeline: Timeline
         view_full_profile: View full profile
+        send_private_message: Send private message
       sidebar:
         badges:
           info: Badges are earned by performing specific activity in the platform.

--- a/decidim-core/spec/helpers/decidim/messaging/conversation_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/messaging/conversation_helper_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Messaging
+    describe ConversationHelper do
+      describe "#text_link_to_current_or_new_conversation_with" do
+        let(:current_user) { create(:user, :confirmed) }
+
+        before do
+          allow(helper).to receive(:current_user).and_return current_user
+          allow(helper).to receive(:user_signed_in?).and_return true
+        end
+
+        context "when user restricts private messaging to people they follow" do
+          let(:user) { create(:user, :confirmed, direct_message_types: "followed-only") }
+
+          it "returns nil" do
+            expect(helper.text_link_to_current_or_new_conversation_with(user)).to be_nil
+          end
+        end
+
+        context "when user doesn't restrict private messaging" do
+          let(:user) { create(:user, :confirmed) }
+          let(:message_link) do
+            "<a title=\"Send private message\" href=\"/conversations/new?recipient_id=#{user.id}\">Send private message</a>"
+          end
+
+          it "returns private message link" do
+            expect(helper.text_link_to_current_or_new_conversation_with(user)).to eql message_link
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/system/proposal_show_spec.rb
+++ b/decidim-proposals/spec/system/proposal_show_spec.rb
@@ -52,16 +52,17 @@ describe "Show a Proposal", type: :system do
         let(:user) { create(:user, :confirmed, organization: organization) }
 
         before do
-          WebMock.allow_net_connect!(net_http_connect_on_start: true)
           login_as user, scope: :user
           visit current_path
         end
 
-        it "includes a link to message the proposal author" do
-          within ".author-data" do
-            find_link.hover
+        context "when author doesn't restrict messaging" do
+          it "includes a link to message the proposal author" do
+            within ".author-data" do
+              find_link.hover
+            end
+            expect(page).to have_link("Send private message")
           end
-          expect(page).to have_link("Send private message")
         end
       end
     end

--- a/decidim-proposals/spec/system/proposal_show_spec.rb
+++ b/decidim-proposals/spec/system/proposal_show_spec.rb
@@ -47,6 +47,23 @@ describe "Show a Proposal", type: :system do
           end
         end
       end
+
+      describe "author tooltip" do
+        let(:user) { create(:user, :confirmed, organization: organization) }
+
+        before do
+          WebMock.allow_net_connect!(net_http_connect_on_start: true)
+          login_as user, scope: :user
+          visit current_path
+        end
+
+        it "includes a link to message the proposal author" do
+          within ".author-data" do
+            find_link.hover
+          end
+          expect(page).to have_link("Send private message")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Replaces "View full profile" link on proposal author tooltip with a "Send private message" link.

Disables link when the author has opted to not be messaged by people they don't follow, and adds an explanation on hover. This is waiting on styling.

Basic functionality is in place, tests are on the way.

#### :pushpin: Related Issues
- Closes https://github.com/decidim/decidim/issues/6989
- Metadecidim issue: https://meta.decidim.org/processes/roadmap/f/122/proposals/15228

#### Testing
Staging link: https://decidim-staging.liquidvoting.io/processes/ea-qui/f/13/proposals/9
(usual seed login: user@example.org / decidim123456)

As a logged-in user, navigate to a proposal and mouse over the author's username link, in the tooltip you should see a link to "Send private message" in place of "View full profile". 

Clicking the click should take you to a conversation with the author.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

![Screen Shot 2021-01-22 at 3 37 49 PM](https://user-images.githubusercontent.com/21290/105511923-62754800-5cc8-11eb-9f64-a33e667a1c97.png)

