### PR TITLE
Add Polling Officers to Voting

### DIFF
--- a/decidim-elections/app/assets/javascripts/decidim/votings/admin/polling_officers_form.js.es6
+++ b/decidim-elections/app/assets/javascripts/decidim/votings/admin/polling_officers_form.js.es6
@@ -1,0 +1,35 @@
+((exports) => {
+  const { createFieldDependentInputs } = exports.DecidimAdmin;
+
+  const $participantType = $("#polling_officer_existing_user");
+
+  createFieldDependentInputs({
+    controllerField: $participantType,
+    wrapperSelector: ".user-fields",
+    dependentFieldsSelector: ".user-fields--email",
+    dependentInputSelector: "input",
+    enablingCondition: ($field) => {
+      return $field.val() === "false"
+    }
+  });
+
+  createFieldDependentInputs({
+    controllerField: $participantType,
+    wrapperSelector: ".user-fields",
+    dependentFieldsSelector: ".user-fields--name",
+    dependentInputSelector: "input",
+    enablingCondition: ($field) => {
+      return $field.val() === "false"
+    }
+  });
+
+  createFieldDependentInputs({
+    controllerField: $participantType,
+    wrapperSelector: ".user-fields",
+    dependentFieldsSelector: ".user-fields--user-picker",
+    dependentInputSelector: "input",
+    enablingCondition: ($field) => {
+      return $field.val() === "true"
+    }
+  });
+})(window);

--- a/decidim-elections/app/commands/decidim/votings/admin/create_polling_officer.rb
+++ b/decidim-elections/app/commands/decidim/votings/admin/create_polling_officer.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Votings
+    module Admin
+      # A command with the business logic to create a new polling officer
+      class CreatePollingOfficer < Rectify::Command
+        # Public: Initializes the command.
+        #
+        # form - A form object with the params
+        # current_user - The user creating the polling officer
+        # voting - The Voting that will hold the polling officer
+        def initialize(form, current_user, voting)
+          @form = form
+          @current_user = current_user
+          @voting = voting
+        end
+
+        # Executes the command. Broadcasts these events:
+        #
+        # - :ok when everything is valid.
+        # - :invalid if the form wasn't valid and we couldn't proceed.
+        #
+        # Returns nothing.
+        def call
+          return broadcast(:invalid) if form.invalid?
+
+          ActiveRecord::Base.transaction do
+            user = retrieve_or_invite_user
+            create_polling_officer(user)
+          end
+
+          broadcast(:ok)
+        rescue ActiveRecord::RecordInvalid
+          form.errors.add(:email, :taken)
+          broadcast(:invalid)
+        end
+
+        private
+
+        attr_reader :form, :voting, :current_user
+
+        def retrieve_or_invite_user
+          existing_user || new_user
+        end
+
+        def create_polling_officer(user)
+          Decidim.traceability.perform_action!(
+            :create,
+            Decidim::Votings::PollingOfficer,
+            current_user,
+            resource: {
+              title: user.name
+            }
+          ) do
+            Decidim::Votings::PollingOfficer.find_or_create_by!(
+              user: user,
+              voting: voting
+            )
+          end
+
+          # TODO: send notitfication to user??
+        end
+
+        def existing_user
+          @existing_user ||= begin
+            tentative_user = User.find_by(
+              email: form.email,
+              organization: voting.organization
+            )
+
+            InviteUserAgain.call(tentative_user, invitation_instructions) if tentative_user && !tentative_user.invitation_accepted?
+
+            tentative_user
+          end
+        end
+
+        def new_user
+          @new_user ||= InviteUser.call(invite_user_form) do
+            on(:ok) do |invited_user|
+              return invited_user
+            end
+          end
+        end
+
+        def invite_user_form
+          OpenStruct.new(name: form.name,
+                         email: form.email.downcase,
+                         organization: voting.organization,
+                         admin: false,
+                         invited_by: current_user,
+                         invitation_instructions: invitation_instructions)
+        end
+
+        def invitation_instructions
+          "invite_collaborator"
+        end
+      end
+    end
+  end
+end

