### PR TITLE
Fix trustees admin menu

### DIFF
--- a/decidim-assemblies/app/views/layouts/decidim/admin/assembly.html.erb
+++ b/decidim-assemblies/app/views/layouts/decidim/admin/assembly.html.erb
@@ -1,5 +1,5 @@
 <% content_for :sidebar_menu_nav do %>
-  <%= sidebar_menu(:assemblies_admin_menu).render do
+  <%= sidebar_menu(:admin_assembly_menu).render do
     public_page_link decidim_assemblies.assembly_path(current_participatory_space)
   end %>
 <% end %>

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -191,6 +191,7 @@ en:
           assembly_members: Members
           attachment_collections: Folders
           attachment_files: Files
+          attachments: Attachments
           categories: Categories
           components: Components
           info: Info

--- a/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
@@ -142,7 +142,7 @@ module Decidim
         end
       end
       initializer "decidim_assemblies.assemblies_admin_menu" do
-        Decidim.menu :assemblies_admin_menu do |menu|
+        Decidim.menu :admin_assembly_menu do |menu|
           menu.add_item :edit_assembly,
                         I18n.t("info", scope: "decidim.admin.menu.assemblies_submenu"),
                         decidim_admin_assemblies.edit_assembly_path(current_participatory_space),

--- a/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
@@ -164,7 +164,7 @@ module Decidim
                         active: is_active_link?(decidim_admin_assemblies.categories_path(current_participatory_space))
 
           menu.add_item :attachments,
-                        I18n.t("attachments", scope: "decidim.admin.menu.conferences_submenu"),
+                        I18n.t("attachments", scope: "decidim.admin.menu.assemblies_submenu"),
                         "#",
                         active: is_active_link?(decidim_admin_assemblies.assembly_attachment_collections_path(current_participatory_space)) ||
                                 is_active_link?(decidim_admin_assemblies.assembly_attachments_path(current_participatory_space)),

--- a/decidim-elections/app/views/layouts/decidim/admin/voting.html.erb
+++ b/decidim-elections/app/views/layouts/decidim/admin/voting.html.erb
@@ -1,5 +1,5 @@
 <% content_for :sidebar_menu_nav do %>
-  <%= sidebar_menu(:decidim_voting_menu).render do
+  <%= sidebar_menu(:admin_voting_menu).render do
     public_page_link decidim_votings.voting_path(current_participatory_space)
   end %>
 <% end %>

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -167,6 +167,8 @@ en:
         exports:
           elections: Elections
           feedback_form_answers: Feedback form answers
+        menu:
+          trustees: Trustees
         models:
           answer:
             name: Answer

--- a/decidim-elections/lib/decidim/elections/admin_engine.rb
+++ b/decidim-elections/lib/decidim/elections/admin_engine.rb
@@ -51,29 +51,17 @@ module Decidim
       end
 
       initializer "decidim_admin_elections.menu_entry" do
-        Decidim.menu :admin_participatory_process_menu do |menu|
-          component = current_participatory_space.components.find_by(manifest_name: :elections)
-          if component
-            menu.add_item :trustees,
-                          "Trustees", # I18n.t("info", scope: "decidim.admin.menu.participatory_processes_submenu"),
-                          Decidim::EngineRouter.admin_proxy(component).trustees_path,
-                          active: is_active_link?(Decidim::EngineRouter.admin_proxy(component).trustees_path),
-                          if: allowed_to?(:update, :process, process: current_participatory_space)
-          end
-        end
-      end
-
-      initializer "decidim_admin_elections.view_hooks" do
-        Decidim::Admin.view_hooks.register(:admin_secondary_nav, priority: Decidim::ViewHooks::MEDIUM_PRIORITY) do |view_context|
-          component = view_context.current_participatory_space.components.find_by(manifest_name: :elections)
-          if component
-            view_context.render(
-              partial: "decidim/elections/admin/shared/trustees_secondary_nav",
-              locals: {
-                current_component: component,
-                engine_router: Decidim::EngineRouter.admin_proxy(component)
-              }
-            )
+        Decidim.participatory_space_registry.manifests.each do |participatory_space|
+          menu_id = :"admin_#{participatory_space.name.to_s.singularize}_menu"
+          Decidim.menu menu_id do |menu|
+            component = current_participatory_space.components.find_by(manifest_name: :elections)
+            if component
+              menu.add_item :trustees,
+                            I18n.t("trustees", scope: "decidim.elections.admin.menu"),
+                            Decidim::EngineRouter.admin_proxy(component).trustees_path,
+                            position: 100,
+                            active: is_active_link?(Decidim::EngineRouter.admin_proxy(component).trustees_path)
+            end
           end
         end
       end

