### PR TITLE
Don't copy counters when copying proposals

### DIFF
--- a/decidim-proposals/app/services/decidim/proposals/proposal_builder.rb
+++ b/decidim-proposals/app/services/decidim/proposals/proposal_builder.rb
@@ -68,9 +68,11 @@ module Decidim
           "answered_at",
           "decidim_component_id",
           "reference",
-          "proposal_votes_count",
+          "comments_count",
           "endorsements_count",
-          "proposal_notes_count"
+          "follows_count",
+          "proposal_notes_count",
+          "proposal_votes_count"
         ).merge(
           "category" => original_proposal.category
         ).merge(

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/import_proposals_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/import_proposals_spec.rb
@@ -97,6 +97,11 @@ module Decidim
               expect(new_proposal.answer).to be_nil
               expect(new_proposal.answered_at).to be_nil
               expect(new_proposal.reference).not_to eq(proposal.reference)
+              expect(new_proposal.comments_count).to eq 0
+              expect(new_proposal.endorsements_count).to eq 0
+              expect(new_proposal.follows_count).to eq 0
+              expect(new_proposal.proposal_notes_count).to eq 0
+              expect(new_proposal.proposal_votes_count).to eq 0
             end
 
             describe "when keep_authors is true" do


### PR DESCRIPTION
#### :tophat: What? Why?
We've been adding some new counter fields in proposals, but we are not excluding them from being copied. 

This PR excludes the counters from being copied.

#### :pushpin: Related Issues
None

#### Testing
Ensure CI is green.