### PR TITLE
Refactor map functionality regarding the drag marker maps

### DIFF
--- a/decidim-core/app/assets/javascripts/decidim/map.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/map.js.es6
@@ -1,4 +1,5 @@
 // = require decidim/map/factory
+// = require decidim/map/integration/forms
 // = require_self
 
 ((exports) => {

--- a/decidim-core/app/assets/javascripts/decidim/map/controller.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/map/controller.js.es6
@@ -39,6 +39,7 @@
       }, config);
 
       this.map = null;
+      this.eventHandlers = {};
 
       MapControllerRegistry.setController(mapId, this);
     }
@@ -83,6 +84,18 @@
         fillColor: this.config.markerColor,
         iconSize: L.point(28, 36)
       });
+    }
+
+    setEventHandler(name, callback) {
+      this.eventHandlers[name] = callback;
+    }
+
+    triggerEvent(eventName, payload) {
+      const handler = this.eventHandlers[eventName];
+      if (typeof handler === "function") {
+        return Reflect.apply(handler, this, payload);
+      }
+      return null;
     }
   }
 

--- a/decidim-core/app/assets/javascripts/decidim/map/controller/drag_marker.es6
+++ b/decidim-core/app/assets/javascripts/decidim/map/controller/drag_marker.es6
@@ -1,0 +1,50 @@
+((exports) => {
+  exports.Decidim = exports.Decidim || {};
+
+  const MapController = exports.Decidim.MapController;
+
+  class MapDragMarkerController extends MapController {
+    start() {
+      if (this.config.marker) {
+        this.addMarker(this.config.marker);
+      } else {
+        this.map.fitWorld();
+      }
+    }
+
+    addMarker(markerData) {
+      const coordinates = {
+        lat: markerData.latitude,
+        lng: markerData.longitude
+      };
+      this.triggerEvent("coordinates", [coordinates]);
+
+      this.marker = L.marker(coordinates, {
+        icon: this.createIcon(),
+        keyboard: true,
+        title: markerData.title,
+        draggable: true
+      });
+      this.marker.on("drag", (ev) => {
+        this.triggerEvent("coordinates", [ev.target.getLatLng()]);
+      });
+      this.marker.addTo(this.map);
+
+      const zoom = parseInt(this.config.zoom, 10) || 14;
+      this.map.setView(coordinates, zoom);
+    }
+
+    getMarker() {
+      return this.marker;
+    }
+
+    removeMarker() {
+      if (this.marker) {
+        this.marker.remove();
+        this.marker = null;
+      }
+    }
+  }
+
+  exports.Decidim.MapDragMarkerController = MapDragMarkerController;
+})(window);

--- a/decidim-core/app/assets/javascripts/decidim/map/controller/markers.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/map/controller/markers.js.es6
@@ -26,11 +26,6 @@
         $(`#${this.config.popupTemplateId}`).html()
       );
 
-      const updateCoordinates = (data) => {
-        $('input[data-type="latitude"]').val(data.lat);
-        $('input[data-type="longitude"]').val(data.lng);
-      };
-
       const bounds = new L.LatLngBounds(
         markersData.map(
           (markerData) => [markerData.latitude, markerData.longitude]
@@ -41,30 +36,18 @@
         let marker = L.marker([markerData.latitude, markerData.longitude], {
           icon: this.createIcon(),
           keyboard: true,
-          title: markerData.title,
-          draggable: markerData.draggable
+          title: markerData.title
         });
 
-        if (markerData.draggable) {
-          updateCoordinates({
-            lat: markerData.latitude,
-            lng: markerData.longitude
-          });
-          marker.on("drag", (ev) => {
-            updateCoordinates(ev.target.getLatLng());
-          });
-        } else {
-          let node = document.createElement("div");
+        let node = document.createElement("div");
 
-          $.tmpl(this.config.popupTemplateId, markerData).appendTo(node);
-
-          marker.bindPopup(node, {
-            maxwidth: 640,
-            minWidth: 500,
-            keepInView: true,
-            className: "map-info"
-          }).openPopup();
-        }
+        $.tmpl(this.config.popupTemplateId, markerData).appendTo(node);
+        marker.bindPopup(node, {
+          maxwidth: 640,
+          minWidth: 500,
+          keepInView: true,
+          className: "map-info"
+        }).openPopup();
 
         this.markerClusters.addLayer(marker);
       });

