### PR TITLE
Fix ARIA roles for the SVG images (icons)

### DIFF
--- a/decidim-accountability/app/views/decidim/accountability/results/_linked_results.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_linked_results.html.erb
@@ -1,7 +1,7 @@
 <div class="card card--action card--list">
   <% resources.each do |result| %>
     <div class="card--list__item">
-      <%= icon "actions", class: "card--list__icon", role: "img", "aria-hidden": true, remove_icon_class: true %>
+      <%= icon "actions", class: "card--list__icon", role: "presentation", "aria-hidden": true, remove_icon_class: true %>
       <%= link_to resource_locator(result).path, class: "card--list__text card__link card__link--block" do %>
         <h5 class="card--list__heading">
           <%= translated_attribute(result.title) %>

--- a/decidim-accountability/app/views/decidim/accountability/results/_results_leaf.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_results_leaf.html.erb
@@ -9,7 +9,7 @@
     <div class="card card--action card--list">
       <% results.each do |result| %>
         <div class="card--list__item">
-          <%= icon "actions", class: "card--list__icon", role: "img", "aria-hidden": true, remove_icon_class: true %>
+          <%= icon "actions", class: "card--list__icon", role: "presentation", "aria-hidden": true, remove_icon_class: true %>
 
           <%= link_to result_path(result), class: "card--list__text card__link card__link--block" do %>
             <h4 class="card--list__heading">

--- a/decidim-accountability/app/views/decidim/participatory_spaces/_result.html.erb
+++ b/decidim-accountability/app/views/decidim/participatory_spaces/_result.html.erb
@@ -1,5 +1,5 @@
 <div class="card--list__item">
-  <%= icon "actions", class: "card--list__icon", role: "img", "aria-hidden": true, remove_icon_class: true %>
+  <%= icon "actions", class: "card--list__icon", role: "presentation", "aria-hidden": true, remove_icon_class: true %>
 
   <%= link_to resource_locator(result).path, class: "card--list__text card__link card__link--block" do %>
       <h4 class="card--list__heading heading6">

--- a/decidim-admin/app/cells/decidim/admin/content_block/show.erb
+++ b/decidim-admin/app/cells/decidim/admin/content_block/show.erb
@@ -4,10 +4,10 @@
     <div>
       <% if has_settings? %>
         <%= link_to edit_content_block_path, class: "mr-s text-muted" do %>
-          <%= icon "pencil", role: "img" %>
+          <%= icon "pencil", role: "presentation", "aria-hidden": true %>
         <% end %>
       <% end %>
-      <%= icon "menu", role: "img" %>
+      <%= icon "menu", role: "presentation", "aria-hidden": true %>
     </div>
   </div>
 </li>

--- a/decidim-admin/app/views/decidim/admin/attachment_collections/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/attachment_collections/index.html.erb
@@ -34,7 +34,7 @@
                       <%= icon_link_to "circle-x", polymorphic_path([collection_for, attachment_collection]), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
                     <% else %>
                       <span class="action-icon" title="<%= t("attachment_collections.index.attachment_collection_used", scope: "decidim.admin") %>" data-tooltip="true" data-disable-hover="false">
-                        <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img" %>
+                        <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "presentation", "aria-hidden": true %>
                       </span>
                     <% end %>
                   <% end %>

--- a/decidim-admin/app/views/decidim/admin/categories/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/categories/index.html.erb
@@ -34,7 +34,7 @@
                       <%= icon_link_to "circle-x", category_path(current_participatory_space, category), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
                     <% else %>
                       <span class="action-icon" title="<%= t("categories.index.category_used", scope: "decidim.admin") %>" data-tooltip="true" data-disable-hover="false">
-                        <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img" %>
+                        <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "presentation", "aria-hidden": true %>
                       </span>
                     <% end %>
                   <% end %>

--- a/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
@@ -45,13 +45,13 @@
                 <% end %>
                 <%= icon_link_to "envelope-closed", current_or_new_conversation_path_with(user), t("decidim.contact"), class:"action-icon--new" %>
                 <% if user.officialized? %>
-                  <%= icon "circle-check", class: "action-icon action-icon--disabled", role: "img" %>
+                  <%= icon "circle-check", class: "action-icon action-icon--disabled", role: "presentation", aria_label: t(".officialize") %>
                   <%= icon_link_to "pencil", new_officialization_path(user_id: user.id), t(".reofficialize"), class: "action-icon--new" %>
                   <%= icon_link_to "circle-x", officialization_path(user.id), t(".unofficialize"), method: :delete, class: "action-icon--reject" %>
                 <% else %>
                   <%= icon_link_to "circle-check", new_officialization_path(user_id: user.id), t(".officialize"), class: "action-icon--verify" %>
-                  <%= icon "pencil", class: "action-icon action-icon--disabled", role: "img" %>
-                  <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img" %>
+                  <%= icon "pencil", class: "action-icon action-icon--disabled", role: "img", aria_label: t(".reofficialize") %>
+                  <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img", aria_label: t(".unofficialize") %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-admin/app/views/decidim/admin/user_groups/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/user_groups/index.html.erb
@@ -81,7 +81,7 @@
                   <% if !user_group.verified? %>
                     <%= icon_link_to "circle-check", decidim_admin.verify_user_group_path(user_group), t("actions.verify", scope: "decidim.admin"), method: :put, class: "action-icon--verify" %>
                   <% else %>
-                    <%= icon "circle-check", class: "action-icon action-icon--disabled", role: "img" %>
+                    <%= icon "circle-check", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.verify", scope: "decidim.admin") %>
                   <% end %>
                 <% end %>
 
@@ -89,7 +89,7 @@
                   <% if !user_group.rejected? %>
                     <%= icon_link_to "circle-x", decidim_admin.reject_user_group_path(user_group), t("actions.reject", scope: "decidim.admin"), method: :put, class: "action-icon--reject" %>
                   <% else %>
-                    <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img" %>
+                    <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.reject", scope: "decidim.admin") %>
                   <% end %>
                 <% end %>
               </td>

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.html.erb
@@ -49,7 +49,7 @@
               <td>
                 <% if assembly.promoted? %>
                   <span data-tooltip class="icon-state icon-highlight" aria-haspopup="true" data-disable-hover="false" title="<%= t("models.assembly.fields.promoted", scope: "decidim.admin") %>">
-                    <%= icon "star", role: "img", "aria-hidden": true %>
+                    <%= icon "star", role: "presentation", "aria-hidden": true %>
                   </span>
                 <% end %>
                 <% if allowed_to? :update, :assembly, assembly: assembly %>

--- a/decidim-blogs/app/views/decidim/blogs/posts/show.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/posts/show.html.erb
@@ -18,7 +18,7 @@
 <div class="row column view-header">
   <div class="m-bottom">
     <%= link_to :posts, class: "small hollow" do %>
-      <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+      <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
       <%= t(".back") %>
     <% end %>
   </div>

--- a/decidim-budgets/app/cells/decidim/budgets/budget_list_item/show.erb
+++ b/decidim-budgets/app/cells/decidim/budgets/budget_list_item/show.erb
@@ -6,14 +6,14 @@
           <%= translated_attribute(title) %>
         </strong>
         <span class="button tiny success card--list__check card--list__check--disabled">
-          <%= icon "check", class: "icon--small", role: "img" %>
+          <%= icon "check", class: "icon--small", role: "img", aria_label: t(".voting_finished") %>
         </span>
       <% else %>
         <%= translated_attribute(title) %>
 
         <% if progress? && !voting_finished? %>
           <span class="button tiny hollow secondary card--list__check card--list__check--disabled">
-            <%= icon "bookmark", class: "icon--small", role: "img" %>
+            <%= icon "bookmark", class: "icon--small", role: "img", aria_label: t(".voting_started") %>
           </span>
         <% end %>
       <% end %>

--- a/decidim-budgets/app/cells/decidim/budgets/budget_list_item/show.erb
+++ b/decidim-budgets/app/cells/decidim/budgets/budget_list_item/show.erb
@@ -6,14 +6,14 @@
           <%= translated_attribute(title) %>
         </strong>
         <span class="button tiny success card--list__check card--list__check--disabled">
-          <%= icon "check", class: "icon--small", role: "img", aria_label: t(".voting_finished") %>
+          <%= icon "check", class: "icon--small", role: "img", aria_label: t("decidim.budgets.budget_list_item.voting_finished") %>
         </span>
       <% else %>
         <%= translated_attribute(title) %>
 
         <% if progress? && !voting_finished? %>
           <span class="button tiny hollow secondary card--list__check card--list__check--disabled">
-            <%= icon "bookmark", class: "icon--small", role: "img", aria_label: t(".voting_started") %>
+            <%= icon "bookmark", class: "icon--small", role: "img", aria_label: t("decidim.budgets.budget_list_item.voting_started") %>
           </span>
         <% end %>
       <% end %>

--- a/decidim-budgets/app/cells/decidim/budgets/budget_m/data.erb
+++ b/decidim-budgets/app/cells/decidim/budgets/budget_m/data.erb
@@ -1,7 +1,7 @@
 <div class="card__icondata">
   <ul class="card-data">
     <li class="card-data__item">
-      <%= icon "euro-outline", class: "icon--big", role: "img", "aria-hidden": true %>
+      <%= icon "euro-outline", class: "icon--big", role: "presentation", "aria-hidden": true %>
     </li>
     <li class="card-data__item">
       <div class="text-left">

--- a/decidim-budgets/app/cells/decidim/budgets/project_m/data.erb
+++ b/decidim-budgets/app/cells/decidim/budgets/project_m/data.erb
@@ -1,7 +1,7 @@
 <div class="card__icondata">
   <ul class="card-data">
     <li class="card-data__item">
-      <%= icon "euro-outline", class: "icon--big", role: "img", "aria-hidden": true %>
+      <%= icon "euro-outline", class: "icon--big", role: "presentation", "aria-hidden": true %>
     </li>
     <li class="card-data__item">
       <div class="text-left">

--- a/decidim-budgets/app/cells/decidim/budgets/project_voted_hint_cell.rb
+++ b/decidim-budgets/app/cells/decidim/budgets/project_voted_hint_cell.rb
@@ -18,7 +18,7 @@ module Decidim
 
       def hint
         contents = []
-        contents << icon("check", role: "img")
+        contents << icon("check", role: "presentation", "aria-hidden": true)
         contents << " "
         contents << t("decidim.budgets.projects.project.you_voted")
       end

--- a/decidim-budgets/app/views/decidim/budgets/admin/budgets/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/budgets/index.html.erb
@@ -48,13 +48,13 @@
                 <% if allowed_to? :update, :budget, budget: budget %>
                   <%= icon_link_to "pencil", edit_budget_path(budget), t("actions.edit", scope: "decidim.budgets"), class: "action-icon--edit" %>
                 <% else %>
