### PR TITLE
Fix the aria attribute names (no `aria` prefix)

### DIFF
--- a/decidim-comments/app/assets/javascripts/decidim/comments/comments.component.test.js
+++ b/decidim-comments/app/assets/javascripts/decidim/comments/comments.component.test.js
@@ -321,7 +321,7 @@ describe("CommentsComponent", () => {
                   </svg>
                   <span class="show-for-sr">Negative</span>
                 </button>
-                <div aria-role="alert" aria-live="assertive" aria-atomic="true" class="selected-state shot-for-sr"></div>
+                <div role="alert" aria-live="assertive" aria-atomic="true" class="selected-state shot-for-sr"></div>
               </div>
 
               ${generateCommentForm("Dummy", 123)}

--- a/decidim-comments/app/cells/decidim/comments/comments/add_comment.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/add_comment.erb
@@ -16,7 +16,7 @@
           <%= icon "thumb-down", role: "presentation", "aria-hidden": true %>
           <span class="show-for-sr"><%= t("decidim.components.add_comment_form.opinion.negative") %></span>
         </button>
-        <div aria-role="alert" aria-live="assertive" aria-atomic="true" class="selected-state show-for-sr"></div>
+        <div role="alert" aria-live="assertive" aria-atomic="true" class="selected-state show-for-sr"></div>
       </div>
     <% end %>
     <%== cell("decidim/comments/comment_form", model, root_depth: root_depth) %>

--- a/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
@@ -31,7 +31,7 @@ end
       <div class="footer-separator">
         <!--separates the footer from the rest of the page,
              creates a sticky footer-->
-        <div class="header" aria-role="banner">
+        <div class="header" role="banner">
           <!-- Topbar -->
           <div class="title-bar">
             <%= link_to t("skip_button", scope: "decidim.accessibility"), url_for(anchor: "content"), class: "skip" %>
@@ -106,7 +106,7 @@ end
           <%= yield %>
         </main>
       </div>
-      <div class="footer" aria-role="contentinfo">
+      <div class="footer" role="contentinfo">
         <%= render partial: "layouts/decidim/main_footer" %>
         <%= render partial: "layouts/decidim/mini_footer" %>
       </div>


### PR DESCRIPTION
#### :tophat: What? Why?
The correct name for the WAI-ARIA role attributes is `role`, not `aria-role` as I've mistakenly written.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #7658, #7698

#### Testing
Test the page with accessibility audit tool.

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.