### PR TITLE
Fix report mailers when author is a meeting

### DIFF
--- a/decidim-core/app/views/decidim/reported_mailer/report.html.erb
+++ b/decidim-core/app/views/decidim/reported_mailer/report.html.erb
@@ -35,7 +35,15 @@
   <% if author_profile_url.present? %>
     <p><%= link_to @author.name, author_profile_url, target: :blank %></p>
   <% else %>
-    <p><%= @author.name %></p>
+    <p>
+      <%=
+        if @author.respond_to?(:name)
+          @author.name
+        elsif @author.respond_to?(:title)
+          translated_attribute(@author.title)
+        end
+        %>
+    </p>
   <% end %>
 <% end %>
 <br>

--- a/decidim-core/app/views/decidim/reported_mailer/report.html.erb
+++ b/decidim-core/app/views/decidim/reported_mailer/report.html.erb
@@ -42,7 +42,7 @@
         elsif @author.respond_to?(:title)
           translated_attribute(@author.title)
         end
-        %>
+      %>
     </p>
   <% end %>
 <% end %>

--- a/decidim-core/spec/mailers/reported_mailer_spec.rb
+++ b/decidim-core/spec/mailers/reported_mailer_spec.rb
@@ -107,7 +107,7 @@ module Decidim
             reportable.coauthorships.destroy_all
             create :coauthorship, coauthorable: reportable, author: meeting
 
-            expect(email_body(mail)).to match(translated meeting.title)
+            expect(email_body(mail)).to match(translated(meeting.title))
           end
         end
       end

--- a/decidim-core/spec/mailers/reported_mailer_spec.rb
+++ b/decidim-core/spec/mailers/reported_mailer_spec.rb
@@ -7,7 +7,7 @@ module Decidim
     let(:organization) { create(:organization, name: "Test Organization") }
     let(:user) { create(:user, :admin, organization: organization) }
     let(:component) { create(:component, organization: organization) }
-    let(:reportable) { create(:proposal, title: Decidim::Faker::Localized.sentence, body: Decidim::Faker::Localized.paragraph(sentence_count: 3)) }
+    let(:reportable) { create(:proposal, title: Decidim::Faker::Localized.sentence, body: Decidim::Faker::Localized.paragraph(3)) }
     let(:moderation) { create(:moderation, reportable: reportable, participatory_space: component.participatory_space, report_count: 1) }
     let(:author) { reportable.creator_identity }
     let!(:report) { create(:report, moderation: moderation, details: "bacon eggs spam") }
@@ -50,31 +50,15 @@ module Decidim
         end
 
         it "includes the reported content" do
-          expect(email_body(mail)).to match("(ID: #{reportable.id})")
           expect(email_body(mail)).to match(reportable.title["en"])
           expect(email_body(mail)).to match(reportable.body["en"])
         end
 
-        it "renders the organization default language when the content language cannot be deduced by the reported content itself" do
-          report.moderation.reportable.title = nil
-          report.moderation.reportable.body = nil
+        it "doesn't include the reported content if it's not present" do
+          reportable.title = nil
+          reportable.body = nil
 
-          expect(email_body(mail)).to match("<b>Content original language</b>")
-          expect(email_body(mail)).to match("English")
-        end
-
-        it "includes the content original language when only one language is present" do
-          report.moderation.reportable.title = { "ca" => "title", "machine_translations" => { "fi" => "title", "se" => "title" } }
-
-          expect(email_body(mail)).to match("<b>Content original language</b>")
-          expect(email_body(mail)).to match(I18n.t("locale.name", locale: "ca"))
-        end
-
-        it "includes the content original language as the organization's default when the content has more than one language" do
-          report.moderation.reportable.title = { "ca" => "title", "fi" => "title", "se" => "title" }
-
-          expect(email_body(mail)).to match("<b>Content original language</b>")
-          expect(email_body(mail)).to match(I18n.t("locale.name", locale: organization.default_locale))
+          expect(email_body(mail)).not_to match("<b>Content</b>")
         end
 
         context "when the author is a user" do
@@ -96,6 +80,18 @@ module Decidim
 
           it "includes the name of the organization" do
             expect(email_body(mail)).to match(author.name)
+          end
+        end
+
+        context "when the author is a meeting" do
+          let(:meetings_component) { create :component, manifest_name: :meetings, organization: reportable.organization }
+          let!(:meeting) { create :meeting, component: meetings_component }
+
+          it "includes the title of the meeting" do
+            reportable.coauthorships.destroy_all
+            create :coauthorship, coauthorable: reportable, author: meeting
+
+            expect(email_body(mail)).to match(translated meeting.title)
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
When a proposal is reported and the author is ameeting, the report email fails to be rendered because it tries to render `author.name` but meetings have a `title` field.

This PR fixes this error.

https://sentry.io/share/issue/ffd341a1bc624bc9a731fac77a75f7b8/

#### :pushpin: Related Issues
None

#### Testing
Ensure CI is green.