### PR TITLE
Fit the map properly on mobile screens with multiple markers

### DIFF
--- a/decidim-core/app/assets/javascripts/decidim/map/controller/markers.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/map/controller/markers.js.es6
@@ -69,7 +69,19 @@
         this.markerClusters.addLayer(marker);
       });
 
-      this.map.fitBounds(bounds, { padding: [100, 100] });
+      // Make sure there is enough space in the map for the padding to be
+      // applied. Otherwise the map will automatically zoom out (test it on
+      // mobile). Make sure there is at least the same amount of width and
+      // height available on both sides + the padding (i.e. 4x padding in
+      // total).
+      const size = this.map.getSize();
+      if (size.y >= 400 && size.x >= 400) {
+        this.map.fitBounds(bounds, { padding: [100, 100] });
+      } else if (size.y >= 120 && size.x >= 120) {
+        this.map.fitBounds(bounds, { padding: [30, 30] });
+      } else {
+        this.map.fitBounds(bounds);
+      }
     }
 
     clearMarkers() {


### PR DESCRIPTION
#### :tophat: What? Why?
When the map has more than 1 marker on it, it will be zoomed out on mobile screens. This is caused by applying too much padding on both sides of the map borders (more than the map has space inside).

This fixes the map fitting by conditionally applying the padding based on the map size.

#### Testing
- Enable geocoding for proposals
- Add at least two proposals with address + map point
- See the proposals listing page on mobile (make sure at least two markers appear on the map)

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
Here is how it looks currently with two markers on mobile:
![Map display with two markers currently](https://user-images.githubusercontent.com/864340/111670347-6a60ec80-8820-11eb-82e3-1ab4eb86817d.png)

Here is how it will look after this fix:
![Map display with two markers after the fix](https://user-images.githubusercontent.com/864340/111670467-895f7e80-8820-11eb-8866-344c59e1eea2.png)