### PR TITLE
Only share tokens if component exists

### DIFF
--- a/decidim-admin/app/views/decidim/admin/components/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/components/_form.html.erb
@@ -78,7 +78,7 @@
         </fieldset>
       <% end %>
 
-      <% unless component.published? %>
+      <% if component && component.persisted? && !component.published? %>
         <%= render partial: "decidim/admin/share_tokens/share_tokens", locals: { share_tokens: form.object.share_tokens } %>
       <% end %>
     </div>

--- a/decidim-participatory_processes/spec/shared/manage_process_components_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_process_components_examples.rb
@@ -24,6 +24,8 @@ shared_examples "manage process components" do
           find(".dummy").click
         end
 
+        expect(page).to have_no_content("Share tokens")
+
         within ".new_component" do
           fill_in_i18n(
             :component_name,
@@ -291,6 +293,14 @@ shared_examples "manage process components" do
     end
 
     context "when the component is unpublished" do
+      it "shows the share tokens section" do
+        within ".component-#{component.id}" do
+          click_link "Configure"
+        end
+
+        expect(page).to have_content("Share tokens")
+      end
+
       it "publishes the component" do
         within ".component-#{component.id}" do
           click_link "Publish"
@@ -317,6 +327,14 @@ shared_examples "manage process components" do
 
     context "when the component is published" do
       let(:published_at) { Time.current }
+
+      it "does not show the share tokens section" do
+        within ".component-#{component.id}" do
+          click_link "Configure"
+        end
+
+        expect(page).to have_no_content("Share tokens")
+      end
 
       it "unpublishes the component" do
         within ".component-#{component.id}" do


### PR DESCRIPTION
#### :tophat: What? Why?
PR #6271 added a way to share components via a specific token. The admin part was lacking some specs and this caused a bug not to be detected: when the component being added has validation errors, the page breaks with an error 500.

This PR fixes the issue and adds some minimal tests.

#### :pushpin: Related Issues
- Related to #6271.

#### Testing
Ensure CI is green.