### PR TITLE
Fix link to "Getting started guide" in README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -73,7 +73,7 @@ decidim decidim_application
 ----
 
 We've set up a guide on how to install, set up and upgrade Decidim.
-See the https://github.com/decidim/decidim/blob/develop/docs/getting_started.md[Getting started guide].
+See the https://docs.decidim.org/en/install/[Getting started guide].
 
 == How to contribute
 


### PR DESCRIPTION
#### :tophat: What? Why?
The link to the "Getting started guide" in README.adoc is broken. I'm not sure, whether the link I changed it to is the correct one.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
