### PR TITLE
Fix comments opinion toggle accessibility

### DIFF
--- a/decidim-comments/app/assets/javascripts/decidim/comments/comments.component.js.es6
+++ b/decidim-comments/app/assets/javascripts/decidim/comments/comments.component.js.es6
@@ -244,10 +244,11 @@
       const $add = $btn.closest(".add-comment");
       const $form = $("form", $add);
       const $opinionButtons = $(".opinion-toggle .button", $add);
+      const $selectedState = $(".opinion-toggle .selected-state", $add);
       const $alignment = $(".alignment-input", $form);
 
-      $opinionButtons.removeClass("is-active");
-      $btn.addClass("is-active");
+      $opinionButtons.removeClass("is-active").attr("aria-pressed", "false");
+      $btn.addClass("is-active").attr("aria-pressed", "true");
 
       if ($btn.is(".opinion-toggle--ok")) {
         $alignment.val(1);
@@ -256,6 +257,9 @@
       } else if ($btn.is(".opinion-toggle--ko")) {
         $alignment.val(-1);
       }
+
+      // Announce the selected state for the screen reader
+      $selectedState.text($btn.data("selected-label"));
     }
 
     /**

--- a/decidim-comments/app/assets/javascripts/decidim/comments/comments.component.test.js
+++ b/decidim-comments/app/assets/javascripts/decidim/comments/comments.component.test.js
@@ -304,21 +304,24 @@ describe("CommentsComponent", () => {
               <h4 class="section-heading">Add your comment</h4>
 
               <div class="opinion-toggle button-group">
-                <button class="button tiny button--muted opinion-toggle--ok">
+                <button aria-pressed="false" class="button tiny button--muted opinion-toggle--ok" data-selected-label="Your opinion about this topic is positive">
                   <svg role="none presentation" class="icon--thumb-up icon">
                     <title></title>
                     <use role="none presentation" href="/assets/decidim/icons-2ba788b32e181c1a7197f7a54a0f03101c146dd434b9e56191690c7c2d7bdae3.svg#icon-thumb-up"></use>
                   </svg>
+                  <span class="show-for-sr">Positive</span>
                 </button>
-                <button class="button tiny button--muted opinion-toggle--meh is-active">
+                <button aria-pressed="true" class="button tiny button--muted opinion-toggle--meh is-active" data-selected-label="Your opinion about this topic is neutral">
                   Neutral
                 </button>
-                <button class="button tiny button--muted opinion-toggle--ko">
+                <button aria-pressed="false" class="button tiny button--muted opinion-toggle--ko" data-selected-label="Your opinion about this topic is negative">
                   <svg role="none presentation" class="icon--thumb-down icon">
                     <title></title>
                     <use role="none presentation" href="/assets/decidim/icons-2ba788b32e181c1a7197f7a54a0f03101c146dd434b9e56191690c7c2d7bdae3.svg#icon-thumb-down"></use>
                   </svg>
+                  <span class="show-for-sr">Negative</span>
                 </button>
+                <div aria-role="alert" aria-live="assertive" class="selected-state shot-for-sr"></div>
               </div>
 
               ${generateCommentForm("Dummy", 123)}
@@ -488,29 +491,43 @@ describe("CommentsComponent", () => {
     describe("opinion toggles", () => {
       let commentSection = null;
       let toggles = null;
+      let toggleContainer = null;
 
       beforeEach(() => {
         commentSection = addComment[addComment.length - 1];
         toggles = commentSection.opinionToggles;
+        toggleContainer = $(toggles[0]).parent();
       });
 
       it("adds the correct alignment on positive toggle", () => {
         $(toggles[0]).trigger("click");
 
+        expect($(toggles[0]).attr("aria-pressed")).toEqual("true");
+        expect($(toggles[1]).attr("aria-pressed")).toEqual("false");
+        expect($(toggles[2]).attr("aria-pressed")).toEqual("false");
         expect($(".alignment-input", commentSection).val()).toEqual("1");
+        expect($(".selected-state", toggleContainer).text()).toEqual("Your opinion about this topic is positive");
       });
 
       it("adds the correct alignment on neutral toggle", () => {
         $(toggles[0]).trigger("click");
         $(toggles[1]).trigger("click");
 
+        expect($(toggles[0]).attr("aria-pressed")).toEqual("false");
+        expect($(toggles[1]).attr("aria-pressed")).toEqual("true");
+        expect($(toggles[2]).attr("aria-pressed")).toEqual("false");
         expect($(".alignment-input", commentSection).val()).toEqual("0");
+        expect($(".selected-state", toggleContainer).text()).toEqual("Your opinion about this topic is neutral");
       });
 
       it("adds the correct alignment on negative toggle", () => {
         $(toggles[2]).trigger("click");
 
+        expect($(toggles[0]).attr("aria-pressed")).toEqual("false");
+        expect($(toggles[1]).attr("aria-pressed")).toEqual("false");
+        expect($(toggles[2]).attr("aria-pressed")).toEqual("true");
         expect($(".alignment-input", commentSection).val()).toEqual("-1");
+        expect($(".selected-state", toggleContainer).text()).toEqual("Your opinion about this topic is negative");
       });
     });
   });

--- a/decidim-comments/app/cells/decidim/comments/comments/add_comment.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/add_comment.erb
@@ -4,15 +4,19 @@
   <% if user_signed_in? %>
     <% if alignment_enabled? %>
       <div class="opinion-toggle button-group">
-        <button class="button tiny button--muted opinion-toggle--ok">
+        <span class="show-for-sr"><%= t("decidim.components.add_comment_form.opinion.label") %></span>
+        <button aria-pressed="false" class="button tiny button--muted opinion-toggle--ok" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.positive_selected") %>">
           <%= icon "thumb-up", role: "none presentation" %>
+          <span class="show-for-sr"><%= t("decidim.components.add_comment_form.opinion.positive") %></span>
         </button>
-        <button class="button tiny button--muted opinion-toggle--meh is-active">
+        <button aria-pressed="true" class="button tiny button--muted opinion-toggle--meh is-active" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.neutral_selected") %>">
           <%= t("decidim.components.add_comment_form.opinion.neutral") %>
         </button>
-        <button class="button tiny button--muted opinion-toggle--ko">
+        <button aria-pressed="false" class="button tiny button--muted opinion-toggle--ko" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.negative_selected") %>">
           <%= icon "thumb-down", role: "none presentation" %>
+          <span class="show-for-sr"><%= t("decidim.components.add_comment_form.opinion.negative") %></span>
         </button>
+        <div aria-role="alert" aria-live="assertive" class="selected-state shot-for-sr"></div>
       </div>
     <% end %>
     <%== cell("decidim/comments/comment_form", model, root_depth: root_depth) %>

--- a/decidim-comments/config/locales/en.yml
+++ b/decidim-comments/config/locales/en.yml
@@ -40,7 +40,13 @@ en:
           user_group_id:
             label: Comment as
         opinion:
+          label: Your opinion about this topic
+          positive: Positive
+          positive_selected: 'Your opinion about this topic is positive'
+          negative: Negative
+          negative_selected: 'Your opinion about this topic is negative'
           neutral: Neutral
+          neutral_selected: 'Your opinion about this topic is neutral'
         remaining_characters: "%{count} characters left"
         remaining_characters_1: "%{count} character left"
         title: Add your comment

--- a/decidim-comments/config/locales/en.yml
+++ b/decidim-comments/config/locales/en.yml
@@ -41,12 +41,12 @@ en:
             label: Comment as
         opinion:
           label: Your opinion about this topic
-          positive: Positive
-          positive_selected: 'Your opinion about this topic is positive'
           negative: Negative
-          negative_selected: 'Your opinion about this topic is negative'
+          negative_selected: Your opinion about this topic is negative
           neutral: Neutral
-          neutral_selected: 'Your opinion about this topic is neutral'
+          neutral_selected: Your opinion about this topic is neutral
+          positive: Positive
+          positive_selected: Your opinion about this topic is positive
         remaining_characters: "%{count} characters left"
         remaining_characters_1: "%{count} character left"
         title: Add your comment

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -187,7 +187,7 @@ shared_examples "comments" do
             expect(page.find(".opinion-toggle--ok")["aria-pressed"]).to eq("true")
             expect(page.find(".opinion-toggle--meh")["aria-pressed"]).to eq("false")
             expect(page.find(".opinion-toggle--ko")["aria-pressed"]).to eq("false")
-            page.find(".opinion-toggle .selected-state", visible: false).to have_content("Your opinion about this topic is positive")
+            expect(page.find(".opinion-toggle .selected-state", visible: false)).to have_content("Your opinion about this topic is positive")
 
             within ".add-comment form" do
               fill_in "add-comment-#{commentable.commentable_type.demodulize}-#{commentable.id}", with: "I am in favor about this!"

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -184,6 +184,10 @@ shared_examples "comments" do
         it "works according to the setting in the commentable" do
           if commentable.comments_have_alignment?
             page.find(".opinion-toggle--ok").click
+            expect(page.find(".opinion-toggle--ok")["aria-pressed"]).to eq("true")
+            expect(page.find(".opinion-toggle--meh")["aria-pressed"]).to eq("false")
+            expect(page.find(".opinion-toggle--ko")["aria-pressed"]).to eq("false")
+            page.find(".opinion-toggle .selected-state", visible: false).to have_content("Your opinion about this topic is positive")
 
             within ".add-comment form" do
               fill_in "add-comment-#{commentable.commentable_type.demodulize}-#{commentable.id}", with: "I am in favor about this!"


### PR DESCRIPTION
#### :tophat: What? Why?
- The comments opinion toggles do not have accessibility labels - fix that
- The comments opinion toggles do not have accessibility states - fix that
- The comments opinion toggles will not announce the changed state - fix that

WCAG 2.1 A / SC 4.1.2

#### :pushpin: Related Issues
- Related to #5942, #6246, #6124, #5684

#### Testing
Enable screen reader and try the comments opinion toggles (switch focus between the buttons and try changing their states).

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.