### PR TITLE
Move votings answer results to its own table

### DIFF
--- a/decidim-elections/app/cells/decidim/elections/election_results/show.erb
+++ b/decidim-elections/app/cells/decidim/elections/election_results/show.erb
@@ -27,18 +27,18 @@
 
                 <div class="progress__bar">
                   <div class="evote__preview-bar">
-                    <div class="progress progress__bar__bar" role="progressbar" tabindex="0" aria-valuenow="<%= votes_percentage_for(answer) %>%" aria-valuemin="0" aria-valuetext="<%= votes_percentage_for(answer) %>% percent" aria-valuemax="100">
-                      <div class="progress-meter progress__bar__bar--complete" style="width: <%= votes_percentage_for(answer) %>%"></div>
-                      <div class="progress__bar__bar--incomplete" style="width:calc(100% - <%= votes_percentage_for(answer) %>%);"></div>
+                    <div class="progress progress__bar__bar" role="progressbar" tabindex="0" aria-valuenow="<%= answer.results_percentage %>%" aria-valuemin="0" aria-valuetext="<%= answer.results_percentage %>% percent" aria-valuemax="100">
+                      <div class="progress-meter progress__bar__bar--complete" style="width: <%= answer.results_percentage %>%"></div>
+                      <div class="progress__bar__bar--incomplete" style="width:calc(100% - <%= answer.results_percentage %>%);"></div>
                     </div>
 
                     <div class="evote__preview-perc">
-                      <%= votes_percentage_for(answer) %>%
+                      <%= answer.results_percentage %>%
                     </div>
                   </div>
 
                   <div class="evote__preview-label">
-                    <%= t("decidim.elections.elections.results.votes", count: answer.votes_count) %>
+                    <%= t("decidim.elections.elections.results.votes", count: answer.results_total) %>
                   </div>
                 </div>
               </div>

--- a/decidim-elections/app/cells/decidim/elections/election_results_cell.rb
+++ b/decidim-elections/app/cells/decidim/elections/election_results_cell.rb
@@ -8,12 +8,6 @@ module Decidim
       def show
         render if model.results_published?
       end
-
-      private
-
-      def votes_percentage_for(answer)
-        answer.question.votes_percentage(answer.votes_count)
-      end
     end
   end
 end

--- a/decidim-elections/app/commands/decidim/elections/admin/update_answer_selection.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/update_answer_selection.rb
@@ -27,7 +27,7 @@ module Decidim
         attr_reader :answer, :selected
 
         def invalid?
-          !answer.question.total_votes.positive?
+          !answer.question.results_total.positive?
         end
 
         def update_answer_selection!

--- a/decidim-elections/app/commands/decidim/elections/trustee_zone/update_election_bulletin_board_status.rb
+++ b/decidim-elections/app/commands/decidim/elections/trustee_zone/update_election_bulletin_board_status.rb
@@ -42,8 +42,7 @@ module Decidim
               result_key = get_answer_id_from_result(key)
               answers = Decidim::Elections::Answer.where(id: result_key)
               answers.each do |answer|
-                answer.votes_count = value
-                answer.save!
+                answer.results.create(votes_count: value)
               end
             end
           end

--- a/decidim-elections/app/commands/decidim/elections/trustee_zone/update_election_bulletin_board_status.rb
+++ b/decidim-elections/app/commands/decidim/elections/trustee_zone/update_election_bulletin_board_status.rb
@@ -42,7 +42,7 @@ module Decidim
               result_key = get_answer_id_from_result(key)
               answers = Decidim::Elections::Answer.where(id: result_key)
               answers.each do |answer|
-                answer.results.create(votes_count: value)
+                answer.results.create!(votes_count: value)
               end
             end
           end

--- a/decidim-elections/app/models/decidim/elections/election.rb
+++ b/decidim-elections/app/models/decidim/elections/election.rb
@@ -92,8 +92,7 @@ module Decidim
       #
       # Returns a boolean.
       def results_published?
