### PR TITLE
Configure capybara puma maximum threads to 1

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -53,7 +53,7 @@ Capybara.register_driver :iphone do |app|
   )
 end
 
-Capybara.server = :puma, { Silent: true }
+Capybara.server = :puma, { Silent: true, Threads: "1:1" }
 
 Capybara.asset_host = "http://localhost:3000"
 


### PR DESCRIPTION
#### :tophat: What? Why?
There is a somewhat concurrent timeout error in the system specs that test the views with iframes.

The issue seems to relate to puma server threads in the Capybara server configuration.

The issue seems to be resolved when we set the minimum and maximum threads to 1.

Here is information about configuring the puma threads:
https://github.com/puma/puma#thread-pool

Example test run that timed out:
https://github.com/decidim/decidim/pull/7362/checks?check_run_id=1889105872

#### Testing
This seems to happen quite constantly when running the admin newsletter templates system spec, so try try running:

```bash
$ cd decidim-admin
$ bundle exec rspec spec/system/admin_manages_newsletter_templates_spec.rb
```

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.