### PR TITLE
Update on_release CI workflow

### DIFF
--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -5,15 +5,24 @@ on:
 
 jobs:
   trigger_docker_build:
-    name: Trigger decidim/docker Build
+    name: Trigger decidim/docker build
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-    - name: Send Dispatch
+    - name: Send dispatch for Github Container Registry build
       run: |
         curl --request POST \
         --user "decidim-bot:${{ secrets.DOCKER_WORKFLOW_PAT }}" \
         --header "Accept: application/vnd.github.everest-preview+json" \
         --header "Content-Type: application/json" \
-        https://api.github.com/repos/decidim/docker/actions/workflows/on_push.yml/dispatches \
+        https://api.github.com/repos/decidim/docker/actions/workflows/github_registry.yml/dispatches \
         --data '{"ref": "master"}'
+    - name: Send dispatch for Docker Hub build
+      run: |
+        curl --request POST \
+        --user "decidim-bot:${{ secrets.DOCKER_WORKFLOW_PAT }}" \
+        --header "Accept: application/vnd.github.everest-preview+json" \
+        --header "Content-Type: application/json" \
+        https://api.github.com/repos/decidim/docker/actions/workflows/dockerhub.yml/dispatches \
+        --data '{"ref": "master"}'
+


### PR DESCRIPTION
#### :tophat: What? Why?

Updates the on_release.yml CI flow to trigger the two separate Github and Docker Hub workflows on decidim/docker. It was still pointing to the previous unified workflow there.

#### :pushpin: Related Issues

PR that introduced this workflow, for context: https://github.com/decidim/decidim/pull/6931

#### Testing

One would have to convert the workflow to run on pull requests, and then trigger a test release.

I'd just wait for the next release to see it working, and fix it in case something goes wrong. There's no nasty side effect involved - the decidim/docker builds will simply not run.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

See the related PR for what it looks like when running.

:hearts: Thank you!
