### PR TITLE
Improve proposals import options

### DIFF
--- a/decidim-proposals/app/commands/decidim/proposals/admin/import_proposals.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/import_proposals.rb
@@ -86,7 +86,7 @@ module Decidim
         end
 
         def proposal_answer_attributes(original_proposal)
-          return {} unless form.keep_answers?
+          return {} unless form.keep_answers
 
           {
             answer: original_proposal.answer,

--- a/decidim-proposals/app/commands/decidim/proposals/admin/import_proposals.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/import_proposals.rb
@@ -48,7 +48,7 @@ module Decidim
           @proposals = Decidim::Proposals::Proposal
                        .where(component: origin_component)
                        .where(state: proposal_states)
-          @proposals = @proposals.where(scope: proposal_scopes) if proposal_scopes.any?
+          @proposals = @proposals.where(scope: proposal_scopes) unless proposal_scopes.empty?
           @proposals
         end
 

--- a/decidim-proposals/app/commands/decidim/proposals/admin/import_proposals.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/import_proposals.rb
@@ -39,15 +39,17 @@ module Decidim
               action_user: form.current_user,
               extra_attributes: {
                 "component" => target_component
-              }
+              }.merge(proposal_answer_attributes(original_proposal))
             )
           end.compact
         end
 
         def proposals
-          Decidim::Proposals::Proposal
-            .where(component: origin_component)
-            .where(state: proposal_states)
+          @proposals = Decidim::Proposals::Proposal
+                       .where(component: origin_component)
+                       .where(state: proposal_states)
+          @proposals = @proposals.where(scope: proposal_scopes) if proposal_scopes.any?
+          @proposals
         end
 
         def proposal_states
@@ -59,6 +61,10 @@ module Decidim
           end
 
           @proposal_states
+        end
+
+        def proposal_scopes
+          @form.scopes
         end
 
         def origin_component
@@ -77,6 +83,17 @@ module Decidim
 
         def proposal_author
           form.keep_authors ? nil : @form.current_organization
+        end
+
+        def proposal_answer_attributes(original_proposal)
+          return {} unless form.keep_answers?
+
+          {
+            answer: original_proposal.answer,
+            answered_at: original_proposal.answered_at,
+            state: original_proposal.state,
+            state_published_at: original_proposal.state_published_at
+          }
         end
       end
     end

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposals_import_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposals_import_form.rb
@@ -10,8 +10,10 @@ module Decidim
 
         attribute :origin_component_id, Integer
         attribute :import_proposals, Boolean
+        attribute :keep_answers, Boolean
         attribute :keep_authors, Boolean
         attribute :states, Array
+        attribute :scope_ids, Array
 
         validates :origin_component_id, :origin_component, :states, :current_component, presence: true
         validates :import_proposals, allow_nil: false, acceptance: true
@@ -30,6 +32,10 @@ module Decidim
 
         def states
           super.reject(&:blank?)
+        end
+
+        def scopes
+          Decidim::Scope.where(organization: current_organization, id: scope_ids)
         end
 
         def origin_component

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals_imports/new.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals_imports/new.html.erb
@@ -17,6 +17,12 @@
           <%= f.check_box :keep_authors %>
         </div>
         <div class="row column">
+          <%= f.check_box :keep_answers %>
+        </div>
+        <div class="row column">
+          <%= scopes_picker_filter f, :scope_ids %>
+        </div>
+        <div class="row column">
           <%= f.check_box :import_proposals %>
         </div>
       </div>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -36,6 +36,7 @@ en:
         origin_component_id: Component to copy the proposals from
       proposals_import:
         import_proposals: Import proposals
+        keep_answers: Keep state and answers
         keep_authors: Keep original authors
       valuation_assignment:
         admin_log:

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/import_proposals_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/import_proposals_spec.rb
@@ -154,6 +154,30 @@ module Decidim
               end
             end
 
+            describe "proposal scopes" do
+              let(:states) { ProposalsImportForm::VALID_STATES.dup }
+              let(:scope) { create(:scope, organization: current_component.organization) }
+              let(:other_scope) { create(:scope, organization: current_component.organization) }
+
+              let(:scopes) { [scope] }
+              let(:scope_ids) { [scope.id] }
+
+              let!(:proposals) do
+                [
+                  create(:proposal, component: proposal.component, scope: scope),
+                  create(:proposal, component: proposal.component, scope: other_scope)
+                ]
+              end
+
+              it "only imports proposals from the selected scope" do
+                expect do
+                  command.call
+                end.to change { Proposal.where(component: current_component).count }.by(1)
+
+                expect(Proposal.where(component: current_component).scope.id).to eq(scope.id)
+              end
+            end
+
             describe "when the proposal has attachments" do
               let!(:attachment) do
                 create(:attachment, attached_to: proposal)


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds these two options when importing proposals from one component to another:
- Import the status of the proposal and the answer
- Import the proposals of a certain scope

#### :pushpin: Related Issues
- Related to [MetaDecidim proposal \#16307](https://meta.decidim.org/processes/roadmap/f/122/proposals/16307)

#### Testing
`decidim-proposals/spec/commands/decidim/proposals/admin/import_proposals_spec.rb`

#### :clipboard: Checklist
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![Proposals import options](https://user-images.githubusercontent.com/8806781/112000875-a9dc5100-8b1e-11eb-952d-1f6fea6118d5.png)

![Proposals import scope picker](https://user-images.githubusercontent.com/8806781/112000894-b19bf580-8b1e-11eb-9584-42eb8133ddcb.png)

:hearts: Thank you!
