### PR TITLE
Fix permission for initiative edit and update

### DIFF
--- a/decidim-initiatives/spec/system/edit_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/edit_initiative_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Edit initiative", type: :system do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, organization: organization) }
+  let(:initiative_title) { translated(initiative.title) }
+  let(:new_title) { "This is my initiative new title" }
+
+  let!(:initiative_type) { create(:initiatives_type, :online_signature_enabled, organization: organization) }
+  let!(:scoped_type) { create(:initiatives_type_scope, type: initiative_type) }
+
+  let!(:other_initiative_type) { create(:initiatives_type, organization: organization) }
+  let!(:other_scoped_type) { create(:initiatives_type_scope, type: initiative_type) }
+
+  let(:initiative_path) { decidim_initiatives.initiative_path(initiative) }
+  let(:edit_initiative_path) { decidim_initiatives.edit_initiative_path(initiative) }
+
+  shared_examples "manage update" do
+    it "can be updated" do
+      visit initiative_path
+
+      click_link("Edit", href: edit_initiative_path)
+
+      expect(page).to have_content "EDIT INITIATIVE"
+
+      within "form.edit_initiative" do
+        fill_in :initiative_title, with: new_title
+        click_button "Update"
+      end
+
+      expect(page).to have_content(new_title)
+    end
+  end
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+  end
+
+  describe "when user is initiative author" do
+    let(:initiative) { create(:initiative, :created, author: user, scoped_type: scoped_type, organization: organization) }
+
+    it_behaves_like "manage update"
+
+    context "when initiative is published" do
+      let(:initiative) { create(:initiative, author: user, scoped_type: scoped_type, organization: organization) }
+
+      it "can't be updated" do
+        visit decidim_initiatives.initiative_path(initiative)
+
+        expect(page).not_to have_content "Edit initiative"
+
+        visit edit_initiative_path
+
+        expect(page).to have_content("not authorized")
+      end
+    end
+  end
+
+  describe "when author is a committee member" do
+    let(:initiative) { create(:initiative, :created, scoped_type: scoped_type, organization: organization) }
+
+    before do
+      create(:initiatives_committee_member, user: user, initiative: initiative)
+    end
+
+    it_behaves_like "manage update"
+  end
+
+  describe "when user is admin" do
+    let(:user) { create(:user, :admin, organization: organization) }
+    let(:initiative) { create(:initiative, :created, scoped_type: scoped_type, organization: organization) }
+
+    it_behaves_like "manage update"
+  end
+
+  describe "when author is not a committee member" do
+    let(:initiative) { create(:initiative, :created, scoped_type: scoped_type, organization: organization) }
+
+    it "renders an error" do
+      visit decidim_initiatives.initiative_path(initiative)
+
+      expect(page).to have_no_content("Edit initiative")
+
+      visit edit_initiative_path
+
+      expect(page).to have_content("not authorized")
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

We found out fixing issue #7622 that EPIC #5736 introduced a permission breach.

The /edit form on the initiative page is accessible by any logged-in user, making any initiative the "create" state editable and updatable by any logged-in user without requiring any special permission (like authorship, membership to the promoter committee). You'll find the patch for this on this [PR](PR link). 

#### :pushpin: Related Issues
- Related to #5736
- Fixes #7622 

#### Testing

- Go to an inititiative where you are not the author.
- Add /edit to the URL
- See that you need to be authorized

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.
