### PR TITLE
Proposal preview with full text and attachments

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/proposals/_proposal_preview.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_proposal_preview.html.erb
@@ -1,1 +1,0 @@
-<%= card_for @proposal, from: @proposal, preview: true %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_wizard_header.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_wizard_header.html.erb
@@ -4,7 +4,10 @@
   <%
     locals = {
       callout_class: "warning",
-      announcement: t("decidim.proposals.proposals.preview.proposal_edit_before_minutes", count: component_settings.proposal_edit_before_minutes)
+      announcement: {
+        title: t("decidim.proposals.proposals.preview.announcement_title"),
+        body: "#{t("decidim.proposals.proposals.preview.announcement_body")}<br><br>#{t("decidim.proposals.proposals.preview.proposal_edit_before_minutes", count: component_settings.proposal_edit_before_minutes)}"
+      }
     }
   %>
   <%= render partial: "decidim/shared/announcement", locals: locals %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/preview.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/preview.html.erb
@@ -3,9 +3,16 @@
 <div class="row">
   <%= render partial: "wizard_aside" %>
 
-  <div class="columns large-6">
+  <div class="columns large-9">
     <%= render partial: "wizard_header", locals: { callout_help_text_class: "warning" } %>
-    <%= render partial: "proposal_preview", locals: { proposal: @proposal } %>
+
+    <div class="row column view-header">
+      <h3 class="heading3"><%= present(@proposal).title(links: true, html_escape: true) %></h3>
+      <%= render_proposal_body(@proposal) %>
+    </div>
+    <div class="row column">
+      <%= attachments_for @proposal %>
+    </div>
 
     <% if component_settings.geocoding_enabled? %>
       <% if has_position?(@proposal) %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/preview.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/preview.html.erb
@@ -5,7 +5,7 @@
 
   <div class="columns large-9">
     <%= render partial: "wizard_header", locals: { callout_help_text_class: "warning" } %>
-    <div class="card">
+    <div class="card card__content">
       <div class="row column view-header">
         <h3 class="heading3"><%= present(@proposal).title(links: true, html_escape: true) %></h3>
         <% unless component_settings.participatory_texts_enabled? %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/preview.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/preview.html.erb
@@ -8,7 +8,12 @@
 
     <div class="row column view-header">
       <h3 class="heading3"><%= present(@proposal).title(links: true, html_escape: true) %></h3>
+      <% unless component_settings.participatory_texts_enabled? %>
+        <%= cell("decidim/coauthorships", @proposal, has_actions: false, size: 3, context: { current_user: current_user }) %>
+      <% end %>
+
       <%= render_proposal_body(@proposal) %>
+      <%= cell "decidim/proposals/proposal_tags", @proposal %>
     </div>
     <div class="row column">
       <%= attachments_for @proposal %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/preview.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/preview.html.erb
@@ -5,15 +5,19 @@
 
   <div class="columns large-9">
     <%= render partial: "wizard_header", locals: { callout_help_text_class: "warning" } %>
+    <div class="card">
+      <div class="row column view-header">
+        <h3 class="heading3"><%= present(@proposal).title(links: true, html_escape: true) %></h3>
+        <% unless component_settings.participatory_texts_enabled? %>
+          <%= cell("decidim/coauthorships", @proposal, has_actions: false, size: 3, context: { current_user: current_user }) %>
+        <% end %>
 
-    <div class="row column view-header">
-      <h3 class="heading3"><%= present(@proposal).title(links: true, html_escape: true) %></h3>
-      <% unless component_settings.participatory_texts_enabled? %>
-        <%= cell("decidim/coauthorships", @proposal, has_actions: false, size: 3, context: { current_user: current_user }) %>
-      <% end %>
+        <%= render_proposal_body(@proposal) %>
 
-      <%= render_proposal_body(@proposal) %>
-      <%= cell "decidim/proposals/proposal_tags", @proposal %>
+      </div>
+      <div class="row column">
+        <%= cell "decidim/proposals/proposal_tags", @proposal %>
+      </div>
     </div>
     <div class="row column">
       <%= attachments_for @proposal %>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -791,6 +791,8 @@ en:
         placeholder:
           address: 37 Homewood Drive Brownsburg, IN 46112
         preview:
+          announcement_title: Your proposal has not yet been published
+          announcement_body: Your proposal has been saved as a draft. It needs to be published for it to appear on the site.
           modify: Modify the proposal
           proposal_edit_before_minutes:
             one: You will be able to edit this proposal during the first minute after the proposal is published. Once this time window passes, you will not be able to edit the proposal.

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -790,8 +790,8 @@ en:
         placeholder:
           address: 37 Homewood Drive Brownsburg, IN 46112
         preview:
-          announcement_title: Your proposal has not yet been published
           announcement_body: Your proposal has been saved as a draft. It needs to be published for it to appear on the site.
+          announcement_title: Your proposal has not yet been published
           modify: Modify the proposal
           proposal_edit_before_minutes:
             one: You will be able to edit this proposal during the first minute after the proposal is published. Once this time window passes, you will not be able to edit the proposal.

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -356,7 +356,6 @@ en:
         actions:
           preview: Preview
         exports:
-          comments: Comments
           proposal_comments: Comments
           proposals: Proposals
         models:
@@ -803,9 +802,6 @@ en:
         proposal:
           creation_date: 'Creation: %{date}'
           view_proposal: View proposal
-        text_and_attachments:
-          comments: Comments
-          edit_proposal: Edit proposal
         proposals:
           empty: There is no proposal yet
           empty_filters: There isn't any proposal with this criteria

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -800,6 +800,9 @@ en:
         proposal:
           creation_date: 'Creation: %{date}'
           view_proposal: View proposal
+        text_and_attachments:
+          comments: Comments
+          edit_proposal: Edit proposal
         proposals:
           empty: There is no proposal yet
           empty_filters: There isn't any proposal with this criteria

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -356,6 +356,7 @@ en:
         actions:
           preview: Preview
         exports:
+          comments: Comments
           proposal_comments: Comments
           proposals: Proposals
         models:


### PR DESCRIPTION
#### :tophat: What? Why?
When creating new proposal, preview step is pretty confusing to many users. One reason for this is that user's body text is truncated after 100 characters. Also user is not able to see his/her uploaded attachments in preview. Here we try to make preview more understandable to users. 

#### :pushpin: Related Issues
According to this it should be already a core feature:
https://meta.decidim.org/processes/roadmap/f/122/proposals/13325

#### Testing
1. Create new proposal with long text(over 100 characters)
2. Go to preview

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![proposalpreview3](https://user-images.githubusercontent.com/19709320/106170907-a3260300-6199-11eb-98e0-66c3de1b4098.png)



:hearts: Thank you!
