### PR TITLE
Add HTML escaping to the spec expectations as the strings are escaped

### DIFF
--- a/decidim-comments/spec/events/decidim/comments/user_group_mentioned_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/user_group_mentioned_event_spec.rb
@@ -28,7 +28,7 @@ describe Decidim::Comments::UserGroupMentionedEvent do
 
   describe "email_subject" do
     it "is generated correctly" do
-      expect(subject.email_subject).to eq("You have been mentioned in #{translated resource.title} as a member of #{group.name}")
+      expect(subject.email_subject).to eq("You have been mentioned in #{html_escape(translated(resource.title))} as a member of #{html_escape(group.name)}")
     end
   end
 
@@ -41,20 +41,20 @@ describe Decidim::Comments::UserGroupMentionedEvent do
   describe "email_outro" do
     it "is generated correctly" do
       expect(subject.email_outro)
-        .to eq("You have received this notification because you are a member of the group #{group.name} that has been mentioned in #{translated resource.title}.")
+        .to eq("You have received this notification because you are a member of the group #{html_escape(group.name)} that has been mentioned in #{html_escape(translated(resource.title))}.")
     end
   end
 
   describe "notification_title" do
     it "is generated correctly" do
       expect(subject.notification_title)
-        .to include("You have been mentioned in <a href=\"#{resource_path}#comment_#{comment.id}\">#{translated resource.title}</a>")
+        .to include("You have been mentioned in <a href=\"#{resource_path}#comment_#{comment.id}\">#{html_escape(translated(resource.title))}</a>")
 
       expect(subject.notification_title)
-        .to include(" as a member of <a href=\"/profiles/#{group.nickname}\">#{group.name} @#{group.nickname}</a>")
+        .to include(" as a member of <a href=\"/profiles/#{group.nickname}\">#{html_escape(group.name)} @#{group.nickname}</a>")
 
       expect(subject.notification_title)
-        .to include(" by <a href=\"/profiles/#{comment_author.nickname}\">#{comment_author.name} @#{comment_author.nickname}</a>")
+        .to include(" by <a href=\"/profiles/#{comment_author.nickname}\">#{html_escape(comment_author.name)} @#{comment_author.nickname}</a>")
     end
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?
This spec failed for me locally because some of the names contained single quote characters.

This adds HTML escaping to the expectations to match what is generated by the event class.

The failures that I saw:

```
  1) Decidim::Comments::UserGroupMentionedEvent email_outro is generated correctly
     Failure/Error:
       expect(subject.email_outro)
         .to eq("You have received this notification because you are a member of the group #{group.name} that has been mentioned in #{translated resource.title}.")
     
       expected: "You have received this notification because you are a member of the group Mayer, O'Reilly and Bauch 22 that has been mentioned in Lanny Flatley 146."
            got: "You have received this notification because you are a member of the group Mayer, O&#39;Reilly and Bauch 22 that has been mentioned in Lanny Flatley 146."
     
       (compared using ==)
     # ./spec/events/decidim/comments/user_group_mentioned_event_spec.rb:51:in `block (3 levels) in <top (required)>'

  2) Decidim::Comments::UserGroupMentionedEvent email_subject when the group name contains HTML-escapable characters is generated correctly
     Failure/Error: expect(subject.email_subject).to eq("You have been mentioned in #{translated resource.title} as a member of #{group.name}")
     
       expected: "You have been mentioned in Chara Tillman 174 as a member of O'Group"
            got: "You have been mentioned in Chara Tillman 174 as a member of O&#39;Group"
```

#### Testing
Force e.g. the group name to be generated using a string that contains characters that need HTML escaping. For example:

```ruby
  let(:group) { create :user_group, name: "O'Group", organization: comment.organization, users: [comment.author, member] }
```

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.