### PR TITLE
Change the timeline date color for accessible color contrast against its background

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/modules/_timeline.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/modules/_timeline.scss
@@ -89,7 +89,7 @@ $timeline-padding: 1rem;
 }
 
 .timeline__date{
-  color: $muted;
+  color: $dark-gray;
 
   .timeline__item--current &{
     color: rgba($white, .8);


### PR DESCRIPTION
#### :tophat: What? Why?
The color contrast between the phases header background and the phase dates for processes is not sufficient.

This darkens the color to make the color contrast difference sufficient.

The background color is `#e8e8e8` and the foreground color is `#97a2b2`.

#### :pushpin: Related Issues
- Related to #5942, #6246, #6124, #5684

#### Testing

1. Go to: https://webaim.org/resources/contrastchecker/
2. Add the old foreground color (`#97a2b2`) as the foreground color
3. Add the body background color (`#e8e8e8`) as the background color
4. See the contrast ratio
5. Repeat the test with the updated foreground color (`#2c2930`)

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
Before:
![Inactive phase header before the change](https://user-images.githubusercontent.com/864340/112533678-e1632b80-8db2-11eb-9131-f59edce9137e.png)

After:
![Inactive phase header after the change](https://user-images.githubusercontent.com/864340/112533704-e9bb6680-8db2-11eb-95ec-00886629afb6.png)