### PR TITLE
Fix the screen reader class name for comments opinion toggle

### DIFF
--- a/decidim-comments/app/cells/decidim/comments/comments/add_comment.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/add_comment.erb
@@ -16,7 +16,7 @@
           <%= icon "thumb-down", role: "presentation", "aria-hidden": true %>
           <span class="show-for-sr"><%= t("decidim.components.add_comment_form.opinion.negative") %></span>
         </button>
-        <div aria-role="alert" aria-live="assertive" aria-atomic="true" class="selected-state shot-for-sr"></div>
+        <div aria-role="alert" aria-live="assertive" aria-atomic="true" class="selected-state show-for-sr"></div>
       </div>
     <% end %>
     <%== cell("decidim/comments/comment_form", model, root_depth: root_depth) %>


### PR DESCRIPTION
#### :tophat: What? Why?
In #7657 the screen reader announce element had a typo. This fixes it.

#### :pushpin: Related Issues
- Related to #7657

#### Testing
See the opinion toggle element for comments.

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.