### PR TITLE
Add missing migration to fix counters in copied proposals

### DIFF
--- a/decidim-proposals/db/migrate/20210318082934_fix_counters_for_copied_proposals.rb
+++ b/decidim-proposals/db/migrate/20210318082934_fix_counters_for_copied_proposals.rb
@@ -3,11 +3,11 @@
 class FixCountersForCopiedProposals < ActiveRecord::Migration[5.2]
   def up
     copies_ids = Decidim::ResourceLink
-      .where(
-        name: "copied_from_component",
-        from_type: "Decidim::Proposals::Proposal",
-        to_type: "Decidim::Proposals::Proposal"
-      ).pluck(:to_id)
+                 .where(
+                   name: "copied_from_component",
+                   from_type: "Decidim::Proposals::Proposal",
+                   to_type: "Decidim::Proposals::Proposal"
+                 ).pluck(:to_id)
 
     Decidim::Proposals::Proposal.where(id: copies_ids).find_each do |record|
       record.class.reset_counters(record.id, :follows)

--- a/decidim-proposals/db/migrate/20210318082934_fix_counters_for_copied_proposals.rb
+++ b/decidim-proposals/db/migrate/20210318082934_fix_counters_for_copied_proposals.rb
@@ -9,7 +9,7 @@ class FixCountersForCopiedProposals < ActiveRecord::Migration[5.2]
         to_type: "Decidim::Proposals::Proposal"
       ).pluck(:to_id)
 
-    Decidim::Proposals::Proposals.where(id: copies_ids).find_each do |record|
+    Decidim::Proposals::Proposal.where(id: copies_ids).find_each do |record|
       record.class.reset_counters(record.id, :follows)
       record.update_comments_count
     end

--- a/decidim-proposals/db/migrate/20210318082934_fix_counters_for_copied_proposals.rb
+++ b/decidim-proposals/db/migrate/20210318082934_fix_counters_for_copied_proposals.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class FixCountersForCopiedProposals < ActiveRecord::Migration[5.2]
+  def up
+    copies_ids = Decidim::ResourceLink
+      .where(
+        name: "copied_from_component",
+        from_type: "Decidim::Proposals::Proposal",
+        to_type: "Decidim::Proposals::Proposal"
+      ).pluck(:to_id)
+
+    Decidim::Proposals::Proposals.where(id: copies_ids).find_each do |record|
+      record.class.reset_counters(record.id, :follows)
+      record.update_comments_count
+    end
+  end
+
+  def down; end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
In PR #7635 I forgot a migration to fix the data. This PR adds it.

#### :pushpin: Related Issues
See #7635.

#### Testing
None.