### PR TITLE
Fix editor image alt tag (#6920)

### DIFF
--- a/decidim-admin/spec/shared/manage_impersonations_examples.rb
+++ b/decidim-admin/spec/shared/manage_impersonations_examples.rb
@@ -275,7 +275,7 @@ shared_examples "manage impersonations examples" do
       page.execute_script("$('#impersonate_user_authorization_birthday').focus()")
     end
 
-    page.find(".datepicker-dropdown .day", text: "12").click
+    page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
 
     expect(page).to have_selector("*[type=submit]", count: 1)
 

--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -80,6 +80,29 @@ describe "Admin manages organization", type: :system do
           )["innerHTML"]).to eq(terms_content.gsub("\n", ""))
         end
       end
+
+      context "when the admin terms of use content has an image with an alt tag" do
+        let(:another_organization) { create(:organization) }
+        let(:image) { create(:attachment, attached_to: another_organization) }
+        let(:organization) do
+          create(
+            :organization,
+            admin_terms_of_use_body: Decidim::Faker::Localized.localized { terms_content }
+          )
+        end
+        let(:terms_content) do
+          <<~HTML
+            <p>Paragraph</p>
+            <p><img src="#{image.url}" alt="foo bar"></p>
+          HTML
+        end
+
+        it "renders an image and its attributes inside the editor" do
+          expect(find(
+            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+          )["innerHTML"]).to eq(terms_content.gsub("\n", ""))
+        end
+      end
     end
   end
 

