### PR TITLE
Rename `develop` branch to `main`

### DIFF
--- a/.github/workflows/ci_accountability.yml
+++ b/.github/workflows/ci_accountability.yml
@@ -2,7 +2,7 @@ name: "[CI] Accountability"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_admin.yml
+++ b/.github/workflows/ci_admin.yml
@@ -2,7 +2,7 @@ name: "[CI] Admin"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -2,7 +2,7 @@ name: "[CI] Api"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_assemblies.yml
+++ b/.github/workflows/ci_assemblies.yml
@@ -2,7 +2,7 @@ name: "[CI] Assemblies"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_blogs.yml
+++ b/.github/workflows/ci_blogs.yml
@@ -2,7 +2,7 @@ name: "[CI] Blogs"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_budgets.yml
+++ b/.github/workflows/ci_budgets.yml
@@ -2,7 +2,7 @@ name: "[CI] Budgets"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_comments.yml
+++ b/.github/workflows/ci_comments.yml
@@ -2,7 +2,7 @@ name: "[CI] Comments"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -39,7 +39,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_conferences.yml
+++ b/.github/workflows/ci_conferences.yml
@@ -2,7 +2,7 @@ name: "[CI] Conferences"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_consultations.yml
+++ b/.github/workflows/ci_consultations.yml
@@ -2,7 +2,7 @@ name: "[CI] Consultations"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_core_system.yml
+++ b/.github/workflows/ci_core_system.yml
@@ -2,7 +2,7 @@ name: "[CI] Core (system specs)"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_core_unit.yml
+++ b/.github/workflows/ci_core_unit.yml
@@ -2,7 +2,7 @@ name: "[CI] Core (unit tests)"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_debates.yml
+++ b/.github/workflows/ci_debates.yml
@@ -2,7 +2,7 @@ name: "[CI] Debates"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_elections.yml
+++ b/.github/workflows/ci_elections.yml
@@ -2,7 +2,7 @@ name: "[CI] Elections"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_forms.yml
+++ b/.github/workflows/ci_forms.yml
@@ -2,7 +2,7 @@ name: "[CI] Forms"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -2,7 +2,7 @@ name: "[CI] Generators"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_initiatives.yml
+++ b/.github/workflows/ci_initiatives.yml
@@ -2,7 +2,7 @@ name: "[CI] Initiatives"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -2,7 +2,7 @@ name: "[CI] Main folder"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_meetings_system_admin.yml
+++ b/.github/workflows/ci_meetings_system_admin.yml
@@ -2,7 +2,7 @@ name: "[CI] Meetings (system admin)"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_meetings_system_public.yml
+++ b/.github/workflows/ci_meetings_system_public.yml
@@ -2,7 +2,7 @@ name: "[CI] Meetings (system public)"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_meetings_unit_tests.yml
+++ b/.github/workflows/ci_meetings_unit_tests.yml
@@ -2,7 +2,7 @@ name: "[CI] Meetings (unit tests)"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_pages.yml
+++ b/.github/workflows/ci_pages.yml
@@ -2,7 +2,7 @@ name: "[CI] Pages"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_participatory_processes.yml
+++ b/.github/workflows/ci_participatory_processes.yml
@@ -2,7 +2,7 @@ name: "[CI] Participatory processes"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_proposals_system_admin.yml
+++ b/.github/workflows/ci_proposals_system_admin.yml
@@ -2,7 +2,7 @@ name: "[CI] Proposals (system admin)"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_proposals_system_public_1.yml
+++ b/.github/workflows/ci_proposals_system_public_1.yml
@@ -2,7 +2,7 @@ name: "[CI] Proposals (system public 1)"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_proposals_system_public_2.yml
+++ b/.github/workflows/ci_proposals_system_public_2.yml
@@ -2,7 +2,7 @@ name: "[CI] Proposals (system public2)"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_proposals_unit_tests.yml
+++ b/.github/workflows/ci_proposals_unit_tests.yml
@@ -2,7 +2,7 @@ name: "[CI] Proposals (unit tests)"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_sortitions.yml
+++ b/.github/workflows/ci_sortitions.yml
@@ -2,7 +2,7 @@ name: "[CI] Sortitions"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_surveys.yml
+++ b/.github/workflows/ci_surveys.yml
@@ -2,7 +2,7 @@ name: "[CI] Surveys"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_system.yml
+++ b/.github/workflows/ci_system.yml
@@ -2,7 +2,7 @@ name: "[CI] System"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_templates.yml
+++ b/.github/workflows/ci_templates.yml
@@ -2,7 +2,7 @@ name: "[CI] Templates"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_verifications.yml
+++ b/.github/workflows/ci_verifications.yml
@@ -2,7 +2,7 @@ name: "[CI] Verifications"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -38,7 +38,7 @@ jobs:
       DATABASE_HOST: localhost
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -2,7 +2,7 @@ name: "[CI] Lint"
 on:
   push:
     branches:
