### PR TITLE
Add aria-label to the area filter on participatory space pages

### DIFF
--- a/decidim-core/app/views/decidim/shared/participatory_space_filters/_filters.html.erb
+++ b/decidim-core/app/views/decidim/shared/participatory_space_filters/_filters.html.erb
@@ -5,9 +5,12 @@
   <div class="columns mediumlarge-6 large-5">
     <%= form.areas_select :area_id,
                           areas_for_select(current_organization),
-                          legend_title: t(".areas"),
-                          label: "",
-                          selected: filter.area_id,
-                          include_blank: t(".select_an_area") %>
+                          {
+                            legend_title: t(".areas"),
+                            label: "",
+                            selected: filter.area_id,
+                            include_blank: t(".select_an_area")
+                          },
+                          "aria-label": t(".areas") %>
   </div>
 <% end %>

--- a/decidim-core/lib/decidim/filter_form_builder.rb
+++ b/decidim-core/lib/decidim/filter_form_builder.rb
@@ -55,9 +55,9 @@ module Decidim
     end
 
     # Wrap the areas select in a custom fieldset.
-    def areas_select(method, collection, options = {})
+    def areas_select(method, collection, options = {}, html_options = {})
       fieldset_wrapper(options[:legend_title], "#{method}_areas_select_filter") do
-        super(method, collection, options)
+        super(method, collection, options, html_options)
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
This adds a missing `aria-label` to the area filter on participatory space pages.

All fields need either an associated `<label>` element or `aria-label` attribute.

#### :pushpin: Related Issues
- Related to #5942, #6246, #6124, #5684

#### Testing
Run the processes index page through an automated accessibility check.

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.