### PR TITLE
Include area in initiatives export

### DIFF
--- a/decidim-initiatives/app/serializers/decidim/initiatives/initiative_serializer.rb
+++ b/decidim-initiatives/app/serializers/decidim/initiatives/initiative_serializer.rb
@@ -24,6 +24,9 @@ module Decidim
           authors: {
             id: resource.author_users.map(&:id),
             name: resource.author_users.map(&:name)
+          },
+          area: {
+            name: resource.area&.name
           }
         }
       end

--- a/decidim-initiatives/lib/decidim/initiatives/test/factories.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/test/factories.rb
@@ -190,6 +190,10 @@ FactoryBot.define do
                type: create(:initiatives_type, :with_user_extra_fields_collection, organization: organization))
       end
     end
+
+    trait :with_area do
+      area { create(:area, organization: organization) }
+    end
   end
 
   factory :initiative_user_vote, class: "Decidim::InitiativesVote" do

--- a/decidim-initiatives/spec/serializers/initiative_serializer_spec.rb
+++ b/decidim-initiatives/spec/serializers/initiative_serializer_spec.rb
@@ -4,10 +4,9 @@ require "spec_helper"
 
 module Decidim::Initiatives
   describe InitiativeSerializer do
-    let(:initiative) { create(:initiative, :with_area) }
-
     subject { described_class.new(initiative) }
 
+    let(:initiative) { create(:initiative, :with_area) }
     let(:serialized) { subject.serialize }
 
     describe "#serialize" do

--- a/decidim-initiatives/spec/serializers/initiative_serializer_spec.rb
+++ b/decidim-initiatives/spec/serializers/initiative_serializer_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Initiatives
+  describe InitiativeSerializer do
+    let(:initiative) { create(:initiative) }
+
+    subject { described_class.new(initiative) }
+
+    let(:serialized) { subject.serialize }
+
+    describe "#serialize" do
+      it "includes the id" do
+        expect(serialized).to include(id: initiative.id)
+      end
+
+      it "includes the title" do
+        expect(serialized).to include(title: initiative.title)
+      end
+
+      it "includes the description" do
+        expect(serialized).to include(description: initiative.description)
+      end
+
+      it "includes the state" do
+        expect(serialized).to include(state: initiative.state)
+      end
+
+      it "includes the created_at timestamp" do
+        expect(serialized).to include(created_at: initiative.created_at)
+      end
+
+      it "includes the published_at timestamp" do
+        expect(serialized).to include(published_at: initiative.published_at)
+      end
+
+      it "includes the signature_end_date" do
+        expect(serialized).to include(signature_end_date: initiative.signature_end_date)
+      end
+
+      it "includes the signature_type" do
+        expect(serialized).to include(signature_type: initiative.signature_type)
+      end
+
+      it "includes the number of signatures (supports)" do
+        expect(serialized).to include(signatures: initiative.supports_count)
+      end
+
+      it "includes the scope name" do
+        expect(serialized[:scope]).to include(name: initiative.scope.name)
+      end
+
+      it "includes the type title" do
+        expect(serialized[:type]).to include(title: initiative.type.title)
+      end
+
+      it "includes the authors' ids" do
+        expect(serialized[:authors]).to include(id: initiative.author_users.map(&:id))
+      end
+
+      it "includes the authors' names" do
+        expect(serialized[:authors]).to include(name: initiative.author_users.map(&:name))
+      end
+    end
+  end
+end

--- a/decidim-initiatives/spec/serializers/initiative_serializer_spec.rb
+++ b/decidim-initiatives/spec/serializers/initiative_serializer_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 module Decidim::Initiatives
   describe InitiativeSerializer do
-    let(:initiative) { create(:initiative) }
+    let(:initiative) { create(:initiative, :with_area) }
 
     subject { described_class.new(initiative) }
 
@@ -61,6 +61,10 @@ module Decidim::Initiatives
 
       it "includes the authors' names" do
         expect(serialized[:authors]).to include(name: initiative.author_users.map(&:name))
+      end
+
+      it "includes the area name" do
+        expect(serialized[:area]).to include(name: initiative.area.name)
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

Includes an initiative's area name to the serialized Initiative fields, to be included when exporting initiatives from the admin.

Also adds overall test coverage to the initiative serializer.

#### :pushpin: Related Issues

Metadecidim issue: https://meta.decidim.org/processes/roadmap/f/122/proposals/16199

#### Testing

1) Go to https://decidim-staging.liquidvoting.io/ and log-in as admin@example.org  / decidim123456

2) Then go to https://decidim-staging.liquidvoting.io/admin/initiatives and click on "Export", then "Initiatives as CSV":

![Screen Shot 2021-01-29 at 7 15 30 PM](https://user-images.githubusercontent.com/21290/106317682-8e637100-6266-11eb-898a-768e243df977.png)

You should see a confirmation message saying the email with the export was sent:

![Screen Shot 2021-01-29 at 7 16 35 PM](https://user-images.githubusercontent.com/21290/106317790-b6eb6b00-6266-11eb-9ab8-05ad1e74f23d.png)

You can view the email and download the exported zip at: https://decidim-staging.liquidvoting.io/letter_opener

And a sample exported zip file here: https://decidim-staging.liquidvoting.io/letter_opener/1611949506_9309008_b5bc353/attachments/initiatives-2021-01-29-71106.zip

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

Nothing changes visually, but here's a screenshot of where to test this:

<img width="1000" alt="initiatives export" src="https://user-images.githubusercontent.com/21290/106159076-567fff00-617c-11eb-95db-2c3a81410d2e.png">


