### PR TITLE
Prevent destroying an election component when elections are present

### DIFF
--- a/decidim-elections/lib/decidim/elections/component.rb
+++ b/decidim-elections/lib/decidim/elections/component.rb
@@ -9,9 +9,10 @@ Decidim.register_component(:elections) do |component|
   component.stylesheet = "decidim/elections/elections"
   component.permissions_class_name = "Decidim::Elections::Permissions"
   component.query_type = "Decidim::Elections::ElectionsType"
-  # component.on(:before_destroy) do |instance|
-  #   # Code executed before removing the component
-  # end
+
+  component.on(:before_destroy) do |instance|
+    raise StandardError, "Can't remove this component" if Decidim::Elections::Election.where(component: instance).any?
+  end
 
   # These actions permissions can be configured in the admin panel
   component.actions = %w(vote)

--- a/decidim-elections/spec/lib/decidim/elections/component_spec.rb
+++ b/decidim-elections/spec/lib/decidim/elections/component_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Elections component" do # rubocop:disable RSpec/DescribeClass
+  subject { component }
+
+  let(:component) { create :elections_component }
+
+  describe "before_destroy hooks" do
+    context "when there are no elections" do
+      it "does not raise any error" do
+        expect { subject.manifest.run_hooks(:before_destroy, subject) }.not_to raise_error
+      end
+    end
+
+    context "with elections" do
+      before do
+        create :election, component: component
+      end
+
+      it "raises an error" do
+        expect { subject.manifest.run_hooks(:before_destroy, subject) }.to raise_error(
+          StandardError,
+          "Can't remove this component"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Prevents an admin from destroying an election component from a participatory space when it contains elections.

#### :pushpin: Related Issues

#### Testing

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![destroy](https://user-images.githubusercontent.com/5033945/106005735-caef6b00-60b4-11eb-9970-b821fe070804.gif)

:hearts: Thank you!
