### PR TITLE
Polling Officer Zone

### DIFF
--- a/decidim-elections/app/commands/decidim/votings/admin/manage_polling_station.rb
+++ b/decidim-elections/app/commands/decidim/votings/admin/manage_polling_station.rb
@@ -17,6 +17,7 @@ module Decidim
           return if president_id.nil?
 
           assign_president(president_id, polling_station)
+          notify_officer(president_id, polling_station.voting)
         end
 
         def unassign_president(polling_station)
@@ -24,26 +25,38 @@ module Decidim
         end
 
         def assign_president(president_id, polling_station)
-          polling_station_president = PollingOfficer.find_by(id: president_id)
-          polling_station_president.presided_polling_station = polling_station
-          polling_station_president.save!
+          polling_officer_for(president_id).update(presided_polling_station: polling_station)
         end
 
         def manage_managers(polling_station, managers_ids)
-          unassign_all_managers(polling_station)
-          assign_new_managers(polling_station, managers_ids)
+          unassign_managers(polling_station.polling_station_manager_ids - managers_ids)
+          assign_managers(polling_station, managers_ids - polling_station.polling_station_manager_ids)
         end
 
-        def unassign_all_managers(polling_station)
-          polling_station.polling_station_managers.each { |manager| manager.update(managed_polling_station: nil) }
+        def unassign_managers(managers_ids)
+          managers_ids.each { |manager_id| polling_officer_for(manager_id).update(managed_polling_station: nil) }
         end
 
-        def assign_new_managers(polling_station, managers_ids)
+        def assign_managers(polling_station, managers_ids)
           managers_ids.each do |manager_id|
-            polling_station_manager = PollingOfficer.find_by(id: manager_id)
-            polling_station_manager.managed_polling_station = polling_station
-            polling_station_manager.save!
+            polling_officer_for(manager_id).update(managed_polling_station: polling_station)
+            notify_officer(manager_id, polling_station.voting)
           end
+        end
+
+        def notify_officer(polling_officer_id, voting)
+          Decidim::EventsManager.publish(
+            event: "decidim.events.votings.polling_officers.polling_station_assigned",
+            event_class: ::Decidim::Votings::PollingOfficers::PollingStationAssignedEvent,
+            resource: voting,
+            affected_users: [polling_officer_for(polling_officer_id).user],
+            followers: [],
+            extra: { polling_officer_id: polling_officer_id }
+          )
+        end
+
+        def polling_officer_for(polling_officer_id)
+          PollingOfficer.find_by(id: polling_officer_id)
         end
       end
     end

--- a/decidim-elections/app/controllers/decidim/votings/polling_officer_zone/application_controller.rb
+++ b/decidim-elections/app/controllers/decidim/votings/polling_officer_zone/application_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Votings
+    module PollingOfficerZone
+      # This controller is the abstract class from which all polling_officer_zone
+      # controllers in their public engines should inherit from.
+
+      class ApplicationController < ::Decidim::ApplicationController
+        include Decidim::UserProfile
+
+        helper_method :polling_officer
+
+        private
+
+        def polling_officer
+          @polling_officer ||= Decidim::Votings::PollingOfficer.for(current_user)
+        end
+
+        def permission_scope
+          :polling_officer_zone
+        end
+
+        def permission_class_chain
+          [
+            Decidim::Votings::Permissions,
+            Decidim::Permissions
+          ]
+        end
+      end
+    end
+  end
+end

--- a/decidim-elections/app/controllers/decidim/votings/polling_officer_zone/application_controller.rb
+++ b/decidim-elections/app/controllers/decidim/votings/polling_officer_zone/application_controller.rb
@@ -9,12 +9,12 @@ module Decidim
       class ApplicationController < ::Decidim::ApplicationController
         include Decidim::UserProfile
 
-        helper_method :polling_officer
+        helper_method :polling_officers
 
         private
 
-        def polling_officer
-          @polling_officer ||= Decidim::Votings::PollingOfficer.for(current_user)
+        def polling_officers
+          @polling_officers ||= Decidim::Votings::PollingOfficer.for(current_user)
         end
 
         def permission_scope

