### PR TITLE
Don't render separators when exporting questionnaires

### DIFF
--- a/decidim-forms/app/models/decidim/forms/answer.rb
+++ b/decidim-forms/app/models/decidim/forms/answer.rb
@@ -21,6 +21,8 @@ module Decidim
       validate :user_questionnaire_same_organization
       validate :question_belongs_to_questionnaire
 
+      scope :not_separator, -> { joins(:question).where.not(decidim_forms_questions: { question_type: Decidim::Forms::Question::SEPARATOR_TYPE }) }
+
       def self.user_collection(user)
         where(decidim_user_id: user.id)
       end

--- a/decidim-forms/app/models/decidim/forms/question.rb
+++ b/decidim-forms/app/models/decidim/forms/question.rb
@@ -48,6 +48,8 @@ module Decidim
 
       validates :question_type, inclusion: { in: TYPES }
 
+      scope :not_separator, -> { where.not(question_type: SEPARATOR_TYPE) }
+
       scope :with_body, -> { where(question_type: %w(short_answer long_answer)) }
       scope :with_choices, -> { where.not(question_type: %w(short_answer long_answer)) }
 

--- a/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_participant_presenter.rb
+++ b/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_participant_presenter.rb
@@ -46,13 +46,13 @@ module Decidim
           with_choices = sibilings.where.not("decidim_forms_questions.question_type in (?)", %w(short_answer long_answer))
                                   .where("decidim_forms_answers.id IN (SELECT decidim_answer_id FROM decidim_forms_answer_choices)").count
 
-          (with_body + with_choices).to_f / questionnaire.questions.count * 100
+          (with_body + with_choices).to_f / questionnaire.questions.not_separator.count * 100
         end
 
         private
 
         def sibilings
-          Answer.where(questionnaire: questionnaire, session_token: participant.session_token).joins(:question).order("decidim_forms_questions.position ASC")
+          Answer.not_separator.where(questionnaire: questionnaire, session_token: participant.session_token).joins(:question).order("decidim_forms_questions.position ASC")
         end
       end
     end

--- a/decidim-forms/app/queries/decidim/forms/questionnaire_user_answers.rb
+++ b/decidim-forms/app/queries/decidim/forms/questionnaire_user_answers.rb
@@ -20,7 +20,8 @@ module Decidim
 
       # Finds and group answers by user for each questionnaire's question.
       def query
-        answers = Answer.where(questionnaire: @questionnaire)
+        answers = Answer.not_separator.joins(:question).where(questionnaire: @questionnaire)
+
         answers.sort_by { |answer| answer.question.position }.group_by { |a| a.user || a.session_token }.values
       end
     end

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/export/_answer.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/export/_answer.html.erb
@@ -24,7 +24,6 @@
 
   <div class="answers">
     <% participant.answers.each do |answer| %>
-      <% next if answer.body == Decidim::Forms::Question::SEPARATOR_TYPE %>
       <h3 class="question"><%= answer.question %></h3>
       <p><%= answer.body %></p>
     <% end %>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/export/_answer.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/export/_answer.html.erb
@@ -24,6 +24,7 @@
 
   <div class="answers">
     <% participant.answers.each do |answer| %>
+      <% next if answer.body == Decidim::Forms::Question::SEPARATOR_TYPE %>
       <h3 class="question"><%= answer.question %></h3>
       <p><%= answer.body %></p>
     <% end %>

--- a/decidim-forms/spec/presenters/decidim/admin/questionnaire_participant_presenter_spec.rb
+++ b/decidim-forms/spec/presenters/decidim/admin/questionnaire_participant_presenter_spec.rb
@@ -8,7 +8,13 @@ module Decidim
 
     let!(:questionnaire) { create(:questionnaire) }
     let!(:user) { create(:user, organization: questionnaire.questionnaire_for.organization) }
-    let!(:questions) { 3.downto(1).map { |n| create :questionnaire_question, questionnaire: questionnaire, position: n } }
+    let!(:questions) do
+      [
+        create(:questionnaire_question, questionnaire: questionnaire, position: 1),
+        create(:questionnaire_question, :separator, questionnaire: questionnaire, position: 2),
+        create(:questionnaire_question, questionnaire: questionnaire, position: 3)
+      ]
+    end
     let!(:answers) do
       questions.map { |question| create :answer, user: user, questionnaire: questionnaire, question: question }.sort_by { |a| a.question.position }
     end
@@ -53,8 +59,9 @@ module Decidim
     end
 
     describe "answers" do
-      it "returns the participant's answers" do
-        expect(subject.answers.map(&:answer)).to eq(answers)
+      it "returns the participant's answers without the separators" do
+        expect(subject.answers.map(&:answer)).to eq([answers.first, answers.last])
+        expect(subject.answers.map(&:answer)).not_to include(answers.second)
       end
     end
 

--- a/decidim-forms/spec/queries/decidim/forms/questionnaire_user_answers_spec.rb
+++ b/decidim-forms/spec/queries/decidim/forms/questionnaire_user_answers_spec.rb
@@ -8,16 +8,22 @@ describe Decidim::Forms::QuestionnaireUserAnswers do
   let!(:questionnaire) { create(:questionnaire) }
   let!(:user_1) { create(:user, organization: questionnaire.questionnaire_for.organization) }
   let!(:user_2) { create(:user, organization: questionnaire.questionnaire_for.organization) }
-  let!(:questions) { 3.downto(1).map { |n| create :questionnaire_question, questionnaire: questionnaire, position: n } }
+  let!(:questions) do
+    [
+      create(:questionnaire_question, questionnaire: questionnaire, position: 3),
+      create(:questionnaire_question, :separator, questionnaire: questionnaire, position: 2),
+      create(:questionnaire_question, questionnaire: questionnaire, position: 1)
+    ]
+  end
   let!(:answers_user_1) { questions.map { |question| create :answer, user: user_1, questionnaire: questionnaire, question: question } }
   let!(:answers_user_2) { questions.map { |question| create :answer, user: user_2, questionnaire: questionnaire, question: question } }
 
-  it "returns the user answers for each user" do
+  it "returns the user answers for each user without the separators" do
     result = subject.query
 
     expect(result).to contain_exactly(
-      answers_user_1.sort { |answer| answer.question.position },
-      answers_user_2.sort { |answer| answer.question.position }
+      [answers_user_1.last, answers_user_1.first],
+      [answers_user_2.last, answers_user_2.first]
     )
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
When exporting questionnaires, questions of type "separator" were being rendered. This PR filters out separators when exporting questionnaires.

#### 📌 Related to

Separate forms in steps #6108

#### Testing
- Add a separator question to a survey's questionnaire
- Answer the survey
- Export survey answers
- Check that separator is not being rendered

### :camera: Screenshots

#### Before (separator being rendered as text in PDF export)
![Separator rendered in PDF](https://user-images.githubusercontent.com/8806781/106141391-4b26d680-6170-11eb-9d3a-5071f3cc21f3.png)



:hearts: Thank you!
