### PR TITLE
Resort Menus

### DIFF
--- a/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
@@ -98,7 +98,7 @@ module Decidim
           menu.item I18n.t("menu.assemblies", scope: "decidim.admin"),
                     decidim_admin_assemblies.assemblies_path,
                     icon_name: "dial",
-                    position: 2.5,
+                    position: 2.2,
                     active: :inclusive,
                     if: allowed_to?(:enter, :space_area, space_name: :assemblies)
         end

--- a/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
@@ -98,7 +98,7 @@ module Decidim
           menu.item I18n.t("menu.assemblies", scope: "decidim.admin"),
                     decidim_admin_assemblies.assemblies_path,
                     icon_name: "dial",
-                    position: 3.5,
+                    position: 2.5,
                     active: :inclusive,
                     if: allowed_to?(:enter, :space_area, space_name: :assemblies)
         end

--- a/decidim-assemblies/lib/decidim/assemblies/engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/engine.rb
@@ -58,7 +58,7 @@ module Decidim
         Decidim.menu :menu do |menu|
           menu.item I18n.t("menu.assemblies", scope: "decidim"),
                     decidim_assemblies.assemblies_path,
-                    position: 2.5,
+                    position: 2.2,
                     if: OrganizationPublishedAssemblies.new(current_organization, current_user).any?,
                     active: :inclusive
         end

--- a/decidim-conferences/lib/decidim/conferences/admin_engine.rb
+++ b/decidim-conferences/lib/decidim/conferences/admin_engine.rb
@@ -94,7 +94,7 @@ module Decidim
           menu.item I18n.t("menu.conferences", scope: "decidim.admin"),
                     decidim_admin_conferences.conferences_path,
                     icon_name: "microphone",
-                    position: 3.9,
+                    position: 2.8,
                     active: :inclusive,
                     if: allowed_to?(:enter, :space_area, space_name: :conferences)
         end

--- a/decidim-conferences/lib/decidim/conferences/admin_engine.rb
+++ b/decidim-conferences/lib/decidim/conferences/admin_engine.rb
@@ -94,7 +94,7 @@ module Decidim
           menu.item I18n.t("menu.conferences", scope: "decidim.admin"),
                     decidim_admin_conferences.conferences_path,
                     icon_name: "microphone",
-                    position: 3.5,
+                    position: 3.9,
                     active: :inclusive,
                     if: allowed_to?(:enter, :space_area, space_name: :conferences)
         end

--- a/decidim-conferences/lib/decidim/conferences/engine.rb
+++ b/decidim-conferences/lib/decidim/conferences/engine.rb
@@ -69,7 +69,7 @@ module Decidim
         Decidim.menu :menu do |menu|
           menu.item I18n.t("menu.conferences", scope: "decidim"),
                     decidim_conferences.conferences_path,
-                    position: 6,
+                    position: 2.8,
                     if: Decidim::Conference.where(organization: current_organization).published.any?,
                     active: :inclusive
         end

--- a/decidim-consultations/lib/decidim/consultations/admin_engine.rb
+++ b/decidim-consultations/lib/decidim/consultations/admin_engine.rb
@@ -77,7 +77,7 @@ module Decidim
           menu.item I18n.t("menu.consultations", scope: "decidim.admin"),
                     decidim_admin_consultations.consultations_path,
                     icon_name: "comment-square",
-                    position: 3.8,
+                    position: 2.65,
                     active: :inclusive,
                     if: allowed_to?(:enter, :space_area, space_name: :consultations)
         end

--- a/decidim-consultations/lib/decidim/consultations/engine.rb
+++ b/decidim-consultations/lib/decidim/consultations/engine.rb
@@ -74,7 +74,7 @@ module Decidim
         Decidim.menu :menu do |menu|
           menu.item I18n.t("menu.consultations", scope: "decidim"),
                     decidim_consultations.consultations_path,
-                    position: 2.8,
+                    position: 2.6,
                     if: Decidim::Consultation.where(organization: current_organization).published.any?,
                     active: :inclusive
         end

