### PR TITLE
Fix slower test performance for Rails 6 tests

### DIFF
--- a/decidim-dev/lib/tasks/generators.rake
+++ b/decidim-dev/lib/tasks/generators.rake
@@ -29,6 +29,7 @@ namespace :decidim do
       "../..",
       "--recreate_db",
       "--skip_gemfile",
+      "--skip_spring",
       "--demo"
     )
   end


### PR DESCRIPTION
#### :tophat: What? Why?
At #7471 @mrcasals pointed out a decrease in the test performance after the changes:
https://github.com/decidim/decidim/pull/7471#issuecomment-797324970

The problem is that the default configuration for the test environment's `cache_classes` option is now set to `false` by default although it was `true` for Rails 5.2.

- Rails 6.x: https://github.com/rails/rails/blob/005e14b2c4c403c7a85902f00d58c32bfc9ecd6c/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt#L13
- Rails 5.2: https://github.com/rails/rails/blob/63d3f3f4d868a5ed9eacf00af2a80278aa005051/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt#L8

When we apply the `--skip_spring` flag to the test app generation command, the configuration is reverted back to `true` as you can see from the linked configuration file template.

#### :pushpin: Related Issues
- Related to #7471

#### Testing
- Run one of the test sets (e.g. `decidim-blogs`) with the `chore/rails-6-upgrade` branch as is.
- Take a note about how long it ran.
- Apply this change.
- Re-create the test app (`bundle exec rake test_app`)
- Re-run the test set you just ran (e.g. `decidim-blogs`), preferably with the same `--seed X` option
- See the difference in performance.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.