### PR TITLE
Show all proposals in map

### DIFF
--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -36,11 +36,13 @@ module Decidim
                        .order(position: :asc)
           render "decidim/proposals/proposals/participatory_texts/participatory_text"
         else
-          @proposals = search
-                       .results
-                       .published
-                       .not_hidden
-                       .includes(:component, :coauthorships)
+          @base_query = search
+                        .results
+                        .published
+                        .not_hidden
+
+          @proposals = @base_query.includes(:component, :coauthorships)
+          @all_geocoded_proposals = @base_query.geocoded
 
           @voted_proposals = if current_user
                                ProposalVote.where(

--- a/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "decidim/shared/component_announcement" %>
 
 <% if component_settings.geocoding_enabled? %>
-  <%= dynamic_map_for proposals_data_for_map(@proposals.select(&:geocoded?)) do %>
+  <%= dynamic_map_for proposals_data_for_map(@all_geocoded_proposals) do %>
     <template id="marker-popup">
       <div class="map-info__content">
         <h3>${title}</h3>


### PR DESCRIPTION
#### :tophat: What? Why?
Currently, the proposals map only shows the proposals that appear in the first page. If you change the page or the filters, the map doesn't get updated.

@decidim/product asked to show all proposals in the map.

Before this PR, the map only showed the geocoded proposals in the first page:

![image](https://user-images.githubusercontent.com/491891/111967210-0e37ea00-8af8-11eb-98ba-a8e528c27a4f.png)

After this PR, it shows all the geocoded proposals in the component:

![image](https://user-images.githubusercontent.com/491891/111967156-ffe9ce00-8af7-11eb-9bdf-77ecfe8410ab.png)

(notice the counts; the second picture is gray because it's taken from my local machine and maps don't render there)

#### :pushpin: Related Issues
None

#### Testing
Ensure CI is green.
