### PR TITLE
Fix admin spec issue regarding tooltip ID selectors starting with numbers

### DIFF
--- a/decidim-admin/spec/system/space_admin_manages_global_moderations_spec.rb
+++ b/decidim-admin/spec/system/space_admin_manages_global_moderations_spec.rb
@@ -39,7 +39,10 @@ describe "Space admin manages global moderations", type: :system do
         expect(page).to have_content("Dummy Title")
 
         tooltip_id = find_link("Visit URL")["data-toggle"]
-        result = page.find("##{tooltip_id}", visible: :all)
+        # Keep the selector as is. If you try to find it with "##{tooltip_id}",
+        # the spec will fail in case the ID happens to have a number as its
+        # first character. This is a problem with the selenimum selectors.
+        result = page.find("[id='#{tooltip_id}']", visible: :all)
         expect(result).to have_content("Dummy Title")
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
This spec failed here in case Foundation generated an ID to the tooltip that started with a number instead of some other character:
https://github.com/decidim/decidim/blob/e8cd4792147fb098ddf9ee4cc1a67b2f1f6ae1a3/decidim-admin/spec/system/space_admin_manages_global_moderations_spec.rb#L42

Here is an example test run where it failed:
https://github.com/decidim/decidim/pull/7343/checks?check_run_id=1872182098

The failure reported by the spec:

```
  1) Space admin manages global moderations when the user can visualize the components can see links to components
     Failure/Error: result = page.find("##{tooltip_id}", visible: :all)

     Selenium::WebDriver::Error::InvalidSelectorError:
       invalid selector: An invalid or illegal selector was specified
         (Session info: headless chrome=88.0.4324.150)
```

This is caused by Selenium not liking ID selectors that start with numbers. In case there is a chance the ID could have a number as its first character, we shouldn't use the hash-selector. Instead, find the element with `[id='...']`.

#### Testing
This does not happen every time as Foundation generates the IDs randomly.

In order to try to replicate, try running the matching spec multiple times:

```bash
$ cd decidim-admin
$ for i in {1..10}; do bundle exec rspec --seed 14097 -e "when the user can visualize the components can see links to components"; done
```

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.