### PR TITLE
Add admin missing translations

### DIFF
--- a/decidim-admin/app/assets/javascripts/decidim/admin/application.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/application.js.es6
@@ -31,6 +31,11 @@
 // = require decidim/geocoding/attach_input
 // = require decidim/session_timeouter
 // = require_self
+// = require decidim/configuration
+// = require decidim/icon
+// = require decidim/external_link
+// = require decidim/form_validator
+
 
 window.Decidim = window.Decidim || {};
 window.DecidimAdmin = window.DecidimAdmin || {};

--- a/decidim-admin/app/assets/javascripts/decidim/admin/application.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/application.js.es6
@@ -32,10 +32,6 @@
 // = require decidim/session_timeouter
 // = require_self
 // = require decidim/configuration
-// = require decidim/icon
-// = require decidim/external_link
-// = require decidim/form_validator
-
 
 window.Decidim = window.Decidim || {};
 window.DecidimAdmin = window.DecidimAdmin || {};

--- a/decidim-admin/app/views/layouts/decidim/admin/_application.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_application.html.erb
@@ -28,6 +28,6 @@
     </div>
     <%= render partial: "layouts/decidim/admin/template_bottom" %>
     <%= render partial: "decidim/shared/confirm_modal" %>
-    <%= render partial: "layouts/decidim/js_configuration" %>
+    <%= render partial: "layouts/decidim/admin/js_configuration" %>
   </body>
 </html>

--- a/decidim-admin/app/views/layouts/decidim/admin/_application.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_application.html.erb
@@ -28,5 +28,6 @@
     </div>
     <%= render partial: "layouts/decidim/admin/template_bottom" %>
     <%= render partial: "decidim/shared/confirm_modal" %>
+    <%= render partial: "layouts/decidim/js_configuration" %>
   </body>
 </html>

--- a/decidim-admin/app/views/layouts/decidim/admin/_js_configuration.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_js_configuration.html.erb
@@ -1,0 +1,26 @@
+<%
+js_configs = {
+  icons_path: image_path("decidim/icons.svg"),
+  messages: {
+    "selfxssWarning": {
+      title: t("decidim.security.selfxss_warning.title"),
+      description: t("decidim.security.selfxss_warning.description")
+    }
+  }
+}
+character_messages = {
+  "charactersAtLeast": {
+    one: t("forms.length_validator.minimum.one", count: "%count%", default: "forms.length_validator.minimum.other"),
+    other: t("forms.length_validator.minimum.other", count: "%count%")
+  },
+  "charactersLeft": {
+    one: t("decidim.components.add_comment_form.remaining_characters_1", count: "%count%"),
+    other: t("decidim.components.add_comment_form.remaining_characters", count: "%count%")
+  }
+}
+%>
+
+<script>
+  Decidim.config.set(<%== js_configs.to_json %>);
+  Decidim.InputCharacterCounter.configureMessages(<%== character_messages.to_json %>);
+</script>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1541,8 +1541,8 @@ en:
     correct_errors: There are errors on the form, please correct them to continue.
     length_validator:
       minimum:
-        one: at least %{count} character
-        other: at least %{count} characters
+        one: At least %{count} character
+        other: At least %{count} characters
     required: Required field
     required_explanation: "* Required fields are marked with an asterisk"
   invisible_captcha:

--- a/decidim-proposals/app/assets/javascripts/decidim/proposals/admin/proposals_form.js.es6
+++ b/decidim-proposals/app/assets/javascripts/decidim/proposals/admin/proposals_form.js.es6
@@ -21,7 +21,7 @@ $(() => {
     $proposalCreatedInMeeting.on("change", toggleDisabledHiddenFields);
     toggleDisabledHiddenFields();
 
-    const $proposalAddress= $form.find("#proposal_address");
+    const $proposalAddress = $form.find("#proposal_address");
     if ($proposalAddress.length !== 0) {
       attachGeocoding($proposalAddress);
     }

--- a/decidim-proposals/app/assets/javascripts/decidim/proposals/admin/proposals_form.js.es6
+++ b/decidim-proposals/app/assets/javascripts/decidim/proposals/admin/proposals_form.js.es6
@@ -21,6 +21,9 @@ $(() => {
     $proposalCreatedInMeeting.on("change", toggleDisabledHiddenFields);
     toggleDisabledHiddenFields();
 
-    attachGeocoding($form.find("#proposal_address"));
+    const $proposalAddress= $form.find("#proposal_address");
+    if ($proposalAddress.length !== 0) {
+      attachGeocoding($proposalAddress);
+    }
   }
 });

--- a/decidim-proposals/spec/system/edit_collaborative_draft_spec.rb
+++ b/decidim-proposals/spec/system/edit_collaborative_draft_spec.rb
@@ -84,7 +84,7 @@ describe "Edit collaborative_drafts", type: :system do
           click_button "Send"
         end
 
-        expect(page).to have_content("at least 15 characters", count: 2)
+        expect(page).to have_content("At least 15 characters", count: 2)
 
         within "form.edit_collaborative_draft" do
           fill_in :collaborative_draft_body, with: "WE DO NOT WANT TO SHOUT IN THE PROPOSAL BODY TEXT!"

--- a/decidim-proposals/spec/system/edit_proposal_spec.rb
+++ b/decidim-proposals/spec/system/edit_proposal_spec.rb
@@ -120,7 +120,7 @@ describe "Edit proposals", type: :system do
           click_button "Send"
         end
 
-        expect(page).to have_content("at least 15 characters", count: 2)
+        expect(page).to have_content("At least 15 characters", count: 2)
 
         within "form.edit_proposal" do
           fill_in :proposal_body, with: "WE DO NOT WANT TO SHOUT IN THE PROPOSAL BODY TEXT!"

--- a/decidim-proposals/spec/system/new_proposals_spec.rb
+++ b/decidim-proposals/spec/system/new_proposals_spec.rb
@@ -43,7 +43,7 @@ describe "Proposals", type: :system do
 
       it "has helper character counter" do
         within "form.new_proposal" do
-          expect(find(".editor").sibling(".form-input-extra-before")).to have_content("at least 15 characters", count: 1)
+          expect(find(".editor").sibling(".form-input-extra-before")).to have_content("At least 15 characters", count: 1)
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
In the admin panel there is a message that is not translated.
When editing an official Proposal the title length validator message always appears in English because translations are not loaded into JavaScript.

This PR also changes the case of the first letter of the `form.length_validator` message. This is: "at least 15 characters" to "At least 15 characters". This way the message doesn't start with downcase in the first part and changes to uppercase in the second part. Second part ("150 characters left") can't be changed because it is reused from `decidim-comments` module where it is used alone.

While working on this PR I also found a JS error when loading the edit proposal page when the proposal has no address. This is also fixed in commit https://github.com/decidim/decidim/pull/7702/commits/105c5f49d93f2fad1915ddb3e6654a0a59bf4460 .

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #?

#### Testing
- Login as an Administrator and, in the admin panel, edit an official proposal
- Change locale to other than English (Catalan or Spanish for example)
- Check that the title length help message with the min characters and remaining characters appears in the current language

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
#### Editing an official Proposal
*Before*
![imatge](https://user-images.githubusercontent.com/199462/112327284-94e5f600-8cb5-11eb-848e-bf6af7f2d29c.png)

*After*
The translation will be corrected in crowdin 
![imatge](https://user-images.githubusercontent.com/199462/112327441-b8a93c00-8cb5-11eb-9902-15755d0b8ce8.png)

:hearts: Thank you!
