### PR TITLE
Fix line breaks in external links

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/extras/_external-links.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/extras/_external-links.scss
@@ -1,6 +1,5 @@
 .external-link-container{
   position: relative;
-  display: inline-block;
 }
 
 .external-link-indicator{


### PR DESCRIPTION
#### :tophat: What? Why?

If you use the WYSWYG editor with links it breaks with the external links.

#### Testing

1. As an admin edit a Process
2. Add a description with links in a paragraph or in a long list
3. Go to the frontend
4. See that the line breaks are broken:
4.1. In lists, the bullet is not well ordered (it's at the bottom, should be at the top) 
4.2. In paragraphs with links in the middle there's a line break, it shouldn't be.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

#### Backend

![image](https://user-images.githubusercontent.com/717367/106885149-7e261880-66e2-11eb-9fc5-4743eef85707.png)

#### Before

![image](https://user-images.githubusercontent.com/717367/106885234-9c8c1400-66e2-11eb-9718-5389719f55ce.png)

#### After

![image](https://user-images.githubusercontent.com/717367/106885212-95650600-66e2-11eb-9061-72afa64f4d99.png)


:hearts: Thank you!
