### PR TITLE
Add aria-label to the free search field in the search filters

### DIFF
--- a/decidim-budgets/app/views/decidim/budgets/projects/_filters.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_filters.html.erb
@@ -4,7 +4,7 @@
   <div class="filters__section">
     <div class="filters__search">
       <div class="input-group">
-        <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t(".search"), title: t(".search"), data: { disable_dynamic_change: true } %>
+        <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t(".search"), title: t(".search"), "aria-label": t(".search"), data: { disable_dynamic_change: true } %>
         <div class="input-group-button">
           <button type="submit" class="button" aria-controls="projects">
             <%= icon "magnifying-glass", aria_label: t(".search"), role: "img" %>

--- a/decidim-consultations/app/views/decidim/consultations/consultations/_filters.html.erb
+++ b/decidim-consultations/app/views/decidim/consultations/consultations/_filters.html.erb
@@ -9,6 +9,7 @@
                               class: "input-group-field",
                               placeholder: t("consultations.filters.search", scope: "decidim"),
                               title: t("consultations.filters.search", scope: "decidim"),
+                              "aria-label": t("consultations.filters.search", scope: "decidim"),
                               data: { disable_dynamic_change: true } %>
         <div class="input-group-button">
           <button type="submit" class="button" aria-controls="consultations">

--- a/decidim-debates/app/views/decidim/debates/debates/_filters.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/_filters.html.erb
@@ -4,7 +4,7 @@
   <div class="filters__section">
     <div class="filters__search">
       <div class="input-group">
-        <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t(".search"), title: t(".search"), data: { disable_dynamic_change: true } %>
+        <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t(".search"), title: t(".search"), "aria-label": t(".search"), data: { disable_dynamic_change: true } %>
         <div class="input-group-button">
           <button type="submit" class="button" aria-controls="debates">
             <%= icon "magnifying-glass", aria_label: t(".search"), role: "img" %>

--- a/decidim-elections/app/views/decidim/elections/elections/_filters.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/_filters.html.erb
@@ -9,6 +9,7 @@
                               class: "input-group-field",
                               placeholder: t(".search"),
                               title: t(".search"),
+                              "aria-label": t(".search"),
                               data: { disable_dynamic_change: true } %>
         <div class="input-group-button">
           <button type="submit" class="button" aria-controls="elections">

--- a/decidim-elections/app/views/decidim/votings/votings/_filters.html.erb
+++ b/decidim-elections/app/views/decidim/votings/votings/_filters.html.erb
@@ -9,6 +9,7 @@
                               class: "input-group-field",
                               placeholder: t(".search"),
                               title: t(".search"),
+                              "aria-label": t(".search"),
                               data: { disable_dynamic_change: true } %>
         <div class="input-group-button">
           <button type="submit" class="button" aria-controls="votings">

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_filters.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_filters.html.erb
@@ -2,7 +2,7 @@
   <div class="filters__section">
     <div class="filters__search">
       <div class="input-group">
-        <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t(".search"), title: t(".search") %>
+        <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t(".search"), title: t(".search"), "aria-label": t(".search") %>
         <div class="input-group-button">
           <button type="submit" class="button">
             <%= icon "magnifying-glass", aria_label: t(".search"), role: "img" %>

--- a/decidim-meetings/app/views/decidim/meetings/directory/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/directory/meetings/index.html.erb
@@ -13,7 +13,7 @@
           <div class="filters__section">
             <div class="filters__search">
               <div class="input-group">
-                <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t(".search"), title: t(".search") %>
+                <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t(".search"), title: t(".search"), "aria-label": t(".search") %>
                 <div class="input-group-button">
                   <button type="submit" class="button">
                     <%= icon "magnifying-glass", aria_label: t(".search"), role: "img" %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
@@ -4,7 +4,7 @@
   <div class="filters__section">
     <div class="filters__search">
       <div class="input-group">
-        <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t(".search"), title: t(".search"), data: { disable_dynamic_change: true } %>
+        <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t(".search"), title: t(".search"), "aria-label": t(".search"), data: { disable_dynamic_change: true } %>
         <div class="input-group-button">
           <button type="submit" class="button" aria-controls="meetings">
             <%= icon "magnifying-glass", aria_label: t(".search"), role: "img" %>

--- a/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/_filters.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/_filters.html.erb
@@ -4,7 +4,7 @@
   <div class="filters__section">
     <div class="filters__search">
       <div class="input-group">
-        <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t(".search"), title: t(".search"), data: { disable_dynamic_change: true } %>
+        <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t(".search"), title: t(".search"), "aria-label": t(".search"), data: { disable_dynamic_change: true } %>
         <div class="input-group-button">
           <button type="submit" class="button" aria-controls="collaborative_drafts">
             <%= icon "magnifying-glass", aria_label: t(".search"), role: "img" %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
@@ -5,7 +5,7 @@
     <div class="filters__section">
       <div class="filters__search">
         <div class="input-group">
-          <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t(".search"), title: t(".search"), data: { disable_dynamic_change: true } %>
+          <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t(".search"), title: t(".search"), "aria-label": t(".search"), data: { disable_dynamic_change: true } %>
           <div class="input-group-button">
             <button type="submit" class="button" aria-controls="proposals">
               <%= icon "magnifying-glass", aria_label: t(".search"), role: "img" %>

--- a/decidim-sortitions/app/views/decidim/sortitions/sortitions/_filters.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/sortitions/_filters.html.erb
@@ -4,7 +4,7 @@
   <div class="filters__section">
     <div class="filters__search">
       <div class="input-group">
-        <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t(".search"), title: t(".search"), data: { disable_dynamic_change: true } %>
+        <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t(".search"), title: t(".search"), "aria-label": t(".search"), data: { disable_dynamic_change: true } %>
         <div class="input-group-button">
           <button type="submit" class="button" aria-controls="sortitions">
             <%= icon "magnifying-glass", aria_label: t(".search"), role: "img" %>


### PR DESCRIPTION
#### :tophat: What? Why?
The free search field in the filters section has a `title` attribute but the field is missing a `<label>` element.

For accessibility, add the `aria-label` attribute for the search fields to fix the missing `<label>` element.

#### :pushpin: Related Issues
- Related to #5942, #6246, #6124, #5684

#### Testing
Run one of the search pages through an automated accessibility check.

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.