### PR TITLE
Don't show deleted users on user group members page

### DIFF
--- a/decidim-core/app/models/decidim/user_group.rb
+++ b/decidim-core/app/models/decidim/user_group.rb
@@ -37,6 +37,10 @@ module Decidim
         .where("extended_data->>'document_number' = ?", number)
     end
 
+    def non_deleted_memberships
+      memberships.where(decidim_users: { deleted_at: nil })
+    end
+
     # Returns the presenter for this author, to be used in the views.
     # Required by ActsAsAuthor.
     def presenter

--- a/decidim-core/app/queries/decidim/user_groups/accepted_memberships.rb
+++ b/decidim-core/app/queries/decidim/user_groups/accepted_memberships.rb
@@ -23,7 +23,7 @@ module Decidim
       # Returns an ActiveRecord::Relation.
       def query
         user_group
-          .memberships
+          .non_deleted_memberships
           .includes(:user)
           .where(role: %w(creator admin member))
       end

--- a/decidim-core/app/queries/decidim/user_groups/admin_memberships.rb
+++ b/decidim-core/app/queries/decidim/user_groups/admin_memberships.rb
@@ -24,7 +24,7 @@ module Decidim
       # Returns an ActiveRecord::Relation.
       def query
         user_group
-          .memberships
+          .non_deleted_memberships
           .includes(:user)
           .where(role: :admin)
       end

--- a/decidim-core/app/queries/decidim/user_groups/member_memberships.rb
+++ b/decidim-core/app/queries/decidim/user_groups/member_memberships.rb
@@ -24,7 +24,7 @@ module Decidim
       # Returns an ActiveRecord::Relation.
       def query
         user_group
-          .memberships
+          .non_deleted_memberships
           .includes(:user)
           .where(role: :member)
       end

--- a/decidim-core/spec/queries/decidim/user_groups/accepted_memberships_spec.rb
+++ b/decidim-core/spec/queries/decidim/user_groups/accepted_memberships_spec.rb
@@ -13,6 +13,8 @@ describe Decidim::UserGroups::AcceptedMemberships do
   let!(:admin) { create :user_group_membership, user_group: user_group, role: :admin }
   let!(:member) { create :user_group_membership, user_group: user_group, role: :member }
   let!(:requested) { create :user_group_membership, user_group: user_group, role: :requested }
+  let(:deleted_user) { create :user, :deleted, organization: organization }
+  let!(:deleted_member) { create :user_group_membership, user_group: user_group, role: :member, user: deleted_user }
 
   it "finds the active memberships for the user group" do
     expect(subject).to match_array([creator, admin, member])

--- a/decidim-core/spec/queries/decidim/user_groups/admin_memberships_spec.rb
+++ b/decidim-core/spec/queries/decidim/user_groups/admin_memberships_spec.rb
@@ -13,6 +13,8 @@ describe Decidim::UserGroups::AdminMemberships do
   let!(:admin) { create :user_group_membership, user_group: user_group, role: :admin }
   let!(:member) { create :user_group_membership, user_group: user_group, role: :member }
   let!(:requested) { create :user_group_membership, user_group: user_group, role: :requested }
+  let(:deleted_user) { create :user, :deleted, organization: organization }
+  let!(:deleted_member) { create :user_group_membership, user_group: user_group, role: :member, user: deleted_user }
 
   it "finds the admin memberships for the user group" do
     expect(subject).to match_array([admin])

--- a/decidim-core/spec/queries/decidim/user_groups/member_memberships_spec.rb
+++ b/decidim-core/spec/queries/decidim/user_groups/member_memberships_spec.rb
@@ -12,6 +12,8 @@ describe Decidim::UserGroups::MemberMemberships do
   let!(:creator) { create :user_group_membership, user_group: user_group, role: :creator }
   let!(:admin) { create :user_group_membership, user_group: user_group, role: :admin }
   let!(:member) { create :user_group_membership, user_group: user_group, role: :member }
+  let(:deleted_user) { create :user, :deleted, organization: organization }
+  let!(:deleted_member) { create :user_group_membership, user_group: user_group, role: :member, user: deleted_user }
   let!(:requested) { create :user_group_membership, user_group: user_group, role: :requested }
 
   it "finds the member memberships for the user group" do


### PR DESCRIPTION
#### :tophat: What? Why?
When accessing the list of memebrs in a user group, sometimes a deleted user is rendered. This causes a server error and nothing is rendered. This PR fixes it.

#### :pushpin: Related Issues
None

#### Testing
Ensure CI is green.