### PR TITLE
Restore consultation's description rich text format

### DIFF
--- a/decidim-consultations/app/views/decidim/consultations/consultations/_consultation_details.html.erb
+++ b/decidim-consultations/app/views/decidim/consultations/consultations/_consultation_details.html.erb
@@ -1,6 +1,6 @@
 <div class="row section" id="consultation-details">
   <div class="columns medium-6 large-5 large-push-1">
-    <p class="lead"><%= decidim_sanitize translated_attribute(consultation.description), strip_tags: true %></p>
+    <p class="lead"><%= decidim_sanitize translated_attribute(consultation.description) %></p>
   </div>
   <div class="columns medium-6 large-5 large-pull-1">
     <% if consultation.introductory_video_url.blank? %>


### PR DESCRIPTION
#### :tophat: What? Why?

This fixes a regression introduced in #5684. The formatting of a consultation's description was ripped off.
Few weeks ago, this was noticed by #6893 but it seems only was backported to v0.22

#### :pushpin: Related Issues

- Related to #5684
- Fixes #5684

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

In public:
![image](https://user-images.githubusercontent.com/9702463/105715419-deb49900-5f1d-11eb-8cbb-4ab023c57268.png)

while in management:
![image](https://user-images.githubusercontent.com/9702463/105715392-d52b3100-5f1d-11eb-8307-b1d63118889f.png)

:hearts: Thank you!
