### PR TITLE
Fix user profile timeline activity cards texts showing "New resource" on updates

### DIFF
--- a/decidim-core/app/cells/decidim/activity/show.erb
+++ b/decidim-core/app/cells/decidim/activity/show.erb
@@ -1,4 +1,4 @@
-<div class="card card--activity">
+<div class="card card--activity" id="<%= element_id %>">
   <div class="card__content">
     <div class="card__text">
       <div class="text-medium">

--- a/decidim-core/app/cells/decidim/activity_cell.rb
+++ b/decidim-core/app/cells/decidim/activity_cell.rb
@@ -84,6 +84,10 @@ module Decidim
       model.user_lazy if resource.respond_to?(:user)
     end
 
+    def element_id
+      "action-#{model.id}"
+    end
+
     private
 
     def published?

--- a/decidim-core/app/cells/decidim/activity_cell.rb
+++ b/decidim-core/app/cells/decidim/activity_cell.rb
@@ -84,6 +84,8 @@ module Decidim
       model.user_lazy if resource.respond_to?(:user)
     end
 
+    delegate :action, to: :model
+
     def element_id
       "action-#{model.id}"
     end

--- a/decidim-debates/app/cells/decidim/debates/debate_activity_cell.rb
+++ b/decidim-debates/app/cells/decidim/debates/debate_activity_cell.rb
@@ -2,13 +2,21 @@
 
 module Decidim
   module Debates
-    # A cell to display when Debate has been created.
+    # A cell to display when actions happen on a debate.
     class DebateActivityCell < ActivityCell
       def title
-        I18n.t(
-          "decidim.debates.last_activity.new_debate_at_html",
-          link: participatory_space_link
-        )
+        case action
+        when "update"
+          I18n.t(
+            "decidim.debates.last_activity.debate_updated_at_html",
+            link: participatory_space_link
+          )
+        else
+          I18n.t(
+            "decidim.debates.last_activity.new_debate_at_html",
+            link: participatory_space_link
+          )
+        end
       end
 
       def resource_link_text

--- a/decidim-debates/config/locales/en.yml
+++ b/decidim-debates/config/locales/en.yml
@@ -172,6 +172,7 @@ en:
         versions_list:
           back_to_resource: Go back to debate
       last_activity:
+        debate_updated_at_html: "<span>Debate updated at %{link}</span>"
         new_debate_at_html: "<span>New debate at %{link}</span>"
       models:
         debate:

--- a/decidim-debates/spec/cells/decidim/debates/debate_activity_cell_spec.rb
+++ b/decidim-debates/spec/cells/decidim/debates/debate_activity_cell_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Debates
+    describe DebateActivityCell, type: :cell do
+      controller Decidim::LastActivitiesController
+
+      let!(:debate) { create(:debate) }
+      let(:action) { :publish }
+      let(:action_log) do
+        create(
+          :action_log,
+          action: action,
+          resource: debate,
+          organization: debate.organization,
+          component: debate.component,
+          participatory_space: debate.participatory_space
+        )
+      end
+
+      context "when rendering" do
+        it "renders the card" do
+          html = cell("decidim/debates/debate_activity", action_log).call
+          expect(html).to have_css("#action-#{action_log.id} .card__content")
+        end
+
+        context "when action is update" do
+          let(:action) { :update }
+
+          it "renders the correct title" do
+            html = cell("decidim/debates/debate_activity", action_log).call
+            expect(html).to have_css("#action-#{action_log.id} .card__content")
+            expect(html).to have_content("Debate updated")
+          end
+        end
+
+        context "when action is create" do
+          let(:action) { :create }
+
+          it "renders the correct title" do
+            html = cell("decidim/debates/debate_activity", action_log).call
+            expect(html).to have_css("#action-#{action_log.id} .card__content")
+            expect(html).to have_content("New debate")
+          end
+        end
+
+        context "when action is publish" do
+          it "renders the correct title" do
+            html = cell("decidim/debates/debate_activity", action_log).call
+            expect(html).to have_css("#action-#{action_log.id} .card__content")
+            expect(html).to have_content("New debate")
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_activity_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_activity_cell.rb
@@ -2,13 +2,21 @@
 
 module Decidim
   module Meetings
-    # A cell to display when a meeting has been created.
+    # A cell to display when actions happen on a meeting.
     class MeetingActivityCell < ActivityCell
       def title
-        I18n.t(
-          "decidim.meetings.last_activity.new_meeting_at_html",
-          link: participatory_space_link
-        )
+        case action
+        when "update"
+          I18n.t(
+            "decidim.meetings.last_activity.meeting_updated_at_html",
+            link: participatory_space_link
+          )
+        else
+          I18n.t(
+            "decidim.meetings.last_activity.new_meeting_at_html",
+            link: participatory_space_link
+          )
+        end
       end
 
       def resource_link_text

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -362,6 +362,7 @@ en:
             space_type: Participatory space
             upcoming: Upcoming
       last_activity:
+        meeting_updated_at_html: "<span>Meeting updated at %{link}</span>"
         new_meeting_at_html: "<span>New meeting at %{link}</span>"
       mailer:
         invite_join_meeting_mailer:

--- a/decidim-meetings/spec/cells/decidim/meetings/meeting_activity_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/meeting_activity_cell_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Meetings
+    describe MeetingActivityCell, type: :cell do
+      controller Decidim::LastActivitiesController
+
+      let!(:meeting) { create(:meeting) }
+      let(:action) { :publish }
+      let(:action_log) do
+        create(
+          :action_log,
+          action: action,
+          resource: meeting,
+          organization: meeting.organization,
+          component: meeting.component,
+          participatory_space: meeting.participatory_space
+        )
+      end
+
+      context "when rendering" do
+        it "renders the card" do
+          html = cell("decidim/meetings/meeting_activity", action_log).call
+          expect(html).to have_css("#action-#{action_log.id} .card__content")
+        end
+
+        context "when action is update" do
+          let(:action) { :update }
+
+          it "renders the correct title" do
+            html = cell("decidim/meetings/meeting_activity", action_log).call
+            expect(html).to have_css("#action-#{action_log.id} .card__content")
+            expect(html).to have_content("Meeting updated")
+          end
+        end
+
+        context "when action is create" do
+          let(:action) { :create }
+
+          it "renders the correct title" do
+            html = cell("decidim/meetings/meeting_activity", action_log).call
+            expect(html).to have_css("#action-#{action_log.id} .card__content")
+            expect(html).to have_content("New meeting")
+          end
+        end
+
+        context "when action is publish" do
+          it "renders the correct title" do
+            html = cell("decidim/meetings/meeting_activity", action_log).call
+            expect(html).to have_css("#action-#{action_log.id} .card__content")
+            expect(html).to have_content("New meeting")
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_activity_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_activity_cell.rb
@@ -2,13 +2,21 @@
 
 module Decidim
   module Proposals
-    # A cell to display when a proposal has been published.
+    # A cell to display when actions happen on a proposal.
     class ProposalActivityCell < ActivityCell
       def title
-        I18n.t(
-          "decidim.proposals.last_activity.new_proposal_at_html",
-          link: participatory_space_link
-        )
+        case action
+        when "update"
+          I18n.t(
+            "decidim.proposals.last_activity.proposal_updated_at_html",
+            link: participatory_space_link
+          )
+        else
+          I18n.t(
+            "decidim.proposals.last_activity.new_proposal_at_html",
+            link: participatory_space_link
+          )
+        end
       end
 
       def resource_link_text

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -666,6 +666,7 @@ en:
         success: Proposal draft was successfully deleted.
       last_activity:
         new_proposal_at_html: "<span>New proposal at %{link}</span>"
+        proposal_updated_at_html: "<span>Proposal updated at %{link}</span>"
       models:
         collaborative_draft:
           fields:

--- a/decidim-proposals/spec/cells/decidim/proposals/proposal_activity_cell_spec.rb
+++ b/decidim-proposals/spec/cells/decidim/proposals/proposal_activity_cell_spec.rb
@@ -9,9 +9,11 @@ module Decidim
 
       let!(:proposal) { create(:proposal) }
       let(:hashtag) { create(:hashtag, name: "myhashtag") }
+      let(:action) { :publish }
       let(:action_log) do
         create(
           :action_log,
+          action: action,
           resource: proposal,
           organization: proposal.organization,
           component: proposal.component,
@@ -22,8 +24,35 @@ module Decidim
       context "when rendering" do
         it "renders the card" do
           html = cell("decidim/proposals/proposal_activity", action_log).call
-          expect(html).to have_css(".card__content")
-          expect(html).to have_content("New proposal")
+          expect(html).to have_css("#action-#{action_log.id} .card__content")
+        end
+
+        context "when action is update" do
+          let(:action) { :update }
+
+          it "renders the correct title" do
+            html = cell("decidim/proposals/proposal_activity", action_log).call
+            expect(html).to have_css("#action-#{action_log.id} .card__content")
+            expect(html).to have_content("Proposal updated")
+          end
+        end
+
+        context "when action is create" do
+          let(:action) { :create }
+
+          it "renders the correct title" do
+            html = cell("decidim/proposals/proposal_activity", action_log).call
+            expect(html).to have_css("#action-#{action_log.id} .card__content")
+            expect(html).to have_content("New proposal")
+          end
+        end
+
+        context "when action is publish" do
+          it "renders the correct title" do
+            html = cell("decidim/proposals/proposal_activity", action_log).call
+            expect(html).to have_css("#action-#{action_log.id} .card__content")
+            expect(html).to have_content("New proposal")
+          end
         end
 
         context "when the proposal has a hashtags" do


### PR DESCRIPTION
#### :tophat: What? Why?
This PR updates the debates, meetings and proposals activity cards so that they can handle the "update" action shown at the user profile activity tab. The full bug report is at #7554.

![image](https://user-images.githubusercontent.com/491891/110327753-acb54d00-801a-11eb-95f5-a8fbcfc21b7a.png)

#### :pushpin: Related Issues
- Fixes #7554

#### Testing
Rely on the test suite. You can also test it with this steps:

1. Create a meeting from the public area
2. Update it with a new title or description
3. Check the Timeline tab in your user profile: it appears twice, there (one for the creation, one for the update). Oldest card shows "New meeting", newest card shows "Meeting updated"

