### PR TITLE
Fix HTML validation on standalone content page

### DIFF
--- a/decidim-core/app/views/decidim/pages/_standalone.html.erb
+++ b/decidim-core/app/views/decidim/pages/_standalone.html.erb
@@ -6,18 +6,16 @@
       </h1>
     </div>
 
-    <main>
-      <%= cell "decidim/tos_page", :announcement %>
+    <%= cell "decidim/tos_page", :announcement %>
 
-      <div class="columns small-12">
-        <div class="card">
-          <div class="card__content"><%= decidim_sanitize translated_attribute page.content %></div>
-        </div>
+    <div class="columns small-12">
+      <div class="card">
+        <div class="card__content"><%= decidim_sanitize translated_attribute page.content %></div>
       </div>
+    </div>
 
-      <div class="columns small-12">
-        <%= cell "decidim/tos_page", :form %>
-      </div>
-    </main>
+    <div class="columns small-12">
+      <%= cell "decidim/tos_page", :form %>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?
All pages can only have a single `<main>` landmark element.

There is one already in the layout:
https://github.com/decidim/decidim/blob/c56e44f11cdec3fea223a4fa73f060db8603dde2/decidim-core/app/views/layouts/decidim/_wrapper.html.erb#L105

I believe this was already fixed at some point during the first round of accessibility fixes. The change has been reverted or I remember incorrectly.

#### :pushpin: Related Issues
- Related to #5942, #6246, #6124, #5684

#### Testing
Run the standalone content page through an automated accessibility audit tool.

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.