### PR TITLE
Fix questionnaire spec factory random question order

### DIFF
--- a/decidim-forms/lib/decidim/forms/test/factories.rb
+++ b/decidim-forms/lib/decidim/forms/test/factories.rb
@@ -17,10 +17,12 @@ FactoryBot.define do
 
     trait :with_questions do
       questions do
+        position = 0
         qs = %w(short_answer long_answer).collect do |text_question_type|
-          build(:questionnaire_question, question_type: text_question_type)
+          build(:questionnaire_question, question_type: text_question_type, position: position)
+          position += 1
         end
-        qs << build(:questionnaire_question, :with_answer_options, question_type: :single_option)
+        qs << build(:questionnaire_question, :with_answer_options, question_type: :single_option, position: position)
         qs
       end
     end

--- a/decidim-forms/lib/decidim/forms/test/factories.rb
+++ b/decidim-forms/lib/decidim/forms/test/factories.rb
@@ -19,8 +19,9 @@ FactoryBot.define do
       questions do
         position = 0
         qs = %w(short_answer long_answer).collect do |text_question_type|
-          build(:questionnaire_question, question_type: text_question_type, position: position)
+          q = build(:questionnaire_question, question_type: text_question_type, position: position)
           position += 1
+          q
         end
         qs << build(:questionnaire_question, :with_answer_options, question_type: :single_option, position: position)
         qs


### PR DESCRIPTION
#### :tophat: What? Why?
The surveys spec, or in fact any spec that uses the `questionnaire` factory's `:with_questions` trait can fail in case the created questions are not in the expected order they were created in.

This fixes the order to be always as expected.

Example test run that failed because of this:
https://github.com/decidim/decidim/pull/7375/checks?check_run_id=1893799448

#### Testing
Run the surveys data serializer spec (`decidim-surveys/spec/serializers/decidim/surveys/data_serializer_spec.rb`)for arbitrary times consequently and at some point it will fail.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.