-                  <%= icon "pencil", class: "action-icon action-icon--disabled", role: "img" %>
+                  <%= icon "pencil", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.edit", scope: "decidim.budgets") %>
                 <% end %>
 
                 <% if allowed_to? :delete, :budget, budget: budget %>
                   <%= icon_link_to "circle-x", budget_path(budget), t("actions.destroy", scope: "decidim.budgets"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.budgets") } %>
                 <% else %>
-                  <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img" %>
+                  <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.destroy", scope: "decidim.budgets") %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/index.html.erb
@@ -64,7 +64,7 @@
                 <% if allowed_to? :destroy, :project, project: project %>
                   <%= icon_link_to "circle-x", resource_locator([budget, project]).show, t("actions.destroy", scope: "decidim.budgets"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.budgets") } %>
                 <% else %>
-                  <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img" %>
+                  <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.destroy", scope: "decidim.budgets") %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-budgets/app/views/decidim/budgets/projects/_filters.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_filters.html.erb
@@ -7,7 +7,7 @@
         <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t(".search"), title: t(".search"), data: { disable_dynamic_change: true } %>
         <div class="input-group-button">
           <button type="submit" class="button" aria-controls="projects">
-            <%= icon "magnifying-glass", aria_label: t(".search"), role: "img", "aria-hidden": true %>
+            <%= icon "magnifying-glass", aria_label: t(".search"), role: "img" %>
           </button>
         </div>
       </div>

--- a/decidim-budgets/app/views/decidim/budgets/projects/_linked_projects.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_linked_projects.html.erb
@@ -1,7 +1,7 @@
 <div class="card card--action card--list">
   <% resources.each do |project| %>
     <div class="card--list__item">
-      <%= icon "actions", class: "card--list__icon", role: "img", "aria-hidden": true, remove_icon_class: true %>
+      <%= icon "actions", class: "card--list__icon", role: "presentation", "aria-hidden": true, remove_icon_class: true %>
       <%= link_to resource_locator([project.budget, project]).path, class: "card--list__text card__link card__link--block" do %>
         <h5 class="card--list__heading">
           <%= translated_attribute(project.title) %>

--- a/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
@@ -21,7 +21,7 @@ edit_link(
 
   <div class="m-bottom">
     <%= link_to resource_locator(budget).path(filter_link_params), class: "muted-link" do %>
-      <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+      <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
       <%= t(".view_all_projects") %>
     <% end %>
   </div>

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -109,6 +109,9 @@ en:
         close_modal: Close modal
         continue: Continue
         more_information: More information
+      budget_list_item:
+        voting_finished: You have voted in this budget
+        voting_started: You have started to vote in this budget
       budgets_list:
         cancel_order:
           more_than_one: delete your vote on %{name} and start over

--- a/decidim-comments/app/assets/javascripts/decidim/comments/comments.component.test.js
+++ b/decidim-comments/app/assets/javascripts/decidim/comments/comments.component.test.js
@@ -163,18 +163,18 @@ describe("CommentsComponent", () => {
             </div>
             <div class="author-data__extra">
                 <button type="button" class="link-alt" data-open="flagModalComment${commentId}" title="Report inappropriate content" aria-controls="flagModalComment${commentId}" aria-haspopup="true" tabindex="0">
-                  <svg role="none presentation" aria-hidden="true" class="icon--flag icon icon--small">
+                  <svg role="presentation" aria-hidden="true" class="icon--flag icon icon--small">
                     <title></title>
-                    <use role="none presentation" href="/assets/decidim/icons-123.svg#icon-flag"></use>
+                    <use href="/assets/decidim/icons-123.svg#icon-flag"></use>
                   </svg>
                   <span class="show-for-sr">Report inappropriate content</span>
                 </button>
 
                 <a title="Get link to single comment" href="/path/to/dummy/123?commentId=${commentId}#comment_${commentId}">
                   <span class="show-for-sr">Get link to single comment</span>
-                  <svg role="none presentation" class="icon--link-intact icon icon--small">
+                  <svg role="presentation" aria-hidden="true" class="icon--link-intact icon icon--small">
                     <title></title>
-                    <use role="none presentation" href="/assets/decidim/icons-123.svg#icon-link-intact"></use>
+                    <use href="/assets/decidim/icons-123.svg#icon-link-intact"></use>
                   </svg>
                 </a>
             </div>
@@ -186,9 +186,9 @@ describe("CommentsComponent", () => {
         <div class="comment__footer">
             <div class="comment__actions">
               <button class="comment__reply muted-link" aria-controls="comment${commentId}-reply" data-toggle="comment${commentId}-reply" aria-expanded="true">
-                <svg role="none presentation" class="icon--pencil icon icon--small">
+                <svg role="presentation" aria-hidden="true" class="icon--pencil icon icon--small">
                   <title></title>
-                  <use role="none presentation" href="/assets/decidim/icons-123.svg#icon-pencil"></use>
+                  <use href="/assets/decidim/icons-123.svg#icon-pencil"></use>
                 </svg>
                 &nbsp;Reply
               </button>
@@ -198,9 +198,9 @@ describe("CommentsComponent", () => {
               <form class="button_to" method="post" action="/comments/${commentId}/votes?weight=1" data-remote="true">
                 <button class="comment__votes--up" title="I agree with this comment" type="submit">
                   <span class="show-for-sr">I agree with this comment</span>
-                  <svg role="none presentation" class="icon--chevron-top icon icon--small">
+                  <svg role="presentation" aria-hidden="true" class="icon--chevron-top icon icon--small">
                     <title></title>
-                    <use role="none presentation" href="/assets/decidim/icons-123.svg#icon-chevron-top"></use>
+                    <use href="/assets/decidim/icons-123.svg#icon-chevron-top"></use>
                   </svg>
                   <span class="comment__votes--count">0</span>
                 </button>
@@ -210,9 +210,9 @@ describe("CommentsComponent", () => {
               <form class="button_to" method="post" action="/comments/${commentId}/votes?weight=-1" data-remote="true">
                 <button class="comment__votes--down" title="I disagree with this comment" type="submit">
                   <span class="show-for-sr">I disagree with this comment</span>
-                  <svg role="none presentation" class="icon--chevron-bottom icon icon--small">
+                  <svg role="presentation" aria-hidden="true" class="icon--chevron-bottom icon icon--small">
                     <title></title>
-                    <use role="none presentation" href="/assets/decidim/icons-123.svg#icon-chevron-bottom"></use>
+                    <use href="/assets/decidim/icons-123.svg#icon-chevron-bottom"></use>
                   </svg>
                   <span class="comment__votes--count">0</span>
                 </button>
@@ -224,9 +224,9 @@ describe("CommentsComponent", () => {
 
         <div class="comment__additionalreply hide">
           <button class="comment__reply muted-link" aria-controls="comment${commentId}-reply" data-toggle="comment${commentId}-reply" aria-expanded="true">
-            <svg role="none presentation" class="icon--pencil icon icon--small">
+            <svg role="presentation" aria-hidden="true" class="icon--pencil icon icon--small">
               <title></title>
-              <use role="none presentation" href="/assets/decidim/icons-123.svg#icon-pencil"></use>
+              <use href="/assets/decidim/icons-123.svg#icon-pencil"></use>
             </svg>
             &nbsp;Reply
           </button>
@@ -305,9 +305,9 @@ describe("CommentsComponent", () => {
 
               <div class="opinion-toggle button-group">
                 <button aria-pressed="false" class="button tiny button--muted opinion-toggle--ok" data-selected-label="Your opinion about this topic is positive">
-                  <svg role="none presentation" class="icon--thumb-up icon">
+                  <svg role="presentation" aria-hidden="true" class="icon--thumb-up icon">
                     <title></title>
-                    <use role="none presentation" href="/assets/decidim/icons-2ba788b32e181c1a7197f7a54a0f03101c146dd434b9e56191690c7c2d7bdae3.svg#icon-thumb-up"></use>
+                    <use href="/assets/decidim/icons-2ba788b32e181c1a7197f7a54a0f03101c146dd434b9e56191690c7c2d7bdae3.svg#icon-thumb-up"></use>
                   </svg>
                   <span class="show-for-sr">Positive</span>
                 </button>
@@ -315,9 +315,9 @@ describe("CommentsComponent", () => {
                   Neutral
                 </button>
                 <button aria-pressed="false" class="button tiny button--muted opinion-toggle--ko" data-selected-label="Your opinion about this topic is negative">
-                  <svg role="none presentation" class="icon--thumb-down icon">
+                  <svg role="presentation" aria-hidden="true" class="icon--thumb-down icon">
                     <title></title>
-                    <use role="none presentation" href="/assets/decidim/icons-2ba788b32e181c1a7197f7a54a0f03101c146dd434b9e56191690c7c2d7bdae3.svg#icon-thumb-down"></use>
+                    <use href="/assets/decidim/icons-2ba788b32e181c1a7197f7a54a0f03101c146dd434b9e56191690c7c2d7bdae3.svg#icon-thumb-down"></use>
                   </svg>
                   <span class="show-for-sr">Negative</span>
                 </button>

--- a/decidim-comments/app/cells/decidim/comments/comment/actions.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/actions.erb
@@ -1,7 +1,7 @@
 <div class="comment__actions">
   <% if can_reply? %>
     <button class="comment__reply muted-link" aria-controls="<%= reply_id %>" data-toggle="<%= reply_id %>">
-      <%= icon "pencil", class: "icon--small", role: "none presentation" %>&nbsp;<%= t("decidim.components.comment.reply") %>
+      <%= icon "pencil", class: "icon--small", role: "presentation", "aria-hidden": true %>&nbsp;<%= t("decidim.components.comment.reply") %>
     </button>
   <% end %>
 </div>

--- a/decidim-comments/app/cells/decidim/comments/comment/show.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/show.erb
@@ -30,7 +30,7 @@
   <% if can_reply? %>
     <div class="comment__additionalreply<%= " hide" unless has_replies? %>">
       <button class="comment__reply muted-link" aria-controls="<%= reply_id %>" data-toggle="<%= reply_id %>">
-        <%= icon "pencil", class: "icon--small", role: "none presentation" %>&nbsp;<%= t("decidim.components.comment.reply") %>
+        <%= icon "pencil", class: "icon--small", role: "presentation", "aria-hidden": true %>&nbsp;<%= t("decidim.components.comment.reply") %>
       </button>
     </div>
     <div class="add-comment hide" id="<%= reply_id %>" data-toggler=".hide">

--- a/decidim-comments/app/cells/decidim/comments/comment/utilities.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/utilities.erb
@@ -1,11 +1,11 @@
 <button type="button" class="link-alt" data-open="<%= current_user.present? ? "flagModalComment#{model.id}" : "loginModal" %>" title="<%= t("decidim.components.comment.report.title") %>" aria-controls="<%= current_user.present? ? "flagModalComment#{model.id}" : "loginModal" %>" aria-haspopup="true" tabindex="0">
-  <%= icon "flag", aria_hidden: true, class: "icon--small", role: "none presentation", "aria-hidden": true %>
+  <%= icon "flag", aria_hidden: true, class: "icon--small", role: "presentation", "aria-hidden": true %>
   <span class="show-for-sr"><%= t("decidim.components.comment.report.title") %></span>
 </button>
 
 <%= link_to "#{commentable_path("commentId" => model.id)}#comment_#{model.id}", title: t("decidim.components.comment.single_comment_link_title") do %>
   <span class="show-for-sr"><%= t("decidim.components.comment.single_comment_link_title") %></span>
-  <%= icon "link-intact", class: "icon--small", role: "none presentation" %>
+  <%= icon "link-intact", class: "icon--small", role: "presentation", "aria-hidden": true %>
 <% end %>
 
 <% if current_user.present? %>

--- a/decidim-comments/app/cells/decidim/comments/comment/votes.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/votes.erb
@@ -2,23 +2,23 @@
   <% if user_signed_in? %>
     <%= button_to decidim_comments.comment_votes_path(model, weight: 1), remote: true, disabled: voted_down?, class: votes_up_classes, title: t("decidim.components.up_vote_button.text") do %>
       <span class="show-for-sr"><%= t("decidim.components.up_vote_button.text") %></span>
-      <%= icon "chevron-top", class: "icon--small", role: "none presentation" %>
+      <%= icon "chevron-top", class: "icon--small", role: "presentation", "aria-hidden": true %>
       <span class="comment__votes--count"><%= up_votes_count %></span>
     <% end %>
     <%= button_to decidim_comments.comment_votes_path(model, weight: -1), remote: true, disabled: voted_up?, class: votes_down_classes, title: t("decidim.components.down_vote_button.text") do %>
       <span class="show-for-sr"><%= t("decidim.components.down_vote_button.text") %></span>
-      <%= icon "chevron-bottom", class: "icon--small", role: "none presentation" %>
+      <%= icon "chevron-bottom", class: "icon--small", role: "presentation", "aria-hidden": true %>
       <span class="comment__votes--count"><%= down_votes_count %></span>
     <% end %>
   <% else %>
     <button class="<%= votes_up_classes %> " title="<%= t("decidim.components.up_vote_button.text") %>" data-open="loginModal">
       <span class="show-for-sr"><%= t("decidim.components.up_vote_button.text") %></span>
-      <%= icon "chevron-top", class: "icon--small", role: "none presentation" %>
+      <%= icon "chevron-top", class: "icon--small", role: "presentation", "aria-hidden": true %>
       <span class="comment__votes--count"><%= up_votes_count %></span>
     </button>
     <button class="<%= votes_down_classes %> " title="<%= t("decidim.components.down_vote_button.text") %>" data-open="loginModal">
       <span class="show-for-sr"><%= t("decidim.components.down_vote_button.text") %></span>
-      <%= icon "chevron-bottom", class: "icon--small", role: "none presentation" %>
+      <%= icon "chevron-bottom", class: "icon--small", role: "presentation", "aria-hidden": true %>
       <span class="comment__votes--count"><%= down_votes_count %></span>
     </button>
   <% end %>

--- a/decidim-comments/app/cells/decidim/comments/comments/add_comment.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/add_comment.erb
@@ -6,14 +6,14 @@
       <div class="opinion-toggle button-group">
         <span class="show-for-sr"><%= t("decidim.components.add_comment_form.opinion.label") %></span>
         <button aria-pressed="false" class="button tiny button--muted opinion-toggle--ok" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.positive_selected") %>">
-          <%= icon "thumb-up", role: "none presentation" %>
+          <%= icon "thumb-up", role: "presentation", "aria-hidden": true %>
           <span class="show-for-sr"><%= t("decidim.components.add_comment_form.opinion.positive") %></span>
         </button>
         <button aria-pressed="true" class="button tiny button--muted opinion-toggle--meh is-active" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.neutral_selected") %>">
           <%= t("decidim.components.add_comment_form.opinion.neutral") %>
         </button>
         <button aria-pressed="false" class="button tiny button--muted opinion-toggle--ko" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.negative_selected") %>">
-          <%= icon "thumb-down", role: "none presentation" %>
+          <%= icon "thumb-down", role: "presentation", "aria-hidden": true %>
           <span class="show-for-sr"><%= t("decidim.components.add_comment_form.opinion.negative") %></span>
         </button>
         <div aria-role="alert" aria-live="assertive" class="selected-state shot-for-sr"></div>

--- a/decidim-conferences/app/cells/decidim/conferences/media_link/show.erb
+++ b/decidim-conferences/app/cells/decidim/conferences/media_link/show.erb
@@ -1,5 +1,5 @@
 <li>
-  <%= icon "external-link", role: "img", "aria-hidden": true %>
+  <%= icon "external-link", role: "presentation", "aria-hidden": true %>
   <div>
     <%= link_to model.link, target: "_blank" do %>
       <strong><%= decidim_html_escape  translated_attribute(model.title) %> </strong>

--- a/decidim-consultations/app/views/layouts/decidim/_question_components.html.erb
+++ b/decidim-consultations/app/views/layouts/decidim/_question_components.html.erb
@@ -7,7 +7,7 @@
           <%= component_icon(current_component) %>
           <%= translated_attribute(current_component.name) %>
         <% else %>
-          <%= external_icon "decidim/pages/icon.svg", role: "img", "aria-hidden": true %>
+          <%= external_icon "decidim/pages/icon.svg", role: "presentation", "aria-hidden": true %>
           <%= t ".question_menu_item" %>
         <% end %>
       </span>

--- a/decidim-consultations/app/views/layouts/decidim/_question_header.html.erb
+++ b/decidim-consultations/app/views/layouts/decidim/_question_header.html.erb
@@ -10,7 +10,7 @@
           </h1>
           <%= link_to decidim_consultations.consultations_path, class: "consultations-header__link" do %>
             <%= t ".back_to_consultation" %>
-            <%= icon "media-play", role: "img", "aria-hidden": true %>
+            <%= icon "media-play", role: "presentation", "aria-hidden": true %>
           <% end %>
         </div>
       </div>

--- a/decidim-core/app/assets/javascripts/decidim/icon.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/icon.js.es6
@@ -1,6 +1,7 @@
 ((exports) => {
   const DEFAULT_ATTRIBUTES = {
-    role: "none presentation"
+    role: "presentation",
+    "aria-hidden": "true"
   };
 
   /**

--- a/decidim-core/app/cells/decidim/address_cell.rb
+++ b/decidim-core/app/cells/decidim/address_cell.rb
@@ -34,7 +34,7 @@ module Decidim
     private
 
     def resource_icon
-      icon "meetings", class: "icon--big", role: "img", "aria-hidden": true
+      icon "meetings", class: "icon--big", role: "presentation", "aria-hidden": true
     end
   end
 end

--- a/decidim-core/app/cells/decidim/author/comments.erb
+++ b/decidim-core/app/cells/decidim/author/comments.erb
@@ -1,6 +1,6 @@
 <% if commentable? %>
   <%= link_to "#{resource_locator(from_context).path}#comments", title: t("decidim.author.comments", count: from_context.comments.count) do %>
-    <%= icon "comment-square", class: "icon--small", role: "img", "aria-hidden": true %>
+    <%= icon "comment-square", class: "icon--small", role: "presentation", "aria-hidden": true %>
     <%= from_context.comments.count %> <%= t("decidim.author.comments", count: from_context.comments.count) %>
   <% end %>
 <% end %>

--- a/decidim-core/app/cells/decidim/author/endorsements.erb
+++ b/decidim-core/app/cells/decidim/author/endorsements.erb
@@ -1,6 +1,6 @@
 <% if endorsable? %>
   <%= link_to "#{resource_locator(from_context).path}#list-of-endorsements", title: t("decidim.author.endorsements",count: from_context.endorsements_count) do %>
-    <%= icon "bullhorn", class: "icon--small", role: "img", "aria-hidden": true %>
+    <%= icon "bullhorn", class: "icon--small", role: "presentation", "aria-hidden": true %>
     <%= from_context.endorsements_count %> <%= t("decidim.author.endorsements", count: from_context.endorsements_count) %>
   <% end %>
 <% end %>

--- a/decidim-core/app/cells/decidim/author/flag.erb
+++ b/decidim-core/app/cells/decidim/author/flag.erb
@@ -1,6 +1,6 @@
 <% if flaggable? %>
   <button type="button" class="link-alt" data-open="<%= current_user.present? ? "flagModal" : "loginModal" %>" title="<%= t("report", scope: "decidim.proposals.proposals.show") %>" aria-controls="<%= current_user.present? ? "flagModal" : "loginModal" %>" aria-haspopup="true" tabindex="0">
-    <%= icon "flag", aria_hidden: true, class: "icon--small", role: "img", "aria-hidden": true %>
+    <%= icon "flag", aria_hidden: true, class: "icon--small", role: "presentation", "aria-hidden": true %>
     <span class="show-for-sr">
       <%= t("report", scope: "decidim.proposals.proposals.show") %>
     </span>

--- a/decidim-core/app/cells/decidim/author/flag_user.erb
+++ b/decidim-core/app/cells/decidim/author/flag_user.erb
@@ -1,6 +1,6 @@
 <% if user_flaggable? && model.try(:id) != current_user.try(:id) %>
   <button type="button" class="link-alt" data-open="<%= current_user.present? ? "flagUserModal" : "loginModal" %>" title="<%= t("report", scope: "decidim.proposals.proposals.show") %>" aria-controls="<%= current_user.present? ? "flagUserModal" : "loginModal" %>" aria-haspopup="true" tabindex="0">
-    <%= icon "flag", aria_hidden: true, class: "icon--small", role: "img", "aria-hidden": true %>
+    <%= icon "flag", aria_hidden: true, class: "icon--small", role: "presentation", "aria-hidden": true %>
     <span class="show-for-sr">
         <%= t("report", scope: "decidim.proposals.proposals.show") %>
     </span>

--- a/decidim-core/app/cells/decidim/author/profile_inline.erb
+++ b/decidim-core/app/cells/decidim/author/profile_inline.erb
@@ -1,5 +1,5 @@
 <span class="author__avatar">
-  <%= image_tag model.avatar_url, alt: t("decidim.author.avatar") %>
+  <%= image_tag model.avatar_url, alt: t("decidim.author.avatar", name: decidim_sanitize(author_name)) %>
 </span>
 
 <% if model.deleted? %>
@@ -18,7 +18,7 @@
     data-allow-html="true"
     data-template-classes="light expanded"
     data-tip-text='<%= h render(:profile_minicard) %>'>
-    <%= author_name %>
+    <%= decidim_sanitize author_name %>
   </span>
 
   <% if model.badge.present? %>
@@ -28,7 +28,7 @@
   <% end %>
 <% else %>
   <span class="author__name">
-    <%= author_name %>
+    <%= decidim_sanitize author_name %>
   </span>
 
   <% if model.badge.present? %>

--- a/decidim-core/app/cells/decidim/author/withdraw.erb
+++ b/decidim-core/app/cells/decidim/author/withdraw.erb
@@ -1,6 +1,6 @@
 <% if withdrawable? %>
   <%= action_authorized_link_to :withdraw, withdraw_path, method: :put, class: "title-action__action button small hollow", title: t("withdraw_btn_hint", scope: "decidim.proposals.proposals.show"), data: { confirm: t("withdraw_confirmation_html", scope: "decidim.proposals.proposals.show") } do %>
     <%= t("withdraw_proposal", scope: "decidim.proposals.proposals.show") %>
-    <%= icon "x", role: "img", "aria-hidden": true %>
+    <%= icon "x", role: "presentation", "aria-hidden": true %>
   <% end %>
 <% end %>

--- a/decidim-core/app/cells/decidim/author_cell.rb
+++ b/decidim-core/app/cells/decidim/author_cell.rb
@@ -7,6 +7,7 @@ module Decidim
   class AuthorCell < Decidim::ViewModel
     include LayoutHelper
     include CellsHelper
+    include Decidim::SanitizeHelper
     include ::Devise::Controllers::Helpers
     include ::Devise::Controllers::UrlHelpers
     include Messaging::ConversationHelper

--- a/decidim-core/app/cells/decidim/badge/show.erb
+++ b/decidim-core/app/cells/decidim/badge/show.erb
@@ -2,7 +2,7 @@
   <div class="card card--badge absolutes badge-<%= badge.name %>">
     <div class="right badge-tip">
       <div data-tooltip data-position="top" title="<%= tooltip %>" data-yeti-box="<%= badge.name %>-tooltip" data-toggle="<%= badge.name %>-tooltip" data-resize="<%= badge.name %>-tooltip" class="has-tip" data-t="<%= badge.name %>-t">
-        <%= icon "info", role: "img", "aria-hidden": true %>
+        <%= icon "info", role: "presentation", "aria-hidden": true %>
       </div>
     </div>
     <div class="card__content">

--- a/decidim-core/app/cells/decidim/content_blocks/footer_sub_hero/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/footer_sub_hero/show.erb
@@ -6,7 +6,7 @@
       <% if current_organization.sign_up_enabled? && !current_user %>
         <%= link_to decidim.new_user_registration_path, class: "button--sc link subhero-cta", title: t("decidim.pages.home.sub_hero.register_title") do %>
           <%= t("decidim.pages.home.footer_sub_hero.register") %>
-          <%= icon "chevron-right", aria_hidden: true, role: "img" %>
+          <%= icon "chevron-right", aria_hidden: true, role: "presentation" %>
         <% end %>
       <% end %>
     </div>

--- a/decidim-core/app/cells/decidim/content_blocks/how_to_participate/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/how_to_participate/show.erb
@@ -7,7 +7,7 @@
       <div class="column">
         <div class="home-bullet">
           <div class="home-bullet__icon">
-            <%= icon "meetings", role: "img", "aria-hidden": true %>
+            <%= icon "meetings", role: "presentation", "aria-hidden": true %>
           </div>
           <div class="home-bullet__desc">
             <h4 class="heading4"><%= t("decidim.pages.home.extended.meetings") %></h4>
@@ -18,7 +18,7 @@
       <div class="column">
         <div class="home-bullet">
           <div class="home-bullet__icon">
-            <%= icon "debates", role: "img", "aria-hidden": true %>
+            <%= icon "debates", role: "presentation", "aria-hidden": true %>
           </div>
           <div class="home-bullet__desc">
             <h4 class="heading4"><%= t("decidim.pages.home.extended.debates") %></h4>
@@ -29,7 +29,7 @@
       <div class="column">
         <div class="home-bullet">
           <div class="home-bullet__icon">
-            <%= icon "proposals", role: "img", "aria-hidden": true %>
+            <%= icon "proposals", role: "presentation", "aria-hidden": true %>
           </div>
           <div class="home-bullet__desc">
             <h4 class="heading4"><%= t("decidim.pages.home.extended.proposals") %></h4>

--- a/decidim-core/app/cells/decidim/content_blocks/sub_hero/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/sub_hero/show.erb
@@ -7,7 +7,7 @@
         <% unless current_user %>
           <%= link_to decidim.new_user_registration_path, class: "button--sc link subhero-cta", title: t("decidim.pages.home.sub_hero.register_title") do %>
             <%= t("decidim.pages.home.sub_hero.register") %>
-            <%= icon "chevron-right", aria_hidden: true, role: "img" %>
+            <%= icon "chevron-right", aria_hidden: true, role: "presentation" %>
           <% end %>
         <% end %>
       </div>

--- a/decidim-core/app/cells/decidim/endorsement_buttons_cell.rb
+++ b/decidim-core/app/cells/decidim/endorsement_buttons_cell.rb
@@ -47,7 +47,7 @@ module Decidim
 
     # Renders the counter of endorsements that appears in m-cards.
     def render_endorsements_count
-      content = icon("bullhorn", class: "icon--small", aria_label: t("decidim.endorsable.endorsements_count"), role: "img")
+      content = icon("bullhorn", class: "icon--small", aria_label: t("decidim.endorsable.endorsements_count"), role: "presentation")
       content += resource.endorsements_count.to_s
       html_class = "button small compact button--shadow secondary"
       html_class += " active" if fully_endorsed?(resource, current_user)

--- a/decidim-core/app/cells/decidim/follow_button_cell.rb
+++ b/decidim-core/app/cells/decidim/follow_button_cell.rb
@@ -41,7 +41,7 @@ module Decidim
 
     def icon_options
       icon_base_options = { aria_hidden: true }
-      return icon_base_options.merge(class: "icon--small", role: "img", "aria-hidden": true) if inline?
+      return icon_base_options.merge(class: "icon--small", role: "presentation", "aria-hidden": true) if inline?
 
       icon_base_options
     end

--- a/decidim-core/app/cells/decidim/navbar_admin_link_cell.rb
+++ b/decidim-core/app/cells/decidim/navbar_admin_link_cell.rb
@@ -43,7 +43,7 @@ module Decidim
     def icon_options
       options = model[:icon_options].presence || {}
 
-      options.merge(role: "img", "aria-hidden": true)
+      options.merge(role: "presentation", "aria-hidden": true)
     end
   end
 end

--- a/decidim-core/app/cells/decidim/profile_sidebar/show.erb
+++ b/decidim-core/app/cells/decidim/profile_sidebar/show.erb
@@ -76,7 +76,7 @@
           <strong class="muted"><%= t("decidim.profiles.sidebar.badges.title") %></strong>
           <div class="badge-tip badge-tip--inline">
             <div data-tooltip data-position="top" title="<%= t("decidim.profiles.sidebar.badges.info") %>" data-yeti-box="badges-tooltip" data-toggle="badges-tooltip" data-resize="badges-tooltip" class="has-tip" data-events="resize">
-              <%= icon "info", class: "icon--small", role: "img", "aria-hidden": true %>
+              <%= icon "info", class: "icon--small", role: "presentation", "aria-hidden": true %>
             </div>
           </div>
         </div>

--- a/decidim-core/app/cells/decidim/user_conversation/conversation_header.erb
+++ b/decidim-core/app/cells/decidim/user_conversation/conversation_header.erb
@@ -5,7 +5,7 @@
     <% end %>
   </div>
   <%= link_to profile_path(user.nickname) do %>
-    <%= image_tag conversation_avatar, alt: conversation_avatar_alt) %>
+    <%= image_tag conversation_avatar, alt: conversation_avatar_alt %>
   <% end %>
 
   <div class="ml-s">

--- a/decidim-core/app/cells/decidim/user_conversation/conversation_header.erb
+++ b/decidim-core/app/cells/decidim/user_conversation/conversation_header.erb
@@ -1,11 +1,11 @@
 <div class="conversation-header flex--cc absolutes">
   <div class="left center mr-s">
     <%= link_to decidim.profile_conversations_path(nickname: user.nickname), class: "card--list__data__icon card--list__data__icon--back" do %>
-      <%= icon "chevron-left", role: "img" %>
+      <%= icon "chevron-left", role: "img", aria_label: t("decidim.user_conversations.show.back") %>
     <% end %>
   </div>
   <%= link_to profile_path(user.nickname) do %>
-    <%= image_tag conversation_avatar, alt: t("decidim.author.avatar") %>
+    <%= image_tag conversation_avatar, alt: conversation_avatar_alt) %>
   <% end %>
 
   <div class="ml-s">

--- a/decidim-core/app/cells/decidim/user_conversation/messages.erb
+++ b/decidim-core/app/cells/decidim/user_conversation/messages.erb
@@ -1,6 +1,6 @@
 <div class="conversation-chat<%= " conversation-chat--offset" if sender_is_user?(sender) %>">
   <%= link_to sender.personal_url do %>
-    <%= image_tag sender.avatar_url, alt: t("decidim.author.avatar") %>
+    <%= image_tag sender.avatar_url, alt: t("decidim.author.avatar", name: decidim_sanitize(sender.name)) %>
   <% end %>
   <div>
     <% messages.each do |message| %>

--- a/decidim-core/app/cells/decidim/user_conversation_cell.rb
+++ b/decidim-core/app/cells/decidim/user_conversation_cell.rb
@@ -6,6 +6,7 @@ module Decidim
     include Decidim::LayoutHelper
     include Decidim::ApplicationHelper
     include Decidim::FormFactory
+    include Decidim::SanitizeHelper
     include Decidim::Core::Engine.routes.url_helpers
     include Messaging::ConversationHelper
 
@@ -41,6 +42,14 @@ module Decidim
         interlocutors.first.avatar_url
       else
         current_user.avatar.default_multiuser_url
+      end
+    end
+
+    def conversation_avatar_alt
+      if interlocutors.count == 1
+        t("decidim.author.avatar", name: decidim_sanitize(interlocutors.first.name))
+      else
+        t("decidim.author.avatar_multiuser")
       end
     end
 

--- a/decidim-core/app/cells/decidim/user_conversations/conversation_item.erb
+++ b/decidim-core/app/cells/decidim/user_conversations/conversation_item.erb
@@ -3,7 +3,7 @@
     <li class="card-data__item">
       <div class="card__link text-center">
         <div class="user-header__avatar">
-          <%= image_tag conversation_avatar(conversation), alt: t("decidim.author.avatar") %>
+          <%= image_tag conversation_avatar(conversation), alt: conversation_avatar_alt(conversation) %>
         </div>
         <span class="text-medium mt-xs"><%= Date::ABBR_DAYNAMES[conversation.created_at.wday] %> <%= conversation.created_at.wday %></span>
       </div>

--- a/decidim-core/app/cells/decidim/user_conversations_cell.rb
+++ b/decidim-core/app/cells/decidim/user_conversations_cell.rb
@@ -4,6 +4,7 @@ module Decidim
   class UserConversationsCell < Decidim::ViewModel
     include Cell::ViewModel::Partial
     include Decidim::LayoutHelper
+    include Decidim::SanitizeHelper
     include CellsPaginateHelper
     include Decidim::Core::Engine.routes.url_helpers
     include Messaging::ConversationHelper
@@ -29,6 +30,12 @@ module Decidim
       return user.avatar.default_multiuser_url unless conversation.interlocutors(user).count == 1
 
       conversation.interlocutors(user).first.avatar_url
+    end
+
+    def conversation_avatar_alt(conversation)
+      return t("decidim.author.avatar_multiuser") unless conversation.interlocutors(user).count == 1
+
+      t("decidim.author.avatar", name: decidim_sanitize(conversation.interlocutors(user).first.name))
     end
 
     def conversation_interlocutors(conversation)

--- a/decidim-core/app/cells/decidim/user_profile/unlinked_user_data.erb
+++ b/decidim-core/app/cells/decidim/user_profile/unlinked_user_data.erb
@@ -2,12 +2,12 @@
   <div class="author-data__main">
     <div class="author author--flex">
       <span class="author__avatar">
-        <%= image_tag avatar, alt: t("avatar", scope: "activemodel.attributes.group") %>
+        <%= image_tag avatar, alt: t("decidim.author.avatar", name: decidim_sanitize(name)) %>
       </span>
       <div>
         <div class="author__name--container">
-          <span class="author__name"><%= name %></span>
-          <%= icon badge, class: "author__verified" if badge.present? %>
+          <span class="author__name"><%= decidim_sanitize(name) %></span>
+          <%= icon badge, class: "author__verified", role: "presentation", "aria-hidden": true if badge.present? %>
         </div>
         <span class="author__nickname"><%= nickname %></span>
       </div>

--- a/decidim-core/app/cells/decidim/user_profile/user_data.erb
+++ b/decidim-core/app/cells/decidim/user_profile/user_data.erb
@@ -2,12 +2,12 @@
   <div class="author-data__main">
     <div class="author author--flex">
       <%= link_to resource_path, class: "author__avatar" do %>
-        <%= image_tag avatar, alt: t("avatar", scope: "activemodel.attributes.group") %>
+        <%= image_tag avatar, alt: t("decidim.author.avatar", name: decidim_sanitize(name)) %>
       <% end %>
       <div>
         <div class="author__name--container">
-          <%= link_to name, resource_path, class: "author__name" %>
-          <%= icon badge, class: "author__verified" if badge.present? %>
+          <%= link_to decidim_sanitize(name), resource_path, class: "author__name" %>
+          <%= icon badge, class: "author__verified", role: "presentation", "aria-hidden": true if badge.present? %>
         </div>
         <%= link_to nickname, resource_path, class: "author__nickname" %>
       </div>

--- a/decidim-core/app/cells/decidim/version_author/show.erb
+++ b/decidim-core/app/cells/decidim/version_author/show.erb
@@ -2,7 +2,7 @@
   <div class="author author--inline">
     <% if author.respond_to?(:avatar_url) %>
       <span class="author__avatar author__avatar--small">
-        <%= image_tag author.avatar_url, alt: "author-avatar" %>
+        <%= image_tag author.avatar_url, alt: t("decidim.author.avatar", name: decidim_sanitize(author_name)) %>
       </span>
     <% end %>
     <span class="author__name">
@@ -11,7 +11,7 @@
           <%= t(".deleted") %>
         </span>
       <% else %>
-        <%= author.try(:name) || author %>
+        <%= decidim_sanitize(author_name || author) %>
       <% end %>
     </span>
   </div>

--- a/decidim-core/app/cells/decidim/version_author/show.erb
+++ b/decidim-core/app/cells/decidim/version_author/show.erb
@@ -8,7 +8,7 @@
     <span class="author__name">
       <% if author.try(:deleted?) %>
         <span class="label label--small label--basic">
-          <%= t(".deleted") %>
+          <%= t("decidim.version_author.show.deleted") %>
         </span>
       <% else %>
         <%= decidim_sanitize(author_name || author) %>

--- a/decidim-core/app/cells/decidim/version_author_cell.rb
+++ b/decidim-core/app/cells/decidim/version_author_cell.rb
@@ -10,6 +10,7 @@ module Decidim
 
     def author_name
       return nil unless author
+      return author if author.is_a?(String)
       return t("decidim.version_author.show.deleted") if author.deleted?
 
       author.name

--- a/decidim-core/app/cells/decidim/version_author_cell.rb
+++ b/decidim-core/app/cells/decidim/version_author_cell.rb
@@ -2,8 +2,17 @@
 
 module Decidim
   class VersionAuthorCell < Decidim::ViewModel
+    include Decidim::SanitizeHelper
+
     def author
       model
+    end
+
+    def author_name
+      return nil unless author
+      return t(".deleted") if author.deleted?
+
+      author.name
     end
   end
 end

--- a/decidim-core/app/cells/decidim/version_author_cell.rb
+++ b/decidim-core/app/cells/decidim/version_author_cell.rb
@@ -10,7 +10,7 @@ module Decidim
 
     def author_name
       return nil unless author
-      return t(".deleted") if author.deleted?
+      return t("decidim.version_author.show.deleted") if author.deleted?
 
       author.name
     end

--- a/decidim-core/app/cells/decidim/versions_list_item/show.erb
+++ b/decidim-core/app/cells/decidim/versions_list_item/show.erb
@@ -14,7 +14,7 @@
   </div>
   <div class="card--list__data">
     <%= link_to version_path, class: "card--list__data__icon" do %>
-      <%= icon "chevron-right", role: "img", aria_label: t(".back") %>
+      <%= icon "chevron-right", role: "img", aria_label: t("decidim.versions_list_item.back") %>
     <% end %>
   </div>
 </div>

--- a/decidim-core/app/cells/decidim/versions_list_item/show.erb
+++ b/decidim-core/app/cells/decidim/versions_list_item/show.erb
@@ -14,7 +14,7 @@
   </div>
   <div class="card--list__data">
     <%= link_to version_path, class: "card--list__data__icon" do %>
-      <%= icon "chevron-right", role: "img", "aria-hidden": true %>
+      <%= icon "chevron-right", role: "img", aria_label: t(".back") %>
     <% end %>
   </div>
 </div>

--- a/decidim-core/app/cells/decidim/wizard_step_form/wizard_aside.erb
+++ b/decidim-core/app/cells/decidim/wizard_step_form/wizard_aside.erb
@@ -2,7 +2,7 @@
   <% if wizard_aside_back_url %>
     <div class="m-bottom">
       <%= link_to wizard_aside_back_url do %>
-        <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+        <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
         <%= i18n_wizard_aside_back %>
       <% end %>
     </div>

--- a/decidim-core/app/views/decidim/amendments/review.html.erb
+++ b/decidim-core/app/views/decidim/amendments/review.html.erb
@@ -3,7 +3,7 @@
     <div class="columns">
       <div class="m-bottom">
         <%= link_to :back do %>
-          <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+          <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
           <%= t(".back") %>
         <% end %>
       </div>

--- a/decidim-core/app/views/decidim/application/_collection.html.erb
+++ b/decidim-core/app/views/decidim/application/_collection.html.erb
@@ -1,6 +1,6 @@
 <% unless attachment_collection.unused? %>
   <div class="docs__container">
-    <span data-toggle="docs-collection-<%= attachment_collection.id %>"><%= icon "caret-right", class: "icon--small", role: "img", "aria-hidden": true %>&nbsp;
+    <span data-toggle="docs-collection-<%= attachment_collection.id %>"><%= icon "caret-right", class: "icon--small", role: "presentation", "aria-hidden": true %>&nbsp;
       <strong><%= translated_attribute(attachment_collection.name) %></strong>
 
       <% attachment_collection_documents_count =  attachment_collection.attachments.select(&:document?).count %>

--- a/decidim-core/app/views/decidim/messaging/conversations/_conversation.html.erb
+++ b/decidim-core/app/views/decidim/messaging/conversations/_conversation.html.erb
@@ -4,9 +4,9 @@
       <div class="card__link text-center">
         <div class="user-header__avatar">
           <% if conversation.interlocutors(current_user).count == 1 %>
-            <%= image_tag conversation.interlocutors(current_user).first.avatar_url, alt: t("decidim.author.avatar") %>
+            <%= image_tag conversation.interlocutors(current_user).first.avatar_url, alt: t("decidim.author.avatar", name: decidim_sanitize(current_user.name)) %>
           <% else %>
-            <%= image_tag current_user.avatar.default_multiuser_url, alt: t("decidim.author.avatar") %>
+            <%= image_tag current_user.avatar.default_multiuser_url, alt: t("decidim.author.avatar_multiuser") %>
           <% end %>
         </div>
         <span class="text-medium mt-xs"><%= Date::ABBR_DAYNAMES[conversation.created_at.wday] %> <%= conversation.created_at.wday %></span>

--- a/decidim-core/app/views/decidim/messaging/conversations/_messages.html.erb
+++ b/decidim-core/app/views/decidim/messaging/conversations/_messages.html.erb
@@ -1,6 +1,6 @@
 <div class="conversation-chat<%= " conversation-chat--offset" if sender_is_user?(sender) %>">
   <%= link_to profile_path(sender.nickname) do %>
-    <%= image_tag sender.avatar_url, alt: t("decidim.author.avatar") %>
+    <%= image_tag sender.avatar_url, alt: t("decidim.author.avatar", name: decidim_sanitize(sender.name)) %>
   <% end %>
   <div>
     <% messages.each do |message| %>

--- a/decidim-core/app/views/decidim/messaging/conversations/_show.html.erb
+++ b/decidim-core/app/views/decidim/messaging/conversations/_show.html.erb
@@ -17,10 +17,10 @@
           </div>
           <% if participants.count == 1 %>
             <%= link_to profile_path(participants.first.nickname) do %>
-              <%= image_tag participants.first.avatar_url, alt: t("decidim.author.avatar") %>
+              <%= image_tag participants.first.avatar_url, alt: t("decidim.author.avatar", name: decidim_sanitize(participants.first.name)) %>
             <% end %>
           <% else %>
-            <%= image_tag current_user.avatar.default_multiuser_url, alt: t("decidim.author.avatar") %>
+            <%= image_tag current_user.avatar.default_multiuser_url, alt: t("decidim.author.avatar_multiuser") %>
           <% end %>
 
           <div class="ml-s">

--- a/decidim-core/app/views/decidim/searches/_filters.html.erb
+++ b/decidim-core/app/views/decidim/searches/_filters.html.erb
@@ -2,7 +2,7 @@
 <% if params.dig(:filter, :resource_type).present? %>
   <p class="text-secondary">
     <%= link_to main_search_path do %>
-      <%= icon "caret-left", class: "icon--small", role: "img", "aria-hidden": true %>&nbsp;<%= t(".back") %>
+      <%= icon "caret-left", class: "icon--small", role: "presentation", "aria-hidden": true %>&nbsp;<%= t(".back") %>
     <% end %>
   </p>
 <% end %>

--- a/decidim-core/app/views/decidim/shared/_embed_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_embed_modal.html.erb
@@ -4,7 +4,7 @@
     <% if try(:resource) %>
       <span class="show-for-sr"><%= resource_title(resource) %></span>
     <% end %>
-    <%= icon "code", class: "icon--after", role: "img", "aria-hidden": true %>
+    <%= icon "code", class: "icon--after", role: "presentation", "aria-hidden": true %>
   </button>
 </div>
 <div class="reveal reveal--embed" id="processEmbed" data-reveal>

--- a/decidim-core/app/views/decidim/shared/_share_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_share_modal.html.erb
@@ -4,7 +4,7 @@
     <% if try(:resource) %>
       <span class="show-for-sr"><%= resource_title(resource) %></span>
     <% end %>
-    <%= icon "share", class: "icon--after", role: "img", "aria-hidden": true %>
+    <%= icon "share", class: "icon--after", role: "presentation", "aria-hidden": true %>
   </button>
 </div>
 <div class="reveal" id="socialShare" data-reveal>
@@ -21,7 +21,7 @@
         desc: h(decidim_meta_description),
         via: decidim_meta_twitter_handler) %>
     <a href="#" class="button" data-open="urlShare">
-      <%= icon "link-intact", role: "img", "aria-hidden": true %>
+      <%= icon "link-intact", role: "presentation", "aria-hidden": true %>
       <%= t(".share_link") %>
     </a>
   </div>

--- a/decidim-core/app/views/decidim/shared/_static_map.html.erb
+++ b/decidim-core/app/views/decidim/shared/_static_map.html.erb
@@ -3,7 +3,7 @@
     <div class="card__content address">
       <div class="address__info">
         <div class="address__icon">
-          <%= icon icon_name, role: "img", "aria-hidden": true, width: 40, height: 70 %>
+          <%= icon icon_name, role: "presentation", "aria-hidden": true, width: 40, height: 70 %>
         </div>
         <div class="address__details">
           <%= render partial: "decidim/shared/address_details", locals: { geolocalizable: geolocalizable } %>

--- a/decidim-core/app/views/layouts/decidim/_omnipresent_banner.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_omnipresent_banner.html.erb
@@ -8,7 +8,7 @@
       <span class="omnipresent-banner-short-description">
         <%= translated_attribute current_organization.omnipresent_banner_short_description %>
       </span>
-      <%= icon "media-play", role: "img", "aria-hidden": true %>
+      <%= icon "media-play", role: "presentation", "aria-hidden": true %>
     <% end %>
   </div>
 <% end %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -258,7 +258,8 @@ en:
       photos:
         related_photos: Related images
     author:
-      avatar: Avatar
+      avatar: 'Avatar: %{name}'
+      avatar_multiuser: Avatar for multiple users
       comments:
         one: comment
         other: comments
@@ -1312,6 +1313,7 @@ en:
         send: Send
         title_reply: Reply
       show:
+        back: Show all conversations
         not_allowed: This user does not accept any more direct messages.
         title: Conversation with %{usernames}
       update:
@@ -1357,6 +1359,7 @@ en:
         number_of_versions: Versions
         title: Versions
     versions_list_item:
+      back: Show all versions
       show:
         version_index: Version %{index}
     welcome_notification:

--- a/decidim-core/spec/helpers/decidim/icon_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/icon_helper_spec.rb
@@ -30,9 +30,9 @@ module Decidim
 
         context "with role attribute specified" do
           it "implements role attribute" do
-            result = helper.component_icon(component, role: "img")
+            result = helper.component_icon(component, role: "presentation")
             expect(result).to eq <<~SVG.strip
-              <svg class="icon external-icon" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36.02 36.02"><circle cx="18.01" cy="18.01" r="15.75" fill="none" stroke="#2ecc71" stroke-width="4"/><circle cx="18.01" cy="18.01" r="11.25" fill="none" stroke="#08BCD0" stroke-width="4"/></svg>
+              <svg class="icon external-icon" role="presentation" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36.02 36.02"><circle cx="18.01" cy="18.01" r="15.75" fill="none" stroke="#2ecc71" stroke-width="4"/><circle cx="18.01" cy="18.01" r="11.25" fill="none" stroke="#08BCD0" stroke-width="4"/></svg>
             SVG
           end
         end

--- a/decidim-debates/app/cells/decidim/debates/debate_m/multiple_dates.erb
+++ b/decidim-debates/app/cells/decidim/debates/debate_m/multiple_dates.erb
@@ -6,7 +6,7 @@
       </strong>
       <%= formatted_start_time %>
     </div>
-    <%= icon "arrow-thin-right", class: "icon--big muted", role: "img", "aria-hidden": true %>
+    <%= icon "arrow-thin-right", class: "icon--big muted", role: "presentation", "aria-hidden": true %>
     <div>
       <strong>
         <%= l end_date, format: :decidim_with_month_name %>

--- a/decidim-debates/app/views/decidim/debates/debates/index.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/index.html.erb
@@ -8,7 +8,7 @@
     <% if current_settings.creation_enabled? && current_component.participatory_space.can_participate?(current_user) %>
       <%= action_authorized_link_to :create, new_debate_path, class: "title-action__action button small", data: { "redirect_url" => new_debate_path } do %>
         <%= t(".new_debate") %>
-        <%= icon "plus", role: "img", "aria-hidden": true %>
+        <%= icon "plus", role: "presentation", "aria-hidden": true %>
       <% end %>
     <% end %>
   </div>

--- a/decidim-debates/app/views/decidim/debates/debates/new.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/new.html.erb
@@ -1,7 +1,7 @@
 <div class="row columns">
   <div class="m-bottom">
     <%= link_to :back, class: "muted-link" do %>
-      <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+      <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
       <%= t(".back") %>
     <% end %>
   </div>

--- a/decidim-debates/app/views/decidim/debates/debates/show.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/show.html.erb
@@ -16,7 +16,7 @@ edit_link(
 <div class="row column view-header">
   <div class="m-bottom">
     <%= link_to debates_path(filter_link_params), class: "small hollow" do %>
-      <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+      <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
       <%= t(".back") %>
     <% end %>
   </div>

--- a/decidim-elections/app/cells/decidim/elections/voting_step_navigation/show.erb
+++ b/decidim-elections/app/cells/decidim/elections/voting_step_navigation/show.erb
@@ -4,7 +4,7 @@
       <a></a>
     <% else %>
       <%= link_to(
-        icon("chevron-left", class: "icon", role: "img") + " " + t("decidim.elections.votes.voting_step.back"),
+        icon("chevron-left", class: "icon", role: "presentation", "aria-hidden": true) + " " + t("decidim.elections.votes.voting_step.back"),
         "#",
         class: "focus__back",
         data: {

--- a/decidim-elections/app/cells/decidim/elections/voting_step_navigation_cell.rb
+++ b/decidim-elections/app/cells/decidim/elections/voting_step_navigation_cell.rb
@@ -23,7 +23,7 @@ module Decidim
       end
 
       def button_continue_text
-        "#{t("decidim.elections.votes.voting_step.continue")}  #{icon("chevron-right", class: "icon", role: "img")}"
+        "#{t("decidim.elections.votes.voting_step.continue")}  #{icon("chevron-right", class: "icon", role: "presentation", "aria-hidden": true)}"
       end
 
       def previous_step_dom_id

--- a/decidim-elections/app/views/decidim/elections/admin/answers/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/answers/index.html.erb
@@ -60,13 +60,13 @@
                 <% if allowed_to? :update, :answer, election: election, question: question, answer: answer %>
                   <%= icon_link_to "pencil", edit_election_question_answer_path(election, question, answer), t("actions.edit", scope: "decidim.elections"), class: "action-icon--edit" %>
                 <% else %>
-                  <%= icon "pencil", class: "action-icon action-icon--disabled", role: "img" %>
+                  <%= icon "pencil", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.edit", scope: "decidim.elections") %>
                 <% end %>
 
                 <% if allowed_to? :delete, :answer, election: election, question: question, answer: answer %>
                   <%= icon_link_to "circle-x", election_question_answer_path(election, question, answer), t("actions.destroy", scope: "decidim.elections"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.elections") } %>
                 <% else %>
-                  <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img" %>
+                  <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.destroy", scope: "decidim.elections") %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-elections/app/views/decidim/elections/admin/elections/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/index.html.erb
@@ -48,26 +48,26 @@
                 <% if allowed_to? :update, :election, election: election %>
                   <%= icon_link_to "pencil", edit_election_path(election), t("actions.edit", scope: "decidim.elections"), class: "action-icon--edit" %>
                 <% else %>
-                  <%= icon "pencil", class: "action-icon action-icon--disabled", role: "img" %>
+                  <%= icon "pencil", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.edit", scope: "decidim.elections") %>
                 <% end %>
 
                 <% if allowed_to? :update, :questionnaire, questionnaire: election.questionnaire %>
                   <%= icon_link_to "people", edit_feedback_form_path(election), t("actions.feedback", scope: "decidim.elections"), class: "action-icon--survey" %>
                 <% else %>
-                  <%= icon "people", class: "action-icon action-icon--disabled", role: "img" %>
+                  <%= icon "people", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.feedback", scope: "decidim.elections") %>
                 <% end %>
 
                 <% if election.published? %>
                   <% if allowed_to?(:unpublish, :election, election: election) %>
                     <%= icon_link_to "x", url_for(action: :unpublish, id: election, controller: "elections"), t("actions.unpublish", scope: "decidim.elections"), class: "action-icon--unpublish", method: :put %>
                   <% else %>
-                    <%= icon "x", class: "action-icon action-icon--disabled", role: "img" %>
+                    <%= icon "x", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.unpublish", scope: "decidim.elections") %>
                   <% end %>
                 <% else %>
                   <% if allowed_to?(:publish, :election, election: election) %>
                     <%= icon_link_to "check", url_for(action: :publish, id: election, controller: "elections"), t("actions.publish", scope: "decidim.elections"), class: "action-icon--publish", method: :put %>
                   <% else %>
-                    <%= icon "check", class: "action-icon action-icon--disabled", role: "img" %>
+                    <%= icon "check", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.publish", scope: "decidim.elections") %>
                   <% end %>
                 <% end %>
 
@@ -76,7 +76,7 @@
                 <% if allowed_to? :delete, :election, election: election %>
                   <%= icon_link_to "circle-x", election_path(election), t("actions.destroy", scope: "decidim.elections"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.elections") } %>
                 <% else %>
-                  <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img" %>
+                  <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.destroy", scope: "decidim.elections") %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-elections/app/views/decidim/elections/admin/questions/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/questions/index.html.erb
@@ -41,13 +41,13 @@
                 <% if allowed_to? :update, :question, election: election, question: question %>
                   <%= icon_link_to "pencil", edit_election_question_path(election, question), t("actions.edit", scope: "decidim.elections"), class: "action-icon--edit" %>
                 <% else %>
-                  <%= icon "pencil", class: "action-icon action-icon--disabled", role: "img" %>
+                  <%= icon "pencil", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.edit", scope: "decidim.elections") %>
                 <% end %>
 
                 <% if allowed_to? :delete, :question, election: election, question: question %>
                   <%= icon_link_to "circle-x", election_question_path(election, question), t("actions.destroy", scope: "decidim.elections"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.elections") } %>
                 <% else %>
-                  <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img" %>
+                  <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.destroy", scope: "decidim.elections") %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-elections/app/views/decidim/elections/admin/steps/_create_election.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/steps/_create_election.html.erb
@@ -7,9 +7,9 @@
     <ul class="no-bullet-indented">
       <% form.messages.each do |key, value| %>
         <% if form.errors.include?(key) %>
-          <li><%= icon "x", role: "img", "aria-hidden": true %>&nbsp;<%= form.errors.messages[key][0].html_safe %></li>
+          <li><%= icon "x", role: "presentation", "aria-hidden": true %>&nbsp;<%= form.errors.messages[key][0].html_safe %></li>
         <% else %>
-          <li><%= icon "check", role: "img", "aria-hidden": true %>&nbsp;<%= value.html_safe %></li>
+          <li><%= icon "check", role: "presentation", "aria-hidden": true %>&nbsp;<%= value.html_safe %></li>
         <% end %>
       <% end %>
     </ul>
@@ -24,7 +24,7 @@
                                           .sort_by {|trustee, used| used ? 0 : 1}
                                           .each do |trustee, used| %>
         <li <%= "class=text-muted" if !used %>>
-          <%= icon trustee.public_key ? "check" : "x", role: "img", "aria-hidden": true %>
+          <%= icon trustee.public_key ? "check" : "x", role: "presentation", "aria-hidden": true %>
           <%= trustee.user.name || trustee.name %> <%= t(".public_key.#{used}").html_safe %>
           <% if used %>
             <%= f.hidden_field :trustee_ids, multiple: true, value: trustee.id %>

--- a/decidim-elections/app/views/decidim/elections/admin/trustees_participatory_spaces/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/trustees_participatory_spaces/index.html.erb
@@ -45,13 +45,13 @@
                 <% if allowed_to?(:update, :trustee_participatory_space, trustee_participatory_space: trustee_current_participatory_space(trustee)) %>
                   <%= icon_link_to considered_icon_action_for(trustee), edit_trustee_path(trustee_current_participatory_space(trustee)), considered_label_action_for(trustee), class: "action-icon--edit" %>
                 <% else %>
-                  <%= icon considered_icon_action_for(trustee), class: "action-icon action-icon--disabled", role: "img" %>
+                  <%= icon considered_icon_action_for(trustee), class: "action-icon action-icon--disabled", role: "img", aria_label: considered_label_action_for(trustee) %>
                 <% end %>
 
                 <% if allowed_to?(:delete, :trustee_participatory_space, trustee_participatory_space: trustee_current_participatory_space(trustee)) %>
                   <%= icon_link_to "circle-x", trustee_path(trustee_current_participatory_space(trustee)), t("actions.destroy", scope: "decidim.elections"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.elections") } %>
                 <% else %>
-                  <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img" %>
+                  <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.destroy", scope: "decidim.elections") %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-elections/app/views/decidim/elections/trustee_zone/elections/_key_ceremony_steps.html.erb
+++ b/decidim-elections/app/views/decidim/elections/trustee_zone/elections/_key_ceremony_steps.html.erb
@@ -36,7 +36,7 @@
   </button>
 
   <%= link_to trustee_path, class: "back button hide" do %>
-    <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+    <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
     <%= t(".back") %>
   <% end %>
 

--- a/decidim-elections/app/views/decidim/elections/trustee_zone/elections/_tally_steps.html.erb
+++ b/decidim-elections/app/views/decidim/elections/trustee_zone/elections/_tally_steps.html.erb
@@ -34,7 +34,7 @@
 </button>
 
 <%= link_to trustee_path, class: "back button hide" do %>
-  <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+  <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
   <%= t(".back") %>
 <% end %>
 

--- a/decidim-elections/app/views/decidim/elections/trustee_zone/trustees/show.html.erb
+++ b/decidim-elections/app/views/decidim/elections/trustee_zone/trustees/show.html.erb
@@ -35,10 +35,10 @@
             <div class="card__support">
               <div>
                 <button class="card__button button small hollow" type="button">
-                  <%= icon "x", role: "img" %> <%= t(".identification_keys.cancel") %>
+                  <%= icon "x", role: "presentation", "aria-hidden": true %> <%= t(".identification_keys.cancel") %>
                 </button>
                 <label class="card__button button small" for="submit_identification_public_key">
-                  <%= icon "check", role: "img" %> <%= t(".identification_keys.submit") %>
+                  <%= icon "check", role: "presentation", "aria-hidden": true %> <%= t(".identification_keys.submit") %>
                 </label>
               </div>
             </div>
@@ -47,7 +47,7 @@
     </div>
     <div id="generate_identification_keys" data-error="<%= t(".identification_keys.generate_error") %>">
       <button class="button">
-        <%= icon "key", role: "img" %> <%= t(".identification_keys.generate") %>
+        <%= icon "key", role: "presentation", "aria-hidden": true %> <%= t(".identification_keys.generate") %>
       </button>
     </div>
   <% else %>
@@ -56,7 +56,7 @@
       <h2><%= t(".identification_keys.title") %></h2>
       <p><%= t(".identification_keys.upload_legend") %></p>
       <button class="button" type="button">
-        <%= icon "data-transfer-upload", role: "img" %> <%= t(".identification_keys.upload") %>
+        <%= icon "data-transfer-upload", role: "presentation", "aria-hidden": true %> <%= t(".identification_keys.upload") %>
       </button>
     </div>
 

--- a/decidim-elections/app/views/decidim/elections/votes/_election_votes_confirm_footer.html.erb
+++ b/decidim-elections/app/views/decidim/elections/votes/_election_votes_confirm_footer.html.erb
@@ -1,7 +1,7 @@
 <div class="focus__footer">
   <div class="row">
     <%= link_to(
-      icon("chevron-left", class: "icon", role: "img") + " " + t("decidim.elections.votes.voting_step.back"),
+      icon("chevron-left", class: "icon", role: "presentation", "aria-hidden": true) + " " + t("decidim.elections.votes.voting_step.back"),
       "#",
       class: "focus__back",
       data: {
@@ -18,7 +18,7 @@
       }
     ) do %>
       <%= t("decidim.elections.votes.confirm.confirm") %>
-      <%= icon("chevron-right", class: "icon", role: "img") %>
+      <%= icon("chevron-right", class: "icon", role: "presentation", "aria-hidden": true) %>
     <% end %>
   </div>
 </div>

--- a/decidim-elections/app/views/decidim/votings/admin/monitoring_committee_members/index.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/monitoring_committee_members/index.html.erb
@@ -29,7 +29,7 @@
                 <% if allowed_to? :delete, :monitoring_committee_member, voting: current_voting, monitoring_committee_member: monitoring_committee_member %>
                   <%= icon_link_to "circle-x", voting_monitoring_committee_member_path(current_voting, monitoring_committee_member), t("actions.destroy", scope: "decidim.votings.monitoring_committee_members"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.votings.monitoring_committee_members") } %>
                 <% else %>
-                  <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img" %>
+                  <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.destroy", scope: "decidim.votings.monitoring_committee_members") %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-elections/app/views/decidim/votings/admin/polling_officers/index.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/polling_officers/index.html.erb
@@ -38,7 +38,7 @@
                 <% if allowed_to? :delete, :polling_officer, voting: current_voting, polling_officer: polling_officer %>
                   <%= icon_link_to "circle-x", voting_polling_officer_path(current_voting, polling_officer), t("actions.destroy", scope: "decidim.votings.polling_officers"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.votings.polling_officers") } %>
                 <% else %>
-                  <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img" %>
+                  <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.destroy", scope: "decidim.votings.polling_officers") %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-elections/app/views/decidim/votings/admin/polling_stations/index.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/polling_stations/index.html.erb
@@ -37,13 +37,13 @@
                 <% if allowed_to? :update, :polling_station, voting: current_voting, polling_station: polling_station %>
                   <%= icon_link_to "pencil", edit_voting_polling_station_path(current_voting, polling_station), t("actions.edit", scope: "decidim.votings.polling_stations"), class: "action-icon--edit" %>
                 <% else %>
-                  <%= icon "pencil", class: "action-icon action-icon--disabled", role: "img" %>
+                  <%= icon "pencil", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.edit", scope: "decidim.votings.polling_stations") %>
                 <% end %>
 
                 <% if allowed_to? :delete, :polling_station, voting: current_voting, polling_station: polling_station %>
                   <%= icon_link_to "circle-x", voting_polling_station_path(current_voting, polling_station), t("actions.destroy", scope: "decidim.votings.polling_stations"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.votings.polling_stations") } %>
                 <% else %>
-                  <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img" %>
+                  <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.destroy", scope: "decidim.votings.polling_stations") %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-forms/app/cells/decidim/forms/step_navigation/show.erb
+++ b/decidim-forms/app/cells/decidim/forms/step_navigation/show.erb
@@ -3,7 +3,7 @@
     <a></a>
   <% else %>
     <%= link_to(
-      icon("caret-left", class: "icon--small", role: "img") + " " + t("decidim.forms.step_navigation.show.back"),
+      icon("caret-left", class: "icon--small", role: "presentation", "aria-hidden": true) + " " + t("decidim.forms.step_navigation.show.back"),
       "#",
       class: "hollow secondary",
       data: {

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
@@ -61,7 +61,7 @@
               <% if allowed_to?(:answer, :initiative, initiative: initiative) %>
                 <%= icon_link_to "comment-square", edit_initiative_answer_path(initiative.slug), t("actions.answer", scope: "decidim.initiatives"), class: "action-icon action-icon--answer" %>
               <% else %>
-                <%= icon "comment-square", scope: "decidim.admin", class: "action-icon action-icon--disabled", role: "img", "aria-hidden": true %>
+                <%= icon "comment-square", scope: "decidim.admin", class: "action-icon action-icon--disabled", role: "presentation", "aria-hidden": true %>
               <% end %>
 
               <% if allowed_to? :read, :initiative, initiative: initiative %>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
@@ -1,6 +1,6 @@
 <% content_for :back_link do %>
   <%= link_to :back do %>
-    <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+    <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
     <%= t(".back") %>
   <% end %>
 <% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/finish.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/finish.html.erb
@@ -1,6 +1,6 @@
 <% content_for :back_link do %>
   <%= link_to :back do %>
-    <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+    <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
     <%= t(".back") %>
   <% end %>
 <% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/previous_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/previous_form.html.erb
@@ -1,6 +1,6 @@
 <% content_for :back_link do %>
   <%= link_to :back do %>
-    <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+    <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
     <%= t(".back") %>
   <% end %>
 <% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/promotal_committee.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/promotal_committee.html.erb
@@ -1,6 +1,6 @@
 <% content_for :back_link do %>
   <%= link_to :back do %>
-    <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+    <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
     <%= t(".back") %>
   <% end %>
 <% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/select_initiative_type.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/select_initiative_type.html.erb
@@ -1,7 +1,7 @@
 <% default_type = available_initiative_types.first %>
 <% content_for :back_link do %>
   <%= link_to initiatives_path do %>
-    <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+    <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
     <%= t(".back") %>
   <% end %>
 <% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/show_similar_initiatives.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/show_similar_initiatives.html.erb
@@ -1,6 +1,6 @@
 <% content_for :back_link do %>
   <%= link_to :back do %>
-    <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+    <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
     <%= t(".back") %>
   <% end %>
 <% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_author.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_author.html.erb
@@ -2,7 +2,7 @@
   <div class="author-data__main ">
     <div class="author author--inline">
       <span class="author__avatar author__avatar--small">
-        <%= image_tag initiative.author_avatar_url, t("decidim.author.avatar", name: decidim_sanitize(initiative.author_name)) %>
+        <%= image_tag initiative.author_avatar_url, alt: t("decidim.author.avatar", name: decidim_sanitize(initiative.author_name)) %>
       </span>
       <span class="author__name">
         <% if initiative.author.deleted? %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_author.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_author.html.erb
@@ -2,7 +2,7 @@
   <div class="author-data__main ">
     <div class="author author--inline">
       <span class="author__avatar author__avatar--small">
-        <%= image_tag initiative.author_avatar_url, alt: t("avatar", scope: "activemodel.attributes.group") %>
+        <%= image_tag initiative.author_avatar_url, t("decidim.author.avatar", name: decidim_sanitize(initiative.author_name)) %>
       </span>
       <span class="author__name">
         <% if initiative.author.deleted? %>
@@ -10,7 +10,7 @@
             <%= t(".deleted") %>
           </span>
         <% else %>
-          <%= initiative.author_name %>
+          <%= decidim_sanitize(initiative.author_name) %>
         <% end %>
       </span>
     </div>
@@ -22,7 +22,7 @@
             <%= image_tag m.user.avatar_url %>
           </span>
           <span class="author__name">
-            <%= m.user.name %>
+            <%= decidim_sanitize(m.user.name) %>
           </span>
         </div>
       <% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_index_header.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_index_header.html.erb
@@ -6,18 +6,18 @@
     <% if current_user && allowed_to?(:create, :initiative) %>
       <%= link_to create_initiative_path(:select_initiative_type), class: "title-action__action button small" do %>
         <%= t(".new_initiative") %>
-        <%= icon "plus", role: "img", "aria-hidden": true %>
+        <%= icon "plus", role: "presentation", "aria-hidden": true %>
       <% end %>
     <% elsif current_user %>
       <button type="button" class="title-action__action button small" data-open="not-authorized-modal" aria-controls="not-authorized-modal" aria-haspopup="true" tabindex="0">
         <%= t(".new_initiative") %>
-        <%= icon "plus", role: "img", "aria-hidden": true %>
+        <%= icon "plus", role: "presentation", "aria-hidden": true %>
       </button>
     <% else %>
       <% content_for(:redirect_after_login) { create_initiative_url(:select_initiative_type) } %>
       <button type="button" class="title-action__action button small" data-open="loginModal" aria-controls="loginModal" aria-haspopup="true" tabindex="0">
         <%= t(".new_initiative") %>
-        <%= icon "plus", role: "img", "aria-hidden": true %>
+        <%= icon "plus", role: "presentation", "aria-hidden": true %>
       </button>
     <% end %>
   <% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_interactions.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_interactions.html.erb
@@ -1,7 +1,7 @@
 <div class="row collapse buttons__row">
   <div class="column collapse">
       <%= link_to "#comments", class: "button small compact hollow button--nomargin expanded" do %>
-        <%= icon "comment-square", class: "icon--small", role: "img", "aria-hidden": true %>
+        <%= icon "comment-square", class: "icon--small", role: "presentation", "aria-hidden": true %>
         <%= stats.comments_count %>
         <%= t(".comments_count.count", count: stats.comments_count) %>
       <% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/edit.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/edit.html.erb
@@ -2,7 +2,7 @@
 
 <div class="row columns">
   <%= link_to :back, class: "muted-link" do %>
-    <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+    <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
     <%= t("back", scope: "decidim.initiatives.edit") %>
   <% end %>
   <h2 class="section-heading"><%= t("title", scope: "decidim.initiatives.edit") %></h2>

--- a/decidim-initiatives/app/views/layouts/decidim/_initiative_creation_header.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/_initiative_creation_header.html.erb
@@ -1,7 +1,7 @@
 <div class="columns large-3">
   <div class="m-bottom">
     <%= link_to :back do %>
-      <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %> <%= t(".back") %>
+      <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %> <%= t(".back") %>
     <% end %>
   </div>
   <div class="section">

--- a/decidim-initiatives/app/views/layouts/decidim/_initiative_signature_creation_header.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/_initiative_signature_creation_header.html.erb
@@ -1,7 +1,7 @@
 <div class="columns large-3">
   <div class="m-bottom">
     <%= link_to initiative_path current_initiative do %>
-      <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %> <%= t(".back") %>
+      <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %> <%= t(".back") %>
     <% end %>
   </div>
   <div class="section">

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_highlighted_list_item/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_highlighted_list_item/show.erb
@@ -9,7 +9,7 @@
     </div>
     <div class="row">
       <time datetime="<%= l(model.start_time, format: :long_dashed) %>" class="column medium-4 text-muted">
-        <%= icon "datetime", class: "mr-xs", role: "img", "aria-hidden": true %>
+        <%= icon "datetime", class: "mr-xs", role: "presentation", "aria-hidden": true %>
         <%= l start_date, format: :decidim_with_month_name %>
       </time>
       <div class="column medium-8 text-muted">

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_m/multiple_dates.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_m/multiple_dates.erb
@@ -6,7 +6,7 @@
       </strong>
       <%= formatted_start_time %>
     </div>
-    <%= icon "arrow-thin-right", class: "icon--big muted", role: "img", "aria-hidden": true %>
+    <%= icon "arrow-thin-right", class: "icon--big muted", role: "presentation", "aria-hidden": true %>
     <div>
       <strong>
         <%= l end_date, format: :decidim_with_month_name %>

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_s/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_s/show.erb
@@ -10,7 +10,7 @@
     <div class="card__text">
       <div class="row collapse text-medium">
         <time datetime="<%= l(model.start_time, format: :long_dashed) %>" class="column medium-4 icon--container">
-          <%= icon "datetime", class: "primary", role: "img", "aria-hidden": true %>
+          <%= icon "datetime", class: "primary", role: "presentation", "aria-hidden": true %>
           &nbsp;
           <%= l start_date, format: :decidim_with_month_name %>
           &nbsp;-&nbsp;

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_url_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_url_cell.rb
@@ -10,7 +10,7 @@ module Decidim
       private
 
       def resource_icon
-        icon "video", class: "icon--big", role: "img", "aria-hidden": true
+        icon "video", class: "icon--big", role: "presentation", "aria-hidden": true
       end
     end
   end

--- a/decidim-meetings/app/views/decidim/meetings/_calendar_modal.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/_calendar_modal.html.erb
@@ -1,6 +1,6 @@
 <button class="button button--title share-link text-center calendar" data-open="calendarShare">
   <%= t(".export_calendar") %>
-  <%= icon "share", class: "icon--after", role: "img", "aria-hidden": true %>
+  <%= icon "share", class: "icon--after", role: "presentation", "aria-hidden": true %>
 </button>
 <div class="reveal" id="calendarShare" data-reveal>
   <div class="reveal__header">

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
@@ -61,7 +61,7 @@
 
                 <% if allowed_to? :update, :meeting, meeting: meeting %>
                   <% if meeting.registration_disabled? %>
-                    <%= icon "people", class: "action-icon action-icon--disabled", role: "img" %>
+                    <%= icon "people", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.registrations", scope: "decidim.meetings") %>
                   <% else %>
                     <%= icon_link_to "people", meeting.on_this_platform? ? edit_meeting_registrations_path(meeting) : meeting.registration_url, t("actions.registrations", scope: "decidim.meetings"), class: "action-icon--registrations" %>
                   <% end %>

--- a/decidim-meetings/app/views/decidim/meetings/meeting_closes/edit.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meeting_closes/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="columns large-3">
     <%= link_to :back do %>
-      <%= icon "chevron-left", class: "icon--small", role: "img" %>
+      <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
       <%= t(".back") %>
     <% end %>
   </div>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_minutes.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_minutes.html.erb
@@ -23,7 +23,7 @@
             </div>
             <div class="card--list__data" aria-hidden="true">
               <%= link_to decidim_url_escape(meeting.minutes.video_url), target: "_blank", class: "card--list__data__icon", rel: "noopener" do %>
-                <%= icon "external-link", role: "img", "aria-hidden": true %>
+                <%= icon "external-link", role: "presentation", "aria-hidden": true %>
               <% end %>
             </div>
           </div>
@@ -37,7 +37,7 @@
             </div>
             <div class="card--list__data" aria-hidden="true">
               <%= link_to decidim_url_escape(meeting.minutes.audio_url), target: "_blank", class: "card--list__data__icon", rel: "noopener" do %>
-                <%= icon "external-link", role: "img", "aria-hidden": true %>
+                <%= icon "external-link", role: "presentation", "aria-hidden": true %>
               <% end %>
             </div>
           </div>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_online_meeting_link.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_online_meeting_link.html.erb
@@ -1,7 +1,7 @@
 <div class="card card--secondary">
   <div class="card__content address">
     <div class="address__info">
-      <%= icon "video", role: "img", "aria-hidden": true, remove_icon_class: true, width: 40, height: 70 %>
+      <%= icon "video", role: "presentation", "aria-hidden": true, remove_icon_class: true, width: 40, height: 70 %>
       <div class="address__details">
         <span><%= link_to(meeting.online_meeting_url, meeting.online_meeting_url, target: "_blank") %></span><br>
         <span><%= translated_attribute meeting.location_hints %></span>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/edit.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="columns large-3">
     <%= link_to :back do %>
-      <%= icon "chevron-left", class: "icon--small", role: "img" %>
+      <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria--hidden": true %>
       <%= t(".back") %>
     <% end %>
   </div>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/index.html.erb
@@ -11,7 +11,7 @@
     <% if allowed_to?(:create, :meeting) %>
       <%= action_authorized_link_to :create, new_meeting_path, class: "title-action__action button small", data: { "redirect_url" => new_meeting_path } do %>
         <%= t("new_meeting", scope: "decidim.meetings.meetings.index") %>
-        <%= icon "plus", role: "img" %>
+        <%= icon "plus", role: "presentation", "aria-hidden": true %>
       <% end %>
     <% end %>
   </div>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/new.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/new.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="columns large-3">
     <%= link_to :back do %>
-      <%= icon "chevron-left", class: "icon--small", role: "img" %>
+      <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
       <%= t(".back") %>
     <% end %>
   </div>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -18,7 +18,7 @@ edit_link(
 <div class="row column view-header">
   <div class="m-bottom">
     <%= link_to meetings_path(filter_link_params), class: "small hollow" do %>
-      <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+      <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
       <%= t(".back") %>
     <% end %>
   </div>
@@ -96,7 +96,7 @@ edit_link(
         <% meeting.services.each do |service| %>
           <div class="card--list__item">
             <div class="card--list__text card--list__text--top">
-              <%= icon "actions", class: "card--list__icon alert", role: "img", "aria-hidden": true %>
+              <%= icon "actions", class: "card--list__icon alert", role: "presentation", "aria-hidden": true %>
               <div>
                 <h3 class="card--list__heading heading-small"><%= translated_attribute(service["title"]) %></h3>
                 <span class="text-medium"><%= translated_attribute(service["description"]) %></span>

--- a/decidim-participatory_processes/app/cells/decidim/participatory_process_groups/content_blocks/title/show.erb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_process_groups/content_blocks/title/show.erb
@@ -5,7 +5,7 @@
       <%= decidim_sanitize translated_attribute(participatory_process_group.description) %>
       <div class="row">
         <div class="column medium-2 text-muted">
-          <%= icon "grid-three-up", role: "img", class: "mr-xs" %>
+          <%= icon "grid-three-up", role: "presentation", "aria-hidden": true, class: "mr-xs" %>
           <%= t("decidim.participatory_process_groups.content_blocks.title.participatory_processes", count: participatory_processes_count) %>
         </div>
         <% if has_meta_scope? %>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_process_steps/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_process_steps/index.html.erb
@@ -6,7 +6,7 @@
       <div class="columns mediumlarge-9 large-7">
         <div class="section">
           <%= link_to participatory_process_path(current_participatory_space), class: "small hollow" do %>
-            <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+            <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
             <%= t(".back_to_process") %>
           <% end %>
 

--- a/decidim-proposals/app/views/decidim/proposals/admin/participatory_texts/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/participatory_texts/index.html.erb
@@ -16,7 +16,7 @@
         <%= form.fields_for(:proposals) do |prop_form| %>
         <% proposal= @drafts[prop_form.index] %>
           <li class="accordion-item <%= proposal.article? ? "is-active" : nil %>" data-accordion-item>
-            <a href="#" class="accordion-title flex--sbc"><%= preview_participatory_text_section_title(proposal) %><span class="mr-m"><%= icon "menu", class: "icon--small", role: "img", "aria-hidden": true %></span></a>
+            <a href="#" class="accordion-title flex--sbc"><%= preview_participatory_text_section_title(proposal) %><span class="mr-m"><%= icon "menu", class: "icon--small", role: "presentation", "aria-hidden": true %></span></a>
             <div class="accordion-content" data-tab-content>
               <%= render "article-preview", { form: prop_form, proposal: proposal } %>
             </div>

--- a/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/_new_collaborative_draft_button.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/_new_collaborative_draft_button.html.erb
@@ -1,11 +1,11 @@
 <% if current_settings.creation_enabled %>
   <%= action_authorized_link_to :create, new_collaborative_draft_path, class: "title-action__action button small", data: { "redirect_url" => new_collaborative_draft_path } do %>
     <%= t(".new_collaborative_draft") %>
-    <%= icon "plus", role: "img", "aria-hidden": true %>
+    <%= icon "plus", role: "presentation", "aria-hidden": true %>
   <% end %>
 <% else %>
   <span class="title-action__action button small disabled">
     <%= t(".new_collaborative_draft") %>
-    <%= icon "plus", role: "img", "aria-hidden": true %>
+    <%= icon "plus", role: "presentation", "aria-hidden": true %>
   </span>
 <% end %>

--- a/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/_wizard_aside.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/_wizard_aside.html.erb
@@ -1,7 +1,7 @@
 <div class="columns large-3">
   <div class="m-bottom">
     <%= link_to :back do %>
-      <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+      <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
       <%= t("back_from_collaborative_draft", scope: "decidim.proposals.collaborative_drafts.wizard_aside").html_safe %>
     <% end %>
   </div>

--- a/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/edit.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/edit.html.erb
@@ -3,7 +3,7 @@
 <div class="row columns">
   <div class="m-bottom">
     <%= link_to :back, class: "muted-link" do %>
-      <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+      <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
       <%= t(".back") %>
     <% end %>
   </div>

--- a/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/show.html.erb
@@ -16,7 +16,7 @@
 <div class="row column view-header">
   <div class="m-bottom">
     <%= link_to collaborative_drafts_path do %>
-      <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+      <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
       <%= t(".back") %>
     <% end %>
   </div>
@@ -92,21 +92,21 @@
         <ul class="card-data">
           <li class="card-data__item authors_status">
             <%= with_tooltip t("decidim.proposals.models.collaborative_draft.fields.authors") do %>
-              <%= icon("people", class: "icon--small", role: "img", "aria-hidden": true) + " " + "#{@collaborative_draft.versions.group_by(&:whodunnit).size}" %>
+              <%= icon("people", class: "icon--small", role: "presentation", "aria-hidden": true) + " " + "#{@collaborative_draft.versions.group_by(&:whodunnit).size}" %>
             <% end %>
           </li>
 
           <li class="card-data__item versions_status">
             <%= link_to collaborative_draft_versions_path(@collaborative_draft) do %>
               <%= with_tooltip t("decidim.proposals.models.collaborative_draft.fields.contributions") do %>
-                <%= icon("pencil", class: "icon--small", role: "img", "aria-hidden": true) + " " + "#{@collaborative_draft.versions.count}" %>
+                <%= icon("pencil", class: "icon--small", role: "presentation", "aria-hidden": true) + " " + "#{@collaborative_draft.versions.count}" %>
               <% end %>
             <% end %>
           </li>
           <li class="card-data__item">
             <%= link_to "#comments" do %>
               <%= with_tooltip t("decidim.proposals.models.collaborative_draft.fields.comments") do %>
-                <%= icon("comment-square", class: "icon--small", role: "img", "aria-hidden": true) + " " + "#{@collaborative_draft.comments_count}" %>
+                <%= icon("comment-square", class: "icon--small", role: "presentation", "aria-hidden": true) + " " + "#{@collaborative_draft.comments_count}" %>
               <% end %>
             <% end %>
           </li>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_wizard_aside.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_wizard_aside.html.erb
@@ -2,7 +2,7 @@
   <div class="m-bottom">
     <% unless @step == :step_2 %>
       <%= link_to proposal_wizard_aside_link_to_back(@step) do %>
-        <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+        <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
         <%= wizard_aside_back_text(@step) %>
       <% end %>
     <% end %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/edit.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/edit.html.erb
@@ -3,7 +3,7 @@
 <div class="row columns">
   <div class="m-bottom">
     <%= link_to :back, class: "muted-link" do %>
-      <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+      <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
       <%= t(".back") %>
     <% end %>
   </div>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
@@ -34,7 +34,7 @@
     <% if current_settings.creation_enabled && current_component.participatory_space.can_participate?(current_user) %>
       <%= action_authorized_link_to :create, new_proposal_path, class: "title-action__action button small", data: { "redirect_url" => new_proposal_path } do %>
         <%= t(".new_proposal") %>
-        <%= icon "plus", role: "img", "aria-hidden": true %>
+        <%= icon "plus", role: "presentation", "aria-hidden": true %>
       <% end %>
     <% end %>
 

--- a/decidim-proposals/app/views/decidim/proposals/proposals/participatory_texts/_proposal_vote_button.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/participatory_texts/_proposal_vote_button.html.erb
@@ -28,7 +28,7 @@
           class: "column button light button--sc success",
           id: "vote_button-#{proposal.id}"
         ) do %>
-          <%= icon("check", class: "icon--small", role: "img", "aria-hidden": true) %>
+          <%= icon("check", class: "icon--small", role: "presentation", "aria-hidden": true) %>
           <%= t("decidim.proposals.proposals.vote_button.already_voted") %>
           <span class="show-for-sr"><%= decidim_html_escape(present(proposal).title) %></span>
         <% end %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/participatory_texts/_view_index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/participatory_texts/_view_index.html.erb
@@ -1,5 +1,5 @@
 <div class="card card__link p-xs flex--fsc reveal__trigger" data-open="participatory-text-index">
-  <%= icon "list", class: "mr-s", role: "img", "aria-hidden": true %>
+  <%= icon "list", class: "mr-s", role: "presentation", "aria-hidden": true %>
   <strong><%= t(".see_index") %></strong>
 </div>
 <div id="participatory-text-index" class="reveal large" data-reveal>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -36,7 +36,7 @@ extra_admin_link(
 
   <div class="m-bottom">
     <%= link_to proposals_path(filter_link_params), class: "small hollow" do %>
-      <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+      <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
       <%= t(".back_to_list") %>
     <% end %>
   </div>

--- a/decidim-sortitions/app/views/decidim/sortitions/sortitions/show.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/sortitions/show.html.erb
@@ -14,7 +14,7 @@
 
   <div class="m-bottom">
     <%= link_to :sortitions, class: "small hollow" do %>
-      <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+      <%= icon "chevron-left", class: "icon--small", role: "presentation", "aria-hidden": true %>
       <%= t(".back") %>
     <% end %>
   </div>

--- a/decidim-verifications/app/views/decidim/verifications/authorizations/_granted_authorization.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/authorizations/_granted_authorization.html.erb
@@ -1,5 +1,5 @@
 <div class="card--list__text">
-  <%= icon "lock-locked", class: "card--list__icon", role: "img", "aria-hidden": true %>
+  <%= icon "lock-locked", class: "card--list__icon", role: "presentation", "aria-hidden": true %>
   <div>
     <h5 class="card--list__heading">
       <%= t("#{authorization.name}.name", scope: "decidim.authorization_handlers") %>

--- a/decidim-verifications/app/views/decidim/verifications/authorizations/index.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/authorizations/index.html.erb
@@ -44,7 +44,7 @@
               </div>
               <div class="card--list__data" aria-hidden="true">
                 <span class="card--list__data__icon">
-                  <%= icon "chevron-right", role: "img", "aria-hidden": true %>
+                  <%= icon "chevron-right", role: "presentation", "aria-hidden": true %>
                 </span>
               </div>
             </div>
@@ -71,7 +71,7 @@
               </div>
               <div class="card--list__data" aria-hidden="true">
                 <span class="card--list__data__icon">
-                  <%= icon "chevron-right", role: "img", "aria-hidden": true %>
+                  <%= icon "chevron-right", role: "presentation", "aria-hidden": true %>
                 </span>
               </div>
             </div>

--- a/decidim_app-design/app/views/public/home-single-process.html.erb
+++ b/decidim_app-design/app/views/public/home-single-process.html.erb
@@ -44,7 +44,7 @@
         ciudad. Ya somos 156000.</h2>
         <%= link_to page_path("user/user-register"), class: "button--sc link subhero-cta" do %>
           Regístrate
-          <%= icon "chevron-right", aria_hidden: true %>
+          <%= icon "chevron-right", role: "presentation", aria_hidden: true %>
         <% end %>
       </div>
     </div>
@@ -232,7 +232,7 @@
         ciudad. Ya somos 156000.</h5>
         <%= link_to page_path("user/user-register"), class: "button--sc link subhero-cta" do %>
           Regístrate
-          <%= icon "chevron-right", aria_hidden: true %>
+          <%= icon "chevron-right", role: "presentation", aria_hidden: true %>
         <% end %>
       </div>
     </div>

--- a/decidim_app-design/app/views/public/home-with-consultation-banners.html.erb
+++ b/decidim_app-design/app/views/public/home-with-consultation-banners.html.erb
@@ -32,7 +32,7 @@
         ciudad. Ya somos 156000.</h2>
         <%= link_to page_path("user/user-register"), class: "button--sc link subhero-cta" do %>
           Regístrate
-          <%= icon "chevron-right", aria_hidden: true %>
+          <%= icon "chevron-right", role: "presentation", aria_hidden: true %>
         <% end %>
       </div>
     </div>
@@ -307,7 +307,7 @@
         ciudad. Ya somos 156000.</h5>
         <%= link_to page_path("user/user-register"), class: "button--sc link subhero-cta" do %>
           Regístrate
-          <%= icon "chevron-right", aria_hidden: true %>
+          <%= icon "chevron-right", role: "presentation", aria_hidden: true %>
         <% end %>
       </div>
     </div>

--- a/decidim_app-design/app/views/public/home-with-helpers.html.erb
+++ b/decidim_app-design/app/views/public/home-with-helpers.html.erb
@@ -48,7 +48,7 @@
           </div>
           <%= link_to page_path("user/user-register"), class: "button--sc link subhero-cta" do %>
           Regístrate
-          <%= icon "chevron-right", aria_hidden: true %>
+          <%= icon "chevron-right", role: "presentation", aria_hidden: true %>
           <% end %>
         </div>
       </div>
@@ -487,7 +487,7 @@
         ciudad. Ya somos 156000.</h5>
         <%= link_to page_path("user/user-register"), class: "button--sc link subhero-cta" do %>
           Regístrate
-          <%= icon "chevron-right", aria_hidden: true %>
+          <%= icon "chevron-right", role: "presentation", aria_hidden: true %>
         <% end %>
       </div>
     </div>

--- a/decidim_app-design/app/views/public/home.html.erb
+++ b/decidim_app-design/app/views/public/home.html.erb
@@ -44,7 +44,7 @@
         ciudad. Ya somos 156000.</h2>
         <%= link_to page_path("user/user-register"), class: "button--sc link subhero-cta" do %>
           Regístrate
-          <%= icon "chevron-right", aria_hidden: true %>
+          <%= icon "chevron-right", role: "presentation", aria_hidden: true %>
         <% end %>
       </div>
     </div>
@@ -345,7 +345,7 @@
         ciudad. Ya somos 156000.</h5>
         <%= link_to page_path("user/user-register"), class: "button--sc link subhero-cta" do %>
           Regístrate
-          <%= icon "chevron-right", aria_hidden: true %>
+          <%= icon "chevron-right", role: "presentation", aria_hidden: true %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
#### :tophat: What? Why?
There are several issues with the WAI-ARIA roles for the SVG icon images in Decidim:

- Apparently the double role `none presentation` is not allowed in all accessibility audit tools although it is a suggested implementation in some resources. The reason being that not all browsers understand the double role. According to https://github.com/dequelabs/axe-core/issues/1462 we should use `role="presentation" aria-hidden="true"` for these cases.
- When using `<svg role="img">`, the images always need an `aria-label` as an alternative text (WCAG 2.1 A / SC 4.1.2)
- When we have multiple "avatar" images on the page, the ARIA labels should be unique, so add the user names to these labels.
- We cannot have links with only content being an `aria-hidden` SVG image. Add proper labels for these.

#### :pushpin: Related Issues
- Related to #5942, #6246, #6124, #5684

#### Testing
Audit the whole service using several automated accessibility audit tools.

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.