--- a/decidim-core/app/assets/javascripts/decidim/map/factory.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/map/factory.js.es6
@@ -1,12 +1,17 @@
 // = require decidim/map/controller
 // = require decidim/map/controller/markers
 // = require decidim/map/controller/static
+// = require decidim/map/controller/drag_marker
 // = require_self
 
 ((exports) => {
   exports.Decidim = exports.Decidim || {};
 
-  const { MapMarkersController, MapStaticController } = exports.Decidim;
+  const {
+    MapMarkersController,
+    MapStaticController,
+    MapDragMarkerController
+  } = exports.Decidim;
 
   /**
    * A factory method that creates a new map controller instance. This method
@@ -17,6 +22,10 @@
    * value "custom" for the map element, this factory method would identify
    * it and then return a different controller for that map than the default.
    * This would allow this types of maps to function differently.
+   *
+   * Note that if you don't have any customizations, you don't have to include
+   * the default JavaScript or CSS for the maps yourself. They are already done
+   * for you.
    *
    * An example how to use in the ERB view:
    *   <%= dynamic_map_for type: "custom" do %>
@@ -42,6 +51,8 @@
   const createMapController = (mapId, config) => {
     if (config.type === "static") {
       return new MapStaticController(mapId, config);
+    } else if (config.type === "drag-marker") {
+      return new MapDragMarkerController(mapId, config);
     }
 
     return new MapMarkersController(mapId, config);

--- a/decidim-core/app/assets/javascripts/decidim/map/integration/forms.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/map/integration/forms.js.es6
@@ -1,0 +1,33 @@
+((exports) => {
+  const $ = exports.$; // eslint-disable-line
+
+  $(() => {
+    $("[data-decidim-map]").on("ready.decidim", (ev, _map, mapConfig) => {
+      const $map = $(ev.target);
+      const ctrl = $map.data("map-controller");
+
+      if (mapConfig.type === "drag-marker") {
+        const inputSelector = $map.data("connected-input");
+        if (!inputSelector) {
+          return;
+        }
+
+        const $inputs = $(inputSelector);
+        if ($inputs.length < 1) {
+          return;
+        }
+
+        ctrl.setEventHandler("coordinates", (latlng) => {
+          $inputs.each((_i, el) => {
+            const $input = $(el);
+            if ($input.data("type") === "latitude") {
+              $input.val(latlng.lat);
+            } else if ($input.data("type") === "longitude") {
+              $input.val(latlng.lng);
+            }
+          })
+        });
+      }
+    });
+  });
+})(window);

--- a/decidim-elections/app/cells/decidim/votings/content_blocks/landing_page/polling_stations/map.erb
+++ b/decidim-elections/app/cells/decidim/votings/content_blocks/landing_page/polling_stations/map.erb
@@ -15,7 +15,4 @@
       </div>
     </div>
   </template>
-
-  <%= stylesheet_link_tag "decidim/map" %>
-  <%= javascript_include_tag "decidim/map" %>
 <% end %>

--- a/decidim-proposals/app/helpers/decidim/proposals/map_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/map_helper.rb
@@ -22,16 +22,16 @@ module Decidim
       end
 
       def proposal_preview_data_for_map(proposal)
-        [
-          proposal.slice(
+        {
+          type: "drag-marker",
+          marker: proposal.slice(
             :latitude,
             :longitude,
             :address
           ).merge(
-            icon: icon("proposals", width: 40, height: 70, remove_icon_class: true),
-            draggable: true
+            icon: icon("proposals", width: 40, height: 70, remove_icon_class: true)
           )
-        ]
+        }
       end
 
       def has_position?(proposal)

--- a/decidim-proposals/app/views/decidim/proposals/proposals/preview.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/preview.html.erb
@@ -26,16 +26,13 @@
     <% if component_settings.geocoding_enabled? %>
       <% if has_position?(@proposal) %>
         <%= render partial: "dynamic_map_instructions" %>
-        <%= dynamic_map_for proposal_preview_data_for_map(@proposal) do %>
-          <%= stylesheet_link_tag "decidim/map" %>
-          <%= javascript_include_tag "decidim/map" %>
-        <% end %>
+        <%= dynamic_map_for proposal_preview_data_for_map(@proposal), "data-connected-input" => ".coordinates-input" %>
         <%= decidim_form_for(@form, url: update_draft_proposal_path(@form), html: { method: :patch }) do |form| %>
           <%= form.hidden_field :title, value: form_presenter.title %>
           <%= form.hidden_field :body, value: form_presenter.body %>
           <%= form.hidden_field :address %>
-          <%= form.hidden_field :latitude, data: { type: "latitude" } %>
-          <%= form.hidden_field :longitude, data: { type: "longitude" } %>
+          <%= form.hidden_field :latitude, class: "coordinates-input", data: { type: "latitude" } %>
+          <%= form.hidden_field :longitude, class: "coordinates-input", data: { type: "longitude" } %>
           <div class="preview--form__hidden">
             <% if @form.categories&.any? %>
               <%= form.categories_select :category_id, @form.categories %>

--- a/decidim-proposals/spec/helpers/map_helper_spec.rb
+++ b/decidim-proposals/spec/helpers/map_helper_spec.rb
@@ -31,12 +31,14 @@ module Decidim
       describe "#proposal_preview_data_for_map" do
         subject { helper.proposal_preview_data_for_map(proposal) }
 
+        let(:marker) { subject[:marker] }
+
         it "returns preview data" do
-          expect(subject.first["latitude"]).to eq(latitude)
-          expect(subject.first["longitude"]).to eq(longitude)
-          expect(subject.first["address"]).to eq(address)
-          expect(subject.first["icon"]).to match(/<svg.+/)
-          expect(subject.first["draggable"]).to eq(true)
+          expect(subject[:type]).to eq("drag-marker")
+          expect(marker["latitude"]).to eq(latitude)
+          expect(marker["longitude"]).to eq(longitude)
+          expect(marker["address"]).to eq(address)
+          expect(marker["icon"]).to match(/<svg.+/)
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Drag marker functionality was added for proposals at #6291.

This mixed the functionality with the existing markers map which is only supposed to be used for displaying the markers. At #6340 it was the intention that each different type of map would have their own controller.

This is a refactor for #6291 to separate the new type of map from the existing, to keep the map controllers leaner.

Also, this separates the jQuery stuff out of the map controller. The idea would be to keep the map functionality separated from the other parts of the view. The intention of the map controllers is to only control them map, as far as possible.

Also, I saw unnecessary includes for the map JS/CSS at `decidim-elections/app/cells/decidim/votings/content_blocks/landing_page/polling_stations/map.erb`. The includes are now handled by the map providers, so they should be kept out of the views:
https://github.com/decidim/decidim/blob/69d5ca1528c2f36a07fc8ed4ff6aa26200ffb771/decidim-core/lib/decidim/map/dynamic_map.rb#L79
https://github.com/decidim/decidim/blob/69d5ca1528c2f36a07fc8ed4ff6aa26200ffb771/decidim-core/lib/decidim/map/provider/dynamic_map/here.rb#L44

It is also an anti pattern to include CSS inside the `<body>` tag as explained at:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link

> For example, the stylesheet link type is body-ok, and therefore <link rel="stylesheet"> is permitted in the body. However, this isn't a good practice to follow; it makes more sense to separate your <link> elements from your body content, putting them in the <head>.

This won't affect any functionality as far as I know.

#### :pushpin: Related Issues
- Related to #6291, #6340

#### Testing
- Enable maps functionality
- Enable geocoding for the proposals
- Create a proposal with an address
- Go to the proposal preview stage to see the drag+drop map

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.