### PR TITLE
Don't render a moderation when its reportable is deleted

### DIFF
--- a/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
@@ -33,6 +33,7 @@
         </thead>
         <tbody>
           <% moderations.each do |moderation| %>
+            <% next unless moderation.reportable %>
             <tr data-id="<%= moderation.id %>">
               <td><%= moderation.reportable.id %></td>
               <td>

--- a/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
@@ -91,6 +91,15 @@ shared_examples "manage moderations" do
       reported_content_slice = moderation.reportable.reported_searchable_content_text.split("\n").first
       expect(page).to have_content(reported_content_slice)
     end
+
+    context "when the reported content does not exist" do
+      it "still renders the page" do
+        moderation.reportable.destroy
+        visit current_path
+
+        expect(page).to have_no_selector("tr[data-id=\"#{moderation.id}\"]")
+      end
+    end
   end
 
   context "when listing hidden resources" do


### PR DESCRIPTION
#### :tophat: What? Why?
When a reported resource is deleted, the moderation panels fail to render. This PR skips the moderation in those cases.

#### :pushpin: Related Issues
- Fixes #7601

#### Testing
Ensure CI is green.