--- a/decidim-elections/app/controllers/decidim/votings/polling_officer_zone/elections_controller.rb
+++ b/decidim-elections/app/controllers/decidim/votings/polling_officer_zone/elections_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Votings
+    module PollingOfficerZone
+      # Space to manage the elections for a Polling Station Officer
+      class PollingStationsController < Decidim::Votings::PollingOfficerZone::ApplicationController
+        helper_method :polling_station
+
+        def show
+          enforce_permission_to :view, :polling_station, polling_officer: polling_officer
+        end
+
+        private
+
+        def polling_station
+          @polling_station ||= Decidim::Votings::PollingStation.find(params[:polling_station_id])
+        end
+      end
+    end
+  end
+end

--- a/decidim-elections/app/controllers/decidim/votings/polling_officer_zone/polling_officers_controller.rb
+++ b/decidim-elections/app/controllers/decidim/votings/polling_officer_zone/polling_officers_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Votings
+    module PollingOfficerZone
+      # Exposes the polling officer zone for polling officer users
+      class PollingOfficersController < Decidim::Votings::PollingOfficerZone::ApplicationController
+        def show
+          enforce_permission_to :view, :polling_officer, polling_officer: polling_officer
+        end
+      end
+    end
+  end
+end

--- a/decidim-elections/app/controllers/decidim/votings/polling_officer_zone/polling_officers_controller.rb
+++ b/decidim-elections/app/controllers/decidim/votings/polling_officer_zone/polling_officers_controller.rb
@@ -5,8 +5,11 @@ module Decidim
     module PollingOfficerZone
       # Exposes the polling officer zone for polling officer users
       class PollingOfficersController < Decidim::Votings::PollingOfficerZone::ApplicationController
+        helper Decidim::Admin::IconLinkHelper
+        helper_method :polling_stations
+
         def show
-          enforce_permission_to :view, :polling_officer, polling_officer: polling_officer
+          enforce_permission_to :view, :polling_officers, polling_officers: polling_officers
         end
       end
     end

--- a/decidim-elections/app/controllers/decidim/votings/polling_officer_zone/polling_stations_controller.rb
+++ b/decidim-elections/app/controllers/decidim/votings/polling_officer_zone/polling_stations_controller.rb
@@ -8,13 +8,13 @@ module Decidim
         helper_method :polling_station
 
         def show
-          enforce_permission_to :view, :polling_station, polling_officer: polling_officer
+          enforce_permission_to :view, :polling_station, polling_officers: polling_officers
         end
 
         private
 
         def polling_station
-          @polling_station ||= Decidim::Votings::PollingStation.find(params[:polling_station_id])
+          @polling_station ||= Decidim::Votings::PollingStation.find(params[:id])
         end
       end
     end

--- a/decidim-elections/app/events/decidim/votings/polling_officers/polling_station_assigned_event.rb
+++ b/decidim-elections/app/events/decidim/votings/polling_officers/polling_station_assigned_event.rb
@@ -30,7 +30,13 @@ module Decidim
         end
 
         def polling_station
-          @polling_station ||= Decidim::Votings::PollingStation.find_by(id: extra[:polling_station_id])
+          @polling_station ||=
+            case polling_officer.role
+            when :president
+              polling_officer.presided_polling_station
+            when :manager
+              polling_officer.managed_polling_station
+            end
         end
       end
     end

--- a/decidim-elections/app/events/decidim/votings/polling_officers/polling_station_assigned_event.rb
+++ b/decidim-elections/app/events/decidim/votings/polling_officers/polling_station_assigned_event.rb
@@ -1,0 +1,38 @@
+# frozen-string_literal: true
+
+module Decidim
+  module Votings
+    module PollingOfficers
+      class PollingStationAssignedEvent < Decidim::Events::SimpleEvent
+        # This event sends a notification when a polling station is assigned to a polling officer
+
+        delegate :organization, to: :user, prefix: false
+        delegate :url_helpers, to: "Decidim::Core::Engine.routes"
+
+        i18n_attributes :polling_station_name, :polling_officer_zone_url, :role
+
+        def polling_station_name
+          @polling_station_name ||= translated_attribute(polling_station.title)
+        end
+
+        def polling_officer_zone_url
+          url_helpers.decidim_votings_polling_officer_zone_url(host: organization.host)
+        end
+
+        def role
+          I18n.t(polling_officer.role, scope: "decidim.votings.polling_officers.roles")
+        end
+
+        private
+
+        def polling_officer
+          @polling_officer ||= Decidim::Votings::PollingOfficer.find_by(id: extra[:polling_officer_id])
+        end
+
+        def polling_station
+          @polling_station ||= Decidim::Votings::PollingStation.find_by(id: extra[:polling_station_id])
+        end
+      end
+    end
+  end
+end

