### PR TITLE
Make API commentable mutation translation attributes optional

### DIFF
--- a/decidim-comments/lib/decidim/comments/mutation_extensions.rb
+++ b/decidim-comments/lib/decidim/comments/mutation_extensions.rb
@@ -16,26 +16,26 @@ module Decidim
 
           argument :id, GraphQL::Types::String, "The commentable's ID", required: true
           argument :type, GraphQL::Types::String, "The commentable's class name. i.e. `Decidim::ParticipatoryProcess`", required: true
-          argument :locale, GraphQL::Types::String, "The locale for which to get the comments text", required: true
-          argument :toggle_translations, GraphQL::Types::Boolean, "Whether the user asked to toggle the machine translations or not.", required: true
+          argument :locale, GraphQL::Types::String, "The locale for which to get the comments text", required: false
+          argument :toggle_translations, GraphQL::Types::Boolean, "Whether the user asked to toggle the machine translations or not.", required: false
         end
 
         type.field :comment, Decidim::Comments::CommentMutationType, null: false do
           description "A comment"
 
           argument :id, GraphQL::Types::ID, "The comment's id", required: true
-          argument :locale, GraphQL::Types::String, "The locale for which to get the comments text", required: true
-          argument :toggle_translations, GraphQL::Types::Boolean, "Whether the user asked to toggle the machine translations or not.", required: true
+          argument :locale, GraphQL::Types::String, "The locale for which to get the comments text", required: false
+          argument :toggle_translations, GraphQL::Types::Boolean, "Whether the user asked to toggle the machine translations or not.", required: false
         end
       end
 
-      def commentable(id:, locale:, toggle_translations:, type:)
+      def commentable(id:, type:, locale: Decidim.default_locale, toggle_translations: false)
         I18n.locale = locale.presence
         RequestStore.store[:toggle_machine_translations] = toggle_translations
         type.constantize.find(id)
       end
 
-      def comment(id:, locale:, toggle_translations:)
+      def comment(id:, locale: Decidim.default_locale, toggle_translations: false)
         I18n.locale = locale.presence
         RequestStore.store[:toggle_machine_translations] = toggle_translations
         Comment.find(id)

--- a/decidim-comments/spec/types/mutation_type_spec.rb
+++ b/decidim-comments/spec/types/mutation_type_spec.rb
@@ -17,6 +17,16 @@ module Decidim
         it "fetches the commentable given its id and commentable_type" do
           expect(response["commentable"]).to include("id" => commentable.id.to_s)
         end
+
+        context "without locale and toggleTranslations arguments" do
+          let(:query) do
+            "{ commentable(id: \"#{commentable.id}\", type: \"#{commentable.commentable_type}\") { id } }"
+          end
+
+          it "fetches the commentable given its id and commentable_type" do
+            expect(response["commentable"]).to include("id" => commentable.id.to_s)
+          end
+        end
       end
 
       describe "comment" do
@@ -25,6 +35,14 @@ module Decidim
 
         it "fetches the comment given its id" do
           expect(response["comment"]).to include("id" => comment.id.to_s)
+        end
+
+        context "without locale and toggleTranslations arguments" do
+          let(:query) { "{ comment(id: \"#{comment.id}\") { id } }" }
+
+          it "fetches the commentable given its id and commentable_type" do
+            expect(response["comment"]).to include("id" => comment.id.to_s)
+          end
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Backports the fix from #7655 to 0.24.

#### :pushpin: Related Issues
- Related to #7655

#### Testing
See #7655

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.