### PR TITLE
Chore homepage statistics with title below the number

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/layouts/_home.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/layouts/_home.scss
@@ -309,29 +309,20 @@
   }
 }
 
-.home-stats__title{
-  color: $muted;
-  font-size: .9rem;
-  letter-spacing: .01em;
-  text-transform: uppercase;
-  font-weight: 600;
-  margin-bottom: 0;
-
-  .home-stats__lowlight &{
-    display: inline;
+.home-stats__highlight,
+.home-stats__lowlight{
+  .statistic__data::after{
+    border: none;
   }
 }
 
-.home-stats__data{
-  text-align: center;
-
+.home-stats__highlight{
   @include breakpoint(medium){
-    float: left;
+    display: flex;
   }
 
-  padding: .25rem;
-
-  .home-stats__highlight &{
+  .statistic__data{
+    margin: 0;
     padding: 1rem 2rem;
 
     @include breakpoint(medium){
@@ -348,38 +339,33 @@
     }
   }
 
-  .home-stats__lowlight &{
-    float: none;
-
-    @include breakpoint(mediumlarge){
-      float: left;
-      width: 33.33%;
-
-      &:first-child,
-      &:last-child{
-        text-align: left;
-        padding-left: 0;
-      }
-    }
-  }
-}
-
-.home-stats__highlight{
-  @include breakpoint(medium){
-    display: flex;
+  .statistic__number{
+    font-size: 4rem;
+    line-height: 1;
   }
 }
 
 .home-stats__lowlight{
-  text-align: center;
-}
+  .statistic__data{
+    padding: .25rem;
+    width: calc(33% - 1rem);
 
-.home-stats__number{
-  font-size: 1.2rem;
-  font-weight: 800;
+    @include breakpoint(mediumlarge){
+      text-align: left;
 
-  .home-stats__highlight &{
-    font-size: 4rem;
-    line-height: 1;
+      &:first-child,
+      &:last-child{
+        padding-left: 0;
+      }
+    }
+  }
+
+  .statistic__number{
+    font-size: 1.2rem;
+    font-weight: 800;
+  }
+
+  .statistic__title{
+    display: inline;
   }
 }

--- a/decidim-core/app/cells/decidim/statistic/show.erb
+++ b/decidim-core/app/cells/decidim/statistic/show.erb
@@ -1,4 +1,4 @@
-<div class="statistic__data">
+<div class="statistic__data <%= stat_dom_class %>">
   <span class="statistic__number">
     <%= stat_number %>
   </span>

--- a/decidim-core/app/cells/decidim/statistic_cell.rb
+++ b/decidim-core/app/cells/decidim/statistic_cell.rb
@@ -5,10 +5,6 @@ module Decidim
   class StatisticCell < Decidim::ViewModel
     include ActionView::Helpers::NumberHelper
 
-    def show
-      render design
-    end
-
     private
 
     def stat_number
@@ -21,10 +17,6 @@ module Decidim
 
     def stat_title
       t(model[:stat_title], scope: "decidim.statistics")
-    end
-
-    def design
-      options[:design].presence || "default"
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Unify the position of the statistics title to be the same in homepage and spaces stats.
With this PR, the organization homepage stats has the number on top of the title, like all other stats.

Follow the thread for more info https://github.com/decidim/decidim/issues/7112#issuecomment-790764253 

#### :pushpin: Related Issues

- Related to #7112

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

![stats-homepage](https://user-images.githubusercontent.com/210216/110931262-5867e100-832a-11eb-98ba-013733d6469d.png)


:hearts: Thank you!