--- a/decidim-elections/app/models/decidim/votings/polling_officer.rb
+++ b/decidim-elections/app/models/decidim/votings/polling_officer.rb
@@ -42,7 +42,18 @@ module Decidim
       end
 
       def self.for(user)
-        find_by(user: user)
+        where(user: user)
+      end
+
+      def role
+        return :president if presided_polling_station.present?
+        return :manager if managed_polling_station.present?
+
+        :unassigned
+      end
+
+      def polling_station
+        presided_polling_station || managed_polling_station
       end
 
       private

--- a/decidim-elections/app/models/decidim/votings/polling_officer.rb
+++ b/decidim-elections/app/models/decidim/votings/polling_officer.rb
@@ -37,6 +37,14 @@ module Decidim
         end
       end
 
+      def self.polling_officer?(user)
+        exists?(user: user)
+      end
+
+      def self.for(user)
+        find_by(user: user)
+      end
+
       private
 
       # Private: check if the voting and the user have the same organization

--- a/decidim-elections/app/permissions/decidim/votings/permissions.rb
+++ b/decidim-elections/app/permissions/decidim/votings/permissions.rb
@@ -10,6 +10,9 @@ module Decidim
 
         return Decidim::Votings::Admin::Permissions.new(user, permission_action, context).permissions if permission_action.scope == :admin
 
+        # Delegate the polling_officer_zone permission checks to the polling officer zone permissions class
+        return Decidim::Votings::PollingOfficerZone::Permissions.new(user, permission_action, context).permissions if permission_action.scope == :polling_officer_zone
+
         permission_action
       end
 

--- a/decidim-elections/app/permissions/decidim/votings/polling_officer_zone/permissions.rb
+++ b/decidim-elections/app/permissions/decidim/votings/polling_officer_zone/permissions.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Votings
+    module PollingOfficerZone
+      class Permissions < Decidim::DefaultPermissions
+        def permissions
+          return permission_action unless permission_action.scope == :polling_officer_zone
+
+          case permission_action.subject
+          when :polling_officer, :polling_station
+            toggle_allow(polling_officer_for_user?) if [:view].member?(permission_action.action)
+          when :user
+            allow! if permission_action.action == :update_profile
+          end
+
+          permission_action
+        end
+
+        private
+
+        def polling_officer_for_user?
+          polling_officer && polling_officer.user == user
+        end
+
+        def polling_officer
+          @polling_officer ||= context.fetch(:polling_officer, nil)
+        end
+      end
+    end
+  end
+end

--- a/decidim-elections/app/permissions/decidim/votings/polling_officer_zone/permissions.rb
+++ b/decidim-elections/app/permissions/decidim/votings/polling_officer_zone/permissions.rb
@@ -8,8 +8,8 @@ module Decidim
           return permission_action unless permission_action.scope == :polling_officer_zone
 
           case permission_action.subject
-          when :polling_officer, :polling_station
-            toggle_allow(polling_officer_for_user?) if [:view].member?(permission_action.action)
+          when :polling_officers, :polling_station
+            toggle_allow(polling_officers_for_user?) if [:view].member?(permission_action.action)
           when :user
             allow! if permission_action.action == :update_profile
           end
@@ -19,12 +19,12 @@ module Decidim
 
         private
 
-        def polling_officer_for_user?
-          polling_officer && polling_officer.user == user
+        def polling_officers_for_user?
+          polling_officers.any? && polling_officers.all? { |polling_officer| polling_officer.user == user }
         end
 
-        def polling_officer
-          @polling_officer ||= context.fetch(:polling_officer, nil)
+        def polling_officers
+          @polling_officers ||= context.fetch(:polling_officers, [])
         end
       end
     end

--- a/decidim-elections/app/presenters/decidim/votings/polling_station_presenter.rb
+++ b/decidim-elections/app/presenters/decidim/votings/polling_station_presenter.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Votings
+    #
+    # Decorator for polling station
+    #
+    class PollingStationPresenter < SimpleDelegator
+      include Decidim::SanitizeHelper
+      include Decidim::TranslatableAttributes
+
+      def polling_station
+        __getobj__
+      end
+
+      def title
+        content = translated_attribute(polling_station.title)
+        decidim_html_escape(content)
+      end
+
+      def address
+        content = translated_attribute(polling_station.address)
+        decidim_html_escape(content)
+      end
+    end
+  end
+end

