### PR TITLE
Fix: Reported users are displayed in all tenants 

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/moderated_users_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/moderated_users_controller.rb
@@ -32,12 +32,16 @@ module Decidim
       private
 
       def reportable
-        @reportable ||= UserModeration.find(params[:id]).user
+        @reportable ||= base_query_finder.find(params[:id]).user
+      end
+
+      def base_query_finder
+        UserModeration.joins(:user).where(decidim_users: { decidim_organization_id: current_organization.id })
       end
 
       def collection
         target_scope = params[:blocked] && params[:blocked] == "true" ? :blocked : :unblocked
-        UserModeration.send(target_scope)
+        base_query_finder.send(target_scope)
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
When reporting a user registered in a tenant, this user is also shown in the admin panel of reported users in other instances of the same multitenant, although that user account does not exist in the rest.

This PR aims to filter and list only reported users from that particular organization. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #7604

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
