### PR TITLE
Accessibility fixes for comments

### DIFF
--- a/decidim-comments/app/cells/decidim/comments/comments/add_comment.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/add_comment.erb
@@ -1,5 +1,5 @@
 <div class="add-comment">
-  <h4 class="section-heading"><%= t("decidim.components.add_comment_form.title") %></h4>
+  <h5 class="section-heading"><%= t("decidim.components.add_comment_form.title") %></h5>
 
   <% if user_signed_in? %>
     <% if alignment_enabled? %>

--- a/decidim-comments/app/cells/decidim/comments/comments/order_control.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/order_control.erb
@@ -7,9 +7,8 @@
     data-disable-hover="true"
     data-click-open="true"
     data-close-on-click="true"
-    tabindex="-1"
     role="menubar">
-    <li class="is-dropdown-submenu-parent opens-right" tabindex="-1" role="none">
+    <li class="is-dropdown-submenu-parent opens-right" role="presentation">
       <a href="#" id="comments-order-menu-control"
         aria-label="<%= t("decidim.components.comment_order_selector.title") %>"
         aria-controls="comments-order-menu"
@@ -19,10 +18,9 @@
         id="comments-order-chooser-menu"
         role="menu"
         aria-labelledby="comments-order-menu-control"
-        tabindex="-1"
         data-submenu="">
         <% available_orders.each do |order_value| %>
-          <li role="none" class="is-submenu-item is-dropdown-submenu-item">
+          <li role="presentation" class="is-submenu-item is-dropdown-submenu-item">
             <%= link_to(
               t("decidim.components.comment_order_selector.order.#{order_value}"),
               decidim_comments.comments_path(commentable_gid: model.to_signed_global_id.to_s, order: order_value, reload: 1),

--- a/decidim-comments/app/cells/decidim/comments/comments/show.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/show.erb
@@ -2,7 +2,7 @@
   <div class="columns large-9 comments-container" id="comments">
     <div class="comments">
       <div class="row collapse order-by">
-        <h2 class="order-by__text section-heading">
+        <h4 class="order-by__text section-heading">
           <% if single_comment? %>
             <%= t("decidim.components.comments.comment_details_title") %>
           <% else %>
@@ -10,7 +10,7 @@
               <%= t("decidim.components.comments.title", count: comments_count) %>
             </span>
           <% end %>
-        </h2>
+        </h4>
         <%= render :order_control %>
       </div>
       <%= single_comment_warning %>


### PR DESCRIPTION
#### :tophat: What? Why?
This applies two accessibility fixes to the comments section:
1. Logical headings order (tested on a single proposal page)
2. The order dropdown fix for the [axe-core](https://github.com/dequelabs/axe-core) accessibility audit tool (same fix as #7708)

#### :pushpin: Related Issues
- Related to #7708, #6253

#### Testing
Run the accessibility audit tool on a single proposal page with comments enabled.

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.