### PR TITLE
Evote - identify with access code

### DIFF
--- a/decidim_app-design/app/assets/stylesheets/components/evote/_evote.scss
+++ b/decidim_app-design/app/assets/stylesheets/components/evote/_evote.scss
@@ -17,6 +17,11 @@
     text-align: center;
   }
 
+  &__grid .row {
+    display: block;
+    text-align: left;
+  }
+
   &__content{
     margin: 1rem auto;
 

--- a/decidim_app-design/app/assets/stylesheets/components/evote/_evote.scss
+++ b/decidim_app-design/app/assets/stylesheets/components/evote/_evote.scss
@@ -17,7 +17,7 @@
     text-align: center;
   }
 
-  &__grid .row {
+  &__grid .row{
     display: block;
     text-align: left;
   }

--- a/decidim_app-design/app/views/public/evote-identification.html.erb
+++ b/decidim_app-design/app/views/public/evote-identification.html.erb
@@ -1,0 +1,9 @@
+<%
+@title = "Evote -- Decidim Barcelona"
+%>
+
+<main class="focus">
+<%= partial "focus_top" %>
+<%= partial "focus_header", locals: { step: "identification" } %>
+<%= partial "focus_content", locals: { step: "identification" } %>
+</main>

--- a/decidim_app-design/app/views/public/index.html.erb
+++ b/decidim_app-design/app/views/public/index.html.erb
@@ -279,6 +279,7 @@
             </li>
             <li><%= link_to "Available elections (follows current component list models)", page_path("evote-poll-list") %></li>
             <li><%= link_to "Election landing page", page_path("evote-poll-landing") %></li>
+            <li><%= link_to "Identification with access code", page_path("evote-identification") %></li>
             <li><%= link_to "Question model 1", page_path("evote-1") %></li>
             <li><%= link_to "Question model 2 (+ more info)", page_path("evote-2") %></li>
             <li><%= link_to "Question model 3 (+ counter)", page_path("evote-3") %></li>

--- a/decidim_app-design/app/views/public/partials/_evote_access_code_modal.html.erb
+++ b/decidim_app-design/app/views/public/partials/_evote_access_code_modal.html.erb
@@ -1,0 +1,21 @@
+<div class="reveal" data-reveal id="evote-access-code-modal">
+  <div class="reveal__header">
+    <h3 class="reveal__title">New Access Code</h3>
+    <button class="close-button" data-close aria-label="Close modal" type="button">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+  <p>
+    You need an Access Code to participate. If you didn't get one by postal mail, we can send you a new one.
+  </p>
+  <div class="row">
+    <div class="columns medium-8 medium-offset-2">
+      <button class="button hollow expanded">Send by email to lorem******um@gmail.com</button>
+    </div>
+  </div>
+  <div class="row">
+    <div class="columns medium-8 medium-offset-2">
+      <button class="button hollow expanded">Send by SMS to 652*****8</button>
+    </div>
+  </div>
+</div>

--- a/decidim_app-design/app/views/public/partials/_evote_participating-rights.html.erb
+++ b/decidim_app-design/app/views/public/partials/_evote_participating-rights.html.erb
@@ -6,8 +6,10 @@
       <% if locals[:success] %>
         <div class="callout success mt-s">
           <h5>Your census data is correct!</h5>
-          <p>If you don't have one, you can <a href="#">ask for an Access Code</a>.</p>
+          <p>In order to vote, you will need an Access Code.</p>
+          <p>If you didn't receive one by postal mail, you can <button type="button" class="link" data-open="evote-access-code-modal">ask for one here</button>.</p>
         </div>
+        <%= partial "evote_access_code_modal" %>
       <% elsif locals[:blocked] %>
         <div class="callout alert mt-s">
           <h5>Too many attempts.</h5>

--- a/decidim_app-design/app/views/public/partials/_focus_content.html.erb
+++ b/decidim_app-design/app/views/public/partials/_focus_content.html.erb
@@ -16,6 +16,8 @@
       <%= partial "focus_content_content_confirmed" %>
     <% elsif locals[:step] == 'verify' %>
       <%= partial "focus_content_content_verify" %>
+    <% elsif locals[:step] == 'identification' %>
+      <%= partial "focus_content_content_identification" %>
     <% end %>
   </div>
 </div>

--- a/decidim_app-design/app/views/public/partials/_focus_content_content_identification.html.erb
+++ b/decidim_app-design/app/views/public/partials/_focus_content_content_identification.html.erb
@@ -58,8 +58,8 @@
   </div>
   <p>
     Don't have an access code?
-    <a href="survey">
-      Ask for a new one.
-    </a>
+    <button type="button" class="link" data-open="evote-access-code-modal">Ask for a new one.</button>
   </p>
+
+  <%= partial "evote_access_code_modal" %>
 </div>

--- a/decidim_app-design/app/views/public/partials/_focus_content_content_identification.html.erb
+++ b/decidim_app-design/app/views/public/partials/_focus_content_content_identification.html.erb
@@ -1,0 +1,65 @@
+<h1 class="heading2">
+  Identify myself with my voting census data
+</h1>
+<div class="evote__content">
+  <div class="evote__grid">
+    <div class="row mt-sm">
+      <div class="columns medium-centered large-8">
+        <p class="text-center"><strong>Fill the following form to access the voting:</strong></p>
+        <div class="card">
+          <div class="card__content">
+            <form>
+              <div>
+                <div>
+                  <label>Document type
+                    <select>
+                      <option disabled="" selected="" hidden="">Select the type of document</option>
+                      <option>Passport</option>
+                      <option>DNI</option>
+                    </select>
+                  </label>
+                </div>
+                <div>
+                  <label>Document number
+                    <input type="text" placeholder="ID number">
+                  </label>
+                </div>
+                <div>
+                  <label>Postal code
+                    <input type="text" placeholder="Postal code number">
+                  </label>
+                </div>
+                <fieldset>
+                  <legend>Date of birth</legend>
+                  <div class="row">
+                    <label class="columns small-4">Day
+                      <input type="text" placeholder="DD">
+                    </label>
+                    <label class="columns small-4">Month
+                      <input type="text" placeholder="MM">
+                    </label>
+                    <label class="columns small-4">Year
+                      <input type="text" placeholder="YY">
+                    </label>
+                  </div>
+                </fieldset>
+                <div>
+                  <label>Access code
+                    <input type="text" placeholder="Access code number">
+                  </label>
+                </div>
+              </div>
+              <button type="button" class="button expanded mt-s mb-none">Start voting</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <p>
+    Don't have an access code?
+    <a href="survey">
+      Ask for a new one.
+    </a>
+  </p>
+</div>

--- a/decidim_app-design/app/views/public/partials/_focus_header.html.erb
+++ b/decidim_app-design/app/views/public/partials/_focus_header.html.erb
@@ -14,6 +14,8 @@
     <div class="focus__steps"><strong>Vote confirmed</strong></div>
   <% elsif locals[:step] == 'verify' %>
     <div class="focus__steps"><strong>Verify your vote</strong></div>
+  <% elsif locals[:step] == 'identification' %>
+    <div class="focus__steps"><strong>Identification</strong></div>
   <% end %>
   <div class="heading5 focus__header-title">
       Consulta sobre el sistema de organización del Comité de Fiestas del Barrio del Fort Pienc


### PR DESCRIPTION
#### :tophat: What? Why?
Identify voter with access code and get a new access code flow.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #7114 #7118

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*

Identify voter with census data and access code:
![photo_2021-03-25 17 26 33](https://user-images.githubusercontent.com/468685/112507854-53297e00-8d8f-11eb-9610-66c1d86edb0b.jpeg)

Get a new access code:
![photo_2021-03-25 17 26 27](https://user-images.githubusercontent.com/468685/112507848-515fba80-8d8f-11eb-8469-a347a4e8d225.jpeg)

Updated view to get a new access code if voter's checking her census data:
![photo_2021-03-25 17 26 30](https://user-images.githubusercontent.com/468685/112507851-51f85100-8d8f-11eb-9822-3c6147d4c392.jpeg)

