### PR TITLE
Bump mimemagic to 0.3.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -554,7 +554,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -554,7 +554,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -554,7 +554,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)


### PR DESCRIPTION
#### :tophat: What? Why?
`mimemagic` 0.3.5 and all previous versions have been yanked. Only 0.3.6 and 0.4.0 are available. The reason seems to be this: https://github.com/minad/mimemagic/issues/97 This makes our tests fail.

This PR updates the dependency so tests can pass again.

#### :pushpin: Related Issues
None

#### Testing
Ensure CI is green.