### PR TITLE
Fix #7487 - Invalid signature on message decryption

### DIFF
--- a/decidim-core/db/migrate/20201127114444_encrypt_authorization_metadatas.rb
+++ b/decidim-core/db/migrate/20201127114444_encrypt_authorization_metadatas.rb
@@ -28,7 +28,7 @@ class EncryptAuthorizationMetadatas < ActiveRecord::Migration[5.2]
   def decrypt_hash(hash)
     hash.transform_values do |value|
       ActiveSupport::JSON.decode(Decidim::AttributeEncryptor.decrypt(value))
-    rescue ActiveSupport::MessageEncryptor::InvalidMessage
+    rescue ActiveSupport::MessageEncryptor::InvalidMessage, ActiveSupport::MessageVerifier::InvalidSignature
       value
     end
   end

--- a/decidim-core/lib/decidim/record_encryptor.rb
+++ b/decidim-core/lib/decidim/record_encryptor.rb
@@ -103,7 +103,7 @@ module Decidim
 
     def decrypt_value(value)
       Decidim::AttributeEncryptor.decrypt(value)
-    rescue ActiveSupport::MessageEncryptor::InvalidMessage
+    rescue ActiveSupport::MessageEncryptor::InvalidMessage, ActiveSupport::MessageVerifier::InvalidSignature
       # Support for legacy unencrypted values. This is necessary e.g. when
       # migrating the original unencrypted values to encrypted values.
       value

--- a/decidim-core/spec/lib/record_encryptor_spec.rb
+++ b/decidim-core/spec/lib/record_encryptor_spec.rb
@@ -62,6 +62,25 @@ module Decidim
         # original value is returned instead.
         expect(subject.name).to eq("Unencrypted")
       end
+
+      it "returns the original value when the decryption fails due to invalid signature" do
+        # Test the decryption process in case the following is configured for
+        # the application (could be the case for installations dating the
+        # pre-Rails 5.2 era):
+        # Rails.application.config.active_support.use_authenticated_message_encryption = false
+        #
+        # This is also true for all instances that have the following in their
+        # `config/application.rb` (Defaults from pre-Rails 5.2):
+        #   config.load_defaults 5.1
+        allow(ActiveSupport::MessageEncryptor).to receive(:use_authenticated_message_encryption).and_return(false)
+
+        subject.instance_variable_set(:@name, "Unencrypted")
+
+        # This would throw an ActiveSupport::MessageVerifier::InvalidSignature
+        # which happens if the decryption fails. This is catched and the
+        # original value is returned instead.
+        expect(subject.name).to eq("Unencrypted")
+      end
     end
 
     it_behaves_like "encrypted record"


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes invalid signature issues with decrypting non-encrypted data on installations that have been generated prior to Rails 5.2.
    
For pre-Rails 5.2 installations or installations that get their configuration defaults from Rails 5.1, the message decryption can fail due to `ActiveSupport::MessageVerifier::InvalidSignature`.

This happens in case you have the following configuration option in one of your initializers (or environment configuration):

```ruby
Rails.application.config.active_support.use_authenticated_message_encryption = false
```

Alternatively, it can also happen if you have the following in your instance's `config/application.rb` because this was the default configuration for pre-Rails 5.2:

```ruby
module DecidimAwesomeTown
  class Application < Rails::Application
    # ...
    config.load_defaults 5.1
    # ...
  end
end
```

#### :pushpin: Related Issues
- Related to #6947
- Fixes #7487

#### Testing
- Create a 0.23 installation
- Make sure you use the explained configurations (e.g. `config.load_defaults 5.1` in `config/application.rb`)
- Create the database, run the migrations for 0.23 and create the seed data
- Run the following query in the console: `Decidim::Authorization.create!(user: Decidim::User.first, name: "postal_code", metadata: {}, verification_metadata: { address: "Awesome street 1", verification_code: "12345", letter_sent_at: Time.current })`
- Upgrade the instance to 0.24.0.rc1
- Run the migrations
- See the error in the console.

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.