### PR TITLE
Improve proposals listing performance after cache implementation

### DIFF
--- a/decidim-assemblies/db/migrate/20210310120444_add_followable_counter_cache_to_assemblies.rb
+++ b/decidim-assemblies/db/migrate/20210310120444_add_followable_counter_cache_to_assemblies.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddFollowableCounterCacheToAssemblies < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_assemblies, :follows_count, :integer, null: false, default: 0, index: true
+
+    reversible do |dir|
+      dir.up do
+        Decidim::Assembly.reset_column_information
+        Decidim::Assembly.find_each do |record|
+          record.class.reset_counters(record.id, :follows)
+        end
+      end
+    end
+  end
+end

--- a/decidim-blogs/db/migrate/20210310120514_add_followable_counter_cache_to_blogs.rb
+++ b/decidim-blogs/db/migrate/20210310120514_add_followable_counter_cache_to_blogs.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddFollowableCounterCacheToBlogs < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_blogs_posts, :follows_count, :integer, null: false, default: 0, index: true
+
+    reversible do |dir|
+      dir.up do
+        Decidim::Blogs::Post.reset_column_information
+        Decidim::Blogs::Post.find_each do |record|
+          record.class.reset_counters(record.id, :follows)
+        end
+      end
+    end
+  end
+end

--- a/decidim-budgets/db/migrate/20210310120613_add_followable_counter_cache_to_budgets.rb
+++ b/decidim-budgets/db/migrate/20210310120613_add_followable_counter_cache_to_budgets.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddFollowableCounterCacheToBudgets < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_budgets_projects, :follows_count, :integer, null: false, default: 0, index: true
+
+    reversible do |dir|
+      dir.up do
+        Decidim::Budgets::Project.reset_column_information
+        Decidim::Budgets::Project.find_each do |record|
+          record.class.reset_counters(record.id, :follows)
+        end
+      end
+    end
+  end
+end

--- a/decidim-conferences/db/migrate/20210310134942_add_followable_counter_cache_to_conferences.rb
+++ b/decidim-conferences/db/migrate/20210310134942_add_followable_counter_cache_to_conferences.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddFollowableCounterCacheToConferences < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_conferences, :follows_count, :integer, null: false, default: 0, index: true
+
+    reversible do |dir|
+      dir.up do
+        Decidim::Conference.reset_column_information
+        Decidim::Conference.find_each do |record|
+          record.class.reset_counters(record.id, :follows)
+        end
+      end
+    end
+  end
+end

--- a/decidim-consultations/db/migrate/20210310120626_add_followable_counter_cache_to_consultations.rb
+++ b/decidim-consultations/db/migrate/20210310120626_add_followable_counter_cache_to_consultations.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddFollowableCounterCacheToConsultations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_consultations_questions, :follows_count, :integer, null: false, default: 0, index: true
+
+    reversible do |dir|
+      dir.up do
+        Decidim::Consultations::Question.reset_column_information
+        Decidim::Consultations::Question.find_each do |record|
+          record.class.reset_counters(record.id, :follows)
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/app/models/decidim/follow.rb
+++ b/decidim-core/app/models/decidim/follow.rb
@@ -4,7 +4,7 @@ module Decidim
   class Follow < ApplicationRecord
     include Decidim::DataPortability
 
-    belongs_to :followable, foreign_key: "decidim_followable_id", foreign_type: "decidim_followable_type", polymorphic: true
+    belongs_to :followable, foreign_key: "decidim_followable_id", foreign_type: "decidim_followable_type", polymorphic: true, counter_cache: true
     belongs_to :user, foreign_key: "decidim_user_id", class_name: "Decidim::User"
 
     validates :user, uniqueness: { scope: [:followable] }

--- a/decidim-core/db/migrate/20210310120640_add_followable_counter_cache_to_users.rb
+++ b/decidim-core/db/migrate/20210310120640_add_followable_counter_cache_to_users.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddFollowableCounterCacheToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_users, :follows_count, :integer, null: false, default: 0, index: true
+
+    reversible do |dir|
+      dir.up do
+        Decidim::User.reset_column_information
+        Decidim::User.find_each do |record|
+          record.class.reset_counters(record.id, :follows)
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/followable.rb
+++ b/decidim-core/lib/decidim/followable.rb
@@ -6,7 +6,12 @@ module Decidim
     extend ActiveSupport::Concern
 
     included do
