### PR TITLE
Change the order of attachments in budgets

### DIFF
--- a/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
@@ -56,6 +56,7 @@ edit_link(
       <%= decidim_sanitize translated_attribute project.description %>
       <%= cell "decidim/budgets/project_tags", project, context: { extra_classes: ["tags--project"] } %>
     </div>
+    <%= attachments_for project %>
     <%= linked_resources_for project, :proposals, "included_proposals" %>
     <%= linked_resources_for project, :results, "included_projects" %>
   </div>
@@ -63,5 +64,4 @@ edit_link(
 
 <%= comments_for project %>
 
-<%= attachments_for project %>
 <%= javascript_include_tag("decidim/budgets/projects") %>

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -291,6 +291,6 @@ en:
         success: Your vote has been successfully canceled
     resource_links:
       included_proposals:
-        project_proposal: 'Proposals included in this project:'
+        project_proposal: Proposals included in this project
   index:
     confirmed_orders_count: Votes count


### PR DESCRIPTION
#### :tophat: What? Why?

* Changes the order of attachments in budgets
* Also remove a double colon from a title 

#### Testing

See budget show page.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

#### Before
![imatge](https://user-images.githubusercontent.com/717367/109795421-3201c180-7c17-11eb-9f78-9ea9301c38ba.png)

#### After
![imatge](https://user-images.githubusercontent.com/717367/109795442-362ddf00-7c17-11eb-975a-4afe9148da35.png)


:hearts: Thank you!
