### PR TITLE
Feature blog post as user group

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/imports_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/imports_controller.rb
@@ -5,6 +5,7 @@ module Decidim
     # This controller allows admins to import resources from a file.
     class ImportsController < Decidim::Admin::ApplicationController
       include Decidim::ComponentPathHelper
+      helper UserGroupHelper
 
       def new
         enforce_permission_to :import, :component_data, component: current_component

--- a/decidim-admin/app/views/decidim/admin/imports/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/imports/new.html.erb
@@ -19,13 +19,7 @@
       </div>
       <% if current_organization.user_groups_enabled? && Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.any? %>
         <div class="field">
-          <%=
-            form.select(
-              :user_group_id,
-              user_groups.map { |g| [g.name, g.id] },
-              include_blank: current_user.name
-            )
-          %>
+          <%= user_group_select_field form, :user_group_id %>
         </div>
       <% end %>
       <div class="grid-x">

--- a/decidim-blogs/app/commands/decidim/blogs/admin/create_post.rb
+++ b/decidim-blogs/app/commands/decidim/blogs/admin/create_post.rb
@@ -32,7 +32,8 @@ module Decidim
             title: @form.title,
             body: @form.body,
             component: @form.current_component,
-            author: @current_user
+            author: @form.user_group
+            # author: @current_user
           }
 
           @post = Decidim.traceability.create!(

--- a/decidim-blogs/app/commands/decidim/blogs/admin/create_post.rb
+++ b/decidim-blogs/app/commands/decidim/blogs/admin/create_post.rb
@@ -32,8 +32,7 @@ module Decidim
             title: @form.title,
             body: @form.body,
             component: @form.current_component,
-            author: @form.user_group
-            # author: @current_user
+            author: @form.user_group || @current_user
           }
 
           @post = Decidim.traceability.create!(

--- a/decidim-blogs/app/controllers/decidim/blogs/admin/posts_controller.rb
+++ b/decidim-blogs/app/controllers/decidim/blogs/admin/posts_controller.rb
@@ -5,6 +5,8 @@ module Decidim
     module Admin
       # This controller allows the create or update a blog.
       class PostsController < Admin::ApplicationController
+        helper UserGroupHelper
+
         def new
           enforce_permission_to :create, :blogpost
           @form = form(PostForm).instance

--- a/decidim-blogs/app/forms/decidim/blogs/admin/post_form.rb
+++ b/decidim-blogs/app/forms/decidim/blogs/admin/post_form.rb
@@ -10,8 +10,17 @@ module Decidim
         translatable_attribute :title, String
         translatable_attribute :body, String
 
+        attribute :user_group_id, Integer
+
         validates :title, translatable_presence: true
         validates :body, translatable_presence: true
+
+        def user_group
+          @user_group ||= Decidim::UserGroup.find_by(
+            organization: current_organization,
+            id: user_group_id.to_i
+          )
+        end
       end
     end
   end

--- a/decidim-blogs/app/views/decidim/blogs/admin/posts/_form.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/admin/posts/_form.html.erb
@@ -3,6 +3,11 @@
     <h2 class="card-title"><%= title %></h2>
   </div>
   <div class="card-section">
+    <% if current_organization.user_groups_enabled? && Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.any? %>
+      <div class="field">
+        <%= user_group_select_field form, :user_group_id %>
+      </div>
+    <% end %>
     <div class="row column">
       <%= form.translated :text_field, :title, autofocus: true %>
     </div>

--- a/decidim-blogs/app/views/decidim/blogs/posts/_posts.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/posts/_posts.html.erb
@@ -9,7 +9,7 @@
           </h3>
           <% end %>
           <div class="card__author">
-            <%= cell "decidim/author", present(post.author), from: post %>
+            <%= cell "decidim/author", present(post.author), from: post, has_actions: true %>
           </div>
         </div>
         <%= decidim_sanitize post_description(post) %>

--- a/decidim-blogs/spec/shared/manage_posts_examples.rb
+++ b/decidim-blogs/spec/shared/manage_posts_examples.rb
@@ -83,4 +83,44 @@ shared_examples "manage posts" do
       end
     end
   end
+
+  context "when user is in user group" do
+    let(:user_group) { create :user_group, :confirmed, :verified, organization: organization }
+    let!(:membership) { create(:user_group_membership, user: user, user_group: user_group) }
+
+    it "can set user group as posts author", :slow do
+      find(".card-title a.button").click
+
+      select user_group.name, from: "post_user_group_id"
+
+      fill_in_i18n(
+        :post_title,
+        "#post-title-tabs",
+        en: "My post",
+        es: "Mi post",
+        ca: "El meu post"
+      )
+
+      fill_in_i18n_editor(
+        :post_body,
+        "#post-body-tabs",
+        en: "A description",
+        es: "Descripción",
+        ca: "Descripció"
+      )
+
+      within ".new_post" do
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_admin_callout("successfully")
+
+      within "table" do
+        expect(page).to have_content(user_group.name)
+        expect(page).to have_content("My post")
+        expect(page).to have_content("Post title 1")
+        expect(page).to have_content("Post title 2")
+      end
+    end
+  end
 end

--- a/decidim-blogs/spec/system/explore_posts_spec.rb
+++ b/decidim-blogs/spec/system/explore_posts_spec.rb
@@ -17,6 +17,18 @@ describe "Explore posts", type: :system do
       expect(page).to have_selector(".card--post", text: translated(old_post.title))
     end
 
+    it "shows comment counts" do
+      visit_component
+      expect(page).to have_selector('a[title="comments"]', text: "comment".pluralize(new_post.comments.count))
+      expect(page).to have_selector('a[title="comments"]', text: "comment".pluralize(old_post.comments.count))
+    end
+
+    it "shows endorsement counts" do
+      visit_component
+      expect(page).to have_selector('a[title="endorsements"]', text: "endorsement".pluralize(new_post.endorsements.count))
+      expect(page).to have_selector('a[title="endorsements"]', text: "endorsement".pluralize(old_post.endorsements.count))
+    end
+
     context "when paginating" do
       let(:collection_size) { 10 }
       let!(:collection) { create_list :post, collection_size, component: component }

--- a/decidim-core/app/cells/decidim/author_cell.rb
+++ b/decidim-core/app/cells/decidim/author_cell.rb
@@ -92,7 +92,7 @@ module Decidim
     end
 
     def actionable?
-      return false if options[:has_actions] == false
+      return options[:has_actions] if options.has_key?(:has_actions)
 
       withdrawable? || flaggable?
     end

--- a/decidim-core/app/controllers/concerns/decidim/amendments_controller.rb
+++ b/decidim-core/app/controllers/concerns/decidim/amendments_controller.rb
@@ -5,6 +5,7 @@ module Decidim
     include Decidim::ApplicationHelper
     include FormFactory
     helper Decidim::ResourceReferenceHelper
+    helper UserGroupHelper
 
     before_action :authenticate_user!
     helper_method :amendment, :amendable, :emendation, :similar_emendations

--- a/decidim-core/app/helpers/decidim/amendments_helper.rb
+++ b/decidim-core/app/helpers/decidim/amendments_helper.rb
@@ -107,16 +107,6 @@ module Decidim
       current_component.current_settings.amendment_promotion_enabled
     end
 
-    # Renders a UserGroup select field in a form.
-    def user_group_select_field(form, name)
-      user_groups = UserGroups::ManageableUserGroups.for(current_user).verified
-      form.select(name,
-                  user_groups.map { |g| [g.name, g.id] },
-                  selected: form.object.user_group_id.presence,
-                  include_blank: current_user.name,
-                  label: t("new.amendment_author", scope: "decidim.amendments"))
-    end
-
     # Return the translated attribute name to use as label in a form.
     # Returns a String.
     def amendments_form_fields_label(attribute)

--- a/decidim-core/app/helpers/decidim/user_group_helper.rb
+++ b/decidim-core/app/helpers/decidim/user_group_helper.rb
@@ -5,15 +5,17 @@ module Decidim
     # Renders a user_group select field in a form.
     # form - FormBuilder object
     # name - attribute user_group_id
+    # options - A hash used to modify the behavior of the select field.
     #
     # Returns nothing.
-    def user_group_select_field(form, name)
+    def user_group_select_field(form, name, options = {})
       user_groups = Decidim::UserGroups::ManageableUserGroups.for(current_user).verified
       form.select(
         name,
         user_groups.map { |g| [g.name, g.id] },
         selected: @form.user_group_id.presence,
-        include_blank: current_user.name
+        include_blank: current_user.name,
+        label: options.has_key?(:label) ? options[:label] : true
       )
     end
   end

--- a/decidim-core/app/helpers/decidim/user_group_helper.rb
+++ b/decidim-core/app/helpers/decidim/user_group_helper.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Decidim
+  module UserGroupHelper
+    # Renders a user_group select field in a form.
+    # form - FormBuilder object
+    # name - attribute user_group_id
+    #
+    # Returns nothing.
+    def user_group_select_field(form, name)
+      user_groups = Decidim::UserGroups::ManageableUserGroups.for(current_user).verified
+      form.select(
+        name,
+        user_groups.map { |g| [g.name, g.id] },
+        selected: @form.user_group_id.presence,
+        include_blank: current_user.name
+      )
+    end
+  end
+end

--- a/decidim-core/app/views/decidim/amendments/edit_draft.html.erb
+++ b/decidim-core/app/views/decidim/amendments/edit_draft.html.erb
@@ -12,7 +12,7 @@
 
             <% if current_organization.user_groups_enabled? && current_user.user_groups.verified.any? %>
               <div class="field">
-                <%= user_group_select_field form, :user_group_id %>
+                <%= user_group_select_field form, :user_group_id, label: t("new.amendment_author", scope: "decidim.amendments") %>
               </div>
             <% end %>
 

--- a/decidim-core/app/views/decidim/amendments/new.html.erb
+++ b/decidim-core/app/views/decidim/amendments/new.html.erb
@@ -14,7 +14,7 @@
 
             <% if current_organization.user_groups_enabled? && current_user.user_groups.verified.any? %>
               <div class="field">
-                <%= user_group_select_field form, :user_group_id %>
+                <%= user_group_select_field form, :user_group_id, label: t("new.amendment_author", scope: "decidim.amendments") %>
               </div>
             <% end %>
 

--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -7,6 +7,7 @@ module Decidim
       helper Decidim::WidgetUrlsHelper
       helper ProposalWizardHelper
       helper ParticipatoryTextsHelper
+      helper UserGroupHelper
       include Decidim::ApplicationHelper
       include Flaggable
       include Withdrawable

--- a/decidim-proposals/app/helpers/decidim/proposals/proposal_wizard_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/proposal_wizard_helper.rb
@@ -107,22 +107,6 @@ module Decidim
         translated_attribute(component_settings.try("proposal_wizard_#{step}_help_text")).present?
       end
 
-      # Renders a user_group select field in a form.
-      # form - FormBuilder object
-      # name - attribute user_group_id
-      #
-      # Returns nothing.
-      def user_group_select_field(form, name)
-        selected = @form.user_group_id.presence
-        user_groups = Decidim::UserGroups::ManageableUserGroups.for(current_user).verified
-        form.select(
-          name,
-          user_groups.map { |g| [g.name, g.id] },
-          selected: selected,
-          include_blank: current_user.name
-        )
-      end
-
       private
 
       def total_steps


### PR DESCRIPTION
#### :tophat: What? Why?
Right now the blog posts are always displayed as written by the user who created them. Some users would like to create the blog posts as one of the groups they belong to, similarly as you can create proposals as a group for instance. Also #6095 removed endorsement and comment counts from next to post title, doesn't seem intentionally(?) so this pull request would bring them back.

Note for devs: I created UserGroupHelper to core because there would have been four(4) similar user_group_select_field methods otherwise.

#### :pushpin: Related Issues
https://meta.decidim.org/processes/roadmap/f/122/proposals/16238

#### Testing
1. Sign in to admin panel
2. Join to user group 
3. Processes -> *pick process* -> Components -> Blog -> New post -> Select user group
4. Post

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![blogusergroupadmin](https://user-images.githubusercontent.com/19709320/108513393-3818a980-72cb-11eb-97b6-1a2865cea3b8.png)
![blogusergroup](https://user-images.githubusercontent.com/19709320/108513472-52528780-72cb-11eb-8809-efd09f86effc.png)

:hearts: Thank you!
