### PR TITLE
Add notification setting: emails on moderations

### DIFF
--- a/decidim-core/app/commands/decidim/create_report.rb
+++ b/decidim-core/app/commands/decidim/create_report.rb
@@ -72,6 +72,8 @@ module Decidim
 
     def send_report_notification_to_moderators
       participatory_space_moderators.each do |moderator|
+        next unless moderator.email_on_moderations
+
         ReportedMailer.report(moderator, @report).deliver_later
       end
     end
@@ -86,6 +88,8 @@ module Decidim
 
     def send_hide_notification_to_moderators
       participatory_space_moderators.each do |moderator|
+        next unless moderator.email_on_moderations
+
         ReportedMailer.hide(moderator, @report).deliver_later
       end
     end

--- a/decidim-core/app/commands/decidim/update_notifications_settings.rb
+++ b/decidim-core/app/commands/decidim/update_notifications_settings.rb
@@ -28,6 +28,7 @@ module Decidim
       @user.newsletter_notifications_at = @form.newsletter_notifications_at
       @user.notification_types = @form.notification_types
       @user.direct_message_types = @form.direct_message_types
+      @user.email_on_moderations = @form.email_on_moderations
     end
   end
 end

--- a/decidim-core/app/forms/decidim/notifications_settings_form.rb
+++ b/decidim-core/app/forms/decidim/notifications_settings_form.rb
@@ -7,6 +7,7 @@ module Decidim
     mimic :user
 
     attribute :email_on_notification, Boolean
+    attribute :email_on_moderations, Boolean
     attribute :newsletter_notifications, Boolean
     attribute :notifications_from_followed, Boolean
     attribute :notifications_from_own_activity, Boolean
@@ -39,6 +40,25 @@ module Decidim
 
     def direct_message_types
       allow_public_contact ? "all" : "followed-only"
+    end
+
+    def user_is_moderator?(user)
+      participatory_space_types.each do |participatory_space_type|
+        participatory_space_type.constantize.all.each do |participatory_space|
+          return true if participatory_space.moderators.include?(user)
+        end
+      end
+      false
+    end
+
+    private
+
+    def participatory_space_types
+      participatory_space_types = []
+      Decidim.participatory_space_manifests.each do |manifest|
+        participatory_space_types << manifest.model_class_name.to_s
+      end
+      participatory_space_types
     end
   end
 end

--- a/decidim-core/app/views/decidim/notifications_settings/show.html.erb
+++ b/decidim-core/app/views/decidim/notifications_settings/show.html.erb
@@ -46,6 +46,17 @@
       </label>
     </div>
 
+    <% if @notifications_settings.user_is_moderator?(current_user) %>
+      <p><strong><%= t(".administrators") %></strong></p>
+      <div class="switch tiny switch-with-label email_on_moderations">
+        <label>
+          <%= f.check_box :email_on_moderations, label: false, class: "switch-input" %>
+          <span class="switch-paddle"></span>
+          <span class="switch-label"><%= t(".email_on_moderations") %></span>
+        </label>
+      </div>
+    <% end %>
+
     <%= f.submit t(".update_notifications_settings") %>
   <% end %>
 </div>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1025,8 +1025,10 @@ en:
       no_notifications: No notifications yet.
     notifications_settings:
       show:
+        administrators: Administrators
         allow_public_contact: Allow anyone to send me a direct message, even if I don't follow them.
         direct_messages: Receive direct messages from anyone
+        email_on_moderations: I want to receive an email every time something is reported for moderation.
         email_on_notification: I want to receive an email every time I receive a notification.
         everything_followed: Everything I follow
         newsletter_notifications: I want to receive newsletters

--- a/decidim-core/db/migrate/20210208134328_add_email_on_moderations_to_users.rb
+++ b/decidim-core/db/migrate/20210208134328_add_email_on_moderations_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddEmailOnModerationsToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_users, :email_on_moderations, :boolean, default: true
+  end
+end

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -136,6 +136,7 @@ FactoryBot.define do
     confirmation_sent_at { Time.current }
     accepted_tos_version { organization.tos_version }
     email_on_notification { true }
+    email_on_moderations { true }
 
     trait :confirmed do
       confirmed_at { Time.current }

