### PR TITLE
Add filter help in all the meetings navigation page

### DIFF
--- a/decidim-meetings/app/views/decidim/meetings/directory/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/directory/meetings/index.html.erb
@@ -8,6 +8,7 @@
 
     <div class="columns mediumlarge-4 large-3">
       <div class="card card--secondary show-for-mediumlarge">
+        <%= render partial: "decidim/shared/filter_form_help", locals: { skip_to_id: "meetings" } %>
         <%= filter_form_for filter, meetings_directory.root_path do |form| %>
           <div class="filters__section">
             <div class="filters__search">


### PR DESCRIPTION
#### :tophat: What? Why?

In the general meetings navigation (/meetings) we didn't have the filter help. This adds it.

Reasons:
* Consistency with other filters
* A11y
* Makes the loading spinner work

#### :pushpin: Related Issues

- Related to #6253
- Related to #6611 

#### Testing

1. Go to /meetings.
2. See filter help at the sidebar.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

#### Before 
![Selecció_815](https://user-images.githubusercontent.com/717367/107741687-f2c60c00-6d0d-11eb-8fb3-2c08bf84830f.png)

#### After

![Selecció_814](https://user-images.githubusercontent.com/717367/107741702-f8bbed00-6d0d-11eb-8a98-50f5fedd8205.png)


:hearts: Thank you!