-      has_many :follows, as: :followable, foreign_key: "decidim_followable_id", foreign_type: "decidim_followable_type", class_name: "Decidim::Follow"
+      has_many :follows,
+               as: :followable,
+               foreign_key: "decidim_followable_id",
+               foreign_type: "decidim_followable_type",
+               class_name: "Decidim::Follow",
+               counter_cache: :follows_count
       has_many :followers, through: :follows, source: :user
     end
 

--- a/decidim-core/spec/commands/decidim/create_follow_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_follow_spec.rb
@@ -13,6 +13,7 @@ module Decidim
     it "creates a follow" do
       expect { described_class.new(form, user1).call }.to broadcast(:ok)
       expect(user2.reload.followers).to include(user1)
+      expect(user2.follows_count).to eq(1)
     end
 
     it "increments the user's score" do

--- a/decidim-core/spec/commands/decidim/delete_follow_spec.rb
+++ b/decidim-core/spec/commands/decidim/delete_follow_spec.rb
@@ -15,6 +15,7 @@ module Decidim
       expect { described_class.new(form, user1).call }.to broadcast(:ok)
 
       expect(user2.reload.followers).not_to include(user1)
+      expect(user2.follows_count).to eq(0)
     end
 
     describe "gamification" do

--- a/decidim-debates/db/migrate/20210310120652_add_followable_counter_cache_to_debates.rb
+++ b/decidim-debates/db/migrate/20210310120652_add_followable_counter_cache_to_debates.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddFollowableCounterCacheToDebates < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_debates_debates, :follows_count, :integer, null: false, default: 0, index: true
+
+    reversible do |dir|
+      dir.up do
+        Decidim::Debates::Debate.reset_column_information
+        Decidim::Debates::Debate.find_each do |record|
+          record.class.reset_counters(record.id, :follows)
+        end
+      end
+    end
+  end
+end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
@@ -276,6 +276,7 @@ RSpec.configure do |config|
           t.integer :coauthorships_count, null: false, default: 0
           t.integer :endorsements_count, null: false, default: 0
           t.integer :comments_count, null: false, default: 0
+          t.integer :follows_count, null: false, default: 0
 
           t.references :decidim_component, index: false
           t.integer :decidim_author_id, index: false

--- a/decidim-elections/db/migrate/20210310120708_add_followable_counter_cache_to_votings.rb
+++ b/decidim-elections/db/migrate/20210310120708_add_followable_counter_cache_to_votings.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddFollowableCounterCacheToVotings < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_votings_votings, :follows_count, :integer, null: false, default: 0, index: true
+
+    reversible do |dir|
+      dir.up do
+        Decidim::Votings::Voting.reset_column_information
+        Decidim::Votings::Voting.find_each do |record|
+          record.class.reset_counters(record.id, :follows)
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/db/migrate/20210310120720_add_followable_counter_cache_to_initiatives.rb
+++ b/decidim-initiatives/db/migrate/20210310120720_add_followable_counter_cache_to_initiatives.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddFollowableCounterCacheToInitiatives < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_initiatives, :follows_count, :integer, null: false, default: 0, index: true
+
+    reversible do |dir|
+      dir.up do
+        Decidim::Initiative.reset_column_information
+        Decidim::Initiative.find_each do |record|
+          record.class.reset_counters(record.id, :follows)
+        end
+      end
+    end
+  end
+end

--- a/decidim-meetings/db/migrate/20210310120731_add_followable_counter_cache_to_meetings.rb
+++ b/decidim-meetings/db/migrate/20210310120731_add_followable_counter_cache_to_meetings.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddFollowableCounterCacheToMeetings < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_meetings_meetings, :follows_count, :integer, null: false, default: 0, index: true
+
+    reversible do |dir|
+      dir.up do
+        Decidim::Meetings::Meeting.reset_column_information
+        Decidim::Meetings::Meeting.find_each do |record|
+          record.class.reset_counters(record.id, :follows)
+        end
+      end
+    end
+  end
+end

--- a/decidim-participatory_processes/db/migrate/20210310120750_add_followable_counter_cache_to_participatory_processes.rb
+++ b/decidim-participatory_processes/db/migrate/20210310120750_add_followable_counter_cache_to_participatory_processes.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddFollowableCounterCacheToParticipatoryProcesses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_participatory_processes, :follows_count, :integer, null: false, default: 0, index: true
+
+    reversible do |dir|
+      dir.up do
+        Decidim::ParticipatoryProcess.reset_column_information
+        Decidim::ParticipatoryProcess.find_each do |record|
+          record.class.reset_counters(record.id, :follows)
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
@@ -132,7 +132,7 @@ module Decidim
         hash << model.cache_key_with_version
         hash << model.proposal_votes_count
         hash << model.endorsements_count
