### PR TITLE
Add aria-atomic="true" to the alert role elements

### DIFF
--- a/decidim-comments/app/assets/javascripts/decidim/comments/comments.component.test.js
+++ b/decidim-comments/app/assets/javascripts/decidim/comments/comments.component.test.js
@@ -321,7 +321,7 @@ describe("CommentsComponent", () => {
                   </svg>
                   <span class="show-for-sr">Negative</span>
                 </button>
-                <div aria-role="alert" aria-live="assertive" class="selected-state shot-for-sr"></div>
+                <div aria-role="alert" aria-live="assertive" aria-atomic="true" class="selected-state shot-for-sr"></div>
               </div>
 
               ${generateCommentForm("Dummy", 123)}

--- a/decidim-comments/app/cells/decidim/comments/comments/add_comment.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/add_comment.erb
@@ -16,7 +16,7 @@
           <%= icon "thumb-down", role: "none presentation" %>
           <span class="show-for-sr"><%= t("decidim.components.add_comment_form.opinion.negative") %></span>
         </button>
-        <div aria-role="alert" aria-live="assertive" class="selected-state shot-for-sr"></div>
+        <div aria-role="alert" aria-live="assertive" aria-atomic="true" class="selected-state shot-for-sr"></div>
       </div>
     <% end %>
     <%== cell("decidim/comments/comment_form", model, root_depth: root_depth) %>

--- a/decidim-core/app/helpers/concerns/decidim/flash_helper_extensions.rb
+++ b/decidim-core/app/helpers/concerns/decidim/flash_helper_extensions.rb
@@ -19,9 +19,12 @@ module Decidim
       #
       # Returns a HTML string.
       def alert_box(value, alert_class, closable)
-        options = { class: "flash callout #{alert_class}" }
+        options = {
+          class: "flash callout #{alert_class}",
+          role: "alert",
+          aria: { atomic: "true" }
+        }
         options[:data] = { closable: "" } if closable
-        options[:role] = "alert"
         content_tag(:div, options) do
           concat value
           concat close_link if closable


### PR DESCRIPTION
#### :tophat: What? Why?
In order to make all assistive technologies read the assertive alerts on the page, we need to apply the `aria-atomic=true` attributes on the alert elements.

#### :pushpin: Related Issues
- Related to #5942, #6246, #6124, #5684

#### Testing
Test the alerts with all assistive technologies.

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.