### PR TITLE
Accessibility fixes for conversations

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_conversation.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_conversation.scss
@@ -4,6 +4,11 @@
 
     border-bottom: $border;
 
+    h1{
+      font-size: $global-font-size;
+      font-weight: normal;
+    }
+
     img{
       width: rem-calc(66);
       height: rem-calc(66);

--- a/decidim-core/app/views/decidim/messaging/conversations/_reply.html.erb
+++ b/decidim-core/app/views/decidim/messaging/conversations/_reply.html.erb
@@ -1,7 +1,7 @@
 <div class="conversation-reply conversation-reply--offset">
-  <h5 class="section-heading">
+  <h2 class="section-heading">
     <%= t(".title") %>
-  </h5>
+  </h2>
 
   <%= form_for form, url: decidim.conversation_path(conversation.id), method: :put, remote: true do |f| %>
     <%= f.label :body, nil, class: "show-for-sr" %>

--- a/decidim-core/app/views/decidim/messaging/conversations/_reply.html.erb
+++ b/decidim-core/app/views/decidim/messaging/conversations/_reply.html.erb
@@ -4,6 +4,7 @@
   </h5>
 
   <%= form_for form, url: decidim.conversation_path(conversation.id), method: :put, remote: true do |f| %>
+    <%= f.label :body, nil, class: "show-for-sr" %>
     <%= f.text_area :body, label: false, rows: 4, required: true, placeholder: t(".placeholder") %>
 
     <%= f.submit t(".send"), class: "button pull-right", data: { disable: true } %>

--- a/decidim-core/app/views/decidim/messaging/conversations/_show.html.erb
+++ b/decidim-core/app/views/decidim/messaging/conversations/_show.html.erb
@@ -24,11 +24,13 @@
           <% end %>
 
           <div class="ml-s">
-            <% if participants.count == 1 %>
-              <%= t(".chat_with") %> <strong><%= participants.first.name %></strong><br><span class="muted">@<%= participants.first.nickname %></span>
-            <% else %>
-              <%= t(".title", usernames: username_list(participants)) %>
-            <% end %>
+            <h1>
+              <% if participants.count == 1 %>
+                <%= t(".chat_with") %> <strong><%= participants.first.name %></strong><br><span class="muted">@<%= participants.first.nickname %></span>
+              <% else %>
+                <%= t(".title", usernames: username_list(participants)) %>
+              <% end %>
+            </h1>
           </div>
         </div>
 

--- a/decidim-core/app/views/decidim/messaging/conversations/_start.html.erb
+++ b/decidim-core/app/views/decidim/messaging/conversations/_start.html.erb
@@ -11,6 +11,7 @@
     <% @form.recipient.each do |recipient| %>
       <%= f.hidden_field :recipient_id, id: nil, name: "conversation[recipient_id][]", value: recipient.id %>
     <% end %>
+    <%= f.label :body, nil, class: "show-for-sr" %>
     <%= f.text_area :body, label: false, rows: 4, required: true %>
 
     <%= f.submit t(".send") %>

--- a/decidim-core/app/views/decidim/messaging/conversations/_start.html.erb
+++ b/decidim-core/app/views/decidim/messaging/conversations/_start.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t(".title")) %>
 
 <div class="add-message">
-  <h5 class="section-heading">
+  <h2 class="section-heading">
     <%= t(".title") %>
-  </h5>
+  </h2>
 
   <%= form_for form, url: decidim.conversations_path, remote: true do |f| %>
     <%= form_required_explanation %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -6,6 +6,8 @@ en:
         delete_reason: Reason to delete your account
       common:
         created_at: Created at
+      conversation:
+        body: Body
       group:
         about: About
         avatar: Avatar
@@ -14,6 +16,8 @@ en:
         name: Name
         nickname: Nickname
         phone: Phone
+      message:
+        body: Body
       report:
         details: Additional comments
       user:


### PR DESCRIPTION
#### :tophat: What? Why?
This fixes the following accessibility issues on the conversations pages:
- The body field is missing a label for start new conversation and reply to conversation
- The single conversation page does not have a `<h1>` title element that all pages should have
- Illogical headings order for the section heading at reply and start new conversation

#### :pushpin: Related Issues
- Related to #5942, #6246, #6124, #5684

#### Testing
Run the conversations pages through an automated accessibility audit tool.

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.