--- a/decidim-elections/app/commands/decidim/votings/admin/create_polling_officer.rb
+++ b/decidim-elections/app/commands/decidim/votings/admin/create_polling_officer.rb
@@ -41,7 +41,7 @@ module Decidim
         attr_reader :form, :voting, :current_user
 
         def retrieve_or_invite_user
-          existing_user || new_user
+          form.user || existing_user || new_user
         end
 
         def create_polling_officer(user)
@@ -58,8 +58,6 @@ module Decidim
               voting: voting
             )
           end
-
-          # TODO: send notitfication to user??
         end
 
         def existing_user

--- a/decidim-elections/app/commands/decidim/votings/admin/destroy_polling_officer.rb
+++ b/decidim-elections/app/commands/decidim/votings/admin/destroy_polling_officer.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Votings
+    module Admin
+      # A command with the business logic to destroy a poling officer
+      class DestroyPollingOfficer < Rectify::Command
+        # Public: Initializes the command.
+        #
+        # polling_officer - the PollingOfficer to destroy
+        # current_user - the user performing this action
+        def initialize(polling_officer, current_user)
+          @polling_officer = polling_officer
+          @current_user = current_user
+        end
+
+        # Executes the command. Broadcasts these events:
+        #
+        # - :ok when everything is valid.
+        # - :invalid if the form wasn't valid and we couldn't proceed.
+        #
+        # Returns nothing.
+        def call
+          destroy_polling_officer!
+          broadcast(:ok)
+        end
+
+        private
+
+        attr_reader :polling_officer, :current_user
+
+        def destroy_polling_officer!
+          extra_info = {
+            resource: {
+              title: polling_officer.user.name
+            }
+          }
+
+          Decidim.traceability.perform_action!(
+            "delete",
+            polling_officer,
+            current_user,
+            extra_info
+          ) do
+            polling_officer.destroy!
+            polling_officer
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-elections/app/controllers/decidim/votings/admin/polling_officers_controller.rb
+++ b/decidim-elections/app/controllers/decidim/votings/admin/polling_officers_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Votings
+    module Admin
+      # This controller allows to create or update a polling officer.
+      class PollingOfficersController < Admin::ApplicationController
+        include VotingAdmin
+
+        helper_method :current_voting, :polling_officers, :polling_officer
+
+        def new
+          enforce_permission_to :create, :polling_officer, voting: current_voting
+          @form = form(PollingOfficerForm).instance
+        end
+
+        def create
+          enforce_permission_to :create, :polling_officer, voting: current_voting
+          @form = form(PollingOfficerForm).from_params(params, voting: current_voting)
+
+          CreatePollingOfficer.call(@form, current_user, current_voting) do
+            on(:ok) do
+              flash[:notice] = I18n.t("polling_officers.create.success", scope: "decidim.votings.admin")
+              redirect_to voting_polling_officers_path(current_voting)
+            end
+
+            on(:invalid) do
+              flash.now[:alert] = I18n.t("polling_officers.create.invalid", scope: "decidim.votings.admin")
+              render action: "new"
+            end
+          end
+        end
+
+        def destroy
+          enforce_permission_to :delete, :polling_officer, voting: current_voting, polling_officer: polling_officer
+
+          DestroyPollingOfficer.call(polling_officer, current_user) do
+            on(:ok) do
+              flash[:notice] = I18n.t("polling_officers.destroy.success", scope: "decidim.votings.admin")
+            end
+
+            on(:invalid) do
+              flash.now[:alert] = I18n.t("polling_officers.destroy.invalid", scope: "decidim.votings.admin")
+            end
+          end
+
+          redirect_to voting_polling_officers_path(current_voting)
+        end
+
+        private
+
+        def polling_officers
+          @polling_officers ||= current_voting.polling_officers
+        end
+
+        def polling_officer
+          @polling_officer ||= polling_officers.find(params[:id])
+        end
+      end
+    end
+  end
+end

--- a/decidim-elections/app/forms/decidim/votings/admin/polling_officer_form.rb
+++ b/decidim-elections/app/forms/decidim/votings/admin/polling_officer_form.rb
@@ -6,9 +6,21 @@ module Decidim
       class PollingOfficerForm < Decidim::Form
         attribute :name, String
         attribute :email, String
