### PR TITLE
Add default order by ID to API list queries

### DIFF
--- a/decidim-core/lib/decidim/api/functions/component_list_base.rb
+++ b/decidim-core/lib/decidim/api/functions/component_list_base.rb
@@ -65,7 +65,7 @@ module Decidim
       # GraphQ query. In that case, ordering by ID will be the secondary order
       # of the records.
       def add_default_order
-        @query.order(:id)
+        @query = @query.order(:id)
       end
 
       def filter_keys_by_settings(kwargs, component)

--- a/decidim-core/lib/decidim/api/functions/component_list_base.rb
+++ b/decidim-core/lib/decidim/api/functions/component_list_base.rb
@@ -40,6 +40,7 @@ module Decidim
         add_filter_keys(args[:filter])
         order = filter_keys_by_settings(args[:order].to_h, component)
         add_order_keys(order)
+        add_default_order
         @query
       end
 
@@ -51,6 +52,21 @@ module Decidim
       end
 
       private
+
+      # Add default order to the query in order to avoid random PostgreSQL
+      # ordering between the queries for different pages of results. If some of
+      # the queried records are updated or new records are added between the
+      # API calls to different pages of records, PostgreSQL can randomly change
+      # the order causing duplicates to appear or some records to disappear from
+      # the results unless the order of the records is explicitly defined.
+      #
+      # Note that this needs to be called as the last method before returning
+      # the query so that it won't affect the desired ordering specified in the
+      # GraphQ query. In that case, ordering by ID will be the secondary order
+      # of the records.
+      def add_default_order
+        @query.order(:id)
+      end
 
       def filter_keys_by_settings(kwargs, component)
         kwargs.select do |key, _value|

--- a/decidim-proposals/spec/types/proposals_type_spec.rb
+++ b/decidim-proposals/spec/types/proposals_type_spec.rb
@@ -21,7 +21,9 @@ module Decidim
 
         it "returns the published proposals" do
           ids = response["proposals"]["edges"].map { |edge| edge["node"]["id"] }
-          expect(ids).to include(*published_proposals.map(&:id).map(&:to_s))
+          # We expect the default order to be ascending by ID, so the array
+          # needs to match exactly the ordered IDs array.
+          expect(ids).to eq(published_proposals.map(&:id).sort.map(&:to_s))
           expect(ids).not_to include(*draft_proposals.map(&:id).map(&:to_s))
           expect(ids).not_to include(*other_proposals.map(&:id).map(&:to_s))
         end


### PR DESCRIPTION
#### :tophat: What? Why?
Currently the list queries in API are not working consistently because they do not define a default order for the query. This can be seen especially when you have multiple pages of records in the API.

PostgreSQL works in mysterious ways but recently we discovered that the default sort order can be randomly changed in case the records are updated. This affects the API list queries in case we have multiple pages of records. If the following happens, we can expect random ordering and possible duplicates between the different pages of the records:
- Have lots of proposals in the DB (multiple pages in the API)
- Call the API to list the proposals without a defined sort order, iterate over every page of the result
- During the API call iteration, run a script at the same time that randomly updates the proposals
- When you run these two simultaneously enough many times, you should expect to see duplicates in the results and possibly some "disappearing" items that have moved to another page during the record updates.

To fix this problem, let's add a default order by ID to the API list query. This won't affect the queries that have defined order through the GraphQL query, as it will be added at the last stage of the query when it becomes a secondary sort criteria in case there is already another sort criteria added before it.

#### Testing
- Create 1000 proposals
- Create a script to fetch all proposals from the API page by page
- Create a script that endlessly runs an update to the `decidim_proposals_proposals` table's records selected randomly. It does not matter what the update is (you could update e.g. the  `updated_at` column), as long as it's done against the main table being queried through the API.
- Start the API fetching script
- Start the script that randomly updates the records (running simultaneously with the API calls)

If the API fetching ends too fast, increase the amount of records in the DB. If you didn't receive any duplicates (or missing records), re-run the scripts as many times as you will bump into the issue.

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.