### PR TITLE
Fix process serializer to consider nil images

### DIFF
--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
@@ -6,14 +6,15 @@ module Decidim
       include Rails.application.routes.mounted_helpers
       include ActionView::Helpers::UrlHelper
 
-      delegate :url, to: :hero_image, prefix: true
-      delegate :url, to: :banner_image, prefix: true
-
       def hero_image_url
+        return unless process.hero_image_url
+
         URI.join(decidim.root_url(host: process.organization.host), process.hero_image_url).to_s
       end
 
       def banner_image_url
+        return unless process.banner_image_url
+
         URI.join(decidim.root_url(host: process.organization.host), process.banner_image_url).to_s
       end
 

--- a/decidim-participatory_processes/spec/presenters/decidim/participatory_processes/participatory_process_presenter_spec.rb
+++ b/decidim-participatory_processes/spec/presenters/decidim/participatory_processes/participatory_process_presenter_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe ParticipatoryProcesses::ParticipatoryProcessPresenter do
+    subject { described_class.new(process) }
+
+    let!(:process) { create(:participatory_process) }
+
+    describe "#hero_image_url" do
+      context "when there's no image" do
+        it "returns nil" do
+          allow(process).to receive(:hero_image_url).and_return(nil)
+
+          expect(subject.hero_image_url).to be_nil
+        end
+      end
+
+      context "when image is a full url" do
+        it "returns nil" do
+          image_url = "http://example.com/image.jpg"
+          allow(process).to receive(:hero_image_url).and_return(image_url)
+
+          expect(subject.hero_image_url).to eq(image_url)
+        end
+      end
+
+      context "when image is a partial path" do
+        it "returns nil" do
+          organization_host = "http://example.org"
+          image_path = "/my/image.jpg"
+          allow(process).to receive(:hero_image_url).and_return(image_path)
+          allow(process.organization).to receive(:host).and_return(organization_host)
+
+          expect(subject.hero_image_url).to eq("http://example.org/my/image.jpg")
+        end
+      end
+    end
+
+    describe "#banner_image_url" do
+      context "when there's no image" do
+        it "returns nil" do
+          allow(process).to receive(:banner_image_url).and_return(nil)
+
+          expect(subject.banner_image_url).to be_nil
+        end
+      end
+
+      context "when image is a full url" do
+        it "returns nil" do
+          image_url = "http://example.com/image.jpg"
+          allow(process).to receive(:banner_image_url).and_return(image_url)
+
+          expect(subject.banner_image_url).to eq(image_url)
+        end
+      end
+
+      context "when image is a partial path" do
+        it "returns nil" do
+          organization_host = "http://example.org"
+          image_path = "/my/image.jpg"
+          allow(process).to receive(:banner_image_url).and_return(image_path)
+          allow(process.organization).to receive(:host).and_return(organization_host)
+
+          expect(subject.banner_image_url).to eq("http://example.org/my/image.jpg")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
When trying to export a participatory process without one of the images (hero image or banner image), the process fails because the presenter assumes the images exist.

This PR makes the presenter take into consideration these cases, so the serializer doesn't fail.

#### :pushpin: Related Issues
None

#### Testing
Create a process without one of the images and try to export it.

#### :clipboard: Checklist
None.