### PR TITLE
Fixing foundation deprecations

### DIFF
--- a/decidim-admin/app/assets/stylesheets/decidim/admin/_variables.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/_variables.scss
@@ -1,3 +1,12 @@
+// Foundation Variables
+$primary-color: null;
+$secondary-color: null;
+$success-color: null;
+$warning-color: null;
+$alert-color: null;
+$-zf-size: null;
+$-zf-bp-value: null;
+
 // Variables
 
 $brand: #9675ce !default;

--- a/decidim-system/app/assets/stylesheets/decidim/system/application.scss
+++ b/decidim-system/app/assets/stylesheets/decidim/system/application.scss
@@ -1,3 +1,12 @@
+// Foundation Variables
+$primary-color: null;
+$secondary-color: null;
+$success-color: null;
+$warning-color: null;
+$alert-color: null;
+$-zf-size: null;
+$-zf-bp-value: null;
+
 @import "foundation_and_overrides";
 @import "layout";
 @import "login";


### PR DESCRIPTION
#### :tophat: What? Why?
While running admin and system specs, i came across the following deprecation warnings:
This PR fixes those warnings 

```ruby 
DEPRECATION WARNING on line 115 of /usr/local/bundle/gems/foundation-rails-6.6.2.0/vendor/assets/scss/util/_color.scss:
!global assignments won't be able to declare new variables in future versions.
Consider adding `$primary-color: null` at the top level.

DEPRECATION WARNING on line 120 of /usr/local/bundle/gems/foundation-rails-6.6.2.0/vendor/assets/scss/util/_color.scss:
!global assignments won't be able to declare new variables in future versions.
Consider adding `$secondary-color: null` at the top level.

DEPRECATION WARNING on line 125 of /usr/local/bundle/gems/foundation-rails-6.6.2.0/vendor/assets/scss/util/_color.scss:
!global assignments won't be able to declare new variables in future versions.
Consider adding `$success-color: null` at the top level.

DEPRECATION WARNING on line 130 of /usr/local/bundle/gems/foundation-rails-6.6.2.0/vendor/assets/scss/util/_color.scss:
!global assignments won't be able to declare new variables in future versions.
Consider adding `$warning-color: null` at the top level.

DEPRECATION WARNING on line 135 of /usr/local/bundle/gems/foundation-rails-6.6.2.0/vendor/assets/scss/util/_color.scss:
!global assignments won't be able to declare new variables in future versions.
Consider adding `$alert-color: null` at the top level.

DEPRECATION WARNING on line 164 of /usr/local/bundle/gems/foundation-rails-6.6.2.0/vendor/assets/scss/util/_breakpoint.scss:
!global assignments won't be able to declare new variables in future versions.
Consider adding `$-zf-size: null` at the top level.

DEPRECATION WARNING on line 369 of /usr/local/bundle/gems/foundation-rails-6.6.2.0/vendor/assets/scss/util/_mixins.scss:
!global assignments won't be able to declare new variables in future versions.
Consider adding `$-zf-bp-value: null` at the top level.
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #7158

#### Testing
Run the test suite on the main development branch, you should see the deprecation there. 
Apply the patch, and you should not be able to see those warnings again

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
