### PR TITLE
Fix infinite redirect loops due to no permissions for the page and referer pointing to the same path

### DIFF
--- a/decidim-core/app/controllers/concerns/decidim/needs_permission.rb
+++ b/decidim-core/app/controllers/concerns/decidim/needs_permission.rb
@@ -21,7 +21,13 @@ module Decidim
       # them they are not authorized.
       def user_has_no_permission
         flash[:alert] = t("actions.unauthorized", scope: "decidim.core")
-        redirect_to(request.referer || user_has_no_permission_path)
+        redirect_to(user_has_no_permission_referer || user_has_no_permission_path)
+      end
+
+      def user_has_no_permission_referer
+        return if request.referer == request.original_url
+
+        request.referer
       end
 
       def user_has_no_permission_path

--- a/decidim-core/spec/controllers/concerns/needs_permission_spec.rb
+++ b/decidim-core/spec/controllers/concerns/needs_permission_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe "NeedsPermission", type: :controller do
+    let!(:organization) { create :organization }
+    let!(:user) { create :user, :confirmed, organization: organization }
+    let!(:another_user) { create :user, :confirmed, organization: organization }
+
+    controller do
+      include Decidim::NeedsPermission
+
+      register_permissions(
+        "test",
+        ::Decidim::Permissions
+      )
+
+      def show
+        enforce_permission_to :update, :user, current_user: request.env["decidim.test_user"]
+
+        render plain: "Hello World"
+      end
+
+      def permission_class_chain
+        ::Decidim.permissions_registry.chain_for("test")
+      end
+
+      def permission_scope
+        :public
+      end
+
+      def user_has_no_permission_path
+        "/you-need-permissions"
+      end
+    end
+
+    before do
+      routes.draw { get "show" => "anonymous#show" }
+
+      request.env["decidim.current_organization"] = organization
+      request.env["decidim.test_user"] = another_user
+      sign_in user if user
+    end
+
+    it "redirects the user to the user_has_no_permissions_path" do
+      get :show
+
+      expect(response).to redirect_to("/you-need-permissions")
+    end
+
+    context "when the request has a referer defined" do
+      let(:referer) { "http://test.host/referer-path" }
+
+      before do
+        request.env["HTTP_REFERER"] = referer
+      end
+
+      it "redirects the user to the referer URL" do
+        get :show
+
+        expect(response).to redirect_to(referer)
+      end
+
+      context "with referer pointing to the current path" do
+        let(:referer) { "http://test.host/show" }
+
+        it "redirects the user to the user_has_no_permission_path" do
+          get :show
+
+          expect(response).to redirect_to("/you-need-permissions")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Occasionally you can end up in a redirect loop if you try to request a page where you don't have permissions to and the browser referer is pointing to the same URL.

This fixes the issue by checking that the referer URL is not the same as the current URL before redirecting there.

#### Testing
I'm not quite sure how to replicate this issue but I have definitely bumped into this in production environments. Of course, you can remediate the issue by closing the browser tab and going to some other URL.

Generally this seems to happen when you have a browser tab open for a page that requires permissions, but later you signed out in some other tab. After this, the previously open tab can go into the infinite redirection loop.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.