-        # doubt: when results are published?
-        bb_results_published? || questions.all? { |question| question.results_total > 1 }
+        bb_results_published?
       end
 
       # Public: Checks if the election results are present

--- a/decidim-elections/app/models/decidim/elections/election.rb
+++ b/decidim-elections/app/models/decidim/elections/election.rb
@@ -92,7 +92,8 @@ module Decidim
       #
       # Returns a boolean.
       def results_published?
-        bb_results_published?
+        # doubt: when results are published?
+        bb_results_published? || questions.all? { |question| question.results_total > 1 }
       end
 
       # Public: Checks if the election results are present

--- a/decidim-elections/app/models/decidim/elections/question.rb
+++ b/decidim-elections/app/models/decidim/elections/question.rb
@@ -23,19 +23,12 @@ module Decidim
         max_selections <= answers.count
       end
 
-      def total_votes
-        answers.sum(:votes_count)
+      def results_total
+        answers.sum(&:results_total)
       end
 
       def slug
         "question-#{id}"
-      end
-
-      def votes_percentage(answer_votes)
-        return 0 unless answer_votes.positive?
-
-        result = answer_votes.to_f / total_votes * 100.0
-        result.round
       end
     end
   end

--- a/decidim-elections/app/models/decidim/elections/result.rb
+++ b/decidim-elections/app/models/decidim/elections/result.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Elections
+    # The data store for a Result in the Decidim::Elections component.
+    class Result < ApplicationRecord
+      include Traceable
+      include Loggable
+
+      belongs_to :answer, foreign_key: "decidim_elections_answer_id", class_name: "Decidim::Elections::Answer", inverse_of: :results
+      belongs_to :polling_station, foreign_key: "decidim_votings_polling_station_id", class_name: "Decidim::Votings::PollingStation", optional: true
+
+      validates :decidim_elections_answer_id, uniqueness: { scope: :polling_station }
+      validates :decidim_votings_polling_station_id, uniqueness: { scope: :answer }
+    end
+  end
+end

--- a/decidim-elections/app/views/decidim/elections/admin/answers/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/answers/index.html.erb
@@ -35,7 +35,7 @@
               </td>
               <% if election.results? %>
                 <td>
-                  <%= answer.votes_count %>
+                  <%= answer.results_total %>
                 </td>
                 <% if answer.selected %>
                   <td class="success">

--- a/decidim-elections/app/views/decidim/elections/admin/steps/_results_published.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/steps/_results_published.html.erb
@@ -26,10 +26,10 @@
                     <% question.answers.each do |answer| %>
                       <tr>
                         <td><%= translated_attribute(answer.title) %></td>
-                        <% if answer.votes_count > 0 %>
-                          <td class="text-success"><%= answer.votes_count %></td>
+                        <% if answer.results_total > 0 %>
+                          <td class="text-success"><%= answer.results_total %></td>
                         <% else %>
-                          <td><%= answer.votes_count %></td>
+                          <td><%= answer.results_total %></td>
                         <% end %>
                         <% if answer.selected %>
                           <td class="text-success"><%= t(".selected") %></td>
@@ -38,6 +38,12 @@
                         <% end %>
                       </tr>
                     <% end %>
+
+                    <tr>
+                      <td></td>
+                      <td class="text-muted"><%= question.results_total %></td>
+                      <td></td>
+                    </tr>
                   </tbody>
                 </table>
               </div>

--- a/decidim-elections/app/views/decidim/elections/admin/steps/_tally_ended.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/steps/_tally_ended.html.erb
@@ -26,10 +26,10 @@
                     <% question.answers.each do |answer| %>
                       <tr>
                         <td><%= translated_attribute(answer.title) %></td>
-                        <% if answer.votes_count > 0 %>
-                          <td class="text-success"><%= answer.votes_count %></td>
+                        <% if answer.results_total > 0 %>
+                          <td class="text-success"><%= answer.results_total %></td>
                         <% else %>