--- a/decidim-elections/app/presenters/decidim/votings/voting_presenter.rb
+++ b/decidim-elections/app/presenters/decidim/votings/voting_presenter.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Votings
+    #
+    # Decorator for voting
+    #
+    class VotingPresenter < SimpleDelegator
+      include Decidim::SanitizeHelper
+      include Decidim::TranslatableAttributes
+
+      def voting
+        __getobj__
+      end
+
+      def title
+        content = translated_attribute(voting.title)
+        decidim_html_escape(content)
+      end
+    end
+  end
+end

--- a/decidim-elections/app/views/decidim/votings/polling_officer_zone/polling_officers/show.html.erb
+++ b/decidim-elections/app/views/decidim/votings/polling_officer_zone/polling_officers/show.html.erb
@@ -1,0 +1,3 @@
+<div class="polling_officer_zone">
+  <%= polling_officer.name %>
+</div>

--- a/decidim-elections/app/views/decidim/votings/polling_officer_zone/polling_officers/show.html.erb
+++ b/decidim-elections/app/views/decidim/votings/polling_officer_zone/polling_officers/show.html.erb
@@ -25,7 +25,8 @@
               <td><%= t(polling_officer.role, scope: "decidim.votings.polling_officers.roles") %></td>
               <td class="table-list__actions">
                 <% if polling_officer.polling_station.present? %>
-                  <%= icon_link_to "eye", polling_officers_polling_station_path(polling_officer, polling_officer.polling_station), t(".actions.manage"), class: "action-icon--manage" %>
+                  <%= icon_link_to "person", polling_officers_polling_station_path(polling_officer, polling_officer.polling_station), t(".actions.identify_person"), class: "action-icon--manage" %>
+                  <%= icon_link_to "envelope-open", polling_officers_polling_station_path(polling_officer, polling_officer.polling_station), t(".actions.count_votes"), class: "action-icon--manage" %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-elections/app/views/decidim/votings/polling_officer_zone/polling_officers/show.html.erb
+++ b/decidim-elections/app/views/decidim/votings/polling_officer_zone/polling_officers/show.html.erb
@@ -1,3 +1,41 @@
 <div class="polling_officer_zone">
-  <%= polling_officer.name %>
+  <div class="callout success">
+    <p><%= t(".polling_officer_role_description") %></p>
+  </div>
+
+  <h2><%= t(".polling_stations.title") %></h2>
+  <% if polling_officers.any? %>
+    <div class="table-scroll">
+      <table class="table-list">
+        <thead>
+          <tr>
+            <th><%= t(".polling_stations.list.voting") %></th>
+            <th><%= t(".polling_stations.list.name") %></th>
+            <th><%= t(".polling_stations.list.address") %></th>
+            <th><%= t(".polling_stations.list.role") %></th>
+            <th><%= t(".polling_stations.list.actions") %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% polling_officers.each do |polling_officer| %>
+            <tr>
+              <td><%= present(polling_officer.voting).title %></td>
+              <td><%= present(polling_officer.polling_station).title %></td>
+              <td><%= present(polling_officer.polling_station).address %></td>
+              <td><%= t(polling_officer.role, scope: "decidim.votings.polling_officers.roles") %></td>
+              <td class="table-list__actions">
+                <% if polling_officer.polling_station.present? %>
+                  <%= icon_link_to "eye", polling_officers_polling_station_path(polling_officer, polling_officer.polling_station), t(".actions.manage"), class: "action-icon--manage" %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <div class="callout warning">
+      <%= t(".polling_stations.no_polling_stations") %>
+    </div>
+  <% end %>
 </div>

--- a/decidim-elections/app/views/decidim/votings/polling_officer_zone/polling_stations/show.html.erb
+++ b/decidim-elections/app/views/decidim/votings/polling_officer_zone/polling_stations/show.html.erb
@@ -1,0 +1,1 @@
+<h2><%= present(polling_station).title %></h2>

--- a/decidim-elections/app/views/layouts/decidim/admin/voting.html.erb
+++ b/decidim-elections/app/views/layouts/decidim/admin/voting.html.erb
@@ -76,6 +76,8 @@
           </li>
         <% end %>
       <% end %>
+
+      <%= Decidim::Admin.view_hooks.render(:admin_secondary_nav, deep_dup) %>
     </ul>
   </div>
 <% end %>

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -491,6 +491,7 @@ en:
             not_supported_browser_description: It looks like you are using a web browser that can't be used to act as a Trustee. Make sure you're using the most recent version of your browser, or try using any of the most popular browsers to be able to complete your Trustee tasks.
             not_supported_browser_title: Upgrade browser to act as a Trustee
             trustee_role_description: You have been assigned to act as a Trustee in some of the elections celebrated in this platform.
