### PR TITLE
Don't schedule CI jobs for locales PRs

### DIFF
--- a/.github/workflows/ci_accountability.yml
+++ b/.github/workflows/ci_accountability.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_accountability.yml
+++ b/.github/workflows/ci_accountability.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_accountability.yml
+++ b/.github/workflows/ci_accountability.yml
@@ -2,9 +2,7 @@ name: "[CI] Accountability"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_admin.yml
+++ b/.github/workflows/ci_admin.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_admin.yml
+++ b/.github/workflows/ci_admin.yml
@@ -2,9 +2,7 @@ name: "[CI] Admin"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_admin.yml
+++ b/.github/workflows/ci_admin.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -2,9 +2,7 @@ name: "[CI] Api"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_assemblies.yml
+++ b/.github/workflows/ci_assemblies.yml
@@ -2,9 +2,7 @@ name: "[CI] Assemblies"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_assemblies.yml
+++ b/.github/workflows/ci_assemblies.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_assemblies.yml
+++ b/.github/workflows/ci_assemblies.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_blogs.yml
+++ b/.github/workflows/ci_blogs.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_blogs.yml
+++ b/.github/workflows/ci_blogs.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_blogs.yml
+++ b/.github/workflows/ci_blogs.yml
@@ -2,9 +2,7 @@ name: "[CI] Blogs"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_budgets.yml
+++ b/.github/workflows/ci_budgets.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_budgets.yml
+++ b/.github/workflows/ci_budgets.yml
@@ -2,9 +2,7 @@ name: "[CI] Budgets"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_budgets.yml
+++ b/.github/workflows/ci_budgets.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_comments.yml
+++ b/.github/workflows/ci_comments.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -20,7 +18,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_comments.yml
+++ b/.github/workflows/ci_comments.yml
@@ -2,9 +2,7 @@ name: "[CI] Comments"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_comments.yml
+++ b/.github/workflows/ci_comments.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_conferences.yml
+++ b/.github/workflows/ci_conferences.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_conferences.yml
+++ b/.github/workflows/ci_conferences.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_conferences.yml
+++ b/.github/workflows/ci_conferences.yml
@@ -2,9 +2,7 @@ name: "[CI] Conferences"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_consultations.yml
+++ b/.github/workflows/ci_consultations.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_consultations.yml
+++ b/.github/workflows/ci_consultations.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_consultations.yml
+++ b/.github/workflows/ci_consultations.yml
@@ -2,9 +2,7 @@ name: "[CI] Consultations"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_core_system.yml
+++ b/.github/workflows/ci_core_system.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_core_system.yml
+++ b/.github/workflows/ci_core_system.yml
@@ -2,9 +2,7 @@ name: "[CI] Core (system specs)"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_core_system.yml
+++ b/.github/workflows/ci_core_system.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_core_unit.yml
+++ b/.github/workflows/ci_core_unit.yml
@@ -2,9 +2,7 @@ name: "[CI] Core (unit tests)"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_core_unit.yml
+++ b/.github/workflows/ci_core_unit.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_core_unit.yml
+++ b/.github/workflows/ci_core_unit.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_debates.yml
+++ b/.github/workflows/ci_debates.yml
@@ -2,9 +2,7 @@ name: "[CI] Debates"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_debates.yml
+++ b/.github/workflows/ci_debates.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_debates.yml
+++ b/.github/workflows/ci_debates.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_elections_system_admin.yml
+++ b/.github/workflows/ci_elections_system_admin.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_elections_system_admin.yml
+++ b/.github/workflows/ci_elections_system_admin.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_elections_system_admin.yml
+++ b/.github/workflows/ci_elections_system_admin.yml
@@ -2,9 +2,7 @@ name: "[CI] Elections (system admin)"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_elections_system_public.yml
+++ b/.github/workflows/ci_elections_system_public.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_elections_system_public.yml
+++ b/.github/workflows/ci_elections_system_public.yml
@@ -2,9 +2,7 @@ name: "[CI] Elections (system public)"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_elections_system_public.yml
+++ b/.github/workflows/ci_elections_system_public.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_elections_unit_tests.yml
+++ b/.github/workflows/ci_elections_unit_tests.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_elections_unit_tests.yml
+++ b/.github/workflows/ci_elections_unit_tests.yml
@@ -2,9 +2,7 @@ name: "[CI] Elections (unit tests)"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_elections_unit_tests.yml
+++ b/.github/workflows/ci_elections_unit_tests.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_forms.yml
+++ b/.github/workflows/ci_forms.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_forms.yml
+++ b/.github/workflows/ci_forms.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_forms.yml
+++ b/.github/workflows/ci_forms.yml
@@ -2,9 +2,7 @@ name: "[CI] Forms"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -2,9 +2,7 @@ name: "[CI] Generators"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_initiatives.yml
+++ b/.github/workflows/ci_initiatives.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_initiatives.yml
+++ b/.github/workflows/ci_initiatives.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_initiatives.yml
+++ b/.github/workflows/ci_initiatives.yml
@@ -2,9 +2,7 @@ name: "[CI] Initiatives"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -6,9 +6,6 @@ on:
       - release/*
       - "*-stable"
       - "!chore/l10n**"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -5,9 +5,10 @@ on:
       - develop
       - release/*
       - "*-stable"
+      - "!chore/l10n**"
   pull_request:
     branches-ignore:
-      - "chore/l10n**"
+      - "chore/l10n*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -2,10 +2,7 @@ name: "[CI] Main folder"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
-  pull-request:
+      - "**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -5,7 +5,6 @@ on:
       - develop
       - release/*
       - "*-stable"
-      - "!chore/l10n**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -7,7 +7,7 @@ on:
       - "*-stable"
   pull_request:
     branches-ignore:
-      - "chore/l10n*"
+      - "chore/l10n**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -5,6 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
+  pull-request:
 
 env:
   CI: "true"

--- a/.github/workflows/ci_meetings_system_admin.yml
+++ b/.github/workflows/ci_meetings_system_admin.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_meetings_system_admin.yml
+++ b/.github/workflows/ci_meetings_system_admin.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_meetings_system_admin.yml
+++ b/.github/workflows/ci_meetings_system_admin.yml
@@ -2,9 +2,7 @@ name: "[CI] Meetings (system admin)"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_meetings_system_public.yml
+++ b/.github/workflows/ci_meetings_system_public.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_meetings_system_public.yml
+++ b/.github/workflows/ci_meetings_system_public.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_meetings_system_public.yml
+++ b/.github/workflows/ci_meetings_system_public.yml
@@ -2,9 +2,7 @@ name: "[CI] Meetings (system public)"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_meetings_unit_tests.yml
+++ b/.github/workflows/ci_meetings_unit_tests.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_meetings_unit_tests.yml
+++ b/.github/workflows/ci_meetings_unit_tests.yml
@@ -2,9 +2,7 @@ name: "[CI] Meetings (unit tests)"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_meetings_unit_tests.yml
+++ b/.github/workflows/ci_meetings_unit_tests.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_pages.yml
+++ b/.github/workflows/ci_pages.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_pages.yml
+++ b/.github/workflows/ci_pages.yml
@@ -2,9 +2,7 @@ name: "[CI] Pages"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_pages.yml
+++ b/.github/workflows/ci_pages.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_participatory_processes.yml
+++ b/.github/workflows/ci_participatory_processes.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_participatory_processes.yml
+++ b/.github/workflows/ci_participatory_processes.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_participatory_processes.yml
+++ b/.github/workflows/ci_participatory_processes.yml
@@ -2,9 +2,7 @@ name: "[CI] Participatory processes"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_proposals_system_admin.yml
+++ b/.github/workflows/ci_proposals_system_admin.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_proposals_system_admin.yml
+++ b/.github/workflows/ci_proposals_system_admin.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_proposals_system_admin.yml
+++ b/.github/workflows/ci_proposals_system_admin.yml
@@ -2,9 +2,7 @@ name: "[CI] Proposals (system admin)"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_proposals_system_public_1.yml
+++ b/.github/workflows/ci_proposals_system_public_1.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_proposals_system_public_1.yml
+++ b/.github/workflows/ci_proposals_system_public_1.yml
@@ -2,9 +2,7 @@ name: "[CI] Proposals (system public 1)"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_proposals_system_public_1.yml
+++ b/.github/workflows/ci_proposals_system_public_1.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_proposals_system_public_2.yml
+++ b/.github/workflows/ci_proposals_system_public_2.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_proposals_system_public_2.yml
+++ b/.github/workflows/ci_proposals_system_public_2.yml
@@ -2,9 +2,7 @@ name: "[CI] Proposals (system public2)"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_proposals_system_public_2.yml
+++ b/.github/workflows/ci_proposals_system_public_2.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_proposals_unit_tests.yml
+++ b/.github/workflows/ci_proposals_unit_tests.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_proposals_unit_tests.yml
+++ b/.github/workflows/ci_proposals_unit_tests.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_proposals_unit_tests.yml
+++ b/.github/workflows/ci_proposals_unit_tests.yml
@@ -2,9 +2,7 @@ name: "[CI] Proposals (unit tests)"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_sortitions.yml
+++ b/.github/workflows/ci_sortitions.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_sortitions.yml
+++ b/.github/workflows/ci_sortitions.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_sortitions.yml
+++ b/.github/workflows/ci_sortitions.yml
@@ -2,9 +2,7 @@ name: "[CI] Sortitions"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_surveys.yml
+++ b/.github/workflows/ci_surveys.yml
@@ -2,9 +2,7 @@ name: "[CI] Surveys"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_surveys.yml
+++ b/.github/workflows/ci_surveys.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_surveys.yml
+++ b/.github/workflows/ci_surveys.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_system.yml
+++ b/.github/workflows/ci_system.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_system.yml
+++ b/.github/workflows/ci_system.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_system.yml
+++ b/.github/workflows/ci_system.yml
@@ -2,9 +2,7 @@ name: "[CI] System"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_templates.yml
+++ b/.github/workflows/ci_templates.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_templates.yml
+++ b/.github/workflows/ci_templates.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_templates.yml
+++ b/.github/workflows/ci_templates.yml
@@ -2,9 +2,7 @@ name: "[CI] Templates"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_verifications.yml
+++ b/.github/workflows/ci_verifications.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_verifications.yml
+++ b/.github/workflows/ci_verifications.yml
@@ -2,9 +2,7 @@ name: "[CI] Verifications"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
 
 env:

--- a/.github/workflows/ci_verifications.yml
+++ b/.github/workflows/ci_verifications.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -6,6 +6,7 @@ on:
       - release/*
       - "*-stable"
       - "!chore/l10n**"
+  pull-request:
 
 env:
   CI: "true"

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "**"
       - "!chore/l10n**"
+      - "!l10n/**"
 
 env:
   CI: "true"

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -5,9 +5,7 @@ on:
       - develop
       - release/*
       - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+      - "!chore/l10n**"
 
 env:
   CI: "true"
@@ -19,7 +17,6 @@ jobs:
   lint:
     name: Lint code
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.2.2

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -2,11 +2,8 @@ name: "[CI] Lint"
 on:
   push:
     branches:
-      - develop
-      - release/*
-      - "*-stable"
+      - "**"
       - "!chore/l10n**"
-  pull-request:
 
 env:
   CI: "true"


### PR DESCRIPTION
#### :tophat: What? Why?
When we get Crowdin updates, we schedule all the CI jobs, even if they're then automatically skipped. This feels weird, since we're scheduling jobs that will be skipped anyway. Also, CI jobs would only be scheduled once the PR is created.

With this approach, we're making sure the CI jobs for Crowdin updates are never even scheduled, and we're running the CI on any push to any branch (instead of waiting for the PR to be created).

#### :pushpin: Related Issues
None

#### Testing
I guess you could play with the code any using differnt branch names? Also, #7535 builds on top of this one. Notice how the tests actually run there, but not in this PR, due to the branch names.

