### PR TITLE
Show created_at in assemblies admin index

### DIFF
--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.html.erb
@@ -65,7 +65,7 @@
                 <% end %>
               </td>
               <td>
-                <%= l(assembly.creation_date, format: :decidim_short) if assembly.creation_date %>
+                <%= l(assembly.created_at, format: :short) %>
               </td>
               <td class="table-list__state">
                 <% if assembly.private_space? %>


### PR DESCRIPTION
#### :tophat: What? Why?
As an administrator I need to see the date when an Assembly was created. Some Assemblies have this blank and it's practically impossible to find this out. 

Mind that there's also a Creation date in Assemblies but this is not something that other spaces and components have. We should be consistent in using *created_at* at least for the admin listing page.


#### Testing
1. Sign in as admin
2. Go to http://localhost:3000/admin/assemblies/ 
3. View created_at in an assembly without "Creation date" field

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

#### Before
![imatge](https://user-images.githubusercontent.com/717367/107204339-d9b31780-69fc-11eb-8059-ab2e8c1e89e5.png)

#### After
![imatge](https://user-images.githubusercontent.com/717367/107204344-db7cdb00-69fc-11eb-8cee-2207b1266e21.png)

:hearts: Thank you!
