### PR TITLE
Voting metrics cell for the landing page

### DIFF
--- a/decidim-elections/app/cells/decidim/votings/content_blocks/landing_page/metrics/show.erb
+++ b/decidim-elections/app/cells/decidim/votings/content_blocks/landing_page/metrics/show.erb
@@ -1,0 +1,12 @@
+<section class="section">
+  <div class="row column">
+    <h3 class="section-heading"><%= t("metrics.heading", scope: "decidim.votings.content_blocks.landing_page") %></h3>
+
+    <% if metrics %>
+      <%= metrics.params %>
+      <div class="row mb-sm">
+        <%= metrics.highlighted %>
+      </div>
+    <% end %>
+  </div>
+</section>

--- a/decidim-elections/app/cells/decidim/votings/content_blocks/landing_page/metrics_cell.rb
+++ b/decidim-elections/app/cells/decidim/votings/content_blocks/landing_page/metrics_cell.rb
@@ -5,8 +5,12 @@ module Decidim
     module ContentBlocks
       module LandingPage
         class MetricsCell < Decidim::ViewModel
-          def show
-            content_tag(:div, "VotingMetricsCell")
+          delegate :current_participatory_space, to: :controller
+
+          def metrics
+            nil
+
+            # @metrics ||= VotingsMetricChartsPresenter.new(participatory_process: current_participatory_space)
           end
         end
       end

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -789,6 +789,8 @@ en:
           description:
             show_less: Read less
             show_more: Read more
+          metrics:
+            heading: Metrics
       monitoring_committee_members:
         actions:
           confirm_destroy: Are you sure?


### PR DESCRIPTION
#### :tophat: What? Why?

This PR implements the public side of the `Decidim::Votings::ContentBlocks::LandingPage::MetricsCell`.

Currently there are no metrics implemented for the votings space so this `cell` is just a placeholder for the metrics to be defined in the future.

#### :pushpin: Related Issues

- Related to #7112
- depends on #7440


#### Testing

- As a participant, visit a voting details page (the metrics cell should be activated on the Landing page admin side):
  <img width="1232" alt="Screenshot 2021-02-26 at 16 34 52" src="https://user-images.githubusercontent.com/210216/109320762-ad96f380-7850-11eb-80b3-97192d61d332.png">

  

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