-                          <td><%= answer.votes_count %></td>
+                          <td><%= answer.results_total %></td>
                         <% end %>
                         <% if answer.selected %>
                           <td class="text-success"><%= t(".selected") %></td>
@@ -38,6 +38,12 @@
                         <% end %>
                       </tr>
                     <% end %>
+
+                    <tr>
+                      <td></td>
+                      <td class="text-muted"><%= question.results_total %></td>
+                      <td></td>
+                    </tr>
                   </tbody>
                 </table>
               </div>

--- a/decidim-elections/app/views/decidim/elections/elections/_results.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/_results.html.erb
@@ -25,16 +25,16 @@
 
                   <div class="progress__bar">
                     <div class="evote__preview-bar">
-                      <div class="progress progress__bar__bar" role="progressbar" tabindex="0" aria-valuenow="<%= answer.question.votes_percentage(answer.votes_count) %>%" aria-valuemin="0" aria-valuetext="<%= answer.question.votes_percentage(answer.votes_count) %>% percent" aria-valuemax="100">
-                        <div class="progress-meter progress__bar__bar--complete" style="width: <%= answer.question.votes_percentage(answer.votes_count) %>%"></div>
-                        <div class="progress__bar__bar--incomplete" style="width:calc(100% - <%= answer.question.votes_percentage(answer.votes_count) %>%);"></div>
+                      <div class="progress progress__bar__bar" role="progressbar" tabindex="0" aria-valuenow="<%= answer.results_percentage %>%" aria-valuemin="0" aria-valuetext="<%= answer.results_percentage %>% percent" aria-valuemax="100">
+                        <div class="progress-meter progress__bar__bar--complete" style="width: <%= answer.results_percentage %>%"></div>
+                        <div class="progress__bar__bar--incomplete" style="width:calc(100% - <%= answer.results_percentage %>%);"></div>
                       </div>
                       <div class="evote__preview-perc">
-                        <%= answer.question.votes_percentage(answer.votes_count) %>%
+                        <%= answer.results_percentage %>%
                       </div>
                       </div>
                       <div class="evote__preview-label">
-                        <%= t(".votes", count: answer.votes_count) %>
+                        <%= t(".votes", count: answer.results_total) %>
                       </div>
                     </div>
                   </div>

--- a/decidim-elections/db/migrate/20210326090435_create_elections_results.rb
+++ b/decidim-elections/db/migrate/20210326090435_create_elections_results.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateElectionsResults < ActiveRecord::Migration[5.2]
+  def change
+    create_table :decidim_elections_results do |t|
+      t.integer :votes_count, default: 0, null: false
+
+      t.belongs_to :decidim_elections_answer, index: true
+      t.belongs_to :decidim_votings_polling_station,
+                   null: true,
+                   index: { name: "index_decidim_elections_results_on_polling_station_id" }
+
+      t.timestamps
+    end
+  end
+end

--- a/decidim-elections/db/migrate/20210330102348_remove_votes_count_from_answer.rb
+++ b/decidim-elections/db/migrate/20210330102348_remove_votes_count_from_answer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveVotesCountFromAnswer < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :decidim_elections_answers, :votes_count
+  end
+end

--- a/decidim-elections/lib/decidim/api/election_answer_type.rb
+++ b/decidim-elections/lib/decidim/api/election_answer_type.rb
@@ -14,10 +14,11 @@ module Decidim
       field :title, Decidim::Core::TranslatedFieldType, "The title for this answer", null: false
       field :description, Decidim::Core::TranslatedFieldType, "The description for this answer", null: true
       field :weight, GraphQL::Types::Int, "The ordering weight for this answer", null: true
-      field :votes_count, GraphQL::Types::Int, "The votes for this answer", null: true, camelize: false
+      field :results_total, GraphQL::Types::Int, "The total sum of votes for this answer", null: true, camelize: false
       field :selected, GraphQL::Types::Boolean, "Is this answer selected?", null: true
 
       field :proposals, [Decidim::Proposals::ProposalType, { null: true }], "The proposals related to this answer", null: true
