### PR TITLE
Replace partials with the cells they render

### DIFF
--- a/decidim-admin/app/helpers/decidim/admin/newsletters_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/newsletters_helper.rb
@@ -131,23 +131,17 @@ module Decidim
         ]
       end
 
-      def newsletter_attention_callout_args
+      def newsletter_attention_callout_announcement
         {
-          announcement: {
-            body: t("warning", scope: "decidim.admin.newsletters.select_recipients_to_deliver").html_safe
-          },
-          callout_class: "warning"
+          body: t("warning", scope: "decidim.admin.newsletters.select_recipients_to_deliver").html_safe
         }
       end
 
-      def newsletter_recipients_count_callout_args
+      def newsletter_recipients_count_callout_announcement
         spinner = "<span id='recipients_count_spinner' class='loading-spinner hide'></span>"
         body = "#{t("recipients_count", scope: "decidim.admin.newsletters.select_recipients_to_deliver", count: recipients_count_query)} #{spinner}"
         {
-          announcement: {
-            body: body
-          },
-          callout_class: "warning"
+          body: body
         }
       end
     end

--- a/decidim-admin/app/views/decidim/admin/newsletters/select_recipients_to_deliver.html.erb
+++ b/decidim-admin/app/views/decidim/admin/newsletters/select_recipients_to_deliver.html.erb
@@ -5,7 +5,7 @@
       <h2 class="card-title"><%= t ".title" %></h2>
     </div>
     <div class="card-section">
-      <%= cell("decidim/announcement", newsletter_attention_callout_args) %>
+      <%= cell("decidim/announcement", newsletter_attention_callout_announcement, callout_class: "warning") %>
 
       <div class="card">
         <div class="card-divider">
@@ -61,7 +61,7 @@
         </div>
       <% end %>
 
-      <%= cell("decidim/announcement", newsletter_recipients_count_callout_args) %>
+      <%= cell("decidim/announcement", newsletter_recipients_count_callout_announcement, callout_class: "warning") %>
 
       <div class="button--double form-general-submit">
         <% if allowed_to?(:update, :newsletter, newsletter: @newsletter) && !@newsletter.sent? %>

--- a/decidim-core/app/cells/decidim/announcement/show.erb
+++ b/decidim-core/app/cells/decidim/announcement/show.erb
@@ -1,11 +1,11 @@
 <div class="row column">
   <%= content_tag :div, class: "callout announcement mb-sm #{callout_class} cell-announcement" do %>
-    <% if announcement.class == Hash && announcement.key?(:title) %>
-      <span><%= decidim_sanitize translated_attribute announcement[:title] %></span>
+    <% if has_title? %>
+      <span><%= clean_title %></span>
 
-      <p><%= decidim_sanitize translated_attribute announcement[:body] %></p>
+      <p><%= clean_body %></p>
     <% else %>
-      <%= decidim_sanitize translated_attribute announcement %>
+      <%= clean_announcement %>
     <% end %>
   <% end %>
 </div>

--- a/decidim-core/app/cells/decidim/announcement_cell.rb
+++ b/decidim-core/app/cells/decidim/announcement_cell.rb
@@ -22,12 +22,32 @@ module Decidim
 
     private
 
+    def has_title?
+      announcement.is_a?(Hash) && announcement.has_key?(:title)
+    end
+
     def callout_class
-      model[:callout_class] ||= "secondary"
+      options[:callout_class] ||= "secondary"
     end
 
     def announcement
-      model[:announcement]
+      model
+    end
+
+    def clean_title
+      clean(announcement[:title])
+    end
+
+    def clean_body
+      clean(announcement[:body])
+    end
+
+    def clean_announcement
+      clean(announcement)
+    end
+
+    def clean(value)
+      decidim_sanitize(translated_attribute(value))
     end
   end
 end

--- a/decidim-core/app/cells/decidim/tos_page/announcement.erb
+++ b/decidim-core/app/cells/decidim/tos_page/announcement.erb
@@ -1,1 +1,1 @@
-<%= cell("decidim/announcement", announcement_args) %>
+<%= cell("decidim/announcement", announcement, announcement_options) %>

--- a/decidim-core/app/cells/decidim/tos_page_cell.rb
+++ b/decidim-core/app/cells/decidim/tos_page_cell.rb
@@ -22,13 +22,16 @@ module Decidim
 
     private
 