+        attribute :user_id, Integer
+        attribute :existing_user, Boolean, default: false
 
-        validates :email, presence: true, format: { with: ::Devise.email_regexp }
-        validates :name, presence: true, format: { with: UserBaseEntity::REGEXP_NAME }
+        validates :email, presence: true, format: { with: ::Devise.email_regexp }, unless: ->(form) { form.existing_user }
+        validates :name, presence: true, format: { with: UserBaseEntity::REGEXP_NAME }, unless: ->(form) { form.existing_user }
+        validates :user, presence: true, if: ->(form) { form.existing_user }
+
+        def map_model(model)
+          self.user_id = model.decidim_user_id
+          self.existing_user = user_id.present?
+        end
+
+        def user
+          @user ||= current_organization.users.find_by(id: user_id)
+        end
       end
     end
   end

--- a/decidim-elections/app/forms/decidim/votings/admin/polling_officer_form.rb
+++ b/decidim-elections/app/forms/decidim/votings/admin/polling_officer_form.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Votings
+    module Admin
+      class PollingOfficerForm < Decidim::Form
+        attribute :name, String
+        attribute :email, String
+
+        validates :email, presence: true, format: { with: ::Devise.email_regexp }
+        validates :name, presence: true, format: { with: UserBaseEntity::REGEXP_NAME }
+      end
+    end
+  end
+end

--- a/decidim-elections/app/models/decidim/votings/polling_officer.rb
+++ b/decidim-elections/app/models/decidim/votings/polling_officer.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Votings
+    class PollingOfficer < ApplicationRecord
+      include Traceable
+      include Loggable
+
+      belongs_to :user, foreign_key: "decidim_user_id", class_name: "Decidim::User", optional: true
+      belongs_to :voting, foreign_key: "decidim_votings_voting_id", class_name: "Decidim::Votings::Voting", inverse_of: :polling_officers
+
+      validate :user_and_voting_same_organization
+
+      private
+
+      # Private: check if the voting and the user have the same organization
+      def user_and_voting_same_organization
+        return if !voting || !user
+
+        errors.add(:voting, :invalid) unless user.organization == voting.organization
+      end
+    end
+  end
+end

--- a/decidim-elections/app/models/decidim/votings/voting.rb
+++ b/decidim-elections/app/models/decidim/votings/voting.rb
@@ -27,7 +27,7 @@ module Decidim
 
       has_many :components, as: :participatory_space, dependent: :destroy
       has_many :polling_stations, foreign_key: "decidim_votings_voting_id", class_name: "Decidim::Votings::PollingStation", inverse_of: :voting, dependent: :destroy
-      has_many :polling_officers, foreign_key: "decidim_votings_voting_id", class_name: "Decidim::Votings::PollingOfficers", inverse_of: :voting, dependent: :destroy
+      has_many :polling_officers, foreign_key: "decidim_votings_voting_id", class_name: "Decidim::Votings::PollingOfficer", inverse_of: :voting, dependent: :destroy
 
       validates :slug, uniqueness: { scope: :organization }
       validates :slug, presence: true, format: { with: Decidim::Votings::Voting.slug_format }

--- a/decidim-elections/app/models/decidim/votings/voting.rb
+++ b/decidim-elections/app/models/decidim/votings/voting.rb
@@ -27,6 +27,7 @@ module Decidim
 
       has_many :components, as: :participatory_space, dependent: :destroy
       has_many :polling_stations, foreign_key: "decidim_votings_voting_id", class_name: "Decidim::Votings::PollingStation", inverse_of: :voting, dependent: :destroy
+      has_many :polling_officers, foreign_key: "decidim_votings_voting_id", class_name: "Decidim::Votings::PollingOfficers", inverse_of: :voting, dependent: :destroy
 
       validates :slug, uniqueness: { scope: :organization }
       validates :slug, presence: true, format: { with: Decidim::Votings::Voting.slug_format }

--- a/decidim-elections/app/permissions/decidim/votings/admin/permissions.rb
+++ b/decidim-elections/app/permissions/decidim/votings/admin/permissions.rb
@@ -58,7 +58,7 @@ module Decidim
         end
 
         def allowed_voting_action?
