### PR TITLE
Fix record encryptor hash values JSON parsing for legacy unencrypted hash values

### DIFF
--- a/decidim-core/lib/decidim/record_encryptor.rb
+++ b/decidim-core/lib/decidim/record_encryptor.rb
@@ -116,7 +116,18 @@ module Decidim
     def decrypt_hash_values(hash)
       return hash unless hash.is_a?(Hash)
 
-      hash.transform_values { |value| ActiveSupport::JSON.decode(decrypt_value(value)) }
+      hash.transform_values do |value|
+        decrypted_value = decrypt_value(value)
+
+        # When handling legacy non-encrypted hash values, the decrypted values
+        # could not be valid JSON strings. They could be normal strings that
+        # cannot be JSON decoded.
+        begin
+          ActiveSupport::JSON.decode(decrypted_value)
+        rescue JSON::ParserError
+          decrypted_value
+        end
+      end
     end
 
     def encrypt_hash_values(hash)

--- a/decidim-core/spec/lib/record_encryptor_spec.rb
+++ b/decidim-core/spec/lib/record_encryptor_spec.rb
@@ -81,6 +81,19 @@ module Decidim
         # original value is returned instead.
         expect(subject.name).to eq("Unencrypted")
       end
+
+      it "returns the original hash values when the JSON parsing fails for the hash values" do
+        subject.instance_variable_set(
+          :@metadata,
+          "email" => "example001@example.org",
+          "verification_code" => "123456789"
+        )
+
+        expect(subject.metadata).to eq(
+          "email" => "example001@example.org",
+          "verification_code" => 123_456_789
+        )
+      end
     end
 
     it_behaves_like "encrypted record"


### PR DESCRIPTION
#### :tophat: What? Why?
When the database contains unecrypted hash values for columns that are set for decryption, the JSON parsing can fail in case the hash contains values that cannot be JSON decoded (e.g. ruby strings).

See more specific description of the problem from this issue comment:
https://github.com/decidim/decidim/issues/7487#issuecomment-788782713

#### :pushpin: Related Issues
- Related to #6947
- Fixes https://github.com/decidim/decidim/issues/7487#issuecomment-788782713

#### Testing
Likely you would be able to test this following the testing instrucitons at: #7488 

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.