### PR TITLE
Fix validations for registration related fields in Conference form

### DIFF
--- a/decidim-conferences/app/forms/decidim/conferences/admin/conference_form.rb
+++ b/decidim-conferences/app/forms/decidim/conferences/admin/conference_form.rb
@@ -43,12 +43,13 @@ module Decidim
 
         validate :slug_uniqueness
 
+        validates :available_slots, presence: true, if: ->(form) { form.registrations_enabled? }
+        validates :available_slots, numericality: { greater_than_or_equal_to: 0 }, if: ->(form) { form.registrations_enabled? && form.available_slots.present? }
         validates :registration_terms, translatable_presence: true, if: ->(form) { form.registrations_enabled? }
-        validates :available_slots, numericality: { greater_than_or_equal_to: 0 }, if: ->(form) { form.registrations_enabled? }
 
         validates :hero_image, passthru: { to: Decidim::Conference }
         validates :banner_image, passthru: { to: Decidim::Conference }
-        validate :available_slots_greater_than_or_equal_to_registrations_count, if: ->(form) { form.registrations_enabled? && form.available_slots.positive? }
+        validate :available_slots_greater_than_or_equal_to_registrations_count, if: ->(form) { form.registrations_enabled? && form.available_slots.try(:positive?) }
 
         validates :start_date, presence: true, date: { before_or_equal_to: :end_date }
         validates :end_date, presence: true, date: { after_or_equal_to: :start_date }

--- a/decidim-conferences/spec/forms/conference_form_spec.rb
+++ b/decidim-conferences/spec/forms/conference_form_spec.rb
@@ -40,6 +40,9 @@ module Decidim
         let(:slug) { "slug" }
         let(:attachment) { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
         let(:show_statistics) { true }
+        let(:registrations_enabled) { false }
+        let(:available_slots) { 20 }
+        let(:registration_terms) { {} }
         let(:objectives) do
           {
             en: "Objectives",
@@ -72,7 +75,10 @@ module Decidim
               "objectives_es" => objectives[:es],
               "objectives_ca" => objectives[:ca],
               "start_date" => start_date,
-              "end_date" => end_date
+              "end_date" => end_date,
+              "registrations_enabled" => registrations_enabled,
+              "available_slots" => available_slots,
+              "registration_terms" => registration_terms
             }
           }
         end
@@ -186,6 +192,27 @@ module Decidim
               expect(subject).to be_valid
             end
           end
+        end
+
+        context "when registrations are enabled" do
+          let(:registrations_enabled) { true }
+          let(:available_slots) { 20 }
+          let(:registration_terms) do
+            {
+              en: "Some registration terms",
+              es: "Algunos terminos de registro",
+              ca: "Alguns termes de registre"
+            }
+          end
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when available_slots is blank" do
+          let(:registrations_enabled) { true }
+          let(:available_slots) { "" }
+
+          it { is_expected.not_to be_valid }
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
When registrations are enabled, if `Conference.available_slots` is left blank the application crashes (see screenshots)

#### :pushpin: Related Issues
This fix is analogous to what was happening in #7636. #7636 was happening in meeting registrations and this one happens in conferences registrations.

#### Testing
*Describe the best way to test or validate your PR.*
- Edit a Conference
- Enable registrations
- delete the content of "available slots" field
- Save
- See the crash

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Before*
![image](https://user-images.githubusercontent.com/199462/112031377-8d024680-8b3b-11eb-9555-7658bc193db4.png)

*After*
![image](https://user-images.githubusercontent.com/199462/112031888-1ade3180-8b3c-11eb-9e71-bb525da78597.png)

:hearts: Thank you!
