### PR TITLE
Improve seeds dates in meetings

### DIFF
--- a/decidim-meetings/lib/decidim/meetings/component.rb
+++ b/decidim-meetings/lib/decidim/meetings/component.rb
@@ -111,6 +111,7 @@ Decidim.register_component(:meetings) do |component|
     end
 
     2.times do
+      start_time = [rand(1..20).weeks.from_now, rand(1..20).weeks.ago].sample
       params = {
         component: component,
         scope: Faker::Boolean.boolean(true_ratio: 0.5) ? global : scopes.sample,
@@ -121,8 +122,8 @@ Decidim.register_component(:meetings) do |component|
         end,
         location: Decidim::Faker::Localized.sentence,
         location_hints: Decidim::Faker::Localized.sentence,
-        start_time: 3.weeks.from_now,
-        end_time: 3.weeks.from_now + 4.hours,
+        start_time: start_time,
+        end_time: start_time + rand(1..4).hours,
         address: "#{Faker::Address.street_address} #{Faker::Address.zip} #{Faker::Address.city}",
         latitude: Faker::Address.latitude,
         longitude: Faker::Address.longitude,
@@ -237,6 +238,7 @@ Decidim.register_component(:meetings) do |component|
         author = user_group.users.sample
       end
 
+      start_time = [rand(1..20).weeks.from_now, rand(1..20).weeks.ago].sample
       params = {
         component: component,
         scope: Faker::Boolean.boolean(true_ratio: 0.5) ? global : scopes.sample,
@@ -247,8 +249,8 @@ Decidim.register_component(:meetings) do |component|
         end,
         location: Decidim::Faker::Localized.sentence,
         location_hints: Decidim::Faker::Localized.sentence,
-        start_time: 3.weeks.from_now,
-        end_time: 3.weeks.from_now + 4.hours,
+        start_time: start_time,
+        end_time: start_time + rand(1..4).hours,
         address: "#{Faker::Address.street_address} #{Faker::Address.zip} #{Faker::Address.city}",
         latitude: Faker::Address.latitude,
         longitude: Faker::Address.longitude,


### PR DESCRIPTION
#### :tophat: What? Why?

I was trying to see the order of meetings in the default seeds related to the start_time, but I found out that we always hardcoded this value (and also the duration of the meeting). 

This PR changes the default seeds so it's random. It also adds support for past meetings. 

#### :pushpin: Related Issues

- Related to #7310 

#### Testing

1. Start with a new seeded database:
```bash
bin/rails db:drop db:create db:migrate && bin/rails db:seed
```
2. Visit http://localhost:3000/meetings/


#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

#### Before

![Selecció_807](https://user-images.githubusercontent.com/717367/107490091-b36eb280-6b89-11eb-9d94-dfbb2e86bd75.png)

#### After

![Selecció_808](https://user-images.githubusercontent.com/717367/107490101-b669a300-6b89-11eb-8ac5-4429fe205bed.png)

:hearts: Thank you!
