### PR TITLE
Raise an alert when there's an error signing an initiative

### DIFF
--- a/decidim-initiatives/app/controllers/decidim/initiatives/initiative_signatures_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/initiative_signatures_controller.rb
@@ -47,9 +47,7 @@ module Decidim
           end
 
           on(:invalid) do
-            render json: {
-              error: I18n.t("create.error", scope: "decidim.initiatives.initiative_votes")
-            }, status: :unprocessable_entity
+            render :error_on_vote, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb
@@ -24,6 +24,8 @@ module Decidim
 
       validates :initiative, :signer, presence: true
 
+      validates :authorized_scopes, presence: true
+
       with_options if: :required_personal_data? do
         validates :name_and_surname, :document_number, :date_of_birth, :postal_code, :encrypted_metadata, :hash_id, presence: true
         validate :document_number_authorized?

--- a/decidim-initiatives/app/views/decidim/initiatives/initiative_signatures/error_on_vote.js.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiative_signatures/error_on_vote.js.erb
@@ -1,0 +1,5 @@
+(function () {
+  'use strict';
+
+  alert("<%= raw I18n.t("create.error", scope: "decidim.initiatives.initiative_votes") %>");
+}());

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/initiative_signatures_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/initiative_signatures_controller_spec.rb
@@ -22,9 +22,8 @@ module Decidim
             it "can't vote" do
               sign_in initiative_with_user_extra_fields.author, scope: :user
               post :create, params: { initiative_slug: initiative_with_user_extra_fields.slug, format: :js }
-              parsed_response = JSON.parse(response.body)
               expect(response).to have_http_status(:unprocessable_entity)
-              expect(parsed_response.keys).to include("error")
+              expect(response.content_type).to eq("text/javascript")
             end
           end
 

--- a/decidim-initiatives/spec/forms/vote_form_spec.rb
+++ b/decidim-initiatives/spec/forms/vote_form_spec.rb
@@ -184,12 +184,14 @@ module Decidim
         subject { form.authorized_scopes }
 
         context "when the authorization is not valid" do
+          subject { form }
+
           before do
             authorization.granted_at = nil
             authorization.save!
           end
 
-          it { is_expected.to be_empty }
+          it { is_expected.not_to be_valid }
         end
 
         context "when an authorization is not needed" do


### PR DESCRIPTION
#### :tophat: What? Why?
#6143 modified the initiatives signing process. The process might now require an authorization to have a `:scope_id` key in the `metadata` field. This was not advertised anywhere and the process was failing silently.

This PR shows an alert to the user when such errors happen, so they at least know there's been an error.

Actually fixing the error depends on work on the individual authorizations in the installation.

#### :pushpin: Related Issues
- Related to #6143

#### Testing
Ensure CI is green