### PR TITLE
Truncate description in meetings map popup

### DIFF
--- a/decidim-meetings/app/helpers/decidim/meetings/map_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/map_helper.rb
@@ -12,7 +12,7 @@ module Decidim
         geocoded_meetings = meetings.select(&:geocoded?)
         geocoded_meetings.map do |meeting|
           meeting.slice(:latitude, :longitude, :address).merge(title: translated_attribute(meeting.title),
-                                                               description: translated_attribute(meeting.description),
+                                                               description: html_truncate(translated_attribute(meeting.description), length: 200),
                                                                startTimeDay: l(meeting.start_time, format: "%d"),
                                                                startTimeMonth: l(meeting.start_time, format: "%B"),
                                                                startTimeYear: l(meeting.start_time, format: "%Y"),


### PR DESCRIPTION
#### :tophat: What? Why?

On meetings with really long descriptions the map popup are broken. See screenshot gif below. 

This PR fixes that 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #5471 (I don't think this PR would close that, as that seems like even without descriptions this would also happen... maybe we need other popup to show in really small viewports or something like that?) 

#### Testing

1. Configure here map 
2. Edit a meeting with a really long description 
3. Go to the meetings map, click in a marker

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

#### Before

![meeting-long_description-before](https://user-images.githubusercontent.com/717367/107483908-ff1d5e00-6b81-11eb-846f-cbfc4a5f8887.gif)

#### After 

![meeting-long_description-after](https://user-images.githubusercontent.com/717367/107483916-02b0e500-6b82-11eb-944b-67cb8cdaf694.gif)


:hearts: Thank you!