-          return unless [:votings, :voting, :polling_station, :polling_stations].member? permission_action.subject
+          return unless [:votings, :voting, :polling_station, :polling_stations, :polling_officer, :polling_officers].member? permission_action.subject
 
           case permission_action.subject
           when :votings
@@ -79,6 +79,15 @@ module Decidim
             end
           when :polling_stations
             toggle_allow(user.admin?) if permission_action.action == :read
+          when :polling_officer
+            case permission_action.action
+            when :create
+              allow!
+            when :delete
+              toggle_allow(polling_officer.present?)
+            end
+          when :polling_officers
+            toggle_allow(user.admin?) if permission_action.action == :read
           end
         end
 
@@ -88,6 +97,10 @@ module Decidim
 
         def polling_station
           @polling_station ||= context.fetch(:polling_station, nil)
+        end
+
+        def polling_officer
+          @polling_officer ||= context.fetch(:polling_officer, nil)
         end
       end
     end

--- a/decidim-elections/app/views/decidim/votings/admin/polling_officers/_form.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/polling_officers/_form.html.erb
@@ -1,0 +1,14 @@
+<div class="card">
+  <div class="card-divider">
+    <h2 class="card-title"><%= title %></h2>
+  </div>
+  <div class="card-section">
+    <div class="row column hashtags__container">
+      <%= form.text_field :email, autofocus: true %>
+    </div>
+
+    <div class="field">
+      <%= form.text_field :name %>
+    </div>
+  </div>
+</div>

--- a/decidim-elections/app/views/decidim/votings/admin/polling_officers/_form.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/polling_officers/_form.html.erb
@@ -2,13 +2,26 @@
   <div class="card-divider">
     <h2 class="card-title"><%= title %></h2>
   </div>
-  <div class="card-section">
-    <div class="row column hashtags__container">
-      <%= form.text_field :email, autofocus: true %>
+  <div class="card-section user-fields">
+    <div class="row column">
+      <%= form.select :existing_user, [[t(".non_user"), false], [t(".existing_user"), true]], label: t(".user_type") %>
     </div>
 
-    <div class="field">
+    <div class="row column user-fields--user-picker">
+      <% prompt_options = { url: decidim_admin.users_organization_url, placeholder: t(".select_user") } %>
+      <%= form.autocomplete_select(:user_id, form.object.user.presence, { multiple: false }, prompt_options) do |user|
+        { value: user.id, label: "#{user.name} (@#{user.nickname})" }
+      end %>
+    </div>
+
+    <div class="row column user-fields--email">
+      <%= form.email_field :email %>
+    </div>
+
+    <div class="row column user-fields--name">
       <%= form.text_field :name %>
     </div>
   </div>
 </div>
+
+<%= javascript_include_tag "decidim/votings/admin/polling_officers_form" %>

--- a/decidim-elections/app/views/decidim/votings/admin/polling_officers/edit.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/polling_officers/edit.html.erb
@@ -1,0 +1,7 @@
+<%= decidim_form_for([current_voting, @form], url: { action: "update" }, html: { class: "form edit_polling_officer" })  do |f| %>
+  <%= render partial: "form", object: f, locals: { title: t(".title") } %>
+
+  <div class="button--double form-general-submit">
+    <%= f.submit t(".update") %>
+  </div>
+<% end %>

--- a/decidim-elections/app/views/decidim/votings/admin/polling_officers/edit.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/polling_officers/edit.html.erb
@@ -1,7 +1,0 @@
-<%= decidim_form_for([current_voting, @form], url: { action: "update" }, html: { class: "form edit_polling_officer" })  do |f| %>
-  <%= render partial: "form", object: f, locals: { title: t(".title") } %>
-
-  <div class="button--double form-general-submit">
-    <%= f.submit t(".update") %>
-  </div>
-<% end %>

