### PR TITLE
Fix initiative-m card hashtags

### DIFF
--- a/decidim-initiatives/app/cells/decidim/initiatives/initiative_m/tags.erb
+++ b/decidim-initiatives/app/cells/decidim/initiatives/initiative_m/tags.erb
@@ -1,5 +1,5 @@
 <% if model.hashtag.present? %>
-  <%= link_to_if(
+  <%= link_to(
     "##{hashtag}",
     "https://twitter.com/hashtag/#{hashtag}",
     class: "card__text--category",

--- a/decidim-initiatives/spec/cells/decidim/initiatives/initiative_m_cell_spec.rb
+++ b/decidim-initiatives/spec/cells/decidim/initiatives/initiative_m_cell_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Initiatives
+  describe InitiativeMCell, type: :cell do
+    controller Decidim::Initiatives::InitiativesController
+
+    subject { cell_html }
+
+    let(:my_cell) { cell("decidim/initiatives/initiative_m", initiative, context: { show_space: show_space }) }
+    let(:cell_html) { my_cell.call }
+    let!(:initiative) { create(:initiative, hashtag: "my_hashtag") }
+    let(:user) { create :user, organization: initiative.organization }
+
+    before do
+      allow(controller).to receive(:current_user).and_return(user)
+    end
+
+    context "when rendering" do
+      let(:show_space) { false }
+
+      it "renders the card" do
+        expect(subject).to have_css(".card--initiative")
+      end
+
+      it "renders the hashtag" do
+        expect(subject).to have_content("#my_hashtag")
+      end
+    end
+  end
+end

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/admin/initiatives_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/admin/initiatives_controller_spec.rb
@@ -2,663 +2,657 @@
 
 require "spec_helper"
 
-module Decidim
-  module Initiatives
-    module Admin
-      describe InitiativesController, type: :controller do
-        routes { Decidim::Initiatives::AdminEngine.routes }
+describe Decidim::Initiatives::Admin::InitiativesController, type: :controller do
+  routes { Decidim::Initiatives::AdminEngine.routes }
 
-        let(:user) { create(:user, :confirmed, organization: organization) }
-        let(:admin_user) { create(:user, :admin, :confirmed, organization: organization) }
-        let(:organization) { create(:organization) }
-        let!(:initiative) { create(:initiative, organization: organization) }
-        let!(:created_initiative) { create(:initiative, :created, organization: organization) }
+  let(:user) { create(:user, :confirmed, organization: organization) }
+  let(:admin_user) { create(:user, :admin, :confirmed, organization: organization) }
+  let(:organization) { create(:organization) }
+  let!(:initiative) { create(:initiative, organization: organization) }
+  let!(:created_initiative) { create(:initiative, :created, organization: organization) }
+
+  before do
+    request.env["decidim.current_organization"] = organization
+  end
+
+  context "when index" do
+    context "and Users without initiatives" do
+      before do
+        sign_in user, scope: :user
+      end
+
+      it "initiative list is not allowed" do
+        get :index
+        expect(flash[:alert]).not_to be_empty
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context "and anonymous users do" do
+      it "initiative list is not allowed" do
+        get :index
+        expect(flash[:alert]).not_to be_empty
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context "and admin users" do
+      before do
+        sign_in admin_user, scope: :user
+      end
+
+      it "initiative list is allowed" do
+        get :index
+        expect(flash[:alert]).to be_nil
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "and initiative author" do
+      before do
+        sign_in initiative.author, scope: :user
+      end
+
+      it "initiative list is allowed" do
+        get :index
+        expect(flash[:alert]).to be_nil
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe "and promotal committee members" do
+      before do
+        sign_in initiative.committee_members.approved.first.user, scope: :user
+      end
+
+      it "initiative list is allowed" do
+        get :index
+        expect(flash[:alert]).to be_nil
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  context "when show" do
+    context "and Users without initiatives" do
+      before do
+        sign_in user, scope: :user
+      end
+
+      it "are not not allowed" do
+        get :show, params: { slug: initiative.to_param }
+        expect(flash[:alert]).not_to be_empty
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context "and anonymous users" do
+      it "are not allowed" do
+        get :show, params: { slug: initiative.to_param }
+        expect(flash[:alert]).not_to be_empty
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context "and admin users" do
+      before do
+        sign_in admin_user, scope: :user
+      end
+
+      it "are allowed" do
+        get :show, params: { slug: initiative.to_param }
+        expect(flash[:alert]).to be_nil
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "and initiative author" do
+      before do
+        sign_in initiative.author, scope: :user
+      end
+
+      it "are allowed" do
+        get :show, params: { slug: initiative.to_param }
+        expect(flash[:alert]).to be_nil
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "and promotal committee members" do
+      before do
+        sign_in initiative.committee_members.approved.first.user, scope: :user
+      end
+
+      it "initiative list is allowed" do
+        get :show, params: { slug: initiative.to_param }
+        expect(flash[:alert]).to be_nil
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  context "when edit" do
+    context "and Users without initiatives" do
+      before do
+        sign_in user, scope: :user
+      end
+
+      it "are not allowed" do
+        get :edit, params: { slug: initiative.to_param }
+        expect(flash[:alert]).not_to be_empty
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context "and anonymous users" do
+      it "are not allowed" do
+        get :edit, params: { slug: initiative.to_param }
+        expect(flash[:alert]).not_to be_empty
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context "and admin users" do
+      before do
+        sign_in admin_user, scope: :user
+      end
+
+      it "are allowed" do
+        get :edit, params: { slug: initiative.to_param }
+        expect(flash[:alert]).to be_nil
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "and initiative author" do
+      before do
+        sign_in initiative.author, scope: :user
+      end
+
+      it "are allowed" do
+        get :edit, params: { slug: initiative.to_param }
+        expect(flash[:alert]).to be_nil
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "and promotal committee members" do
+      before do
+        sign_in initiative.committee_members.approved.first.user, scope: :user
+      end
+
+      it "are allowed" do
+        get :edit, params: { slug: initiative.to_param }
+        expect(flash[:alert]).to be_nil
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  context "when update" do
+    let(:valid_attributes) do
+      attrs = attributes_for(:initiative, organization: organization)
+      attrs[:signature_end_date] = I18n.l(attrs[:signature_end_date], format: :decidim_short)
+      attrs[:signature_start_date] = I18n.l(attrs[:signature_start_date], format: :decidim_short)
+      attrs
+    end
+
+    context "and Users without initiatives" do
+      before do
+        sign_in user, scope: :user
+      end
+
+      it "are not allowed" do
+        put :update,
+            params: {
+              slug: initiative.to_param,
+              initiative: valid_attributes
+            }
+        expect(flash[:alert]).not_to be_empty
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context "and anonymous users do" do
+      it "are not allowed" do
+        put :update,
+            params: {
+              slug: initiative.to_param,
+              initiative: valid_attributes
+            }
+        expect(flash[:alert]).not_to be_empty
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context "and admin users" do
+      before do
+        sign_in admin_user, scope: :user
+      end
+
+      it "are allowed" do
+        put :update,
+            params: {
+              slug: initiative.to_param,
+              initiative: valid_attributes
+            }
+        expect(flash[:alert]).to be_nil
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context "and initiative author" do
+      context "and initiative published" do
+        before do
+          sign_in initiative.author, scope: :user
+        end
+
+        it "are not allowed" do
+          put :update,
+              params: {
+                slug: initiative.to_param,
+                initiative: valid_attributes
+              }
+          expect(flash[:alert]).not_to be_nil
+          expect(response).to have_http_status(:found)
+        end
+      end
+
+      context "and initiative created" do
+        let(:initiative) { create(:initiative, :created, organization: organization) }
 
         before do
-          request.env["decidim.current_organization"] = organization
+          sign_in initiative.author, scope: :user
         end
 
-        context "when index" do
-          context "and Users without initiatives" do
-            before do
-              sign_in user, scope: :user
-            end
+        it "are allowed" do
+          put :update,
+              params: {
+                slug: initiative.to_param,
+                initiative: valid_attributes
+              }
+          expect(flash[:alert]).to be_nil
+          expect(response).to have_http_status(:found)
+        end
+      end
+    end
 
-            it "initiative list is not allowed" do
-              get :index
-              expect(flash[:alert]).not_to be_empty
-              expect(response).to have_http_status(:found)
-            end
-          end
-
-          context "and anonymous users do" do
-            it "initiative list is not allowed" do
-              get :index
-              expect(flash[:alert]).not_to be_empty
-              expect(response).to have_http_status(:found)
-            end
-          end
-
-          context "and admin users" do
-            before do
-              sign_in admin_user, scope: :user
-            end
-
-            it "initiative list is allowed" do
-              get :index
-              expect(flash[:alert]).to be_nil
-              expect(response).to have_http_status(:ok)
-            end
-          end
-
-          context "and initiative author" do
-            before do
-              sign_in initiative.author, scope: :user
-            end
-
-            it "initiative list is allowed" do
-              get :index
-              expect(flash[:alert]).to be_nil
-              expect(response).to have_http_status(:ok)
-            end
-          end
-
-          describe "and promotal committee members" do
-            before do
-              sign_in initiative.committee_members.approved.first.user, scope: :user
-            end
-
-            it "initiative list is allowed" do
-              get :index
-              expect(flash[:alert]).to be_nil
-              expect(response).to have_http_status(:ok)
-            end
-          end
+    context "and promotal committee members" do
+      context "and initiative published" do
+        before do
+          sign_in initiative.committee_members.approved.first.user, scope: :user
         end
 
-        context "when show" do
-          context "and Users without initiatives" do
-            before do
-              sign_in user, scope: :user
-            end
+        it "are not allowed" do
+          put :update,
+              params: {
+                slug: initiative.to_param,
+                initiative: valid_attributes
+              }
+          expect(flash[:alert]).not_to be_nil
+          expect(response).to have_http_status(:found)
+        end
+      end
 
-            it "are not not allowed" do
-              get :show, params: { slug: initiative.to_param }
-              expect(flash[:alert]).not_to be_empty
-              expect(response).to have_http_status(:found)
-            end
-          end
+      context "and initiative created" do
+        let(:initiative) { create(:initiative, :created, organization: organization) }
 
-          context "and anonymous users" do
-            it "are not allowed" do
-              get :show, params: { slug: initiative.to_param }
-              expect(flash[:alert]).not_to be_empty
-              expect(response).to have_http_status(:found)
-            end
-          end
-
-          context "and admin users" do
-            before do
-              sign_in admin_user, scope: :user
-            end
-
-            it "are allowed" do
-              get :show, params: { slug: initiative.to_param }
-              expect(flash[:alert]).to be_nil
-              expect(response).to have_http_status(:ok)
-            end
-          end
-
-          context "and initiative author" do
-            before do
-              sign_in initiative.author, scope: :user
-            end
-
-            it "are allowed" do
-              get :show, params: { slug: initiative.to_param }
-              expect(flash[:alert]).to be_nil
-              expect(response).to have_http_status(:ok)
-            end
-          end
-
-          context "and promotal committee members" do
-            before do
-              sign_in initiative.committee_members.approved.first.user, scope: :user
-            end
-
-            it "initiative list is allowed" do
-              get :show, params: { slug: initiative.to_param }
-              expect(flash[:alert]).to be_nil
-              expect(response).to have_http_status(:ok)
-            end
-          end
+        before do
+          sign_in initiative.committee_members.approved.first.user, scope: :user
         end
 
-        context "when edit" do
-          context "and Users without initiatives" do
-            before do
-              sign_in user, scope: :user
-            end
+        it "are allowed" do
+          put :update,
+              params: {
+                slug: initiative.to_param,
+                initiative: valid_attributes
+              }
+          expect(flash[:alert]).to be_nil
+          expect(response).to have_http_status(:found)
+        end
+      end
+    end
+  end
 
-            it "are not allowed" do
-              get :edit, params: { slug: initiative.to_param }
-              expect(flash[:alert]).not_to be_empty
-              expect(response).to have_http_status(:found)
-            end
-          end
-
-          context "and anonymous users" do
-            it "are not allowed" do
-              get :edit, params: { slug: initiative.to_param }
-              expect(flash[:alert]).not_to be_empty
-              expect(response).to have_http_status(:found)
-            end
-          end
-
-          context "and admin users" do
-            before do
-              sign_in admin_user, scope: :user
-            end
-
-            it "are allowed" do
-              get :edit, params: { slug: initiative.to_param }
-              expect(flash[:alert]).to be_nil
-              expect(response).to have_http_status(:ok)
-            end
-          end
-
-          context "and initiative author" do
-            before do
-              sign_in initiative.author, scope: :user
-            end
-
-            it "are allowed" do
-              get :edit, params: { slug: initiative.to_param }
-              expect(flash[:alert]).to be_nil
-              expect(response).to have_http_status(:ok)
-            end
-          end
-
-          context "and promotal committee members" do
-            before do
-              sign_in initiative.committee_members.approved.first.user, scope: :user
-            end
-
-            it "are allowed" do
-              get :edit, params: { slug: initiative.to_param }
-              expect(flash[:alert]).to be_nil
-              expect(response).to have_http_status(:ok)
-            end
-          end
+  context "when GET send_to_technical_validation" do
+    context "and Initiative in created state" do
+      context "and has not enough committee members" do
+        before do
+          created_initiative.author.confirm
+          sign_in created_initiative.author, scope: :user
         end
 
-        context "when update" do
-          let(:valid_attributes) do
-            attrs = attributes_for(:initiative, organization: organization)
-            attrs[:signature_end_date] = I18n.l(attrs[:signature_end_date], format: :decidim_short)
-            attrs[:signature_start_date] = I18n.l(attrs[:signature_start_date], format: :decidim_short)
-            attrs
-          end
+        it "does not pass to technical validation phase" do
+          created_initiative.type.update(minimum_committee_members: 4)
+          get :send_to_technical_validation, params: { slug: created_initiative.to_param }
 
-          context "and Users without initiatives" do
-            before do
-              sign_in user, scope: :user
-            end
-
-            it "are not allowed" do
-              put :update,
-                  params: {
-                    slug: initiative.to_param,
-                    initiative: valid_attributes
-                  }
-              expect(flash[:alert]).not_to be_empty
-              expect(response).to have_http_status(:found)
-            end
-          end
-
-          context "and anonymous users do" do
-            it "are not allowed" do
-              put :update,
-                  params: {
-                    slug: initiative.to_param,
-                    initiative: valid_attributes
-                  }
-              expect(flash[:alert]).not_to be_empty
-              expect(response).to have_http_status(:found)
-            end
-          end
-
-          context "and admin users" do
-            before do
-              sign_in admin_user, scope: :user
-            end
-
-            it "are allowed" do
-              put :update,
-                  params: {
-                    slug: initiative.to_param,
-                    initiative: valid_attributes
-                  }
-              expect(flash[:alert]).to be_nil
-              expect(response).to have_http_status(:found)
-            end
-          end
-
-          context "and initiative author" do
-            context "and initiative published" do
-              before do
-                sign_in initiative.author, scope: :user
-              end
-
-              it "are not allowed" do
-                put :update,
-                    params: {
-                      slug: initiative.to_param,
-                      initiative: valid_attributes
-                    }
-                expect(flash[:alert]).not_to be_nil
-                expect(response).to have_http_status(:found)
-              end
-            end
-
-            context "and initiative created" do
-              let(:initiative) { create(:initiative, :created, organization: organization) }
-
-              before do
-                sign_in initiative.author, scope: :user
-              end
-
-              it "are allowed" do
-                put :update,
-                    params: {
-                      slug: initiative.to_param,
-                      initiative: valid_attributes
-                    }
-                expect(flash[:alert]).to be_nil
-                expect(response).to have_http_status(:found)
-              end
-            end
-          end
-
-          context "and promotal committee members" do
-            context "and initiative published" do
-              before do
-                sign_in initiative.committee_members.approved.first.user, scope: :user
-              end
-
-              it "are not allowed" do
-                put :update,
-                    params: {
-                      slug: initiative.to_param,
-                      initiative: valid_attributes
-                    }
-                expect(flash[:alert]).not_to be_nil
-                expect(response).to have_http_status(:found)
-              end
-            end
-
-            context "and initiative created" do
-              let(:initiative) { create(:initiative, :created, organization: organization) }
-
-              before do
-                sign_in initiative.committee_members.approved.first.user, scope: :user
-              end
-
-              it "are allowed" do
-                put :update,
-                    params: {
-                      slug: initiative.to_param,
-                      initiative: valid_attributes
-                    }
-                expect(flash[:alert]).to be_nil
-                expect(response).to have_http_status(:found)
-              end
-            end
-          end
+          created_initiative.reload
+          expect(created_initiative).not_to be_validating
         end
 
-        context "when GET send_to_technical_validation" do
-          context "and Initiative in created state" do
-            context "and has not enough committee members" do
-              before do
-                created_initiative.author.confirm
-                sign_in created_initiative.author, scope: :user
-              end
+        it "does pass to technical validation phase" do
+          created_initiative.type.update(minimum_committee_members: 3)
+          get :send_to_technical_validation, params: { slug: created_initiative.to_param }
 
-              it "does not pass to technical validation phase" do
-                created_initiative.type.update(minimum_committee_members: 4)
-                get :send_to_technical_validation, params: { slug: created_initiative.to_param }
+          created_initiative.reload
+          expect(created_initiative).to be_validating
+        end
+      end
 
-                created_initiative.reload
-                expect(created_initiative).not_to be_validating
-              end
+      context "and User is not the owner of the initiative" do
+        let(:other_user) { create(:user, organization: organization) }
 
-              it "does pass to technical validation phase" do
-                created_initiative.type.update(minimum_committee_members: 3)
-                get :send_to_technical_validation, params: { slug: created_initiative.to_param }
-
-                created_initiative.reload
-                expect(created_initiative).to be_validating
-              end
-            end
-
-            context "and User is not the owner of the initiative" do
-              let(:other_user) { create(:user, organization: organization) }
-
-              before do
-                sign_in other_user, scope: :user
-              end
-
-              it "Raises an error" do
-                get :send_to_technical_validation, params: { slug: created_initiative.to_param }
-                expect(flash[:alert]).not_to be_empty
-                expect(response).to have_http_status(:found)
-              end
-            end
-
-            context "and User is the owner of the initiative. It is in created state" do
-              before do
-                created_initiative.author.confirm
-                sign_in created_initiative.author, scope: :user
-              end
-
-              it "Passes to technical validation phase" do
-                get :send_to_technical_validation, params: { slug: created_initiative.to_param }
-
-                created_initiative.reload
-                expect(created_initiative).to be_validating
-              end
-            end
-          end
-
-          context "and Initiative in discarded state" do
-            let!(:discarded_initiative) { create(:initiative, :discarded, organization: organization) }
-
-            before do
-              sign_in discarded_initiative.author, scope: :user
-            end
-
-            it "Passes to technical validation phase" do
-              get :send_to_technical_validation, params: { slug: discarded_initiative.to_param }
-
-              discarded_initiative.reload
-              expect(discarded_initiative).to be_validating
-            end
-          end
-
-          context "and Initiative not in created or discarded state (published)" do
-            before do
-              sign_in initiative.author, scope: :user
-            end
-
-            it "Raises an error" do
-              get :send_to_technical_validation, params: { slug: initiative.to_param }
-              expect(flash[:alert]).not_to be_empty
-              expect(response).to have_http_status(:found)
-            end
-          end
+        before do
+          sign_in other_user, scope: :user
         end
 
-        context "when POST publish" do
-          let!(:initiative) { create(:initiative, :validating, organization: organization) }
+        it "Raises an error" do
+          get :send_to_technical_validation, params: { slug: created_initiative.to_param }
+          expect(flash[:alert]).not_to be_empty
+          expect(response).to have_http_status(:found)
+        end
+      end
 
-          context "and Initiative owner" do
-            before do
-              sign_in initiative.author, scope: :user
-            end
-
-            it "Raises an error" do
-              post :publish, params: { slug: initiative.to_param }
-              expect(flash[:alert]).not_to be_empty
-              expect(response).to have_http_status(:found)
-            end
-          end
-
-          context "and Administrator" do
-            let!(:admin) { create(:user, :confirmed, :admin, organization: organization) }
-
-            before do
-              sign_in admin, scope: :user
-            end
-
-            it "initiative gets published" do
-              post :publish, params: { slug: initiative.to_param }
-              expect(response).to have_http_status(:found)
-
-              initiative.reload
-              expect(initiative).to be_published
-              expect(initiative.published_at).not_to be_nil
-              expect(initiative.signature_start_date).not_to be_nil
-              expect(initiative.signature_end_date).not_to be_nil
-            end
-          end
+      context "and User is the owner of the initiative. It is in created state" do
+        before do
+          created_initiative.author.confirm
+          sign_in created_initiative.author, scope: :user
         end
 
-        context "when DELETE unpublish" do
-          context "and Initiative owner" do
-            before do
-              sign_in initiative.author, scope: :user
-            end
+        it "Passes to technical validation phase" do
+          get :send_to_technical_validation, params: { slug: created_initiative.to_param }
 
-            it "Raises an error" do
-              delete :unpublish, params: { slug: initiative.to_param }
-              expect(flash[:alert]).not_to be_empty
-              expect(response).to have_http_status(:found)
-            end
-          end
-
-          context "and Administrator" do
-            let(:admin) { create(:user, :confirmed, :admin, organization: organization) }
-
-            before do
-              sign_in admin, scope: :user
-            end
-
-            it "initiative gets unpublished" do
-              delete :unpublish, params: { slug: initiative.to_param }
-              expect(response).to have_http_status(:found)
-
-              initiative.reload
-              expect(initiative).not_to be_published
-              expect(initiative).to be_discarded
-              expect(initiative.published_at).to be_nil
-            end
-          end
+          created_initiative.reload
+          expect(created_initiative).to be_validating
         end
+      end
+    end
 
-        context "when DELETE discard" do
-          let(:initiative) { create(:initiative, :validating, organization: organization) }
+    context "and Initiative in discarded state" do
+      let!(:discarded_initiative) { create(:initiative, :discarded, organization: organization) }
 
-          context "and Initiative owner" do
-            before do
-              sign_in initiative.author, scope: :user
-            end
+      before do
+        sign_in discarded_initiative.author, scope: :user
+      end
 
-            it "Raises an error" do
-              delete :discard, params: { slug: initiative.to_param }
-              expect(flash[:alert]).not_to be_empty
-              expect(response).to have_http_status(:found)
-            end
-          end
+      it "Passes to technical validation phase" do
+        get :send_to_technical_validation, params: { slug: discarded_initiative.to_param }
 
-          context "and Administrator" do
-            let(:admin) { create(:user, :confirmed, :admin, organization: organization) }
+        discarded_initiative.reload
+        expect(discarded_initiative).to be_validating
+      end
+    end
 
-            before do
-              sign_in admin, scope: :user
-            end
+    context "and Initiative not in created or discarded state (published)" do
+      before do
+        sign_in initiative.author, scope: :user
+      end
 
-            it "initiative gets discarded" do
-              delete :discard, params: { slug: initiative.to_param }
-              expect(response).to have_http_status(:found)
+      it "Raises an error" do
+        get :send_to_technical_validation, params: { slug: initiative.to_param }
+        expect(flash[:alert]).not_to be_empty
+        expect(response).to have_http_status(:found)
+      end
+    end
+  end
 
-              initiative.reload
-              expect(initiative).to be_discarded
-              expect(initiative.published_at).to be_nil
-            end
-          end
-        end
+  context "when POST publish" do
+    let!(:initiative) { create(:initiative, :validating, organization: organization) }
 
-        context "when POST accept" do
-          let!(:initiative) { create(:initiative, :acceptable, signature_type: "any", organization: organization) }
+    context "and Initiative owner" do
+      before do
+        sign_in initiative.author, scope: :user
+      end
 
-          context "and Initiative owner" do
-            before do
-              sign_in initiative.author, scope: :user
-            end
+      it "Raises an error" do
+        post :publish, params: { slug: initiative.to_param }
+        expect(flash[:alert]).not_to be_empty
+        expect(response).to have_http_status(:found)
+      end
+    end
 
-            it "Raises an error" do
-              post :accept, params: { slug: initiative.to_param }
-              expect(flash[:alert]).not_to be_empty
-              expect(response).to have_http_status(:found)
-            end
-          end
+    context "and Administrator" do
+      let!(:admin) { create(:user, :confirmed, :admin, organization: organization) }
 
-          context "when Administrator" do
-            let!(:admin) { create(:user, :confirmed, :admin, organization: organization) }
+      before do
+        sign_in admin, scope: :user
+      end
 
-            before do
-              sign_in admin, scope: :user
-            end
+      it "initiative gets published" do
+        post :publish, params: { slug: initiative.to_param }
+        expect(response).to have_http_status(:found)
 
-            it "initiative gets published" do
-              post :accept, params: { slug: initiative.to_param }
-              expect(response).to have_http_status(:found)
+        initiative.reload
+        expect(initiative).to be_published
+        expect(initiative.published_at).not_to be_nil
+        expect(initiative.signature_start_date).not_to be_nil
+        expect(initiative.signature_end_date).not_to be_nil
+      end
+    end
+  end
 
-              initiative.reload
-              expect(initiative).to be_accepted
-            end
-          end
-        end
+  context "when DELETE unpublish" do
+    context "and Initiative owner" do
+      before do
+        sign_in initiative.author, scope: :user
+      end
 
-        context "when DELETE reject" do
-          let!(:initiative) { create(:initiative, :rejectable, signature_type: "any", organization: organization) }
+      it "Raises an error" do
+        delete :unpublish, params: { slug: initiative.to_param }
+        expect(flash[:alert]).not_to be_empty
+        expect(response).to have_http_status(:found)
+      end
+    end
 
-          context "and Initiative owner" do
-            before do
-              sign_in initiative.author, scope: :user
-            end
+    context "and Administrator" do
+      let(:admin) { create(:user, :confirmed, :admin, organization: organization) }
 
-            it "Raises an error" do
-              delete :reject, params: { slug: initiative.to_param }
-              expect(flash[:alert]).not_to be_empty
-              expect(response).to have_http_status(:found)
-            end
-          end
+      before do
+        sign_in admin, scope: :user
+      end
 
-          context "when Administrator" do
-            let!(:admin) { create(:user, :confirmed, :admin, organization: organization) }
+      it "initiative gets unpublished" do
+        delete :unpublish, params: { slug: initiative.to_param }
+        expect(response).to have_http_status(:found)
 
-            before do
-              sign_in admin, scope: :user
-            end
+        initiative.reload
+        expect(initiative).not_to be_published
+        expect(initiative).to be_discarded
+        expect(initiative.published_at).to be_nil
+      end
+    end
+  end
 
-            it "initiative gets rejected" do
-              delete :reject, params: { slug: initiative.to_param }
-              expect(response).to have_http_status(:found)
-              expect(flash[:alert]).to be_nil
+  context "when DELETE discard" do
+    let(:initiative) { create(:initiative, :validating, organization: organization) }
 
-              initiative.reload
-              expect(initiative).to be_rejected
-            end
-          end
-        end
+    context "and Initiative owner" do
+      before do
+        sign_in initiative.author, scope: :user
+      end
 
-        context "when GET export_votes" do
-          let(:initiative) { create(:initiative, organization: organization, signature_type: "any") }
+      it "Raises an error" do
+        delete :discard, params: { slug: initiative.to_param }
+        expect(flash[:alert]).not_to be_empty
+        expect(response).to have_http_status(:found)
+      end
+    end
 
-          context "and author" do
-            before do
-              sign_in initiative.author, scope: :user
-            end
+    context "and Administrator" do
+      let(:admin) { create(:user, :confirmed, :admin, organization: organization) }
 
-            it "is not allowed" do
-              get :export_votes, params: { slug: initiative.to_param, format: :csv }
-              expect(flash[:alert]).not_to be_empty
-              expect(response).to have_http_status(:found)
-            end
-          end
+      before do
+        sign_in admin, scope: :user
+      end
 
-          context "and promotal committee" do
-            before do
-              sign_in initiative.committee_members.approved.first.user, scope: :user
-            end
+      it "initiative gets discarded" do
+        delete :discard, params: { slug: initiative.to_param }
+        expect(response).to have_http_status(:found)
 
-            it "is not allowed" do
-              get :export_votes, params: { slug: initiative.to_param, format: :csv }
-              expect(flash[:alert]).not_to be_empty
-              expect(response).to have_http_status(:found)
-            end
-          end
+        initiative.reload
+        expect(initiative).to be_discarded
+        expect(initiative.published_at).to be_nil
+      end
+    end
+  end
 
-          context "and admin user" do
-            let!(:vote) { create(:initiative_user_vote, initiative: initiative) }
+  context "when POST accept" do
+    let!(:initiative) { create(:initiative, :acceptable, signature_type: "any", organization: organization) }
 
-            before do
-              sign_in admin_user, scope: :user
-            end
+    context "and Initiative owner" do
+      before do
+        sign_in initiative.author, scope: :user
+      end
 
-            it "is allowed" do
-              get :export_votes, params: { slug: initiative.to_param, format: :csv }
-              expect(flash[:alert]).to be_nil
-              expect(response).to have_http_status(:ok)
-            end
-          end
-        end
+      it "Raises an error" do
+        post :accept, params: { slug: initiative.to_param }
+        expect(flash[:alert]).not_to be_empty
+        expect(response).to have_http_status(:found)
+      end
+    end
 
-        context "when GET export_pdf_signatures" do
-          let(:initiative) { create(:initiative, :with_user_extra_fields_collection, organization: organization) }
+    context "when Administrator" do
+      let!(:admin) { create(:user, :confirmed, :admin, organization: organization) }
 
-          context "and author" do
-            before do
-              sign_in initiative.author, scope: :user
-            end
+      before do
+        sign_in admin, scope: :user
+      end
 
-            it "is not allowed" do
-              get :export_pdf_signatures, params: { slug: initiative.to_param, format: :pdf }
-              expect(flash[:alert]).not_to be_empty
-              expect(response).to have_http_status(:found)
-            end
-          end
+      it "initiative gets published" do
+        post :accept, params: { slug: initiative.to_param }
+        expect(response).to have_http_status(:found)
 
-          context "and admin" do
-            before do
-              sign_in admin_user, scope: :user
-            end
+        initiative.reload
+        expect(initiative).to be_accepted
+      end
+    end
+  end
 
-            it "is allowed" do
-              get :export_pdf_signatures, params: { slug: initiative.to_param, format: :pdf }
-              expect(flash[:alert]).to be_nil
-              expect(response).to have_http_status(:ok)
-            end
-          end
-        end
+  context "when DELETE reject" do
+    let!(:initiative) { create(:initiative, :rejectable, signature_type: "any", organization: organization) }
 
-        context "when GET export" do
-          context "and user" do
-            before do
-              sign_in user, scope: :user
-            end
+    context "and Initiative owner" do
+      before do
+        sign_in initiative.author, scope: :user
+      end
 
-            it "is not allowed" do
-              get :export, params: { format: :csv }
-              expect(flash[:alert]).not_to be_empty
-              expect(response).to have_http_status(:found)
-            end
-          end
+      it "Raises an error" do
+        delete :reject, params: { slug: initiative.to_param }
+        expect(flash[:alert]).not_to be_empty
+        expect(response).to have_http_status(:found)
+      end
+    end
 
-          context "and admin" do
-            before do
-              sign_in admin_user, scope: :user
-            end
+    context "when Administrator" do
+      let!(:admin) { create(:user, :confirmed, :admin, organization: organization) }
 
-            it "is allowed" do
-              get :export, params: { format: :csv }
-              expect(flash[:alert]).to be_nil
-              expect(response).to have_http_status(:found)
-            end
-          end
-        end
+      before do
+        sign_in admin, scope: :user
+      end
+
+      it "initiative gets rejected" do
+        delete :reject, params: { slug: initiative.to_param }
+        expect(response).to have_http_status(:found)
+        expect(flash[:alert]).to be_nil
+
+        initiative.reload
+        expect(initiative).to be_rejected
+      end
+    end
+  end
+
+  context "when GET export_votes" do
+    let(:initiative) { create(:initiative, organization: organization, signature_type: "any") }
+
+    context "and author" do
+      before do
+        sign_in initiative.author, scope: :user
+      end
+
+      it "is not allowed" do
+        get :export_votes, params: { slug: initiative.to_param, format: :csv }
+        expect(flash[:alert]).not_to be_empty
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context "and promotal committee" do
+      before do
+        sign_in initiative.committee_members.approved.first.user, scope: :user
+      end
+
+      it "is not allowed" do
+        get :export_votes, params: { slug: initiative.to_param, format: :csv }
+        expect(flash[:alert]).not_to be_empty
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context "and admin user" do
+      let!(:vote) { create(:initiative_user_vote, initiative: initiative) }
+
+      before do
+        sign_in admin_user, scope: :user
+      end
+
+      it "is allowed" do
+        get :export_votes, params: { slug: initiative.to_param, format: :csv }
+        expect(flash[:alert]).to be_nil
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  context "when GET export_pdf_signatures" do
+    let(:initiative) { create(:initiative, :with_user_extra_fields_collection, organization: organization) }
+
+    context "and author" do
+      before do
+        sign_in initiative.author, scope: :user
+      end
+
+      it "is not allowed" do
+        get :export_pdf_signatures, params: { slug: initiative.to_param, format: :pdf }
+        expect(flash[:alert]).not_to be_empty
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context "and admin" do
+      before do
+        sign_in admin_user, scope: :user
+      end
+
+      it "is allowed" do
+        get :export_pdf_signatures, params: { slug: initiative.to_param, format: :pdf }
+        expect(flash[:alert]).to be_nil
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  context "when GET export" do
+    context "and user" do
+      before do
+        sign_in user, scope: :user
+      end
+
+      it "is not allowed" do
+        get :export, params: { format: :csv }
+        expect(flash[:alert]).not_to be_empty
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context "and admin" do
+      before do
+        sign_in admin_user, scope: :user
+      end
+
+      it "is allowed" do
+        get :export, params: { format: :csv }
+        expect(flash[:alert]).to be_nil
+        expect(response).to have_http_status(:found)
       end
     end
   end

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/initiatives_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/initiatives_controller_spec.rb
@@ -108,10 +108,10 @@ describe Decidim::Initiatives::InitiativesController, type: :controller do
     context "and update an initiative" do
       it "are allowed" do
         put :update,
-          params: {
-            slug: created_initiative.to_param,
-            initiative: valid_attributes
-          }
+            params: {
+              slug: created_initiative.to_param,
+              initiative: valid_attributes
+            }
         expect(flash[:alert]).to be_nil
         expect(response).to have_http_status(:found)
       end
@@ -122,10 +122,10 @@ describe Decidim::Initiatives::InitiativesController, type: :controller do
         invalid_attributes = valid_attributes.merge(title: nil)
 
         put :update,
-          params: {
-            slug: created_initiative.to_param,
-            initiative: invalid_attributes
-          }
+            params: {
+              slug: created_initiative.to_param,
+              initiative: invalid_attributes
+            }
 
         expect(flash[:alert]).not_to be_empty
         expect(response).to have_http_status(:ok)

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/initiatives_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/initiatives_controller_spec.rb
@@ -2,169 +2,165 @@
 
 require "spec_helper"
 
-module Decidim
-  module Initiatives
-    describe InitiativesController, type: :controller do
-      routes { Decidim::Initiatives::Engine.routes }
+describe Decidim::Initiatives::InitiativesController, type: :controller do
+  routes { Decidim::Initiatives::Engine.routes }
 
-      let(:organization) { create(:organization) }
-      let!(:initiative) { create(:initiative, organization: organization) }
-      let!(:created_initiative) { create(:initiative, :created, organization: organization) }
+  let(:organization) { create(:organization) }
+  let!(:initiative) { create(:initiative, organization: organization) }
+  let!(:created_initiative) { create(:initiative, :created, organization: organization) }
 
+  before do
+    request.env["decidim.current_organization"] = organization
+  end
+
+  describe "GET index" do
+    it "Only returns published initiatives" do
+      get :index
+      expect(subject.helpers.initiatives).to include(initiative)
+      expect(subject.helpers.initiatives).not_to include(created_initiative)
+    end
+
+    context "when order by most_voted" do
+      let(:voted_initiative) { create(:initiative, organization: organization) }
+      let!(:vote) { create(:initiative_user_vote, initiative: voted_initiative) }
+
+      it "most voted appears first" do
+        get :index, params: { order: "most_voted" }
+
+        expect(subject.helpers.initiatives.first).to eq(voted_initiative)
+      end
+    end
+
+    context "when order by most recent" do
+      let!(:old_initiative) { create(:initiative, organization: organization, created_at: initiative.created_at - 12.months) }
+
+      it "most recent appears first" do
+        get :index, params: { order: "recent" }
+        expect(subject.helpers.initiatives.first).to eq(initiative)
+      end
+    end
+
+    context "when order by most recently published" do
+      let!(:old_initiative) { create(:initiative, organization: organization, published_at: initiative.published_at - 12.months) }
+
+      it "most recent appears first" do
+        get :index, params: { order: "recently_published" }
+        expect(subject.helpers.initiatives.first).to eq(initiative)
+      end
+    end
+
+    context "when order by most commented" do
+      let(:commented_initiative) { create(:initiative, organization: organization) }
+      let!(:comment) { create(:comment, commentable: commented_initiative) }
+
+      it "most commented appears fisrt" do
+        get :index, params: { order: "most_commented" }
+        expect(subject.helpers.initiatives.first).to eq(commented_initiative)
+      end
+    end
+  end
+
+  describe "GET show" do
+    context "and any user" do
+      it "Shows published initiatives" do
+        get :show, params: { slug: initiative.slug }
+        expect(subject.helpers.current_initiative).to eq(initiative)
+      end
+
+      it "Throws exception on non published initiatives" do
+        get :show, params: { slug: created_initiative.slug }
+        expect(flash[:alert]).not_to be_empty
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context "and initiative Owner" do
       before do
-        request.env["decidim.current_organization"] = organization
+        sign_in created_initiative.author, scope: :user
       end
 
-      describe "GET index" do
-        it "Only returns published initiatives" do
-          get :index
-          expect(subject.helpers.initiatives).to include(initiative)
-          expect(subject.helpers.initiatives).not_to include(created_initiative)
-        end
+      it "Unpublished initiatives are shown too" do
+        get :show, params: { slug: created_initiative.slug }
+        expect(subject.helpers.current_initiative).to eq(created_initiative)
+      end
+    end
+  end
 
-        context "when order by most_voted" do
-          let(:voted_initiative) { create(:initiative, organization: organization) }
-          let!(:vote) { create(:initiative_user_vote, initiative: voted_initiative) }
+  describe "Edit initiative as promoter" do
+    before do
+      sign_in created_initiative.author, scope: :user
+    end
 
-          it "most voted appears first" do
-            get :index, params: { order: "most_voted" }
+    let(:valid_attributes) do
+      attrs = attributes_for(:initiative, organization: organization)
+      attrs[:signature_end_date] = I18n.l(attrs[:signature_end_date], format: :decidim_short)
+      attrs[:signature_start_date] = I18n.l(attrs[:signature_start_date], format: :decidim_short)
+      attrs[:type_id] = created_initiative.type.id
+      attrs
+    end
 
-            expect(subject.helpers.initiatives.first).to eq(voted_initiative)
-          end
-        end
+    it "edit when user is allowed" do
+      get :edit, params: { slug: created_initiative.slug }
+      expect(flash[:alert]).to be_nil
+      expect(response).to have_http_status(:ok)
+    end
 
-        context "when order by most recent" do
-          let!(:old_initiative) { create(:initiative, organization: organization, created_at: initiative.created_at - 12.months) }
+    context "and update an initiative" do
+      it "are allowed" do
+        put :update,
+          params: {
+            slug: created_initiative.to_param,
+            initiative: valid_attributes
+          }
+        expect(flash[:alert]).to be_nil
+        expect(response).to have_http_status(:found)
+      end
+    end
 
-          it "most recent appears first" do
-            get :index, params: { order: "recent" }
-            expect(subject.helpers.initiatives.first).to eq(initiative)
-          end
-        end
+    context "when initiative is invalid" do
+      it "does not update when title is nil" do
+        invalid_attributes = valid_attributes.merge(title: nil)
 
-        context "when order by most recently published" do
-          let!(:old_initiative) { create(:initiative, organization: organization, published_at: initiative.published_at - 12.months) }
+        put :update,
+          params: {
+            slug: created_initiative.to_param,
+            initiative: invalid_attributes
+          }
 
-          it "most recent appears first" do
-            get :index, params: { order: "recently_published" }
-            expect(subject.helpers.initiatives.first).to eq(initiative)
-          end
-        end
-
-        context "when order by most commented" do
-          let(:commented_initiative) { create(:initiative, organization: organization) }
-          let!(:comment) { create(:comment, commentable: commented_initiative) }
-
-          it "most commented appears fisrt" do
-            get :index, params: { order: "most_commented" }
-            expect(subject.helpers.initiatives.first).to eq(commented_initiative)
-          end
-        end
+        expect(flash[:alert]).not_to be_empty
+        expect(response).to have_http_status(:ok)
       end
 
-      describe "GET show" do
-        context "and any user" do
-          it "Shows published initiatives" do
-            get :show, params: { slug: initiative.slug }
-            expect(subject.helpers.current_initiative).to eq(initiative)
+      context "when the existing initiative has attachments and there are other errors on the form" do
+        let!(:created_initiative) do
+          create(
+            :initiative,
+            :created,
+            :with_photos,
+            :with_documents,
+            organization: organization
+          )
+        end
+
+        include_context "with controller rendering the view" do
+          let(:invalid_attributes) do
+            valid_attributes.merge(
+              title: nil,
+              photos: created_initiative.photos.map { |a| a.id.to_s },
+              documents: created_initiative.documents.map { |a| a.id.to_s }
+            )
           end
 
-          it "Throws exception on non published initiatives" do
-            get :show, params: { slug: created_initiative.slug }
-            expect(flash[:alert]).not_to be_empty
-            expect(response).to have_http_status(:found)
-          end
-        end
-
-        context "and initiative Owner" do
-          before do
-            sign_in created_initiative.author, scope: :user
-          end
-
-          it "Unpublished initiatives are shown too" do
-            get :show, params: { slug: created_initiative.slug }
-            expect(subject.helpers.current_initiative).to eq(created_initiative)
-          end
-        end
-      end
-
-      describe "Edit initiative as promoter" do
-        before do
-          sign_in created_initiative.author, scope: :user
-        end
-
-        let(:valid_attributes) do
-          attrs = attributes_for(:initiative, organization: organization)
-          attrs[:signature_end_date] = I18n.l(attrs[:signature_end_date], format: :decidim_short)
-          attrs[:signature_start_date] = I18n.l(attrs[:signature_start_date], format: :decidim_short)
-          attrs[:type_id] = created_initiative.type.id
-          attrs
-        end
-
-        it "edit when user is allowed" do
-          get :edit, params: { slug: created_initiative.slug }
-          expect(flash[:alert]).to be_nil
-          expect(response).to have_http_status(:ok)
-        end
-
-        context "and update an initiative" do
-          it "are allowed" do
-            put :update,
-                params: {
-                  slug: created_initiative.to_param,
-                  initiative: valid_attributes
-                }
-            expect(flash[:alert]).to be_nil
-            expect(response).to have_http_status(:found)
-          end
-        end
-
-        context "when initiative is invalid" do
-          it "does not update when title is nil" do
-            invalid_attributes = valid_attributes.merge(title: nil)
-
-            put :update,
-                params: {
-                  slug: created_initiative.to_param,
-                  initiative: invalid_attributes
-                }
+          it "displays the editing form with errors" do
+            put :update, params: {
+              slug: created_initiative.to_param,
+              initiative: invalid_attributes
+            }
 
             expect(flash[:alert]).not_to be_empty
             expect(response).to have_http_status(:ok)
-          end
-
-          context "when the existing initiative has attachments and there are other errors on the form" do
-            let!(:created_initiative) do
-              create(
-                :initiative,
-                :created,
-                :with_photos,
-                :with_documents,
-                organization: organization
-              )
-            end
-
-            include_context "with controller rendering the view" do
-              let(:invalid_attributes) do
-                valid_attributes.merge(
-                  title: nil,
-                  photos: created_initiative.photos.map { |a| a.id.to_s },
-                  documents: created_initiative.documents.map { |a| a.id.to_s }
-                )
-              end
-
-              it "displays the editing form with errors" do
-                put :update, params: {
-                  slug: created_initiative.to_param,
-                  initiative: invalid_attributes
-                }
-
-                expect(flash[:alert]).not_to be_empty
-                expect(response).to have_http_status(:ok)
-                expect(subject).to render_template(:edit)
-                expect(response.body).to include("An error has occurred")
-              end
-            end
+            expect(subject).to render_template(:edit)
+            expect(response.body).to include("An error has occurred")
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
Initiatives with hashtags fail to render and make the page break. This can cause failures in the global search page, not just in the initiatives index.

#### :pushpin: Related Issues
- Fixes #7671

#### Testing
Ensure CI is green.