### PR TITLE
Fix color contrast against the sidebar navigation background

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/_variables.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/_variables.scss
@@ -11,8 +11,8 @@ $-zf-bp-value: null;
 
 $primary: #cb3c29 !default;
 $primary-rgb: 239,96,77 !default;
-$secondary: #3e7f8b !default;
-$secondary-rgb: 89,154,166 !default;
+$secondary: #39747f !default;
+$secondary-rgb: 57,116,127 !default;
 $success: #57d685 !default;
 $success-rgb: 87,214,133 !default;
 $warning: #ffae00 !default;


### PR DESCRIPTION
#### :tophat: What? Why?
The contrast difference for the link color (secondary color) against the sidebar navigation bacground color is too low for AA level accessibility.

This slightly darkens the default secondary color, so that it passes the color contrast check.

Note that this affects all links and other elements using the secondary color. The color difference is very slight, though (see screenshots).

#### :pushpin: Related Issues
- Related to #5942, #6246, #6124, #5684

#### Testing
1. Go to: https://webaim.org/resources/contrastchecker/
2. Add the old secondary color (`#3e7f8b`) as the foreground color
3. Add the sidebar active link background color (`#e8e8e8`) as the background color
4. See the contrast ratio
5. Repeat the test with the updated foreground color (`#39747f`)

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

Before:
![Profile sidebar links before the change](https://user-images.githubusercontent.com/864340/112531382-2e91ce00-8db0-11eb-94a3-e6d8ba3aea46.png)

After:
![Profile sidebar links after the change](https://user-images.githubusercontent.com/864340/112531421-394c6300-8db0-11eb-9007-5f3ccc3b6365.png)