### PR TITLE
Add reason fieldset to the report modal for accessibility

### DIFF
--- a/decidim-core/app/cells/decidim/flag_modal/show.erb
+++ b/decidim-core/app/cells/decidim/flag_modal/show.erb
@@ -10,13 +10,16 @@
   <% else %>
     <p><%= t("decidim.shared.flag_modal.description") %></p>
     <%= decidim_form_for report_form, url: decidim.report_path(sgid: model.to_sgid.to_s), method: :post, html: { id: nil } do |f| %>
-      <%= f.collection_radio_buttons :reason, [
-        [:spam, t("decidim.shared.flag_modal.spam")],
-        [:offensive, t("decidim.shared.flag_modal.offensive")],
-        [:does_not_belong, t("decidim.shared.flag_modal.does_not_belong", organization_name: current_organization.name)]
-      ], :first, :last do |builder| %>
-        <%= builder.label { builder.radio_button(id: nil) + builder.text } %>
-      <% end %>
+      <fieldset>
+        <legend><%= t("decidim.shared.flag_modal.reason") %></legend>
+        <%= f.collection_radio_buttons :reason, [
+          [:spam, t("decidim.shared.flag_modal.spam")],
+          [:offensive, t("decidim.shared.flag_modal.offensive")],
+          [:does_not_belong, t("decidim.shared.flag_modal.does_not_belong", organization_name: current_organization.name)]
+        ], :first, :last do |builder| %>
+          <%= builder.label { builder.radio_button(id: nil) + builder.text } %>
+        <% end %>
+      </fieldset>
       <%= f.text_area :details, rows: 4, id: nil %>
       <%= f.submit t("decidim.shared.flag_modal.report") %>
     <% end %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1229,6 +1229,7 @@ en:
         description: Is this content inappropriate?
         does_not_belong: Contains illegal activity, suicide threats, personal information, or something else you think doesn't belong on %{organization_name}.
         offensive: Contains racism, sexism, slurs, personal attacks, death threats, suicide requests or any form of hate speech.
+        reason: Reason
         report: Report
         spam: Contains clickbait, advertising, scams or script bots.
         title: Report inappropriate content


### PR DESCRIPTION
#### :tophat: What? Why?
Add a fieldset for the report modal's reason radios (issue reported by automated accessibility audit).

WCAG 2.1 A / SC 1.3.1, 3.3.2

#### :pushpin: Related Issues
- Related to #5942, #6246, #6124, #5684

#### Testing
Audit pages with comments with multiple accessibility audit tools.

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.