### PR TITLE
Fix dropdown menu accessibility audits

### DIFF
--- a/decidim-core/app/views/decidim/shared/_orders.html.erb
+++ b/decidim-core/app/views/decidim/shared/_orders.html.erb
@@ -7,17 +7,17 @@
       data-disable-hover="true"
       data-click-open="true"
       data-close-on-click="true"
-      tabindex="-1">
-      <li class="is-dropdown-submenu-parent" tabindex="-1">
-        <a href="#" id="<%= menu_id %>-control" aria-controls="<%= menu_id %>" aria-haspopup="true" title="<%= t("#{i18n_scope}.label") %>"><%= t("#{i18n_scope}.#{order}") %></a>
+      role="menubar">
+      <li class="is-dropdown-submenu-parent" role="presentation">
+        <a href="#" id="<%= menu_id %>-control" aria-controls="<%= menu_id %>" aria-haspopup="true" title="<%= t("#{i18n_scope}.label") %>" role="menuitem"><%= t("#{i18n_scope}.#{order}") %></a>
 
-        <ul id="<%= menu_id %>" class="menu" role="menu" aria-labelledby="<%= menu_id %>-control" tabindex="-1">
+        <ul id="<%= menu_id %>" class="menu" role="menu" aria-labelledby="<%= menu_id %>-control">
           <% orders.each do |order_name| %>
-            <li>
+            <li role="presentation">
               <%= order_link order_name,
                           i18n_scope: i18n_scope,
                           title: t("#{i18n_scope}.label"),
-                          tabindex: "-1" %>
+                          role: "menuitem" %>
             </li>
           <% end %>
         </ul>

--- a/decidim-core/app/views/decidim/shared/_results_per_page.html.erb
+++ b/decidim-core/app/views/decidim/shared/_results_per_page.html.erb
@@ -7,18 +7,18 @@
       data-disable-hover="true"
       data-click-open="true"
       data-close-on-click="true"
-      tabindex="-1">
-      <li class="is-dropdown-submenu-parent" tabindex="-1">
-        <a href="#" id="<%= menu_id %>-control" aria-controls="<%= menu_id %>" aria-haspopup="true" title="<%= t("decidim.shared.results_per_page.title") %>"><%= per_page %></a>
-        <ul id="<%= menu_id %>" class="menu" role="menu" aria-labelledby="<%= menu_id %>-control" tabindex="-1">
+      role="menubar">
+      <li class="is-dropdown-submenu-parent" role="presentation">
+        <a href="#" id="<%= menu_id %>-control" aria-controls="<%= menu_id %>" aria-haspopup="true" title="<%= t("decidim.shared.results_per_page.title") %>" role="menuitem"><%= per_page %></a>
+        <ul id="<%= menu_id %>" class="menu" role="menu" aria-labelledby="<%= menu_id %>-control">
           <% Decidim::Paginable::OPTIONS.each do |per_page_option| %>
-            <li>
+            <li role="presentation">
               <%= link_to per_page_option,
                           url_for(params.to_unsafe_h.merge(page: nil, per_page: per_page_option)),
                           data: { per_page_option: per_page_option },
                           remote: true,
                           title: t("decidim.shared.results_per_page.title"),
-                          tabindex: "-1" %>
+                          role: "menuitem" %>
             </li>
           <% end %>
         </ul>

--- a/decidim-core/app/views/layouts/decidim/_language_chooser.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_language_chooser.html.erb
@@ -5,12 +5,12 @@
       data-disable-hover="true"
       data-click-open="true"
       data-close-on-click="true"
-      tabindex="-1">
-      <li class="is-dropdown-submenu-parent" tabindex="-1">
-        <%= link_to t("name", scope: "locale"), "#language-chooser-menu", id: "language-chooser-control", "aria-label": t("layouts.decidim.language_chooser.choose_language"), "aria-controls": "language-chooser-menu", "aria-haspopup": "true" %>
-        <ul class="menu is-dropdown-submenu" id="language-chooser-menu" role="menu" aria-labelledby="language-chooser-control" tabindex="-1">
+      role="menubar">
+      <li class="is-dropdown-submenu-parent" role="presentation">
+        <%= link_to t("name", scope: "locale"), "#language-chooser-menu", id: "language-chooser-control", "aria-label": t("layouts.decidim.language_chooser.choose_language"), "aria-controls": "language-chooser-menu", "aria-haspopup": "true", role: "menuitem" %>
+        <ul class="menu is-dropdown-submenu" id="language-chooser-menu" role="menu" aria-labelledby="language-chooser-control">
           <% (available_locales - [I18n.locale.to_s]).each do |locale| %>