--- a/decidim-core/app/assets/javascripts/decidim/editor.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/editor.js.es6
@@ -2,7 +2,7 @@
 // = require_self
 
 ((exports) => {
-  const quillFormats = ["bold", "italic", "link", "underline", "header", "list", "video"];
+  const quillFormats = ["bold", "italic", "link", "underline", "header", "list", "video", "image", "alt"];
 
   const createQuillEditor = (container) => {
     const toolbar = $(container).data("toolbar");

--- a/decidim-debates/spec/shared/manage_debates_examples.rb
+++ b/decidim-debates/spec/shared/manage_debates_examples.rb
@@ -91,12 +91,12 @@ RSpec.shared_examples "manage debates" do
     end
 
     page.execute_script("$('#debate_start_time').focus()")
-    page.find(".datepicker-dropdown .day", text: "12").click
+    page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
     page.find(".datepicker-dropdown .hour", text: "10:00").click
     page.find(".datepicker-dropdown .minute", text: "10:50").click
 
     page.execute_script("$('#debate_end_time').focus()")
-    page.find(".datepicker-dropdown .day", text: "12").click
+    page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
     page.find(".datepicker-dropdown .hour", text: "12:00").click
     page.find(".datepicker-dropdown .minute", text: "12:50").click
 

--- a/decidim-elections/spec/system/admin_manages_elections_spec.rb
+++ b/decidim-elections/spec/system/admin_manages_elections_spec.rb
@@ -52,12 +52,12 @@ describe "Admin manages elections", type: :system do
     end
 
     page.execute_script("$('#election_start_time').focus()")
-    page.find(".datepicker-dropdown .day", text: "12").click
+    page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
     page.find(".datepicker-dropdown .hour", text: "10:00").click
     page.find(".datepicker-dropdown .minute", text: "10:50").click
 
     page.execute_script("$('#election_end_time').focus()")
-    page.find(".datepicker-dropdown .day", text: "12").click
+    page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
     page.find(".datepicker-dropdown .hour", text: "12:00").click
     page.find(".datepicker-dropdown .minute", text: "12:50").click
 

--- a/decidim-meetings/spec/shared/manage_meetings_examples.rb
+++ b/decidim-meetings/spec/shared/manage_meetings_examples.rb
@@ -185,12 +185,12 @@ shared_examples "manage meetings" do
     fill_in_services
 
     page.execute_script("$('#meeting_start_time').focus()")
-    page.find(".datepicker-dropdown .day", text: "12").click
+    page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
     page.find(".datepicker-dropdown .hour", text: "10:00").click
     page.find(".datepicker-dropdown .minute", text: "10:50").click
 
     page.execute_script("$('#meeting_end_time').focus()")
-    page.find(".datepicker-dropdown .day", text: "12").click
+    page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
     page.find(".datepicker-dropdown .hour", text: "12:00").click
     page.find(".datepicker-dropdown .minute", text: "12:50").click
 
@@ -248,12 +248,12 @@ shared_examples "manage meetings" do
       fill_in :meeting_address, with: address
 
       page.execute_script("$('#meeting_start_time').focus()")
-      page.find(".datepicker-dropdown .day", text: "12").click
+      page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
       page.find(".datepicker-dropdown .hour", text: "10:00").click
       page.find(".datepicker-dropdown .minute", text: "10:50").click
 
       page.execute_script("$('#meeting_end_time').focus()")
-      page.find(".datepicker-dropdown .day", text: "12").click
+      page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
       page.find(".datepicker-dropdown .hour", text: "12:00").click
       page.find(".datepicker-dropdown .minute", text: "12:50").click
 
@@ -355,12 +355,12 @@ shared_examples "manage meetings" do
 
       fill_in :meeting_address, with: address
       page.execute_script("$('#meeting_start_time').focus()")
-      page.find(".datepicker-dropdown .day", text: "12").click
+      page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
       page.find(".datepicker-dropdown .hour", text: "10:00").click
       page.find(".datepicker-dropdown .minute", text: "10:50").click
 
       page.execute_script("$('#meeting_end_time').focus()")
-      page.find(".datepicker-dropdown .day", text: "12").click
+      page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
       page.find(".datepicker-dropdown .hour", text: "12:00").click
       page.find(".datepicker-dropdown .minute", text: "12:50").click
 

--- a/decidim-participatory_processes/spec/shared/manage_process_steps_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_process_steps_examples.rb
@@ -36,7 +36,7 @@ shared_examples "manage process steps examples" do
     )
 
     page.execute_script("$('#participatory_process_step_start_date').focus()")
-    page.find(".datepicker-dropdown .day", text: "12").click
+    page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
     page.execute_script("$('#participatory_process_step_end_date').focus()")
     page.find(".datepicker-dropdown .day", text: "22").click
 

--- a/decidim-verifications/spec/system/authorizations_spec.rb
+++ b/decidim-verifications/spec/system/authorizations_spec.rb
@@ -29,7 +29,7 @@ describe "Authorizations", type: :system, with_authorization_workflows: ["dummy_
       it "redirects the user to the authorization form after the first sign in" do
         fill_in "Document number", with: "123456789X"
         page.execute_script("$('#authorization_handler_birthday').focus()")
-        page.find(".datepicker-dropdown .day", text: "12").click
+        page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
 
         click_button "Send"
         expect(page).to have_content("You've been successfully authorized")

--- a/decidim-verifications/spec/system/authorizations_spec.rb
+++ b/decidim-verifications/spec/system/authorizations_spec.rb
@@ -84,7 +84,7 @@ describe "Authorizations", type: :system, with_authorization_workflows: ["dummy_
 
         fill_in "Document number", with: "123456789X"
         page.execute_script("$('#authorization_handler_birthday').focus()")
-        page.find(".datepicker-dropdown .day", text: "12").click
+        page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
         click_button "Send"
 
         expect(page).to have_content("You've been successfully authorized")
@@ -109,7 +109,7 @@ describe "Authorizations", type: :system, with_authorization_workflows: ["dummy_
 
         fill_in "Document number", with: "12345678"
         page.execute_script("$('#authorization_handler_birthday').focus()")
-        page.find(".datepicker-dropdown .day", text: "12").click
+        page.find(".datepicker-dropdown .day:not(.new)", text: "12").click
         click_button "Send"
 
         expect(page).to have_content("There was a problem creating the authorization.")


### PR DESCRIPTION
#### :tophat: What? Why?
This PR backports #6920 to `release/0.22-stable`. It also includes a backport of #7256 in order to fix the test suite.

#### :pushpin: Related Issues
- Related to #6920

#### Testing
Ensure test suite is green