### PR TITLE
Fix datepicker tests to not match upcoming month's days

### DIFF
--- a/decidim-debates/spec/shared/manage_debates_examples.rb
+++ b/decidim-debates/spec/shared/manage_debates_examples.rb
@@ -93,12 +93,12 @@ RSpec.shared_examples "manage debates" do
     end
 
     page.execute_script("$('#debate_start_time').focus()")
-    page.find(".datepicker-dropdown .day", text: "12").click
+    page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
     page.find(".datepicker-dropdown .hour", text: "10:00").click
     page.find(".datepicker-dropdown .minute", text: "10:50").click
 
     page.execute_script("$('#debate_end_time').focus()")
-    page.find(".datepicker-dropdown .day", text: "12").click
+    page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
     page.find(".datepicker-dropdown .hour", text: "12:00").click
     page.find(".datepicker-dropdown .minute", text: "12:50").click
 

--- a/decidim-elections/spec/system/admin_manages_elections_spec.rb
+++ b/decidim-elections/spec/system/admin_manages_elections_spec.rb
@@ -51,12 +51,12 @@ describe "Admin manages elections", type: :system do
     end
 
     page.execute_script("$('#election_start_time').focus()")
-    page.find(".datepicker-dropdown .day", text: "12").click
+    page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
     page.find(".datepicker-dropdown .hour", text: "10:00").click
     page.find(".datepicker-dropdown .minute", text: "10:50").click
 
     page.execute_script("$('#election_end_time').focus()")
-    page.find(".datepicker-dropdown .day", text: "12").click
+    page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
     page.find(".datepicker-dropdown .hour", text: "12:00").click
     page.find(".datepicker-dropdown .minute", text: "12:50").click
 

--- a/decidim-elections/spec/system/admin_manages_votings_spec.rb
+++ b/decidim-elections/spec/system/admin_manages_votings_spec.rb
@@ -26,12 +26,12 @@ describe "Admin manages votings", type: :system do
 
     it "creates a new voting" do
       page.execute_script("$('#voting_start_time').focus()")
-      page.find(".datepicker-dropdown .day", text: "12").click
+      page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
       page.find(".datepicker-dropdown .hour", text: "10:00").click
       page.find(".datepicker-dropdown .minute", text: "10:50").click
 
       page.execute_script("$('#voting_end_time').focus()")
-      page.find(".datepicker-dropdown .day", text: "12").click
+      page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
       page.find(".datepicker-dropdown .hour", text: "12:00").click
       page.find(".datepicker-dropdown .minute", text: "12:50").click
 
@@ -77,12 +77,12 @@ describe "Admin manages votings", type: :system do
 
     it "fails to create a new voting" do
       page.execute_script("$('#voting_start_time').focus()")
-      page.find(".datepicker-dropdown .day", text: "12").click
+      page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
       page.find(".datepicker-dropdown .hour", text: "10:00").click
       page.find(".datepicker-dropdown .minute", text: "10:50").click
 
       page.execute_script("$('#voting_end_time').focus()")
-      page.find(".datepicker-dropdown .day", text: "12").click
+      page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
       page.find(".datepicker-dropdown .hour", text: "12:00").click
       page.find(".datepicker-dropdown .minute", text: "12:50").click
 

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
@@ -195,12 +195,12 @@ describe "Admin manages meetings", type: :system, serves_map: true, serves_geoco
     select "Registration disabled", from: :meeting_registration_type
 
     page.execute_script("$('#meeting_start_time').focus()")
-    page.find(".datepicker-dropdown .day", text: "12").click
+    page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
     page.find(".datepicker-dropdown .hour", text: "10:00").click
     page.find(".datepicker-dropdown .minute", text: "10:50").click
 
     page.execute_script("$('#meeting_end_time').focus()")
-    page.find(".datepicker-dropdown .day", text: "12").click
+    page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
     page.find(".datepicker-dropdown .hour", text: "12:00").click
     page.find(".datepicker-dropdown .minute", text: "12:50").click
 
