### PR TITLE
Fix proposal title minimum length validation of 15 characters

### DIFF
--- a/decidim-core/app/validators/etiquette_validator.rb
+++ b/decidim-core/app/validators/etiquette_validator.rb
@@ -9,7 +9,6 @@ class EtiquetteValidator < ActiveModel::EachValidator
     validate_caps(record, attribute, value)
     validate_marks(record, attribute, value)
     validate_caps_first(record, attribute, value)
-    validate_length(record, attribute, value)
   end
 
   private
@@ -30,11 +29,5 @@ class EtiquetteValidator < ActiveModel::EachValidator
     return if value.scan(/\A[a-z]{1}/).empty?
 
     record.errors.add(attribute, options[:message] || :must_start_with_caps)
-  end
-
-  def validate_length(record, attribute, value)
-    return if value.length > 15
-
-    record.errors.add(attribute, options[:message] || :too_short)
   end
 end

--- a/decidim-core/spec/validators/etiquette_validator_spec.rb
+++ b/decidim-core/spec/validators/etiquette_validator_spec.rb
@@ -81,10 +81,4 @@ describe EtiquetteValidator do
       it { is_expected.to be_valid }
     end
   end
-
-  context "when the body is too short" do
-    let(:body) { "Oh my god" }
-
-    it { is_expected.to be_invalid }
-  end
 end

--- a/decidim-dev/app/forms/decidim/dummy_resources/dummy_resource_form.rb
+++ b/decidim-dev/app/forms/decidim/dummy_resources/dummy_resource_form.rb
@@ -14,7 +14,7 @@ module Decidim
       attachments_attribute :photos
 
       validates :title, :body, presence: true, etiquette: true
-      validates :title, length: { maximum: 150 }
+      validates :title, length: { in: 15..150 }
     end
   end
 end

--- a/decidim-proposals/spec/shared/proposal_form_examples.rb
+++ b/decidim-proposals/spec/shared/proposal_form_examples.rb
@@ -95,6 +95,18 @@ shared_examples "a proposal form" do |options|
     it { is_expected.to be_invalid }
   end
 
+  context "when the title is the minimum length" do
+    let(:title) do
+      if options[:i18n] == false
+        "Length is right"
+      else
+        { en: "Length is right" }
+      end
+    end
+
+    it { is_expected.to be_valid }
+  end
+
   unless options[:skip_etiquette_validation]
     context "when the body is not etiquette-compliant" do
       let(:body) do


### PR DESCRIPTION
#### :tophat: What? Why?
The proposal's minimum length is defined at 15 characters as defined by:
https://github.com/decidim/decidim/blob/5469c52a5f5b5e8eba8f787eea160d3118704b60/decidim-proposals/app/forms/decidim/proposals/proposal_wizard_create_step_form.rb#L15

Entering a title of exactly 15 characters will pass the front-end character counter/validation as it reaches the minimum amount of characters.

However, backend validation will fail because the etiquette validator requires the proposal title to have at least 16 characters as defined by:
https://github.com/decidim/decidim/blob/5469c52a5f5b5e8eba8f787eea160d3118704b60/decidim-core/app/validators/etiquette_validator.rb#L36

The user experience right now is quite confusing as the front-end tells the length is enough but when the user submits the form, there will be errors. Also, why do we need a double check for the length?

#### Testing
- Go to create a new proposal
- Enter a title exactly at 15 characters long, e.g. "Length is right"
- Submit the form
- See the validation error

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.