### PR TITLE
Invalidate all user sessions when destroying the account

### DIFF
--- a/decidim-core/app/commands/decidim/destroy_account.rb
+++ b/decidim-core/app/commands/decidim/destroy_account.rb
@@ -30,6 +30,8 @@ module Decidim
     private
 
     def destroy_user_account!
+      @user.invalidate_all_sessions!
+
       @user.name = ""
       @user.nickname = ""
       @user.email = ""

--- a/decidim-core/db/migrate/20210302150803_invalidate_all_sessions_for_deleted_users.rb
+++ b/decidim-core/db/migrate/20210302150803_invalidate_all_sessions_for_deleted_users.rb
@@ -4,9 +4,7 @@ class InvalidateAllSessionsForDeletedUsers < ActiveRecord::Migration[5.2]
   def up
     Decidim::User.reset_column_information
 
-    Decidim::User.where.not(deleted_at: nil).find_each do |user|
-      user.invalidate_all_sessions!
-    end
+    Decidim::User.where.not(deleted_at: nil).find_each(&:invalidate_all_sessions!)
   end
 
   def down; end

--- a/decidim-core/db/migrate/20210302150803_invalidate_all_sessions_for_deleted_users.rb
+++ b/decidim-core/db/migrate/20210302150803_invalidate_all_sessions_for_deleted_users.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class InvalidateAllSessionsForDeletedUsers < ActiveRecord::Migration[5.2]
+  def up
+    Decidim::User.reset_column_information
+
+    Decidim::User.where.not(deleted_at: nil).find_each do |user|
+      user.invalidate_all_sessions!
+    end
+  end
+
+  def down; end
+end

--- a/decidim-core/spec/commands/decidim/destroy_account_spec.rb
+++ b/decidim-core/spec/commands/decidim/destroy_account_spec.rb
@@ -38,6 +38,12 @@ module Decidim
         expect { command.call }.to broadcast(:ok)
       end
 
+      it "changes the auth salt to invalidate all other sessions" do
+        old_salt = user.authenticatable_salt
+        command.call
+        expect(user.reload.authenticatable_salt).not_to eq(old_salt)
+      end
+
       it "stores the deleted_at and delete_reason to the user" do
         command.call
         expect(user.reload.delete_reason).to eq(data[:delete_reason])


### PR DESCRIPTION
#### :tophat: What? Why?
If you have multiple sessions open (in multiple browsers), and from one of them you delete the account, you're still logged into the other sessions. This causes users to be able to participate, but their name will always appear as "Deleted user". This has been reported in Decidim Barcelona.

This PR invalidates the other sessions after destroying the account.

#### :pushpin: Related Issues
Builds on top of #5553.

#### Testing
Ensure CI is green.