### PR TITLE
Fix report modal form accessibility

### DIFF
--- a/decidim-core/app/cells/decidim/flag_modal/show.erb
+++ b/decidim-core/app/cells/decidim/flag_modal/show.erb
@@ -17,10 +17,10 @@
           [:offensive, t("decidim.shared.flag_modal.offensive")],
           [:does_not_belong, t("decidim.shared.flag_modal.does_not_belong", organization_name: current_organization.name)]
         ], :first, :last do |builder| %>
-          <%= builder.label { builder.radio_button(id: nil) + builder.text } %>
+          <label><%= builder.radio_button(id: nil) + builder.text %></label>
         <% end %>
       </fieldset>
-      <%= f.text_area :details, rows: 4, id: nil %>
+      <%= f.text_area :details, rows: 4, id: "#{modal_id}_details", label_options: { for: "#{modal_id}_details" } %>
       <%= f.submit t("decidim.shared.flag_modal.report") %>
     <% end %>
   <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
There are two accessibility issues in the report (flag) modal which are fixed by this PR:
- The radio buttons do not have an `id` but the label has a `for` attribute. Remove the `for` attribute from the label.
- The details textarea does not have an `id` but its label has a `for` attribute that does not have a corresponding `id`. Make sure the `id` matches with the `for` attribute.

#### :pushpin: Related Issues
- Related to #5942, #6246, #6124, #5684

#### Testing
Run any page (e.g. single proposal page) with flag modals through an automated accessibility audit tool.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing]
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.