-        hash << Digest::MD5.hexdigest(model.component.settings.to_json)
+        hash << Digest::MD5.hexdigest(model.component.cache_key_with_version)
         hash << Digest::MD5.hexdigest(resource_image_path) if resource_image_path
         if current_user
           hash << current_user.cache_key_with_version

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
@@ -138,7 +138,7 @@ module Decidim
           hash << current_user.cache_key_with_version
           hash << current_user.follows?(model) ? 1 : 0
         end
-        hash << Digest::MD5.hexdigest(model.followers.to_json)
+        hash << model.follows_count
         hash << Digest::MD5.hexdigest(model.coauthorships.map(&:cache_key_with_version).to_s)
 
         hash.join("/")

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
@@ -139,7 +139,7 @@ module Decidim
           hash << current_user.follows?(model) ? 1 : 0
         end
         hash << model.follows_count
-        hash << Digest::MD5.hexdigest(model.coauthorships.map(&:cache_key_with_version).to_s)
+        hash << Digest::MD5.hexdigest(model.authors.map(&:cache_key_with_version).to_s)
 
         hash.join("/")
       end

--- a/decidim-proposals/db/migrate/20210310102839_add_followable_counter_cache_to_proposals.rb
+++ b/decidim-proposals/db/migrate/20210310102839_add_followable_counter_cache_to_proposals.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddFollowableCounterCacheToProposals < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_proposals_proposals, :follows_count, :integer, null: false, default: 0, index: true
+
+    reversible do |dir|
+      dir.up do
+        Decidim::Proposals::Proposal.reset_column_information
+        Decidim::Proposals::Proposal.find_each do |record|
+          record.class.reset_counters(record.id, :follows)
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/db/migrate/20210310120812_add_followable_counter_cache_to_collaborative_drafts.rb
+++ b/decidim-proposals/db/migrate/20210310120812_add_followable_counter_cache_to_collaborative_drafts.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddFollowableCounterCacheToCollaborativeDrafts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_proposals_collaborative_drafts, :follows_count, :integer, null: false, default: 0, index: true
+
+    reversible do |dir|
+      dir.up do
+        Decidim::Proposals::CollaborativeDraft.reset_column_information
+        Decidim::Proposals::CollaborativeDraft.find_each do |record|
+          record.class.reset_counters(record.id, :follows)
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/cells/decidim/proposals/proposal_m_cell_spec.rb
+++ b/decidim-proposals/spec/cells/decidim/proposals/proposal_m_cell_spec.rb
@@ -136,6 +136,7 @@ module Decidim::Proposals
           component_settings = component.settings
           old_hash = my_cell.send(:cache_hash)
           component.settings = { foo: "bar" }
+          component.save!
 
           expect(my_cell.send(:cache_hash)).not_to eq(old_hash)
 


### PR DESCRIPTION
#### :tophat: What? Why?
After caching was added to proposals in #6808, the proposals listing page became very sluggish to load, even when results are being loaded from cache. You can see the effect by browsing Metadecidim's proposals components.

After some investigation, the reason for the poor performance turned out to be the cache hash generation for the proposal cards and particularly the line that takes the followers of the proposal into account here:
https://github.com/decidim/decidim/blob/b7a2ac876cb96a7fb553977f5a864bd9186f0307/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb#L141

Implementing a counter cache for the follows improves the performance greatly as my investigation shows below. These are the average response times with 10 consecutive requests for the proposals listing page with cache disabled and in the development environment:

- Current implementation with poorly performing `cache_hash`: 23,47s / req
- `cache_hash` removed (i.e. no caching for the proposal cards, as it was before #6808): 11,58s / req
- With follows counter cache (after this PR): 11,26s / req

**EDIT NOTE**: These numbers were taken before implementing all the changes, see discussion below. After all the changes I've run the same test with 10 requests averaging at 11,35s / req (I ran it 3 times and it was consistent).

Further discussion is available at:
https://github.com/decidim/decidim/discussions/7574

#### :pushpin: Related Issues
- Related to #6808, #7574

#### Testing
1. Create a Decidim instance with the default seed data
2. Get the URL to one of the proposals listing pages from your instance
3. Run the following command to see the response time of the page for 10 consecutive requests:
```bash
$ for i in {1..10}; do curl -so /dev/null -w '%{time_total}\n' http://localhost:3000/URL_TO_PROPOSALS_COMPONENT; done
```
4. See the performance change when comparing before and after this PR  

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.