### PR TITLE
Further default orders for the API

### DIFF
--- a/decidim-core/lib/decidim/api/functions/component_list.rb
+++ b/decidim-core/lib/decidim/api/functions/component_list.rb
@@ -16,6 +16,7 @@ module Decidim
     # use ComponentListBase instead
     class ComponentList
       include NeedsApiFilterAndOrder
+      include NeedsApiDefaultOrder
       attr_reader :model_class
 
       def initialize
@@ -29,6 +30,7 @@ module Decidim
         @query = @query.where(participatory_space: participatory_space).published
         add_filter_keys(args[:filter])
         add_order_keys(args[:order].to_h)
+        add_default_order
         @query
       end
     end

--- a/decidim-core/lib/decidim/api/functions/component_list_base.rb
+++ b/decidim-core/lib/decidim/api/functions/component_list_base.rb
@@ -27,6 +27,7 @@ module Decidim
     #
     class ComponentListBase
       include NeedsApiFilterAndOrder
+      include NeedsApiDefaultOrder
       attr_reader :model_class
 
       def initialize(model_class:)
@@ -52,21 +53,6 @@ module Decidim
       end
 
       private
-
-      # Add default order to the query in order to avoid random PostgreSQL
-      # ordering between the queries for different pages of results. If some of
-      # the queried records are updated or new records are added between the
-      # API calls to different pages of records, PostgreSQL can randomly change
-      # the order causing duplicates to appear or some records to disappear from
-      # the results unless the order of the records is explicitly defined.
-      #
-      # Note that this needs to be called as the last method before returning
-      # the query so that it won't affect the desired ordering specified in the
-      # GraphQ query. In that case, ordering by ID will be the secondary order
-      # of the records.
-      def add_default_order
-        @query = @query.order(:id)
-      end
 
       def filter_keys_by_settings(kwargs, component)
         kwargs.select do |key, _value|

--- a/decidim-core/lib/decidim/api/functions/needs_api_default_order.rb
+++ b/decidim-core/lib/decidim/api/functions/needs_api_default_order.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Core
+    module NeedsApiDefaultOrder
+      private
+
+      # Add default order to the query in order to avoid random PostgreSQL
+      # ordering between the queries for different pages of results. If some of
+      # the queried records are updated or new records are added between the
+      # API calls to different pages of records, PostgreSQL can randomly change
+      # the order causing duplicates to appear or some records to disappear from
+      # the results unless the order of the records is explicitly defined.
+      #
+      # Note that this needs to be called as the last method before returning
+      # the query so that it won't affect the desired ordering specified in the
+      # GraphQ query. In that case, ordering by ID will be the secondary order
+      # of the records.
+      def add_default_order
+        @query = @query.order(:id)
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/api/functions/participatory_space_list_base.rb
+++ b/decidim-core/lib/decidim/api/functions/participatory_space_list_base.rb
@@ -9,6 +9,7 @@ module Decidim
     # https://github.com/rmosolgo/graphql-ruby/blob/v1.6.8/guides/fields/function.md
     class ParticipatorySpaceListBase
       include NeedsApiFilterAndOrder
+      include NeedsApiDefaultOrder
       attr_reader :manifest
 
       def initialize(manifest:)
@@ -27,6 +28,7 @@ module Decidim
 
         add_filter_keys(args[:filter])
         add_order_keys(args[:order].to_h)
+        add_default_order
         @query
       end
     end

--- a/decidim-core/lib/decidim/core/api.rb
+++ b/decidim-core/lib/decidim/core/api.rb
@@ -6,6 +6,7 @@ module Decidim
     autoload :ComponentList, "decidim/api/functions/component_list"
     autoload :ComponentListBase, "decidim/api/functions/component_list_base"
     autoload :NeedsApiFilterAndOrder, "decidim/api/functions/needs_api_filter_and_order"
+    autoload :NeedsApiDefaultOrder, "decidim/api/functions/needs_api_default_order"
     autoload :ParticipatorySpaceFinderBase, "decidim/api/functions/participatory_space_finder_base"
     autoload :ParticipatorySpaceListBase, "decidim/api/functions/participatory_space_list_base"
     autoload :UserEntityFinder, "decidim/api/functions/user_entity_finder"

--- a/decidim-core/spec/types/participatory_space_type_spec.rb
+++ b/decidim-core/spec/types/participatory_space_type_spec.rb
@@ -32,7 +32,8 @@ module Decidim
         it "only includes the published components" do
           component_ids = response["components"].map { |c| c["id"].to_i }
 