+      field :results, [Decidim::Elections::ElectionResultType, { null: true }], "The voting results related to this answer", null: true
     end
   end
 end

--- a/decidim-elections/lib/decidim/api/election_result_type.rb
+++ b/decidim-elections/lib/decidim/api/election_result_type.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Elections
+    # This type represents a result of an answer to an election question.
+    class ElectionResultType < Decidim::Api::Types::BaseObject
+      description "A voting result for an answer"
+
+      field :id, GraphQL::Types::ID, "The internal ID of this result", null: false
+      field :votes_count, GraphQL::Types::Int, "The vote count", null: false
+    end
+  end
+end

--- a/decidim-elections/lib/decidim/api/election_result_type.rb
+++ b/decidim-elections/lib/decidim/api/election_result_type.rb
@@ -7,7 +7,11 @@ module Decidim
       description "A voting result for an answer"
 
       field :id, GraphQL::Types::ID, "The internal ID of this result", null: false
+      field :created_at, Decidim::Core::DateTimeType, "When this result was created", null: true
+      field :updated_at, Decidim::Core::DateTimeType, "When this result was updated", null: true
       field :votes_count, GraphQL::Types::Int, "The vote count", null: false
+      field :answer, Decidim::Elections::ElectionAnswerType, "The answer for this result", null: false
+      field :polling_station, Decidim::Votings::PollingStationType, null: true
     end
   end
 end

--- a/decidim-elections/lib/decidim/api/polling_station_type.rb
+++ b/decidim-elections/lib/decidim/api/polling_station_type.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Votings
+    # This type represents a polling station.
+    class PollingStationType < Decidim::Api::Types::BaseObject
+      description "A polling station for a voting"
+
+      field :id, GraphQL::Types::ID, "The internal ID of this polling station", null: false
+      field :title, Decidim::Core::TranslatedFieldType, "The title for this polling station", null: true
+      field :address, GraphQL::Types::String, "The physical address of this polling station (used for geolocation)", null: true
+      field :coordinates, Decidim::Core::CoordinatesType, "Physical coordinates for this polling station", null: true
+      field :location, Decidim::Core::TranslatedFieldType, "The location of this polling station (free format)", null: true
+      field :location_hints, Decidim::Core::TranslatedFieldType, "The location of this polling station (free format)", null: true
+      field :created_at, Decidim::Core::DateTimeType, "When this polling station was created", null: true
+      field :updated_at, Decidim::Core::DateTimeType, "When this polling station was updated", null: true
+      field :voting, Decidim::Votings::VotingType, null: false
+
+      def coordinates
+        [object.latitude, object.longitude]
+      end
+    end
+  end
+end

--- a/decidim-elections/lib/decidim/elections/answer_serializer.rb
+++ b/decidim-elections/lib/decidim/elections/answer_serializer.rb
@@ -28,7 +28,7 @@ module Decidim
           question_title: question.title,
           answer_id: answer.id,
           answer_title: answer.title,
-          answer_votes: answer.votes_count
+          answer_votes: answer.results_total
         }
       end
 

--- a/decidim-elections/lib/decidim/elections/api.rb
+++ b/decidim-elections/lib/decidim/elections/api.rb
@@ -2,6 +2,7 @@
 
 module Decidim
   module Elections
+    autoload :ElectionResultType, "decidim/api/election_result_type"
     autoload :ElectionAnswerType, "decidim/api/election_answer_type"
     autoload :ElectionQuestionType, "decidim/api/election_question_type"
     autoload :ElectionType, "decidim/api/election_type"

--- a/decidim-elections/lib/decidim/elections/component.rb
+++ b/decidim-elections/lib/decidim/elections/component.rb
@@ -133,8 +133,7 @@ Decidim.register_component(:elections) do |component|
                 Decidim::Faker::Localized.paragraph(sentence_count: 3)
               end,
               weight: Faker::Number.number(digits: 1),