--- a/decidim-elections/app/views/decidim/votings/admin/polling_officers/index.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/polling_officers/index.html.erb
@@ -1,0 +1,41 @@
+<div class="card" id="polling_officers">
+  <div class="card-divider">
+    <h2 class="card-title">
+      <%= t(".title") %>
+      <%= link_to t("actions.new", scope: "decidim.votings.polling_officers", name: t("models.polling_officer.name", scope: "decidim.votings.admin")), new_voting_polling_officer_path(current_voting), class: "button tiny button--title" if allowed_to? :create, :polling_officer, voting: current_voting %>
+    </h2>
+  </div>
+
+  <div class="card-section">
+    <div class="table-scroll">
+      <table class="table-list">
+        <thead>
+          <tr>
+            <th><%= t("models.polling_officer.fields.name", scope: "decidim.votings.admin") %></th>
+            <th><%= t("models.polling_officer.fields.email", scope: "decidim.votings.admin") %></th>
+            <th class="actions"><%= t("actions.title", scope: "decidim.votings.polling_officers") %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% polling_officers.each do |polling_officer| %>
+            <tr data-id="<%= polling_officer.id %>">
+              <td>
+                <%= polling_officer.user.name %>
+              </td>
+              <td>
+                <%= polling_officer.user.email %>
+              </td>
+              <td class="table-list__actions">
+                <% if allowed_to? :delete, :polling_officer, voting: current_voting, polling_officer: polling_officer %>
+                  <%= icon_link_to "circle-x", voting_polling_officer_path(current_voting, polling_officer), t("actions.destroy", scope: "decidim.votings.polling_officers"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.votings.polling_officers") } %>
+                <% else %>
+                  <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img" %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/decidim-elections/app/views/decidim/votings/admin/polling_officers/new.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/polling_officers/new.html.erb
@@ -1,0 +1,7 @@
+<%= decidim_form_for([current_voting, @form], html: { class: "form new_polling_officer" }) do |f| %>
+  <%= render partial: "form", object: f, locals: { title: t(".title") } %>
+
+  <div class="button--double form-general-submit">
+    <%= f.submit t(".create") %>
+  </div>
+<% end %>

--- a/decidim-elections/app/views/layouts/decidim/admin/voting.html.erb
+++ b/decidim-elections/app/views/layouts/decidim/admin/voting.html.erb
@@ -56,6 +56,14 @@
           </li>
         <% end %>
       <% end %>
+
+      <% if allowed_to?(:read, :polling_officers) %>
+        <% if !current_participatory_space.online_voting? %>
+          <li <% if is_active_link?(decidim_admin_votings.voting_polling_officers_path(current_participatory_space)) %> class="is-active" <% end %>>
+            <%= aria_selected_link_to t("polling_officers", scope: "decidim.votings.admin.menu.votings_submenu"), decidim_admin_votings.voting_polling_officers_path(current_participatory_space) %>
+          </li>
+        <% end %>
+      <% end %>
     </ul>
   </div>
 <% end %>

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -541,8 +541,8 @@ en:
         models:
           polling_officer:
             fields:
-              name: Name
               email: Email
+              name: Name
             name: Polling Officer
           polling_station:
             fields:
@@ -562,6 +562,11 @@ en:
           destroy:
             invalid: There was a problem deleting this polling officer
             success: Polling officer successfully deleted
+          form:
+            existing_user: Existing participant
+            non_user: Invite new participant
+            select_user: Search by name, email or nickname
+            user_type: Participant type
           index:
             title: Polling officers
           new:

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -536,8 +536,14 @@ en:
             attachments: Attachments
             components: Components
             info: Information
+            polling_officers: Polling Officers
             polling_stations: Polling Stations
         models:
+          polling_officer:
+            fields:
+              name: Name
+              email: Email
+            name: Polling Officer
           polling_station:
             fields:
               address: Address
@@ -549,6 +555,18 @@ en:
               promoted: Highlighted
               published: Published
               title: Title
+        polling_officers:
+          create:
+            invalid: There was a problem creating this polling officer
+            success: Polling officer successfully created
+          destroy:
+            invalid: There was a problem deleting this polling officer
+            success: Polling officer successfully deleted
+          index:
+            title: Polling officers
+          new:
+            create: Create
+            title: Create polling officer
         polling_stations:
           create:
             invalid: There was a problem creating this polling station
@@ -618,6 +636,12 @@ en:
             active_votings: Active votings
             see_all_votings: See all votings
             votings_button_title: Link to the Votings page displaying all the votings
+      polling_officers:
+        actions:
+          confirm_destroy: Are you sure?
+          destroy: Delete
+          new: New
+          title: Actions
       polling_stations:
         actions:
           confirm_destroy: Are you sure?

--- a/decidim-elections/db/migrate/20210208090441_add_polling_officers_to_votings.rb
+++ b/decidim-elections/db/migrate/20210208090441_add_polling_officers_to_votings.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddPollingOfficersToVotings < ActiveRecord::Migration[5.2]
+  def change
+    create_table :decidim_votings_polling_officers do |t|
+      t.references :decidim_votings_voting, index: { name: "decidim_votings_votings_polling_officers" }
+      t.references :decidim_user, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/decidim-elections/lib/decidim/votings/admin_engine.rb
+++ b/decidim-elections/lib/decidim/votings/admin_engine.rb
@@ -17,6 +17,7 @@ module Decidim
           end
 
           resources :polling_stations
+          resources :polling_officers, only: [:new, :create, :destroy, :index]
           resources :attachments, controller: "voting_attachments"
           resources :attachment_collections, controller: "voting_attachment_collections"
         end

--- a/decidim-elections/lib/decidim/votings/test/factories.rb
+++ b/decidim-elections/lib/decidim/votings/test/factories.rb
@@ -58,4 +58,9 @@ FactoryBot.define do
     longitude { Faker::Address.longitude }
     voting { create(:voting) }
   end
+
+  factory :polling_officer, class: "Decidim::Votings::PollingOfficer" do
+    user
+    voting { create :voting, organization: user.organization }
+  end
 end

--- a/decidim-elections/spec/commands/decidim/votings/admin/create_polling_officer_spec.rb
+++ b/decidim-elections/spec/commands/decidim/votings/admin/create_polling_officer_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Votings
+    module Admin
+      describe CreatePollingOfficer do
+        subject { described_class.new(form, current_user, voting) }
+
+        let!(:existing_user) { create :user, email: existing_user_email, organization: voting.organization }
+        let!(:current_user) { create :user, email: ::Faker::Internet.email, organization: voting.organization }
+        let(:voting) { create :voting }
+        let(:name) { ::Faker::Name.name }
+        let(:email) { ::Faker::Internet.email }
+        let(:existing_user_email) { "existing_user@example.org" }
+        let(:form) do
+          double(
+            invalid?: invalid,
+            email: email,
+            name: name,
+            current_participatory_space: voting
+          )
+        end
+        let(:invalid) { false }
+
+        context "when the form is not valid" do
+          let(:invalid) { true }
+
+          it "is not valid" do
+            expect { subject.call }.to broadcast(:invalid)
+          end
+        end
+
+        context "when everything is ok" do
+          it "creates the polling officer" do
+            subject.call
+
+            expect(Decidim::Votings::PollingOfficer.count).to eq 1
+            expect(Decidim::Votings::PollingOfficer.first.voting).to eq voting
+          end
+
+          it "traces the action", versioning: true do
+            expect(Decidim.traceability)
+              .to receive(:perform_action!)
+              .with(:create, Decidim::Votings::PollingOfficer, current_user, resource: hash_including(:title))
+              .and_call_original
+
+            expect { subject.call }.to change(Decidim::ActionLog, :count)
+            action_log = Decidim::ActionLog.last
+            expect(action_log.version).to be_present
+          end
+
+          context "when there is no user with the given email" do
+            let(:email) { "not_yet_existing@example.com" }
+
+            it "creates a new user with the given email" do
+              subject.call
+              created_user = Decidim::User.last
+              expect(created_user.email).to eq(email)
+            end
+          end
+
+          context "when the user already exists" do
+            let(:email) { existing_user_email }
+
+            before do
+              subject.call
+            end
+
+            it "doesn't create a new user" do
+              expect { subject.call }.to broadcast(:ok)
+
+              polling_officers = Decidim::Votings::PollingOfficer.where(user: existing_user)
+
+              expect(polling_officers.count).to eq 1
+            end
+          end
+
+          context "when the user hasn't accepted the invitation" do
+            before do
+              existing_user.invite!
+            end
+
+            it "gets the invitation resent" do
+              expect { subject.call }.to have_enqueued_job(ActionMailer::DeliveryJob)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-elections/spec/commands/decidim/votings/admin/destroy_polling_officer_spec.rb
+++ b/decidim-elections/spec/commands/decidim/votings/admin/destroy_polling_officer_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Votings
+    module Admin
+      describe DestroyPollingOfficer do
+        subject { described_class.new(polling_officer, current_user) }
+
+        let(:voting) { create :voting }
+        let!(:user) { create :user, :confirmed, organization: voting.organization }
+        let(:polling_officer) { create :polling_officer, user: user, voting: voting }
+        let!(:current_user) { create :user, email: "some_email@example.org", organization: voting.organization }
+
+        context "when everything is ok" do
+          let(:log_info) do
+            {
+              resource: {
+                title: user.name
+              }
+            }
+          end
+
+          it "destroys the polling_officer" do
+            subject.call
+            expect { polling_officer.reload }.to raise_error(ActiveRecord::RecordNotFound)
+          end
+
+          it "traces the action", versioning: true do
+            expect(Decidim.traceability)
+              .to receive(:perform_action!)
+              .with("delete", polling_officer, current_user, log_info)
+              .and_call_original
+
+            expect { subject.call }.to change(Decidim::ActionLog, :count)
+
+            action_log = Decidim::ActionLog.last
+            expect(action_log.version).to be_present
+            expect(action_log.version.event).to eq "destroy"
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-elections/spec/forms/decidim/votings/admin/polling_officer_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/votings/admin/polling_officer_form_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Votings
+    module Admin
+      describe PollingOfficerForm do
+        subject(:form) { described_class.from_params(attributes) }
+
+        let(:name) { ::Faker::Name.name }
+        let(:email) { ::Faker::Internet.email }
+        let(:attributes) do
+          {
+            name: name,
+            email: email
+          }
+        end
+
+        it { is_expected.to be_valid }
+
+        describe "when email is invalid" do
+          let(:email) { "invalid#email.org" }
+
+          it { is_expected.not_to be_valid }
+        end
+
+        describe "when email is missing" do
+          let(:email) { nil }
+
+          it { is_expected.not_to be_valid }
+        end
+
+        describe "when name is invalid" do
+          let(:name) { "Miao<121" }
+
+          it { is_expected.not_to be_valid }
+        end
+
+        describe "when name is missing" do
+          let(:name) { nil }
+
+          it { is_expected.not_to be_valid }
+        end
+      end
+    end
+  end
+end

--- a/decidim-elections/spec/forms/decidim/votings/admin/polling_officer_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/votings/admin/polling_officer_form_spec.rb
@@ -6,41 +6,76 @@ module Decidim
   module Votings
     module Admin
       describe PollingOfficerForm do
-        subject(:form) { described_class.from_params(attributes) }
+        subject(:form) { described_class.from_params(attributes).with_context(context) }
 
-        let(:name) { ::Faker::Name.name }
-        let(:email) { ::Faker::Internet.email }
-        let(:attributes) do
+        let(:organization) { create :organization }
+        let(:context) do
           {
-            name: name,
-            email: email
+            current_organization: organization
           }
         end
 
-        it { is_expected.to be_valid }
-
-        describe "when email is invalid" do
-          let(:email) { "invalid#email.org" }
-
-          it { is_expected.not_to be_valid }
+        let(:name) { ::Faker::Name.name }
+        let(:email) { ::Faker::Internet.email }
+        let(:user_id) { nil }
+        let(:existing_user) { false }
+        let(:attributes) do
+          {
+            name: name,
+            email: email,
+            existing_user: existing_user,
+            user_id: user_id
+          }
         end
 
-        describe "when email is missing" do
-          let(:email) { nil }
+        context "when existing user is false" do
+          describe "when email and name are present" do
+            it { is_expected.to be_valid }
+          end
 
-          it { is_expected.not_to be_valid }
+          describe "when email is invalid" do
+            let(:email) { "invalid#email.org" }
+
+            it { is_expected.not_to be_valid }
+          end
+
+          describe "when name is invalid" do
+            let(:name) { "Miao<121" }
+
+            it { is_expected.not_to be_valid }
+          end
+
+          describe "when name is missing" do
+            let(:name) { nil }
+
+            it { is_expected.not_to be_valid }
+          end
+
+          describe "when email is missing" do
+            let(:email) { nil }
+
+            it { is_expected.not_to be_valid }
+          end
         end
 
-        describe "when name is invalid" do
-          let(:name) { "Miao<121" }
+        context "when existing user is true" do
+          let(:existing_user) { true }
 
-          it { is_expected.not_to be_valid }
-        end
+          describe "when name and email are missing but user_id is present" do
+            let(:name) { nil }
+            let(:email) { nil }
+            let(:user_id) { create(:user, organization: organization).id }
 
-        describe "when name is missing" do
-          let(:name) { nil }
+            it { is_expected.to be_valid }
+          end
 
-          it { is_expected.not_to be_valid }
+          describe "when name, email and user_id are missing" do
+            let(:name) { nil }
+            let(:email) { nil }
+            let(:user_id) { nil }
+
+            it { is_expected.not_to be_valid }
+          end
         end
       end
     end

--- a/decidim-elections/spec/system/admin/admin_manages_voting_polling_officers_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_voting_polling_officers_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin manages polling officers", type: :system do
+  include_context "when administrating a voting"
+
+  let(:other_user) { create :user, organization: organization, email: "my_email@example.org" }
+  let!(:polling_officer) { create :polling_officer, user: other_user, voting: voting }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim_admin_votings.edit_voting_path(voting)
+    click_link "Polling Officers"
+  end
+
+  it "shows polling officer list" do
+    within "#polling_officers table" do
+      expect(page).to have_content(polling_officer.user.email)
+    end
+  end
+
+  context "when creating a new polling officer" do
+    let(:existing_user) { create :user, organization: voting.organization }
+
+    before do
+      click_link("New")
+    end
+
+    it "creates a new user" do
+      within ".new_polling_officer" do
+        fill_in :polling_officer_email, with: "joe@doe.com"
+        fill_in :polling_officer_name, with: "Joe Doe"
+
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_admin_callout("successfully")
+
+      within "#polling_officers table" do
+        expect(page).to have_content(other_user.email)
+        expect(page).to have_content("joe@doe.com")
+      end
+    end
+
+    it "uses an existing user" do
+      within ".new_polling_officer" do
+        select "Existing participant", from: :polling_officer_existing_user
+        autocomplete_select "#{existing_user.name} (@#{existing_user.nickname})", from: :user_id
+
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_admin_callout("successfully")
+
+      within "#polling_officers table" do
+        expect(page).to have_content(other_user.email)
+        expect(page).to have_content(existing_user.email)
+      end
+    end
+  end
+
+  context "when deleting a polling officer" do
+    it "deletes the polling officer" do
+      within find("#polling_officers tr", text: other_user.email) do
+        accept_confirm { click_link "Delete" }
+      end
+
+      expect(page).to have_admin_callout("successfully")
+
+      within "#polling_officers table" do
+        expect(page).to have_no_content(other_user.email)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR is a follow-up of #7300 and another building block of #7105 
Adds Polling Officers to the Voting space.

A Polling Officer can be an existing Decidim user or a new one that gets invited as consequence of the creation of the Polling Officer.

This PR allows an admin user to:
 - See the list of existing Polling Officers;
 - Create a Polling Officer;
 - Delete a Polling Officer.
The update operation has not been implemented because it would not make sense to edit a Polling Officer (it is just a reference to a user).

PS: as for Polling Stations, Polling Officers are only shown when a Voting is in person or hybrid (hidden when it is only online).

#### :pushpin: Related Issues
- Related to #7105

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![Screenshot 2021-02-09 at 17 14 14](https://user-images.githubusercontent.com/5033945/107392843-62fc4400-6afa-11eb-9039-d4164254f3ac.png)
![Screenshot 2021-02-09 at 17 14 33](https://user-images.githubusercontent.com/5033945/107392848-6394da80-6afa-11eb-80eb-7269979ec042.png)
![Screenshot 2021-02-09 at 17 14 58](https://user-images.githubusercontent.com/5033945/107392851-642d7100-6afa-11eb-8403-1f58e9aab876.png)

:hearts: Thank you!
