### PR TITLE
Fix random order inconsistencies

### DIFF
--- a/decidim-core/app/controllers/concerns/decidim/orderable.rb
+++ b/decidim-core/app/controllers/concerns/decidim/orderable.rb
@@ -29,7 +29,9 @@ module Decidim
       # Returns: A random float number between -1 and 1 to be used as a
       # random seed at the database.
       def random_seed
-        @random_seed ||= session.fetch(:random_seed, (rand * 2 - 1)).to_f
+        @random_seed ||= begin
+          session[:random_seed] ||= rand * 2 - 1
+        end.to_f
       end
     end
   end

--- a/decidim-core/lib/decidim/randomable.rb
+++ b/decidim-core/lib/decidim/randomable.rb
@@ -12,7 +12,12 @@ module Decidim
       def order_randomly(seed)
         transaction do
           connection.execute("SELECT setseed(#{connection.quote(seed)})")
-          order(Arel.sql("RANDOM()")).load
+          # Include the record IDs as a base number for the order calculation
+          # in order to avoid PostgreSQL random ordering when the records are
+          # updated. PostgreSQL can randomly change the base ordering in case
+          # the records are changed which is not desired as we want consistent
+          # orders for the records.
+          order(arel_table[primary_key] * Arel.sql("RANDOM()")).load
         end
       end
     end

--- a/decidim-core/spec/controllers/concerns/orderable.rb
+++ b/decidim-core/spec/controllers/concerns/orderable.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe ActionController::Base, type: :controller do
+    let(:view) { controller.view_context }
+
+    controller do
+      include Decidim::Orderable
+
+      def available_orders
+        %w(random other)
+      end
+    end
+
+    describe "#order" do
+      let(:params) { {} }
+
+      before do
+        allow(controller).to receive(:params).and_return(params)
+      end
+
+      it "returns random order by default without the order parameter" do
+        expect(view.order).to eq("random")
+      end
+
+      context "with random order given through params" do
+        let(:params) { { order: "random" } }
+
+        it "returns random order" do
+          expect(view.order).to eq("random")
+        end
+      end
+
+      context "with other order given through params" do
+        let(:params) { { order: "other" } }
+
+        it "returns other order" do
+          expect(view.order).to eq("other")
+        end
+      end
+    end
+
+    describe "#random_seed" do
+      it "creates a new random seed between -1..1 when not defined" do
+        expect(view.random_seed).to be_a(Float)
+        expect(view.random_seed).to be_between(-1, 1)
+      end
+
+      it "returns the same random seed for concecutive calls" do
+        first_seed = view.random_seed
+        expect(view.random_seed).to be(first_seed)
+      end
+
+      context "when the session defines the random seed" do
+        let(:session) { { random_seed: test_seed } }
+        let(:test_seed) { 0.123456789 }
+
+        before do
+          allow(controller).to receive(:session).and_return(session)
+        end
+
+        it "returns the random seed from the session variable" do
+          expect(view.random_seed).to be(test_seed)
+        end
+
+        context "when the session variable is set as string" do
+          let(:session) { { random_seed: test_seed.to_s } }
+
+          it "returns the random seed as float from the session variable" do
+            expect(view.random_seed).to be_a(Float)
+            expect(view.random_seed).to be(test_seed)
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/controllers/decidim/proposals/proposals_controller_spec.rb
+++ b/decidim-proposals/spec/controllers/decidim/proposals/proposals_controller_spec.rb
@@ -30,7 +30,16 @@ module Decidim
             get :index
             expect(response).to have_http_status(:ok)
             expect(subject).to render_template(:index)
-            expect(assigns(:proposals).order_values).to eq(["RANDOM()"])
+            expect(assigns(:proposals).order_values).to eq(
+              [
+                Decidim::Proposals::Proposal.arel_table[
+                  Decidim::Proposals::Proposal.primary_key
+                ] * Arel.sql("RANDOM()")
+              ]
+            )
+            expect(assigns(:proposals).order_values.map(&:to_sql)).to eq(
+              ["\"decidim_proposals_proposals\".\"id\" * RANDOM()"]
+            )
           end
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?
There seems to be a consistent issue over the random ordering of records that has had multiple attempts to be fixed in the past (see related issues). The issue still persist.

There seems to be two separate issues related to this as far as I could identify:
1. The random seed is not properly stored in the session variable as I believe was the intention
2. The random order calculation at PostgreSQL can be inconsistent in case any of the the ordered table's records are changed during the user session as explained at #7424.

This fixes both of these issues:
1. The first issue is quite trivial, the value never got stored into the session bag, so fix that.
2. The second issue adds the record IDs as the "base" numbers for the random ordering which should provide more consistent results.

#### :pushpin: Related Issues
- Related to https://meta.decidim.org/processes/bug-report/f/210/proposals/14295
- Related to https://meta.decidim.org/processes/roadmap/f/122/proposals/15830
- Related to #5019, #5376, #7424
- (hopefully) Fixes https://meta.decidim.org/processes/roadmap/f/122/proposals/15830

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.