### PR TITLE
Change all `master` references to `develop`

### DIFF
--- a/.github/workflows/ci_accountability.yml
+++ b/.github/workflows/ci_accountability.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_admin.yml
+++ b/.github/workflows/ci_admin.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_assemblies.yml
+++ b/.github/workflows/ci_assemblies.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_blogs.yml
+++ b/.github/workflows/ci_blogs.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_budgets.yml
+++ b/.github/workflows/ci_budgets.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_comments.yml
+++ b/.github/workflows/ci_comments.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -40,7 +39,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_conferences.yml
+++ b/.github/workflows/ci_conferences.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_consultations.yml
+++ b/.github/workflows/ci_consultations.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_core_system.yml
+++ b/.github/workflows/ci_core_system.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_core_unit.yml
+++ b/.github/workflows/ci_core_unit.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_debates.yml
+++ b/.github/workflows/ci_debates.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_elections.yml
+++ b/.github/workflows/ci_elections.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_forms.yml
+++ b/.github/workflows/ci_forms.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_initiatives.yml
+++ b/.github/workflows/ci_initiatives.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -23,7 +22,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_meetings_system_admin.yml
+++ b/.github/workflows/ci_meetings_system_admin.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_meetings_system_public.yml
+++ b/.github/workflows/ci_meetings_system_public.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_meetings_unit_tests.yml
+++ b/.github/workflows/ci_meetings_unit_tests.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_pages.yml
+++ b/.github/workflows/ci_pages.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_participatory_processes.yml
+++ b/.github/workflows/ci_participatory_processes.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_proposals_system_admin.yml
+++ b/.github/workflows/ci_proposals_system_admin.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_proposals_system_public_1.yml
+++ b/.github/workflows/ci_proposals_system_public_1.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_proposals_system_public_2.yml
+++ b/.github/workflows/ci_proposals_system_public_2.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_proposals_unit_tests.yml
+++ b/.github/workflows/ci_proposals_unit_tests.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_sortitions.yml
+++ b/.github/workflows/ci_sortitions.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_surveys.yml
+++ b/.github/workflows/ci_surveys.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_system.yml
+++ b/.github/workflows/ci_system.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_templates.yml
+++ b/.github/workflows/ci_templates.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_verifications.yml
+++ b/.github/workflows/ci_verifications.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - master
       - release/*
       - "*-stable"
   pull_request:
@@ -24,7 +23,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -45,7 +45,7 @@ You can read in detail about this process in https://docs.decidim.org/en/governa
 
 == Do you want to contribute to Decidim design?
 
-* Go to the https://github.com/decidim/decidim/tree/master/decidim_app-design[Decidim design folder] and propose the changes that you want.
+* Go to the https://github.com/decidim/decidim/tree/develop/decidim_app-design[Decidim design folder] and propose the changes that you want.
 
 == Do you want to improve an existing language in Decidim?
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 :doctype: book
 
-image::https://cdn.rawgit.com/decidim/decidim/master/logo.svg[Decidim Logo,400]
+image::https://cdn.rawgit.com/decidim/decidim/develop/logo.svg[Decidim Logo,400]
 
 The participatory democracy framework.
 
@@ -19,7 +19,7 @@ image:https://img.shields.io/gem/v/decidim.svg[Gem,link=https://rubygems.org/gem
 
 Code quality
 
-image:https://codecov.io/gh/decidim/decidim/branch/develop/graph/badge.svg[codecov,link=https://codecov.io/gh/decidim/decidim] image:https://api.codeclimate.com/v1/badges/ad8fa445086e491486b6/maintainability[Maintainability,link=https://codeclimate.com/github/decidim/decidim/maintainability] image:https://d322cqt584bo4o.cloudfront.net/decidim/localized.svg[Crowdin,link=https://crowdin.com/project/decidim] image:http://inch-ci.org/github/decidim/decidim.svg?branch=master[Inline docs,link=http://inch-ci.org/github/decidim/decidim] image:https://rocketvalidator.com/badges/a11y_issues.svg?url=http://staging.decidim.codegram.com/[Accessibility issues,link=https://rocketvalidator.com/badges/link?url=http://staging.decidim.codegram.com/&report=a11y] image:https://rocketvalidator.com/badges/html_issues.svg?url=http://staging.decidim.codegram.com/[HTML issues,link=https://rocketvalidator.com/badges/link?url=http://staging.decidim.codegram.com/&report=html]
+image:https://codecov.io/gh/decidim/decidim/branch/develop/graph/badge.svg[codecov,link=https://codecov.io/gh/decidim/decidim] image:https://api.codeclimate.com/v1/badges/ad8fa445086e491486b6/maintainability[Maintainability,link=https://codeclimate.com/github/decidim/decidim/maintainability] image:https://d322cqt584bo4o.cloudfront.net/decidim/localized.svg[Crowdin,link=https://crowdin.com/project/decidim] image:http://inch-ci.org/github/decidim/decidim.svg?branch=develop[Inline docs,link=http://inch-ci.org/github/decidim/decidim] image:https://rocketvalidator.com/badges/a11y_issues.svg?url=http://staging.decidim.codegram.com/[Accessibility issues,link=https://rocketvalidator.com/badges/link?url=http://staging.decidim.codegram.com/&report=a11y] image:https://rocketvalidator.com/badges/html_issues.svg?url=http://staging.decidim.codegram.com/[HTML issues,link=https://rocketvalidator.com/badges/link?url=http://staging.decidim.codegram.com/&report=html]
 
 Test suite
 
@@ -73,7 +73,7 @@ decidim decidim_application
 ----
 
 We've set up a guide on how to install, set up and upgrade Decidim.
-See the https://github.com/decidim/decidim/blob/master/docs/getting_started.md[Getting started guide].
+See the https://github.com/decidim/decidim/blob/develop/docs/getting_started.md[Getting started guide].
 
 == How to contribute
 

--- a/decidim-core/README.md
+++ b/decidim-core/README.md
@@ -22,7 +22,7 @@ bundle
 
 ## Users
 
-User authentication is set up with [`Devise`](https://github.com/plataformatec/devise) with its modules, see the [`Decidim::User`](https://github.com/decidim/decidim/blob/master/decidim-core/app/models/decidim/user.rb) model configuration and its setup [initializer](https://github.com/decidim/decidim/blob/master/decidim-core/config/initializers/devise.rb).
+User authentication is set up with [`Devise`](https://github.com/plataformatec/devise) with its modules, see the [`Decidim::User`](https://github.com/decidim/decidim/blob/develop/decidim-core/app/models/decidim/user.rb) model configuration and its setup [initializer](https://github.com/decidim/decidim/blob/develop/decidim-core/config/initializers/devise.rb).
 
 ## Amendments
 
@@ -70,7 +70,7 @@ This can be done in an initializer (like user does), in a participatory_space ma
 
 ## Metrics docs
 
-Core adds an implementation to show APP metrics within some pages. You can see specific documentation at [Metrics](https://github.com/decidim/decidim/tree/master/docs/advanced/metrics.md)
+Core adds an implementation to show APP metrics within some pages. You can see specific documentation at [Metrics](https://github.com/decidim/decidim/tree/develop/docs/advanced/metrics.md)
 
 ## Contributing
 

--- a/decidim-generators/spec/generators_spec.rb
+++ b/decidim-generators/spec/generators_spec.rb
@@ -110,7 +110,8 @@ module Decidim
         end
 
         context "with --branch flag" do
-          let(:command) { "decidim --branch master #{test_app}" }
+          let(:default_branch) { "develop" }
+          let(:command) { "decidim --branch #{default_branch} #{test_app}" }
 
           it_behaves_like "a new production application"
         end

--- a/decidim-initiatives/README.md
+++ b/decidim-initiatives/README.md
@@ -53,7 +53,7 @@ Just use the following line:
 Decidim::Initiatives.do_not_require_authorization = true
 ```
 
-All the settings and their default values which can be overriden can be found in the file [`lib/decidim/initiatives.rb`](https://github.com/decidim/decidim/blob/master/decidim-initiatives/lib/decidim/initiatives.rb).
+All the settings and their default values which can be overriden can be found in the file [`lib/decidim/initiatives.rb`](https://github.com/decidim/decidim/blob/develop/decidim-initiatives/lib/decidim/initiatives.rb).
 
 For example, you can also change the minimum number of required committee members to 1 (default is 2) by adding this line:
 ```

--- a/decidim-system/app/views/decidim/system/shared/_notices.html.erb
+++ b/decidim-system/app/views/decidim/system/shared/_notices.html.erb
@@ -3,7 +3,7 @@
 <% if Decidim::Organization.none? %>
   <div class="flash callout warning">
     <% guide = link_to t(".our_getting_started_guide"),
-                       "https://github.com/decidim/decidim/blob/master/docs/getting_started.md",
+                       "https://docs.decidim.org/",
                        target: :blank %>
 
     <%= t(".no_organization_warning_html", guide: guide) %>

--- a/decidim-verifications/README.md
+++ b/decidim-verifications/README.md
@@ -166,7 +166,7 @@ on the context where the authorization is being performed.
 
 For example, you can require authorization for supporting proposals in a participatory
 process, and also restrict it to users with postal codes 12345 and 12346. The
-[example authorization handler](https://github.com/decidim/decidim/blob/master/decidim-generators/lib/decidim/generators/app_templates/dummy_authorization_handler.rb)
+[example authorization handler](https://github.com/decidim/decidim/blob/develop/decidim-generators/lib/decidim/generators/app_templates/dummy_authorization_handler.rb)
 included in this module allows to do that. As an admin user, you should visit
 the proposals componenent permissions screen, choose the `Example authorization`
 as the authorization handler name for the `vote` action and enter "12345, 12346"
@@ -204,8 +204,8 @@ Decidim::Verifications.register_workflow(:my_verification) do |workflow|
 end
 ```
 
-Check the [example authorization handler](https://github.com/decidim/decidim/blob/master/decidim-generators/lib/decidim/generators/app_templates/dummy_authorization_handler.rb)
-and the [DefaultActionAuthorizer class](https://github.com/decidim/decidim/blob/master/decidim-verifications/lib/decidim/verifications/default_action_authorizer.rb)
+Check the [example authorization handler](https://github.com/decidim/decidim/blob/develop/decidim-generators/lib/decidim/generators/app_templates/dummy_authorization_handler.rb)
+and the [DefaultActionAuthorizer class](https://github.com/decidim/decidim/blob/develop/decidim-verifications/lib/decidim/verifications/default_action_authorizer.rb)
 for additional technical details.
 
 ## How Handlers work
@@ -241,8 +241,8 @@ See [Decidim](https://github.com/decidim/decidim).
 
 See [Decidim](https://github.com/decidim/decidim).
 
-[authorization handler base class]: https://github.com/decidim/decidim/blob/master/decidim-verifications/app/services/decidim/authorization_handler.rb
-[example SMS gateway]: https://github.com/decidim/decidim/blob/master/decidim-verifications/lib/decidim/verifications/sms/example_gateway.rb
+[authorization handler base class]: https://github.com/decidim/decidim/blob/develop/decidim-verifications/app/services/decidim/authorization_handler.rb
+[example SMS gateway]: https://github.com/decidim/decidim/blob/develop/decidim-verifications/lib/decidim/verifications/sms/example_gateway.rb
 
 [Decidim Barcelona]: https://github.com/AjuntamentdeBarcelona/decidim-barcelona/blob/master/app/services/census_authorization_handler.rb
 [Decidim Terrassa]: https://github.com/AjuntamentDeTerrassa/decidim-terrassa/blob/master/app/services/census_authorization_handler.rb

--- a/docs/modules/customize/pages/authorizations.adoc
+++ b/docs/modules/customize/pages/authorizations.adoc
@@ -19,4 +19,4 @@ Each decidim instance is in full control of its authorizations, and can customiz
 * The different methods to be used by users to get verified. For example, through a census, by uploading their identity documents, or by receiving a verification home at their address.
 * The different actions in decidim that require authorization, and which authorization method they require. For example, a decidim instance might choose to require census authorization to create proposals, but a fully verified address via a verification code sent by postal mail for voting on proposals.
 
-See https://github.com/decidim/decidim/blob/master/decidim-verifications/README.md[decidim-verifications's README] and https://decidim.org/modules[Decidim's Modules page].
+See https://github.com/decidim/decidim/blob/develop/decidim-verifications/README.md[decidim-verifications's README] and https://decidim.org/modules[Decidim's Modules page].

--- a/docs/modules/customize/pages/styles.adoc
+++ b/docs/modules/customize/pages/styles.adoc
@@ -54,7 +54,7 @@ Notice that you can resize this textarea.
 
 You can go to app/assets/stylesheets/application.css.sass on your generated applications. There you can override any class using CSS with SASS.
 
-In https://github.com/decidim/decidim/blob/master/decidim-core/app/assets/stylesheets/decidim/_variables.scss[decidim-core/app/assets/stylesheets/decidim/_variables.scss] you can find the `variables` that can be overriden in your `sass`.
+In https://github.com/decidim/decidim/blob/develop/decidim-core/app/assets/stylesheets/decidim/_variables.scss[decidim-core/app/assets/stylesheets/decidim/_variables.scss] you can find the `variables` that can be overriden in your `sass`.
 
 We use http://sass-lang.com/guide[SASS, with SCSS syntax] as CSS preprocessor.
 

--- a/docs/modules/develop/pages/components.adoc
+++ b/docs/modules/develop/pages/components.adoc
@@ -4,7 +4,7 @@ Components are the core contract between external xref:develop:modules.adoc[modu
 
 == Creating a new component
 
-If you want to create a new component, you can use https://github.com/decidim/decidim/tree/master/decidim-generators[decidim-generators] to
+If you want to create a new component, you can use https://github.com/decidim/decidim/tree/develop/decidim-generators[decidim-generators] to
 automatically generate a decidim component skeleton, or copy the basic structure
 of an existing mantained plugin.
 
@@ -13,7 +13,7 @@ of an existing mantained plugin.
 decidim --component engine_name
 ----
 
-Components are just gems with one or more Rails engines included in it. You can use as an example https://github.com/decidim/decidim/tree/master/decidim-pages[decidim-pages].
+Components are just gems with one or more Rails engines included in it. You can use as an example https://github.com/decidim/decidim/tree/develop/decidim-pages[decidim-pages].
 
 Check out the `lib/decidim/pages` folder: It includes several files, the most important of which is `component.rb`.
 
@@ -125,4 +125,4 @@ This sections explains how to add dummy content to a development application.
 === Tips and Tricks
 
 * Take advantage of the Faker gem, already in decidim.
-* If you need content for i18n fields, you can use https://github.com/decidim/decidim/blob/master/decidim-core/lib/decidim/faker/localized.rb[Localizaed], which uses `Faker` internally.
+* If you need content for i18n fields, you can use https://github.com/decidim/decidim/blob/develop/decidim-core/lib/decidim/faker/localized.rb[Localizaed], which uses `Faker` internally.

--- a/docs/modules/develop/pages/guide_git_conventions.adoc
+++ b/docs/modules/develop/pages/guide_git_conventions.adoc
@@ -21,6 +21,8 @@ git checkout -b feature/xxx
 
 Implement the feature, and open a Pull Request as normal, but against `develop` branch. As this is the most common operation, `develop` is the default branch instead of `master`.
 
+Please note that Decidim does not use the `master` branch.
+
 == Naming branches
 
 We would like to have all branches following this namings:

--- a/docs/modules/develop/pages/how_to_fix_metrics.adoc
+++ b/docs/modules/develop/pages/how_to_fix_metrics.adoc
@@ -15,7 +15,7 @@ We have identified only one culprit here: "orphans" records, meaning records who
 
 === Peaks in generated metrics
 
-If somehow the metrics jobs fail to execute for a period of time, big differences can appear in metrics. So first make sure that you have metrics for every day, if not https://github.com/decidim/decidim/blob/master/docs/advanced/metrics.md[generate them].
+If somehow the metrics jobs fail to execute for a period of time, big differences can appear in metrics. So first make sure that you have metrics for every day, if not https://github.com/decidim/decidim/blob/develop/docs/advanced/metrics.md[generate them].
 
 If you have metrics generated for almost everyday and still see drastic changes from day to day, take into account that changing the visibility of a component or participatory space (making them private or unpublishing them) will naturally cause big differences in generated metrics.
 

--- a/docs/modules/develop/pages/newsletter_templates.adoc
+++ b/docs/modules/develop/pages/newsletter_templates.adoc
@@ -2,7 +2,7 @@
 
 The newsletter templates allow the user to select a template amongst a set of of them, and use it as base to send newsletters. This allow for more customization on newsletter, tematic newsletters, etc.
 
-Code-wise, they use the content blocks system internally, so https://github.com/decidim/decidim/blob/master/docs/advanced/content_blocks.md[check the docs] for that section first.
+Code-wise, they use the content blocks system internally, so https://github.com/decidim/decidim/blob/develop/docs/advanced/content_blocks.md[check the docs] for that section first.
 
 == Adding a new template
 

--- a/docs/modules/develop/pages/releases.adoc
+++ b/docs/modules/develop/pages/releases.adoc
@@ -1,7 +1,6 @@
 = Releasing new versions
 
-In order to release new version you need to be owner of all the gems at RubyGems, ask one of the owners to add you before releasing.
-(Try `gem owner decidim`).
+In order to release new version you need to be owner of all the gems at RubyGems, ask one of the owners to add you before releasing. Try `gem owner decidim` to find out the owners of the gem. It's worth making sure you're owner of all gems.
 
 Remember to follow the Gitflow branching workflow.
 
@@ -97,7 +96,8 @@ If this is a *Release Candidate version* release, the steps to follow are:
 . Run `bin/rake webpack`, this will update the JavaScript bundle.
 . Commit all the changes: `git add . && git commit -m "Bump to rcXX version" && git push origin release/x.y-stable`.
 . Tag the release candidate with `git tag vX.Y.Z.rcN && git push origin vX.Y.Z.rcN`.
-. Usually, at this point, the release branch is deployed to meta-decidim during, at least, one week to validate the stability of the version.
+
+Usually, at this point, the release branch is deployed to Metadecidim during, at least, one week to validate the stability of the version.
 
 === During the validation period
 
@@ -106,43 +106,19 @@ If this is a *Release Candidate version* release, the steps to follow are:
 
 == Major/Minor versions
 
-Release Candidates will be tested in a production server (usually meta-decidim) during some period of time (a week at least), when they are considered ready, it is time for them to be merged into `master`:
+Release Candidates will be tested in a production server (usually Metadecidim) during some period of time (a week at least). When they are considered ready, it is time for them to be released:
 
 . Checkout the release stable branch `git checkout release/x.y-stable`.
 . Update `.decidim-version` by removing the `.rcN` suffix, leaving a clean version number like `x.y.z`
 . Run `bin/rake update_versions`, this will update all references to the new version.
 . Run `bin/rake bundle`, this will update all the `Gemfile.lock` files
 . Run `bin/rake webpack`, this will update the JavaScript bundle.
+. Update `CHANGELOG.MD`.
+At the top you should have an `Unreleased` header with the `Added`, `Changed`, `Fixed` and `Removed` empty sections.
+After that, the header with the current version and link like `+## [0.20.0](https://github.com/decidim/decidim/tree/v0.20.0)+` and again the headers for the `Added`, `Changed`, `Fixed` and `Removed` sections.
 . Commit all the changes: `git add . && git commit -m "Bump to v0.XX.0 final version" && git push origin release/x.y-stable`.
-. Create the PR for the new version.
- .. `git checkout master && git pull && git checkout -b release/x.y.z`
- .. The following strategy has been discarded because it produces a lot of problems (still needs manual intervention for many files, backported commits via cherry-pick are applied twice, etc..)
-  ... `git merge release/x.y-stable`
-  ... `git checkout --theirs *`
-  ... `git checkout --theirs .github/* \.*`
-  ... Review changes in `CHANGELOG.md`, manually update and create a "changelog" commit if required.
- .. The simpler is to have two clones of the project, let's name current clone A, in `release/x.y.z`.
-The clone B is in `release/x.y-stable`.
-Now do the following from a file explorer
-  ... Remove all files except `.git` from clone A.
-  ... Copy all files except `.git` from clone B.
-  ... Paste all files except `.git` to clone A.
-  ... Commit the differences to be merged to `master`: `git add -A && git commit -m "Merge release 0.x.y"`
- .. `git push origin release/x.y.z`
- .. Create the PR.
-The base for this PR should be `master`, but GitHub may crash if there are a lot of changes.
-As a workaround create the branch against `develop` and, when created, change the base to `master`.
- .. Still don't merge it.
-. Before merging the PR to upgrade `master`, check that the stable branch for the previous version exists.
-For instance, if we are going to release v0.22.0, there should be a `release/0.21-stable` branch in the repository.
-If such branch does not exists, it has to be created now, before merging the new release.
-So, if this is the release of v0.22.0, branch off `release/0.21-stable` from `master`.
-These stable branches will be able to receive bugfixes, backports and will be the origin of patch releases for older releases.
-. Merge (after proper peer review) the PR to `master` and remove `release/x.y.z` branch.
-. Run `git checkout master && git pull && bin/rake release_all`, this will create all the tags, push the commits and tags and release the gems to RubyGems.
+. Run `git pull && bin/rake release_all`, this will create all the tags, push the commits and tags and release the gems to RubyGems.
 . Once all the gems are published you should create a new release at this repository, just go to the https://github.com/decidim/decidim/releases[releases page] and create a new one.
-. Create the stable branch for the current version if it does not exist.
-From `master`: `git checkout -b release/x.y-stable && git push origin release/x.y-stable`.
 . Update Decidim's Docker repository as explained in the Docker images section below.
 . Update Crowdin synchronization configuration with Github:
  .. Add the new `release/x.y-stable` branch.

--- a/docs/modules/install/pages/index.adoc
+++ b/docs/modules/install/pages/index.adoc
@@ -86,7 +86,7 @@ Visit http://localhost:3000 to see your app running.
 
 == Configuration & setup
 
-Decidim comes pre-configured with some safe defaults, but can be changed through the `config/initializers/decidim.rb` file in your app. Check the comments there or read the comments in https://github.com/decidim/decidim/blob/master/decidim-core/lib/decidim/core.rb[the source file] (the part with the `config_accessor` calls) for more up-to-date info.
+Decidim comes pre-configured with some safe defaults, but can be changed through the `config/initializers/decidim.rb` file in your app. Check the comments there or read the comments in https://github.com/decidim/decidim/blob/develop/decidim-core/lib/decidim/core.rb[the source file] (the part with the `config_accessor` calls) for more up-to-date info.
 
 === Scheduled tasks
 
@@ -133,7 +133,7 @@ This will create a system user with the email and password you set. We recommend
 
 Then, visit the `/system` dashboard and login with the email and passwords you just entered and create your organization. You're done! :tada:
 
-You can check the https://github.com/decidim/decidim/tree/master/decidim-system/README.md[`decidim-system` README file] for more info on how organizations work.
+You can check the https://github.com/decidim/decidim/tree/develop/decidim-system/README.md[`decidim-system` README file] for more info on how organizations work.
 
 == Checklist
 

--- a/docs/modules/install/pages/update.adoc
+++ b/docs/modules/install/pages/update.adoc
@@ -92,4 +92,4 @@ gem "decidim-dev", DECIDIM_VERSION
 . Make a full backup of the database before updating, just in case something unexpected happens.
 . If you are more than update away. Always update from one version to the immediately next one and then repeat the process until you are up to date.
 . Always check the instructions for a certain version upgrade in https://github.com/decidim/decidim/releases. Some releases require to perform certain actions as they may change some database structures. Follow that instructions if you are affected.
-. Check also the file https://github.com/decidim/decidim/blob/master/CHANGELOG.md It may have relevant information for updates between versions.
+. Check also the file https://github.com/decidim/decidim/blob/develop/CHANGELOG.md It may have relevant information for updates between versions.


### PR DESCRIPTION
#### :tophat: What? Why?
This PR updates all references to `master` branch by either removing them or replacing them with references to `develop`. This comes from the discussion in https://github.com/decidim/decidim/discussions/7226.

In the future, we might rename `develop` to `main`.

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/discussions/7226

#### Testing
Everything should be green in the CI