+            polling_officer_role_description: You have been assigned to act as a Polling Station Officer (President or Manager) in some of the elections celebrated in this platform.
           update:
             success: Your identification public key was successfully stored.
       votes:
@@ -799,13 +800,31 @@ en:
             votings_button_title: Link to the Votings page displaying all the votings
       polling_officer_zone:
         menu:
-          polling_officer_zone: Polling officer zone
+          polling_officer_zone: Polling Officer zone
+        polling_officers:
+          show:
+            actions:
+              manage: Manage
+            polling_officer_role_description: You have been assigned to act as a Polling Station Officer (President or Manager) in some of the elections celebrated in this platform.
+            polling_stations:
+              list:
+                actions: Actions
+                address: Address
+                name: Name
+                role: Your role
+                voting: Voting
+              no_polling_stations: You are not assigned to any Polling Station yet.
+              title: Polling Stations
       polling_officers:
         actions:
           confirm_destroy: Are you sure?
           destroy: Delete
           new: New
           title: Actions
+        roles:
+          manager: Manager
+          president: President
+          unassigned: Unassigned
       polling_stations:
         actions:
           confirm_destroy: Are you sure?

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -804,7 +804,8 @@ en:
         polling_officers:
           show:
             actions:
-              manage: Manage
+              count_votes: Count the votes in the ballot box
+              identify_person: Identify and verify a person
             polling_officer_role_description: You have been assigned to act as a Polling Station Officer (President or Manager) in some of the elections celebrated in this platform.
             polling_stations:
               list:

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -491,7 +491,6 @@ en:
             not_supported_browser_description: It looks like you are using a web browser that can't be used to act as a Trustee. Make sure you're using the most recent version of your browser, or try using any of the most popular browsers to be able to complete your Trustee tasks.
             not_supported_browser_title: Upgrade browser to act as a Trustee
             trustee_role_description: You have been assigned to act as a Trustee in some of the elections celebrated in this platform.
-            polling_officer_role_description: You have been assigned to act as a Polling Station Officer (President or Manager) in some of the elections celebrated in this platform.
           update:
             success: Your identification public key was successfully stored.
       votes:

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -797,6 +797,9 @@ en:
             active_votings: Active votings
             see_all_votings: See all votings
             votings_button_title: Link to the Votings page displaying all the votings
+      polling_officer_zone:
+        menu:
+          polling_officer_zone: Polling officer zone
       polling_officers:
         actions:
           confirm_destroy: Are you sure?

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -587,6 +587,13 @@ en:
             email_outro: You have received this notification because you've voted for the %{resource_name} election.
             email_subject: Your vote for %{resource_name} was accepted.
             notification_title: 'Your vote was accepted. Verify your vote <a href="%{verify_url}">here</a> using your vote token: %{encrypted_vote_hash}'
+      votings:
+        polling_officers:
+          polling_station_assigned:
+            email_intro: You have been assigned as %{role} of the Polling Station %{polling_station_name} in <a href="%{resource_url}">%{resource_title}</a>. You can manage the Polling Station from the dedicated <a href="%{polling_officer_zone_url}">Polling Officer Zone</a>.
+            email_outro: You have received this notification because you have been assigned as %{role} of %{polling_station_name}.
+            email_subject: You are %{role} of the Polling Station %{polling_station_name}.
+            notification_title: You are %{role} of the Polling Station %{polling_station_name} in the voting <a href="%{resource_path}">%{resource_title}</a>.
     help:
       participatory_spaces:
         votings:

--- a/decidim-elections/lib/decidim/votings.rb
+++ b/decidim-elections/lib/decidim/votings.rb
@@ -2,8 +2,10 @@
 
 require "decidim/votings/admin"
 require "decidim/votings/api"
+require "decidim/votings/polling_officer_zone"
 require "decidim/votings/engine"
 require "decidim/votings/admin_engine"
+require "decidim/votings/polling_officer_zone_engine"
 require "decidim/votings/participatory_space"
 
 module Decidim

--- a/decidim-elections/lib/decidim/votings/participatory_space.rb
+++ b/decidim-elections/lib/decidim/votings/participatory_space.rb
@@ -74,3 +74,9 @@ Decidim.register_participatory_space(:votings) do |participatory_space|
     end
   end
 end
