### PR TITLE
Revert "Don't schedule CI jobs for locales PRs (#7534)"

### DIFF
--- a/.github/workflows/ci_accountability.yml
+++ b/.github/workflows/ci_accountability.yml
@@ -2,9 +2,12 @@ name: "[CI] Accountability"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_admin.yml
+++ b/.github/workflows/ci_admin.yml
@@ -2,9 +2,12 @@ name: "[CI] Admin"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -2,9 +2,12 @@ name: "[CI] Api"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_assemblies.yml
+++ b/.github/workflows/ci_assemblies.yml
@@ -2,9 +2,12 @@ name: "[CI] Assemblies"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_blogs.yml
+++ b/.github/workflows/ci_blogs.yml
@@ -2,9 +2,12 @@ name: "[CI] Blogs"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_budgets.yml
+++ b/.github/workflows/ci_budgets.yml
@@ -2,9 +2,12 @@ name: "[CI] Budgets"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_comments.yml
+++ b/.github/workflows/ci_comments.yml
@@ -2,9 +2,12 @@ name: "[CI] Comments"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -17,6 +20,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_conferences.yml
+++ b/.github/workflows/ci_conferences.yml
@@ -2,9 +2,12 @@ name: "[CI] Conferences"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_consultations.yml
+++ b/.github/workflows/ci_consultations.yml
@@ -2,9 +2,12 @@ name: "[CI] Consultations"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_core_system.yml
+++ b/.github/workflows/ci_core_system.yml
@@ -2,9 +2,12 @@ name: "[CI] Core (system specs)"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_core_unit.yml
+++ b/.github/workflows/ci_core_unit.yml
@@ -2,9 +2,12 @@ name: "[CI] Core (unit tests)"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_debates.yml
+++ b/.github/workflows/ci_debates.yml
@@ -2,9 +2,12 @@ name: "[CI] Debates"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_elections_system_admin.yml
+++ b/.github/workflows/ci_elections_system_admin.yml
@@ -2,9 +2,12 @@ name: "[CI] Elections (system admin)"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_elections_system_public.yml
+++ b/.github/workflows/ci_elections_system_public.yml
@@ -2,9 +2,12 @@ name: "[CI] Elections (system public)"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_elections_unit_tests.yml
+++ b/.github/workflows/ci_elections_unit_tests.yml
@@ -2,9 +2,12 @@ name: "[CI] Elections (unit tests)"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_forms.yml
+++ b/.github/workflows/ci_forms.yml
@@ -2,9 +2,12 @@ name: "[CI] Forms"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -2,9 +2,12 @@ name: "[CI] Generators"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_initiatives.yml
+++ b/.github/workflows/ci_initiatives.yml
@@ -2,9 +2,12 @@ name: "[CI] Initiatives"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -2,7 +2,12 @@ name: "[CI] Main folder"
 on:
   push:
     branches:
-      - "**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_meetings_system_admin.yml
+++ b/.github/workflows/ci_meetings_system_admin.yml
@@ -2,9 +2,12 @@ name: "[CI] Meetings (system admin)"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_meetings_system_public.yml
+++ b/.github/workflows/ci_meetings_system_public.yml
@@ -2,9 +2,12 @@ name: "[CI] Meetings (system public)"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_meetings_unit_tests.yml
+++ b/.github/workflows/ci_meetings_unit_tests.yml
@@ -2,9 +2,12 @@ name: "[CI] Meetings (unit tests)"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_pages.yml
+++ b/.github/workflows/ci_pages.yml
@@ -2,9 +2,12 @@ name: "[CI] Pages"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_participatory_processes.yml
+++ b/.github/workflows/ci_participatory_processes.yml
@@ -2,9 +2,12 @@ name: "[CI] Participatory processes"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_proposals_system_admin.yml
+++ b/.github/workflows/ci_proposals_system_admin.yml
@@ -2,9 +2,12 @@ name: "[CI] Proposals (system admin)"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_proposals_system_public_1.yml
+++ b/.github/workflows/ci_proposals_system_public_1.yml
@@ -2,9 +2,12 @@ name: "[CI] Proposals (system public 1)"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_proposals_system_public_2.yml
+++ b/.github/workflows/ci_proposals_system_public_2.yml
@@ -2,9 +2,12 @@ name: "[CI] Proposals (system public2)"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_proposals_unit_tests.yml
+++ b/.github/workflows/ci_proposals_unit_tests.yml
@@ -2,9 +2,12 @@ name: "[CI] Proposals (unit tests)"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_sortitions.yml
+++ b/.github/workflows/ci_sortitions.yml
@@ -2,9 +2,12 @@ name: "[CI] Sortitions"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_surveys.yml
+++ b/.github/workflows/ci_surveys.yml
@@ -2,9 +2,12 @@ name: "[CI] Surveys"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_system.yml
+++ b/.github/workflows/ci_system.yml
@@ -2,9 +2,12 @@ name: "[CI] System"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_templates.yml
+++ b/.github/workflows/ci_templates.yml
@@ -2,9 +2,12 @@ name: "[CI] Templates"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/ci_verifications.yml
+++ b/.github/workflows/ci_verifications.yml
@@ -2,9 +2,12 @@ name: "[CI] Verifications"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
       postgres:

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -2,9 +2,12 @@ name: "[CI] Lint"
 on:
   push:
     branches:
-      - "**"
-      - "!chore/l10n**"
-      - "!l10n/**"
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
 
 env:
   CI: "true"
@@ -16,6 +19,7 @@ jobs:
   lint:
     name: Lint code
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.3.0


### PR DESCRIPTION
#### :tophat: What? Why?
This PR reverts #7534 as it's breaking the pipelines for PRs coming from forks.

#### :pushpin: Related Issues
None

#### Testing
None.