### PR TITLE
Ignore warning on CI when no artifacts to upload

### DIFF
--- a/.github/workflows/ci_accountability.yml
+++ b/.github/workflows/ci_accountability.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_accountability.yml
+++ b/.github/workflows/ci_accountability.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_admin.yml
+++ b/.github/workflows/ci_admin.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_admin.yml
+++ b/.github/workflows/ci_admin.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_assemblies.yml
+++ b/.github/workflows/ci_assemblies.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_assemblies.yml
+++ b/.github/workflows/ci_assemblies.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_blogs.yml
+++ b/.github/workflows/ci_blogs.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_blogs.yml
+++ b/.github/workflows/ci_blogs.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_budgets.yml
+++ b/.github/workflows/ci_budgets.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_budgets.yml
+++ b/.github/workflows/ci_budgets.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_comments.yml
+++ b/.github/workflows/ci_comments.yml
@@ -67,7 +67,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_comments.yml
+++ b/.github/workflows/ci_comments.yml
@@ -72,3 +72,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_conferences.yml
+++ b/.github/workflows/ci_conferences.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_conferences.yml
+++ b/.github/workflows/ci_conferences.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_consultations.yml
+++ b/.github/workflows/ci_consultations.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_consultations.yml
+++ b/.github/workflows/ci_consultations.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_core_system.yml
+++ b/.github/workflows/ci_core_system.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_core_system.yml
+++ b/.github/workflows/ci_core_system.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_core_unit.yml
+++ b/.github/workflows/ci_core_unit.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_core_unit.yml
+++ b/.github/workflows/ci_core_unit.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_debates.yml
+++ b/.github/workflows/ci_debates.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_debates.yml
+++ b/.github/workflows/ci_debates.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_elections.yml
+++ b/.github/workflows/ci_elections.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_elections.yml
+++ b/.github/workflows/ci_elections.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_forms.yml
+++ b/.github/workflows/ci_forms.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_forms.yml
+++ b/.github/workflows/ci_forms.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_initiatives.yml
+++ b/.github/workflows/ci_initiatives.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_initiatives.yml
+++ b/.github/workflows/ci_initiatives.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_meetings_system_admin.yml
+++ b/.github/workflows/ci_meetings_system_admin.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh decidim-meetings-system-admin $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_meetings_system_admin.yml
+++ b/.github/workflows/ci_meetings_system_admin.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_meetings_system_public.yml
+++ b/.github/workflows/ci_meetings_system_public.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh decidim-meetings-system-public $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_meetings_system_public.yml
+++ b/.github/workflows/ci_meetings_system_public.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_meetings_unit_tests.yml
+++ b/.github/workflows/ci_meetings_unit_tests.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_meetings_unit_tests.yml
+++ b/.github/workflows/ci_meetings_unit_tests.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_pages.yml
+++ b/.github/workflows/ci_pages.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_pages.yml
+++ b/.github/workflows/ci_pages.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_participatory_processes.yml
+++ b/.github/workflows/ci_participatory_processes.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_participatory_processes.yml
+++ b/.github/workflows/ci_participatory_processes.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_proposals_system_admin.yml
+++ b/.github/workflows/ci_proposals_system_admin.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh decidim-proposals-system-admin $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_proposals_system_admin.yml
+++ b/.github/workflows/ci_proposals_system_admin.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_proposals_system_public_1.yml
+++ b/.github/workflows/ci_proposals_system_public_1.yml
@@ -63,7 +63,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh decidim-proposals-system-public $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_proposals_system_public_1.yml
+++ b/.github/workflows/ci_proposals_system_public_1.yml
@@ -68,3 +68,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_proposals_system_public_2.yml
+++ b/.github/workflows/ci_proposals_system_public_2.yml
@@ -63,7 +63,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh decidim-proposals-system-public $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_proposals_system_public_2.yml
+++ b/.github/workflows/ci_proposals_system_public_2.yml
@@ -68,3 +68,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_proposals_unit_tests.yml
+++ b/.github/workflows/ci_proposals_unit_tests.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_proposals_unit_tests.yml
+++ b/.github/workflows/ci_proposals_unit_tests.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_sortitions.yml
+++ b/.github/workflows/ci_sortitions.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_sortitions.yml
+++ b/.github/workflows/ci_sortitions.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_surveys.yml
+++ b/.github/workflows/ci_surveys.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_surveys.yml
+++ b/.github/workflows/ci_surveys.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_system.yml
+++ b/.github/workflows/ci_system.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_system.yml
+++ b/.github/workflows/ci_system.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_templates.yml
+++ b/.github/workflows/ci_templates.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_templates.yml
+++ b/.github/workflows/ci_templates.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/ci_verifications.yml
+++ b/.github/workflows/ci_verifications.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_verifications.yml
+++ b/.github/workflows/ci_verifications.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
+          if-no-files-found: ignore


### PR DESCRIPTION
#### :tophat: What? Why?
When the CI is green and there's no screenshots to upload, the job includes a warning:

![image](https://user-images.githubusercontent.com/491891/108379362-21f4e580-7206-11eb-812b-71a3e9dc9b90.png)

This PR configures the `upload/artifacts` action to ignore the warning.

#### :pushpin: Related Issues
None

#### Testing
Ensure CI is green and no warnings about missing artifacts are raised.