### PR TITLE
Fix showing trustees menu on consultations module

### DIFF
--- a/decidim-consultations/app/views/layouts/decidim/admin/question.html.erb
+++ b/decidim-consultations/app/views/layouts/decidim/admin/question.html.erb
@@ -1,5 +1,5 @@
 <% content_for :sidebar_menu_nav do %>
-  <%= sidebar_menu(:admin_consultation_question_menu).render do
+  <%= sidebar_menu(:admin_question_menu).render do
     public_page_link decidim_consultations.consultation_path(current_participatory_space.consultation)
   end %>
 <% end %>

--- a/decidim-consultations/lib/decidim/consultations/admin_engine.rb
+++ b/decidim-consultations/lib/decidim/consultations/admin_engine.rb
@@ -87,8 +87,8 @@ module Decidim
         end
       end
 
-      initializer "decidim_consultations.admin_consultation_question_menu" do
-        Decidim.menu :admin_consultation_question_menu do |menu|
+      initializer "decidim_consultations.admin_question_menu" do
+        Decidim.menu :admin_question_menu do |menu|
           menu.add_item :edit_consultation,
                         I18n.t("consultation", scope: "decidim.admin.menu.questions_submenu"),
                         decidim_admin_consultations.edit_consultation_path(current_participatory_space.consultation),

--- a/decidim-elections/lib/decidim/elections/admin_engine.rb
+++ b/decidim-elections/lib/decidim/elections/admin_engine.rb
@@ -54,14 +54,14 @@ module Decidim
         Decidim.participatory_space_registry.manifests.each do |participatory_space|
           menu_id = :"admin_#{participatory_space.name.to_s.singularize}_menu"
           Decidim.menu menu_id do |menu|
-            component = current_participatory_space.components.find_by(manifest_name: :elections)
-            if component
-              menu.add_item :trustees,
-                            I18n.t("trustees", scope: "decidim.elections.admin.menu"),
-                            Decidim::EngineRouter.admin_proxy(component).trustees_path,
-                            position: 100,
-                            active: is_active_link?(Decidim::EngineRouter.admin_proxy(component).trustees_path)
-            end
+            component = current_participatory_space.try(:components)&.find_by(manifest_name: :elections)
+            next unless component
+
+            menu.add_item :trustees,
+                          I18n.t("trustees", scope: "decidim.elections.admin.menu"),
+                          Decidim::EngineRouter.admin_proxy(component).trustees_path,
+                          position: 100,
+                          active: is_active_link?(Decidim::EngineRouter.admin_proxy(component).trustees_path)
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
The consultations participatory space doesn't have a components list, so the elections code to show the Trustees menu fails there. This PR fixes that.

This PR also modifies the consultations module to allow to see the Trustees menu in the questions if there is any Elections component. That doesn't seem to have much sense, and I don't like to name the menu as `:admin_question_menu`, but it will keep the system consistent until we remove that module completely. Anyway, the source of the problem is that the question participatory space is called `question` instead of `consultation_question`, so this is a problem that we already had.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #7772

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
