### PR TITLE
Use first photo attachment as card image for blog posts and meetings

### DIFF
--- a/decidim-blogs/app/views/decidim/blogs/posts/_posts.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/posts/_posts.html.erb
@@ -1,6 +1,9 @@
 <div class="row small-12">
   <% paginate_posts.each do |post| %>
     <div class="card card--post">
+      <% if post.photo.present? %>
+        <%= image_tag post.photo.url, class: "card__image" %>
+      <% end %>
       <div class="card__content">
         <div class="card__header">
           <%= link_to post, class: "card__link" do %>

--- a/decidim-blogs/spec/system/explore_posts_spec.rb
+++ b/decidim-blogs/spec/system/explore_posts_spec.rb
@@ -9,6 +9,8 @@ describe "Explore posts", type: :system do
   let!(:old_post) { create(:post, component: component, created_at: Time.current - 2.days) }
   let!(:new_post) { create(:post, component: component, created_at: Time.current) }
 
+  let!(:image) { create(:attachment, attached_to: old_post) }
+
   describe "index" do
     it "shows all posts for the given process" do
       visit_component
@@ -27,6 +29,11 @@ describe "Explore posts", type: :system do
       visit_component
       expect(page).to have_selector('a[title="endorsements"]', text: "endorsement".pluralize(new_post.endorsements.count))
       expect(page).to have_selector('a[title="endorsements"]', text: "endorsement".pluralize(old_post.endorsements.count))
+    end
+
+    it "shows images" do
+      visit_component
+      expect(page).to have_selector(".card--post img.card__image")
     end
 
     context "when paginating" do

--- a/decidim-core/lib/decidim/has_attachments.rb
+++ b/decidim-core/lib/decidim/has_attachments.rb
@@ -15,28 +15,35 @@ module Decidim
                inverse_of: :attached_to,
                as: :attached_to
 
-      # All the attachments that are photos for this process.
+      # The first attachment that is a photo for this model.
+      #
+      # Returns an Attachment
+      def photo
+        @photo ||= photos.first
+      end
+
+      # All the attachments that are photos for this model.
       #
       # Returns an Array<Attachment>
       def photos
         @photos ||= attachments.select(&:photo?)
       end
 
-      # All the attachments that are documents for this process.
+      # All the attachments that are documents for this model.
       #
       # Returns an Array<Attachment>
       def documents
         @documents ||= attachments.includes(:attachment_collection).select(&:document?)
       end
 
-      # All the attachments that are documents for this process that has a collection.
+      # All the attachments that are documents for this model that has a collection.
       #
       # Returns an Array<Attachment>
       def documents_with_collection
         documents.select(&:attachment_collection_id?)
       end
 
-      # All the attachments that are documents for this process that not has a collection.
+      # All the attachments that are documents for this model that not has a collection.
       #
       # Returns an Array<Attachment>
       def documents_without_collection

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_m_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_m_cell.rb
@@ -31,6 +31,14 @@ module Decidim
 
       private
 
+      def resource_image_path
+        model.photo&.url
+      end
+
+      def has_image?
+        true
+      end
+
       def spans_multiple_dates?
         start_date != end_date
       end

--- a/decidim-meetings/spec/cells/decidim/meetings/meeting_m_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/meeting_m_cell_spec.rb
@@ -19,6 +19,14 @@ module Decidim::Meetings
       it "renders the card" do
         expect(cell_html).to have_css(".card--meeting")
       end
+
+      context "when an image is attached to the meeting" do
+        let!(:attachment) { create(:attachment, attached_to: meeting) }
+
+        it "renders the picture" do
+          expect(cell_html).to have_css(".card__image")
+        end
+      end
     end
 
     context "when title contains special html entities" do


### PR DESCRIPTION
#### :tophat: What? Why?
Use first photo attachment as card image for blog posts and meetings to provide visual support for these kind of cards.

#### :pushpin: Related Issues
- Related to [MetaDecidim proposal \#16240](https://meta.decidim.org/processes/roadmap/f/122/proposals/16240)
- Related to [MetaDecidim proposal \#16292](https://meta.decidim.org/processes/roadmap/f/122/proposals/16292)
- Supersedes #7537 

#### Testing
- Add an attachment to a meeting ➡️  View meetings list
- Add an attachment to a blog post ➡️  View blog posts list

#### :clipboard: Checklist
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots



#### Meetings - List
![Meetings - List](https://user-images.githubusercontent.com/8806781/110646272-081c4200-81b7-11eb-9a19-ae3ed862941b.png)

#### Meetings - Detail
![Meetings - Detail](https://user-images.githubusercontent.com/8806781/110646198-f8046280-81b6-11eb-9a96-0f7a5c2f0ff4.png)


#### Blog posts - List
![Blog post - List](https://user-images.githubusercontent.com/8806781/110644295-3dc02b80-81b5-11eb-9e25-6aeab857cc84.png)

#### Blog posts - Detail
![Blog post - Detail](https://user-images.githubusercontent.com/8806781/110644290-3bf66800-81b5-11eb-95e1-3db50eda4492.png)



:hearts: Thank you!