--- a/decidim-consultations/lib/decidim/consultations/engine.rb
+++ b/decidim-consultations/lib/decidim/consultations/engine.rb
@@ -74,7 +74,7 @@ module Decidim
         Decidim.menu :menu do |menu|
           menu.item I18n.t("menu.consultations", scope: "decidim"),
                     decidim_consultations.consultations_path,
-                    position: 2.6,
+                    position: 2.65,
                     if: Decidim::Consultation.where(organization: current_organization).published.any?,
                     active: :inclusive
         end

--- a/decidim-elections/lib/decidim/votings/admin_engine.rb
+++ b/decidim-elections/lib/decidim/votings/admin_engine.rb
@@ -57,7 +57,7 @@ module Decidim
           menu.item I18n.t("menu.votings", scope: "decidim.votings.admin"),
                     decidim_admin_votings.votings_path,
                     icon_name: "comment-square",
-                    position: 3.7,
+                    position: 2.6,
                     active: :inclusive,
                     if: allowed_to?(:enter, :space_area, space_name: :votings)
         end

--- a/decidim-elections/lib/decidim/votings/engine.rb
+++ b/decidim-elections/lib/decidim/votings/engine.rb
@@ -57,7 +57,7 @@ module Decidim
         Decidim.menu :menu do |menu|
           menu.item I18n.t("menu.votings", scope: "decidim"),
                     decidim_votings.votings_path,
-                    position: 2.7,
+                    position: 2.6,
                     if: Decidim::Votings::Voting.where(organization: current_organization).published.any?,
                     active: :inclusive
         end

--- a/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
@@ -96,7 +96,7 @@ module Decidim
           menu.item I18n.t("menu.initiatives", scope: "decidim.admin"),
                     decidim_admin_initiatives.initiatives_path,
                     icon_name: "chat",
-                    position: 3.7,
+                    position: 2.4,
                     active: :inclusive,
                     if: allowed_to?(:enter, :space_area, space_name: :initiatives)
         end

--- a/decidim-initiatives/lib/decidim/initiatives/engine.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/engine.rb
@@ -94,7 +94,7 @@ module Decidim
         Decidim.menu :menu do |menu|
           menu.item I18n.t("menu.initiatives", scope: "decidim"),
                     decidim_initiatives.initiatives_path,
-                    position: 2.6,
+                    position: 2.4,
                     active: :inclusive
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
*Please describe your pull request.*
Right now there are some inconsistencies in the prioritization of menu options in the admin menu.

In the admin menu we have a conflict between assemblies and conferences, and between initiatives and votings. Here is the current ordering with the proposed corrections:

- dashboard, position: 1
- participatory_processes, position: 2
- **assemblies, position: 3.5 => 2.2**
- **initiatives, position: 3.7 => 2.4**
- **votings, position: 3.7 => 2.6**
- **consultations, position: 3.8 => 2.65**
- **conferences, position: 3.5 => 2.8**
- moderation, position: 4
- static_pages, position: 4.5
- users, position: 5
- newsletters, position: 6
- settings, position: 7
- admin_log, position: 10
- templates, position: 12

In the main public menu there's no conflict between options but current sorting for participatory spaces seems that could be improved to follow the same increment between all participatory spaces (leaving the same logical distance between each space):

- home, position: 1
- processes, position: 2
- **assemblies, position: 2.5 => 2.2**
- **initiatives, position: 2.6 => 2.4**
- **votings, position: 2.8 => 2.6**
- **consultations, position: 2.8 => 2.65**
- **conferences, position: 6 => 2.8**
- help, position: 7


#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
# Admin menu after rework
![imatge](https://user-images.githubusercontent.com/199462/109017798-ca4bf380-76b7-11eb-96c2-b74bd5f18f47.png)

# Public menu after rework
![imatge](https://user-images.githubusercontent.com/199462/109018305-46ded200-76b8-11eb-8638-ea6f8a202649.png)


:hearts: Thank you!