-          expect(component_ids).to include(*published_components.map(&:id))
+          # Ordered by ID by default.
+          expect(component_ids.sort).to eq(published_components.map(&:id))
           expect(component_ids).not_to include(*unpublished_components.map(&:id))
         end
       end

--- a/decidim-participatory_processes/spec/lib/query_extensions_spec.rb
+++ b/decidim-participatory_processes/spec/lib/query_extensions_spec.rb
@@ -16,6 +16,9 @@ module Decidim
         let(:query) { %({ participatoryProcesses { id }}) }
 
         it "returns all the processes" do
+          ids = response["participatoryProcesses"].map { |pr| pr["id"] }
+          # Result should be sorted by ID by default.
+          expect(ids).to eq([process1, process2].map(&:id).sort.map(&:to_s))
           expect(response["participatoryProcesses"]).to include("id" => process1.id.to_s)
           expect(response["participatoryProcesses"]).to include("id" => process2.id.to_s)
           expect(response["participatoryProcesses"]).not_to include("id" => process3.id.to_s)

--- a/decidim-participatory_processes/spec/lib/query_extensions_spec.rb
+++ b/decidim-participatory_processes/spec/lib/query_extensions_spec.rb
@@ -47,42 +47,6 @@ module Decidim
         end
       end
 
-      describe "participatoryProcesses" do
-        let!(:process1) { create(:participatory_process, organization: current_organization) }
-        let!(:process2) { create(:participatory_process, organization: current_organization) }
-        let!(:process3) { create(:participatory_process) }
-
-        let(:query) { %({ participatoryProcesses { id }}) }
-
-        it "returns all the processes" do
-          expect(response["participatoryProcesses"]).to include("id" => process1.id.to_s)
-          expect(response["participatoryProcesses"]).to include("id" => process2.id.to_s)
-          expect(response["participatoryProcesses"]).not_to include("id" => process3.id.to_s)
-        end
-      end
-
-      describe "participatoryProcess" do
-        let(:query) { %({ participatoryProcess(id: \"#{id}\") { id }}) }
-
-        context "with a participatory process that belongs to the current organization" do
-          let!(:process) { create(:participatory_process, organization: current_organization) }
-          let(:id) { process.id }
-
-          it "returns the process" do
-            expect(response["participatoryProcess"]).to eq("id" => process.id.to_s)
-          end
-        end
-
-        context "with a participatory process of another organization" do
-          let!(:process) { create(:participatory_process) }
-          let(:id) { process.id }
-
-          it "returns nil" do
-            expect(response["participatoryProcess"]).to be_nil
-          end
-        end
-      end
-
       describe "participatoryProcessGroups" do
         let!(:group1) { create(:participatory_process_group, :with_participatory_processes, organization: current_organization) }
         let!(:group2) { create(:participatory_process_group, :with_participatory_processes, organization: current_organization) }


### PR DESCRIPTION
#### :tophat: What? Why?
- Move the API default order adding implemented in #7424 to its own module
- Apply the default order also for the `Decidim::Core::ComponentList` class
- Apply the default order also for the `Decidim::Core::ParticipatorySpaceListBase` class
- Update the related tests to expect the correct order

This also removes redundant tests from [`decidim-participatory_processes/spec/lib/query_extensions_spec.rb `](https://github.com/decidim/decidim/blob/ff3e693e208431769b74e2eccb29e7e1acd3cf8a/decidim-participatory_processes/spec/lib/query_extensions_spec.rb):
- `describe "participatoryProcesses" do`
  * https://github.com/decidim/decidim/blob/ff3e693e208431769b74e2eccb29e7e1acd3cf8a/decidim-participatory_processes/spec/lib/query_extensions_spec.rb#L11-L23
  * https://github.com/decidim/decidim/blob/ff3e693e208431769b74e2eccb29e7e1acd3cf8a/decidim-participatory_processes/spec/lib/query_extensions_spec.rb#L47-L59
- `describe "participatoryProcess" do`
  * https://github.com/decidim/decidim/blob/ff3e693e208431769b74e2eccb29e7e1acd3cf8a/decidim-participatory_processes/spec/lib/query_extensions_spec.rb#L25-L45
  * https://github.com/decidim/decidim/blob/ff3e693e208431769b74e2eccb29e7e1acd3cf8a/decidim-participatory_processes/spec/lib/query_extensions_spec.rb#L61-L81

We don't need the same test twice.

#### :pushpin: Related Issues
- Related to #7424

#### Testing
See #7424.

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.