### PR TITLE
Fix heading order on the home page

### DIFF
--- a/decidim-core/app/cells/decidim/content_blocks/how_to_participate/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/how_to_participate/show.erb
@@ -1,7 +1,7 @@
 <section class="extended home-section">
   <div class="wrapper-home">
     <div class="row column text-center">
-      <h3 class="heading3"><%= t("decidim.pages.home.extended.how_to_participate") %></h3>
+      <h2 class="heading3"><%= t("decidim.pages.home.extended.how_to_participate") %></h2>
     </div>
     <div class="row small-up-1 medium-up-3 home-bullets">
       <div class="column">
@@ -10,7 +10,7 @@
             <%= icon "meetings", role: "presentation", "aria-hidden": true %>
           </div>
           <div class="home-bullet__desc">
-            <h4 class="heading4"><%= t("decidim.pages.home.extended.meetings") %></h4>
+            <h3 class="heading4"><%= t("decidim.pages.home.extended.meetings") %></h3>
             <p><%= t("decidim.pages.home.extended.meetings_explanation") %></p>
           </div>
         </div>
@@ -21,7 +21,7 @@
             <%= icon "debates", role: "presentation", "aria-hidden": true %>
           </div>
           <div class="home-bullet__desc">
-            <h4 class="heading4"><%= t("decidim.pages.home.extended.debates") %></h4>
+            <h3 class="heading4"><%= t("decidim.pages.home.extended.debates") %></h3>
             <p><%= t("decidim.pages.home.extended.debates_explanation") %></p>
           </div>
         </div>
@@ -32,7 +32,7 @@
             <%= icon "proposals", role: "presentation", "aria-hidden": true %>
           </div>
           <div class="home-bullet__desc">
-            <h4 class="heading4"><%= t("decidim.pages.home.extended.proposals") %></h4>
+            <h3 class="heading4"><%= t("decidim.pages.home.extended.proposals") %></h3>
             <p><%= t("decidim.pages.home.extended.proposals_explanation") %></p>
           </div>
         </div>


### PR DESCRIPTION
#### :tophat: What? Why?
Accessibility rules require the heading order to be logic. This fixes the heading order on the home page.

#### Testing
Test the webpage with the linked accessibility audit tool.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.