### PR TITLE
Fix announcements when sending an empty translations hash

### DIFF
--- a/decidim-core/app/cells/decidim/announcement_cell.rb
+++ b/decidim-core/app/cells/decidim/announcement_cell.rb
@@ -31,7 +31,7 @@ module Decidim
     end
 
     def announcement
-      model
+      translated_attribute(model)
     end
 
     def clean_title

--- a/decidim-core/app/cells/decidim/announcement_cell.rb
+++ b/decidim-core/app/cells/decidim/announcement_cell.rb
@@ -2,20 +2,27 @@
 
 module Decidim
   # This cell renders an announcement
-  # the `model` is spected to be a Hash with two keys:
-  #  `announcement` is mandatory, its the message to show
-  #  `callout_class` is optional, the css class modifier
+  #
+  # The `model` is expected to be a Hash with two keys:
+  #   - `body` is mandatory, its the message to show
+  #   - `title` is mandatory, a title to show
   #
   # {
-  #   announcement: { ... },
-  #   callout_class: "warning"
+  #   title: "...", # mandatory
+  #   body: "..." # mandatory
   # }
+  #
+  # It can also receive a single value to show as text. It can either be a String
+  # or a value accepted by the `translated_attribute` method.
+  #
+  # As options, the cell accepts a Hash with these keys:
+  #   - `callout_class`: The Css class to apply. Default to `"secondary"`
   #
   class AnnouncementCell < Decidim::ViewModel
     include Decidim::SanitizeHelper
 
     def show
-      return unless announcement.presence
+      return if clean_body.blank? && clean_announcement.blank?
 
       render :show
     end
@@ -31,15 +38,23 @@ module Decidim
     end
 
     def announcement
-      translated_attribute(model)
+      model
     end
 
     def clean_title
       clean(announcement[:title])
     end
 
+    def body
+      return announcement.presence unless announcement.is_a?(Hash)
+
+      announcement[:body].presence
+    end
+
     def clean_body
-      Array(announcement[:body]).map { |paragraph| tag.p(clean(paragraph)) }.join("")
+      return unless body
+
+      Array(body).map { |paragraph| tag.p(clean(paragraph)) }.join("")
     end
 
     def clean_announcement

--- a/decidim-core/spec/cells/decidim/announcement_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/announcement_cell_spec.rb
@@ -19,7 +19,7 @@ module Decidim
     context "when passing an empty string" do
       let(:announcement) { "" }
 
-      it "renders the card" do
+      it "does not render the card" do
         html = cell("decidim/announcement", announcement).call
         expect(html).to render_nothing
       end
@@ -28,7 +28,7 @@ module Decidim
     context "when passing an empty translations hash" do
       let(:announcement) { { en: "" } }
 
-      it "renders the card" do
+      it "does not render the card" do
         html = cell("decidim/announcement", announcement).call
         expect(html).to render_nothing
       end

--- a/decidim-core/spec/cells/decidim/announcement_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/announcement_cell_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe AnnouncementCell, type: :cell do
+    controller Decidim::LastActivitiesController
+
+    context "when passing a non-empty string" do
+      let(:announcement) { "My announcement" }
+
+      it "renders the card" do
+        html = cell("decidim/announcement", announcement).call
+        expect(html).to have_css(".callout.announcement.cell-announcement")
+        expect(html).to have_text(announcement)
+      end
+    end
+
+    context "when passing an empty string" do
+      let(:announcement) { "" }
+
+      it "renders the card" do
+        html = cell("decidim/announcement", announcement).call
+        expect(html).to render_nothing
+      end
+    end
+
+    context "when passing an empty translations hash" do
+      let(:announcement) { { en: "" } }
+
+      it "renders the card" do
+        html = cell("decidim/announcement", announcement).call
+        expect(html).to render_nothing
+      end
+    end
+
+    context "when passing a non-empty translations hash" do
+      let(:announcement) { { en: "My announcement", ca: "Translated value" } }
+
+      it "renders the card" do
+        html = cell("decidim/announcement", announcement).call
+        expect(html).to have_css(".callout.announcement.cell-announcement")
+        expect(html).to have_text("My announcement")
+      end
+    end
+  end
+end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/cell_matchers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/cell_matchers.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Decidim
+  module CellMatchers
+    RSpec::Matchers.define :render_nothing do |_expected_value|
+      match do |actual_value|
+        expect(actual_value).to have_no_selector("html")
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include Decidim::CellMatchers, type: :cell
+end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/cell_matchers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/cell_matchers.rb
@@ -2,10 +2,12 @@
 
 module Decidim
   module CellMatchers
-    RSpec::Matchers.define :render_nothing do |_expected_value|
+    RSpec::Matchers.define :render_nothing do |expected_value|
       match do |actual_value|
         expect(actual_value).to have_no_selector("html")
       end
+
+      diffable
     end
   end
 end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/cell_matchers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/cell_matchers.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module CellMatchers
-    RSpec::Matchers.define :render_nothing do |expected_value|
+    RSpec::Matchers.define :render_nothing do |_expected_value|
       match do |actual_value|
         expect(actual_value).to have_no_selector("html")
       end

--- a/decidim-proposals/app/views/decidim/proposals/proposals/edit.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/edit.html.erb
@@ -13,7 +13,7 @@
 <div class="row">
   <div class="columns large-6 medium-centered">
     <div class="card">
-      <%= cell("decidim/announcement", component_settings.new_proposal_help_text) %>
+      <%= cell("decidim/announcement", translated_attribute(component_settings.new_proposal_help_text)) %>
 
       <div class="card__content">
         <%= decidim_form_for(@form) do |form| %>


### PR DESCRIPTION
#### :tophat: What? Why?
In the proposal edit page we see this when there's no help text:

![image](https://user-images.githubusercontent.com/491891/110443634-6ca6a680-80bc-11eb-9c82-cd04cc0c5efa.png)

This happens due to PR #7251, which changed the API to generate announcements. This PR fixes the display of this particular announcement:

With no text:
![image](https://user-images.githubusercontent.com/491891/110443739-8c3dcf00-80bc-11eb-900b-7e7bdce2635d.png)

With text:
![image](https://user-images.githubusercontent.com/491891/110444277-1dad4100-80bd-11eb-8a42-091da38732c9.png)

This PR generalizes the solution for all announcements, and adds a new RSpec matcher to test that the cell renders nothing.

#### :pushpin: Related Issues
None

#### Testing
Ensure CI is green.
