### PR TITLE
Fix puffing-billy timeout error when stopping the event machine

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/puffing_billy.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/puffing_billy.rb
@@ -55,5 +55,3 @@ Billy.module_eval do
     end
   end
 end
-
-raise Object.const_source_location(:EM).inspect

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/puffing_billy.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/puffing_billy.rb
@@ -37,6 +37,8 @@ module BillyProxyPatch
     return unless EM.reactor_running?
 
     super
+  rescue Timeout::Error
+    nil
   end
 end
 Billy::Proxy.prepend(BillyProxyPatch)
@@ -53,3 +55,5 @@ Billy.module_eval do
     end
   end
 end
+
+raise Object.const_source_location(:EM).inspect


### PR DESCRIPTION
#### :tophat: What? Why?
Puffing billy is occasionally failing tests because it fails to stop the event machine server due to a timeout error.

Example run that failed because of this:
https://github.com/decidim/decidim/pull/7664/checks?check_run_id=2165261947

This is apparently happening on this line:
https://github.com/oesmith/puffing-billy/blob/fc12d19cfa27182463c5c300acacd517a557d339/lib/billy/proxy.rb#L29
(which is calling `#port` which is trying to fetch the socket which apparently times out)

Another possibility is the following line that tries stops the event machine:
https://github.com/oesmith/puffing-billy/blob/fc12d19cfa27182463c5c300acacd517a557d339/lib/billy/proxy.rb#L30

The line after that would already catch this error, so it's not the cause.

The exception that you would see when this happens in the test output looks similar to this:

```
RuntimeError:
  eventmachine not initialized: evma_get_sockname
# /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/puffing_billy.rb:39:in `stop'
# ------------------
# --- Caused by: ---
# Timeout::Error:
#   execution expired
#   /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/puffing_billy.rb:39:in `stop'
```

#### :pushpin: Related Issues
- Related to #7364

#### Testing
Run some test set for an arbitrary amount of times to see the failure occasionally.

Or take a look at one of the failing runs at CI.

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.