### PR TITLE
Fix the failing initiatives system spec

### DIFF
--- a/decidim-initiatives/spec/system/initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/initiatives_spec.rb
@@ -64,7 +64,7 @@ describe "Initiatives", type: :system do
       end
 
       it "displays the filter initiative type filter" do
-        within ".new_filter[action='/initiatives']" do
+        within ".new_filter[action$='/initiatives']" do
           expect(page).to have_content(/Type/i)
         end
       end
@@ -73,7 +73,7 @@ describe "Initiatives", type: :system do
         let!(:unpublished_initiative) { nil }
 
         it "doesn't display the initiative type filter" do
-          within ".new_filter[action='/initiatives']" do
+          within ".new_filter[action$='/initiatives']" do
             expect(page).not_to have_content(/Type/i)
           end
         end


### PR DESCRIPTION
#### :tophat: What? Why?
There is one initiatives spec that seems to be failing quite constantly in many PRs, e.g.
https://github.com/decidim/decidim/pull/7336/checks?check_run_id=1874705739

This is an attempt to fix it. After trying it locally, it seems it fails when the form action has the whole URL in it instead of the path only. This changes the spec to search for the form with the action that ends with the searched term.

#### Testing
Run the initiatives specs (the whole set).

The failure only seems to happen occasionally, don't know why.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.