### PR TITLE
Don't allow filtering meetings by user group if setting is disabled

### DIFF
--- a/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
@@ -17,8 +17,9 @@ module Decidim
         origin_values = []
         origin_values << TreePoint.new("official", t("decidim.meetings.meetings.filters.origin_values.official"))
         origin_values << TreePoint.new("citizens", t("decidim.meetings.meetings.filters.origin_values.citizens")) # todo
-        # if component_settings enabled enabled
-        origin_values << TreePoint.new("user_group", t("decidim.meetings.meetings.filters.origin_values.user_groups")) # todo
+        if current_organization.user_groups_enabled?
+          origin_values << TreePoint.new("user_group", t("decidim.meetings.meetings.filters.origin_values.user_groups")) # todo
+        end
         # if current_organization.user_groups_enabled? and component_settings enabled enabled
 
         TreeNode.new(


### PR DESCRIPTION
#### :tophat: What? Why?
Visiting the meetings index page, the filters will always display the user_groups filter, even though in the organization settings it can be disabled. 

This PR is also meant to add the same functionality as presented in Proposals... 

https://github.com/decidim/decidim/blob/37f3093fcf4e9d08ec78899a9e77638559fde773/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb#L181

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
