### PR TITLE
Fix map accessibility issue - Map bottom position missing label

### DIFF
--- a/decidim-core/app/helpers/decidim/map_helper.rb
+++ b/decidim-core/app/helpers/decidim/map_helper.rb
@@ -93,16 +93,17 @@ module Decidim
       end
 
       map_html_options = { id: "map", class: "google-map" }.merge(html_options)
+      bottom_id = "#{map_html_options[:id]}_bottom"
 
       help = content_tag(:div, class: "map__help") do
         sr_content = content_tag(:p, t("screen_reader_explanation", scope: "decidim.map.dynamic"), class: "show-for-sr")
-        link = link_to(t("skip_button", scope: "decidim.map.dynamic"), "#map_bottom", class: "skip")
+        link = link_to(t("skip_button", scope: "decidim.map.dynamic"), "##{bottom_id}", class: "skip")
 
         sr_content + link
       end
       content_tag :div, class: "row column" do
         map = builder.map_element(map_html_options, &block)
-        bottom = content_tag(:div, "", id: "map_bottom")
+        bottom = content_tag(:div, "", id: bottom_id)
 
         help + map + bottom
       end

--- a/decidim-core/app/helpers/decidim/map_helper.rb
+++ b/decidim-core/app/helpers/decidim/map_helper.rb
@@ -102,9 +102,9 @@ module Decidim
       end
       content_tag :div, class: "row column" do
         map = builder.map_element(map_html_options, &block)
-        link = link_to("", "#", id: "map_bottom")
+        bottom = content_tag(:div, "", id: "map_bottom")
 
-        help + map + link
+        help + map + bottom
       end
     end
 

--- a/decidim-core/lib/decidim/core/test/shared_examples/map_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/map_examples.rb
@@ -74,7 +74,13 @@ shared_context "with frontend map elements" do
           #{head_extra}
         </head>
         <body>
-          #{document_inner}
+          <header>
+            <a href="#content">Skip to main content</a>
+          </header>
+          <main id="content">
+            <h1>Map Test</h1>
+            #{document_inner}
+          </main>
           <script type="text/javascript">
             // This is just to indicate to Capybara that the page has fully
             // finished loading.
@@ -119,16 +125,27 @@ shared_examples "a page with dynamic map" do
     let(:html_body) do
       builder = subject
       template.instance_eval do
-        builder.map_element(id: "map", class: "google-map") do
-          content_tag(:span, "", id: "map_inner")
+        # Create two separate map elements to make sure generating multiple
+        # map elements won't produce any HTML or accessibility validation
+        # errors.
+        content = builder.map_element(id: "map1", class: "google-map") do
+          content_tag(:span, "", id: "map1_inner")
         end
+        content += builder.map_element(id: "map2", class: "google-map") do
+          content_tag(:span, "", id: "map2_inner")
+        end
+        content
       end
     end
   end
 
-  it "displays the map" do
-    expect(page).to have_selector("#map.google-map", visible: :all)
-    expect(page).to have_selector("#map_inner", visible: :all)
+  it_behaves_like "accessible page"
+
+  it "displays the maps" do
+    expect(page).to have_selector("#map1.google-map", visible: :all)
+    expect(page).to have_selector("#map1_inner", visible: :all)
+    expect(page).to have_selector("#map2.google-map", visible: :all)
+    expect(page).to have_selector("#map2_inner", visible: :all)
   end
 end
 

--- a/decidim-core/spec/system/map/dynamic_map/builder_spec.rb
+++ b/decidim-core/spec/system/map/dynamic_map/builder_spec.rb
@@ -12,11 +12,17 @@ module Decidim
           # inspection in the rspec expectations.
           <<~HEAD
             <script type="text/javascript">
+              window.mapIndex = 1;
               L.tileLayer = function(url, config) {
-                $("body").append('<div id="tile_layer_url"></div>');
-                $("body").append('<div id="tile_layer_config"></div>');
-                $("#tile_layer_url").text(url);
-                $("#tile_layer_config").text(JSON.stringify(config));
+                var urlId = "tile_layer_url" + window.mapIndex;
+                var configId = "tile_layer_config" + window.mapIndex;
+
+                $("#content").append('<div id="' + urlId + '"></div>');
+                $("#content").append('<div id="' + configId + '"></div>');
+                $("#" + urlId).text(url);
+                $("#" + configId).text(JSON.stringify(config));
+
+                window.mapIndex++;
 
                 var mockLayer = { addTo: function(target) {} };
                 return mockLayer;
@@ -27,11 +33,11 @@ module Decidim
 
         it "sets up the tile layer" do
           expect(page).to have_selector(
-            "#tile_layer_url",
+            "#tile_layer_url1",
             text: options[:tile_layer][:url]
           )
           expect(page).to have_selector(
-            "#tile_layer_config",
+            "#tile_layer_config1",
             text: options[:tile_layer][:options].to_json
           )
         end

--- a/decidim-core/spec/system/map/provider/dynamic_map/here_builder_spec.rb
+++ b/decidim-core/spec/system/map/provider/dynamic_map/here_builder_spec.rb
@@ -23,9 +23,14 @@ module Decidim
               # further inspection in the rspec expectations.
               <<~HEAD
                 <script type="text/javascript">
+                window.mapIndex = 1;
                   L.tileLayer.here = function(config) {
-                    $("body").append('<div id="tile_layer_config"></div>');
-                    $("#tile_layer_config").text(JSON.stringify(config));
+                    var configId = "tile_layer_config" + window.mapIndex;
+
+                    $("#content").append('<div id="' + configId + '"></div>');
+                    $("#" + configId).text(JSON.stringify(config));
+
+                    window.mapIndex++;
 
                     var mockLayer = { addTo: function(target) {} };
                     return mockLayer;
@@ -36,7 +41,7 @@ module Decidim
 
             it "sets up the tile layer" do
               expect(page).to have_selector(
-                "#tile_layer_config",
+                "#tile_layer_config1",
                 text: options[:tile_layer][:options].to_json
               )
             end


### PR DESCRIPTION
#### :tophat: What? Why?
Right now we have a bottom position for the map indicated by an anchor element `<a>`. It is missing a label which is required for all `<a>` elements. This changes the element to a `<div>` which doesn't require a label.

This also makes sure that the bottom element ID is unique when there are multiple maps on the same page.

Also, I added accessibility + HTML validation tests for the map specs. They are now also testing the case with two separate maps on the same page.

#### :pushpin: Related Issues
- Related to #5942, #6246, #6124, #5684

#### Testing
Run the modified map specs.

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.