### PR TITLE
Use real resource controller for filterable concern in system tests

### DIFF
--- a/decidim-accountability/spec/system/admin/admin_filters_searches_and_paginates_results_spec.rb
+++ b/decidim-accountability/spec/system/admin/admin_filters_searches_and_paginates_results_spec.rb
@@ -7,10 +7,7 @@ describe "Admin filters, searches, and paginates results", type: :system do
   include_context "with filterable context"
 
   let(:manifest_name) { "accountability" }
-
-  # Override :filterable_concern used by decidim-admin/lib/decidim/admin/test/filterable_examples.rb,
-  # which would include a :route_key value of "results", rather than "accountability".
-  let(:filterable_concern) { "Decidim::Accountability::Admin::Filterable".constantize }
+  let(:resource_controller) { Decidim::Accountability::Admin::ResultsController }
 
   context "when filtering by scope" do
     let!(:scope1) do

--- a/decidim-admin/lib/decidim/admin/test/filterable_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/filterable_examples.rb
@@ -2,16 +2,9 @@
 
 shared_context "with filterable context" do
   let(:factory_name) { model_name.singular_route_key }
-  let(:module_name) { model_name.route_key.camelize }
-  let(:filterable_concern) { "Decidim::#{module_name}::Admin::Filterable".constantize }
-
-  let(:filterable_fake_controller) do
-    FILTERABLE_CONCERN ||= filterable_concern
-    class FilterableFakeController < Decidim::ApplicationController; include FILTERABLE_CONCERN; end
-  end
 
   def filterable_method(method_name)
-    (@controller ||= filterable_fake_controller.new).send(method_name)
+    resource_controller.new.send(method_name)
   end
 
   def apply_filter(options, filter)

--- a/decidim-admin/spec/system/admin_manages_officializations_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_officializations_spec.rb
@@ -6,7 +6,7 @@ describe "Admin manages officializations", type: :system do
   include_context "with filterable context"
 
   let(:model_name) { Decidim::User.model_name }
-  let(:filterable_concern) { Decidim::Admin::Officializations::Filterable }
+  let(:resource_controller) { Decidim::Admin::OfficializationsController }
 
   let(:organization) { create(:organization) }
 

--- a/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
@@ -6,6 +6,7 @@ describe "Admin manages assemblies", type: :system do
   include_context "when admin administrating an assembly"
 
   let(:model_name) { assembly.class.model_name }
+  let(:resource_controller) { Decidim::Assemblies::Admin::AssembliesController }
 
   shared_examples "creating an assembly" do
     let(:image1_filename) { "city.jpeg" }

--- a/decidim-conferences/spec/system/admin/admin_manages_conferences_spec.rb
+++ b/decidim-conferences/spec/system/admin/admin_manages_conferences_spec.rb
@@ -16,6 +16,7 @@ describe "Admin manages conferences", type: :system do
 
   describe "listing conferences" do
     let(:model_name) { conference.class.model_name }
+    let(:resource_controller) { Decidim::Conferences::Admin::ConferencesController }
 
     it_behaves_like "filtering collection by published/unpublished"
   end

--- a/decidim-consultations/spec/system/admin/admin_manages_consultations_spec.rb
+++ b/decidim-consultations/spec/system/admin/admin_manages_consultations_spec.rb
@@ -13,6 +13,7 @@ describe "Admin manages consultations", type: :system do
 
   describe "listing consultations" do
     let(:model_name) { consultation.class.model_name }
+    let(:resource_controller) { Decidim::Consultations::Admin::ConsultationsController }
 
     it_behaves_like "filtering collection by published/unpublished"
   end

--- a/decidim-elections/spec/system/admin/admin_manages_votings_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_votings_spec.rb
@@ -11,8 +11,9 @@ describe "Admin manages votings", type: :system do
     visit decidim_admin_votings.votings_path
   end
 
-  describe "listing votings" do
+  describe "when listing votings" do
     let(:model_name) { voting.class.model_name }
+    let(:resource_controller) { Decidim::Votings::Admin::VotingsController }
 
     it_behaves_like "filtering collection by published/unpublished"
   end

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiatives_spec.rb
@@ -8,6 +8,7 @@ describe "Admin manages initiatives", type: :system do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, :admin, organization: organization) }
   let(:model_name) { Decidim::Initiative.model_name }
+  let(:resource_controller) { Decidim::Initiatives::Admin::InitiativesController }
   let(:type1) { create :initiatives_type, organization: organization }
   let(:type2) { create :initiatives_type, organization: organization }
   let(:scoped_type1) { create :initiatives_type_scope, type: type1 }

--- a/decidim-participatory_processes/spec/shared/manage_processes_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_processes_examples.rb
@@ -6,6 +6,7 @@ shared_examples "manage processes examples" do
     let!(:process_with_group) { create(:participatory_process, organization: organization, participatory_process_group: process_group) }
     let!(:process_without_group) { create(:participatory_process, organization: organization) }
     let(:model_name) { participatory_process.class.model_name }
+    let(:resource_controller) { Decidim::ParticipatoryProcesses::Admin::ParticipatoryProcessesController }
 
     def filter_by_group(group_title)
       visit current_path

--- a/decidim-proposals/spec/system/admin/filter_proposals_spec.rb
+++ b/decidim-proposals/spec/system/admin/filter_proposals_spec.rb
@@ -9,6 +9,7 @@ describe "Admin filters proposals", type: :system do
   STATES = Decidim::Proposals::Proposal::POSSIBLE_STATES.map(&:to_sym)
 
   let(:model_name) { Decidim::Proposals::Proposal.model_name }
+  let(:resource_controller) { Decidim::Proposals::Admin::ProposalsController }
 
   def create_proposal_with_trait(trait)
     create(:proposal, trait, component: component, skip_injection: true)


### PR DESCRIPTION
#### :tophat: What? Why?
Thus far, in the system tests the `Admin::Filterable` controller concern was tested by [including it in a "fake" controller defined in a shared context in the specs](https://github.com/decidim/decidim/pull/7402/files#diff-b35dd3998f0af127bbb62659b8549b930850dc137364bdf8192b83595226cbcbL8-L11).
This worked fine for the general case, but this approach has already given some headaches in the past and worked around (see [here](https://github.com/decidim/decidim/pull/7402/files#diff-b35dd3998f0af127bbb62659b8549b930850dc137364bdf8192b83595226cbcbL8-L11) and [here](https://github.com/decidim/decidim/pull/7402/files#diff-d3f338ab257cff136cc481ecf5045777492d2288350b573aebbb691d5627754dL9)).

In https://github.com/decidim/decidim/pull/7344 we're adding a new resource (`PollingStations`) using those shared examples, when another resource in the same module (`Votings`) already takes advantage of it.
This causes the `FilterableFakeController` to be monkey-patched twice inside the same context and the tests to fail because they end up using the wrong Concern.

This PR forces the tests to declare upfront the real controller the tests shall be run against.
Since we are talking about system tests, this is probably also a better approach than mocking the controller.
#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
