### PR TITLE
Filter Polling Stations by Polling Officers assigned/not assigned

### DIFF
--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -71,6 +71,11 @@ en:
   decidim:
     admin:
       filters:
+        officers_assigned_eq:
+          label: Officers
+          values:
+            assigned: Assigned
+            unassigned: Not assigned
         search_placeholder:
           ? title_or_address_or_manager_name_or_manager_email_or_manager_nickname_or_president_name_or_president_email_or_president_nickname_cont
           : Search %{collection} by title, address or officer name/email/nickname.

--- a/decidim-elections/spec/system/admin/admin_manages_voting_polling_stations_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_voting_polling_stations_spec.rb
@@ -70,6 +70,26 @@ describe "Admin manages polling stations", type: :system, serves_geocoding_autoc
           expect(page).not_to have_content(translated(polling_station.title))
         end
       end
+
+      context "when filtering by assigned/unussigned" do
+        let(:polling_station_with_president) { create(:polling_station, voting: voting) }
+        let(:polling_station_with_both) { create(:polling_station, voting: voting) }
+        let!(:polling_station_unassigned) { create(:polling_station, voting: voting) }
+
+        let!(:president) { create(:polling_officer, voting: voting, presided_polling_station: polling_station_with_president) }
+        let!(:manager) { create(:polling_officer, voting: voting, managed_polling_station: polling_station_with_both) }
+        let!(:other_president) { create(:polling_officer, voting: voting, presided_polling_station: polling_station_with_both) }
+
+        it_behaves_like "a filtered collection", options: "Officers", filter: "Assigned" do
+          let(:in_filter) { translated(polling_station_with_both.title) }
+          let(:not_in_filter) { translated(polling_station_with_president.title) }
+        end
+
+        it_behaves_like "a filtered collection", options: "Officers", filter: "Not assigned" do
+          let(:in_filter) { translated(polling_station_unassigned.title) }
+          let(:not_in_filter) { translated(polling_station_with_both.title) }
+        end
+      end
     end
 
     it "can add a polling station to a process", :serves_geocoding_autocomplete do


### PR DESCRIPTION
#### :tophat: What? Why?
This is yet another building block for #7105, #7106. More PRs will follow.

Adds a filter in the Polling Station index that allows filtering by Polling Officers assigned/not assigned (i.e. does the Polling Station have both president and manager(s) assigned?)

As in #7417, we want to filter on a combination of conditions, so the same workaround has been used.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to  #7105, #7106

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
https://user-images.githubusercontent.com/5033945/108227920-a9772180-713e-11eb-8dc6-529611afdff1.mov


:hearts: Thank you!
