### PR TITLE
Fix record encryptor hash values JSON parsing for legacy unencrypted hash values

### DIFF
--- a/decidim-core/lib/decidim/record_encryptor.rb
+++ b/decidim-core/lib/decidim/record_encryptor.rb
@@ -116,7 +116,18 @@ module Decidim
     def decrypt_hash_values(hash)
       return hash unless hash.is_a?(Hash)
 
-      hash.transform_values { |value| ActiveSupport::JSON.decode(decrypt_value(value)) }
+      hash.transform_values do |value|
+        decrypted_value = decrypt_value(value)
+
+        # When handling legacy non-encrypted hash values, the decrypted values
+        # could not be valid JSON strings. They could be normal strings that
+        # cannot be JSON decoded.
+        begin
+          ActiveSupport::JSON.decode(decrypted_value)
+        rescue JSON::ParserError
+          decrypted_value
+        end
+      end
     end
 
     def encrypt_hash_values(hash)

--- a/decidim-core/spec/lib/record_encryptor_spec.rb
+++ b/decidim-core/spec/lib/record_encryptor_spec.rb
@@ -81,6 +81,19 @@ module Decidim
         # original value is returned instead.
         expect(subject.name).to eq("Unencrypted")
       end
+
+      it "returns the original hash values when the JSON parsing fails for the hash values" do
+        subject.instance_variable_set(
+          :@metadata,
+          "email" => "example001@example.org",
+          "verification_code" => "123456789"
+        )
+
+        expect(subject.metadata).to eq(
+          "email" => "example001@example.org",
+          "verification_code" => 123_456_789
+        )
+      end
     end
 
     it_behaves_like "encrypted record"


### PR DESCRIPTION
#### :tophat: What? Why?
Backport of #7494 to 0.24.

#### :pushpin: Related Issues
None

#### Testing
Ensure CI is green