### PR TITLE
Fix the missing aria-controls element on pages with comments

### DIFF
--- a/decidim-comments/app/assets/javascripts/decidim/comments/comments.component.test.js
+++ b/decidim-comments/app/assets/javascripts/decidim/comments/comments.component.test.js
@@ -251,7 +251,7 @@ describe("CommentsComponent", () => {
 
   beforeEach(() => {
     let orderSelector = `
-      <ul class="dropdown menu" data-dropdown-menu="data-dropdown-menu" data-autoclose="false" data-disable-hover="true" data-click-open="true" data-close-on-click="true" tabindex="-1" role="menubar">
+      <ul id="comments-order-menu" class="dropdown menu" data-dropdown-menu="data-dropdown-menu" data-autoclose="false" data-disable-hover="true" data-click-open="true" data-close-on-click="true" tabindex="-1" role="menubar">
         <li class="is-dropdown-submenu-parent opens-right" tabindex="-1" role="none">
           <a href="#" id="comments-order-menu-control" aria-label="Order by:" aria-controls="comments-order-menu" aria-haspopup="true" role="menuitem">Older</a>
           <ul class="menu is-dropdown-submenu submenu first-sub vertical" id="comments-order-chooser-menu" role="menu" aria-labelledby="comments-order-menu-control" tabindex="-1" data-submenu="">

--- a/decidim-comments/app/cells/decidim/comments/comments/order_control.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/order_control.erb
@@ -1,6 +1,7 @@
 <div class="order-by__dropdown order-by__dropdown--right">
   <span class="order-by__text"><%= t("decidim.components.comment_order_selector.title") %></span>
-  <ul class="dropdown menu"
+  <ul id="comments-order-menu"
+    class="dropdown menu"
     data-dropdown-menu="data-dropdown-menu"
     data-autoclose="false"
     data-disable-hover="true"


### PR DESCRIPTION
#### :tophat: What? Why?
We have an element on the page with `aria-controls` pointer attribute here:
https://github.com/decidim/decidim/blob/a7a3803479be8d55e2041f19fca14ce64ed57630/decidim-comments/app/cells/decidim/comments/comments/order_control.erb#L14

There is no element on the page with such ID.

This adds the ID.

#### :pushpin: Related Issues
- Related to #5942, #6246, #6124, #5684

#### Testing
Test one of the pages with comments using an automated accessibility audit tool.

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.