-    def announcement_args
+    def announcement
       {
-        callout_class: "warning",
-        announcement: {
-          title: t("required_review.title", scope: "decidim.pages.terms_and_conditions"),
-          body: t("required_review.body", scope: "decidim.pages.terms_and_conditions")
-        }
+        title: t("required_review.title", scope: "decidim.pages.terms_and_conditions"),
+        body: t("required_review.body", scope: "decidim.pages.terms_and_conditions")
+      }
+    end
+
+    def announcement_options
+      {
+        callout_class: "warning"
       }
     end
   end

--- a/decidim-core/app/views/decidim/shared/_announcement.html.erb
+++ b/decidim-core/app/views/decidim/shared/_announcement.html.erb
@@ -1,1 +1,0 @@
-<%= cell("decidim/announcement", local_assigns) %>

--- a/decidim-core/app/views/decidim/shared/_component_announcement.html.erb
+++ b/decidim-core/app/views/decidim/shared/_component_announcement.html.erb
@@ -1,5 +1,5 @@
 <% if translated_attribute(current_settings.announcement).present? %>
-  <%= render partial: "decidim/shared/announcement", locals: { announcement: current_settings.announcement } %>
+  <%= cell("decidim/announcement", current_settings.announcement) %>
 <% elsif translated_attribute(component_settings.announcement).present? %>
-  <%= render partial: "decidim/shared/announcement", locals: { announcement: component_settings.announcement } %>
+  <%= cell("decidim/announcement", component_settings.announcement) %>
 <% end %>

--- a/decidim-core/app/views/decidim/shared/_flag_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_flag_modal.html.erb
@@ -1,1 +1,0 @@
-<%= cell("decidim/flag_modal", reportable) %>

--- a/decidim-debates/app/controllers/decidim/debates/debates_controller.rb
+++ b/decidim-debates/app/controllers/decidim/debates/debates_controller.rb
@@ -13,7 +13,7 @@ module Decidim
       include Flaggable
       include Decidim::Debates::Orderable
 
-      helper_method :debates, :debate, :form_presenter, :paginated_debates, :report_form, :close_debate_form
+      helper_method :debates, :debate, :form_presenter, :paginated_debates, :close_debate_form
 
       def new
         enforce_permission_to :create, :debate
@@ -103,10 +103,6 @@ module Decidim
 
       def debate
         @debate ||= debates.find_by(id: params[:id])
-      end
-
-      def report_form
-        @report_form ||= form(Decidim::ReportForm).from_params(reason: "spam")
       end
 
       def close_debate_form

