### PR TITLE
Fix the integration schema spec expectation's published at date

### DIFF
--- a/decidim-proposals/spec/types/integration_schema_spec.rb
+++ b/decidim-proposals/spec/types/integration_schema_spec.rb
@@ -57,7 +57,7 @@ describe "Decidim::Api::QueryType" do
       "official" => proposal.official?,
       "participatoryTextLevel" => proposal.participatory_text_level,
       "position" => proposal.position,
-      "publishedAt" => proposal.created_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "publishedAt" => proposal.published_at.iso8601.to_s.gsub("Z", "+00:00"),
       "reference" => proposal.reference,
       "scope" => proposal.scope,
       "state" => proposal.state,


### PR DESCRIPTION
#### :tophat: What? Why?
In the proposals integration schema spec, the published at date is fetched from a wrong attribute which can cause the spec to fail occasionally.

This fixes the spec.

Example test run that failed:
https://github.com/decidim/decidim/pull/7362/checks?check_run_id=1893423572

#### Testing
The easiest way to replicate the issue is to locally change the published at date for the proposal factory here:
https://github.com/decidim/decidim/blob/2e24da9cfc183c5a35a50766d0b91258ef149af3/decidim-proposals/lib/decidim/proposals/test/factories.rb#L276

Change that line to:
```ruby
    published_at { Time.current + 1.minute }
```

After that, run the spec that failed:

```bash
$ cd decidim-proposals
$ bundle exec rspec spec/types/integration_schema_spec.rb
```

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.