### PR TITLE
Fix C4 PlantUML references in docs 

### DIFF
--- a/docs/modules/develop/pages/c4_component.adoc
+++ b/docs/modules/develop/pages/c4_component.adoc
@@ -1,7 +1,7 @@
 [plantuml]
 ....
 @startuml
-!includeurl https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Component.puml
+!includeurl https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/v2.0.1/C4_Component.puml
 
 ' uncomment the following line to make proposals
 'LAYOUT_AS_SKETCH

--- a/docs/modules/develop/pages/c4_container.adoc
+++ b/docs/modules/develop/pages/c4_container.adoc
@@ -1,7 +1,7 @@
 [plantuml]
 ....
 @startuml
-!includeurl https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
+!includeurl https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/v2.0.1/C4_Container.puml
 
 ' uncomment the following line to make proposals
 'LAYOUT_AS_SKETCH

--- a/docs/modules/develop/pages/c4_context.adoc
+++ b/docs/modules/develop/pages/c4_context.adoc
@@ -1,7 +1,7 @@
 [plantuml]
 ....
 @startuml
-!includeurl https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Context.puml
+!includeurl https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/v2.0.1/C4_Context.puml
 
 ' uncomment the following line to make proposals
 'LAYOUT_AS_SKETCH

--- a/docs/modules/develop/pages/guide_architecture.adoc
+++ b/docs/modules/develop/pages/guide_architecture.adoc
@@ -1,4 +1,4 @@
-= Achitecture
+= Architecture
 
 For better understanding Decidim, here you have some diagrams based in the https://c4model.com[C4 model].
 


### PR DESCRIPTION
#### :tophat: What? Why?

We were pointing to master in C4 PlantUML, this is bad because it could break (and it broke already). 

This PR fixes that by pointing to the last release. Also it fixes a typo in this same page. 

#### :pushpin: Related Issues

- Related to https://github.com/plantuml-stdlib/C4-PlantUML/issues/118

#### Testing

Build the docs pointing to this branch. There shouldn't be any warning.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.


:hearts: Thank you!
