### PR TITLE
Only show moderations from current organization in Global Moderation panel

### DIFF
--- a/decidim-admin/app/controllers/concerns/decidim/admin/global_moderation_context.rb
+++ b/decidim-admin/app/controllers/concerns/decidim/admin/global_moderation_context.rb
@@ -15,9 +15,8 @@ module Decidim
         end
 
         # Private: Finds the participatory spaces the current user is admin to.
-        # This is only used for users that are "participatoy space admins", not
-        # organization-wide admins. This method will later be used to find out
-        # what moderations can the current user manage.
+        # This method will later be used to find out what moderations the
+        # current user can manage.
         #
         # Returns an Array.
         def spaces_user_is_admin_to

--- a/decidim-admin/app/controllers/concerns/decidim/admin/global_moderation_context.rb
+++ b/decidim-admin/app/controllers/concerns/decidim/admin/global_moderation_context.rb
@@ -27,7 +27,8 @@ module Decidim
                 .find_participatory_space_manifest(manifest.name)
                 .participatory_spaces
                 .call(current_organization)&.select do |space|
-                  space.moderators.exists?(id: current_user.id)
+                  space.moderators.exists?(id: current_user.id) ||
+                    space.admins.exists?(id: current_user.id)
                 end
             end
         end
@@ -39,11 +40,7 @@ module Decidim
         # Returns an `ActiveRecord::Relation`
         def moderations_for_user
           @moderations_for_user ||=
-            if current_user.admin?
-              Decidim::Moderation.all
-            else
-              Decidim::Moderation.where(participatory_space: spaces_user_is_admin_to)
-            end
+            Decidim::Moderation.where(participatory_space: spaces_user_is_admin_to)
         end
       end
     end

--- a/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
@@ -24,6 +24,16 @@ shared_examples "manage moderations" do
   end
 
   context "when listing moderations" do
+    it "only lists moderations for the current organization" do
+      external_reportable = create :dummy_resource
+      external_moderation = create(:moderation, reportable: external_reportable, report_count: 1, reported_content: external_reportable.reported_searchable_content_text)
+      create(:report, moderation: external_moderation)
+
+      visit current_path
+
+      expect(page).to have_no_selector("tr[data-id=\"#{external_moderation.id}\"]")
+    end
+
     it "user can review them" do
       moderations.each do |moderation|
         within "tr[data-id=\"#{moderation.id}\"]" do


### PR DESCRIPTION
#### :tophat: What? Why?
While investigating https://github.com/decidim/decidim/issues/7604 I realized the global moderation panel was showing data from other organizations when the user was an organization admin.

#### :pushpin: Related Issues
- Related to #7604


#### Testing
Ensure CI is green.