### PR TITLE
Fix migration from #7640

### DIFF
--- a/decidim-proposals/db/migrate/20210318082934_fix_counters_for_copied_proposals.rb
+++ b/decidim-proposals/db/migrate/20210318082934_fix_counters_for_copied_proposals.rb
@@ -10,7 +10,6 @@ class FixCountersForCopiedProposals < ActiveRecord::Migration[5.2]
                  ).pluck(:to_id)
 
     Decidim::Proposals::Proposal.where(id: copies_ids).find_each do |record|
-      record.class.reset_counters(record.id, :follows)
       record.update_comments_count
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
#7640 introduced a backport for a migration that tried to update a counter that does not exist in 0.23. This PR fixes the migration.

#### :pushpin: Related Issues
See #7640

#### Testing
None