### PR TITLE
Improve changelog generator

### DIFF
--- a/bin/changelog_generator
+++ b/bin/changelog_generator
@@ -47,7 +47,10 @@ def crowdin?(commit)
 end
 
 def get_pr_id(commit)
-  commit.scan(/\d+/).last
+  id = commit.scan(/#\d+/).last
+  return unless id
+
+  id.delete_prefix("#")
 end
 
 def get_pr_data(commit)
@@ -134,7 +137,7 @@ types.each do |type_title, type_data|
 
       handled_ids << id
 
-      if type_data[:skip_modules]
+      if type_data[:skip_modules] || modules_list.empty?
         output "- #{title} #{pr_link(id)}"
       else
         output "- #{modules_list.join(", ")}: #{title} #{pr_link(id)}"


### PR DESCRIPTION
#### :tophat: What? Why?
This PR improves the changelog generator:

- If the PR does not affect any module, fix the output by hiding the extra `:`.
- Fix PR ID parsing by looking for the `#` symbol too and cleaning it up later. Otherwise, the regular expression might match the commit hash and use that as PR ID

#### :pushpin: Related Issues
- Related to #7461

#### Testing
Check https://github.com/decidim/decidim/pull/7474 which uses those changes to generate the changelog.