### PR TITLE
Fix rendering of proposals in map

### DIFF
--- a/decidim-proposals/app/helpers/decidim/proposals/map_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/map_helper.rb
@@ -15,10 +15,14 @@ module Decidim
       end
 
       def proposal_data_for_map(proposal)
-        proposal.slice(:latitude, :longitude, :address).merge(title: proposal.title,
-                                                              body: truncate(translated_attribute(proposal.body), length: 100),
-                                                              icon: icon("proposals", width: 40, height: 70, remove_icon_class: true),
-                                                              link: proposal_path(proposal))
+        proposal
+          .slice(:latitude, :longitude, :address)
+          .merge(
+            title: decidim_html_escape(present(proposal).title),
+            body: html_truncate(decidim_sanitize(present(proposal).body), length: 100),
+            icon: icon("proposals", width: 40, height: 70, remove_icon_class: true),
+            link: proposal_path(proposal)
+          )
       end
 
       def proposal_preview_data_for_map(proposal)

--- a/decidim-proposals/spec/helpers/map_helper_spec.rb
+++ b/decidim-proposals/spec/helpers/map_helper_spec.rb
@@ -43,16 +43,22 @@ module Decidim
       describe "#proposal_data_for_map" do
         subject { helper.proposal_data_for_map(proposal) }
 
+        let(:fake_body) { "<script>alert(\"HEY\")</script> This is my long, but still super interesting, body of my also long, but also super interesting, proposal. Check it out!" }
+        let(:fake_title) { "<script>alert(\"HEY\")</script> This is my title" }
+
         before do
           allow(helper).to receive(:proposal_path).and_return(Decidim::Proposals::ProposalPresenter.new(proposal).proposal_path)
         end
 
         it "returns preview data" do
+          allow(proposal).to receive(:body).and_return(en: fake_body)
+          allow(proposal).to receive(:title).and_return(en: fake_title)
+
           expect(subject["latitude"]).to eq(latitude)
           expect(subject["longitude"]).to eq(longitude)
           expect(subject["address"]).to eq(address)
-          expect(subject["title"]).to eq(proposal.title)
-          expect(subject["body"]).to eq(truncate(translated_attribute(proposal.body), length: 100))
+          expect(subject["title"]).to eq("&lt;script&gt;alert(&quot;HEY&quot;)&lt;/script&gt; This is my title")
+          expect(subject["body"]).to eq("alert(&quot;HEY&quot;) This is my long, but still super interesting, body of my also long, but also super inte...")
           expect(subject["link"]).to eq(Decidim::Proposals::ProposalPresenter.new(proposal).proposal_path)
           expect(subject["icon"]).to match(/<svg.+/)
         end


### PR DESCRIPTION
#### :tophat: What? Why?
#6291 introduced some changes in the rendering of the proposals map. This seemed to get a merge issue with proposals being moved to i18n, so here's what currently appears on the map:

![image](https://user-images.githubusercontent.com/491891/111644106-ce26ed80-87ff-11eb-8cca-e45fb670228c.png)

This PR improves the display of proposals in the map by fixing the title and removing HTML tags in the description. Here's how it looks with the PR applied:

![image](https://user-images.githubusercontent.com/491891/111644044-be0f0e00-87ff-11eb-84b1-c8799f9bbcec.png)
(map is grey because the screenshot is from my local app)

#### :pushpin: Related Issues
None

#### Testing
Ensure CI is green.