### PR TITLE
fix css caret from dropdown-menu in admin

### DIFF
--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_user-login.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_user-login.scss
@@ -17,10 +17,9 @@
   }
 
   .dropdown.menu > li.is-dropdown-submenu-parent > a::after{
-    border-color: var(--secondary);
     border-top-color: $white;
-    border-width: 4px;
+    border-width: 6px;
     right: 0;
-    margin-top: -1px;
+    margin-top: -3px;
   }
 }


### PR DESCRIPTION
#### :tophat: What? Why?

Fixes the (out-of-style) caret from the user-menu in the admin dashboard, top right.


🪲 probably introduced with #7172

- currently in `develop`:  
  <img width="408" alt="Screenshot 2021-02-09 at 16 42 25" src="https://user-images.githubusercontent.com/210216/107388301-fc752700-6af5-11eb-8df4-6a27ec6831d2.png">
- this pr:  
  <img width="406" alt="Screenshot 2021-02-09 at 16 33 52" src="https://user-images.githubusercontent.com/210216/107388309-ff701780-6af5-11eb-98a9-95fbfa0f8bff.png">


#### :pushpin: Related Issues
- none

#### Testing


#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