-              selected: Faker::Boolean.boolean(true_ratio: 0.2), # false
-              votes_count: 0
+              selected: Faker::Boolean.boolean(true_ratio: 0.2) # false
             },
             visibility: "all"
           )
@@ -227,8 +226,7 @@ Decidim.register_component(:elections) do |component|
                 Decidim::Faker::Localized.paragraph(sentence_count: 3)
               end,
               weight: Faker::Number.number(digits: 1),
-              selected: Faker::Boolean.boolean(true_ratio: 0.2), # false
-              votes_count: 0
+              selected: Faker::Boolean.boolean(true_ratio: 0.2) # false
             },
             visibility: "all"
           )
@@ -323,8 +321,7 @@ Decidim.register_component(:elections) do |component|
                 Decidim::Faker::Localized.paragraph(sentence_count: 3)
               end,
               weight: Faker::Number.number(digits: 1),
-              selected: Faker::Boolean.boolean(true_ratio: 0.5),
-              votes_count: Faker::Number.number(digits: 3)
+              selected: Faker::Boolean.boolean(true_ratio: 0.5)
             },
             visibility: "all"
           )
@@ -334,6 +331,11 @@ Decidim.register_component(:elections) do |component|
             description: Decidim::Faker::Localized.sentence(word_count: 5),
             attached_to: answer,
             file: File.new(File.join(__dir__, "seeds", "city.jpeg")) # Keep after attached_to
+          )
+
+          Decidim::Elections::Result.create!(
+            votes_count: Faker::Number.number(digits: 3),
+            answer: answer
           )
         end
 
@@ -416,8 +418,7 @@ Decidim.register_component(:elections) do |component|
               Decidim::Faker::Localized.paragraph(sentence_count: 3)
             end,
             weight: Faker::Number.number(digits: 1),
-            selected: Faker::Boolean.boolean(true_ratio: 0.2), # false
-            votes_count: 0
+            selected: Faker::Boolean.boolean(true_ratio: 0.2) # false
           },
           visibility: "all"
         )

--- a/decidim-elections/lib/decidim/elections/test/factories.rb
+++ b/decidim-elections/lib/decidim/elections/test/factories.rb
@@ -116,10 +116,10 @@ FactoryBot.define do
       finished
       bb_status { "vote_ended" }
 
-      after(:build) do |election|
+      after(:create) do |election|
         election.questions.each do |question|
           question.answers.each do |answer|
-            answer.votes_count = Faker::Number.number(digits: 1)
+            create(:election_result, answer: answer)
           end
         end
       end
@@ -219,10 +219,11 @@ FactoryBot.define do
     description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     weight { Faker::Number.number(digits: 1) }
     selected { false }
-    votes_count { 0 }
 
     trait :with_votes do
-      votes_count { Faker::Number.number(digits: 1) }
+      after(:build) do |answer|
+        create(:election_result, answer: answer)
+      end
     end
 
     trait :with_photos do
@@ -239,6 +240,15 @@ FactoryBot.define do
           )
         end
       end
+    end
+  end
+
+  factory :election_result, class: "Decidim::Elections::Result" do
+    answer { create :election_answer }
+    votes_count { Faker::Number.number(digits: 1) }
+
+    trait :with_polling_station do
+      polling_station
     end
   end
 

--- a/decidim-elections/lib/decidim/votings/api.rb
+++ b/decidim-elections/lib/decidim/votings/api.rb
@@ -3,5 +3,6 @@
 module Decidim
   module Votings
     autoload :VotingType, "decidim/api/voting_type"
+    autoload :PollingStationType, "decidim/api/polling_station_type"
   end
 end

--- a/decidim-elections/spec/lib/decidim/elections/answer_serializer_spec.rb
+++ b/decidim-elections/spec/lib/decidim/elections/answer_serializer_spec.rb
@@ -32,8 +32,8 @@ module Decidim
           end
         end
 