+
+Decidim.register_global_engine(
+  :decidim_votings_polling_officer_zone,
+  Decidim::Votings::PollingOfficerZoneEngine,
+  at: "/polling_officer"
+)

--- a/decidim-elections/lib/decidim/votings/participatory_space.rb
+++ b/decidim-elections/lib/decidim/votings/participatory_space.rb
@@ -78,5 +78,5 @@ end
 Decidim.register_global_engine(
   :decidim_votings_polling_officer_zone,
   Decidim::Votings::PollingOfficerZoneEngine,
-  at: "/polling_officer"
+  at: "/polling_officers"
 )

--- a/decidim-elections/lib/decidim/votings/polling_officer_zone.rb
+++ b/decidim-elections/lib/decidim/votings/polling_officer_zone.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Votings
+    # This module contains all the domain logic associated to Decidim's Votings
+    # polling officer zone.
+    module PollingOfficerZone
+    end
+  end
+end

--- a/decidim-elections/lib/decidim/votings/polling_officer_zone_engine.rb
+++ b/decidim-elections/lib/decidim/votings/polling_officer_zone_engine.rb
@@ -11,8 +11,8 @@ module Decidim
       paths["lib/tasks"] = nil
 
       routes do
-        resource :polling_officer, path: "/", only: [:show] do
-          resource :polling_stations, only: [:show]
+        resource :polling_officers, path: "/", only: [:show] do
+          resources :polling_stations, only: [:show]
         end
       end
 

--- a/decidim-elections/lib/decidim/votings/polling_officer_zone_engine.rb
+++ b/decidim-elections/lib/decidim/votings/polling_officer_zone_engine.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Votings
+    # This is the engine that runs on the public interface for polling officers of `decidim-elections`.
+    # It mostly handles rendering the polling officers frontend zone.
+    class PollingOfficerZoneEngine < ::Rails::Engine
+      isolate_namespace Decidim::Votings::PollingOfficerZone
+
+      paths["db/migrate"] = nil
+      paths["lib/tasks"] = nil
+
+      routes do
+        resource :polling_officer, path: "/", only: [:show] do
+          resource :polling_stations, only: [:show]
+        end
+      end
+
+      def load_seed
+        nil
+      end
+
+      initializer "decidim_elections.polling_officer_zone.menu" do
+        Decidim.menu :user_menu do |menu|
+          menu.item I18n.t("menu.polling_officer_zone", scope: "decidim.votings.polling_officer_zone"),
+                    decidim.decidim_votings_polling_officer_zone_path,
+                    active: :inclusive,
+                    if: Decidim::Votings::PollingOfficer.polling_officer?(current_user)
+        end
+      end
+    end
+  end
+end

--- a/decidim-elections/spec/commands/decidim/votings/admin/create_polling_station_spec.rb
+++ b/decidim-elections/spec/commands/decidim/votings/admin/create_polling_station_spec.rb
@@ -95,6 +95,21 @@ module Decidim
             expect(president.reload.presided_polling_station).to eq polling_station
             expect(polling_station.reload.polling_station_president).to eq president
           end
+
+          it "notifies the president" do
+            expect(Decidim::EventsManager)
+              .to receive(:publish)
+              .with(
+                event: "decidim.events.votings.polling_officers.polling_station_assigned",
+                event_class: PollingOfficers::PollingStationAssignedEvent,
+                resource: voting,
+                affected_users: [president.user],
+                followers: [],
+                extra: { polling_officer_id: president.id }
+              )
+
+            subject.call
+          end
         end
 
         context "when selecting managers" do
@@ -107,6 +122,23 @@ module Decidim
               expect(manager.reload.managed_polling_station).to eq polling_station
               expect(polling_station.reload.polling_station_managers).to include(manager)
             end
+          end
+
+          it "notifies the manmagers" do
+            managers.each do |manager|
+              expect(Decidim::EventsManager)
+                .to receive(:publish)
+                .with(
+                  event: "decidim.events.votings.polling_officers.polling_station_assigned",
+                  event_class: PollingOfficers::PollingStationAssignedEvent,
+                  resource: voting,
+                  affected_users: [manager.user],
+                  followers: [],
+                  extra: { polling_officer_id: manager.id }
+                )
+            end
+
+            subject.call
           end
         end
       end

