### PR TITLE
Simplify codecov statuses

### DIFF
--- a/.github/upload_coverage.sh
+++ b/.github/upload_coverage.sh
@@ -8,7 +8,7 @@ SHA=`jq -r ".pull_request.head.sha // .check_run.head_sha // .after" $EVENT_PAYL
 
 if [ $PRID = "null" ]
 then
-  bash <(curl -s https://codecov.io/bash) -n $REPORT_NAME -C $SHA
+  bash <(curl -s https://codecov.io/bash) -n $REPORT_NAME -C $SHA -F $REPORT_NAME
 else
-  bash <(curl -s https://codecov.io/bash) -n $REPORT_NAME -C $SHA -P $PRID
+  bash <(curl -s https://codecov.io/bash) -n $REPORT_NAME -C $SHA -P $PRID -F $REPORT_NAME
 fi

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,5 +9,6 @@ coverage:
     project:
       default:
         threshold: 0.1%
+        branches: develop
 github_checks:
   annotations: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,6 +9,7 @@ coverage:
     project:
       default:
         threshold: 0.1%
-        branches: develop
+        branches:
+          - develop
 github_checks:
   annotations: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,7 +7,8 @@ ignore:
 coverage:
   status:
     project:
-      default:
+      default: false
+      develop:
         threshold: 0.1%
         branches:
           - develop

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,8 +7,7 @@ ignore:
 coverage:
   status:
     project:
-      default: false
-      develop:
+      default:
         threshold: 0.1%
         flag_coverage_not_uploaded_behavior: exclude
         flags:

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,7 +10,31 @@ coverage:
       default: false
       develop:
         threshold: 0.1%
-        branches:
-          - develop
+        flag_coverage_not_uploaded_behavior: exclude
+        flags:
+          - decidim-accountability
+          - decidim-admin
+          - decidim-api
+          - decidim-assemblies
+          - decidim-blogs
+          - decidim-budgets
+          - decidim-comments
+          - decidim-conferences
+          - decidim-consultations
+          - decidim-core
+          - decidim-debates
+          - decidim-elections
+          - decidim-forms
+          - decidim-generators
+          - decidim-initiatives
+          - decidim-meetings
+          - decidim-pages
+          - decidim-participatory_processes
+          - decidim-proposals
+          - decidim-sortitions
+          - decidim-surveys
+          - decidim-system
+          - decidim-templates
+          - decidim-verifications
 github_checks:
   annotations: false


### PR DESCRIPTION
#### :tophat: What? Why?
After #7693 was merged, at some Prs some modules might not run the jobs. This means Codecov might report a misleading percentage in its "Project" status check.

This Pr removes the project status from all branches except `develop`.

#### :pushpin: Related Issues
#7693

#### Testing
Ensure Codecov status is not triggered by this PR.