### PR TITLE
Fix non-unique IDs element in filter hash cash

### DIFF
--- a/decidim-budgets/app/views/decidim/budgets/projects/_filters_small_view.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_filters_small_view.html.erb
@@ -13,6 +13,6 @@
     </button>
   </div>
   <div class="filters">
-    <%= render partial: "filters" %>
+    <%= render partial: "filters", locals: { type: :small } %>
   </div>
 </div>

--- a/decidim-consultations/app/views/decidim/consultations/consultations/_filters_small_view.html.erb
+++ b/decidim-consultations/app/views/decidim/consultations/consultations/_filters_small_view.html.erb
@@ -18,6 +18,6 @@
     </button>
   </div>
   <div class="filters">
-    <%= render partial: "filters" %>
+    <%= render partial: "filters", locals: { type: :small } %>
   </div>
 </div>

--- a/decidim-core/app/helpers/decidim/filters_helper.rb
+++ b/decidim-core/app/helpers/decidim/filters_helper.rb
@@ -29,9 +29,10 @@ module Decidim
       end
     end
 
-    def filter_cache_hash(filter)
+    def filter_cache_hash(filter, type = nil)
       hash = []
       hash << "decidim/proposals/filters"
+      hash << type.to_s if type.present?
       hash << I18n.locale.to_s
       hash << Digest::MD5.hexdigest(filter.to_json)
 

--- a/decidim-core/app/views/decidim/searches/_filters_small_view.html.erb
+++ b/decidim-core/app/views/decidim/searches/_filters_small_view.html.erb
@@ -13,6 +13,6 @@
     </button>
   </div>
   <div class="filters">
-    <%= render partial: "filters" %>
+    <%= render partial: "filters", locals: { type: :small } %>
   </div>
 </div>

--- a/decidim-core/spec/helpers/decidim/filters_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/filters_helper_spec.rb
@@ -78,29 +78,43 @@ module Decidim
     end
 
     describe "#filter_cache_hash" do
-      it "generate a unique hash" do
-        old_hash = helper.filter_cache_hash(filter)
+      let(:type) { :test }
 
-        expect(helper.filter_cache_hash(filter)).to eq(old_hash)
+      it "generate a unique hash" do
+        old_hash = helper.filter_cache_hash(filter, type)
+
+        expect(helper.filter_cache_hash(filter, type)).to eq(old_hash)
+      end
+
+      it "stores filter type" do
+        expect(helper.filter_cache_hash(filter, type)).to start_with("decidim/proposals/filters/test/en")
+      end
+
+      context "when no type is provided" do
+        let(:type) { nil }
+
+        it "doesn't stores filter type" do
+          expect(helper.filter_cache_hash(filter)).to start_with("decidim/proposals/filters/en")
+        end
       end
 
       context "when current locale changes" do
         let(:alt_locale) { :ca }
 
         it "generate a different hash" do
-          old_hash = helper.filter_cache_hash(filter)
+          old_hash = helper.filter_cache_hash(filter, type)
           allow(I18n).to receive(:locale).and_return(alt_locale)
 
-          expect(helper.filter_cache_hash(filter)).not_to eq(old_hash)
+          expect(helper.filter_cache_hash(filter, type)).not_to eq(old_hash)
         end
       end
 
       context "when filter is different" do
         it "generate a different hash" do
-          old_hash = helper.filter_cache_hash(filter)
+          old_hash = helper.filter_cache_hash(filter, type)
           filter.test_attribute = "dummy-filter"
 
-          expect(helper.filter_cache_hash(filter)).not_to eq(old_hash)
+          expect(helper.filter_cache_hash(filter, type)).not_to eq(old_hash)
         end
       end
     end

--- a/decidim-debates/app/views/decidim/debates/debates/_filters_small_view.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/_filters_small_view.html.erb
@@ -13,6 +13,6 @@
     </button>
   </div>
   <div class="filters">
-    <%= render partial: "filters" %>
+    <%= render partial: "filters", locals: { type: :small } %>
   </div>
 </div>

--- a/decidim-elections/app/views/decidim/elections/elections/_filters_small_view.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/_filters_small_view.html.erb
@@ -13,6 +13,6 @@
     </button>
   </div>
   <div class="filters">
-    <%= render partial: "filters" %>
+    <%= render partial: "filters", locals: { type: :small } %>
   </div>
 </div>

--- a/decidim-elections/app/views/decidim/votings/votings/_filters_small_view.html.erb
+++ b/decidim-elections/app/views/decidim/votings/votings/_filters_small_view.html.erb
@@ -18,6 +18,6 @@
     </button>
   </div>
   <div class="filters">
-    <%= render partial: "filters" %>
+    <%= render partial: "filters", locals: { type: :small } %>
   </div>
 </div>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_filters_small_view.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_filters_small_view.html.erb
@@ -13,6 +13,6 @@
     </button>
   </div>
   <div class="filters">
-    <%= render partial: "filters" %>
+    <%= render partial: "filters", locals: { type: :small } %>
   </div>
 </div>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_filters_small_view.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_filters_small_view.html.erb
@@ -13,6 +13,6 @@
     </button>
   </div>
   <div class="filters">
-    <%= render partial: "filters" %>
+    <%= render partial: "filters", locals: { type: :small } %>
   </div>
 </div>

--- a/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/_filters_small_view.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/_filters_small_view.html.erb
@@ -13,6 +13,6 @@
     </button>
   </div>
   <div class="filters">
-    <%= render partial: "filters" %>
+    <%= render partial: "filters", locals: { type: :small } %>
   </div>
 </div>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: "decidim/shared/filter_form_help", locals: { skip_to_id: "proposals" } %>
 
-<% cache filter_cache_hash(filter) do %>
+<% cache filter_cache_hash(filter, defined?(type) ? type : nil) do %>
   <%= filter_form_for filter do |form| %>
     <div class="filters__section">
       <div class="filters__search">

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_filters_small_view.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_filters_small_view.html.erb
@@ -13,6 +13,6 @@
     </button>
   </div>
   <div class="filters">
-    <%= render partial: "filters" %>
+    <%= render partial: "filters", locals: { type: :small } %>
   </div>
 </div>

--- a/decidim-sortitions/app/views/decidim/sortitions/sortitions/_filters_small_view.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/sortitions/_filters_small_view.html.erb
@@ -13,6 +13,6 @@
     </button>
   </div>
   <div class="filters">
-    <%= render partial: "filters" %>
+    <%= render partial: "filters", locals: { type: :small } %>
   </div>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?
Caching functionality was added to the proposals listing view in #6808
Filters for mobile have the same generated HTML than the filter for desktop, causing an issue with unique ids.

filter_hash_cache now accepts a parameter `type` which is a symbol and serves the purpose to generate a different cache hash.

#### :pushpin: Related Issues
- Related to #6808
- Fixes #7528

#### Testing
* Run `rails dev:cache`
* Got to a proposals page, check for errors in the javascript console.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
<img width="1680" alt="Capture d’écran 2021-03-03 à 21 55 28" src="https://user-images.githubusercontent.com/20232956/109873909-b59acd00-7c6e-11eb-88a7-85766f1c832d.png">
