### PR TITLE
Exit on CI workflow dispatch failures

### DIFF
--- a/.github/workflows/on_docs_update.yml
+++ b/.github/workflows/on_docs_update.yml
@@ -13,7 +13,6 @@ jobs:
     timeout-minutes: 60
     steps:
     - name: Send dispatch for trigger_build workflow
-      id: dispatch
       run: |
         curl --fail --show-error \
         --request POST \

--- a/.github/workflows/on_docs_update.yml
+++ b/.github/workflows/on_docs_update.yml
@@ -1,6 +1,8 @@
 name: "On docs update"
 on:
   push:
+    branches:
+    - develop
     paths:
     - 'docs/**'
 
@@ -8,7 +10,6 @@ jobs:
   trigger_documentation_build:
     name: Trigger decidim/documentation build
     runs-on: ubuntu-latest
-    if: "github.ref == 'refs/heads/develop'"
     timeout-minutes: 60
     steps:
     - name: Send dispatch for trigger_build workflow

--- a/.github/workflows/on_docs_update.yml
+++ b/.github/workflows/on_docs_update.yml
@@ -5,18 +5,19 @@ on:
     - 'docs/**'
 
 jobs:
-  trigger_docker_build:
+  trigger_documentation_build:
     name: Trigger decidim/documentation build
     runs-on: ubuntu-latest
     if: "github.ref == 'refs/heads/develop'"
     timeout-minutes: 60
     steps:
     - name: Send dispatch for trigger_build workflow
+      id: dispatch
       run: |
-        curl --request POST \
+        curl --fail --show-error \
+        --request POST \
         --user "decidim-bot:${{ secrets.DOCS_WORKFLOW_PAT }}" \
         --header "Accept: application/vnd.github.everest-preview+json" \
         --header "Content-Type: application/json" \
         https://api.github.com/repos/decidim/documentation/actions/workflows/trigger_build.yml/dispatches \
         --data '{"ref": "master"}'
-

--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -11,7 +11,8 @@ jobs:
     steps:
     - name: Send dispatch for Github Container Registry build
       run: |
-        curl --request POST \
+        curl --fail --show-error \
+        --request POST \
         --user "decidim-bot:${{ secrets.DOCKER_WORKFLOW_PAT }}" \
         --header "Accept: application/vnd.github.everest-preview+json" \
         --header "Content-Type: application/json" \
@@ -19,10 +20,10 @@ jobs:
         --data '{"ref": "master"}'
     - name: Send dispatch for Docker Hub build
       run: |
-        curl --request POST \
+        curl --fail --show-error \
+        --request POST \
         --user "decidim-bot:${{ secrets.DOCKER_WORKFLOW_PAT }}" \
         --header "Accept: application/vnd.github.everest-preview+json" \
         --header "Content-Type: application/json" \
         https://api.github.com/repos/decidim/docker/actions/workflows/dockerhub.yml/dispatches \
         --data '{"ref": "master"}'
-


### PR DESCRIPTION
#### :tophat: What? Why?

Workflow dispatches currently fail silently on error, and their steps show as successful on the CI. This PR configures curl to send an exit signal when that happens, forcing the step to fail.

Also cleans up the branch constraint by removing the conditional and configuring it at the top of the workflow.

#### :pushpin: Related Issues

In response to https://github.com/decidim/decidim/pull/7360#issuecomment-784103194

#### Testing

This was tested by switching the workflow to `pull_request`, turning off the branch restriction, commenting out the existing curl and running: 

```bash
curl --fail --show-error https://httpbin.org/status/403
```

(there's a new `--fail-with-body` option, but it's not available on Github runner's current `curl` version)

To test the actual updated workflow, you can delete the PAT secret to force an auth error.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

![Screen Shot 2021-03-02 at 2 46 13 PM](https://user-images.githubusercontent.com/21290/109665464-19859e80-7b66-11eb-9869-216b7ec14b1f.png)
