### PR TITLE
Rename "weight" to "order position"

### DIFF
--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -25,7 +25,7 @@ en:
       component:
         name: Name
         published_at: Published at
-        weight: Weight
+        weight: Order position
       id: ID
       import:
         user_group_id: Create imports as
@@ -112,12 +112,12 @@ en:
         show_in_footer: Show in the footer
         slug: URL slug
         title: Title
-        weight: Weight
+        weight: Order position
       static_page_topic:
         description: Description
         show_in_footer: Show in the footer
         title: Title
-        weight: Weight
+        weight: Order position
       user_group_csv_verification:
         file: File
     errors:

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -53,7 +53,7 @@ en:
         target: Who participates
         title: Title
         twitter: Twitter
-        weight: Weight
+        weight: Order position
         youtube: YouTube
       assembly_member:
         birthday: Birthday

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -7,7 +7,7 @@ en:
         description: Description
         title: Title
         total_budget: Total budget
-        weight: Weight
+        weight: Order position
       project:
         budget_amount: Budget amount
         decidim_category_id: Category

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -207,7 +207,7 @@ en:
             price: Price
             registrations_count: Registrations count
             title: Title
-            weight: Weight
+            weight: Order position
           name: Registration type
       partners:
         create:

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -35,7 +35,7 @@ en:
         subtitle: Subtitle
         target: Who participates
         title: Title
-        weight: Weight
+        weight: Order position
       participatory_process_group:
         description: Description
         developer_group: Promoter group


### PR DESCRIPTION
#### :tophat: What? Why?
In Decidim many "order" columns use the label "Weight" for an unknown reason.

It is not really weight because if it was weight, the items with higher weight should come first.

This is a term I always hear administrators find extremely confusing.

I suggest renaming it to "Order position" to better represent what it does. This way, maybe people would understand more easily that 0 comes **before** 1, not after it.

#### Testing
Go to the admin panel to see views with the term "weight".

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.