### PR TITLE
Align Data Picker selected values styles

### DIFF
--- a/decidim-core/app/views/decidim/widgets/_data_picker.html.erb
+++ b/decidim-core/app/views/decidim/widgets/_data_picker.html.erb
@@ -1,6 +1,6 @@
 <div id="<%= picker_options[:id] %>" class="data-picker <%= picker_options[:class] %>" data-picker-name="<%= picker_options[:name] %>">
   <div class="picker-values"><% items.each do |item, params| %>
-    <div><a href="<%= params[:url] %>" data-picker-value="<%= item.id %>"><%= params[:text] %></a></div>
+    <div><a href="<%= params[:url] %>" class="label primary" data-picker-value="<%= item.id %>"><span aria-hidden="true">×</span> <%= params[:text] %></a></div>
   <% end %></div>
   <div class="picker-prompt"><a href="<%= prompt_params[:url] %>"><%= prompt_params[:text] %></a></div>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?
The selected values of a data picker were styled differently when showing the values stored in DB (styled by the ruby view) and when dynamically added by the user (styled by the data picker's javascript).

This PR aligns the styles, as asked by @decidim/product [here](https://github.com/decidim/decidim/issues/7105#issuecomment-783281358)

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #7105

#### Testing
Data picker with multiple selection is implemented for the proposal picker (used in the Accountability component) and in the polling officer picker (used in Voting's Polling Stations).

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
BEFORE
<img width="542" alt="Screenshot 2021-02-23 at 16 19 33" src="https://user-images.githubusercontent.com/5033945/108865112-2862d300-75f3-11eb-93e5-d8774004fa04.png">

AFTER
<img width="542" alt="Screenshot 2021-02-23 at 16 19 18" src="https://user-images.githubusercontent.com/5033945/108865069-1bde7a80-75f3-11eb-8cd5-82845e7d335d.png">

:hearts: Thank you!
