### PR TITLE
Allow multiple lines in announcement block

### DIFF
--- a/decidim-core/app/cells/decidim/announcement/show.erb
+++ b/decidim-core/app/cells/decidim/announcement/show.erb
@@ -3,13 +3,7 @@
     <% if has_title? %>
       <p class="heading2"><%= clean_title %></p>
 
-      <% if has_array_body? %>
-        <% announcement[:body].each do |paragraph| %>
-          <p><%= clean_paragraph(paragraph) %></p>
-        <% end %>
-      <% else %>
-        <p><%= clean_body %></p>
-      <% end %>
+      <%= clean_body %>
     <% else %>
       <%= clean_announcement %>
     <% end %>

--- a/decidim-core/app/cells/decidim/announcement/show.erb
+++ b/decidim-core/app/cells/decidim/announcement/show.erb
@@ -5,12 +5,11 @@
 
       <% if has_array_body? %>
         <% announcement[:body].each do |paragraph| %>
-          <%= clean_paragraph(paragraph) %>
+          <p><%= clean_paragraph(paragraph) %></p>
         <% end %>
       <% else %>
         <p><%= clean_body %></p>
       <% end %>
-
     <% else %>
       <%= clean_announcement %>
     <% end %>

--- a/decidim-core/app/cells/decidim/announcement/show.erb
+++ b/decidim-core/app/cells/decidim/announcement/show.erb
@@ -4,7 +4,9 @@
       <p class="heading2"><%= clean_title %></p>
 
       <% if has_array_body? %>
-
+        <% announcement[:body].each do |paragraph| %>
+          <%= clean_paragraph(paragraph) %>
+        <% end %>
       <% else %>
         <p><%= clean_body %></p>
       <% end %>

--- a/decidim-core/app/cells/decidim/announcement/show.erb
+++ b/decidim-core/app/cells/decidim/announcement/show.erb
@@ -1,9 +1,14 @@
 <div class="row column">
   <%= content_tag :div, class: "callout announcement mb-sm #{callout_class} cell-announcement" do %>
     <% if has_title? %>
-      <span><%= clean_title %></span>
+      <p class="heading2"><%= clean_title %></p>
 
-      <p><%= clean_body %></p>
+      <% if has_array_body? %>
+
+      <% else %>
+        <p><%= clean_body %></p>
+      <% end %>
+
     <% else %>
       <%= clean_announcement %>
     <% end %>

--- a/decidim-core/app/cells/decidim/announcement_cell.rb
+++ b/decidim-core/app/cells/decidim/announcement_cell.rb
@@ -43,11 +43,7 @@ module Decidim
     end
 
     def clean_body
-      clean(announcement[:body])
-    end
-
-    def clean_paragraph(paragraph)
-      clean(paragraph)
+      Array(announcement[:body]).map { |paragraph| tag.p(clean(paragraph)) }.join("")
     end
 
     def clean_announcement

--- a/decidim-core/app/cells/decidim/announcement_cell.rb
+++ b/decidim-core/app/cells/decidim/announcement_cell.rb
@@ -26,10 +26,6 @@ module Decidim
       announcement.is_a?(Hash) && announcement.has_key?(:title)
     end
 
-    def has_array_body?
-      announcement.has_key?(:body) && announcement[:body].is_a?(Array)
-    end
-
     def callout_class
       options[:callout_class] ||= "secondary"
     end

--- a/decidim-core/app/cells/decidim/announcement_cell.rb
+++ b/decidim-core/app/cells/decidim/announcement_cell.rb
@@ -26,6 +26,10 @@ module Decidim
       announcement.is_a?(Hash) && announcement.has_key?(:title)
     end
 
+    def has_array_body?
+      announcement.has_key?(:body) && announcement[:body].is_a?(Array)
+    end
+
     def callout_class
       options[:callout_class] ||= "secondary"
     end

--- a/decidim-core/app/cells/decidim/announcement_cell.rb
+++ b/decidim-core/app/cells/decidim/announcement_cell.rb
@@ -46,6 +46,10 @@ module Decidim
       clean(announcement[:body])
     end
 
+    def clean_paragraph(paragraph)
+      clean(paragraph)
+    end
+
     def clean_announcement
       clean(announcement)
     end

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
@@ -67,7 +67,6 @@
     <% if @form.photos.any? %>
       <% @form.photos.each do |photo| %>
         <div class="callout gallery__item" data-closable>
-          <%# raise photo.inspect %>
           <%= image_tag photo.thumbnail_url, class: "thumbnail", alt: photo.file.file.filename %>
           <%= form.hidden_field :photos, multiple: true, value: photo.id, id: "photo-#{photo.id}" %>
           <button class="close-button"

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
@@ -67,6 +67,7 @@
     <% if @form.photos.any? %>
       <% @form.photos.each do |photo| %>
         <div class="callout gallery__item" data-closable>
+          <%# raise photo.inspect %>
           <%= image_tag photo.thumbnail_url, class: "thumbnail", alt: photo.file.file.filename %>
           <%= form.hidden_field :photos, multiple: true, value: photo.id, id: "photo-#{photo.id}" %>
           <button class="close-button"

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_wizard_header.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_wizard_header.html.erb
@@ -3,7 +3,8 @@
     "decidim/announcement",
     {
       title: t("decidim.proposals.proposals.preview.announcement_title"),
-      body: "#{t("decidim.proposals.proposals.preview.announcement_body")}<br><br>#{t("decidim.proposals.proposals.preview.proposal_edit_before_minutes", count: component_settings.proposal_edit_before_minutes)}"
+      body: [t("decidim.proposals.proposals.preview.announcement_body"),
+             t("decidim.proposals.proposals.preview.proposal_edit_before_minutes", count: component_settings.proposal_edit_before_minutes)]
     },
     callout_class: "warning"
   ) %>


### PR DESCRIPTION
#### :tophat: What? Why?
Currently announcement block supports title, but it shows it same way as body text. Also body takes currently only single string and because of that we must html tags inside string if we want to divide text. This pull request adds support for array values for announcement[:body], adds heading2 css class to announcement[:title] and uses these changes in proposals preview.

#### Testing
Go to new proposals preview (step 4)

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/19709320/107501449-13705380-6ba0-11eb-9b0b-7e66fbeb9f51.png)


:hearts: Thank you!
