### PR TITLE
Fix record encryptor trying to decrypt or decode non-String values

### DIFF
--- a/decidim-core/lib/decidim/attribute_encryptor.rb
+++ b/decidim-core/lib/decidim/attribute_encryptor.rb
@@ -7,7 +7,15 @@ module Decidim
     end
 
     def self.decrypt(string_encrypted)
-      cryptor.decrypt_and_verify(string_encrypted) if string_encrypted.present?
+      return if string_encrypted.blank?
+
+      # `ActiveSupport::MessageEncryptor` expects all values passed to the
+      # `#decrypt_and_verify` method to be instances of String as the message
+      # verifier calls `#split` on the value objects: https://git.io/JqfOO.
+      # If something else is passed, just return the value as is.
+      return string_encrypted unless string_encrypted.is_a?(String)
+
+      cryptor.decrypt_and_verify(string_encrypted)
     end
 
     def self.cryptor

--- a/decidim-core/lib/decidim/record_encryptor.rb
+++ b/decidim-core/lib/decidim/record_encryptor.rb
@@ -102,13 +102,6 @@ module Decidim
     end
 
     def decrypt_value(value)
-      # The legacy metadata values can be something else than Strings which
-      # cannot be decrypted. `ActiveSupport::MessageEncryptor` expects all
-      # values passed to the `#decrypt_and_verify` method to be instances of
-      # String as the message verifier calls `#split` on the value objects:
-      # https://git.io/JqfOO.
-      return value unless value.is_a?(String)
-
       Decidim::AttributeEncryptor.decrypt(value)
     rescue ActiveSupport::MessageEncryptor::InvalidMessage, ActiveSupport::MessageVerifier::InvalidSignature
       # Support for legacy unencrypted values. This is necessary e.g. when

--- a/decidim-core/spec/lib/attribute_encryptor_spec.rb
+++ b/decidim-core/spec/lib/attribute_encryptor_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe AttributeEncryptor do
+    describe ".decrypt" do
+      context "when the passed value is blank" do
+        let(:value) { "" }
+
+        it "returns nil" do
+          expect(described_class.decrypt(value)).to eq(nil)
+        end
+      end
+
+      context "when the passed value is a hash" do
+        let(:value) { { "foo" => "bar" } }
+
+        it "returns the original value" do
+          expect(described_class.decrypt(value)).to eq(value)
+        end
+      end
+
+      context "when the passed value is an Integer" do
+        let(:value) { 123 }
+
+        it "returns the original value" do
+          expect(described_class.decrypt(value)).to eq(123)
+        end
+      end
+
+      context "when the passed value is an a test double" do
+        let(:value) { double }
+
+        it "returns the original value" do
+          expect(described_class.decrypt(value)).to be(value)
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/lib/attribute_encryptor_spec.rb
+++ b/decidim-core/spec/lib/attribute_encryptor_spec.rb
@@ -36,6 +36,46 @@ module Decidim
           expect(described_class.decrypt(value)).to be(value)
         end
       end
+
+      context "when the passed value is an invalid encrypted string" do
+        let(:value) { "foobar" }
+
+        it "raises ActiveSupport::MessageEncryptor::InvalidMessage" do
+          expect { described_class.decrypt(value) }.to raise_error(
+            ActiveSupport::MessageEncryptor::InvalidMessage
+          )
+        end
+
+        context "with Rails 5.1 defaults" do
+          before do
+            allow(ActiveSupport::MessageEncryptor).to receive(
+              :use_authenticated_message_encryption
+            ).and_return(false)
+          end
+
+          it "raises ActiveSupport::MessageVerifier::InvalidSignature" do
+            expect { described_class.decrypt(value) }.to raise_error(
+              ActiveSupport::MessageVerifier::InvalidSignature
+            )
+          end
+        end
+      end
+
+      context "when the passed value is a correctly encrypted string" do
+        let(:value) { "+7Mv1nXW5obXnkaDUW+9Bqg=--qgiVKMTttTRKwd6f--Bx1yDcuZYwNv7Oj55MnE3g==" }
+
+        before do
+          # Temporarily change the secret so that it matches the secret used
+          # when encrypting the value.
+          allow(Rails.application.secrets).to receive(
+            :secret_key_base
+          ).and_return("testsecret")
+        end
+
+        it "returns the decrypted value" do
+          expect(described_class.decrypt(value)).to eq("Decidim")
+        end
+      end
     end
   end
 end

--- a/decidim-core/spec/lib/record_encryptor_spec.rb
+++ b/decidim-core/spec/lib/record_encryptor_spec.rb
@@ -94,6 +94,38 @@ module Decidim
           "verification_code" => 123_456_789
         )
       end
+
+      it "returns the original hash values for deep hashes that cannot be passed to decryption" do
+        deep_metadata = {
+          "location" => {
+            "Country" => {
+              "Province" => {
+                "Region" => {
+                  "Sub-region" => {
+                    "Municipality" => {
+                      "Quarter" => {
+                        "Block" => "Street"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "extras" => {
+            "foo" => {
+              "bar" => "baz"
+            }
+          }
+        }
+
+        subject.instance_variable_set(
+          :@metadata,
+          deep_metadata
+        )
+
+        expect(subject.metadata).to eq(deep_metadata)
+      end
     end
 
     it_behaves_like "encrypted record"


### PR DESCRIPTION
#### :tophat: What? Why?
Currently the record decryption fails if the unencrypted values are something else than a String or something that can be converted to a String as explained at:
https://github.com/decidim/decidim/issues/7487#issuecomment-790445272

This checks the type of the value before passing it to decryption or to JSON decoding for hash values.

#### :pushpin: Related Issues
- Related to #6947
- Fixes https://github.com/decidim/decidim/issues/7487#issuecomment-790445272

#### Testing
See the testing instructions at: #7488

But for the authorization record, add deeper hash values to match this case:
```ruby
Decidim::Authorization.create!(
  user: Decidim::User.first,
  name: "postal_code",
  metadata: {},
  verification_metadata: {
    foo: { bar: "baz" }
  }
)
```

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.