### PR TITLE
Fix ehterpad compatibility for old meetings

### DIFF
--- a/decidim-forms/app/models/decidim/forms/questionnaire.rb
+++ b/decidim-forms/app/models/decidim/forms/questionnaire.rb
@@ -36,6 +36,8 @@ module Decidim
 
       # salt is used to generate secure hash in anonymous answers
       def set_default_salt
+        return unless defined?(salt)
+
         self.salt ||= Tokenizer.random_salt
       end
     end

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -96,7 +96,8 @@ module Decidim
                         index_on_create: ->(meeting) { meeting.visible? },
                         index_on_update: ->(meeting) { meeting.visible? })
 
-      after_initialize :set_default_salt
+      # we create a salt for the meeting only on new meetings to prevent changing old IDs for existing (Ether)PADs
+      before_create :set_default_salt
 
       # Return registrations of a particular meeting made by users representing a group
       def user_group_registrations

--- a/decidim-meetings/lib/decidim/meetings/test/factories.rb
+++ b/decidim-meetings/lib/decidim/meetings/test/factories.rb
@@ -38,7 +38,6 @@ FactoryBot.define do
     registration_type { :on_this_platform }
     type_of_meeting { :in_person }
     component { build(:component, manifest_name: "meetings") }
-    salt { SecureRandom.hex(32) }
 
     author do
       component.try(:organization)

--- a/decidim-meetings/spec/models/meeting_spec.rb
+++ b/decidim-meetings/spec/models/meeting_spec.rb
@@ -187,6 +187,49 @@ module Decidim::Meetings
       end
     end
 
+    describe "#salt" do
+      it "salt is empty before saving" do
+        expect(subject.salt).not_to be_present
+      end
+
+      context "when is created" do
+        before do
+          meeting.save!
+        end
+
+        it "has a salt defined" do
+          expect(subject.salt).to be_present
+        end
+      end
+
+      context "when is updated" do
+        let!(:meeting) { create :meeting }
+
+        context "and salt is empty" do
+          before do
+            meeting.start_time = 1.day.from_now
+            meeting.salt = ""
+            meeting.save!
+          end
+
+          it "salt remains empty" do
+            expect(subject.salt).not_to be_present
+          end
+        end
+
+        context "and salt is present" do
+          before do
+            meeting.start_time = 1.day.from_now
+            meeting.save!
+          end
+
+          it "salt remains the same" do
+            expect(subject.salt).to be_present
+          end
+        end
+      end
+    end
+
     describe "pad_is_visible?" do
       let(:pad) { instance_double(EtherpadLite::Pad, id: "pad-id", read_only_id: "read-only-id") }
 


### PR DESCRIPTION
#### :tophat: What? Why?

#6850 introduced a more secure pattern for generating random ids in questionnaires and meetings. 

Meetings use this to generate the id for the etherpad related boards. However the current implementation uses the `after_initialize` callback that creates a salt on a new meeting creation if it is empty. This leads to generate random ids for pads and loosing the old link with already existing pads. This is not a problem for newly created meetings as the salt is read from the database.

I propose to use the callback `before_create` instead, so the salt is generated only when a new meeting is created and updates or fetches to existing ones do not manipulate empty `salt` values.

On the other hand, this affects version 0.23.2 due the recent backport #7327.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #6850, #7327

#### Testing

You need to test this by having etherpad activated and upgrading an existing Decidim version. Old meetings will stop showing the existing etherpads linked.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
