### PR TITLE
Make category in the API non-mandatory

### DIFF
--- a/decidim-core/lib/decidim/api/interfaces/categorizable_interface.rb
+++ b/decidim-core/lib/decidim/api/interfaces/categorizable_interface.rb
@@ -7,7 +7,7 @@ module Decidim
       include Decidim::Api::Types::BaseInterface
       description "An interface that can be used in categorizable objects."
 
-      field :category, Decidim::Core::CategoryType, "The object's category", null: false
+      field :category, Decidim::Core::CategoryType, "The object's category", null: true
     end
   end
 end

--- a/decidim-core/lib/decidim/core/test/shared_examples/categorizable_interface_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/categorizable_interface_examples.rb
@@ -5,15 +5,23 @@ require "spec_helper"
 shared_examples_for "categorizable interface" do
   let!(:category) { create(:category, participatory_space: model.participatory_space) }
 
-  before do
-    model.update(category: category)
-  end
-
   describe "category" do
     let(:query) { "{ category { id } }" }
 
-    it "has a category" do
-      expect(response).to include("category" => { "id" => category.id.to_s })
+    context "when model has category" do
+      before do
+        model.update(category: category)
+      end
+
+      it "has a category" do
+        expect(response).to include("category" => { "id" => category.id.to_s })
+      end
+    end
+
+    context "when model has no category" do
+      it "returns null" do
+        expect(response).to include("category" => nil)
+      end
     end
   end
 end

--- a/decidim-proposals/spec/types/proposals_type_spec.rb
+++ b/decidim-proposals/spec/types/proposals_type_spec.rb
@@ -27,6 +27,20 @@ module Decidim
           expect(ids).not_to include(*draft_proposals.map(&:id).map(&:to_s))
           expect(ids).not_to include(*other_proposals.map(&:id).map(&:to_s))
         end
+
+        context "when querying proposals with categories" do
+          let(:category) { create(:category, participatory_space: model.participatory_space) }
+          let!(:proposal_with_category) { create(:proposal, component: model, category: category) }
+          let(:all_proposals) { published_proposals + [proposal_with_category] }
+
+          let(:query) { "{ proposals { edges { node { id, category { id } } } } }" }
+
+          it "return proposals with and without categories" do
+            ids = response["proposals"]["edges"].map { |edge| edge["node"]["id"] }
+            expect(ids.count).to eq(3)
+            expect(ids).to eq(all_proposals.map(&:id).sort.map(&:to_s))
+          end
+        end
       end
 
       describe "proposal" do


### PR DESCRIPTION
#### :tophat: What? Why?

Currently querying the api with something like this:

```graphql
{
  component(id: 123) {
    { 
       ...on Proposal {
         proposals { 
            edges { 
              node { 
                id, 
                category { id }
             }
          } 
       }
    }
  }
}
```
Does not return proposals without categories. 
As category is not mandatory the api should honor that.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing

Just try to fetch any proposal without category with a query with the category element.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*


:hearts: Thank you!
