### PR TITLE
Fix display of debates with multiple dates

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_extra.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_extra.scss
@@ -1,50 +1,50 @@
-.extra {
+.extra{
   text-align: center;
   margin-bottom: 1rem;
 
-  .button:last-of-type {
+  .button:last-of-type{
     margin-bottom: 0;
   }
 
-  .follow-button {
+  .follow-button{
     margin-top: 1rem;
   }
 }
 
-.extra__suport-number {
+.extra__suport-number{
   display: block;
   font-weight: 600;
   font-size: 3rem;
   line-height: 1;
 }
 
-.extra__suport-text {
+.extra__suport-text{
   display: block;
   line-height: 1;
-  font-size: 0.9rem;
-  margin-bottom: 0.5rem;
+  font-size: .9rem;
+  margin-bottom: .5rem;
 }
 
-.extra__date {
+.extra__date{
   font-size: 3rem;
   line-height: 1;
 }
 
-.extra__date-container {
+.extra__date-container{
   margin-bottom: 1rem;
 }
 
-.extra__month {
+.extra__month{
   display: block;
   font-size: 1rem;
 }
 
-.extra__time {
+.extra__time{
   display: block;
   font-size: 1.2rem;
-  margin: 0.5rem 0 0;
+  margin: .5rem 0 0;
 }
 
-.extra--text {
+.extra--text{
   text-align: left;
 }

--- a/decidim-core/app/assets/stylesheets/decidim/modules/_extra.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_extra.scss
@@ -1,46 +1,50 @@
-.extra{
+.extra {
   text-align: center;
   margin-bottom: 1rem;
 
-  .button:last-of-type{
+  .button:last-of-type {
     margin-bottom: 0;
   }
 
-  .follow-button{
+  .follow-button {
     margin-top: 1rem;
   }
 }
 
-.extra__suport-number{
+.extra__suport-number {
   display: block;
   font-weight: 600;
   font-size: 3rem;
   line-height: 1;
 }
 
-.extra__suport-text{
+.extra__suport-text {
   display: block;
   line-height: 1;
-  font-size: .9rem;
-  margin-bottom: .5rem;
+  font-size: 0.9rem;
+  margin-bottom: 0.5rem;
 }
 
-.extra__date{
+.extra__date {
   font-size: 3rem;
   line-height: 1;
 }
 
-.extra__month{
+.extra__date-container {
+  margin-bottom: 1rem;
+}
+
+.extra__month {
   display: block;
   font-size: 1rem;
 }
 
-.extra__time{
+.extra__time {
   display: block;
   font-size: 1.2rem;
-  margin: .5rem 0 0;
+  margin: 0.5rem 0 0;
 }
 
-.extra--text{
+.extra--text {
   text-align: left;
 }

--- a/decidim-core/app/cells/decidim/date/show.erb
+++ b/decidim-core/app/cells/decidim/date/show.erb
@@ -1,0 +1,31 @@
+<div class="extra__date-container">
+  <% if same_day? %>
+    <div class="extra__date">
+      <%= l start_time, format: "%d" %>
+      <span class="extra__month"><%= l start_time, format: "%B#{ " %Y" if show_year?}" %></span>
+    </div>
+    <div class="extra__time">
+      <%= l start_time, format: "%H:%M" %> - <%= l end_time, format: "%H:%M" %>
+    </div>
+  <% else %>
+    <div>
+      <div class="extra__date">
+        <%= l start_time, format: "%d" %>
+        <span class="extra__month"><%= l start_time, format: "%B#{ " %Y" if show_year?}" %></span>
+      </div>
+      <div class="extra__time">
+        <%= l start_time, format: "%H:%M" %>
+      </div>
+    </div>
+    <%= icon "arrow-thin-right" %>
+    <div>
+      <div class="extra__date">
+        <%= l end_time, format: "%d" %>
+        <span class="extra__month"><%= l end_time, format: "%B#{ " %Y" if show_year?}" %></span>
+      </div>
+      <div class="extra__time">
+        <%= l end_time, format: "%H:%M" %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/decidim-core/app/cells/decidim/date_cell.rb
+++ b/decidim-core/app/cells/decidim/date_cell.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This cell renders a date or a date range
+  # the `model` is expected to be an hash with two keys:
+  #  `start` is the starting datetime
+  #  `end` is the ending datetime
+  # both are optional
+  #
+  # {
+  #   start: model.start_time,
+  #   end: model.end_time
+  # }
+  #
+  class DateCell < Decidim::ViewModel
+    include Decidim::IconHelper
+
+    def show
+      return unless start_time && end_time
+
+      render :show
+    end
+
+    private
+
+    def start_time
+      model[:start]
+    end
+
+    def end_time
+      model[:end]
+    end
+
+    def same_day?
+      start_time.beginning_of_day == end_time.beginning_of_day
+    end
+
+    def same_year?
+      start_time.beginning_of_year == end_time.beginning_of_year
+    end
+
+    def show_year?
+      !same_year? || !current_year?(start_time) || !current_year?(end_time)
+    end
+
+    def current_year?(time)
+      time.year == Time.zone.now.year
+    end
+  end
+end

--- a/decidim-core/spec/cells/decidim/date_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/date_cell_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::DateCell, type: :cell do
+  subject { my_cell.call }
+
+  controller Decidim::Debates::DebatesController
+
+  let(:my_cell) { cell("decidim/date", model) }
+  let!(:organization) { create(:organization) }
+  let(:user) { create(:user, :confirmed, organization: organization) }
+  let(:model) { { start: start_time, end: end_time } }
+  let(:start_time) { Time.zone.now - 1.hour }
+  let(:start_time_past_year) { Time.zone.now - 1.year }
+  let(:end_time_same_date) { Time.zone.now + 1.hour }
+  let(:end_time_different_date) { Time.zone.now + 1.day }
+  let(:end_time_different_year) { Time.zone.now + 1.year }
+  let(:end_time_past_year) { start_time_past_year + 1.hour }
+
+  context "when rendering a date" do
+    let(:end_time) { end_time_same_date }
+
+    it "renders a Date card" do
+      expect(subject).to have_css(".extra__date-container")
+    end
+  end
+
+  context "when start and end time are on the same date" do
+    let(:end_time) { end_time_same_date }
+
+    it "renders only one date and time" do
+      has_date 1
+      has_time 1
+    end
+  end
+
+  context "when start and end time are on different dates" do
+    let(:end_time) { end_time_different_date }
+
+    it "renders the two dates and times" do
+      has_date 2
+      has_time 2
+    end
+  end
+
+  context "when start and end time are on different years" do
+    let(:end_time) { end_time_different_year }
+
+    it "renders the two dates and times" do
+      has_date 2
+      has_time 2
+    end
+
+    it "renders two year elements" do
+      expect(subject).to have_content(start_time.year.to_s)
+      expect(subject).to have_content(end_time.year.to_s)
+    end
+  end
+
+  context "when start time is not the current year" do
+    let(:start_time) { start_time_past_year }
+    let(:end_time) { end_time_past_year }
+
+    it "renders two year elements" do
+      expect(subject).to have_content(start_time.year.to_s)
+      expect(subject).to have_content(end_time.year.to_s)
+    end
+  end
+
+  def has_time(count)
+    expect(subject).to have_css(".extra__time", count: count)
+  end
+
+  def has_date(count)
+    expect(subject).to have_css(".extra__date", count: count)
+  end
+
+  def has_month(count)
+    expect(subject).to have_css(".extra__month", count: count)
+  end
+end

--- a/decidim-debates/app/views/decidim/debates/debates/show.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/show.html.erb
@@ -45,14 +45,7 @@ edit_link(
     <% end %>
     <div class="card extra">
       <div class="card__content">
-        <% if debate.start_time.present? && debate.end_time.present? %>
-          <div class="extra__date">
-            <%= l debate.start_time, format: "%d" %> <span class="extra__month"><%= l debate.start_time, format: "%B" %></span>
-          </div>
-          <div class="extra__time">
-            <%= l debate.start_time, format: "%H:%M" %> - <%= l debate.end_time, format: "%H:%M" %>
-          </div>
-        <% end %>
+        <%= cell("decidim/date", { start: debate.start_time, end: debate.end_time }) %>
 
         <% if endorsements_enabled? && allowed_to?(:endorse, :debate, debate: debate) %>
           <div class="row collapse buttons__row">


### PR DESCRIPTION
#### :tophat: What? Why?
Implement Date cell to use in debates in order to correctly display start and end times when the debate start day and end day are different. The logic is the following:

- If it starts and ends on the same date, only date and start and end time are displayed
- If if starts and ends on a different date, both start and end date and time are displayed
- If either the starting year or the end year are not the current year, the year is displayed
- If the starting year and the end year are different, the year is also displayed

#### :pushpin: Related Issues
- Fixes #6103

#### Testing
- Visit a debate that starts and ends in different dates 

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

#### Same date
![Same date](https://user-images.githubusercontent.com/8806781/107982485-6db84c80-6fc4-11eb-98aa-0767b80a9f59.png)

#### Different date, same year
![Different date, same year](https://user-images.githubusercontent.com/8806781/107982510-7a3ca500-6fc4-11eb-9769-4f468f71c0eb.png)

#### Different year
![Different year](https://user-images.githubusercontent.com/8806781/107982519-7d379580-6fc4-11eb-895d-3d5eecd5b1f8.png)


:hearts: Thank you!
