### PR TITLE
Do not change the global test app configs during specs

### DIFF
--- a/decidim-core/spec/system/session_timeout_spec.rb
+++ b/decidim-core/spec/system/session_timeout_spec.rb
@@ -10,8 +10,8 @@ describe "Session timeout", type: :system do
 
   context "when session is about to timeout" do
     before do
-      Devise.timeout_in = 2.minutes
-      Decidim.config.session_timeouter_interval = 1000
+      allow(Devise).to receive(:timeout_in).and_return(2.minutes)
+      allow(Decidim.config).to receive(:session_timeouter_interval).and_return(1000)
       switch_to_host(organization.host)
       login_as current_user, scope: :user
     end


### PR DESCRIPTION
#### :tophat: What? Why?
There are some test runs that cause the user to be signed out during the test. This is because the session timeout spec right now changes the global configuration for the whole test app:
https://github.com/decidim/decidim/blob/c75aab55d9b65a84c74cf68a13c574c67f201d34/decidim-core/spec/system/session_timeout_spec.rb#L13-L14

This change will have to be merged in with #7467 as well, ping @lahdeero.

#### :pushpin: Related Issues
- Related to #7282, #7459

#### Testing
Run the whole test sets (e.g. `decidim-core`) enough many times and you will occasionally see the session sign outs due to the configuration change.

It depends on the order of the tests to be run in.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.