### PR TITLE
Don't include JS file manually

### DIFF
--- a/decidim-core/app/views/layouts/decidim/_timeout_modal.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_timeout_modal.html.erb
@@ -16,5 +16,3 @@
     </div>
   </div>
 <% end %>
-
-<%= javascript_include_tag "decidim/session_timeouter" %>


### PR DESCRIPTION
#### :tophat: What? Why?
#7282 added a `javascript_include_tag` call, but the file is not present in the precompiled files list, so it fails in production. This PR removes the call to the method because the file is already included in the main bundle.

#### :pushpin: Related Issues
- Related to #7282

#### Testing
Ensure CI is green