### PR TITLE
Remove proposals dependency from the debates module

### DIFF
--- a/decidim-debates/app/controllers/decidim/debates/versions_controller.rb
+++ b/decidim-debates/app/controllers/decidim/debates/versions_controller.rb
@@ -4,7 +4,7 @@ module Decidim
   module Debates
     # Exposes Debates versions so users can see how a Debate has been updated
     # through time.
-    class VersionsController < Decidim::Proposals::ApplicationController
+    class VersionsController < Decidim::Debates::ApplicationController
       include Decidim::ApplicationHelper
       include Decidim::ResourceVersionsConcern
 

--- a/decidim-debates/app/views/decidim/debates/versions/show.html.erb
+++ b/decidim-debates/app/views/decidim/debates/versions/show.html.erb
@@ -5,6 +5,6 @@
     index: params[:id],
     versioned_resource: versioned_resource,
     versions_path: proc { url_for(action: :index) },
-    i18n_scope: "decidim.debates.debates.versions.#{item_name.to_s.pluralize}"
+    i18n_scope: "decidim.debates.debates.versions.debates"
   ) %>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?
The debates versions controller is right now depending on the proposals module here:
https://github.com/decidim/decidim/blob/c09e5b76b04b41e096d591793f7495b6a9f3bdfe/decidim-debates/app/controllers/decidim/debates/versions_controller.rb#L7

The only reason is this line which is depending on a helper in the proposals module:
https://github.com/decidim/decidim/blob/c09e5b76b04b41e096d591793f7495b6a9f3bdfe/decidim-debates/app/views/decidim/debates/versions/show.html.erb#L8

This removes the proposals dependency from the debates module.

#### :pushpin: Related Issues
- Related to #7690

#### Testing
Try installing the debates module without the proposals module.

To test the change, run the versions system test in the proposals module:

```bash
$ cd decidim-debates
$ bundle exec rspec spec/system/debates_versions_spec.rb
```

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.