### PR TITLE
Fix invalid signature on message decryption

### DIFF
--- a/decidim-core/db/migrate/20201127114444_encrypt_authorization_metadatas.rb
+++ b/decidim-core/db/migrate/20201127114444_encrypt_authorization_metadatas.rb
@@ -28,7 +28,7 @@ class EncryptAuthorizationMetadatas < ActiveRecord::Migration[5.2]
   def decrypt_hash(hash)
     hash.transform_values do |value|
       ActiveSupport::JSON.decode(Decidim::AttributeEncryptor.decrypt(value))
-    rescue ActiveSupport::MessageEncryptor::InvalidMessage
+    rescue ActiveSupport::MessageEncryptor::InvalidMessage, ActiveSupport::MessageVerifier::InvalidSignature
       value
     end
   end

--- a/decidim-core/lib/decidim/record_encryptor.rb
+++ b/decidim-core/lib/decidim/record_encryptor.rb
@@ -103,7 +103,7 @@ module Decidim
 
     def decrypt_value(value)
       Decidim::AttributeEncryptor.decrypt(value)
-    rescue ActiveSupport::MessageEncryptor::InvalidMessage
+    rescue ActiveSupport::MessageEncryptor::InvalidMessage, ActiveSupport::MessageVerifier::InvalidSignature
       # Support for legacy unencrypted values. This is necessary e.g. when
       # migrating the original unencrypted values to encrypted values.
       value

--- a/decidim-core/spec/lib/record_encryptor_spec.rb
+++ b/decidim-core/spec/lib/record_encryptor_spec.rb
@@ -62,6 +62,25 @@ module Decidim
         # original value is returned instead.
         expect(subject.name).to eq("Unencrypted")
       end
+
+      it "returns the original value when the decryption fails due to invalid signature" do
+        # Test the decryption process in case the following is configured for
+        # the application (could be the case for installations dating the
+        # pre-Rails 5.2 era):
+        # Rails.application.config.active_support.use_authenticated_message_encryption = false
+        #
+        # This is also true for all instances that have the following in their
+        # `config/application.rb` (Defaults from pre-Rails 5.2):
+        #   config.load_defaults 5.1
+        allow(ActiveSupport::MessageEncryptor).to receive(:use_authenticated_message_encryption).and_return(false)
+
+        subject.instance_variable_set(:@name, "Unencrypted")
+
+        # This would throw an ActiveSupport::MessageVerifier::InvalidSignature
+        # which happens if the decryption fails. This is catched and the
+        # original value is returned instead.
+        expect(subject.name).to eq("Unencrypted")
+      end
     end
 
     it_behaves_like "encrypted record"


### PR DESCRIPTION
#### :tophat: What? Why?
Backport of #7488 to 0.24. See original PR for more info.

#### :pushpin: Related Issues
None

#### Testing
Ensure CI is green.