### PR TITLE
Show attachment menu as active only when subitem is active

### DIFF
--- a/decidim-elections/lib/decidim/votings/admin_engine.rb
+++ b/decidim-elections/lib/decidim/votings/admin_engine.rb
@@ -121,6 +121,8 @@ module Decidim
           menu.add_item :attachments,
                         I18n.t("attachments", scope: "decidim.votings.admin.menu.votings_submenu"),
                         "#",
+                        active: is_active_link?(decidim_admin_votings.voting_attachment_collections_path(current_participatory_space)) ||
+                                is_active_link?(decidim_admin_votings.voting_attachments_path(current_participatory_space)),
                         if: allowed_to?(:read, :attachment_collection) || allowed_to?(:read, :attachment),
                         submenu: { target_menu: :decidim_votings_attachments_menu }
 

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
@@ -190,6 +190,8 @@ module Decidim
           menu.add_item :attachments,
                         I18n.t("attachments", scope: "decidim.admin.menu.participatory_processes_submenu"),
                         "#",
+                        active: is_active_link?(decidim_admin_participatory_processes.participatory_process_attachment_collections_path(current_participatory_space)) ||
+                                is_active_link?(decidim_admin_participatory_processes.participatory_process_attachments_path(current_participatory_space)),
                         if: allowed_to?(:read, :attachment_collection) || allowed_to?(:read, :attachment),
                         submenu: { target_menu: :admin_participatory_process_attachments_menu }
 


### PR DESCRIPTION
#### :tophat: What? Why?
After the major refactor of the menus, the Attachment menu entries for `Voting` and `ParticipatoryProcess` lost  the `active` option, making them always active.

This PR sets them to be only active when one of their subitems is active.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
BEFORE
The "Attachment" menu item is active even though we're on the "Info" tab

![Screenshot 2021-03-31 at 09 41 57](https://user-images.githubusercontent.com/5033945/113108609-71670200-9205-11eb-81ba-02841b66d569.png)

AFTER

![Screenshot 2021-03-31 at 09 40 39](https://user-images.githubusercontent.com/5033945/113108782-a410fa80-9205-11eb-8e73-3efc4c9a46c0.png)


:hearts: Thank you!