--- a/decidim-debates/app/views/decidim/debates/debates/show.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/show.html.erb
@@ -110,7 +110,7 @@ edit_link(
       <%= render_debate_description(debate) %>
 
       <% if debate.closed? %>
-        <%= cell("decidim/announcement", { announcement: { title: t(".debate_conclusions_are", date: l(debate.closed_at, format: :decidim_short)), body: simple_format(translated_attribute(debate.conclusions)) }, callout_class: "success" }) %>
+        <%= cell("decidim/announcement", { title: t(".debate_conclusions_are", date: l(debate.closed_at, format: :decidim_short)), body: simple_format(translated_attribute(debate.conclusions)) }, callout_class: "success") %>
       <% end %>
 
       <% if translated_attribute(debate.instructions).present? %>

--- a/decidim-debates/app/views/decidim/debates/debates/show.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/show.html.erb
@@ -133,13 +133,7 @@ edit_link(
 
 <%= comments_for debate %>
 
-<%=
-  render partial: "decidim/shared/flag_modal", locals: {
-    reportable: debate,
-    form: report_form,
-    url: decidim.report_path(sgid: debate.to_sgid.to_s)
-  }
-%>
+<%= cell("decidim/flag_modal", debate) %>
 <%=
   render partial: "close_debate_modal", locals: {
     debate: debate,

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -53,8 +53,6 @@ module Decidim
       def show
         raise ActionController::RoutingError, "Not Found" unless meeting
 
-        @report_form = form(Decidim::ReportForm).from_params(reason: "spam")
-
         return if meeting.current_user_can_visit_meeting?(current_user)
 
         flash[:alert] = I18n.t("meeting.not_allowed", scope: "decidim.meetings")

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -173,10 +173,4 @@ edit_link(
 <%= comments_for meeting %>
 <%= pad_iframe_for meeting %>
 
-<%=
-  render partial: "decidim/shared/flag_modal", locals: {
-    reportable: meeting,
-    form: @report_form,
-    url: decidim.report_path(sgid: meeting.to_sgid.to_s)
-  }
-%>
+<%= cell("decidim/flag_modal", meeting) %>

--- a/decidim-meetings/app/views/decidim/participatory_spaces/_upcoming_meeting_for_card.html.erb
+++ b/decidim-meetings/app/views/decidim/participatory_spaces/_upcoming_meeting_for_card.html.erb
@@ -1,4 +1,4 @@
 <div class="card__block">
-    <strong class="text-small"><%= t("upcoming_meeting", scope: "decidim.participatory_spaces.upcoming_meeting_for_card") %></strong>
+  <strong class="text-small"><%= t("upcoming_meeting", scope: "decidim.participatory_spaces.upcoming_meeting_for_card") %></strong>
   <%= cell("decidim/meetings/meeting_m", upcoming_meeting).date %>
 </div>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
@@ -21,10 +21,7 @@
              locals: { text: t("private_space", scope: "decidim.participatory_processes.show") } %>
 <% end %>
 
-<% if translated_attribute(current_participatory_space.announcement).present? %>
-  <%= render partial: "decidim/shared/announcement",
-             locals: { announcement: current_participatory_space.announcement } %>
-<% end %>
+<%= cell("decidim/announcement", current_participatory_space.announcement) %>
 
 <div class="row column">
   <div class="row">

--- a/decidim-proposals/app/controllers/decidim/proposals/collaborative_drafts_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/collaborative_drafts_controller.rb
@@ -36,7 +36,6 @@ module Decidim
       def show
         raise ActionController::RoutingError, "Not Found" unless retrieve_collaborative_draft
 
-        @report_form = form(Decidim::ReportForm).from_params(reason: "spam")
         @request_access_form = form(RequestAccessToCollaborativeDraftForm).from_params({})
         @accept_request_form = form(AcceptAccessToCollaborativeDraftForm).from_params({})
         @reject_request_form = form(RejectAccessToCollaborativeDraftForm).from_params({})

--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -56,8 +56,6 @@ module Decidim
 
       def show
         raise ActionController::RoutingError, "Not Found" if @proposal.blank? || !can_show_proposal?
-
-        @report_form = form(Decidim::ReportForm).from_params(reason: "spam")
       end
 
       def new

--- a/decidim-proposals/app/helpers/decidim/proposals/proposals_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/proposals_helper.rb
@@ -4,13 +4,10 @@ module Decidim
   module Proposals
     # Simple helpers to handle markup variations for proposals
     module ProposalsHelper
-      def proposal_reason_callout_args
+      def proposal_reason_callout_announcement
         {
-          announcement: {
-            title: proposal_reason_callout_title,
-            body: decidim_sanitize(translated_attribute(@proposal.answer))
-          },
-          callout_class: proposal_reason_callout_class
+          title: proposal_reason_callout_title,
+          body: decidim_sanitize(translated_attribute(@proposal.answer))
         }
       end
 

--- a/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/_wizard_header.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/_wizard_header.html.erb
@@ -1,11 +1,11 @@
 <% if translated_attribute(component_settings.new_proposal_help_text).present? %>
-  <%= render partial: "decidim/shared/announcement", locals: { announcement: component_settings.new_proposal_help_text } %>
+  <%= cell("decidim/announcement", component_settings.new_proposal_help_text) %>
 <% end %>
 
 <% if proposal_wizard_step_help_text?(@step) %>
   <div class="proposal_wizard_help_text">
     <% callout_step_help_text_class ||= nil %>
-    <%= render partial: "decidim/shared/announcement", locals: { announcement: component_settings.try("proposal_wizard_#{@step}_help_text"), callout_class: callout_step_help_text_class } %>
+    <%= cell("decidim/announcement", component_settings.try("proposal_wizard_#{@step}_help_text"), callout_class: callout_step_help_text_class) %>
   </div>
 <% end %>
 

--- a/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/edit.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/edit.html.erb
@@ -13,9 +13,7 @@
 <div class="row">
   <div class="columns large-6 medium-centered">
     <div class="card">
-      <% if translated_attribute(component_settings.new_proposal_help_text).present? %>
-        <%= render partial: "decidim/shared/announcement", locals: { announcement: component_settings.new_proposal_help_text } %>
-      <% end %>
+      <%= cell("decidim/announcement", component_settings.new_proposal_help_text) %>
 
       <div class="card__content">
         <%= decidim_form_for(@form) do |form| %>

--- a/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/show.html.erb
@@ -125,10 +125,4 @@
 <%= attachments_for @collaborative_draft %>
 <%= comments_for @collaborative_draft %>
 
-<%=
-  render partial: "decidim/shared/flag_modal", locals: {
-    reportable: @collaborative_draft,
-    form: @report_form,
-    url: decidim.report_path(sgid: @collaborative_draft.to_sgid.to_s)
-  }
-%>
+<%= cell("decidim/flag_modal", @collaborative_draft) %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_wizard_header.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_wizard_header.html.erb
@@ -1,22 +1,24 @@
-<% if translated_attribute(component_settings.new_proposal_help_text).present? && @step != :step_4 %>
-  <%= render partial: "decidim/shared/announcement", locals: { announcement: component_settings.new_proposal_help_text } %>
-<% elsif @step == :step_4 %>
-  <%
-    locals = {
-      callout_class: "warning",
-      announcement: {
-        title: t("decidim.proposals.proposals.preview.announcement_title"),
-        body: "#{t("decidim.proposals.proposals.preview.announcement_body")}<br><br>#{t("decidim.proposals.proposals.preview.proposal_edit_before_minutes", count: component_settings.proposal_edit_before_minutes)}"
-      }
-    }
-  %>
-  <%= render partial: "decidim/shared/announcement", locals: locals %>
+<% if @step == :step_4 %>
+  <%= cell(
+    "decidim/announcement",
+    {
+      title: t("decidim.proposals.proposals.preview.announcement_title"),
+      body: "#{t("decidim.proposals.proposals.preview.announcement_body")}<br><br>#{t("decidim.proposals.proposals.preview.proposal_edit_before_minutes", count: component_settings.proposal_edit_before_minutes)}"
+    },
+    callout_class: "warning"
+  ) %>
+<% else %>
+  <%= cell("decidim/announcement", component_settings.new_proposal_help_text) %>
 <% end %>
 
 <% if proposal_wizard_step_help_text?(@step) %>
   <div class="proposal_wizard_help_text">
     <% callout_step_help_text_class ||= nil %>
-    <%= render partial: "decidim/shared/announcement", locals: { announcement: component_settings.try("proposal_wizard_#{@step}_help_text"), callout_class: callout_step_help_text_class } %>
+    <%= cell(
+      "decidim/announcement",
+      component_settings.try("proposal_wizard_#{@step}_help_text"),
+      callout_class: callout_step_help_text_class
+    ) %>
   </div>
 <% end %>
 

--- a/decidim-proposals/app/views/decidim/proposals/proposals/edit.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/edit.html.erb
@@ -13,9 +13,7 @@
 <div class="row">
   <div class="columns large-6 medium-centered">
     <div class="card">
-      <% if translated_attribute(component_settings.new_proposal_help_text).present? %>
-        <%= render partial: "decidim/shared/announcement", locals: { announcement: component_settings.new_proposal_help_text } %>
-      <% end %>
+      <%= cell("decidim/announcement", component_settings.new_proposal_help_text) %>
 
       <div class="card__content">
         <%= decidim_form_for(@form) do |form| %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -138,10 +138,4 @@ extra_admin_link(
 
 <%= comments_for @proposal %>
 
-<%=
-  render partial: "decidim/shared/flag_modal", locals: {
-    reportable: @proposal,
-    form: @report_form,
-    url: decidim.report_path(sgid: @proposal.to_sgid.to_s)
-  }
-%>
+<%= cell("decidim/flag_modal", @proposal) %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -68,7 +68,7 @@ extra_admin_link(
       <%= cell "decidim/proposals/proposal_tags", @proposal %>
     </div>
 
-    <%= cell("decidim/announcement", proposal_reason_callout_args) if @proposal.answered? && @proposal.published_state? %>
+    <%= cell("decidim/announcement", proposal_reason_callout_announcement, callout_class: proposal_reason_callout_class) if @proposal.answered? && @proposal.published_state? %>
 
     <%= linked_resources_for @proposal, :results, "included_proposals" %>
     <%= linked_resources_for @proposal, :projects, "included_proposals" %>


### PR DESCRIPTION
#### :tophat: What? Why?
As described in #7250, some partials only render a cell without any logic check. In these cases, we'd better use the cell directly and we'll avoid the extra render.

#### :pushpin: Related Issues
- Fixes #7250

#### Testing
Test suite should be green.