### PR TITLE
Ensure Rails is locked to 5.2.4.x series

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,7 @@ PATH
       premailer-rails (~> 1.10)
       rack (~> 2.2, >= 2.2.3)
       rack-attack (~> 6.0)
-      rails (>= 5.2.4.5, < 6.0.x)
+      rails (~> 5.2.4.5)
       rails-i18n (~> 5.0)
       rectify (~> 0.13.0)
       redis (~> 4.1)

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -59,7 +59,7 @@ Gem::Specification.new do |s|
   s.add_dependency "premailer-rails", "~> 1.10"
   s.add_dependency "rack", "~> 2.2", ">= 2.2.3"
   s.add_dependency "rack-attack", "~> 6.0"
-  s.add_dependency "rails", ">= 5.2.4.5", "< 6.0.x"
+  s.add_dependency "rails", "~> 5.2.4.5"
   s.add_dependency "rails-i18n", "~> 5.0"
   s.add_dependency "rectify", "~> 0.13.0"
   s.add_dependency "redis", "~> 4.1"

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -110,7 +110,7 @@ PATH
       premailer-rails (~> 1.10)
       rack (~> 2.2, >= 2.2.3)
       rack-attack (~> 6.0)
-      rails (>= 5.2.4.5, < 6.0.x)
+      rails (~> 5.2.4.5)
       rails-i18n (~> 5.0)
       rectify (~> 0.13.0)
       redis (~> 4.1)

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -110,7 +110,7 @@ PATH
       premailer-rails (~> 1.10)
       rack (~> 2.2, >= 2.2.3)
       rack-attack (~> 6.0)
-      rails (>= 5.2.4.5, < 6.0.x)
+      rails (~> 5.2.4.5)
       rails-i18n (~> 5.0)
       rectify (~> 0.13.0)
       redis (~> 4.1)


### PR DESCRIPTION
#### :tophat: What? Why?
While reviewing #7424, the generators CI job failed because it was trying to install  Rails `6.0.0.beta1` version instead of keeping to 5.2.4.5. 

This PR changes the version specs to force Rails stay on the 5.2.4.x series.

#### :pushpin: Related Issues
- Related to #7422

#### Testing
Ensure CI is green