### PR TITLE
Voting: show callout when Polling Stations miss Polling Officers

### DIFF
--- a/decidim-elections/app/assets/config/admin/decidim_votings_manifest.js
+++ b/decidim-elections/app/assets/config/admin/decidim_votings_manifest.js
@@ -1,3 +1,4 @@
 //= link decidim/votings/admin/polling_officers_form.js
 //= link decidim/votings/admin/polling_officers_picker.js
 //= link decidim/votings/admin/polling_stations_form.js
+//= link decidim/votings/admin/monitoring_committee_members_form.js

--- a/decidim-elections/app/models/decidim/votings/polling_station.rb
+++ b/decidim-elections/app/models/decidim/votings/polling_station.rb
@@ -40,6 +40,10 @@ module Decidim
 
       geocoded_by :address
 
+      def missing_officers?
+        polling_station_president.nil? || polling_station_managers.empty?
+      end
+
       private
 
       # Private: check if the president is in the same voting

--- a/decidim-elections/app/models/decidim/votings/voting.rb
+++ b/decidim-elections/app/models/decidim/votings/voting.rb
@@ -116,6 +116,10 @@ module Decidim
         !in_person_voting? && !has_elections?
       end
 
+      def polling_stations_with_missing_officers?
+        !online_voting? && polling_stations.any?(&:missing_officers?)
+      end
+
       def available_polling_officers
         polling_officers
           .where(presided_polling_station_id: nil)

--- a/decidim-elections/app/views/layouts/decidim/admin/voting.html.erb
+++ b/decidim-elections/app/views/layouts/decidim/admin/voting.html.erb
@@ -93,6 +93,11 @@
         <span class="callout-text"><%= t("votings.edit.add_election_component", scope: "decidim.votings.admin") %></span>
       </div>
     <% end %>
+    <% if current_participatory_space.polling_stations_with_missing_officers? %>
+      <div class="callout alert callout--full">
+        <span class="callout-text"><%= t("votings.edit.assign_missing_officers", scope: "decidim.votings.admin") %></span>
+      </div>
+    <% end %>
     <%= yield %>
   </div>
 <% end %>

--- a/decidim-elections/app/views/layouts/decidim/admin/voting.html.erb
+++ b/decidim-elections/app/views/layouts/decidim/admin/voting.html.erb
@@ -89,14 +89,10 @@
 
   <div class="voting-content">
     <% if current_participatory_space.needs_elections? %>
-      <div class="callout alert callout--full">
-        <span class="callout-text"><%= t("votings.edit.add_election_component", scope: "decidim.votings.admin") %></span>
-      </div>
+      <%= cell("decidim/announcement", t("votings.edit.add_election_component", scope: "decidim.votings.admin"), callout_class: "alert") %>
     <% end %>
     <% if current_participatory_space.polling_stations_with_missing_officers? %>
-      <div class="callout alert callout--full">
-        <span class="callout-text"><%= t("votings.edit.assign_missing_officers", scope: "decidim.votings.admin") %></span>
-      </div>
+      <%= cell("decidim/announcement", t("votings.edit.assign_missing_officers", scope: "decidim.votings.admin"), callout_class: "alert") %>
     <% end %>
     <%= yield %>
   </div>

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -757,6 +757,7 @@ en:
             success: Voting successfully created
           edit:
             add_election_component: You don't have any election configured for this voting. Please add it in the Components section
+            assign_missing_officers: There are Polling Stations without President and/or Managers. Please assign them from the Polling stations section
             update: Update
           form:
             select_a_voting_type: Please select a voting type

--- a/decidim-elections/spec/system/admin/admin_manages_voting_polling_stations_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_voting_polling_stations_spec.rb
@@ -39,6 +39,10 @@ describe "Admin manages polling stations", type: :system, serves_geocoding_autoc
         end
       end
 
+      it "has the callout warning of missing officers" do
+        expect(page).to have_admin_callout("There are Polling Stations without President and/or Managers")
+      end
+
       context "when searching by title" do
         let(:searched_station) { create(:polling_station, voting: voting) }
 
@@ -175,6 +179,7 @@ describe "Admin manages polling stations", type: :system, serves_geocoding_autoc
       end
 
       expect(page).to have_admin_callout("successfully")
+      expect(page).not_to have_admin_callout("There are Polling Stations without President and/or Managers")
 
       within "#polling_stations table" do
         expect(page).to have_text("Another polling station")

--- a/decidim-elections/spec/system/admin/admin_manages_voting_polling_stations_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_voting_polling_stations_spec.rb
@@ -40,7 +40,7 @@ describe "Admin manages polling stations", type: :system, serves_geocoding_autoc
       end
 
       it "has the callout warning of missing officers" do
-        expect(page).to have_admin_callout("There are Polling Stations without President and/or Managers")
+        expect(page).to have_text("There are Polling Stations without President and/or Managers")
       end
 
       context "when searching by title" do
@@ -179,7 +179,7 @@ describe "Admin manages polling stations", type: :system, serves_geocoding_autoc
       end
 
       expect(page).to have_admin_callout("successfully")
-      expect(page).not_to have_admin_callout("There are Polling Stations without President and/or Managers")
+      expect(page).not_to have_text("There are Polling Stations without President and/or Managers")
 
       within "#polling_stations table" do
         expect(page).to have_text("Another polling station")

--- a/decidim-elections/spec/system/admin/admin_manages_votings_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_votings_spec.rb
@@ -291,6 +291,8 @@ describe "Admin manages votings", type: :system do
       expect(page).to have_content("Landing Page")
       expect(page).to have_content("Components")
       expect(page).to have_content("Attachments")
+      expect(page).to have_content("Polling Stations")
+      expect(page).to have_content("Polling Officers")
       expect(page).to have_css(".is-active", text: "Information")
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
This is the final PR for #7105 and #7106 🎉 

To prevent the user from misconfiguring an in person/hybrid Voting, we show a callout whenever there are Polling Stations with no President or Manager(s) assigned.
This is similar to what happens when a Voting is online/hybrid and there is no Election component in the space (#7217)

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #7105
- Fixes #7106

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/5033945/108346630-e21b0780-71df-11eb-9606-faabca304091.png)


:hearts: Thank you!
