### PR TITLE
Show newer meetings first

### DIFF
--- a/decidim-meetings/app/controllers/decidim/meetings/admin/application_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/application_controller.rb
@@ -13,7 +13,7 @@ module Decidim
         helper_method :meetings, :meeting
 
         def meetings
-          @meetings ||= Meeting.where(component: current_component).order(:start_time).page(params[:page]).per(15)
+          @meetings ||= Meeting.where(component: current_component).order(start_time: :desc).page(params[:page]).per(15)
         end
 
         def meeting

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -90,7 +90,7 @@ module Decidim
       end
 
       def meetings
-        @meetings ||= paginate(search.results.order(:start_time))
+        @meetings ||= paginate(search.results.order(start_time: :desc))
       end
 
       def registration

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
@@ -19,6 +19,16 @@ describe "Admin manages meetings", type: :system, serves_map: true, serves_geoco
     stub_geocoding(address, [latitude, longitude])
   end
 
+  describe "listing meetings" do
+    it "lists the meetings by start date" do
+      old_meeting = create :meeting, scope: scope, services: [], component: current_component, start_time: 2.years.ago
+      visit current_path
+
+      expect(page).to have_selector("tbody tr:first-child", text: Decidim::Meetings::MeetingPresenter.new(meeting).title)
+      expect(page).to have_selector("tbody tr:last-child", text: Decidim::Meetings::MeetingPresenter.new(old_meeting).title)
+    end
+  end
+
   describe "admin form" do
     before { click_on "New meeting" }
 


### PR DESCRIPTION
#### :tophat: What? Why?
PR #6975 changed the column by which meetings are sorted (from `created_at` to `start_date`), which makes total sense. But it also changed the criteria to sort them (it showed the oldest ones first).

This PR swaps the order criteria to show the newest ones first, sorted by the same column:

BEFORE:
![image](https://user-images.githubusercontent.com/491891/112135139-be2b5700-8bcd-11eb-9896-edbc9aae7386.png)

AFTER:
![image](https://user-images.githubusercontent.com/491891/112135074-ae137780-8bcd-11eb-8192-0553553a24e3.png)

#### :pushpin: Related Issues
- Related to #6975
- Fixes #7602

#### Testing
Nothing.