--- a/decidim-elections/spec/events/decidim/votings/polling_officers/polling_station_assigned_event_spec.rb
+++ b/decidim-elections/spec/events/decidim/votings/polling_officers/polling_station_assigned_event_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Votings
+    module PollingOfficers
+      describe PollingStationAssignedEvent do
+        include_context "when a simple event"
+
+        let(:event_name) { "decidim.events.votings.polling_officers.polling_station_assigned" }
+        let(:organization) { create(:organization) }
+        let(:voting) { create(:voting, organization: organization) }
+        let(:polling_station) { create(:polling_station, voting: voting) }
+        let(:resource) { voting }
+        let(:polling_officer) { create(:polling_officer, user: user, managed_polling_station: polling_station, voting: voting) }
+        let(:extra) { { polling_officer_id: polling_officer.id, polling_station_id: polling_station.id } }
+        let(:polling_station_name) { translated(polling_station.title) }
+        let(:voting_title) { translated(voting.title) }
+        let(:voting_path) { "/votings/#{voting.slug}?voting_slug=#{voting.slug}" }
+        let(:voting_url) { "http://#{organization.host}#{voting_path}" }
+        let(:polling_officer_zone_url) { "http://#{organization.host}/polling_officers" }
+
+        it_behaves_like "a simple event"
+
+        describe "email_subject" do
+          it "is generated correctly" do
+            expect(subject.email_subject).to eq("You are Manager of the Polling Station #{polling_station_name}.")
+          end
+        end
+
+        describe "email_intro" do
+          it "is generated correctly" do
+            expect(subject.email_intro)
+              .to eq("You have been assigned as Manager of the Polling Station #{polling_station_name} in <a href=\"#{voting_url}\">#{voting_title}</a>. You can manage the Polling Station from the dedicated <a href=\"#{polling_officer_zone_url}\">Polling Officer Zone</a>.")
+          end
+        end
+
+        describe "email_outro" do
+          it "is generated correctly" do
+            expect(subject.email_outro)
+              .to eq("You have received this notification because you have been assigned as Manager of #{polling_station_name}.")
+          end
+        end
+
+        describe "notification_title" do
+          it "is generated correctly" do
+            expect(subject.notification_title)
+              .to eq("You are Manager of the Polling Station #{polling_station_name} in the voting <a href=\"#{voting_path}\">#{voting_title}</a>.")
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-elections/spec/events/decidim/votings/polling_officers/polling_station_assigned_event_spec.rb
+++ b/decidim-elections/spec/events/decidim/votings/polling_officers/polling_station_assigned_event_spec.rb
@@ -14,7 +14,7 @@ module Decidim
         let(:polling_station) { create(:polling_station, voting: voting) }
         let(:resource) { voting }
         let(:polling_officer) { create(:polling_officer, user: user, managed_polling_station: polling_station, voting: voting) }
-        let(:extra) { { polling_officer_id: polling_officer.id, polling_station_id: polling_station.id } }
+        let(:extra) { { polling_officer_id: polling_officer.id } }
         let(:polling_station_name) { translated(polling_station.title) }
         let(:voting_title) { translated(voting.title) }
         let(:voting_path) { "/votings/#{voting.slug}?voting_slug=#{voting.slug}" }

--- a/decidim-elections/spec/permissions/decidim/votings/polling_officer_zone/permissions_spec.rb
+++ b/decidim-elections/spec/permissions/decidim/votings/polling_officer_zone/permissions_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Votings
+    module PollingOfficerZone
+      describe Permissions do
+        subject { described_class.new(user, permission_action, context).permissions.allowed? }
+
+        let(:user) { create :user, organization: voting.organization }
+        let(:context) do
+          {
+            polling_officers: permission_polling_officers
+          }
+        end
+        let(:voting) { create(:voting) }
+        let(:polling_officers) { [create(:polling_officer, user: user, voting: voting)] }
+        let(:permission_polling_officers) { polling_officers }
+        let(:permission_action) { Decidim::PermissionAction.new(action) }
+
+        shared_examples "not allowed when a polling officer is not attached to the current user" do
+          context "when a polling officer is not attached to a user" do
+            let!(:polling_officers) { create_list(:polling_officer, 2) }
+
+            it { is_expected.to be_falsey }
+          end
+        end
+
+        context "when scope is not polling officer zone" do
+          let(:action) do
+            { scope: :foo, action: :bar, subject: :polling_officers }
+          end
+
+          it_behaves_like "permission is not set"
+        end
+
+        context "when subject is not correct" do
+          let(:action) do
+            { scope: :polling_officer_zone, action: :view, subject: :foo }
+          end
+
+          it_behaves_like "permission is not set"
+        end
+
+        context "when action is not correct" do
+          let(:action) do
+            { scope: :polling_officer_zone, action: :foo, subject: :polling_officers }
+          end
+
+          it_behaves_like "permission is not set"
+        end
+
+        describe "view polling officer" do
+          let(:action) do
+            { scope: :polling_officer_zone, action: :view, subject: :polling_officers }
+          end
+
+          it { is_expected.to eq true }
+
+          it_behaves_like "not allowed when a polling officer is not attached to the current user"
+        end
+
+        describe "view polling station" do
+          let(:action) do
+            { scope: :polling_officer_zone, action: :view, subject: :polling_station }
+          end
+
+          it { is_expected.to eq true }
+
+          it_behaves_like "not allowed when a polling officer is not attached to the current user"
+        end
+      end
+    end
+  end
+end

