### PR TITLE
Validate the HTML for the account page

### DIFF
--- a/decidim-core/app/views/decidim/account/show.html.erb
+++ b/decidim-core/app/views/decidim/account/show.html.erb
@@ -22,7 +22,7 @@
       <% else %>
         <% if current_organization.sign_in_enabled? %>
           <p>
-            <a data-toggle="passwordChange" class="change-password"><%= t ".change_password" %></a>
+            <a data-toggle="passwordChange" class="change-password" href="#passwordChange"><%= t ".change_password" %></a>
           </p>
           <div id="passwordChange" class="toggle-show" data-toggler=".is-expanded">
             <%= render partial: "password_fields", locals: { form: f } %>

--- a/decidim_app-design/app/views/public/user/user-settings.html.erb
+++ b/decidim_app-design/app/views/public/user/user-settings.html.erb
@@ -68,7 +68,7 @@
                         </label>
                       </div>
                       <p>
-                        <a data-toggle="passwordChange">Cambiar contrasenya</a>
+                        <a data-toggle="passwordChange" href="#passwordChange">Cambiar contrasenya</a>
                       </p>
                       <div id="passwordChange" class="toggle-show"
                         data-toggler=".is-expanded">


### PR DESCRIPTION
#### :tophat: What? Why?
On the account page we have an anchor element without the `href` attribute. Anchors need either `href` or a specific custom `role`.

#### :pushpin: Related Issues
- Related to #5942, #6246, #6124, #5684

#### Testing
Run the account managing page through a HTML validator.

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.