### PR TITLE
Fix record encryptor trying to decrypt empty strings

### DIFF
--- a/decidim-core/lib/decidim/record_encryptor.rb
+++ b/decidim-core/lib/decidim/record_encryptor.rb
@@ -129,6 +129,8 @@ module Decidim
         # cannot be JSON decoded.
         begin
           ActiveSupport::JSON.decode(decrypted_value)
+        rescue TypeError
+          ""
         rescue JSON::ParserError
           decrypted_value
         end

--- a/decidim-core/spec/lib/record_encryptor_spec.rb
+++ b/decidim-core/spec/lib/record_encryptor_spec.rb
@@ -112,6 +112,7 @@ module Decidim
               }
             }
           },
+          "foobar" => "",
           "extras" => {
             "foo" => {
               "bar" => "baz"


### PR DESCRIPTION
#### :tophat: What? Why?
When an authorization has a Hash with an empty string, the decryption process fails. This Pr fixes it.

#### :pushpin: Related Issues
- Related to #6947
- Fixes https://github.com/decidim/decidim/issues/7487#issuecomment-790692803

#### Testing
Probably same as in #7488.