### PR TITLE
Add render space to cache hash

### DIFF
--- a/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
@@ -134,6 +134,7 @@ module Decidim
         hash << model.endorsements_count
         hash << Digest::MD5.hexdigest(model.component.settings.to_json)
         hash << Digest::MD5.hexdigest(resource_image_path) if resource_image_path
+        hash << render_space? ? 1 : 0
         if current_user
           hash << current_user.cache_key_with_version
           hash << current_user.follows?(model) ? 1 : 0

--- a/decidim-proposals/spec/cells/decidim/proposals/proposal_m_cell_spec.rb
+++ b/decidim-proposals/spec/cells/decidim/proposals/proposal_m_cell_spec.rb
@@ -214,6 +214,15 @@ module Decidim::Proposals
           expect(cached_proposals.uniq.length).to eq(5)
         end
       end
+
+      context "when space is rendered" do
+        it "generates a different hash" do
+          old_hash = my_cell.send(:cache_hash)
+          my_cell.context.merge!({ show_space: true })
+
+          expect(my_cell.send(:cache_hash)).not_to eq(old_hash)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Fix proposal card caching causes the participatory space to display inconsistently

#### :pushpin: Related Issues
- Related to  #6808
- Fixes #7564

#### Testing
* Run rails dev:cache
* Go to search
* Search with some term that you are sure to find a good amount of proposals (I used the term "meetings" but it may vary depending on the cache situation)
* Pick the search to show results only for "Proposals"
* See that in some cards the participatory space is not printed (it should be)
* Go to a proposals component
* Search with the same term as you did in the global search
* See that in some cards the participatory space is printed (it should NOT be)

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.