-            <li lang="<%= locale %>"><%= link_to locale_name(locale), decidim.locale_path(locale: locale), method: :post, tabindex: "-1" %></li>
+            <li lang="<%= locale %>" role="presentation"><%= link_to locale_name(locale), decidim.locale_path(locale: locale), method: :post, role: "menuitem" %></li>
           <% end %>
         </ul>
       </li>

--- a/decidim-core/app/views/layouts/decidim/_user_menu.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_user_menu.html.erb
@@ -1,10 +1,10 @@
-<li><%= link_to t(".profile"), decidim.account_path, tabindex: "-1" %></li>
+<li role="presentation"><%= link_to t(".profile"), decidim.account_path, role: "menuitem" %></li>
 <% if current_user.nickname.present? && !current_user.managed? %>
-  <li><%= link_to t(".public_profile"), decidim.profile_path(current_user.nickname), tabindex: "-1" %></li>
+  <li role="presentation"><%= link_to t(".public_profile"), decidim.profile_path(current_user.nickname), role: "menuitem" %></li>
 <% end %>
-<li><%= link_to t(".notifications"), decidim.notifications_path, tabindex: "-1" %></li>
-<li><%= link_to t(".conversations"), decidim.conversations_path, tabindex: "-1" %></li>
+<li role="presentation"><%= link_to t(".notifications"), decidim.notifications_path, role: "menuitem" %></li>
+<li role="presentation"><%= link_to t(".conversations"), decidim.conversations_path, role: "menuitem" %></li>
 <% if allowed_to? :read, :admin_dashboard %>
-  <li><%= link_to t(".admin_dashboard"), decidim_admin.root_path, tabindex: "-1" %></li>
+  <li role="presentation"><%= link_to t(".admin_dashboard"), decidim_admin.root_path, role: "menuitem" %></li>
 <% end %>
-<li><%= link_to t(".sign_out"), decidim.destroy_user_session_path, method: :delete, class: "sign-out-link", tabindex: "-1" %></li>
+<li role="presentation"><%= link_to t(".sign_out"), decidim.destroy_user_session_path, method: :delete, class: "sign-out-link", role: "menuitem" %></li>

--- a/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
@@ -63,10 +63,11 @@ end
                     data-autoclose="false"
                     data-disable-hover="true"
                     data-click-open="true"
-                    data-close-on-click="true">
-                    <li class="is-dropdown-submenu-parent show-for-medium" tabindex="-1">
-                      <%= link_to current_user.name, decidim.account_path, id: "user-menu-control", "aria-controls": "user-menu", "aria-haspopup": "true", "aria-label": t("layouts.decidim.user_menu.account", name: current_user.name) %>
-                      <ul class="menu is-dropdown-submenu" id="user-menu" role="menu" aria-labelledby="user-menu-control" tabindex="-1">
+                    data-close-on-click="true"
+                    role="menubar">
+                    <li class="is-dropdown-submenu-parent show-for-medium" role="presentation">
+                      <%= link_to current_user.name, decidim.account_path, id: "user-menu-control", "aria-controls": "user-menu", "aria-haspopup": "true", "aria-label": t("layouts.decidim.user_menu.account", name: current_user.name), "role": "menuitem" %>
+                      <ul class="menu is-dropdown-submenu" id="user-menu" role="menu" aria-labelledby="user-menu-control">
                         <%= render partial: "layouts/decidim/user_menu" %>
                       </ul>
                       <div data-set="nav-login-holder" class="show-for-medium">


### PR DESCRIPTION
#### :tophat: What? Why?
The dropdown menus are failing audits with [some accessibility audit tools](https://github.com/dequelabs/axe-core) because of the following error:

```
       1) aria-required-children: Certain ARIA roles must contain particular children (critical)
           https://dequeuniversity.com/rules/axe/4.1/aria-required-children?application=axeAPI
           The following 1 node violate this rule:
           
               Selector: .dropdown
               HTML: <ul class="dropdown menu" data-dropdown-menu="iixs77-dropdown-menu" data-autoclose="false" data-disable-hover="true" data-click-open="true" data-close-on-click="true" tabindex="-1" role="menubar">
               Fix any of the following:
               - Required ARIA children role not present: menuitemradio, menuitem, menuitemcheckbox
```

The reason why id doesn't recognize the children is with the `tabindex="-1"` attribute on the elements.

The `tabindex="-1"` was added so that the screen readers would not announce there is a list. But this can be also fixed with proper ARIA roles which this PR adds (and removes the unnecessary `tabindex="-1"`).

#### :pushpin: Related Issues
- Related to #6253

#### Testing
Test the webpage with the linked accessibility audit tool.

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.