### PR TITLE
Don't overwrite mailer reply_to

### DIFF
--- a/decidim-core/app/mailers/decidim/application_mailer.rb
+++ b/decidim-core/app/mailers/decidim/application_mailer.rb
@@ -17,7 +17,7 @@ module Decidim
       return if @organization.nil? || @organization.smtp_settings.blank?
 
       mail.from = @organization.smtp_settings["from"].presence || mail.from
-      mail.reply_to = mail.from || Decidim.config.mailer_reply
+      mail.reply_to = mail.reply_to || Decidim.config.mailer_reply
       mail.delivery_method.settings.merge!(
         address: @organization.smtp_settings["address"],
         port: @organization.smtp_settings["port"],

--- a/decidim-core/spec/mailers/application_mailer_spec.rb
+++ b/decidim-core/spec/mailers/application_mailer_spec.rb
@@ -18,8 +18,10 @@ module Decidim
           "from" => from
         }
       end
-      let(:mail) { described_class.send_email(user, organization) }
+      let(:mail) { described_class.send_email(user, organization, subject, reply_to) }
       let(:from) { "" }
+      let(:reply_to) { nil }
+      let(:subject) { "Test subject" }
 
       it "update correctly mail.delivery_method.settings" do
         expect(mail.delivery_method.settings[:address]).to eq("mail.gotham.gov")
@@ -29,11 +31,12 @@ module Decidim
       end
 
       context "when there is no organization at all" do
-        let(:mail) { described_class.send_email(user, nil) }
+        let(:mail) { described_class.send_email(user, nil, subject, reply_to) }
 
         it "returns default values" do
           expect(mail.from).to eq(["change-me@example.org"])
           expect(mail.reply_to).to eq(nil)
+          expect(mail.subject).to eq(subject)
         end
       end
 
@@ -42,16 +45,14 @@ module Decidim
 
         it "returns default values" do
           expect(mail.from).to eq(["change-me@example.org"])
-          expect(mail.reply_to).to eq(nil)
         end
       end
 
       context "when from is not set" do
         let(:from) { nil }
 
-        it "set default values for mail.from and mail.reply_to" do
+        it "set default values for mail.from" do
           expect(mail.from).to eq(["change-me@example.org"])
-          expect(mail.reply_to).to eq(["change-me@example.org"])
         end
       end
 
@@ -60,7 +61,29 @@ module Decidim
 
         it "set default values for mail.from and mail.reply_to" do
           expect(mail.from).to eq(["decide@gotham.org"])
-          expect(mail.reply_to).to eq(["decide@gotham.org"])
+        end
+      end
+
+      context "when reply_to is set" do
+        let(:reply_to_address) { "villain@gotham.org" }
+        let(:reply_to) { "Arthur Fleck <#{reply_to_address}>" }
+
+        it "set given reply_to" do
+          expect(mail.reply_to).to eq([reply_to_address])
+        end
+      end
+
+      context "when reply_to is unset" do
+        it "uses default config" do
+          expect(mail.from).to eq(["change-me@example.org"])
+        end
+      end
+
+      context "when subject is set" do
+        let(:subject) { "Custom subject" }
+
+        it "sets subject" do
+          expect(mail.subject).to eq("Custom subject")
         end
       end
     end

--- a/decidim-dev/app/mailers/decidim/dummy_resources/dummy_resource_mailer.rb
+++ b/decidim-dev/app/mailers/decidim/dummy_resources/dummy_resource_mailer.rb
@@ -7,12 +7,12 @@ module Decidim
         @user = user
         @organization = organization
 
-        args = { to: "#{user.name} <#{user.email}>" }
-        args[:subject] = subject if subject
-        args[:reply_to] = reply_to if reply_to
+        hash = { to: "#{user.name} <#{user.email}>" }
+        hash[:subject] = subject if subject
+        hash[:reply_to] = reply_to if reply_to
 
         mail(
-          args
+          hash
         ) do |format|
           format.text { "This is the test" }
           format.html { "<p>This is a mail </p>" }

--- a/decidim-dev/app/mailers/decidim/dummy_resources/dummy_resource_mailer.rb
+++ b/decidim-dev/app/mailers/decidim/dummy_resources/dummy_resource_mailer.rb
@@ -3,11 +3,17 @@
 module Decidim
   module DummyResources
     class DummyResourceMailer < ApplicationMailer
-      def send_email(user, organization)
+      def send_email(user, organization, subject, reply_to)
         @user = user
         @organization = organization
 
-        mail(to: "#{user.name} <#{user.email}>") do |format|
+        args = { to: "#{user.name} <#{user.email}>" }
+        args[:subject] = subject if subject
+        args[:reply_to] = reply_to if reply_to
+
+        mail(
+          args
+        ) do |format|
           format.text { "This is the test" }
           format.html { "<p>This is a mail </p>" }
         end


### PR DESCRIPTION
#### :tophat: What? Why?
Currently mailers reply_to is overridden in application mailer for unknown reason(?) But it looks like a bug because it's set always to mail.from.

#### :pushpin: Related Issues
#6664

#### Testing
```
cd decidim-core
bundle exec rspec app/mailers/decidim/dummy_resources/dummy_resource_mailer.rb
```

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