--- a/decidim-elections/spec/system/polling_officer_zone_spec.rb
+++ b/decidim-elections/spec/system/polling_officer_zone_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Polling Officer zone", type: :system do
+  let(:organization) { create(:organization, :secure_context) }
+  let(:user) { create(:user, :confirmed, organization: organization) }
+  let(:polling_officers) { [assigned_polling_officer, unassigned_polling_officer] }
+  let(:voting) { create(:voting, organization: organization) }
+  let(:other_voting) { create(:voting, organization: organization) }
+  let(:polling_station) { create(:polling_station, voting: voting) }
+  let(:assigned_polling_officer) { create(:polling_officer, voting: voting, user: user, presided_polling_station: polling_station) }
+  let(:unassigned_polling_officer) { create(:polling_officer, voting: other_voting, user: user) }
+
+  before do
+    polling_officers
+    switch_to_secure_context_host
+    login_as user, scope: :user
+  end
+
+  it "can access to the polling officer zone" do
+    visit decidim.account_path
+
+    expect(page).to have_content("Polling Officer zone")
+
+    click_link "Polling Officer zone"
+
+    expect(page).to have_content(translated(voting.title))
+    expect(page).to have_content(translated(other_voting.title))
+  end
+
+  context "when the user is not a polling officer" do
+    let(:polling_officers) { [create(:polling_officer)] }
+
+    it "can't access to the polling officer zone" do
+      visit decidim.account_path
+
+      expect(page).not_to have_content("Polling Officer zone")
+
+      visit decidim.decidim_elections_trustee_zone_path
+
+      expect(page).to have_content("You are not authorized to perform this action")
+
+      expect(page).to have_current_path(decidim.root_path)
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR introduces 2 features:
 1. Allows a user acting as a Polling Officer to access the Polling Officer Zone from their account page;
 2. Notifies a user when they are assigned as president/manager of a Polling Station with the instructions on how to access the Polling Officer Zone.

##### 1. Polling Officer Zone
The Polling Officer Zone is based on the Trustee Zone implemented here: https://github.com/decidim/decidim/pull/6615

Notice that, for the moment, a Polling Officer can only see the Polling Stations they are assigned to, while the actions they con perform on the PS are not yet implemented (blank page).
The UI is rough and will be improved in upcoming tasks (and well the design will be available).

##### 2. Polling Officer Notification
In order to only send notifications to Officers when they are assigned to a Polling Station, and not when other Polling Officers are added/removed, we now assign/unassign only those officers that need it ([instead of unassign all old + assign all new as done before](https://github.com/decidim/decidim/pull/7439/files#diff-5b1b2f44ffecb2634c985f8a123e332cb471da7665e88baa31392182a0370a2cL32-L45))

#### :pushpin: Related Issues
- Fixes #7123 

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
POLLING OFFICER ZONE
<img width="1283" alt="Screenshot 2021-02-23 at 13 05 34" src="https://user-images.githubusercontent.com/5033945/108842588-c9dd2b00-75d9-11eb-968f-f3b3ec9f7618.png">


NOTIFICATION
<img width="1220" alt="Screenshot 2021-02-23 at 13 04 53" src="https://user-images.githubusercontent.com/5033945/108842601-d06ba280-75d9-11eb-951e-cc3cc4638cf1.png">


EMAIL
<img width="474" alt="Screenshot 2021-02-23 at 13 16 34" src="https://user-images.githubusercontent.com/5033945/108842568-c5187700-75d9-11eb-9c05-363208faf63d.png">

:hearts: Thank you!
