### PR TITLE
Let admins delete proposal attachments

### DIFF
--- a/decidim-core/app/commands/decidim/attachment_methods.rb
+++ b/decidim-core/app/commands/decidim/attachment_methods.rb
@@ -16,6 +16,15 @@ module Decidim
       )
     end
 
+    def delete_attachment(attachment)
+      if attachment.present?
+        check_delete_file = attachment[:delete_file]
+        attachment_id = attachment[:id].to_i
+
+        Attachment.find(attachment_id).delete if check_delete_file == "1" && attachment_id == proposal.documents.first.id
+      end
+    end
+
     def attachment_invalid?
       if attachment.invalid? && attachment.errors.has_key?(:file)
         @form.attachment.errors.add :file, attachment.errors[:file]

--- a/decidim-core/app/commands/decidim/attachment_methods.rb
+++ b/decidim-core/app/commands/decidim/attachment_methods.rb
@@ -17,12 +17,7 @@ module Decidim
     end
 
     def delete_attachment(attachment)
-      if attachment.present?
-        check_delete_file = attachment[:delete_file]
-        attachment_id = attachment[:id].to_i
-
-        Attachment.find(attachment_id).delete if check_delete_file == "1" && attachment_id == proposal.documents.first.id
-      end
+      Attachment.find(attachment.id).delete if attachment.id == proposal.documents.first.id
     end
 
     def attachment_invalid?
@@ -51,6 +46,10 @@ module Decidim
 
     def process_attachments?
       attachments_allowed? && attachment_present? && attachment_file_uploaded?
+    end
+
+    def delete_attachment?
+      @form.attachment&.delete_file.present?
     end
   end
 end

--- a/decidim-core/app/forms/decidim/attachment_form.rb
+++ b/decidim-core/app/forms/decidim/attachment_form.rb
@@ -8,6 +8,7 @@ module Decidim
 
     attribute :title, String
     attribute :file
+    attribute :delete_file, Boolean
 
     mimic :attachment
 

--- a/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal.rb
@@ -28,10 +28,7 @@ module Decidim
         def call
           return broadcast(:invalid) if form.invalid?
 
-          if defined?(params)
-            attachment = params[:proposal][:attachment]
-            delete_attachment(attachment)
-          end
+          delete_attachment(form.attachment) if delete_attachment?
 
           if process_attachments?
             @proposal.attachments.destroy_all

--- a/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal.rb
@@ -28,6 +28,11 @@ module Decidim
         def call
           return broadcast(:invalid) if form.invalid?
 
+          if defined?(params)
+            attachment = params[:proposal][:attachment]
+            delete_attachment(attachment)
+          end
+
           if process_attachments?
             @proposal.attachments.destroy_all
 

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
@@ -136,8 +136,11 @@ module Decidim
           enforce_permission_to :edit, :proposal, proposal: proposal
 
           @form = form(Admin::ProposalForm).from_params(params)
-          check_delete_file = params[:proposal][:attachment][:delete_file]
-          attachment_id = params[:proposal][:attachment][:id].to_i
+
+          if params[:proposal][:attachment].present?
+            check_delete_file = params[:proposal][:attachment][:delete_file]
+            attachment_id = params[:proposal][:attachment][:id].to_i
+          end
 
           Attachment.find(params[:proposal][:attachment][:id].to_i).delete if check_delete_file == "1" && attachment_id == proposal.documents.first.id
 

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
@@ -131,13 +131,6 @@ module Decidim
 
           @form = form(Admin::ProposalForm).from_params(params)
 
-          if params[:proposal][:attachment].present?
-            check_delete_file = params[:proposal][:attachment][:delete_file]
-            attachment_id = params[:proposal][:attachment][:id].to_i
-          end
-
-          Attachment.find(params[:proposal][:attachment][:id].to_i).delete if check_delete_file == "1" && attachment_id == proposal.documents.first.id
-
           Admin::UpdateProposal.call(@form, @proposal) do
             on(:ok) do |_proposal|
               flash[:notice] = t("proposals.update.success", scope: "decidim")

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
@@ -124,12 +124,6 @@ module Decidim
         def edit
           enforce_permission_to :edit, :proposal, proposal: proposal
           @form = form(Admin::ProposalForm).from_model(proposal)
-          document = proposal.documents.first
-          @form.attachment = if document.present?
-                               form(AttachmentForm).from_params({ file: document.file, title: translated_attribute(document.title) })
-                             else
-                               form(AttachmentForm).from_params({})
-                             end
         end
 
         def update

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
@@ -139,9 +139,7 @@ module Decidim
           check_delete_file = params[:proposal][:attachment][:delete_file]
           attachment_id = params[:proposal][:attachment][:id].to_i
 
