### PR TITLE
Fix: hide help section when it has no content

### DIFF
--- a/decidim-admin/spec/system/admin_manages_help_sections_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_help_sections_spec.rb
@@ -31,5 +31,22 @@ describe "Admin manages help sections", type: :system do
       help_content = Decidim::ContextualHelpSection.find_content(organization, :participatory_processes)
       expect(help_content).to include("en" => "<p>Well hello!</p>")
     end
+
+    it "destroys the section when it is empty" do
+      clear_i18n_editor :help_sections_sections_participatory_processes_content, "#sections_participatory_processes_content", [:en]
+
+      click_button "Save"
+
+      within ".callout.success" do
+        expect(page).to have_content("successfully")
+      end
+
+      within "#sections_participatory_processes_content-content-panel-0" do
+        expect(page).to have_content("")
+      end
+
+      help_content = Decidim::ContextualHelpSection.find_content(organization, :participatory_processes)
+      expect(help_content).to eq({})
+    end
   end
 end

--- a/decidim-core/app/assets/javascripts/decidim/editor.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/editor.js.es6
@@ -59,7 +59,7 @@
       });
       container.dispatchEvent(event);
 
-      if (text === "\n") {
+      if (text === "\n" || text === "\n\n") {
         $input.val("");
       } else {
         $input.val(quill.root.innerHTML);

--- a/decidim-core/app/models/decidim/contextual_help_section.rb
+++ b/decidim-core/app/models/decidim/contextual_help_section.rb
@@ -33,7 +33,7 @@ module Decidim
         section_id: id
       )
 
-      if content.present? && content.values.any? { |translation| translation.present? && translation != "<p><br></p>" }
+      if content.present? && content.values.any? { |translation| translation.gsub(%r{</?[^>]*>}, "").present? }
         item.update!(content: content)
       else
         item.destroy!

--- a/decidim-core/app/models/decidim/contextual_help_section.rb
+++ b/decidim-core/app/models/decidim/contextual_help_section.rb
@@ -33,7 +33,7 @@ module Decidim
         section_id: id
       )
 
-      if content.present? && content.values.any?(&:present?)
+      if content.present? && content.values.any? { |translation| translation.present? && translation != "<p><br></p>" }
         item.update!(content: content)
       else
         item.destroy!

--- a/decidim-core/app/models/decidim/contextual_help_section.rb
+++ b/decidim-core/app/models/decidim/contextual_help_section.rb
@@ -33,7 +33,7 @@ module Decidim
         section_id: id
       )
 
-      if content.present? && content.values.any? { |translation| translation.gsub(%r{</?[^>]*>}, "").present? }
+      if content.present? && content.values.any?(&:present?)
         item.update!(content: content)
       else
         item.destroy!

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb
@@ -101,7 +101,7 @@ module TranslationHelpers
   def clear_editor(locator)
     page.execute_script <<-SCRIPT
       $('##{locator}').siblings('.editor-container').find('.ql-editor')[0].innerHTML = "<p><br></p>";
-      $('##{locator}').val("<p><br></p>")
+      $('##{locator}').val("")
     SCRIPT
   end
 

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb
@@ -67,6 +67,20 @@ module TranslationHelpers
     end
   end
 
+  # Handles how to clear i18n form fields which uses a WYSIWYG editor.
+  #
+  # field - the name of the field that should be cleared, without the
+  #   locale-related part (e.g. `:participatory_process_title`)
+  # tab_selector - a String representing the ID of the HTML element that holds
+  #   the tabs for this input. It ususally is `"#<attribute_name>-tabs" (e.g.
+  #   "#title-tabs")
+  # locales - an Array with the locales IDs.
+  def clear_i18n_editor(field, tab_selector, locales)
+    clear_i18n_fields(field, tab_selector, locales) do |locator|
+      clear_editor locator
+    end
+  end
+
   # Handles how to fill a WYSIWYG editor.
   #
   # locator - The input field ID. The DOM element is selected using jQuery.
@@ -81,6 +95,16 @@ module TranslationHelpers
     SCRIPT
   end
 
+  # Handles how to clear a WYSIWYG editor.
+  #
+  # locator - The input field ID. The DOM element is selected using jQuery.
+  def clear_editor(locator)
+    page.execute_script <<-SCRIPT
+      $('##{locator}').siblings('.editor-container').find('.ql-editor')[0].innerHTML = "<p><br></p>";
+      $('##{locator}').val("<p><br></p>")
+    SCRIPT
+  end
+
   private
 
   def fill_in_i18n_fields(field, tab_selector, localized_values)
@@ -89,6 +113,15 @@ module TranslationHelpers
         click_link I18n.with_locale(locale) { t("name", scope: "locale") }
       end
       yield "#{field}_#{locale}", value
+    end
+  end
+
+  def clear_i18n_fields(field, tab_selector, locales)
+    locales.each do |locale|
+      within tab_selector do
+        click_link I18n.with_locale(locale) { t("name", scope: "locale") }
+      end
+      yield "#{field}_#{locale}"
     end
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?
As spotted by @carolromero [here](https://github.com/decidim/decidim/issues/7101#issuecomment-767415189), help section banners for participatory spaces were rendered even when all their translations are removed from the admin panel.

This happened because `quilljs` (the editor) adds an annoying `\n\n` when the user clears the input box. This led the command that updates a contextual help to think the translation is not empty, thus not deleting it.

This PR sets the editor's `val` to "" when the `innerHTML` is `\n\n` (was already done for when it's `\n`).

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #7174 

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
BEFORE
![image](https://user-images.githubusercontent.com/5033945/105846089-f94d4780-5fdb-11eb-9e6c-98243d8c1f6b.png)

AFTER
![image](https://user-images.githubusercontent.com/5033945/105846122-01a58280-5fdc-11eb-9bfc-4e504eb4a71d.png)


:hearts: Thank you!
