### PR TITLE
Remove the opacity from process upcoming/past/all filters for accessible contrast

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_order-by.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_order-by.scss
@@ -54,10 +54,6 @@ $order-border: $border;
 
 .order-by__tabs{
   display: inline-block;
-
-  span{
-    opacity: .5;
-  }
 }
 
 .order-by__tab{


### PR DESCRIPTION
#### :tophat: What? Why?
The color contrast between the body background and the time filters for proposals is not sufficient.

This removes the opacity to make the contrast ratio sufficient.

The background color is `#fafafa` and the foreground color is `#b6b2b5` (= `#726a70` with 50% opacity against the background).

#### :pushpin: Related Issues
- Related to #5942, #6246, #6124, #5684

#### Testing
1. Go to: https://webaim.org/resources/contrastchecker/
2. Add the old foreground color (`#b6b2b5`) as the foreground color
3. Add the body background color (`#fafafa`) as the background color
4. See the contrast ratio
5. Repeat the test with the updated foreground color (`#726a70`)

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
Before:
![Process filters before the change](https://user-images.githubusercontent.com/864340/112532892-0905c400-8db2-11eb-9316-94ef89f4e14c.png)

After:
![Process filters after the change](https://user-images.githubusercontent.com/864340/112532922-11f69580-8db2-11eb-807e-92ba77605635.png)