### PR TITLE
Add a landmark ARIA role to the cookie banner

### DIFF
--- a/decidim-core/app/views/layouts/decidim/_cookie_warning.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_cookie_warning.html.erb
@@ -1,5 +1,5 @@
 <% unless cookies_accepted? %>
-  <div class="cookie-warning">
+  <div class="cookie-warning" role="region">
     <%= t(".description_html", link: link_to(t(".link_label"), decidim.page_path("terms-and-conditions"), title: t(".link_label"), target: "_blank")) %>
     <div class="cookie-warning__action">
       <%= button_to t(".ok"), decidim.accept_cookies_path, method: :get, remote: true, class: "button tiny cookie-bar__button" %>

--- a/decidim_app-design/app/views/public/partials/_cookie_bar.html.erb
+++ b/decidim_app-design/app/views/public/partials/_cookie_bar.html.erb
@@ -1,4 +1,4 @@
-<div class="cookie-warning">
+<div class="cookie-warning" role="region">
   Aquest lloc web fa servir cookies pròpies i de tercers per millorar
   l’experiència de navegació, i oferir continguts i serveis d’interès.
   En continuar la navegació entenem que s’accepta


### PR DESCRIPTION
#### :tophat: What? Why?
According to some accessibility criteria, all content on the page must be contained within a [landmark role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#landmark_roles):
https://dequeuniversity.com/rules/axe/4.1/region

This adds a `region` landmark role to the cookie warning which is not otherwise contained inside any other landmark.

#### :pushpin: Related Issues
- Related to #5942, #6246, #6124, #5684

#### Testing
Validate any page using [axe-core](https://github.com/dequelabs/axe-core).

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.