### PR TITLE
Fix forms specs for manage display conditions random question order

### DIFF
--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_display_conditions.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_display_conditions.rb
@@ -39,18 +39,21 @@ shared_examples_for "add display conditions" do
     context "when questionnaire has more than one question" do
       let!(:question_short_answer) do
         create(:questionnaire_question,
+               position: 0,
                questionnaire: questionnaire,
                body: Decidim::Faker::Localized.sentence,
                question_type: "short_answer")
       end
       let!(:question_long_answer) do
         create(:questionnaire_question,
+               position: 1,
                questionnaire: questionnaire,
                body: Decidim::Faker::Localized.sentence,
                question_type: "long_answer")
       end
       let!(:question_single_option) do
         create(:questionnaire_question,
+               position: 2,
                questionnaire: questionnaire,
                body: Decidim::Faker::Localized.sentence,
                question_type: "single_option",
@@ -58,6 +61,7 @@ shared_examples_for "add display conditions" do
       end
       let!(:question_multiple_option) do
         create(:questionnaire_question,
+               position: 3,
                questionnaire: questionnaire,
                body: Decidim::Faker::Localized.sentence,
                question_type: "multiple_option",


### PR DESCRIPTION
#### :tophat: What? Why?
The forms specs for managing question display conditions fails occasionally due to incorrect order of the questions. The spec is assuming the questions are in the order defined by the spec but they all have position of `0` when they can be ordered in random order.

This fixes it by specifying the position of each question to according to the assumed order.

Example test run that failed:
https://github.com/decidim/decidim/pull/7366/checks?check_run_id=1890338991

#### Testing
Run the failing spec multiple times:

```bash
$ cd decidim-surveys
$ for i in {1..100}; do bundle exec rspec spec/system/admin_manages_surveys_spec.rb --seed 26065 -e " when the questionnaire is not already answered behaves like add display conditions when adding display conditions to a question when questionnaire has more than one question when clicking add display condition button fills condition_question select with saved questions from questionnaire"; done
```

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.