### PR TITLE
Add accessibility labels to the `<nav>` menus

### DIFF
--- a/decidim-admin/app/helpers/decidim/admin/menu_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/menu_helper.rb
@@ -9,7 +9,8 @@ module Decidim
         @main_menu ||= ::Decidim::MenuPresenter.new(
           :admin_menu,
           self,
-          active_class: "is-active"
+          active_class: "is-active",
+          label: t("layouts.decidim.header.main_menu")
         )
       end
 

--- a/decidim-core/app/helpers/decidim/menu_helper.rb
+++ b/decidim-core/app/helpers/decidim/menu_helper.rb
@@ -9,7 +9,8 @@ module Decidim
         :menu,
         self,
         element_class: "main-nav__link",
-        active_class: "main-nav__link--active"
+        active_class: "main-nav__link--active",
+        label: t("layouts.decidim.header.main_menu")
       )
     end
 
@@ -19,7 +20,8 @@ module Decidim
         :user_menu,
         self,
         element_class: "tabs-title",
-        active_class: "is-active"
+        active_class: "is-active",
+        label: t("layouts.decidim.user_menu.title")
       )
     end
   end

--- a/decidim-core/app/presenters/decidim/menu_presenter.rb
+++ b/decidim-core/app/presenters/decidim/menu_presenter.rb
@@ -28,7 +28,7 @@ module Decidim
     end
 
     def render
-      content_tag :nav, class: "main-nav" do
+      content_tag :nav, class: "main-nav", "aria-label": @options.fetch(:label, nil) do
         render_menu
       end
     end

--- a/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
@@ -52,7 +52,7 @@ end
                 </button>
               </div>
               <% if current_user %>
-                <nav class="topbar__dropmenu topbar__user__logged">
+                <nav class="topbar__dropmenu topbar__user__logged" aria-label="<%= t("layouts.decidim.header.user_menu") %>">
                   <%= link_to decidim.notifications_path, class: "topbar__notifications #{current_user.notifications.any? ? "is-active" : ""}" do %>
                     <%= icon "bell", role: "img", aria_label: t("layouts.decidim.user_menu.notifications") %>
                   <% end %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1563,9 +1563,11 @@ en:
         made_with_open_source: Website made with <a target="_blank" href="https://github.com/decidim/decidim">free software</a>.
       header:
         close_menu: Close menu
+        main_menu: Main menu
         navigation: Navigation
         sign_in: Sign In
         sign_up: Sign Up
+        user_menu: User menu
       impersonation_warning:
         close_session: Close session
         description_html: You are managing the participant <b>%{user_name}</b>.
@@ -1594,6 +1596,7 @@ en:
         profile: My account
         public_profile: My public profile
         sign_out: Sign out
+        title: Profile links
       user_profile:
         account: Account
         authorizations: Authorizations

--- a/decidim-system/app/helpers/decidim/system/menu_helper.rb
+++ b/decidim-system/app/helpers/decidim/system/menu_helper.rb
@@ -6,7 +6,11 @@ module Decidim
     module MenuHelper
       # Public: Returns the main menu presenter object
       def main_menu
-        @main_menu ||= ::Decidim::MenuPresenter.new(:system_menu, self)
+        @main_menu ||= ::Decidim::MenuPresenter.new(
+          :system_menu,
+          self,
+          label: t("layouts.decidim.header.main_menu")
+        )
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Adds accessibility labels to the `<nav>` menus in the layout to pass automated accessibility audit checks.

#### Testing
Run the home page HTML through [axe-core](https://github.com/dequelabs/axe-core) when logged in.

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.