### PR TITLE
Remove custom focus outlines/backgrounds from the comments elements

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_comments.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_comments.scss
@@ -108,12 +108,6 @@ $comment-form-bg: $light-gray;
   float: right;
   margin-top: .5rem;
 
-  button:focus{
-    background-color: $secondary;
-    color: $white;
-    outline: none;
-  }
-
   form.button_to{
     display: inline-block;
   }
@@ -208,12 +202,6 @@ $comment-form-bg: $light-gray;
 
   a:hover{
     text-decoration: underline;
-  }
-
-  a:focus{
-    background-color: var(--secondary);
-    color: $white;
-    outline: none;
   }
 
   .button{


### PR DESCRIPTION
#### :tophat: What? Why?
The comments elements have custom outlines and backgrounds on focus which are causing accessibility violations when customizing the default primary/secondary colors.

I think it would be better to keep these consistent with the other button/link elements, so their color contrasts can be controller better in the instance itself. This outline color can be also controlled from the admin panel.

WCAG 2.1 AA / SC 1.4.3

#### :pushpin: Related Issues
- Related to #5942, #6246, #6124, #5684

#### Testing
Go to see the comments component with at least one comment and not signed in (see screenshots)

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
Before:
![Comments focus outlines before the change](https://user-images.githubusercontent.com/864340/111918391-8c12db80-8a8d-11eb-8a8e-76be0cec6e65.png)

After:
![Comments focus outlines after the change](https://user-images.githubusercontent.com/864340/111918398-92a15300-8a8d-11eb-9f5a-c2b35cd98e8a.png)