--- a/decidim-elections/lib/decidim/votings/admin_engine.rb
+++ b/decidim-elections/lib/decidim/votings/admin_engine.rb
@@ -98,7 +98,7 @@ module Decidim
       end
 
       initializer "decidim_votings.decidim_voting_menu" do
-        Decidim.menu :decidim_voting_menu do |menu|
+        Decidim.menu :admin_voting_menu do |menu|
           menu.add_item :edit_voting,
                         I18n.t("info", scope: "decidim.votings.admin.menu.votings_submenu"),
                         decidim_admin_votings.edit_voting_path(current_participatory_space),

--- a/decidim-elections/spec/system/admin/admin_manages_trustees_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_trustees_spec.rb
@@ -104,7 +104,7 @@ describe "Admin manages trustees", type: :system do
     end
   end
 
-  context "within an assembly" do
+  context "when inside an assembly" do
     let(:participatory_space) { create(:assembly, organization: organization) }
 
     it "shows the trustees page" do
@@ -112,7 +112,7 @@ describe "Admin manages trustees", type: :system do
     end
   end
 
-  context "within a voting" do
+  context "when inside a voting" do
     let(:participatory_space) { create(:voting, organization: organization) }
 
     it "shows the trustees page" do

--- a/decidim-elections/spec/system/admin/admin_manages_trustees_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_trustees_spec.rb
@@ -3,14 +3,14 @@
 require "spec_helper"
 
 describe "Admin manages trustees", type: :system do
-  let!(:participatory_space) { create :participatory_process }
   let(:manifest_name) { "elections" }
 
   include_context "when managing a component as an admin"
+
   before do
     switch_to_host(organization.host)
     login_as user, scope: :user
-    visit_trustees
+    visit_component_admin
     click_link "Trustees"
   end
 
@@ -104,7 +104,19 @@ describe "Admin manages trustees", type: :system do
     end
   end
 
-  def visit_trustees
-    visit decidim_admin_participatory_processes.edit_participatory_process_path(participatory_space)
+  context "within an assembly" do
+    let(:participatory_space) { create(:assembly, organization: organization) }
+
+    it "shows the trustees page" do
+      expect(page).to have_content("New Trustee")
+    end
+  end
+
+  context "within a voting" do
+    let(:participatory_space) { create(:voting, organization: organization) }
+
+    it "shows the trustees page" do
+      expect(page).to have_content("New Trustee")
+    end
   end
 end

--- a/decidim-initiatives/app/views/layouts/decidim/admin/initiative.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/admin/initiative.html.erb
@@ -1,5 +1,5 @@
 <% content_for :sidebar_menu_nav do %>
-  <%= sidebar_menu(:decidim_initiative_menu).render do
+  <%= sidebar_menu(:admin_initiative_menu).render do
     public_page_link decidim_initiatives.initiative_path(current_participatory_space)
   end %>
 <% end %>

--- a/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
@@ -115,7 +115,7 @@ module Decidim
       end
 
       initializer "admin_decidim_initiative.admin_menu" do
-        Decidim.menu :decidim_initiative_menu do |menu|
+        Decidim.menu :admin_initiative_menu do |menu|
           menu.add_item :edit_initiative,
                         I18n.t("menu.information", scope: "decidim.admin"),
                         decidim_admin_initiatives.edit_initiative_path(current_participatory_space),


### PR DESCRIPTION
#### :tophat: What? Why?
The Trustees menu in the admin zone of participatory spaces should be shown on all participatory spaces with an Elections component, but it was only included on the Participatory Processes spaces. 

This PR fixes this problem, normalizing first the names of these menus with the format `:admin_[participatory_space]_menu` (e.g. `:admin_voting_menu`, `:admin_assembly_menu`, etc.) and then adding the menu element to that menu of each registered participatory space. Some tests to check this on assemblies and votings are also added (I didn't add for other spaces because they are not loaded during elections tests).

In the future, we could improve this PR creating a new menu with the common items for all participatory spaces and rendering it after the specific space menu, but that would need to refactor all menu presenter classes, as they only support rendering one menu.

This PR also fixes a silly issue with a missing translation on the assemblies submenu.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
