### PR TITLE
Fix require session timeouter javascript in admin application.js

### DIFF
--- a/decidim-admin/app/assets/javascripts/decidim/admin/application.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/application.js.es6
@@ -29,6 +29,7 @@
 // = require ./officializations
 // = require decidim/input_character_counter
 // = require decidim/geocoding/attach_input
+// = require decidim/session_timeouter
 // = require_self
 
 window.Decidim = window.Decidim || {};


### PR DESCRIPTION
#### :tophat: What? Why?
#7282 Required session_timeouter.js twice (in bundle and view), #7383 removed manual include from the view, but after it doesn't show warning in admin panel. Here we add javascript to admin bundle also, so that we can show the warning in admin panel too.

#### :pushpin: Related Issues
#7282 
#7383 

#### Testing
1. Change config.timeout_in = 2.minutes @ decidim-core/config/initializers/devise.rb
2. (Re)start development_app, login as admin and got to admin panel
3. Idle 30s (to see warning) and 90s to get automatically logged out.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![admin_timeout](https://user-images.githubusercontent.com/19709320/107957458-51f37d00-6fa9-11eb-859e-b8b5e0476397.png)

:hearts: Thank you!
