### PR TITLE
Ignore the `state_published_at` field when importing proposals

### DIFF
--- a/decidim-proposals/app/services/decidim/proposals/proposal_builder.rb
+++ b/decidim-proposals/app/services/decidim/proposals/proposal_builder.rb
@@ -63,6 +63,7 @@ module Decidim
           "created_at",
           "updated_at",
           "state",
+          "state_published_at",
           "answer",
           "answered_at",
           "decidim_component_id",

--- a/decidim-proposals/db/migrate/20210127115628_fix_answered_proposals_after_copy.rb
+++ b/decidim-proposals/db/migrate/20210127115628_fix_answered_proposals_after_copy.rb
@@ -6,6 +6,9 @@ class FixAnsweredProposalsAfterCopy < ActiveRecord::Migration[5.2]
 
     result = Decidim::Proposals::Proposal.where.not(state_published_at: nil).where(state: nil, id: proposals_after_copy)
 
-    result.update_all(state_published_at: nil)
+    result.find_each do |proposal|
+      proposal.state_published_at = nil
+      proposal.save!
+    end
   end
 end

--- a/decidim-proposals/db/migrate/20210127115628_fix_answered_proposals_after_copy.rb
+++ b/decidim-proposals/db/migrate/20210127115628_fix_answered_proposals_after_copy.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class FixAnsweredProposalsAfterCopy < ActiveRecord::Migration[5.2]
+  def change
+    proposals_after_copy = Decidim::ResourceLink.where(from_type: "Decidim::Proposals::Proposal").pluck(:from_id)
+
+    result = Decidim::Proposals::Proposal.where.not(state_published_at: nil).where(state: nil, id: proposals_after_copy)
+
+    result.update_all(state_published_at: nil)
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This comes from a bug reported at Decidim Barcelona.

When copying proposals from one component to the other, if the source component has anwers active and made to be publish immediately, imported proposals will not appear in the public side of the component.

This seems to be caused by the copying process. It ignores the state of the answer, but keeps the publishing timestamp of the answer. Then, when fetching the proposals to be shown in the public area, proposals with this setup are ignored on purpose.

This PR fixes the process that copies proposals from one component to the other so that the problem won't happen again. 

This snippet should fix the proposals affected by this:

```ruby
  proposals_after_copy = Decidim::ResourceLink.where(from_type: "Decidim::Proposals::Proposal").pluck(:from_id)

  result = Decidim::Proposals::Proposal.where.not(state_published_at: nil).where(state: nil, id: proposals_after_copy)

  result.update_all(state_published_at: nil)
```

#### :pushpin: Related Issues
- Related to #5810

#### Testing
- Have a proposals component on the admin. Ensure that component has answers enabled, and publishes them immediately.
- From the admin, answer one proposal from that component by accepting the result (note the ID).
- Create a new proposals component in the same participatory space. Answers should be disabled for this one.
- In this new component, import proposals from the previous component. 
- Go to the public area of that new component, the proposal that was accepted doesn't appear publicly.

With this fix, repeating all the steps should show the accepted proposal.

