### PR TITLE
Fix map preview when there is no address

### DIFF
--- a/decidim-proposals/app/helpers/decidim/proposals/map_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/map_helper.rb
@@ -16,29 +16,31 @@ module Decidim
 
       def proposal_data_for_map(proposal)
         proposal
-          .slice(:latitude, :longitude, :address)
-          .merge(
-            title: decidim_html_escape(present(proposal).title),
-            body: html_truncate(decidim_sanitize(present(proposal).body), length: 100),
-            icon: icon("proposals", width: 40, height: 70, remove_icon_class: true),
-            link: proposal_path(proposal)
-          )
+            .slice(:latitude, :longitude, :address)
+            .merge(
+                title: decidim_html_escape(present(proposal).title),
+                body: html_truncate(decidim_sanitize(present(proposal).body), length: 100),
+                icon: icon("proposals", width: 40, height: 70, remove_icon_class: true),
+                link: proposal_path(proposal)
+            )
       end
 
       def proposal_preview_data_for_map(proposal)
         {
-          type: "drag-marker",
-          marker: proposal.slice(
-            :latitude,
-            :longitude,
-            :address
-          ).merge(
-            icon: icon("proposals", width: 40, height: 70, remove_icon_class: true)
-          )
+            type: "drag-marker",
+            marker: proposal.slice(
+                :latitude,
+                :longitude,
+                :address
+            ).merge(
+                icon: icon("proposals", width: 40, height: 70, remove_icon_class: true)
+            )
         }
       end
 
       def has_position?(proposal)
+        return unless proposal.address.present?
+
         proposal.latitude.present? && proposal.longitude.present?
       end
     end

--- a/decidim-proposals/app/helpers/decidim/proposals/map_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/map_helper.rb
@@ -16,30 +16,30 @@ module Decidim
 
       def proposal_data_for_map(proposal)
         proposal
-            .slice(:latitude, :longitude, :address)
-            .merge(
-                title: decidim_html_escape(present(proposal).title),
-                body: html_truncate(decidim_sanitize(present(proposal).body), length: 100),
-                icon: icon("proposals", width: 40, height: 70, remove_icon_class: true),
-                link: proposal_path(proposal)
-            )
+          .slice(:latitude, :longitude, :address)
+          .merge(
+            title: decidim_html_escape(present(proposal).title),
+            body: html_truncate(decidim_sanitize(present(proposal).body), length: 100),
+            icon: icon("proposals", width: 40, height: 70, remove_icon_class: true),
+            link: proposal_path(proposal)
+          )
       end
 
       def proposal_preview_data_for_map(proposal)
         {
-            type: "drag-marker",
-            marker: proposal.slice(
-                :latitude,
-                :longitude,
-                :address
-            ).merge(
-                icon: icon("proposals", width: 40, height: 70, remove_icon_class: true)
-            )
+          type: "drag-marker",
+          marker: proposal.slice(
+            :latitude,
+            :longitude,
+            :address
+          ).merge(
+            icon: icon("proposals", width: 40, height: 70, remove_icon_class: true)
+          )
         }
       end
 
       def has_position?(proposal)
-        return unless proposal.address.present?
+        return if proposal.address.blank?
 
         proposal.latitude.present? && proposal.longitude.present?
       end

--- a/decidim-proposals/spec/shared/proposals_wizards_examples.rb
+++ b/decidim-proposals/spec/shared/proposals_wizards_examples.rb
@@ -323,6 +323,19 @@ shared_examples "proposals wizards" do |options|
           expect(page).to have_content("EDIT PROPOSAL DRAFT")
         end
       end
+
+      context "when there is no address" do
+        let!(:proposal_draft) { create(:proposal, :draft, users: [user], address: nil, component: component, title: proposal_title, body: proposal_body) }
+
+        it "doesn't shows a preview" do
+          expect(page).to have_content(proposal_title)
+          expect(page).to have_content(user.name)
+          expect(page).to have_content(proposal_body)
+
+          expect(page).not_to have_css(".dynamic-map-instructions")
+          expect(page).not_to have_css(".google-map")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Fix map preview when there is no address

#### :pushpin: Related Issues
- Fixes #7606

#### Testing

- Go to the proposal component settings in the admin panel.
- Click on 'Geocoding enabled'.
- Create a proposal without address from the frontend.
- Go to the final step of the wizard.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
