### PR TITLE
Document automated docker release builds

### DIFF
--- a/docs/modules/develop/pages/releases.adoc
+++ b/docs/modules/develop/pages/releases.adoc
@@ -173,6 +173,4 @@ After that, the header with the current version and link like `+## [0.20.0](http
 
 == Docker images for each release
 
-. After each release, you should update our https://github.com/decidim/docker[Docker repository] so new images are build for the new release.
-To do it, create a PR that just updates `DECIDIM_VERSION` at https://github.com/decidim/docker/blob/master/circle.yml[circle.yml].
-Then the continous integration circleci build will generate the images and they will be published to docker hub when the PR is merged.
+Each release triggers a [Github workflow](https://github.com/decidim/decidim/blob/develop/.github/workflows/on_release.yml) that re-builds and publishes the [decidim/docker images](https://github.com/decidim/docker) to [Github Container Registry](https://github.com/orgs/decidim/packages) and [Docker Hub](https://hub.docker.com/repository/docker/decidim/decidim).


### PR DESCRIPTION
#### :tophat: What? Why?

Updates the docs with information on recently added automated docker release builds. Apologies for not submitting it earlier!

#### :pushpin: Related Issues

Automated release builds PR: https://github.com/decidim/decidim/pull/6931

#### Testing

I guess testing here would be viewing the rendered updated doc, but not sure how this can be done without pulling the changes locally and rendering it manually.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

Changes aren't in the user interface.