### PR TITLE
Ensure pagination elements per page is a valid option

### DIFF
--- a/decidim-core/app/controllers/concerns/decidim/paginable.rb
+++ b/decidim-core/app/controllers/concerns/decidim/paginable.rb
@@ -20,7 +20,7 @@ module Decidim
       def per_page
         if OPTIONS.include?(params[:per_page])
           params[:per_page]
-        elsif params[:page]
+        elsif params[:per_page]
           sorted = OPTIONS.sort
           params[:per_page].to_i.clamp(sorted.first, sorted.last)
         else

--- a/decidim-core/app/controllers/concerns/decidim/paginable.rb
+++ b/decidim-core/app/controllers/concerns/decidim/paginable.rb
@@ -20,6 +20,9 @@ module Decidim
       def per_page
         if OPTIONS.include?(params[:per_page])
           params[:per_page]
+        elsif params[:page]
+          sorted = OPTIONS.sort
+          params[:per_page].to_i.clamp(sorted.first, sorted.last)
         else
           OPTIONS.first
         end

--- a/decidim-core/app/controllers/concerns/decidim/paginable.rb
+++ b/decidim-core/app/controllers/concerns/decidim/paginable.rb
@@ -18,7 +18,11 @@ module Decidim
       end
 
       def per_page
-        params[:per_page] || OPTIONS.first
+        if OPTIONS.include?(params[:per_page])
+          params[:per_page]
+        else
+          OPTIONS.first
+        end
       end
 
       def page_offset

--- a/decidim-proposals/spec/controllers/decidim/proposals/proposals_controller_spec.rb
+++ b/decidim-proposals/spec/controllers/decidim/proposals/proposals_controller_spec.rb
@@ -43,14 +43,14 @@ module Decidim
           end
 
           it "sets two different collections" do
-            geocoded_proposals = create_list :proposal, 10, component: component
+            geocoded_proposals = create_list :proposal, 10, component: component, latitude: 1.1, longitude: 2.2
             _non_geocoded_proposals = create_list :proposal, 2, component: component, latitude: nil, longitude: nil
 
-            get :index, params: { per_page: 5 }
+            get :index
             expect(response).to have_http_status(:ok)
             expect(subject).to render_template(:index)
 
-            expect(assigns(:proposals).count).to eq 5
+            expect(assigns(:proposals).count).to eq 12
             expect(assigns(:all_geocoded_proposals)).to match_array(geocoded_proposals)
           end
         end


### PR DESCRIPTION
#### :tophat: What? Why?
When paginating elements, users can override the `per_page` param in the URL and this is taken into account. This could cause problems to the server when rendering big lists (imagine a list of >800 PRs being rendered at the same time).

#### :pushpin: Related Issues
None

#### Testing
Ensure CI is green.