-          if check_delete_file == "1" && attachment_id == proposal.documents.first.id
-            Attachment.find(params[:proposal][:attachment][:id].to_i).delete
-          end
+          Attachment.find(params[:proposal][:attachment][:id].to_i).delete if check_delete_file == "1" && attachment_id == proposal.documents.first.id
 
           Admin::UpdateProposal.call(@form, @proposal) do
             on(:ok) do |_proposal|

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
@@ -20,6 +20,11 @@ module Decidim
 
           self.title = presenter.title(all_locales: title.is_a?(Hash))
           self.body = presenter.body(all_locales: body.is_a?(Hash))
+          self.attachment = if model.documents.first.present?
+                              { file: model.documents.first.file, title: translated_attribute(model.documents.first.title) }
+                            else
+                              {}
+                            end
         end
       end
     end

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
@@ -84,6 +84,10 @@
 
             <div class="row column">
               <%= form.upload :file, optional: false %>
+              <% if proposal.documents.present? %>
+                <%= form.hidden_field :id, value: proposal.documents.first.id %>
+                <%= form.check_box :delete_file, label: t('.delete_attachment'), value: proposal.documents.first.id %>
+              <% end %>
             </div>
           <% end %>
         </fieldset>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
@@ -86,7 +86,7 @@
               <%= form.upload :file, optional: false %>
               <% if proposal.documents.present? %>
                 <%= form.hidden_field :id, value: proposal.documents.first.id %>
-                <%= form.check_box :delete_file, label: t('.delete_attachment'), value: proposal.documents.first.id %>
+                <%= form.check_box :delete_file, label: t(".delete_attachment"), value: proposal.documents.first.id %>
               <% end %>
             </div>
           <% end %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
@@ -84,9 +84,11 @@
 
             <div class="row column">
               <%= form.upload :file, optional: false %>
-              <% if proposal.documents.present? %>
-                <%= form.hidden_field :id, value: proposal.documents.first.id %>
-                <%= form.check_box :delete_file, label: t(".delete_attachment"), value: proposal.documents.first.id %>
+              <% if params[:id].present? %>
+                <% if proposal.documents.present? %>
+                  <%= form.hidden_field :id, value: proposal.documents.first.id %>
+                  <%= form.check_box :delete_file, label: t(".delete_attachment"), value: proposal.documents.first.id %>
+                <% end %>
               <% end %>
             </div>
           <% end %>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -423,6 +423,7 @@ en:
           form:
             attachment_legend: "(Optional) Add an attachment"
             created_in_meeting: This proposal comes from a meeting
+            delete_attachment: Delete attachment
             select_a_category: Select a category
             select_a_meeting: Select a meeting
           index:

--- a/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
@@ -58,6 +58,39 @@ describe "Admin edits proposals", type: :system do
         expect(page).to have_content("not authorized")
       end
     end
+
+    context "when the proposal has attachement", processing_uploads_for: Decidim::AttachmentUploader do
+      let!(:component) do
+        create(:proposal_component,
+               :with_creation_enabled,
+               :with_attachments_allowed,
+               manifest: manifest,
+               participatory_space: participatory_process)
+      end
+
+      let!(:proposal) do
+        create(:proposal,
+               :official,
+               component: component,
+               title: "Proposal with attachments",
+               body: "This is my proposal and I want to upload attachments.")
+      end
+
+      let!(:document) { create(:attachment, :with_pdf, attached_to: proposal) }
+
+      it "can be remove attachment" do
+        visit_component_admin
+        find("a.action-icon--edit-proposal").click
+        find("input#proposal_attachment_delete_file").set(true)
+        find(".form-general-submit .button").click
+
+        expect(page).to have_content("Proposal successfully updated.")
+
+        visit_component_admin
+        find("a.action-icon--edit-proposal").click
+        expect(page).to have_no_content("Current file")
+      end
+    end
   end
 
   describe "editing a non-official proposal" do


### PR DESCRIPTION
#### :tophat: What? Why?

When you edit a proposal, if it has an attachment it does not appear in the edit view.
Now it appears and can also be deleted.

#### :pushpin: Related Issues
- Fixes #6569 

#### Testing
1. Processes > Select a Process
2. In Components > Proposals
3. Select or create a proposal with attachments activated.
4. Attach a file (not image) > Update
5. Select the same proposal and check you can show file and deleted.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![Captura de pantalla de 2021-02-01 12-41-40](https://user-images.githubusercontent.com/75725233/106454329-db279180-648a-11eb-9f7d-1ff36288b42a.png)


:hearts: Thank you!
