### PR TITLE
Fix form builder assuming proposals module availability

### DIFF
--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -622,7 +622,7 @@ module Decidim
       length_validator = find_validator(attribute, ActiveModel::Validations::LengthValidator)
       return length_validator.options[type] if length_validator
 
-      length_validator = find_validator(attribute, ProposalLengthValidator)
+      length_validator = find_validator(attribute, ProposalLengthValidator) if Object.const_defined?("ProposalLengthValidator")
       if length_validator
         length = length_validator.options[type]
         return length.call(object) if length.respond_to?(:call)

--- a/decidim-core/spec/lib/form_builder_spec.rb
+++ b/decidim-core/spec/lib/form_builder_spec.rb
@@ -20,6 +20,7 @@ module Decidim
         include TranslatableAttributes
 
         attribute :slug, String
+        attribute :proposal_title, String
         attribute :category_id, Integer
         attribute :number, Integer
         attribute :max_number, Integer
@@ -34,6 +35,10 @@ module Decidim
         translatable_attribute :short_description, String
 
         validates :slug, presence: true
+        validates :proposal_title, proposal_length: {
+          minimum: 15,
+          maximum: ->(_record) { 50 }
+        }
         validates :number, length: { minimum: 10, maximum: 30 }
         validates :max_number, length: { maximum: 50 }
         validates :min_number, length: { minimum: 10 }
@@ -469,6 +474,48 @@ module Decidim
 
           it "injects presence validations" do
             expect(parsed.css("input[required='required']")).not_to be_empty
+          end
+
+          it "injects a span to show an error" do
+            expect(parsed.css("span.form-error")).not_to be_empty
+          end
+
+          context "when the validation has a condition and it is false" do
+            let(:output) do
+              builder.text_field :conditional_presence
+            end
+
+            it "does not inject the presence validations" do
+              expect(parsed.css("input[required='required']")).to be_empty
+            end
+
+            it "does nto inject a span to show an error" do
+              expect(parsed.css("span.form-error")).to be_empty
+            end
+          end
+
+          context "without the proposals module" do
+            before do
+              allow(Object).to receive(:const_defined?).and_call_original
+              allow(Object).to receive(:const_defined?).with(
+                "ProposalLengthValidator"
+              ).and_return(false)
+              allow(builder).to receive(:find_validator).and_call_original
+            end
+
+            it "injects the validations and does not reference ProposalLengthValidator" do
+              expect(builder).not_to receive(:find_validator).with(
+                :number,
+                ProposalLengthValidator
+              )
+              output # Calls the builder
+            end
+          end
+        end
+
+        context "with proposal length validation" do
+          let(:output) do
+            builder.text_field :proposal_title
           end
 
           it "injects a span to show an error" do


### PR DESCRIPTION
#### :tophat: What? Why?
When you don't install the proposals module, the form builder will assume its presence.

#### Testing
- Install Decidim without the proposals module
- Go to any page with forms (which is any page when logged out, as the login form is displayed)

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.