### PR TITLE
Remove console warnings from the conversations views

### DIFF
--- a/decidim-core/app/cells/decidim/user_conversations/add_conversation_users.erb
+++ b/decidim-core/app/cells/decidim/user_conversations/add_conversation_users.erb
@@ -12,7 +12,6 @@
             class="js-multiple-mentions mentions__container"
             placeholder="<%= t("decidim.user_conversations.index.add_users_placeholder") %>"
             data-noresults="<%= t("decidim.user_conversations.index.no_results") %>"
-            data-tribute="yes"
             contenteditable="true"
             data-direct-messages-disabled="<%= t("decidim.user_conversations.index.participant_with_disabled_message_reception") %>"
             aria-expanded="false">

--- a/decidim-core/app/views/decidim/messaging/conversations/_add_conversation_users.html.erb
+++ b/decidim-core/app/views/decidim/messaging/conversations/_add_conversation_users.html.erb
@@ -12,7 +12,6 @@
             class="js-multiple-mentions mentions__container"
             placeholder="<%= t(".add_users_placeholder") %>"
             data-noresults="<%= t(".no_results") %>"
-            data-tribute="yes"
             contenteditable="true"
             data-direct-messages-disabled="<%= t("decidim.messaging.conversations.add_conversation_users.participant_with_disabled_message_reception") %>">
       </div>


### PR DESCRIPTION
#### :tophat: What? Why?
This removes the unnecessary `data-tribute` attributes from elements which caused `tribute.attach(...)` calls to display the following warning in the console:
![image](https://user-images.githubusercontent.com/864340/109794009-1221cc00-7c1e-11eb-80e4-1cd5890c8013.png)

The `data-tribute` is something that Tribte internally adds to these elements, so we don't need to specify it manually. Calling `tribute.attach(...)` is enough.

This won't affect the functionality of the Tribute elements, it will only remove the console warning.

#### Testing
- Click the "Conversations" link under the profile menu (menu dropdown from the user's name, top right corner)
- Open developer console in that view
- See the console warning "Tribute was already bound to INPUT" (before this fix)
- See the console warning disappear (after applying this fix)

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.