-        it "serializes the votes" do
-          expect(serialized[:answer_votes]).to eq(answer.votes_count)
+        it "serializes the results total" do
+          expect(serialized[:answer_votes]).to eq(answer.results_total)
         end
 
         it "serializes the election id" do

--- a/decidim-elections/spec/system/admin/admin_manages_election_steps_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_election_steps_spec.rb
@@ -219,7 +219,7 @@ describe "Admin manages election steps", :vcr, :billy, :slow, type: :system do
         expect(page).to have_content("Calculated results")
         expect(page).to have_content(translated(question.title))
         expect(page).to have_content(translated(answer.title))
-        expect(page).to have_content(answer.votes_count)
+        expect(page).to have_content(answer.results_total)
       end
     end
   end

--- a/decidim-elections/spec/types/decidim/elections/election_answer_type_spec.rb
+++ b/decidim-elections/spec/types/decidim/elections/election_answer_type_spec.rb
@@ -50,11 +50,11 @@ module Decidim
         end
       end
 
-      describe "votes" do
-        let(:query) { "{ votes_count }" }
+      describe "results_total" do
+        let(:query) { "{ results_total }" }
 
         it "returns the votes for this answer" do
-          expect(response["votes_count"]).to eq(model.votes_count)
+          expect(response["results_total"]).to eq(model.results_total)
         end
       end
 

--- a/decidim-elections/spec/types/decidim/elections/election_result_type_spec.rb
+++ b/decidim-elections/spec/types/decidim/elections/election_result_type_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/api/test/type_context"
+require "decidim/core/test/shared_examples/traceable_interface_examples"
+
+module Decidim
+  module Elections
+    describe ElectionResultType, type: :graphql do
+      include_context "with a graphql class type"
+
+      let(:polling_station) { create(:polling_station) }
+      let(:model) { create(:election_result) }
+
+      describe "id" do
+        let(:query) { "{ id }" }
+
+        it "returns all the required fields" do
+          expect(response).to include("id" => model.id.to_s)
+        end
+      end
+
+      describe "votes_count" do
+        let(:query) { "{ votesCount }" }
+
+        it "returns the votes for this answer" do
+          expect(response["votesCount"]).to eq(model.votes_count)
+        end
+      end
+    end
+  end
+end

--- a/decidim-elections/spec/types/decidim/elections/election_result_type_spec.rb
+++ b/decidim-elections/spec/types/decidim/elections/election_result_type_spec.rb
@@ -10,21 +10,53 @@ module Decidim
       include_context "with a graphql class type"
 
       let(:polling_station) { create(:polling_station) }
-      let(:model) { create(:election_result) }
+      let(:model) { create(:election_result, polling_station: polling_station) }
 
       describe "id" do
         let(:query) { "{ id }" }
 
         it "returns all the required fields" do
-          expect(response).to include("id" => model.id.to_s)
+          expect(response["id"]).to eq(model.id.to_s)
         end
       end
 
       describe "votes_count" do
         let(:query) { "{ votesCount }" }
 
-        it "returns the votes for this answer" do
+        it "returns the votes count" do
           expect(response["votesCount"]).to eq(model.votes_count)
+        end
+      end
+
+      describe "createdAt" do
+        let(:query) { "{ createdAt }" }
+
+        it "returns when the voting was created" do
+          expect(response["createdAt"]).to eq(model.created_at.to_time.iso8601)
+        end
+      end
+
+      describe "updatedAt" do
+        let(:query) { "{ updatedAt }" }
+
+        it "returns when the voting was updated" do
+          expect(response["updatedAt"]).to eq(model.updated_at.to_time.iso8601)
+        end
+      end
+
+      describe "answer" do
+        let(:query) { "{ answer { id } }" }
+
+        it "returns the answer for this result" do
+          expect(response["answer"]["id"]).to eq(model.answer.id.to_s)
+        end
+      end
+
+      describe "polling station" do
+        let(:query) { "{ pollingStation { id } }" }
+
+        it "returns the polling station for this result" do
+          expect(response["pollingStation"]["id"]).to eq(model.polling_station.id.to_s)
         end
       end
     end

