### PR TITLE
Fix warnings of `have_content nil`

### DIFF
--- a/decidim-budgets/spec/system/orders_spec.rb
+++ b/decidim-budgets/spec/system/orders_spec.rb
@@ -140,7 +140,7 @@ describe "Orders", type: :system do
           expect(page).to have_content "1 project selected"
 
           within ".budget-summary__selected" do
-            expect(page).to have_content project.title[I18n.locale]
+            expect(page).to have_selector(".budget-summary__selected-item", text: project.title[I18n.locale.to_s], visible: :hidden)
           end
 
           within "#order-progress .budget-summary__progressbox" do
@@ -175,7 +175,7 @@ describe "Orders", type: :system do
           expect(page).to have_content "1 project selected"
 
           within ".budget-summary__selected" do
-            expect(page).to have_content project.title[I18n.locale]
+            expect(page).to have_selector(".budget-summary__selected-item", text: project.title[I18n.locale.to_s], visible: :hidden)
           end
 
           within "#order-progress .budget-summary__progressbox" do
@@ -211,7 +211,7 @@ describe "Orders", type: :system do
           expect(page).to have_content "1 project selected"
 
           within ".budget-summary__selected" do
-            expect(page).to have_content project.title[I18n.locale]
+            expect(page).to have_selector(".budget-summary__selected-item", text: project.title[I18n.locale.to_s], visible: :hidden)
           end
 
           within "#order-progress .budget-summary__progressbox" do
@@ -246,7 +246,7 @@ describe "Orders", type: :system do
           expect(page).to have_content "1 project selected"
 
           within ".budget-summary__selected" do
-            expect(page).to have_content project.title[I18n.locale]
+            expect(page).to have_selector(".budget-summary__selected-item", text: project.title[I18n.locale.to_s], visible: :hidden)
           end
 
           within "#order-progress .budget-summary__progressbox" do


### PR DESCRIPTION
#### :tophat: What? Why?
fix to resolve #7371 

#### :pushpin: Related Issues
- Fixes #7371 

#### Testing
Execute rspec spec/system/orders_spec.rb

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