@@ -267,12 +267,12 @@ describe "Admin manages meetings", type: :system, serves_map: true, serves_geoco
         select "Registration disabled", from: :meeting_registration_type
 
         page.execute_script("$('#meeting_start_time').focus()")
-        page.find(".datepicker-dropdown .day", text: "12").click
+        page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
         page.find(".datepicker-dropdown .hour", text: "10:00").click
         page.find(".datepicker-dropdown .minute", text: "10:50").click
 
         page.execute_script("$('#meeting_end_time').focus()")
-        page.find(".datepicker-dropdown .day", text: "12").click
+        page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
         page.find(".datepicker-dropdown .hour", text: "12:00").click
         page.find(".datepicker-dropdown .minute", text: "12:50").click
       end
@@ -356,12 +356,12 @@ describe "Admin manages meetings", type: :system, serves_map: true, serves_geoco
       fill_in_geocoding :meeting_address, with: address
 
       page.execute_script("$('#meeting_start_time').focus()")
-      page.find(".datepicker-dropdown .day", text: "12").click
+      page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
       page.find(".datepicker-dropdown .hour", text: "10:00").click
       page.find(".datepicker-dropdown .minute", text: "10:50").click
 
       page.execute_script("$('#meeting_end_time').focus()")
-      page.find(".datepicker-dropdown .day", text: "12").click
+      page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
       page.find(".datepicker-dropdown .hour", text: "12:00").click
       page.find(".datepicker-dropdown .minute", text: "12:50").click
 
@@ -470,12 +470,12 @@ describe "Admin manages meetings", type: :system, serves_map: true, serves_geoco
       select "Registration disabled", from: :meeting_registration_type
 
       page.execute_script("$('#meeting_start_time').focus()")
-      page.find(".datepicker-dropdown .day", text: "12").click
+      page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
       page.find(".datepicker-dropdown .hour", text: "10:00").click
       page.find(".datepicker-dropdown .minute", text: "10:50").click
 
       page.execute_script("$('#meeting_end_time').focus()")
-      page.find(".datepicker-dropdown .day", text: "12").click
+      page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
       page.find(".datepicker-dropdown .hour", text: "12:00").click
       page.find(".datepicker-dropdown .minute", text: "12:50").click
 

--- a/decidim-participatory_processes/spec/shared/manage_process_steps_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_process_steps_examples.rb
@@ -36,7 +36,7 @@ shared_examples "manage process steps examples" do
     )
 
     page.execute_script("$('#participatory_process_step_start_date').focus()")
-    page.find(".datepicker-dropdown .day", text: "12").click
+    page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
     page.execute_script("$('#participatory_process_step_end_date').focus()")
     page.find(".datepicker-dropdown .day", text: "22").click
 

--- a/decidim-verifications/spec/system/authorizations_spec.rb
+++ b/decidim-verifications/spec/system/authorizations_spec.rb
@@ -29,7 +29,7 @@ describe "Authorizations", type: :system, with_authorization_workflows: ["dummy_
       it "redirects the user to the authorization form after the first sign in" do
         fill_in "Document number", with: "123456789X"
         page.execute_script("$('#authorization_handler_birthday').focus()")
-        page.find(".datepicker-dropdown .day", text: "12").click
+        page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
 
         click_button "Send"
         expect(page).to have_content("You've been successfully authorized")


### PR DESCRIPTION
#### :tophat: What? Why?
February 2021 is special for datepicker tests because there appear 2 "12th" days, so specs start failing because they don't understand what element should be picked:

![image](https://user-images.githubusercontent.com/491891/106433088-fc2eb900-646f-11eb-80b9-b95017da01b8.png)

This PR enforces specs to check for the correct element.

#### :pushpin: Related Issues
None

#### Testing
Ensure test suite is green.