--- a/decidim-core/spec/commands/decidim/create_report_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_report_spec.rb
@@ -9,6 +9,7 @@ module Decidim
       let(:component) { create(:component, organization: organization) }
       let(:reportable) { create(:dummy_resource, component: component) }
       let!(:admin) { create(:user, :admin, :confirmed, organization: organization) }
+      let!(:admin_no_moderation_mail) { create(:user, :admin, :confirmed, organization: organization, email_on_moderations: false) }
       let(:user) { create(:user, :confirmed, organization: organization) }
       let(:form) { ReportForm.from_params(form_params) }
       let(:form_params) do
@@ -77,6 +78,15 @@ module Decidim
           expect(ReportedMailer)
             .to have_received(:report)
             .with(admin, last_report)
+        end
+
+        it "doesnt send an email to the admin when he/she doesnt allow it" do
+          allow(ReportedMailer).to receive(:report).and_call_original
+          command.call
+          last_report = Report.last
+          expect(ReportedMailer)
+            .not_to have_received(:report)
+            .with(admin_no_moderation_mail, last_report)
         end
 
         context "and the reportable has been already reported two times" do

--- a/decidim-core/spec/commands/decidim/update_notifications_settings_spec.rb
+++ b/decidim-core/spec/commands/decidim/update_notifications_settings_spec.rb
@@ -10,6 +10,7 @@ module Decidim
     let(:data) do
       {
         email_on_notification: true,
+        email_on_moderations: true,
         newsletter_notifications_at: Time.current,
         direct_message_types: "followed-only"
       }
@@ -19,6 +20,7 @@ module Decidim
       double(
         notification_types: "none",
         email_on_notification: data[:email_on_notification],
+        email_on_moderations: data[:email_on_moderations],
         newsletter_notifications_at: data[:newsletter_notifications_at],
         direct_message_types: data[:direct_message_types],
         valid?: valid

--- a/decidim-core/spec/forms/notifications_settings_form_spec.rb
+++ b/decidim-core/spec/forms/notifications_settings_form_spec.rb
@@ -9,6 +9,7 @@ module Decidim
         notifications_from_followed: notifications_from_followed,
         notifications_from_own_activity: notifications_from_own_activity,
         email_on_notification: email_on_notification,
+        email_on_moderations: email_on_moderations,
         newsletter_notifications: newsletter_notifications,
         allow_public_contact: allow_public_contact
       ).with_context(
@@ -21,6 +22,7 @@ module Decidim
     let(:notifications_from_followed) { "1" }
     let(:notifications_from_own_activity) { "1" }
     let(:email_on_notification) { "1" }
+    let(:email_on_moderations) { "1" }
     let(:newsletter_notifications) { "1" }
     let(:allow_public_contact) { "1" }
 
@@ -147,6 +149,30 @@ module Decidim
 
         it "maps the fields correctly" do
           expect(subject.allow_public_contact).to eq false
+        end
+      end
+    end
+
+    describe "#user_is_moderator?" do
+      context "when an organization has a moderator and a regular user " do
+        let(:organization) { create :organization, available_locales: [:en] }
+        let(:participatory_space) { create :participatory_process, organization: organization }
+        let(:moderator) do
+          create(
+            :process_moderator,
+            :confirmed,
+            organization: organization,
+            participatory_process: participatory_space
+          )
+        end
+        let(:user) { create :user, organization: organization }
+
+        it "returns false when user isnt a moderator" do
+          expect(subject.user_is_moderator?(user)).to eq false
+        end
+
+        it "returns true when user is a moderator" do
+          expect(subject.user_is_moderator?(moderator)).to eq true
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Currently admins (or moderators) doesn't have chance to opt out from the "A resource has been reported" emails. This pull request adds option for the user to disable moderation emails to him/her.

#### :pushpin: Related Issues
https://meta.decidim.org/processes/roadmap/f/122/proposals/14324

#### Testing
1. Login as admin/moderator 
2. My account -> Notifications settings -> uncheck "I want to receive an email every time something is reported for moderation."
3. Report something (proposal's comment for example)
4. Check mail

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![email_on_moderations](https://user-images.githubusercontent.com/19709320/107352125-29184700-6ad4-11eb-931a-86405efdde51.png)


:hearts: Thank you!