-      - develop
+      - main
       - release/*
       - "*-stable"
   pull_request:
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-        if: "github.ref != 'refs/heads/develop'"
+        if: "github.ref != 'refs/heads/main'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -9,7 +9,7 @@ Please note that by making a Pull Request in this repository you're agreeing wit
 == Did you find a bug?
 
 * *Do not open up a GitHub issue if the bug is a security vulnerability in Decidim*, and instead send us an email to security [at] decidim.org.
-See https://github.com/decidim/decidim/blob/develop/SECURITY.adoc[full security policy].
+See https://github.com/decidim/decidim/blob/main/SECURITY.adoc[full security policy].
 * *Ensure the bug was not already reported* by searching on GitHub under https://github.com/decidim/decidim/issues[Issues] and on https://meta.decidim.org/processes/bug-report/f/210/proposals[Metadecidim].
 * If you're unable to find an open issue addressing the problem, https://github.com/decidim/decidim/issues/new?template=Bug_report.md[open a new one on GitHub].
 Be sure to include a *title and clear description*, as much relevant information as possible, and a *code sample* or an *executable test case* demonstrating the expected behavior that is not occurring.
@@ -45,7 +45,7 @@ You can read in detail about this process in https://docs.decidim.org/en/governa
 
 == Do you want to contribute to Decidim design?
 
-* Go to the https://github.com/decidim/decidim/tree/develop/decidim_app-design[Decidim design folder] and propose the changes that you want.
+* Go to the https://github.com/decidim/decidim/tree/main/decidim_app-design[Decidim design folder] and propose the changes that you want.
 
 == Do you want to improve an existing language in Decidim?
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 :doctype: book
 
-image::https://cdn.rawgit.com/decidim/decidim/develop/logo.svg[Decidim Logo,400]
+image::https://cdn.rawgit.com/decidim/decidim/main/logo.svg[Decidim Logo,400]
 
 The participatory democracy framework.
 
@@ -19,35 +19,35 @@ image:https://img.shields.io/gem/v/decidim.svg[Gem,link=https://rubygems.org/gem
 
 Code quality
 
-image:https://codecov.io/gh/decidim/decidim/branch/develop/graph/badge.svg[codecov,link=https://codecov.io/gh/decidim/decidim] image:https://api.codeclimate.com/v1/badges/ad8fa445086e491486b6/maintainability[Maintainability,link=https://codeclimate.com/github/decidim/decidim/maintainability] image:https://d322cqt584bo4o.cloudfront.net/decidim/localized.svg[Crowdin,link=https://crowdin.com/project/decidim] image:http://inch-ci.org/github/decidim/decidim.svg?branch=develop[Inline docs,link=http://inch-ci.org/github/decidim/decidim] image:https://rocketvalidator.com/badges/a11y_issues.svg?url=http://staging.decidim.codegram.com/[Accessibility issues,link=https://rocketvalidator.com/badges/link?url=http://staging.decidim.codegram.com/&report=a11y] image:https://rocketvalidator.com/badges/html_issues.svg?url=http://staging.decidim.codegram.com/[HTML issues,link=https://rocketvalidator.com/badges/link?url=http://staging.decidim.codegram.com/&report=html]
+image:https://codecov.io/gh/decidim/decidim/branch/main/graph/badge.svg[codecov,link=https://codecov.io/gh/decidim/decidim] image:https://api.codeclimate.com/v1/badges/ad8fa445086e491486b6/maintainability[Maintainability,link=https://codeclimate.com/github/decidim/decidim/maintainability] image:https://d322cqt584bo4o.cloudfront.net/decidim/localized.svg[Crowdin,link=https://crowdin.com/project/decidim] image:http://inch-ci.org/github/decidim/decidim.svg?branch=main[Inline docs,link=http://inch-ci.org/github/decidim/decidim] image:https://rocketvalidator.com/badges/a11y_issues.svg?url=http://staging.decidim.codegram.com/[Accessibility issues,link=https://rocketvalidator.com/badges/link?url=http://staging.decidim.codegram.com/&report=a11y] image:https://rocketvalidator.com/badges/html_issues.svg?url=http://staging.decidim.codegram.com/[HTML issues,link=https://rocketvalidator.com/badges/link?url=http://staging.decidim.codegram.com/&report=html]
 
 Test suite
 
 +++<details>++++++<summary>+++See all+++</summary>+++
-image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Accountability/develop.svg?label=%5BCI%5D%20Accountability[Accountability,link=https://github.com/decidim/decidim/actions]
-image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Api/develop.svg?label=%5BCI%5D%20Api[Api,link=https://github.com/decidim/decidim/actions]
-image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Assemblies/develop.svg?label=%5BCI%5D%20Assemblies[Assemblies,link=https://github.com/decidim/decidim/actions]
-image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Blogs/develop.svg?label=%5BCI%5D%20Blogs[Blogs,link=https://github.com/decidim/decidim/actions]
-image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Budgets/develop.svg?label=%5BCI%5D%20Budgets[Budgets,link=https://github.com/decidim/decidim/actions]
-image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Comments/develop.svg?label=%5BCI%5D%20Comments[Comments,link=https://github.com/decidim/decidim/actions]
-image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Conferences/develop.svg?label=%5BCI%5D%20Conferences[Conferences,link=https://github.com/decidim/decidim/actions]
-image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Consultations/develop.svg?label=%5BCI%5D%20Consultations[Consultations,link=https://github.com/decidim/decidim/actions]
-image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Core/develop.svg?label=%5BCI%5D%20Core[Core,link=https://github.com/decidim/decidim/actions]
-image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Debates/develop.svg?label=%5BCI%5D%20Debates[Debates,link=https://github.com/decidim/decidim/actions]
-image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Forms/develop.svg?label=%5BCI%5D%20Forms[Forms,link=https://github.com/decidim/decidim/actions]
-image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Generators/develop.svg?label=%5BCI%5D%20Generators[Generators,link=https://github.com/decidim/decidim/actions]
-image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Initiatives/develop.svg?label=%5BCI%5D%20Initiatives[Initiatives,link=https://github.com/decidim/decidim/actions]
-image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Main%20folder/develop.svg?label=%5BCI%5D%20Main[Main,link=https://github.com/decidim/decidim/actions]
-image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Meetings/develop.svg?label=%5BCI%5D%20Meetings[Meetings,link=https://github.com/decidim/decidim/actions]
-image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Pages/develop.svg?label=%5BCI%5D%20Pages[Pages,link=https://github.com/decidim/decidim/actions]
-image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Participatory%20processes/develop.svg?label=%5BCI%5D%20Participatory%20processes[Participatory processes,link=https://github.com/decidim/decidim/actions]
-image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Proposals%20(system%20admin)/develop.svg?label=%5BCI%5D%20Proposals%20(system%20admin)[Proposals (system admin),link=https://github.com/decidim/decidim/actions]
-image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Proposals%20(system%20public)/develop.svg?label=%5BCI%5D%20Proposals%20(system%20public)[Proposals (system admin),link=https://github.com/decidim/decidim/actions]
-image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Proposals%20(unit%20tests)/develop.svg?label=%5BCI%5D%20Proposals%20(unit%20tests)[Proposals (unit tests),link=https://github.com/decidim/decidim/actions]
-image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Sortitions/develop.svg?label=%5BCI%5D%20Sortitions[Sortitions,link=https://github.com/decidim/decidim/actions]
-image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Surveys/develop.svg?label=%5BCI%5D%20Surveys[Surveys,link=https://github.com/decidim/decidim/actions]
-image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20System/develop.svg?label=%5BCI%5D%20System[System,link=https://github.com/decidim/decidim/actions]
-image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Verifications/develop.svg?label=%5BCI%5D%20Verifications[Verifications,link=https://github.com/decidim/decidim/actions]
+image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Accountability/main.svg?label=%5BCI%5D%20Accountability[Accountability,link=https://github.com/decidim/decidim/actions]
+image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Api/main.svg?label=%5BCI%5D%20Api[Api,link=https://github.com/decidim/decidim/actions]
+image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Assemblies/main.svg?label=%5BCI%5D%20Assemblies[Assemblies,link=https://github.com/decidim/decidim/actions]
+image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Blogs/main.svg?label=%5BCI%5D%20Blogs[Blogs,link=https://github.com/decidim/decidim/actions]
+image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Budgets/main.svg?label=%5BCI%5D%20Budgets[Budgets,link=https://github.com/decidim/decidim/actions]
+image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Comments/main.svg?label=%5BCI%5D%20Comments[Comments,link=https://github.com/decidim/decidim/actions]
+image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Conferences/main.svg?label=%5BCI%5D%20Conferences[Conferences,link=https://github.com/decidim/decidim/actions]
+image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Consultations/main.svg?label=%5BCI%5D%20Consultations[Consultations,link=https://github.com/decidim/decidim/actions]
+image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Core/main.svg?label=%5BCI%5D%20Core[Core,link=https://github.com/decidim/decidim/actions]
+image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Debates/main.svg?label=%5BCI%5D%20Debates[Debates,link=https://github.com/decidim/decidim/actions]
+image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Forms/main.svg?label=%5BCI%5D%20Forms[Forms,link=https://github.com/decidim/decidim/actions]
+image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Generators/main.svg?label=%5BCI%5D%20Generators[Generators,link=https://github.com/decidim/decidim/actions]
+image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Initiatives/main.svg?label=%5BCI%5D%20Initiatives[Initiatives,link=https://github.com/decidim/decidim/actions]
+image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Main%20folder/main.svg?label=%5BCI%5D%20Main[Main,link=https://github.com/decidim/decidim/actions]
+image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Meetings/main.svg?label=%5BCI%5D%20Meetings[Meetings,link=https://github.com/decidim/decidim/actions]
+image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Pages/main.svg?label=%5BCI%5D%20Pages[Pages,link=https://github.com/decidim/decidim/actions]
+image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Participatory%20processes/main.svg?label=%5BCI%5D%20Participatory%20processes[Participatory processes,link=https://github.com/decidim/decidim/actions]
+image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Proposals%20(system%20admin)/main.svg?label=%5BCI%5D%20Proposals%20(system%20admin)[Proposals (system admin),link=https://github.com/decidim/decidim/actions]
+image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Proposals%20(system%20public)/main.svg?label=%5BCI%5D%20Proposals%20(system%20public)[Proposals (system admin),link=https://github.com/decidim/decidim/actions]
+image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Proposals%20(unit%20tests)/main.svg?label=%5BCI%5D%20Proposals%20(unit%20tests)[Proposals (unit tests),link=https://github.com/decidim/decidim/actions]
+image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Sortitions/main.svg?label=%5BCI%5D%20Sortitions[Sortitions,link=https://github.com/decidim/decidim/actions]
+image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Surveys/main.svg?label=%5BCI%5D%20Surveys[Surveys,link=https://github.com/decidim/decidim/actions]
+image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20System/main.svg?label=%5BCI%5D%20System[System,link=https://github.com/decidim/decidim/actions]
+image:https://img.shields.io/github/workflow/status/decidim/decidim/%5BCI%5D%20Verifications/main.svg?label=%5BCI%5D%20Verifications[Verifications,link=https://github.com/decidim/decidim/actions]
 +++</details>+++
 
 '''

--- a/README.adoc
+++ b/README.adoc
@@ -73,7 +73,7 @@ decidim decidim_application
 ----
 
 We've set up a guide on how to install, set up and upgrade Decidim.
-See the https://github.com/decidim/decidim/blob/develop/docs/getting_started.md[Getting started guide].
+See the https://github.com/decidim/decidim/blob/main/docs/getting_started.md[Getting started guide].
 
 == How to contribute
 

--- a/decidim-core/README.md
+++ b/decidim-core/README.md
@@ -22,7 +22,7 @@ bundle
 
 ## Users
 
-User authentication is set up with [`Devise`](https://github.com/plataformatec/devise) with its modules, see the [`Decidim::User`](https://github.com/decidim/decidim/blob/develop/decidim-core/app/models/decidim/user.rb) model configuration and its setup [initializer](https://github.com/decidim/decidim/blob/develop/decidim-core/config/initializers/devise.rb).
+User authentication is set up with [`Devise`](https://github.com/plataformatec/devise) with its modules, see the [`Decidim::User`](https://github.com/decidim/decidim/blob/main/decidim-core/app/models/decidim/user.rb) model configuration and its setup [initializer](https://github.com/decidim/decidim/blob/main/decidim-core/config/initializers/devise.rb).
 
 ## Amendments
 
@@ -70,7 +70,7 @@ This can be done in an initializer (like user does), in a participatory_space ma
 
 ## Metrics docs
 
-Core adds an implementation to show APP metrics within some pages. You can see specific documentation at [Metrics](https://github.com/decidim/decidim/tree/develop/docs/advanced/metrics.md)
+Core adds an implementation to show APP metrics within some pages. You can see specific documentation at [Metrics](https://github.com/decidim/decidim/tree/main/docs/advanced/metrics.md)
 
 ## Contributing
 

--- a/decidim-dev/lib/tasks/locale_checker.rake
+++ b/decidim-dev/lib/tasks/locale_checker.rake
@@ -5,7 +5,7 @@ namespace :decidim do
   task check_locales: :environment do
     FileUtils.remove_dir("tmp/decidim_repo", true)
 
-    branch = ENV["TARGET_BRANCH"] || "develop"
+    branch = ENV["TARGET_BRANCH"] || "main"
     status = system("git clone --depth=1 --single-branch --branch #{branch} https://github.com/decidim/decidim tmp/decidim_repo")
     return unless status
 

--- a/decidim-elections/README.md
+++ b/decidim-elections/README.md
@@ -8,7 +8,7 @@ The Elections module adds elections to any participatory space.
 
 Elections will be available as a Component for a Participatory Space.
 
-In order to celebrate [End-to-end auditable votings](https://en.wikipedia.org/wiki/End-to-end_auditable_voting_systems) using the Elections module, you will need to connect your Decidim instance with an instance of the [Decidim Bulletin Board application](https://github.com/decidim/decidim-bulletin-board/). To create this connection, please check the [instructions](https://github.com/decidim/decidim/blob/develop/docs/services/elections_bulletin_board.md).
+In order to celebrate [End-to-end auditable votings](https://en.wikipedia.org/wiki/End-to-end_auditable_voting_systems) using the Elections module, you will need to connect your Decidim instance with an instance of the [Decidim Bulletin Board application](https://github.com/decidim/decidim-bulletin-board/). To create this connection, please check the [instructions](https://github.com/decidim/decidim/blob/main/docs/services/elections_bulletin_board.md).
 
 ## Installation
 

--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -35,7 +35,7 @@ module Decidim
 
       class_option :edge, type: :boolean,
                           default: false,
-                          desc: "Use GitHub's edge version from develop branch"
+                          desc: "Use GitHub's edge version from main branch"
 
       class_option :branch, type: :string,
                             default: nil,
@@ -103,7 +103,7 @@ module Decidim
         gem_modifier = if options[:path]
                          "path: \"#{options[:path]}\""
                        elsif options[:edge]
-                         "git: \"https://github.com/decidim/decidim.git\", branch: \"develop\""
+                         "git: \"https://github.com/decidim/decidim.git\", branch: \"main\""
                        elsif options[:branch]
                          "git: \"https://github.com/decidim/decidim.git\", branch: \"#{options[:branch]}\""
                        else

--- a/decidim-generators/spec/generators_spec.rb
+++ b/decidim-generators/spec/generators_spec.rb
@@ -109,7 +109,7 @@ module Decidim
       end
 
       context "with --branch flag" do
-        let(:default_branch) { "develop" }
+        let(:default_branch) { "main" }
         let(:command) { "decidim --branch #{default_branch} #{test_app}" }
 
         it_behaves_like "a new production application"

--- a/decidim-initiatives/README.md
+++ b/decidim-initiatives/README.md
@@ -53,7 +53,7 @@ Just use the following line:
 Decidim::Initiatives.do_not_require_authorization = true
 ```
 
-All the settings and their default values which can be overriden can be found in the file [`lib/decidim/initiatives.rb`](https://github.com/decidim/decidim/blob/develop/decidim-initiatives/lib/decidim/initiatives.rb).
+All the settings and their default values which can be overriden can be found in the file [`lib/decidim/initiatives.rb`](https://github.com/decidim/decidim/blob/main/decidim-initiatives/lib/decidim/initiatives.rb).
 
 For example, you can also change the minimum number of required committee members to 1 (default is 2) by adding this line:
 ```

--- a/decidim-verifications/README.md
+++ b/decidim-verifications/README.md
@@ -166,7 +166,7 @@ on the context where the authorization is being performed.
 
 For example, you can require authorization for supporting proposals in a participatory
 process, and also restrict it to users with postal codes 12345 and 12346. The
-[example authorization handler](https://github.com/decidim/decidim/blob/develop/decidim-generators/lib/decidim/generators/app_templates/dummy_authorization_handler.rb)
+[example authorization handler](https://github.com/decidim/decidim/blob/main/decidim-generators/lib/decidim/generators/app_templates/dummy_authorization_handler.rb)
 included in this module allows to do that. As an admin user, you should visit
 the proposals componenent permissions screen, choose the `Example authorization`
 as the authorization handler name for the `vote` action and enter "12345, 12346"
@@ -204,8 +204,8 @@ Decidim::Verifications.register_workflow(:my_verification) do |workflow|
 end
 ```
 
-Check the [example authorization handler](https://github.com/decidim/decidim/blob/develop/decidim-generators/lib/decidim/generators/app_templates/dummy_authorization_handler.rb)
-and the [DefaultActionAuthorizer class](https://github.com/decidim/decidim/blob/develop/decidim-verifications/lib/decidim/verifications/default_action_authorizer.rb)
+Check the [example authorization handler](https://github.com/decidim/decidim/blob/main/decidim-generators/lib/decidim/generators/app_templates/dummy_authorization_handler.rb)
+and the [DefaultActionAuthorizer class](https://github.com/decidim/decidim/blob/main/decidim-verifications/lib/decidim/verifications/default_action_authorizer.rb)
 for additional technical details.
 
 ## How Handlers work
@@ -241,8 +241,8 @@ See [Decidim](https://github.com/decidim/decidim).
 
 See [Decidim](https://github.com/decidim/decidim).
 
-[authorization handler base class]: https://github.com/decidim/decidim/blob/develop/decidim-verifications/app/services/decidim/authorization_handler.rb
-[example SMS gateway]: https://github.com/decidim/decidim/blob/develop/decidim-verifications/lib/decidim/verifications/sms/example_gateway.rb
+[authorization handler base class]: https://github.com/decidim/decidim/blob/main/decidim-verifications/app/services/decidim/authorization_handler.rb
+[example SMS gateway]: https://github.com/decidim/decidim/blob/main/decidim-verifications/lib/decidim/verifications/sms/example_gateway.rb
 
 [Decidim Barcelona]: https://github.com/AjuntamentdeBarcelona/decidim-barcelona/blob/master/app/services/census_authorization_handler.rb
 [Decidim Terrassa]: https://github.com/AjuntamentDeTerrassa/decidim-terrassa/blob/master/app/services/census_authorization_handler.rb

--- a/docs/modules/customize/pages/authorizations.adoc
+++ b/docs/modules/customize/pages/authorizations.adoc
@@ -19,4 +19,4 @@ Each decidim instance is in full control of its authorizations, and can customiz
 * The different methods to be used by users to get verified. For example, through a census, by uploading their identity documents, or by receiving a verification home at their address.
 * The different actions in decidim that require authorization, and which authorization method they require. For example, a decidim instance might choose to require census authorization to create proposals, but a fully verified address via a verification code sent by postal mail for voting on proposals.
 
-See https://github.com/decidim/decidim/blob/develop/decidim-verifications/README.md[decidim-verifications's README] and https://decidim.org/modules[Decidim's Modules page].
+See https://github.com/decidim/decidim/blob/main/decidim-verifications/README.md[decidim-verifications's README] and https://decidim.org/modules[Decidim's Modules page].

--- a/docs/modules/customize/pages/menu.adoc
+++ b/docs/modules/customize/pages/menu.adoc
@@ -21,5 +21,5 @@ Depending in the kind of space and module, then you can see or not some of the s
 
 There's also a https://github.com/OpenSourcePolitics/decidim-module-navbar_links[NavBar links module] made by the community that you can use to add your custom links.
 
-Finally if you want to dive in the code that handles this, a good starting point is the https://rubydoc.info/github/decidim/decidim/develop/Decidim/Menu[Menu API].
+Finally if you want to dive in the code that handles this, a good starting point is the https://rubydoc.info/github/decidim/decidim/main/Decidim/Menu[Menu API].
 

--- a/docs/modules/customize/pages/styles.adoc
+++ b/docs/modules/customize/pages/styles.adoc
@@ -54,7 +54,7 @@ Notice that you can resize this textarea.
 
 You can go to app/assets/stylesheets/application.css.sass on your generated applications. There you can override any class using CSS with SASS.
 
-In https://github.com/decidim/decidim/blob/develop/decidim-core/app/assets/stylesheets/decidim/_variables.scss[decidim-core/app/assets/stylesheets/decidim/_variables.scss] you can find the `variables` that can be overriden in your `sass`.
+In https://github.com/decidim/decidim/blob/main/decidim-core/app/assets/stylesheets/decidim/_variables.scss[decidim-core/app/assets/stylesheets/decidim/_variables.scss] you can find the `variables` that can be overriden in your `sass`.
 
 We use http://sass-lang.com/guide[SASS, with SCSS syntax] as CSS preprocessor.
 

--- a/docs/modules/develop/pages/components.adoc
+++ b/docs/modules/develop/pages/components.adoc
@@ -4,7 +4,7 @@ Components are the core contract between external xref:develop:modules.adoc[modu
 
 == Creating a new component
 
-If you want to create a new component, you can use https://github.com/decidim/decidim/tree/develop/decidim-generators[decidim-generators] to
+If you want to create a new component, you can use https://github.com/decidim/decidim/tree/main/decidim-generators[decidim-generators] to
 automatically generate a decidim component skeleton, or copy the basic structure
 of an existing mantained plugin.
 
@@ -13,7 +13,7 @@ of an existing mantained plugin.
 decidim --component engine_name
 ----
 
-Components are just gems with one or more Rails engines included in it. You can use as an example https://github.com/decidim/decidim/tree/develop/decidim-pages[decidim-pages].
+Components are just gems with one or more Rails engines included in it. You can use as an example https://github.com/decidim/decidim/tree/main/decidim-pages[decidim-pages].
 
 Check out the `lib/decidim/pages` folder: It includes several files, the most important of which is `component.rb`.
 
@@ -125,4 +125,4 @@ This sections explains how to add dummy content to a development application.
 === Tips and Tricks
 
 * Take advantage of the Faker gem, already in decidim.
-* If you need content for i18n fields, you can use https://github.com/decidim/decidim/blob/develop/decidim-core/lib/decidim/faker/localized.rb[Localizaed], which uses `Faker` internally.
+* If you need content for i18n fields, you can use https://github.com/decidim/decidim/blob/main/decidim-core/lib/decidim/faker/localized.rb[Localizaed], which uses `Faker` internally.

--- a/docs/modules/develop/pages/guide.adoc
+++ b/docs/modules/develop/pages/guide.adoc
@@ -1,16 +1,16 @@
 = Developing Decidim
 
-* xref:develop:guide_architecture.adoc[Architecture]
-* xref:develop:guide_changelog.adoc[Changelog]
-* xref:develop:guide_commands.adoc[Commands]
-* xref:develop:guide_development_app.adoc[Development App]
-* xref:develop:guide_example_apps.adoc[Example Applications]
-* xref:develop:guide_git_conventions.adoc[Git conventions]
-* xref:develop:guide_github_projects.adoc[GitHub Projects Workflow]
-* xref:develop:guide_semver.adoc[Semantic Versioning]
+* xref:main:guide_architecture.adoc[Architecture]
+* xref:main:guide_changelog.adoc[Changelog]
+* xref:main:guide_commands.adoc[Commands]
+* xref:main:guide_mainment_app.adoc[Development App]
+* xref:main:guide_example_apps.adoc[Example Applications]
+* xref:main:guide_git_conventions.adoc[Git conventions]
+* xref:main:guide_github_projects.adoc[GitHub Projects Workflow]
+* xref:main:guide_semver.adoc[Semantic Versioning]
 
 == Good to know
 
 * There is an application with current designs at: https://decidim-design.herokuapp.com/
 * We follow https://12factor.net/[12factor recommendations]
-* For testing, refer to the xref:develop:testing.adoc[testing] guide.
+* For testing, refer to the xref:main:testing.adoc[testing] guide.

--- a/docs/modules/develop/pages/guide_git_conventions.adoc
+++ b/docs/modules/develop/pages/guide_git_conventions.adoc
@@ -2,24 +2,24 @@
 
 == GitFlow Branching model
 
-The Decidim respository follows the GitFlow branching model. There are good documentations on it at:
+The Decidim repository loosely follows the GitFlow branching model. There are good documentations on it at:
 
 * https://nvie.com/posts/a-successful-git-branching-model/[the original post]
 * https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow[Atlassian tutorial]
 
-This model introduces the `develop` branch as a kind of queue for new features to enter into the next release.
+This model introduces the `develop` branch as a kind of queue for new features to enter into the next release. Instead, Decidim uses `main` for this role and does not use the `master` branch at all.
 
-In summary, Decidim developers that work on `+feature/...+` or `+fix/...+` branches will branch off from `develop` and must be merged back into `develop`.
+In summary, Decidim developers that work on `+feature/...+` or `+fix/...+` branches will branch off from `main` and must be merged back into `main`.
 
-Then, to start a new feature branch off from `develop` in the following way:
+Then, to start a new feature branch off from `main` in the following way:
 
 [source,bash]
 ----
-git checkout develop
+git checkout main
 git checkout -b feature/xxx
 ----
 
-Implement the feature, and open a Pull Request as normal, but against `develop` branch. As this is the most common operation, `develop` is the default branch instead of `master`.
+Implement the feature, and open a Pull Request as normal, checking that it goes against `main` branch. As this is the most common operation, `main` is the default branch.
 
 Please note that Decidim does not use the `master` branch.
 

--- a/docs/modules/develop/pages/how_to_fix_metrics.adoc
+++ b/docs/modules/develop/pages/how_to_fix_metrics.adoc
@@ -15,7 +15,7 @@ We have identified only one culprit here: "orphans" records, meaning records who
 
 === Peaks in generated metrics
 
-If somehow the metrics jobs fail to execute for a period of time, big differences can appear in metrics. So first make sure that you have metrics for every day, if not https://github.com/decidim/decidim/blob/develop/docs/advanced/metrics.md[generate them].
+If somehow the metrics jobs fail to execute for a period of time, big differences can appear in metrics. So first make sure that you have metrics for every day, if not https://github.com/decidim/decidim/blob/main/docs/advanced/metrics.md[generate them].
 
 If you have metrics generated for almost everyday and still see drastic changes from day to day, take into account that changing the visibility of a component or participatory space (making them private or unpublishing them) will naturally cause big differences in generated metrics.
 

--- a/docs/modules/develop/pages/modules.adoc
+++ b/docs/modules/develop/pages/modules.adoc
@@ -12,7 +12,7 @@ You can see some of our more popular modules at https://decidim.org/modules[Deci
 You can have multiple modules types:
 
 * For Spaces
-* For xref:develop:components.adoc[Components]
+* For xref:main:components.adoc[Components]
 * For Verifications
 
 == Example

--- a/docs/modules/develop/pages/newsletter_templates.adoc
+++ b/docs/modules/develop/pages/newsletter_templates.adoc
@@ -2,7 +2,7 @@
 
 The newsletter templates allow the user to select a template amongst a set of of them, and use it as base to send newsletters. This allow for more customization on newsletter, tematic newsletters, etc.
 
-Code-wise, they use the content blocks system internally, so https://github.com/decidim/decidim/blob/develop/docs/advanced/content_blocks.md[check the docs] for that section first.
+Code-wise, they use the content blocks system internally, so https://github.com/decidim/decidim/blob/main/docs/advanced/content_blocks.md[check the docs] for that section first.
 
 == Adding a new template
 

--- a/docs/modules/develop/pages/releases.adoc
+++ b/docs/modules/develop/pages/releases.adoc
@@ -6,14 +6,14 @@ Remember to follow the Gitflow branching workflow.
 
 == Create the stable branch for the release
 
-. Go to develop with `git checkout develop`
+. Go to main with `git checkout main`
 . Create the release branch `git checkout -b release/x.y-stable && git push origin release/x.y-stable`.
 . If required, add the release branch to Crowdin so that any pending translations will generate a PR to this branch.
 
-Mark `develop` as the reference to the next release:
+Mark `main` as the reference to the next release:
 
-. Go back to develop with `git checkout develop`
-. Turn develop into the `dev` branch for the next release:
+. Go back to main with `git checkout main`
+. Turn main into the `dev` branch for the next release:
  .. Update `.decidim-version` to the new `dev` development version: `x.y.z.dev`, where `x.y.z` is the new semver number for the next version
  .. Run `bin/rake update_versions`, this will update all references to the new version.
  .. Run `bin/rake bundle`, this will update all the `Gemfile.lock` files
@@ -45,11 +45,11 @@ After that, the header with the current version and link with the same beforemen
   Please check [0.XX-stable](https://github.com/decidim/decidim/blob/release/0.XX-stable/CHANGELOG.md) for previous changes.
 ----
 
-. Push the changes `git add . && git commit -m "Bump develop to next release version" && git push origin develop`
+. Push the changes `git add . && git commit -m "Bump main to next release version" && git push origin main`
 
 == Producing the CHANGELOG.md
 
-Look for the "Bump develop to next release version" commit sha1.
+Look for the "Bump main to next release version" commit sha1.
 You can do it either visually with `gitk .decidim-version` or by blaming `git blame .decidim-version`.
 
 Here you have different options to see what happened from one revision to another:
@@ -101,7 +101,7 @@ Usually, at this point, the release branch is deployed to Metadecidim during, at
 
 === During the validation period
 
-. During the validation period, bugfixes must be implemented directly to the current `release/x.y.z-stable` branch and ported to `develop`.
+. During the validation period, bugfixes must be implemented directly to the current `release/x.y.z-stable` branch and ported to `main`.
 . During the validation period, translations to the officially supported languages must be added to Crowdin and, when completed, merged into `release/x.y.z-stable`.
 
 == Major/Minor versions
@@ -149,4 +149,4 @@ After that, the header with the current version and link like `+## [0.20.0](http
 
 == Docker images for each release
 
-Each release triggers a [Github workflow](https://github.com/decidim/decidim/blob/develop/.github/workflows/on_release.yml) that re-builds and publishes the [decidim/docker images](https://github.com/decidim/docker) to [Github Container Registry](https://github.com/orgs/decidim/packages) and [Docker Hub](https://hub.docker.com/repository/docker/decidim/decidim).
+Each release triggers a [Github workflow](https://github.com/decidim/decidim/blob/main/.github/workflows/on_release.yml) that re-builds and publishes the [decidim/docker images](https://github.com/decidim/docker) to [Github Container Registry](https://github.com/orgs/decidim/packages) and [Docker Hub](https://hub.docker.com/repository/docker/decidim/decidim).

--- a/docs/modules/install/pages/index.adoc
+++ b/docs/modules/install/pages/index.adoc
@@ -86,7 +86,7 @@ Visit http://localhost:3000 to see your app running.
 
 == Configuration & setup
 
-Decidim comes pre-configured with some safe defaults, but can be changed through the `config/initializers/decidim.rb` file in your app. Check the comments there or read the comments in https://github.com/decidim/decidim/blob/develop/decidim-core/lib/decidim/core.rb[the source file] (the part with the `config_accessor` calls) for more up-to-date info.
+Decidim comes pre-configured with some safe defaults, but can be changed through the `config/initializers/decidim.rb` file in your app. Check the comments there or read the comments in https://github.com/decidim/decidim/blob/main/decidim-core/lib/decidim/core.rb[the source file] (the part with the `config_accessor` calls) for more up-to-date info.
 
 === Scheduled tasks
 
@@ -133,7 +133,7 @@ This will create a system user with the email and password you set. We recommend
 
 Then, visit the `/system` dashboard and login with the email and passwords you just entered and create your organization. You're done! :tada:
 
-You can check the https://github.com/decidim/decidim/tree/develop/decidim-system/README.md[`decidim-system` README file] for more info on how organizations work.
+You can check the https://github.com/decidim/decidim/tree/main/decidim-system/README.md[`decidim-system` README file] for more info on how organizations work.
 
 == Checklist
 
@@ -143,6 +143,6 @@ There are several things you need to check before making your putting your appli
 
 We always welcome new contributors of all levels to the project. If you are not confident enough with Ruby or web development you can look for https://github.com/decidim/decidim/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22[issues labeled `good first issue`] to start contibuting and learning the internals of the project by doing easy jobs.
 
-We also have a xref:develop:guide.adoc[developer's reference] that will help you getting started with your environment and our daily commands, routines, etc.
+We also have a xref:main:guide.adoc[developer's reference] that will help you getting started with your environment and our daily commands, routines, etc.
 
 Finally, you can also find other ways of helping us on our xref:contribute:index.adoc[contribution guide].

--- a/docs/modules/install/pages/update.adoc
+++ b/docs/modules/install/pages/update.adoc
@@ -92,4 +92,4 @@ gem "decidim-dev", DECIDIM_VERSION
 . Make a full backup of the database before updating, just in case something unexpected happens.
 . If you are more than update away. Always update from one version to the immediately next one and then repeat the process until you are up to date.
 . Always check the instructions for a certain version upgrade in https://github.com/decidim/decidim/releases. Some releases require to perform certain actions as they may change some database structures. Follow that instructions if you are affected.
-. Check also the file https://github.com/decidim/decidim/blob/develop/CHANGELOG.md It may have relevant information for updates between versions.
+. Check also the file https://github.com/decidim/decidim/blob/main/CHANGELOG.md It may have relevant information for updates between versions.


### PR DESCRIPTION
#### :tophat: What? Why?
According to the discussion in https://github.com/decidim/decidim/discussions/7226 and as a follow-up of #7267, this PR updates all references to the `develop` branch to refer to `main`.

This might break a few things:

- `decidim-generators` will fail in this PR because we have 2 tests trying to install decidim from the `main` branch, but it doesn't exist yet. 

Related things to do:

- After merging this PR, merge https://github.com/decidim/documentation/pull/44
- Rename `develop` to `main` from Settings
- Fix Crowdin config

#### :pushpin: Related Issues
- Related to #7267

#### Testing
Not sure.
