### PR TITLE
Fix the failing consultations system spec

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb
@@ -108,6 +108,9 @@ module TranslationHelpers
   private
 
   def fill_in_i18n_fields(field, tab_selector, localized_values)
+    # Ensure the field is visible in the view to avoid "element has zero size"
+    # errors
+    find(tab_selector).scroll_to(:top)
     localized_values.each do |locale, value|
       within tab_selector do
         click_link I18n.with_locale(locale) { t("name", scope: "locale") }
@@ -117,6 +120,9 @@ module TranslationHelpers
   end
 
   def clear_i18n_fields(field, tab_selector, locales)
+    # Ensure the field is visible in the view to avoid "element has zero size"
+    # errors
+    find(tab_selector).scroll_to(:top)
     locales.each do |locale|
       within tab_selector do
         click_link I18n.with_locale(locale) { t("name", scope: "locale") }

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb
@@ -110,7 +110,7 @@ module TranslationHelpers
   def fill_in_i18n_fields(field, tab_selector, localized_values)
     # Ensure the field is visible in the view to avoid "element has zero size"
     # errors
-    find(tab_selector).scroll_to(:top)
+    scroll_to(find(tab_selector))
     localized_values.each do |locale, value|
       within tab_selector do
         click_link I18n.with_locale(locale) { t("name", scope: "locale") }
@@ -122,7 +122,7 @@ module TranslationHelpers
   def clear_i18n_fields(field, tab_selector, locales)
     # Ensure the field is visible in the view to avoid "element has zero size"
     # errors
-    find(tab_selector).scroll_to(:top)
+    scroll_to(find(tab_selector))
     locales.each do |locale|
       within tab_selector do
         click_link I18n.with_locale(locale) { t("name", scope: "locale") }


### PR DESCRIPTION
#### :tophat: What? Why?
There is a consultations system spec that seems to be failing occasionally. I figured it helps if the element the translation helper is trying to find is visible in the current screen when this test runs.

For example, failing in this run:
https://github.com/decidim/decidim/pull/7336/checks?check_run_id=1874705606

The error to be seen in the test output:

```
  1) Admin manages questions creating a question creates a new question
     Failure/Error:
       fill_in_i18n(
         :question_participatory_scope,
         "#question-participatory_scope-tabs",
         en: "Participatory scope"
       )

     Selenium::WebDriver::Error::ElementNotInteractableError:
       element not interactable: element has zero size
         (Session info: headless chrome=88.0.4324.150)

     # #0 0x5635e8b92199 <unknown>
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb:113:in `block (2 levels) in fill_in_i18n_fields'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb:112:in `block in fill_in_i18n_fields'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb:111:in `each'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb:111:in `fill_in_i18n_fields'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb:50:in `fill_in_i18n'
     # ./spec/system/admin/admin_manages_questions_spec.rb:31:in `block (4 levels) in <top (required)>'
     # ./spec/system/admin/admin_manages_questions_spec.rb:15:in `block (3 levels) in <top (required)>'
```

#### Testing
Run the failing consultations spec with the seed `18102`:

```bash
$ cd /path/to/decidim
$ cd decidim-consultations
$ bundle exec rspec spec/system/admin/admin_manages_questions_spec.rb --seed 18102
```

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.