### PR TITLE
Fix `--edge` generators to use the default branch

### DIFF
--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -103,7 +103,7 @@ module Decidim
         gem_modifier = if options[:path]
                          "path: \"#{options[:path]}\""
                        elsif options[:edge]
-                         "git: \"https://github.com/decidim/decidim.git\""
+                         "git: \"https://github.com/decidim/decidim.git\", branch: \"develop\""
                        elsif options[:branch]
                          "git: \"https://github.com/decidim/decidim.git\", branch: \"#{options[:branch]}\""
                        else

--- a/decidim-generators/spec/generators_spec.rb
+++ b/decidim-generators/spec/generators_spec.rb
@@ -102,19 +102,17 @@ module Decidim
         it_behaves_like "a new production application"
       end
 
-      if ENV["GITHUB_REF"] && ENV["GITHUB_REF"].match?("develop")
-        context "with --edge flag" do
-          let(:command) { "decidim --edge #{test_app}" }
+      context "with --edge flag" do
+        let(:command) { "decidim --edge #{test_app}" }
 
-          it_behaves_like "a new production application"
-        end
+        it_behaves_like "a new production application"
+      end
 
-        context "with --branch flag" do
-          let(:default_branch) { "develop" }
-          let(:command) { "decidim --branch #{default_branch} #{test_app}" }
+      context "with --branch flag" do
+        let(:default_branch) { "develop" }
+        let(:command) { "decidim --branch #{default_branch} #{test_app}" }
 
-          it_behaves_like "a new production application"
-        end
+        it_behaves_like "a new production application"
       end
 
       context "with --path flag" do


### PR DESCRIPTION
#### :tophat: What? Why?
Since we no longer have the `master` branch, the generators need to be updated. This problem wasn't caught earlier because some of the specs only ran on `develop`. I've removed the `if` so that all specs run in all branches.

#### :pushpin: Related Issues
- Related to #7267 

#### Testing
Rely on test suite

