### PR TITLE
Show processes finishing today

### DIFF
--- a/decidim-participatory_processes/app/models/decidim/participatory_process.rb
+++ b/decidim-participatory_processes/app/models/decidim/participatory_process.rb
@@ -124,7 +124,7 @@ module Decidim
     def active?
       return false if start_date.blank?
 
-      start_date < Date.current && (end_date.blank? || end_date > Date.current)
+      start_date <= Date.current && (end_date.blank? || end_date >= Date.current)
     end
 
     def past?

--- a/decidim-participatory_processes/app/models/decidim/participatory_process.rb
+++ b/decidim-participatory_processes/app/models/decidim/participatory_process.rb
@@ -74,7 +74,7 @@ module Decidim
 
     scope :past, -> { where(arel_table[:end_date].lt(Date.current)) }
     scope :upcoming, -> { where(arel_table[:start_date].gt(Date.current)) }
-    scope :active, -> { where(arel_table[:start_date].lteq(Date.current).and(arel_table[:end_date].gt(Date.current).or(arel_table[:end_date].eq(nil)))) }
+    scope :active, -> { where(arel_table[:start_date].lteq(Date.current).and(arel_table[:end_date].gteq(Date.current).or(arel_table[:end_date].eq(nil)))) }
 
     searchable_fields({
                         scope_id: :decidim_scope_id,

--- a/decidim-participatory_processes/spec/models/decidim/participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/models/decidim/participatory_process_spec.rb
@@ -62,10 +62,11 @@ module Decidim
       let!(:past) { create :participatory_process, :past }
       let!(:upcoming) { create :participatory_process, :upcoming }
       let!(:active) { create :participatory_process, :active }
+      let!(:ends_today) { create :participatory_process, start_date: 1.month.ago, end_date: Date.current }
 
       describe "active_spaces" do
         it "returns the currently active ones" do
-          expect(described_class.active_spaces).to include active
+          expect(described_class.active_spaces).to match_array [active, ends_today]
           expect(described_class.active_spaces).not_to include past
           expect(described_class.active_spaces).not_to include upcoming
         end

--- a/decidim-participatory_processes/spec/models/decidim/participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/models/decidim/participatory_process_spec.rb
@@ -35,6 +35,53 @@ module Decidim
       it { is_expected.to be_valid }
     end
 
+    describe "#active?" do
+      context "when it ends in the past" do
+        it "returns false" do
+          participatory_process.end_date = 1.day.ago
+          expect(participatory_process).not_to be_active
+        end
+      end
+
+      context "when it starts before today and ends in the future" do
+        it "returns true" do
+          participatory_process.start_date = 1.week.ago
+          participatory_process.end_date = 1.week.from_now
+          expect(participatory_process).to be_active
+        end
+      end
+
+      context "when it starts today and ends in the future" do
+        it "returns true" do
+          participatory_process.start_date = Date.current
+          participatory_process.end_date = 1.week.from_now
+          expect(participatory_process).to be_active
+        end
+      end
+
+      context "when it ends today" do
+        it "returns true" do
+          participatory_process.start_date = 1.week.ago
+          participatory_process.end_date = Date.current
+          expect(participatory_process).to be_active
+        end
+      end
+
+      context "when it starts in the future and ends in the future" do
+        it "returns false" do
+          participatory_process.end_date = 1.day.from_now
+          expect(participatory_process).not_to be_past
+        end
+      end
+
+      context "when it doesn't have an end date" do
+        it "returns false" do
+          participatory_process.end_date = nil
+          expect(participatory_process).not_to be_past
+        end
+      end
+    end
+
     describe "#past?" do
       context "when it ends in the past" do
         it "returns true" do


### PR DESCRIPTION
#### :tophat: What? Why?
*Please describe your pull request.*
ParticipatoryProcesses finishing on the current day (today) are not being listed in the public view.

This is a tricky bug because in some cases it seems the bug does not exist:

- If there's only one process it is being rendered because the Search thinks there are no :active, :upcoming and :past, and finally queries for :all.
- If there are many processes but all start today they are all rendered for the same reason as with one single event, the `ParticipatoryProcesses#active?` method. This is why the seeded processes in the development_app are still visible although the bug.

In fact there are two bugs affecting two places of the`ParticipatoryProcess` class:

- the `ParticipatoryProcesses#active` scope. Only the `end_date` constraint is wrong.
-  and the `ParticipatoryProcesses#active?` method. Both the `start_date` and the `end_date` ought also to consider the current date.

The counters in top of the listed cards  are not affected by this bug.
The list of Highlighted processes is not affected by this bug.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*
If a participatory process finishes today I expect it to be listed as an active process.
Create a participatory process finishing today, and make sure there is at least another process not starting neither finishing today.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*The process finishing today (12/03/2021) is being rendered*

![image](https://user-images.githubusercontent.com/199462/110967333-8bc06500-8356-11eb-9812-516dd15167b4.png)


:hearts: Thank you!