--- a/decidim-elections/spec/types/decidim/votings/polling_station_type_spec.rb
+++ b/decidim-elections/spec/types/decidim/votings/polling_station_type_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/api/test/type_context"
+
+module Decidim
+  module Votings
+    describe PollingStationType, type: :graphql do
+      include_context "with a graphql class type"
+
+      let(:model) { create(:polling_station) }
+
+      describe "id" do
+        let(:query) { "{ id }" }
+
+        it "returns all the required fields" do
+          expect(response["id"]).to eq(model.id.to_s)
+        end
+      end
+
+      describe "title" do
+        let(:query) { "{ title { translation(locale: \"ca\") } }" }
+
+        it "returns the polling station's title" do
+          expect(response["title"]["translation"]).to eq(model.title["ca"])
+        end
+      end
+
+      describe "address" do
+        let(:query) { "{ address }" }
+
+        it "returns the polling station's address" do
+          expect(response["address"]).to eq(model.address)
+        end
+      end
+
+      describe "coordinates" do
+        let(:query) { "{ coordinates { latitude longitude } }" }
+
+        it "returns the polling station's address" do
+          expect(response["coordinates"]).to include(
+            "latitude" => model.latitude,
+            "longitude" => model.longitude
+          )
+        end
+      end
+
+      describe "location" do
+        let(:query) { "{ location { translation(locale: \"ca\") } }" }
+
+        it "returns the polling station's location" do
+          expect(response["location"]["translation"]).to eq(model.location["ca"])
+        end
+      end
+
+      describe "locationHints" do
+        let(:query) { "{ locationHints { translation(locale: \"ca\") } }" }
+
+        it "returns the polling station's location_hints" do
+          expect(response["locationHints"]["translation"]).to eq(model.location_hints["ca"])
+        end
+      end
+
+      describe "createdAt" do
+        let(:query) { "{ createdAt }" }
+
+        it "returns when the polling station was created" do
+          expect(response["createdAt"]).to eq(model.created_at.to_time.iso8601)
+        end
+      end
+
+      describe "updatedAt" do
+        let(:query) { "{ updatedAt }" }
+
+        it "returns when the polling station was updated" do
+          expect(response["updatedAt"]).to eq(model.updated_at.to_time.iso8601)
+        end
+      end
+
+      describe "voting" do
+        let(:query) { "{ voting { id } }" }
+
+        it "returns the voting space for this polling station" do
+          expect(response["voting"]["id"]).to eq(model.voting.id.to_s)
+        end
+      end
+    end
+  end
+end

--- a/decidim-elections/spec/types/integration_schema_spec.rb
+++ b/decidim-elections/spec/types/integration_schema_spec.rb
@@ -36,7 +36,7 @@ describe "Decidim::Api::QueryType" do
               "title" => { "translation" => a.title[locale] },
               "versions" => [],
               "versionsCount" => 0,
-              "votes_count" => a.votes_count.to_i,
+              "results_total" => a.results_total.to_i,
               "weight" => a.weight.to_i
             }
           end,
@@ -111,7 +111,7 @@ describe "Decidim::Api::QueryType" do
                       id
                     }
                     versionsCount
-                    votes_count
+                    results_total
                     weight
                   }
                   description {
@@ -191,7 +191,7 @@ describe "Decidim::Api::QueryType" do
                 id
               }
               versionsCount
-              votes_count
+              results_total
               weight
             }
             description {


### PR DESCRIPTION
#### :tophat: What? Why?

This PR extracts the `votes_count` from `Decidim::Election::Answer` to its own model `Decidim::Election::Result` so that results can come from different origins: polling stations and from online/bulletin board.

This is a first step towards #7128

#### :pushpin: Related Issues

- Related to #7128


#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
