### PR TITLE
Do not crash if mandatory fields are blank and registrations are enabled

### DIFF
--- a/decidim-meetings/spec/controllers/decidim/meetings/admin/registrations_controller_spec.rb
+++ b/decidim-meetings/spec/controllers/decidim/meetings/admin/registrations_controller_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Meetings::Admin::RegistrationsController, type: :controller do
+  routes { Decidim::Meetings::AdminEngine.routes }
+
+  let(:organization) { create(:organization) }
+  let(:user) { create :user, :admin, :confirmed, organization: organization }
+  let(:participatory_process) { create :participatory_process, organization: organization }
+  let(:meeting_component) { create(:meeting_component, participatory_space: participatory_process) }
+  let(:meeting) { create :meeting, component: meeting_component }
+
+  let(:available_slots) { 0 }
+  let(:reserved_slots) { 0 }
+  let(:params) do
+    {
+      meeting_id: meeting.id,
+      registrations_enabled: true,
+      registration_form_enabled: false,
+      available_slots: available_slots,
+      reserved_slots: reserved_slots,
+      registration_terms: {}
+    }
+  end
+
+  before do
+    request.env["decidim.current_organization"] = organization
+    request.env["decidim.current_participatory_process"] = participatory_process
+    request.env["decidim.current_component"] = meeting_component
+    sign_in user
+  end
+
+  describe "#update" do
+    context "when available_slots is blank" do
+      let(:available_slots) { nil }
+
+      it "renders the form again with alert message" do
+        put :update, params: params
+
+        expect(subject).to render_template(:edit)
+        expect(flash[:alert]).not_to be_empty
+      end
+    end
+
+    context "when reserved_slots is blank" do
+      let(:reserved_slots) { nil }
+
+      it "renders the index view" do
+        put :update, params: params
+
+        expect(subject).to render_template(:edit)
+        expect(flash[:alert]).not_to be_empty
+      end
+    end
+  end
+end

--- a/decidim-meetings/spec/forms/admin/meeting_registrations_form_spec.rb
+++ b/decidim-meetings/spec/forms/admin/meeting_registrations_form_spec.rb
@@ -65,8 +65,20 @@ module Decidim::Meetings
       it { is_expected.not_to be_valid }
     end
 
+    context "when the available slots is blank" do
+      let(:available_slots) { "" }
+
+      it { is_expected.not_to be_valid }
+    end
+
     context "when the reserved slots is negative" do
       let(:reserved_slots) { -1 }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context "when the reserved slots is blank" do
+      let(:reserved_slots) { "" }
 
       it { is_expected.not_to be_valid }
     end


### PR DESCRIPTION
#### :tophat: What? Why?
*Please describe your pull request.*
On the meetings registration page, in the admin. There's a crash when registrations are enabled and either `available_slots` or `reserved_slots` are blank and the form is submitted.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*
1. Edit a meeting and set its "Registration type" to "On this platform". Save
2. Go to meetings registrations page in the admin
2. Mark the check "Registrations enabled"
3. Delete the content of "Available slots for this meeting" and "Reserved slots"
4. Save
5. The form is rendered again with error and both fields are marked as "can't be blank"

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![image](https://user-images.githubusercontent.com/199462/111513827-7b8ef800-8751-11eb-9fb9-a6bca47207ea.png)


:hearts: Thank you!
