### PR TITLE
Fix NULL error with weight field in assemblies & processes

### DIFF
--- a/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_form.rb
+++ b/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_form.rb
@@ -45,7 +45,7 @@ module Decidim
         attribute :parent_id, Integer
         attribute :participatory_processes_ids, Array[Integer]
         attribute :scope_id, Integer
-        attribute :weight, Integer
+        attribute :weight, Integer, default: 0
 
         attribute :is_transparent, Boolean
         attribute :promoted, Boolean
@@ -79,6 +79,8 @@ module Decidim
 
         validates :banner_image, passthru: { to: Decidim::Assembly }
         validates :hero_image, passthru: { to: Decidim::Assembly }
+
+        validates :weight, presence: true
 
         alias organization current_organization
 

--- a/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_form.rb
+++ b/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_form.rb
@@ -32,7 +32,7 @@ module Decidim
         attribute :scope_id, Integer
         attribute :related_process_ids, Array[Integer]
         attribute :scope_type_max_depth_id, Integer
-        attribute :weight, Integer
+        attribute :weight, Integer, default: 0
 
         attribute :private_space, Boolean
         attribute :promoted, Boolean
@@ -58,6 +58,8 @@ module Decidim
 
         validates :banner_image, passthru: { to: Decidim::ParticipatoryProcess }
         validates :hero_image, passthru: { to: Decidim::ParticipatoryProcess }
+
+        validates :weight, presence: true
 
         alias organization current_organization
 


### PR DESCRIPTION
#### :tophat: What? Why?
An error with the weight in the assemblies and processes forms has been fixed.

A default value(default: 0) and a validation(required field) have been added to the form.

#### :pushpin: Related Issues
- Fixes #7483 

#### Testing

1. Sign in as administrator
2. Go to http://localhost:3000/admin/participatory_processes/new
3. Fill only the mandatory fields with any string without weight
4. Save the form
5. All OK

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
